### PR TITLE
[release-4.17] OCPBUGS-44628: Implement Managed Identities in HyperShift

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2630,12 +2630,33 @@ func (r *HostedControlPlaneReconciler) reconcileCloudProviderConfig(ctx context.
 			return fmt.Errorf("failed to reconcile Azure cloud config: %w", err)
 		}
 
+		// Reconcile the Cloud Provider configuration secret
 		withSecrets := manifests.AzureProviderConfigWithCredentials(hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r, withSecrets, func() error {
 			return azure.ReconcileCloudConfigWithCredentials(withSecrets, hcp, credentialsSecret)
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile Azure cloud config with credentials: %w", err)
 		}
+
+		// Reconcile the Azure Disk configuration secret
+		// TODO this just copies the cloud provider secret at the moment. There will be a follow-on PR to provide
+		// different credentials for Azure Disk and Azure File (right below).
+		// This is related to https://github.com/openshift/csi-operator/pull/290.
+		azureDiskConfigSecret := manifests.AzureDiskConfigWithCredentials(hcp.Namespace)
+		if _, err := createOrUpdate(ctx, r, azureDiskConfigSecret, func() error {
+			return azure.ReconcileCloudConfigWithCredentials(azureDiskConfigSecret, hcp, credentialsSecret)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile Azure disk config: %w", err)
+		}
+
+		// Reconcile the Azure File configuration secret
+		azureFileConfigSecret := manifests.AzureFileConfigWithCredentials(hcp.Namespace)
+		if _, err := createOrUpdate(ctx, r, azureFileConfigSecret, func() error {
+			return azure.ReconcileCloudConfigWithCredentials(azureFileConfigSecret, hcp, credentialsSecret)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile Azure disk config: %w", err)
+		}
+
 	case hyperv1.OpenStackPlatform:
 		credentialsSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: hcp.Namespace, Name: hcp.Spec.Platform.OpenStack.IdentityRef.Name}}
 		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/azure.go
@@ -25,3 +25,21 @@ func AzureProviderConfigWithCredentials(ns string) *corev1.Secret {
 		},
 	}
 }
+
+func AzureDiskConfigWithCredentials(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "azure-disk-csi-config",
+			Namespace: ns,
+		},
+	}
+}
+
+func AzureFileConfigWithCredentials(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "azure-file-csi-config",
+			Namespace: ns,
+		},
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/secretproviderclass.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/secretproviderclass.go
@@ -1,0 +1,50 @@
+package manifests
+
+import (
+	"fmt"
+	"github.com/openshift/hypershift/support/azureutil"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	secretsstorev1 "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
+)
+
+const (
+	objectFormat = `
+array:
+  - |
+    objectName: %s
+    objectType: secret
+`
+)
+
+// ManagedAzureKeyVaultSecretProviderClass returns an instance of a SecretProviderClass completed with its name, Azure Key Vault set
+// up, and the certificate name it needs to pull from the Key Vault.
+//
+// https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-identity-access?tabs=azure-portal&pivots=access-with-a-user-assigned-managed-identity
+func ManagedAzureKeyVaultSecretProviderClass(secretProviderClassName, namespace, keyVaultName, KeyVaultTenantID, certificateName string) *secretsstorev1.SecretProviderClass {
+	return &secretsstorev1.SecretProviderClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretProviderClassName,
+			Namespace: namespace,
+		},
+		Spec: secretsstorev1.SecretProviderClassSpec{
+			Provider: "azure",
+			Parameters: map[string]string{
+				"usePodIdentity":         "false",
+				"useVMManagedIdentity":   "true",
+				"userAssignedIdentityID": azureutil.GetKeyVaultAuthorizedUser(),
+				"keyvaultName":           keyVaultName,
+				"tenantId":               KeyVaultTenantID,
+				"objects":                formatSecretProviderClassObject(certificateName),
+			},
+		},
+	}
+}
+
+// formatSecretProviderClassObject places the certificate name in the appropriate string structure the
+// SecretProviderClass expects for an object. More details here:
+// - https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-identity-access?tabs=azure-portal&pivots=access-with-a-user-assigned-managed-identity#configure-managed-identity
+// - https://secrets-store-csi-driver.sigs.k8s.io/concepts.html?highlight=object#custom-resource-definitions-crds
+func formatSecretProviderClassObject(certName string) string {
+	return fmt.Sprintf(objectFormat, certName)
+}

--- a/support/azureutil/azureutil.go
+++ b/support/azureutil/azureutil.go
@@ -3,12 +3,14 @@ package azureutil
 import (
 	"context"
 	"fmt"
-	"k8s.io/utils/ptr"
+	"os"
 	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -216,4 +218,13 @@ func VerifyResourceGroupLocationsMatch(ctx context.Context, hc *hyperv1.HostedCl
 	}
 
 	return nil
+}
+
+// IsAroHCP returns true if the managed service environment variable is set to ARO-HCP
+func IsAroHCP() bool {
+	return os.Getenv("MANAGED_SERVICE") == hyperv1.AroHCP
+}
+
+func GetKeyVaultAuthorizedUser() string {
+	return os.Getenv(config.AROHCPKeyVaultManagedIdentityClientID)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request introduces the ARO HCP feature to use managed identities in 4.17.z. This pull request backports the following PRs:
- https://github.com/openshift/hypershift/pull/4861
- https://github.com/openshift/hypershift/pull/4960

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-44628](https://issues.redhat.com/browse/OCPBUGS-44628)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.