### PR TITLE
OCPBUGS-42338: Update KCM node monitor grace period

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment.go
@@ -334,6 +334,11 @@ func kcmArgs(p *KubeControllerManagerParams) []string {
 	if p.DisableProfiling {
 		args = append(args, "--profiling=false")
 	}
+	if p.PlatformType == hyperv1.IBMCloudPlatform {
+		args = append(args, "--node-monitor-grace-period=55s")
+	} else {
+		args = append(args, "--node-monitor-grace-period=50s")
+	}
 	args = append(args, []string{
 		fmt.Sprintf("--cert-dir=%s", cpath(kcmVolumeCertDir().Name, "")),
 		fmt.Sprintf("--cluster-cidr=%s", p.ClusterCIDR),
@@ -361,7 +366,6 @@ func kcmArgs(p *KubeControllerManagerParams) []string {
 		"--cluster-signing-duration=17520h",
 		fmt.Sprintf("--tls-cert-file=%s", cpath(kcmVolumeServerCert().Name, corev1.TLSCertKey)),
 		fmt.Sprintf("--tls-private-key-file=%s", cpath(kcmVolumeServerCert().Name, corev1.TLSPrivateKeyKey)),
-		"--node-monitor-grace-period=50s",
 	}...)
 	for _, f := range p.FeatureGates() {
 		args = append(args, fmt.Sprintf("--feature-gates=%s", f))

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/params.go
@@ -23,6 +23,7 @@ type KubeControllerManagerParams struct {
 	CloudProviderConfig *corev1.LocalObjectReference `json:"cloudProviderConfig"`
 	CloudProviderCreds  *corev1.LocalObjectReference `json:"cloudProviderCreds"`
 	Port                int32                        `json:"port"`
+	PlatformType        hyperv1.PlatformType
 	ServiceCIDR         string
 	ClusterCIDR         string
 	APIServer           *configv1.APIServerSpec `json:"apiServer"`
@@ -55,6 +56,7 @@ func NewKubeControllerManagerParams(ctx context.Context, hcp *hyperv1.HostedCont
 	if hcp.Spec.Platform.Type == hyperv1.AzurePlatform {
 		params.CloudProvider = "external"
 	}
+	params.PlatformType = hcp.Spec.Platform.Type
 
 	if hcp.Spec.Configuration != nil {
 		params.FeatureGate = hcp.Spec.Configuration.FeatureGate


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow-up to https://github.com/openshift/hypershift/pull/4786

The Kubernetes controller manager default for node monitor grace period is not sufficient to avoid node readiness flaps during brief connectivity problems. Change is restricted to IBMCloud only.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #https://issues.redhat.com/browse/OCPBUGS-42338

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.