### PR TITLE
OCPBUGS-44689: skip np image validation when skipReleaseImageValidation annotation is present on HC

### DIFF
--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -584,6 +584,10 @@ func (r *NodePoolReconciler) getReleaseImage(ctx context.Context, hostedCluster 
 		return nil, err
 	}
 
+	if _, exists := hostedCluster.Annotations[hyperv1.SkipReleaseImageValidation]; exists {
+		return ReleaseImage, nil
+	}
+
 	wantedVersion, err := semver.Parse(ReleaseImage.Version())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**: Allows for skipping NP image validation, we currently don't do this and when pre testing 4.19 payloads it causes failures.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/browse/[OCPBUGS-44689](https://issues.redhat.com/browse/OCPBUGS-44689)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.