### PR TITLE
HOSTEDCP-2075: DNS and NodePort address CEL

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -773,7 +773,7 @@ type NodePortPublishingStrategy struct {
 type LoadBalancerPublishingStrategy struct {
 	// hostname is the name of the DNS record that will be created pointing to the LoadBalancer and passed through to consumers of the service.
 	// If ommited, the value will be infered from the corev1.Service Load balancer type .status.
-	// +kubebuilder:validation:XValidation:rule=`self.matches('^(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$')`,message="baseDomain must be a valid base domain (e.g., example.com)"
+	// +kubebuilder:validation:XValidation:rule=`self.matches('^(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$')`,message="hostname must be a valid base domain (e.g., example.com)"
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:MinLength=1
 	// +optional
@@ -798,6 +798,7 @@ type DNSSpec struct {
 	// If baseDomainPrefix is ommitted, the hostedCluster.name will be used as the subdomain.
 	// Once set, this field is immutable.
 	// When the value is the empty string "", the controller might default to a value depending on the platform.
+	// +kubebuilder:validation:XValidation:rule=`self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')`,message="baseDomain must be a valid domain (e.g., example, example.com, sub.example.com)"
 	// +kubebuilder:validation:XValidation:rule=`oldSelf == "" || self == oldSelf`, message="baseDomain is immutable"
 	// +kubebuilder:validation:MaxLength=253
 	// +immutable
@@ -808,6 +809,7 @@ type DNSSpec struct {
 	// It will be used to confgure ingress in the hosted cluster through the subdomain baseDomainPrefix.baseDomain.
 	// If baseDomainPrefix is ommitted, the hostedCluster.name will be used as the subdomain.
 	// Set baseDomainPrefix to an empty string "", if you don't want a prefix at all (not even hostedCluster.name) to be prepended to baseDomain.
+	// +kubebuilder:validation:XValidation:rule=`self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')`,message="baseDomainPrefix must be a valid domain (e.g., example, example.com, sub.example.com)"
 	// This field is immutable.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="baseDomainPrefix is immutable"
 	// +kubebuilder:validation:MaxLength=253

--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -760,7 +760,7 @@ type NodePortPublishingStrategy struct {
 	// address is the host/ip that the NodePort service is exposed over.
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:XValidation:rule=`self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$') || self.matches('^((\\d{1,3}\\.){3}\\d{1,3})$') || self.matches('^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$')`, message="address must be a valid hostname, IPv4, or IPv6 address"
+	// +kubebuilder:validation:XValidation:rule=`isIP(self) || self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$') || self.matches('^((\\d{1,3}\\.){3}\\d{1,3})$') || self.matches('^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$')`, message="address must be a valid hostname, IPv4, or IPv6 address"
 	// +required
 	Address string `json:"address"`
 

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -3915,7 +3915,7 @@ spec:
                               x-kubernetes-validations:
                               - message: address must be a valid hostname, IPv4, or
                                   IPv6 address
-                                rule: self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
+                                rule: isIP(self) || self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
                                   || self.matches('^((\\d{1,3}\\.){3}\\d{1,3})$')
                                   || self.matches('^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$')
                             port:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -2073,6 +2073,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomain must be a valid domain (e.g., example, example.com,
+                        sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomain is immutable
                       rule: oldSelf == "" || self == oldSelf
                   baseDomainPrefix:
@@ -2085,6 +2088,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomainPrefix must be a valid domain (e.g., example,
+                        example.com, sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomainPrefix is immutable
                       rule: self == oldSelf
                   privateZoneID:
@@ -3892,7 +3898,7 @@ spec:
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: baseDomain must be a valid base domain (e.g.,
+                              - message: hostname must be a valid base domain (e.g.,
                                   example.com)
                                 rule: self.matches('^(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$')
                           type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AROHCPManagedIdentities.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AROHCPManagedIdentities.yaml
@@ -2069,6 +2069,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomain must be a valid domain (e.g., example, example.com,
+                        sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomain is immutable
                       rule: oldSelf == "" || self == oldSelf
                   baseDomainPrefix:
@@ -2081,6 +2084,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomainPrefix must be a valid domain (e.g., example,
+                        example.com, sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomainPrefix is immutable
                       rule: self == oldSelf
                   privateZoneID:
@@ -4137,7 +4143,7 @@ spec:
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: baseDomain must be a valid base domain (e.g.,
+                              - message: hostname must be a valid base domain (e.g.,
                                   example.com)
                                 rule: self.matches('^(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$')
                           type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AROHCPManagedIdentities.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AROHCPManagedIdentities.yaml
@@ -4160,7 +4160,7 @@ spec:
                               x-kubernetes-validations:
                               - message: address must be a valid hostname, IPv4, or
                                   IPv6 address
-                                rule: self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
+                                rule: isIP(self) || self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
                                   || self.matches('^((\\d{1,3}\\.){3}\\d{1,3})$')
                                   || self.matches('^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$')
                             port:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -3924,7 +3924,7 @@ spec:
                               x-kubernetes-validations:
                               - message: address must be a valid hostname, IPv4, or
                                   IPv6 address
-                                rule: self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
+                                rule: isIP(self) || self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
                                   || self.matches('^((\\d{1,3}\\.){3}\\d{1,3})$')
                                   || self.matches('^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$')
                             port:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -2090,6 +2090,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomain must be a valid domain (e.g., example, example.com,
+                        sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomain is immutable
                       rule: oldSelf == "" || self == oldSelf
                   baseDomainPrefix:
@@ -2102,6 +2105,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomainPrefix must be a valid domain (e.g., example,
+                        example.com, sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomainPrefix is immutable
                       rule: self == oldSelf
                   privateZoneID:
@@ -3901,7 +3907,7 @@ spec:
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: baseDomain must be a valid base domain (e.g.,
+                              - message: hostname must be a valid base domain (e.g.,
                                   example.com)
                                 rule: self.matches('^(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$')
                           type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -2311,6 +2311,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomain must be a valid domain (e.g., example, example.com,
+                        sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomain is immutable
                       rule: oldSelf == "" || self == oldSelf
                   baseDomainPrefix:
@@ -2323,6 +2326,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomainPrefix must be a valid domain (e.g., example,
+                        example.com, sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomainPrefix is immutable
                       rule: self == oldSelf
                   privateZoneID:
@@ -4122,7 +4128,7 @@ spec:
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: baseDomain must be a valid base domain (e.g.,
+                              - message: hostname must be a valid base domain (e.g.,
                                   example.com)
                                 rule: self.matches('^(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$')
                           type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -4145,7 +4145,7 @@ spec:
                               x-kubernetes-validations:
                               - message: address must be a valid hostname, IPv4, or
                                   IPv6 address
-                                rule: self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
+                                rule: isIP(self) || self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
                                   || self.matches('^((\\d{1,3}\\.){3}\\d{1,3})$')
                                   || self.matches('^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$')
                             port:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -4055,7 +4055,7 @@ spec:
                               x-kubernetes-validations:
                               - message: address must be a valid hostname, IPv4, or
                                   IPv6 address
-                                rule: self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
+                                rule: isIP(self) || self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
                                   || self.matches('^((\\d{1,3}\\.){3}\\d{1,3})$')
                                   || self.matches('^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$')
                             port:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -2221,6 +2221,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomain must be a valid domain (e.g., example, example.com,
+                        sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomain is immutable
                       rule: oldSelf == "" || self == oldSelf
                   baseDomainPrefix:
@@ -2233,6 +2236,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomainPrefix must be a valid domain (e.g., example,
+                        example.com, sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomainPrefix is immutable
                       rule: self == oldSelf
                   privateZoneID:
@@ -4032,7 +4038,7 @@ spec:
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: baseDomain must be a valid base domain (e.g.,
+                              - message: hostname must be a valid base domain (e.g.,
                                   example.com)
                                 rule: self.matches('^(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$')
                           type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -2069,6 +2069,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomain must be a valid domain (e.g., example, example.com,
+                        sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomain is immutable
                       rule: oldSelf == "" || self == oldSelf
                   baseDomainPrefix:
@@ -2081,6 +2084,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomainPrefix must be a valid domain (e.g., example,
+                        example.com, sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomainPrefix is immutable
                       rule: self == oldSelf
                   privateZoneID:
@@ -4354,7 +4360,7 @@ spec:
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: baseDomain must be a valid base domain (e.g.,
+                              - message: hostname must be a valid base domain (e.g.,
                                   example.com)
                                 rule: self.matches('^(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$')
                           type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -4377,7 +4377,7 @@ spec:
                               x-kubernetes-validations:
                               - message: address must be a valid hostname, IPv4, or
                                   IPv6 address
-                                rule: self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
+                                rule: isIP(self) || self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
                                   || self.matches('^((\\d{1,3}\\.){3}\\d{1,3})$')
                                   || self.matches('^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$')
                             port:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -2014,6 +2014,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomain must be a valid domain (e.g., example, example.com,
+                        sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomain is immutable
                       rule: oldSelf == "" || self == oldSelf
                   baseDomainPrefix:
@@ -2026,6 +2029,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomainPrefix must be a valid domain (e.g., example,
+                        example.com, sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomainPrefix is immutable
                       rule: self == oldSelf
                   privateZoneID:
@@ -3748,7 +3754,7 @@ spec:
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: baseDomain must be a valid base domain (e.g.,
+                              - message: hostname must be a valid base domain (e.g.,
                                   example.com)
                                 rule: self.matches('^(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$')
                           type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -3771,7 +3771,7 @@ spec:
                               x-kubernetes-validations:
                               - message: address must be a valid hostname, IPv4, or
                                   IPv6 address
-                                rule: self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
+                                rule: isIP(self) || self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
                                   || self.matches('^((\\d{1,3}\\.){3}\\d{1,3})$')
                                   || self.matches('^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$')
                             port:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AROHCPManagedIdentities.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AROHCPManagedIdentities.yaml
@@ -4016,7 +4016,7 @@ spec:
                               x-kubernetes-validations:
                               - message: address must be a valid hostname, IPv4, or
                                   IPv6 address
-                                rule: self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
+                                rule: isIP(self) || self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
                                   || self.matches('^((\\d{1,3}\\.){3}\\d{1,3})$')
                                   || self.matches('^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$')
                             port:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AROHCPManagedIdentities.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AROHCPManagedIdentities.yaml
@@ -2010,6 +2010,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomain must be a valid domain (e.g., example, example.com,
+                        sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomain is immutable
                       rule: oldSelf == "" || self == oldSelf
                   baseDomainPrefix:
@@ -2022,6 +2025,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomainPrefix must be a valid domain (e.g., example,
+                        example.com, sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomainPrefix is immutable
                       rule: self == oldSelf
                   privateZoneID:
@@ -3993,7 +3999,7 @@ spec:
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: baseDomain must be a valid base domain (e.g.,
+                              - message: hostname must be a valid base domain (e.g.,
                                   example.com)
                                 rule: self.matches('^(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$')
                           type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -2031,6 +2031,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomain must be a valid domain (e.g., example, example.com,
+                        sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomain is immutable
                       rule: oldSelf == "" || self == oldSelf
                   baseDomainPrefix:
@@ -2043,6 +2046,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomainPrefix must be a valid domain (e.g., example,
+                        example.com, sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomainPrefix is immutable
                       rule: self == oldSelf
                   privateZoneID:
@@ -3757,7 +3763,7 @@ spec:
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: baseDomain must be a valid base domain (e.g.,
+                              - message: hostname must be a valid base domain (e.g.,
                                   example.com)
                                 rule: self.matches('^(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$')
                           type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -3780,7 +3780,7 @@ spec:
                               x-kubernetes-validations:
                               - message: address must be a valid hostname, IPv4, or
                                   IPv6 address
-                                rule: self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
+                                rule: isIP(self) || self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
                                   || self.matches('^((\\d{1,3}\\.){3}\\d{1,3})$')
                                   || self.matches('^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$')
                             port:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -4001,7 +4001,7 @@ spec:
                               x-kubernetes-validations:
                               - message: address must be a valid hostname, IPv4, or
                                   IPv6 address
-                                rule: self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
+                                rule: isIP(self) || self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
                                   || self.matches('^((\\d{1,3}\\.){3}\\d{1,3})$')
                                   || self.matches('^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$')
                             port:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -2252,6 +2252,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomain must be a valid domain (e.g., example, example.com,
+                        sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomain is immutable
                       rule: oldSelf == "" || self == oldSelf
                   baseDomainPrefix:
@@ -2264,6 +2267,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomainPrefix must be a valid domain (e.g., example,
+                        example.com, sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomainPrefix is immutable
                       rule: self == oldSelf
                   privateZoneID:
@@ -3978,7 +3984,7 @@ spec:
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: baseDomain must be a valid base domain (e.g.,
+                              - message: hostname must be a valid base domain (e.g.,
                                   example.com)
                                 rule: self.matches('^(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$')
                           type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -3911,7 +3911,7 @@ spec:
                               x-kubernetes-validations:
                               - message: address must be a valid hostname, IPv4, or
                                   IPv6 address
-                                rule: self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
+                                rule: isIP(self) || self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
                                   || self.matches('^((\\d{1,3}\\.){3}\\d{1,3})$')
                                   || self.matches('^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$')
                             port:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -2162,6 +2162,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomain must be a valid domain (e.g., example, example.com,
+                        sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomain is immutable
                       rule: oldSelf == "" || self == oldSelf
                   baseDomainPrefix:
@@ -2174,6 +2177,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomainPrefix must be a valid domain (e.g., example,
+                        example.com, sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomainPrefix is immutable
                       rule: self == oldSelf
                   privateZoneID:
@@ -3888,7 +3894,7 @@ spec:
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: baseDomain must be a valid base domain (e.g.,
+                              - message: hostname must be a valid base domain (e.g.,
                                   example.com)
                                 rule: self.matches('^(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$')
                           type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -4233,7 +4233,7 @@ spec:
                               x-kubernetes-validations:
                               - message: address must be a valid hostname, IPv4, or
                                   IPv6 address
-                                rule: self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
+                                rule: isIP(self) || self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
                                   || self.matches('^((\\d{1,3}\\.){3}\\d{1,3})$')
                                   || self.matches('^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$')
                             port:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -2010,6 +2010,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomain must be a valid domain (e.g., example, example.com,
+                        sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomain is immutable
                       rule: oldSelf == "" || self == oldSelf
                   baseDomainPrefix:
@@ -2022,6 +2025,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomainPrefix must be a valid domain (e.g., example,
+                        example.com, sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomainPrefix is immutable
                       rule: self == oldSelf
                   privateZoneID:
@@ -4210,7 +4216,7 @@ spec:
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: baseDomain must be a valid base domain (e.g.,
+                              - message: hostname must be a valid base domain (e.g.,
                                   example.com)
                                 rule: self.matches('^(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$')
                           type: object

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
@@ -5050,7 +5050,7 @@ spec:
                               x-kubernetes-validations:
                               - message: address must be a valid hostname, IPv4, or
                                   IPv6 address
-                                rule: self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
+                                rule: isIP(self) || self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
                                   || self.matches('^((\\d{1,3}\\.){3}\\d{1,3})$')
                                   || self.matches('^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$')
                             port:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
@@ -2487,6 +2487,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomain must be a valid domain (e.g., example, example.com,
+                        sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomain is immutable
                       rule: oldSelf == "" || self == oldSelf
                   baseDomainPrefix:
@@ -2499,6 +2502,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomainPrefix must be a valid domain (e.g., example,
+                        example.com, sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomainPrefix is immutable
                       rule: self == oldSelf
                   privateZoneID:
@@ -5027,7 +5033,7 @@ spec:
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: baseDomain must be a valid base domain (e.g.,
+                              - message: hostname must be a valid base domain (e.g.,
                                   example.com)
                                 rule: self.matches('^(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$')
                           type: object

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
@@ -4329,7 +4329,7 @@ spec:
                               x-kubernetes-validations:
                               - message: address must be a valid hostname, IPv4, or
                                   IPv6 address
-                                rule: self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
+                                rule: isIP(self) || self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
                                   || self.matches('^((\\d{1,3}\\.){3}\\d{1,3})$')
                                   || self.matches('^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$')
                             port:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
@@ -2487,6 +2487,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomain must be a valid domain (e.g., example, example.com,
+                        sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomain is immutable
                       rule: oldSelf == "" || self == oldSelf
                   baseDomainPrefix:
@@ -2499,6 +2502,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomainPrefix must be a valid domain (e.g., example,
+                        example.com, sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomainPrefix is immutable
                       rule: self == oldSelf
                   privateZoneID:
@@ -4306,7 +4312,7 @@ spec:
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: baseDomain must be a valid base domain (e.g.,
+                              - message: hostname must be a valid base domain (e.g.,
                                   example.com)
                                 rule: self.matches('^(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$')
                           type: object

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
@@ -5050,7 +5050,7 @@ spec:
                               x-kubernetes-validations:
                               - message: address must be a valid hostname, IPv4, or
                                   IPv6 address
-                                rule: self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
+                                rule: isIP(self) || self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
                                   || self.matches('^((\\d{1,3}\\.){3}\\d{1,3})$')
                                   || self.matches('^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$')
                             port:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
@@ -2487,6 +2487,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomain must be a valid domain (e.g., example, example.com,
+                        sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomain is immutable
                       rule: oldSelf == "" || self == oldSelf
                   baseDomainPrefix:
@@ -2499,6 +2502,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomainPrefix must be a valid domain (e.g., example,
+                        example.com, sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomainPrefix is immutable
                       rule: self == oldSelf
                   privateZoneID:
@@ -5027,7 +5033,7 @@ spec:
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: baseDomain must be a valid base domain (e.g.,
+                              - message: hostname must be a valid base domain (e.g.,
                                   example.com)
                                 rule: self.matches('^(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$')
                           type: object

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
@@ -4906,7 +4906,7 @@ spec:
                               x-kubernetes-validations:
                               - message: address must be a valid hostname, IPv4, or
                                   IPv6 address
-                                rule: self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
+                                rule: isIP(self) || self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
                                   || self.matches('^((\\d{1,3}\\.){3}\\d{1,3})$')
                                   || self.matches('^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$')
                             port:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
@@ -2428,6 +2428,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomain must be a valid domain (e.g., example, example.com,
+                        sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomain is immutable
                       rule: oldSelf == "" || self == oldSelf
                   baseDomainPrefix:
@@ -2440,6 +2443,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomainPrefix must be a valid domain (e.g., example,
+                        example.com, sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomainPrefix is immutable
                       rule: self == oldSelf
                   privateZoneID:
@@ -4883,7 +4889,7 @@ spec:
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: baseDomain must be a valid base domain (e.g.,
+                              - message: hostname must be a valid base domain (e.g.,
                                   example.com)
                                 rule: self.matches('^(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$')
                           type: object

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
@@ -2428,6 +2428,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomain must be a valid domain (e.g., example, example.com,
+                        sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomain is immutable
                       rule: oldSelf == "" || self == oldSelf
                   baseDomainPrefix:
@@ -2440,6 +2443,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomainPrefix must be a valid domain (e.g., example,
+                        example.com, sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomainPrefix is immutable
                       rule: self == oldSelf
                   privateZoneID:
@@ -4162,7 +4168,7 @@ spec:
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: baseDomain must be a valid base domain (e.g.,
+                              - message: hostname must be a valid base domain (e.g.,
                                   example.com)
                                 rule: self.matches('^(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$')
                           type: object

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
@@ -4185,7 +4185,7 @@ spec:
                               x-kubernetes-validations:
                               - message: address must be a valid hostname, IPv4, or
                                   IPv6 address
-                                rule: self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
+                                rule: isIP(self) || self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
                                   || self.matches('^((\\d{1,3}\\.){3}\\d{1,3})$')
                                   || self.matches('^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$')
                             port:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
@@ -4906,7 +4906,7 @@ spec:
                               x-kubernetes-validations:
                               - message: address must be a valid hostname, IPv4, or
                                   IPv6 address
-                                rule: self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
+                                rule: isIP(self) || self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$')
                                   || self.matches('^((\\d{1,3}\\.){3}\\d{1,3})$')
                                   || self.matches('^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$')
                             port:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
@@ -2428,6 +2428,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomain must be a valid domain (e.g., example, example.com,
+                        sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomain is immutable
                       rule: oldSelf == "" || self == oldSelf
                   baseDomainPrefix:
@@ -2440,6 +2443,9 @@ spec:
                     maxLength: 253
                     type: string
                     x-kubernetes-validations:
+                    - message: baseDomainPrefix must be a valid domain (e.g., example,
+                        example.com, sub.example.com)
+                      rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
                     - message: baseDomainPrefix is immutable
                       rule: self == oldSelf
                   privateZoneID:
@@ -4883,7 +4889,7 @@ spec:
                               minLength: 1
                               type: string
                               x-kubernetes-validations:
-                              - message: baseDomain must be a valid base domain (e.g.,
+                              - message: hostname must be a valid base domain (e.g.,
                                   example.com)
                                 rule: self.matches('^(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$')
                           type: object

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -392,6 +392,94 @@ func TestOnCreateAPIUX(t *testing.T) {
 					mutateInput            func(*hyperv1.HostedCluster)
 					expectedErrorSubstring string
 				}{
+					{
+						name: "when servicePublishingStrategy is nodePort and addresses valid hostname, IPv4 and IPv6 it should pass",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.Services = []hyperv1.ServicePublishingStrategyMapping{
+								{
+									Service: hyperv1.APIServer,
+									ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+										Type: hyperv1.NodePort,
+										NodePort: &hyperv1.NodePortPublishingStrategy{
+											Address: "kas.example.com",
+										},
+									},
+								},
+								{
+									Service: hyperv1.Ignition,
+									ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+										Type: hyperv1.NodePort,
+										NodePort: &hyperv1.NodePortPublishingStrategy{
+											Address: "127.0.0.1",
+										},
+									},
+								},
+								{
+									Service: hyperv1.Konnectivity,
+									ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+										Type: hyperv1.NodePort,
+										NodePort: &hyperv1.NodePortPublishingStrategy{
+											Address: "fd2e:6f44:5dd8:c956::14",
+										},
+									},
+								},
+								{
+									Service: hyperv1.OAuthServer,
+									ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+										Type: hyperv1.NodePort,
+										NodePort: &hyperv1.NodePortPublishingStrategy{
+											Address: "fd2e:6f44:5dd8:c956:0000:0000:0000:0014",
+										},
+									},
+								},
+							}
+						},
+						expectedErrorSubstring: "",
+					},
+					{
+						name: "when servicePublishingStrategy is nodePort and addresses is invalid it should fail",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.Services = []hyperv1.ServicePublishingStrategyMapping{
+								{
+									Service: hyperv1.APIServer,
+									ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+										Type: hyperv1.NodePort,
+										NodePort: &hyperv1.NodePortPublishingStrategy{
+											Address: "@foo",
+										},
+									},
+								},
+								{
+									Service: hyperv1.Ignition,
+									ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+										Type: hyperv1.NodePort,
+										NodePort: &hyperv1.NodePortPublishingStrategy{
+											Address: "127.0.0.1",
+										},
+									},
+								},
+								{
+									Service: hyperv1.Konnectivity,
+									ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+										Type: hyperv1.NodePort,
+										NodePort: &hyperv1.NodePortPublishingStrategy{
+											Address: "fd2e:6f44:5dd8:c956::14",
+										},
+									},
+								},
+								{
+									Service: hyperv1.OAuthServer,
+									ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+										Type: hyperv1.NodePort,
+										NodePort: &hyperv1.NodePortPublishingStrategy{
+											Address: "fd2e:6f44:5dd8:c956:0000:0000:0000:0014",
+										},
+									},
+								},
+							}
+						},
+						expectedErrorSubstring: "address must be a valid hostname, IPv4, or IPv6 address",
+					},
 					// {
 					// 	name: "when serviceType is 'APIServer' and publishing strategy is 'Route' and hostname is not set it should fail",
 					// 	mutateInput: func(hc *hyperv1.HostedCluster) {

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -44,6 +44,102 @@ func TestOnCreateAPIUX(t *testing.T) {
 			}
 		}{
 			{
+				name: "when based domain is not valid it should fail",
+				file: "hostedcluster-base.yaml",
+				validations: []struct {
+					name                   string
+					mutateInput            func(*hyperv1.HostedCluster)
+					expectedErrorSubstring string
+				}{
+					{
+						name: "when baseDomain has invalid chars it should fail",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.DNS.BaseDomain = "@foo"
+						},
+						expectedErrorSubstring: "baseDomain must be a valid domain (e.g., example, example.com, sub.example.com)",
+					},
+					{
+						name: "when baseDomain is a valid hierarchical domain with two levels it should pass",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.DNS.BaseDomain = "foo.bar"
+						},
+						expectedErrorSubstring: "",
+					},
+					{
+						name: "when baseDomain is a valid hierarchical domain it with 3 levels should pass",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.DNS.BaseDomain = "123.foo.bar"
+						},
+						expectedErrorSubstring: "",
+					},
+					{
+						name: "when baseDomain is a single subdomain it should pass",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.DNS.BaseDomain = "foo"
+						},
+						expectedErrorSubstring: "",
+					},
+					{
+						name: "when baseDomain is empty it should pass",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.DNS.BaseDomain = ""
+						},
+						expectedErrorSubstring: "",
+					},
+					{
+						name: "when baseDomainPrefix has invalid chars it should fail",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.DNS.BaseDomainPrefix = ptr.To("@foo")
+						},
+						expectedErrorSubstring: "baseDomainPrefix must be a valid domain (e.g., example, example.com, sub.example.com)",
+					},
+					{
+						name: "when baseDomainPrefix is a valid hierarchical domain with two levels it should pass",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.DNS.BaseDomainPrefix = ptr.To("foo.bar")
+						},
+						expectedErrorSubstring: "",
+					},
+					{
+						name: "when baseDomainPrefix is a valid hierarchical domain it with 3 levels should pass",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.DNS.BaseDomainPrefix = ptr.To("123.foo.bar")
+						},
+						expectedErrorSubstring: "",
+					},
+					{
+						name: "when baseDomainPrefix is a single subdomain it should pass",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.DNS.BaseDomainPrefix = ptr.To("foo")
+						},
+						expectedErrorSubstring: "",
+					},
+					{
+						name: "when baseDomainPrefix is empty it should pass",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.DNS.BaseDomainPrefix = ptr.To("")
+						},
+						expectedErrorSubstring: "",
+					},
+					{
+						name: "when publicZoneID and privateZoneID are empty it should pass",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.DNS.PublicZoneID = ""
+							hc.Spec.DNS.PrivateZoneID = ""
+						},
+						expectedErrorSubstring: "",
+					},
+					{
+						name: "when publicZoneID and privateZoneID are set it should pass",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.DNS.PublicZoneID = "123"
+							hc.Spec.DNS.PrivateZoneID = "123"
+						},
+						expectedErrorSubstring: "",
+					},
+				},
+			},
+			{
 				name: "when feature gated fields are used it should fail",
 				file: "hostedcluster-base.yaml",
 				validations: []struct {

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -773,7 +773,7 @@ type NodePortPublishingStrategy struct {
 type LoadBalancerPublishingStrategy struct {
 	// hostname is the name of the DNS record that will be created pointing to the LoadBalancer and passed through to consumers of the service.
 	// If ommited, the value will be infered from the corev1.Service Load balancer type .status.
-	// +kubebuilder:validation:XValidation:rule=`self.matches('^(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$')`,message="baseDomain must be a valid base domain (e.g., example.com)"
+	// +kubebuilder:validation:XValidation:rule=`self.matches('^(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$')`,message="hostname must be a valid base domain (e.g., example.com)"
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:MinLength=1
 	// +optional
@@ -798,6 +798,7 @@ type DNSSpec struct {
 	// If baseDomainPrefix is ommitted, the hostedCluster.name will be used as the subdomain.
 	// Once set, this field is immutable.
 	// When the value is the empty string "", the controller might default to a value depending on the platform.
+	// +kubebuilder:validation:XValidation:rule=`self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')`,message="baseDomain must be a valid domain (e.g., example, example.com, sub.example.com)"
 	// +kubebuilder:validation:XValidation:rule=`oldSelf == "" || self == oldSelf`, message="baseDomain is immutable"
 	// +kubebuilder:validation:MaxLength=253
 	// +immutable
@@ -808,6 +809,7 @@ type DNSSpec struct {
 	// It will be used to confgure ingress in the hosted cluster through the subdomain baseDomainPrefix.baseDomain.
 	// If baseDomainPrefix is ommitted, the hostedCluster.name will be used as the subdomain.
 	// Set baseDomainPrefix to an empty string "", if you don't want a prefix at all (not even hostedCluster.name) to be prepended to baseDomain.
+	// +kubebuilder:validation:XValidation:rule=`self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')`,message="baseDomainPrefix must be a valid domain (e.g., example, example.com, sub.example.com)"
 	// This field is immutable.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="baseDomainPrefix is immutable"
 	// +kubebuilder:validation:MaxLength=253

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -760,7 +760,7 @@ type NodePortPublishingStrategy struct {
 	// address is the host/ip that the NodePort service is exposed over.
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:XValidation:rule=`self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$') || self.matches('^((\\d{1,3}\\.){3}\\d{1,3})$') || self.matches('^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$')`, message="address must be a valid hostname, IPv4, or IPv6 address"
+	// +kubebuilder:validation:XValidation:rule=`isIP(self) || self.matches('^(([a-zA-Z0-9][-a-zA-Z0-9]*\\.)+[a-zA-Z]{2,}|localhost)$') || self.matches('^((\\d{1,3}\\.){3}\\d{1,3})$') || self.matches('^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$')`, message="address must be a valid hostname, IPv4, or IPv6 address"
 	// +required
 	Address string `json:"address"`
 


### PR DESCRIPTION
/hold
goes after https://github.com/openshift/hypershift/pull/5155

**What this PR does / why we need it**:
Add cel and e2e input validation for DNS and nodepool.address

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.