### PR TITLE
NO-JIRA: Disable ASOAPI feature gate for CAPz

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
@@ -90,7 +90,7 @@ func (a Azure) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hy
 					Args: []string{
 						"--namespace=$(MY_NAMESPACE)",
 						"--leader-elect=true",
-						"--feature-gates=MachinePool=false",
+						"--feature-gates=MachinePool=false,ASOAPI=false",
 					},
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
This was enabled by default here https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/4969/files#diff-bd8758c39c0deb35ee6c5c387594f6575580918777fbf2926f5762c7c9fce755L68

We don't install these CRDs hence the controllers complain.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.