### PR TITLE
OCPBUGS-44655,OCPBUGS-43083: Fix IPv6 Disconnected HCP deployments

### DIFF
--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -648,7 +648,7 @@ func (opts *RawCreateOptions) Validate(ctx context.Context) (*ValidatedCreateOpt
 		if err != nil {
 			return nil, fmt.Errorf("could not retrieve kube clientset: %w", err)
 		}
-		if err := validateMgmtClusterAndNodePoolCPUArchitectures(ctx, opts, kc); err != nil {
+		if err := validateMgmtClusterAndNodePoolCPUArchitectures(ctx, opts, kc, &hyperutil.RegistryClientImageMetadataProvider{}); err != nil {
 			return nil, err
 		}
 	}
@@ -1012,7 +1012,7 @@ func parseTolerationString(str string) (*corev1.Toleration, error) {
 // validateMgmtClusterAndNodePoolCPUArchitectures checks if a multi-arch release image or release stream was provided.
 // If none were provided, checks to make sure the NodePool CPU arch and the management cluster CPU arch match; if they
 // do not, the CLI will return an error since the NodePool will fail to complete during runtime.
-func validateMgmtClusterAndNodePoolCPUArchitectures(ctx context.Context, opts *RawCreateOptions, kc kubeclient.Interface) error {
+func validateMgmtClusterAndNodePoolCPUArchitectures(ctx context.Context, opts *RawCreateOptions, kc kubeclient.Interface, imageMetadataProvider hyperutil.ImageMetadataProvider) error {
 	validMultiArchImage := false
 
 	// Check if the release image is multi-arch
@@ -1021,8 +1021,7 @@ func validateMgmtClusterAndNodePoolCPUArchitectures(ctx context.Context, opts *R
 		if err != nil {
 			return fmt.Errorf("failed to read pull secret file: %w", err)
 		}
-
-		validMultiArchImage, err = registryclient.IsMultiArchManifestList(ctx, opts.ReleaseImage, pullSecret)
+		validMultiArchImage, err = registryclient.IsMultiArchManifestList(ctx, opts.ReleaseImage, pullSecret, imageMetadataProvider)
 		if err != nil {
 			return err
 		}

--- a/cmd/cluster/core/create_test.go
+++ b/cmd/cluster/core/create_test.go
@@ -6,6 +6,8 @@ import (
 
 	. "github.com/onsi/gomega"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
+	"github.com/openshift/hypershift/support/util/fakeimagemetadataprovider"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1 "k8s.io/api/core/v1"
@@ -19,9 +21,13 @@ func TestValidateMgmtClusterAndNodePoolCPUArchitectures(t *testing.T) {
 
 	fakeKubeClient := fakekubeclient.NewSimpleClientset()
 	fakeDiscovery, ok := fakeKubeClient.Discovery().(*fakediscovery.FakeDiscovery)
-
 	if !ok {
 		t.Fatalf("failed to convert FakeDiscovery")
+	}
+
+	fakeMetadataProvider := &fakeimagemetadataprovider.FakeRegistryClientImageMetadataProvider{
+		Result:   &dockerv1client.DockerImageConfig{},
+		Manifest: fakeimagemetadataprovider.FakeManifest{},
 	}
 
 	// if you want to fake a specific version
@@ -80,7 +86,7 @@ func TestValidateMgmtClusterAndNodePoolCPUArchitectures(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			err := validateMgmtClusterAndNodePoolCPUArchitectures(ctx, tc.opts, fakeKubeClient)
+			err := validateMgmtClusterAndNodePoolCPUArchitectures(ctx, tc.opts, fakeKubeClient, fakeMetadataProvider)
 			if tc.expectError {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cvo/reconcile.go
@@ -115,7 +115,7 @@ func cvoLabels() map[string]string {
 
 var port int32 = 8443
 
-func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, deploymentConfig config.DeploymentConfig, controlPlaneImage, releaseImage, cliImage, availabilityProberImage, clusterID string, updateService configv1.URL, platformType hyperv1.PlatformType, oauthEnabled, enableCVOManagementClusterMetricsAccess bool, featureSet configv1.FeatureSet) error {
+func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, deploymentConfig config.DeploymentConfig, controlPlaneReleaseImage, dataPlaneReleaseImage, cliImage, availabilityProberImage, clusterID string, updateService configv1.URL, platformType hyperv1.PlatformType, oauthEnabled, enableCVOManagementClusterMetricsAccess bool, featureSet configv1.FeatureSet) error {
 	ownerRef.ApplyTo(deployment)
 
 	// preserve existing resource requirements for main CVO container
@@ -138,11 +138,11 @@ func ReconcileDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef
 			Spec: corev1.PodSpec{
 				AutomountServiceAccountToken: ptr.To(false),
 				InitContainers: []corev1.Container{
-					util.BuildContainer(cvoContainerPrepPayload(), buildCVOContainerPrepPayload(releaseImage, platformType, oauthEnabled, featureSet)),
+					util.BuildContainer(cvoContainerPrepPayload(), buildCVOContainerPrepPayload(dataPlaneReleaseImage, platformType, oauthEnabled, featureSet)),
 					util.BuildContainer(cvoContainerBootstrap(), buildCVOContainerBootstrap(cliImage, clusterID)),
 				},
 				Containers: []corev1.Container{
-					util.BuildContainer(cvoContainerMain(), buildCVOContainerMain(controlPlaneImage, releaseImage, deployment.Namespace, updateService, enableCVOManagementClusterMetricsAccess)),
+					util.BuildContainer(cvoContainerMain(), buildCVOContainerMain(controlPlaneReleaseImage, dataPlaneReleaseImage, deployment.Namespace, updateService, enableCVOManagementClusterMetricsAccess)),
 				},
 				Volumes: []corev1.Volume{
 					util.BuildVolume(cvoVolumePayload(), buildCVOVolumePayload),
@@ -331,6 +331,7 @@ func preparePayloadScript(platformType hyperv1.PlatformType, oauthEnabled bool, 
 			"    release.openshift.io/delete: \"true\"",
 		)
 	}
+	stmts = append(stmts, "EOF")
 	return strings.Join(stmts, "\n")
 }
 
@@ -361,17 +362,17 @@ oc get clusterversion/version &> /dev/null || oc create -f /tmp/clusterversion.y
 	return fmt.Sprintf(scriptTemplate, clusterID, payloadDir)
 }
 
-func buildCVOContainerMain(image, releaseImage, namespace string, updateService configv1.URL, enableCVOManagementClusterMetricsAccess bool) func(c *corev1.Container) {
+func buildCVOContainerMain(controlPlaneReleaseImage, dataPlaneReleaseImage, namespace string, updateService configv1.URL, enableCVOManagementClusterMetricsAccess bool) func(c *corev1.Container) {
 	cpath := func(vol, file string) string {
 		return path.Join(volumeMounts.Path(cvoContainerMain().Name, vol), file)
 	}
 	return func(c *corev1.Container) {
-		c.Image = image
+		c.Image = controlPlaneReleaseImage
 		c.Command = []string{"cluster-version-operator"}
 		c.Args = []string{
 			"start",
 			"--release-image",
-			releaseImage,
+			dataPlaneReleaseImage,
 			"--enable-auto-update=false",
 			"--kubeconfig",
 			path.Join(volumeMounts.Path(c.Name, cvoVolumeKubeconfig().Name), kas.KubeconfigKey),

--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
@@ -40,7 +40,7 @@ func etcdPodSelector() map[string]string {
 
 func NewEtcdParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider imageprovider.ReleaseImageProvider) (*EtcdParams, error) {
 
-	ipv4, err := hyputils.IsIPv4(hcp.Spec.Networking.ClusterNetwork[0].CIDR.String())
+	ipv4, err := hyputils.IsIPv4CIDR(hcp.Spec.Networking.ClusterNetwork[0].CIDR.String())
 	if err != nil {
 		return nil, fmt.Errorf("error checking the ClusterNetworkCIDR: %v", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -988,6 +988,7 @@ func (r *HostedControlPlaneReconciler) reconcileCPOV2(ctx context.Context, hcp *
 		SetDefaultSecurityContext: r.SetDefaultSecurityContext,
 		MetricsSet:                r.MetricsSet,
 		EnableCIDebugOutput:       r.EnableCIDebugOutput,
+		ImageMetadataProvider:     r.ImageMetadataProvider,
 	}
 
 	var errs []error

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -175,6 +175,7 @@ type HostedControlPlaneReconciler struct {
 	awsSession                              *session.Session
 	reconcileInfrastructureStatus           func(ctx context.Context, hcp *hyperv1.HostedControlPlane) (infra.InfrastructureStatus, error)
 	EnableCVOManagementClusterMetricsAccess bool
+	ImageMetadataProvider                   util.ImageMetadataProvider
 
 	IsCPOV2 bool
 }
@@ -3639,9 +3640,47 @@ func (r *HostedControlPlaneReconciler) reconcileClusterVersionOperator(ctx conte
 		}
 	}
 
+	var (
+		controlPlaneReleaseImage string
+		dataPlaneReleaseImage    string
+	)
+	// The CVO prepare-payload script needs the ReleaseImage digest for disconnected environments
+	pullSecret := common.PullSecret(hcp.Namespace)
+	if err := r.Get(ctx, client.ObjectKeyFromObject(pullSecret), pullSecret); err != nil {
+		return fmt.Errorf("failed to get pull secret for namespace %s: %w", hcp.Namespace, err)
+	}
+
+	cpRef, err := registryclient.GetCorrectArchImage(ctx, "cluster-version-operator", p.ControlPlaneImage, pullSecret.Data[corev1.DockerConfigJsonKey], r.ImageMetadataProvider)
+	if err != nil {
+		return fmt.Errorf("failed to parse control plane release image %s: %w", cpRef, err)
+	}
+
+	_, cpReleaseImageRef, err := r.ImageMetadataProvider.GetDigest(ctx, cpRef, pullSecret.Data[corev1.DockerConfigJsonKey])
+	if err != nil {
+		return fmt.Errorf("failed to get control plane release image digest %s: %w", cpRef, err)
+	}
+
+	controlPlaneReleaseImage = fmt.Sprintf("%s/%s/%s", cpReleaseImageRef.Registry, cpReleaseImageRef.Namespace, cpReleaseImageRef.NameString())
+
+	if p.ControlPlaneImage != hcp.Spec.ReleaseImage {
+		dpRef, err := registryclient.GetCorrectArchImage(ctx, "cluster-version-operator", hcp.Spec.ReleaseImage, pullSecret.Data[corev1.DockerConfigJsonKey], r.ImageMetadataProvider)
+		if err != nil {
+			return fmt.Errorf("failed to parse data plane release image %s: %w", dpRef, err)
+		}
+
+		_, dpReleaseImageRef, err := r.ImageMetadataProvider.GetDigest(ctx, dpRef, pullSecret.Data[corev1.DockerConfigJsonKey])
+		if err != nil {
+			return fmt.Errorf("failed to get data plane release image digest %s: %w", dpRef, err)
+		}
+
+		dataPlaneReleaseImage = fmt.Sprintf("%s/%s/%s", dpReleaseImageRef.Registry, dpReleaseImageRef.Namespace, dpReleaseImageRef.NameString())
+	} else {
+		dataPlaneReleaseImage = controlPlaneReleaseImage
+	}
+
 	deployment := manifests.ClusterVersionOperatorDeployment(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, deployment, func() error {
-		return cvo.ReconcileDeployment(deployment, p.OwnerRef, p.DeploymentConfig, p.ControlPlaneImage, p.ReleaseImage, p.CLIImage, p.AvailabilityProberImage, p.ClusterID, hcp.Spec.UpdateService, p.PlatformType, util.HCPOAuthEnabled(hcp), r.EnableCVOManagementClusterMetricsAccess, p.FeatureSet)
+		return cvo.ReconcileDeployment(deployment, p.OwnerRef, p.DeploymentConfig, controlPlaneReleaseImage, dataPlaneReleaseImage, p.CLIImage, p.AvailabilityProberImage, p.ClusterID, hcp.Spec.UpdateService, p.PlatformType, util.HCPOAuthEnabled(hcp), r.EnableCVOManagementClusterMetricsAccess, p.FeatureSet)
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile cluster version operator deployment: %w", err)
 	}
@@ -3939,7 +3978,7 @@ func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx con
 
 			var getCatalogImagesErr error
 			olmCatalogImagesOnce.Do(func() {
-				catalogImages, err = olm.GetCatalogImages(ctx, *hcp, pullSecret.Data[corev1.DockerConfigJsonKey], registryclient.GetListDigest)
+				catalogImages, err = olm.GetCatalogImages(ctx, *hcp, pullSecret.Data[corev1.DockerConfigJsonKey], registryclient.GetListDigest, r.ImageMetadataProvider)
 				if err != nil {
 					getCatalogImagesErr = err
 					return

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -1817,5 +1817,14 @@ func componentsFakeDependencies(componentName string, namespace string) []client
 		fakeComponents = append(fakeComponents, fakeComponentTemplate.DeepCopy())
 	}
 
+	pullSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "pull-secret", Namespace: "hcp-namespace"},
+		Data: map[string][]byte{
+			corev1.DockerConfigJsonKey: []byte(`{}`),
+		},
+	}
+
+	fakeComponents = append(fakeComponents, pullSecret.DeepCopy())
+
 	return fakeComponents
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -34,8 +34,10 @@ import (
 	"github.com/openshift/hypershift/support/releaseinfo"
 	fakereleaseprovider "github.com/openshift/hypershift/support/releaseinfo/fake"
 	"github.com/openshift/hypershift/support/testutil"
+	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/util/fakeimagemetadataprovider"
 	"go.uber.org/zap/zaptest"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -1649,6 +1651,7 @@ func TestControlPlaneComponents(t *testing.T) {
 					VPC: &hyperv1.PowerVSVPC{},
 				},
 			},
+			ReleaseImage: "quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64",
 		},
 	}
 
@@ -1664,8 +1667,12 @@ func TestControlPlaneComponents(t *testing.T) {
 		CreateOrUpdateProviderV2: upsert.NewV2(false),
 		ReleaseImageProvider:     testutil.FakeImageProvider(),
 		UserReleaseImageProvider: testutil.FakeImageProvider(),
-		HCP:                      hcp,
-		SkipPredicate:            true,
+		ImageMetadataProvider: &fakeimagemetadataprovider.FakeRegistryClientImageMetadataProvider{
+			Result:   &dockerv1client.DockerImageConfig{},
+			Manifest: fakeimagemetadataprovider.FakeManifest{},
+		},
+		HCP:           hcp,
+		SkipPredicate: true,
 	}
 	for _, featureSet := range []configv1.FeatureSet{configv1.Default, configv1.TechPreviewNoUpgrade} {
 		cpContext.HCP.Spec.Configuration.FeatureGate.FeatureGateSelection.FeatureSet = featureSet

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
@@ -122,9 +122,9 @@ func findTagReference(tags []imagev1.TagReference, name string) *imagev1.TagRefe
 	return nil
 }
 
-func GetCatalogImages(ctx context.Context, hcp hyperv1.HostedControlPlane, pullSecret []byte, digestLister registryclient.DigestListerFN) (map[string]string, error) {
+func GetCatalogImages(ctx context.Context, hcp hyperv1.HostedControlPlane, pullSecret []byte, digestLister registryclient.DigestListerFN, imageMetadataProvider util.ImageMetadataProvider) (map[string]string, error) {
 	imageRef := hcp.Spec.ReleaseImage
-	imageConfig, _, _, err := registryclient.GetMetadata(ctx, imageRef, pullSecret)
+	imageConfig, _, _, err := imageMetadataProvider.GetMetadata(ctx, imageRef, pullSecret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get image metadata: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/params.go
@@ -84,7 +84,7 @@ func NewPKIParams(hcp *hyperv1.HostedControlPlane,
 	// Even with that, we cannot set more than one AdvertiseAddress so both
 	// are not supported at the same time.
 	// Check this for more info: https://github.com/kubernetes/enhancements/issues/2438
-	ipv4, err := util.IsIPv4(p.ServiceCIDR[0])
+	ipv4, err := util.IsIPv4CIDR(p.ServiceCIDR[0])
 	if err != nil || ipv4 {
 		p.NodeInternalAPIServerIP = util.AdvertiseAddressWithDefault(hcp, config.DefaultAdvertiseIPv4Address)
 	} else {

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-aws/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-aws/zz_fixture_TestControlPlaneComponents.yaml
@@ -26,7 +26,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-aws/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-aws/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -26,7 +26,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-azure/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-azure/zz_fixture_TestControlPlaneComponents.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-azure/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-azure/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-kubevirt/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-kubevirt/zz_fixture_TestControlPlaneComponents.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-kubevirt/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-kubevirt/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-openstack/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-openstack/zz_fixture_TestControlPlaneComponents.yaml
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         hypershift.openshift.io/control-plane-component: cloud-controller-manager-openstack

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-openstack/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-openstack/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         hypershift.openshift.io/control-plane-component: cloud-controller-manager-openstack

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-powervs/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-powervs/zz_fixture_TestControlPlaneComponents.yaml
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         hypershift.openshift.io/control-plane-component: cloud-controller-manager-powervs

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-powervs/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-powervs/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         hypershift.openshift.io/control-plane-component: cloud-controller-manager-powervs

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/zz_fixture_TestControlPlaneComponents.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: cluster-autoscaler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: cluster-autoscaler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-policy-controller/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-policy-controller/zz_fixture_TestControlPlaneComponents.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: cluster-policy-controller

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-policy-controller/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-policy-controller/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: cluster-policy-controller

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents.yaml
@@ -284,6 +284,7 @@ spec:
             annotations:
               include.release.openshift.io/ibm-cloud-managed: "true"
               release.openshift.io/delete: "true"
+          EOF
         command:
         - /bin/bash
         image: cluster-version-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents.yaml
@@ -30,7 +30,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: payload,update-payloads
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: cluster-version-operator
@@ -85,6 +85,7 @@ spec:
         - name: CLUSTER_PROFILE
           value: ibm-cloud-managed
         - name: RELEASE_IMAGE
+          value: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         - name: NODE_NAME
           valueFrom:
             fieldRef:
@@ -287,7 +288,7 @@ spec:
           EOF
         command:
         - /bin/bash
-        image: cluster-version-operator
+        image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         imagePullPolicy: IfNotPresent
         name: prepare-payload
         resources:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -30,7 +30,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: payload,update-payloads
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: cluster-version-operator
@@ -85,6 +85,7 @@ spec:
         - name: CLUSTER_PROFILE
           value: ibm-cloud-managed
         - name: RELEASE_IMAGE
+          value: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         - name: NODE_NAME
           valueFrom:
             fieldRef:
@@ -284,9 +285,10 @@ spec:
             annotations:
               include.release.openshift.io/ibm-cloud-managed: "true"
               release.openshift.io/delete: "true"
+          EOF
         command:
         - /bin/bash
-        image: cluster-version-operator
+        image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         imagePullPolicy: IfNotPresent
         name: prepare-payload
         resources:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents.yaml
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: etcd

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       annotations:
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: etcd

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/zz_fixture_TestControlPlaneComponents.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: hosted-cluster-config-operator
@@ -89,6 +89,7 @@ spec:
         - name: KUBERNETES_VERSION
           value: "1.30"
         - name: OPERATE_ON_RELEASE_IMAGE
+          value: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         - name: OPENSHIFT_IMG_OVERRIDES
           value: =
         image: hosted-cluster-config-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: hosted-cluster-config-operator
@@ -89,6 +89,7 @@ spec:
         - name: KUBERNETES_VERSION
           value: "1.30"
         - name: OPERATE_ON_RELEASE_IMAGE
+          value: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         - name: OPENSHIFT_IMG_OVERRIDES
           value: =
         image: hosted-cluster-config-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: bootstrap-manifests,logs
         component.hypershift.openshift.io/config-hash: 19dc307e1d8949e23415eb6680075ec3
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: kube-apiserver

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: bootstrap-manifests,logs
         component.hypershift.openshift.io/config-hash: 19dc307e1d8949e23415eb667d1e0a2d
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: kube-apiserver

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: logs,certs
         component.hypershift.openshift.io/config-hash: "1252551421580954"
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: kube-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: logs,certs
         component.hypershift.openshift.io/config-hash: "1252551421580954"
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: kube-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cert-work
         component.hypershift.openshift.io/config-hash: 022a8a3a
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cert-work
         component.hypershift.openshift.io/config-hash: 022a8a3a
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: work-logs,oas-trust-anchor
         component.hypershift.openshift.io/config-hash: 19dc307e3415eb666d06370b
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: openshift-apiserver

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: work-logs,oas-trust-anchor
         component.hypershift.openshift.io/config-hash: 19dc307e3415eb666d06370b
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: openshift-apiserver

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-controller-manager/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-controller-manager/zz_fixture_TestControlPlaneComponents.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         component.hypershift.openshift.io/config-hash: 8bcb4d22
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: openshift-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-controller-manager/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-controller-manager/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         component.hypershift.openshift.io/config-hash: 8bcb4d22
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: openshift-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: work-logs
         component.hypershift.openshift.io/config-hash: 19dc307e3415eb66
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: openshift-oauth-apiserver

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: work-logs
         component.hypershift.openshift.io/config-hash: 19dc307e3415eb66
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: openshift-oauth-apiserver

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-route-controller-manager/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-route-controller-manager/zz_fixture_TestControlPlaneComponents.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         component.hypershift.openshift.io/config-hash: 57c9c948
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: openshift-route-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-route-controller-manager/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-route-controller-manager/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         component.hypershift.openshift.io/config-hash: 57c9c948
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: openshift-route-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/router/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/router/zz_fixture_TestControlPlaneComponents.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         component.hypershift.openshift.io/config-hash: 417672c4
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: private-router

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/router/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/router/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         component.hypershift.openshift.io/config-hash: 417672c4
-        hypershift.openshift.io/release-image: ""
+        hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
         app: private-router

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment.go
@@ -8,9 +8,11 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
 	hyperapi "github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
 	"github.com/openshift/hypershift/support/util"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -37,11 +39,18 @@ func (cvo *clusterVersionOperator) adaptDeployment(cpContext component.WorkloadC
 		featureSet = cpContext.HCP.Spec.Configuration.FeatureGate.FeatureSet
 	}
 
+	// The CVO prepare-payload script needs the ReleaseImage digest for disconnected environments
+	controlPlaneReleaseImage, dataPlaneReleaseImage, err := discoverCVOReleaseImages(cpContext)
+	if err != nil {
+		return fmt.Errorf("failed to discover CVO release images: %w", err)
+	}
+
 	util.UpdateContainer("prepare-payload", deployment.Spec.Template.Spec.InitContainers, func(c *corev1.Container) {
 		c.Args = []string{
 			"-c",
 			preparePayloadScript(cpContext.HCP.Spec.Platform.Type, util.HCPOAuthEnabled(cpContext.HCP), featureSet),
 		}
+		c.Image = controlPlaneReleaseImage
 	})
 	util.UpdateContainer("bootstrap", deployment.Spec.Template.Spec.InitContainers, func(c *corev1.Container) {
 		c.Env = append(c.Env, corev1.EnvVar{
@@ -53,7 +62,7 @@ func (cvo *clusterVersionOperator) adaptDeployment(cpContext component.WorkloadC
 	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		util.UpsertEnvVar(c, corev1.EnvVar{
 			Name:  "RELEASE_IMAGE",
-			Value: cpContext.HCP.Spec.ReleaseImage,
+			Value: dataPlaneReleaseImage,
 		})
 
 		if updateService := cpContext.HCP.Spec.UpdateService; updateService != "" {
@@ -210,6 +219,7 @@ func preparePayloadScript(platformType hyperv1.PlatformType, oauthEnabled bool, 
 			"    release.openshift.io/delete: \"true\"",
 		)
 	}
+	stmts = append(stmts, "EOF")
 	return strings.Join(stmts, "\n")
 }
 
@@ -238,4 +248,46 @@ func resourcesToRemove(platformType hyperv1.PlatformType) []client.Object {
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "csi-snapshot-controller", Namespace: "openshift-cluster-storage-operator"}},
 		}
 	}
+}
+
+func discoverCVOReleaseImages(cpContext component.WorkloadContext) (string, string, error) {
+	var (
+		controlPlaneReleaseImage string
+		dataPlaneReleaseImage    string
+	)
+
+	pullSecret := common.PullSecret(cpContext.HCP.Namespace)
+	if err := cpContext.Client.Get(cpContext.Context, client.ObjectKeyFromObject(pullSecret), pullSecret); err != nil {
+		return "", "", fmt.Errorf("failed to get pull secret for namespace %s: %w", cpContext.HCP.Namespace, err)
+	}
+
+	cpRef, err := registryclient.GetCorrectArchImage(cpContext.Context, "cluster-version-operator", cpContext.HCP.Spec.ReleaseImage, pullSecret.Data[corev1.DockerConfigJsonKey], cpContext.ImageMetadataProvider)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to parse control plane release image %s: %w", cpRef, err)
+	}
+
+	_, cpReleaseImageRef, err := cpContext.ImageMetadataProvider.GetDigest(cpContext.Context, cpRef, pullSecret.Data[corev1.DockerConfigJsonKey])
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get control plane release image digest %s: %w", cpRef, err)
+	}
+
+	controlPlaneReleaseImage = fmt.Sprintf("%s/%s/%s", cpReleaseImageRef.Registry, cpReleaseImageRef.Namespace, cpReleaseImageRef.NameString())
+
+	if cpContext.HCP.Spec.ControlPlaneReleaseImage != nil && *cpContext.HCP.Spec.ControlPlaneReleaseImage != cpContext.HCP.Spec.ReleaseImage {
+		dpRef, err := registryclient.GetCorrectArchImage(cpContext.Context, "cluster-version-operator", cpContext.HCP.Spec.ReleaseImage, pullSecret.Data[corev1.DockerConfigJsonKey], cpContext.ImageMetadataProvider)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to parse data plane release image %s: %w", dpRef, err)
+		}
+
+		_, dpReleaseImageRef, err := cpContext.ImageMetadataProvider.GetDigest(cpContext.Context, dpRef, pullSecret.Data[corev1.DockerConfigJsonKey])
+		if err != nil {
+			return "", "", fmt.Errorf("failed to get data plane release image digest %s: %w", dpRef, err)
+		}
+
+		dataPlaneReleaseImage = fmt.Sprintf("%s/%s/%s", dpReleaseImageRef.Registry, dpReleaseImageRef.Namespace, dpReleaseImageRef.NameString())
+	} else {
+		dataPlaneReleaseImage = controlPlaneReleaseImage
+	}
+
+	return controlPlaneReleaseImage, dataPlaneReleaseImage, nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/statefulset.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/statefulset.go
@@ -21,7 +21,7 @@ func adaptStatefulSet(cpContext component.WorkloadContext, sts *appsv1.StatefulS
 	hcp := cpContext.HCP
 	managedEtcdSpec := hcp.Spec.Etcd.Managed
 
-	ipv4, err := util.IsIPv4(hcp.Spec.Networking.ClusterNetwork[0].CIDR.String())
+	ipv4, err := util.IsIPv4CIDR(hcp.Spec.Networking.ClusterNetwork[0].CIDR.String())
 	if err != nil {
 		return fmt.Errorf("error checking the ClusterNetworkCIDR: %v", err)
 	}

--- a/control-plane-operator/hostedclusterconfigoperator/cmd.go
+++ b/control-plane-operator/hostedclusterconfigoperator/cmd.go
@@ -259,6 +259,10 @@ func (o *HostedClusterConfigOperator) Run(ctx context.Context) error {
 		OpenShiftImageRegistryOverrides: imageRegistryOverrides,
 	}
 
+	imageMetaDataProvider := &util.RegistryClientImageMetadataProvider{
+		OpenShiftImageRegistryOverrides: imageRegistryOverrides,
+	}
+
 	apiReadingClient, err := client.New(mgr.GetConfig(), client.Options{Scheme: hyperapi.Scheme})
 	if err != nil {
 		return fmt.Errorf("failed to construct api reading client: %w", err)
@@ -299,6 +303,7 @@ func (o *HostedClusterConfigOperator) Run(ctx context.Context) error {
 		OAuthPort:             o.OAuthPort,
 		OperateOnReleaseImage: os.Getenv("OPERATE_ON_RELEASE_IMAGE"),
 		EnableCIDebugOutput:   o.enableCIDebugOutput,
+		ImageMetaDataProvider: *imageMetaDataProvider,
 	}
 	configmetrics.Register(mgr.GetCache())
 	return operatorConfig.Start(ctx)

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas/reconcile.go
@@ -29,7 +29,7 @@ func ReconcileKASEndpointSlice(endpointSlice *discoveryv1.EndpointSlice, address
 		endpointSlice.Labels = map[string]string{}
 	}
 	endpointSlice.Labels[discoveryv1.LabelServiceName] = "kubernetes"
-	ipv4, err := util.IsIPv4(address)
+	ipv4, err := util.IsIPv4Address(address)
 	if err != nil || ipv4 {
 		endpointSlice.AddressType = discoveryv1.AddressTypeIPv4
 	} else {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm/params.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm/params.go
@@ -3,9 +3,11 @@ package olm
 import (
 	"context"
 	"fmt"
+
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/olm"
 	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
+	"github.com/openshift/hypershift/support/util"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -17,8 +19,8 @@ type OperatorLifecycleManagerParams struct {
 	OLMCatalogPlacement     hyperv1.OLMCatalogPlacement
 }
 
-func NewOperatorLifecycleManagerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, pullSecret *corev1.Secret, digestLister registryclient.DigestListerFN) (*OperatorLifecycleManagerParams, error) {
-	catalogImages, err := olm.GetCatalogImages(ctx, *hcp, pullSecret.Data[corev1.DockerConfigJsonKey], digestLister)
+func NewOperatorLifecycleManagerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, pullSecret *corev1.Secret, digestLister registryclient.DigestListerFN, imageMetadataProvider util.ImageMetadataProvider) (*OperatorLifecycleManagerParams, error) {
+	catalogImages, err := olm.GetCatalogImages(ctx, *hcp, pullSecret.Data[corev1.DockerConfigJsonKey], digestLister, imageMetadataProvider)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get catalog images: %w", err)
 	}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -131,6 +131,7 @@ type reconciler struct {
 	oauthPort                 int32
 	versions                  map[string]string
 	operateOnReleaseImage     string
+	ImageMetaDataProvider     util.RegistryClientImageMetadataProvider
 	registryclient.DigestListerFN
 }
 
@@ -190,6 +191,7 @@ func Setup(ctx context.Context, opts *operator.HostedClusterConfigOperatorConfig
 		versions:                  opts.Versions,
 		operateOnReleaseImage:     opts.OperateOnReleaseImage,
 		DigestListerFN:            registryclient.GetListDigest,
+		ImageMetaDataProvider:     opts.ImageMetaDataProvider,
 	}})
 	if err != nil {
 		return fmt.Errorf("failed to construct controller: %w", err)
@@ -1687,7 +1689,7 @@ func (r *reconciler) reconcileOLM(ctx context.Context, hcp *hyperv1.HostedContro
 
 	olmCatalogImagesOnce.Do(func() {
 		var err error
-		p, err = olm.NewOperatorLifecycleManagerParams(ctx, hcp, pullSecret, digestLister)
+		p, err = olm.NewOperatorLifecycleManagerParams(ctx, hcp, pullSecret, digestLister, &r.ImageMetaDataProvider)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to create OperatorLifecycleManagerParams: %w", err))
 			return

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -141,6 +141,9 @@ func TestReconcileErrorHandling(t *testing.T) {
 		fakeDigestLister := func(ctx context.Context, image string, pullSecret []byte) (digest.Digest, error) {
 			return "", nil
 		}
+		imageMetaDataProvider := supportutil.RegistryClientImageMetadataProvider{
+			OpenShiftImageRegistryOverrides: map[string][]string{},
+		}
 
 		r := &reconciler{
 			client:                 fakeClient,
@@ -153,6 +156,7 @@ func TestReconcileErrorHandling(t *testing.T) {
 			hcpNamespace:           "bar",
 			releaseProvider:        &fakereleaseprovider.FakeReleaseProvider{},
 			DigestListerFN:         fakeDigestLister,
+			ImageMetaDataProvider:  imageMetaDataProvider,
 		}
 		_, err := r.Reconcile(context.Background(), controllerruntime.Request{})
 		if err != nil {

--- a/control-plane-operator/hostedclusterconfigoperator/operator/config.go
+++ b/control-plane-operator/hostedclusterconfigoperator/operator/config.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
 	"github.com/openshift/hypershift/support/upsert"
+	"github.com/openshift/hypershift/support/util"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 )
@@ -73,6 +74,7 @@ type HostedClusterConfigOperatorConfig struct {
 	OperateOnReleaseImage        string
 	EnableCIDebugOutput          bool
 	ListDigestsFN                registryclient.DigestListerFN
+	ImageMetaDataProvider        util.RegistryClientImageMetadataProvider
 
 	kubeClient kubeclient.Interface
 }

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -379,7 +379,6 @@ func NewStartCommand() *cobra.Command {
 			"token-minter":                   tokenMinterImage,
 			util.CPOImageName:                cpoImage,
 			util.CPPKIOImageName:             cpoImage,
-			"cluster-version-operator":       os.Getenv("OPERATE_ON_RELEASE_IMAGE"),
 		}
 		for name, image := range imageOverrides {
 			componentImages[name] = image
@@ -418,6 +417,10 @@ func NewStartCommand() *cobra.Command {
 			OpenShiftImageRegistryOverrides: imageRegistryOverrides,
 		}
 
+		imageMetaDataProvider := &util.RegistryClientImageMetadataProvider{
+			OpenShiftImageRegistryOverrides: imageRegistryOverrides,
+		}
+
 		defaultIngressDomain := os.Getenv(config.DefaultIngressDomainEnvVar)
 
 		metricsSet, err := metrics.MetricsSetFromEnv()
@@ -442,6 +445,7 @@ func NewStartCommand() *cobra.Command {
 			CertRotationScale:                       certRotationScale,
 			EnableCVOManagementClusterMetricsAccess: enableCVOManagementClusterMetricsAccess,
 			IsCPOV2:                                 isCPOV2,
+			ImageMetadataProvider:                   imageMetaDataProvider,
 		}).SetupWithManager(mgr, upsert.New(enableCIDebugOutput).CreateOrUpdate); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "hosted-control-plane")
 			os.Exit(1)

--- a/hypershift-operator/controllers/nodepool/conditions_test.go
+++ b/hypershift-operator/controllers/nodepool/conditions_test.go
@@ -3,6 +3,9 @@ package nodepool
 import (
 	"context"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/blang/semver"
 	"github.com/openshift/api/image/docker10"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
@@ -13,8 +16,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
-	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -219,9 +220,13 @@ func TestUpdatingConfigCondition(t *testing.T) {
 			r := &NodePoolReconciler{
 				Client:          client,
 				ReleaseProvider: &fakereleaseprovider.FakeReleaseProvider{Version: semver.MustParse("4.18.0").String()},
-				ImageMetadataProvider: &fakeimagemetadataprovider.FakeImageMetadataProvider{Result: &dockerv1client.DockerImageConfig{Config: &docker10.DockerConfig{
-					Labels: map[string]string{},
-				}}},
+				ImageMetadataProvider: &fakeimagemetadataprovider.FakeRegistryClientImageMetadataProvider{
+					Result: &dockerv1client.DockerImageConfig{
+						Config: &docker10.DockerConfig{
+							Labels: map[string]string{},
+						},
+					},
+				},
 			}
 
 			if tc.machineSetExists {
@@ -365,9 +370,13 @@ func TestUpdatingVersionCondition(t *testing.T) {
 			r := &NodePoolReconciler{
 				Client:          client,
 				ReleaseProvider: &fakereleaseprovider.FakeReleaseProvider{Version: semver.MustParse("4.18.0").String()},
-				ImageMetadataProvider: &fakeimagemetadataprovider.FakeImageMetadataProvider{Result: &dockerv1client.DockerImageConfig{Config: &docker10.DockerConfig{
-					Labels: map[string]string{},
-				}}},
+				ImageMetadataProvider: &fakeimagemetadataprovider.FakeRegistryClientImageMetadataProvider{
+					Result: &dockerv1client.DockerImageConfig{
+						Config: &docker10.DockerConfig{
+							Labels: map[string]string{},
+						},
+					},
+				},
 			}
 
 			if tc.machineSetExists {

--- a/hypershift-operator/controllers/nodepool/haproxy.go
+++ b/hypershift-operator/controllers/nodepool/haproxy.go
@@ -105,7 +105,7 @@ func (r *NodePoolReconciler) reconcileHAProxyIgnitionConfig(ctx context.Context,
 	}
 
 	// This provides support for HTTP Proxy on IPv6 scenarios
-	ipv4, err := util.IsIPv4(hcluster.Spec.Networking.ServiceNetwork[0].CIDR.String())
+	ipv4, err := util.IsIPv4CIDR(hcluster.Spec.Networking.ServiceNetwork[0].CIDR.String())
 	if err != nil {
 		return "", true, fmt.Errorf("error checking the stack in the first ServiceNetworkCIDR %s: %w", hcluster.Spec.Networking.ServiceNetwork[0].CIDR.String(), err)
 	}

--- a/hypershift-operator/controllers/nodepool/secret_janitor_test.go
+++ b/hypershift-operator/controllers/nodepool/secret_janitor_test.go
@@ -156,7 +156,7 @@ spec:
 			//We need the ReleaseProvider to stay at 4.18 so that the token doesn't get updated when bumping releases,
 			// this protects us from possibly hiding other factors that might be causing the token to be updated
 			ReleaseProvider: &fakereleaseprovider.FakeReleaseProvider{Version: semver.MustParse("4.18.0").String()},
-			ImageMetadataProvider: &fakeimagemetadataprovider.FakeImageMetadataProvider{Result: &dockerv1client.DockerImageConfig{Config: &docker10.DockerConfig{
+			ImageMetadataProvider: &fakeimagemetadataprovider.FakeRegistryClientImageMetadataProvider{Result: &dockerv1client.DockerImageConfig{Config: &docker10.DockerConfig{
 				Labels: map[string]string{},
 			}}},
 		},

--- a/ignition-server/cmd/run_local_ignitionprovider.go
+++ b/ignition-server/cmd/run_local_ignitionprovider.go
@@ -92,15 +92,20 @@ func (o *RunLocalIgnitionProviderOptions) Run(ctx context.Context) error {
 		return fmt.Errorf("unable to create image file cache: %w", err)
 	}
 
+	imageMetaDataProvider := &util.RegistryClientImageMetadataProvider{
+		OpenShiftImageRegistryOverrides: map[string][]string{},
+	}
+
 	p := &controllers.LocalIgnitionProvider{
-		Client:              cl,
-		ReleaseProvider:     &releaseinfo.ProviderWithOpenShiftImageRegistryOverridesDecorator{},
-		CloudProvider:       "",
-		Namespace:           o.Namespace,
-		WorkDir:             o.WorkDir,
-		PreserveOutput:      true,
-		ImageFileCache:      imageFileCache,
-		FeatureGateManifest: o.FeatureGateManifest,
+		Client:                cl,
+		ReleaseProvider:       &releaseinfo.ProviderWithOpenShiftImageRegistryOverridesDecorator{},
+		ImageMetadataProvider: imageMetaDataProvider,
+		CloudProvider:         "",
+		Namespace:             o.Namespace,
+		WorkDir:               o.WorkDir,
+		PreserveOutput:        true,
+		ImageFileCache:        imageFileCache,
+		FeatureGateManifest:   o.FeatureGateManifest,
 	}
 
 	payload, err := p.GetPayload(ctx, o.Image, config.String(), "", "", "")

--- a/ignition-server/cmd/start.go
+++ b/ignition-server/cmd/start.go
@@ -149,6 +149,10 @@ func setUpPayloadStoreReconciler(ctx context.Context, registryOverrides map[stri
 		return nil, fmt.Errorf("unable to create image file cache: %w", err)
 	}
 
+	imageMetaDataProvider := &util.RegistryClientImageMetadataProvider{
+		OpenShiftImageRegistryOverrides: util.ConvertImageRegistryOverrideStringToMap(os.Getenv("OPENSHIFT_IMG_OVERRIDES")),
+	}
+
 	if err = (&controllers.TokenSecretReconciler{
 		Client:       mgr.GetClient(),
 		PayloadStore: payloadStore,
@@ -163,12 +167,13 @@ func setUpPayloadStoreReconciler(ctx context.Context, registryOverrides map[stri
 				},
 				OpenShiftImageRegistryOverrides: util.ConvertImageRegistryOverrideStringToMap(os.Getenv("OPENSHIFT_IMG_OVERRIDES")),
 			},
-			Client:              mgr.GetClient(),
-			Namespace:           os.Getenv(namespaceEnvVariableName),
-			CloudProvider:       cloudProvider,
-			WorkDir:             cacheDir,
-			ImageFileCache:      imageFileCache,
-			FeatureGateManifest: featureGateManifest,
+			Client:                mgr.GetClient(),
+			Namespace:             os.Getenv(namespaceEnvVariableName),
+			CloudProvider:         cloudProvider,
+			WorkDir:               cacheDir,
+			ImageFileCache:        imageFileCache,
+			FeatureGateManifest:   featureGateManifest,
+			ImageMetadataProvider: imageMetaDataProvider,
 		},
 	}).SetupWithManager(ctx, mgr); err != nil {
 		return nil, fmt.Errorf("unable to create controller: %w", err)

--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -72,6 +72,10 @@ type LocalIgnitionProvider struct {
 	// to render the ignition payload.
 	FeatureGateManifest string
 
+	// ImageMetaDataProvider is used to get the image metadata for the images
+	// used in the ignition payload.
+	ImageMetadataProvider *util.RegistryClientImageMetadataProvider
+
 	ImageFileCache *imageFileCache
 
 	lock sync.Mutex
@@ -191,11 +195,24 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage, cu
 		return nil, fmt.Errorf("release image does not contain machine-config-operator (images: %v)", imageProvider.ComponentImages())
 	}
 
-	mcoImage, err = registryclient.GetCorrectArchImage(ctx, component, mcoImage, pullSecret)
+	mcoImage, err = registryclient.GetCorrectArchImage(ctx, component, mcoImage, pullSecret, p.ImageMetadataProvider)
 	if err != nil {
 		return nil, err
 	}
-	log.Info("discovered machine-config-operator image", "image", mcoImage)
+
+	log.Info(fmt.Sprintf("discovered image %s image %v", component, mcoImage))
+
+	// Making sure image uses the registry override for disconnected environments
+	checkedMcoImage, err := p.ImageMetadataProvider.GetOverride(ctx, mcoImage, pullSecret)
+	if err != nil {
+		return nil, err
+	}
+
+	mcoComposedImage := fmt.Sprintf("%s/%s/%s", checkedMcoImage.Registry, checkedMcoImage.Namespace, checkedMcoImage.NameString())
+	if mcoComposedImage != mcoImage {
+		mcoImage = mcoComposedImage
+		log.Info(fmt.Sprintf("using mirrored %s image %v", component, mcoImage))
+	}
 
 	// Set up the base working directory
 	workDir, err := os.MkdirTemp(p.WorkDir, "get-payload")
@@ -329,12 +346,24 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage, cu
 			return fmt.Errorf("release image does not contain $%s (images: %v)", clusterConfigComponent, imageProvider.ComponentImages())
 		}
 
-		clusterConfigImage, err = registryclient.GetCorrectArchImage(ctx, clusterConfigComponent, clusterConfigImage, pullSecret)
+		clusterConfigImage, err = registryclient.GetCorrectArchImage(ctx, clusterConfigComponent, clusterConfigImage, pullSecret, p.ImageMetadataProvider)
 		if err != nil {
 			return err
 		}
 
-		log.Info(fmt.Sprintf("discovered  image %s image %v", clusterConfigComponent, clusterConfigImage))
+		log.Info(fmt.Sprintf("discovered image %s image %v", clusterConfigComponent, clusterConfigImage))
+
+		// Making sure image uses the registry override for disconnected environments
+		checkedClusterConfigImage, err := p.ImageMetadataProvider.GetOverride(ctx, clusterConfigImage, pullSecret)
+		if err != nil {
+			return err
+		}
+
+		ccaComposedImage := fmt.Sprintf("%s/%s/%s", checkedClusterConfigImage.Registry, checkedClusterConfigImage.Namespace, checkedClusterConfigImage.NameString())
+		if ccaComposedImage != clusterConfigImage {
+			clusterConfigImage = ccaComposedImage
+			log.Info(fmt.Sprintf("using mirrored %s image %v", clusterConfigComponent, ccaComposedImage))
+		}
 
 		file, err := os.Create(filepath.Join(binDir, clusterConfigComponent))
 		if err != nil {
@@ -750,7 +779,7 @@ EOF
    --asset-input-dir %[2]s/input \
    --asset-output-dir %[2]s/output \
    --rendered-manifest-files=%[2]s/manifests \
-   --payload-version=%[4]s 
+   --payload-version=%[4]s
 cp %[2]s/manifests/99_feature-gate.yaml %[3]s/99_feature-gate.yaml
 `
 	}

--- a/support/controlplane-component/controlplane-component.go
+++ b/support/controlplane-component/controlplane-component.go
@@ -39,6 +39,7 @@ type ControlPlaneContext struct {
 	HCP                      *hyperv1.HostedControlPlane
 	ReleaseImageProvider     imageprovider.ReleaseImageProvider
 	UserReleaseImageProvider imageprovider.ReleaseImageProvider
+	ImageMetadataProvider    util.ImageMetadataProvider
 
 	InfraStatus               infra.InfrastructureStatus
 	SetDefaultSecurityContext bool
@@ -57,6 +58,7 @@ type WorkloadContext struct {
 	HCP                      *hyperv1.HostedControlPlane
 	ReleaseImageProvider     imageprovider.ReleaseImageProvider
 	UserReleaseImageProvider imageprovider.ReleaseImageProvider
+	ImageMetadataProvider    util.ImageMetadataProvider
 
 	InfraStatus               infra.InfrastructureStatus
 	SetDefaultSecurityContext bool
@@ -75,6 +77,7 @@ func (cp *ControlPlaneContext) workloadContext() WorkloadContext {
 		SetDefaultSecurityContext: cp.SetDefaultSecurityContext,
 		EnableCIDebugOutput:       cp.EnableCIDebugOutput,
 		MetricsSet:                cp.MetricsSet,
+		ImageMetadataProvider:     cp.ImageMetadataProvider,
 	}
 }
 

--- a/support/globalconfig/network.go
+++ b/support/globalconfig/network.go
@@ -32,7 +32,7 @@ func ReconcileNetworkConfig(cfg *configv1.Network, hcp *hyperv1.HostedControlPla
 	for _, entry := range hcp.Spec.Networking.ClusterNetwork {
 		hostPrefix := uint32(entry.HostPrefix)
 		if hostPrefix == 0 {
-			ipv4, err := util.IsIPv4(entry.CIDR.String())
+			ipv4, err := util.IsIPv4CIDR(entry.CIDR.String())
 			if err != nil {
 				return fmt.Errorf("the CIDR %s included in the cluster network spec is not valid: %w", entry.CIDR.String(), err)
 			}

--- a/support/releaseinfo/registryclient/client_test.go
+++ b/support/releaseinfo/registryclient/client_test.go
@@ -2,19 +2,68 @@ package registryclient
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/manifestlist"
 	. "github.com/onsi/gomega"
+	"github.com/opencontainers/go-digest"
+	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
+	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
 )
 
 const (
-	ReleaseImage1     = "quay.io/openshift-release-dev/ocp-release@sha256:1a101ef5215da468cea8bd2eb47114e85b2b64a6b230d5882f845701f55d057f"
-	ReleaseImage2     = "quay.io/openshift-release-dev/ocp-release:4.11.0-0.nightly-multi-2022-07-12-131716"
-	ManifestMediaType = "application/vnd.docker.distribution.manifest.v2+json"
-	LinuxOS           = "linux"
+	ReleaseImage1         = "quay.io/openshift-release-dev/ocp-release@sha256:1a101ef5215da468cea8bd2eb47114e85b2b64a6b230d5882f845701f55d057f"
+	ReleaseImage2         = "quay.io/openshift-release-dev/ocp-release:4.11.0-0.nightly-multi-2022-07-12-131716"
+	ManifestMediaType     = "application/vnd.docker.distribution.manifest.v2+json"
+	ManifestListMediaType = "application/vnd.docker.distribution.manifest.list.v2+json"
+	ImageIndexMediaType   = "application/vnd.oci.image.index.v1+json"
+	LinuxOS               = "linux"
 )
+
+type fakeRegistryClientImageMetadataProvider struct {
+	mediaType string
+	result    *dockerv1client.DockerImageConfig
+	digest    string
+	ref       *reference.DockerImageReference
+}
+type fakeManifest struct {
+	mediaType string
+}
+
+func (f *fakeRegistryClientImageMetadataProvider) ImageMetadata(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, error) {
+	return f.result, nil
+}
+
+func (f *fakeRegistryClientImageMetadataProvider) GetManifest(ctx context.Context, imageRef string, pullSecret []byte) (distribution.Manifest, error) {
+	_, _, err := GetRepoSetup(ctx, imageRef, pullSecret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve manifest %s: %w", imageRef, err)
+	}
+	return &fakeManifest{
+		f.mediaType,
+	}, nil
+}
+
+func (f *fakeRegistryClientImageMetadataProvider) GetDigest(ctx context.Context, imageRef string, pullSecret []byte) (digest.Digest, *reference.DockerImageReference, error) {
+	var err error
+	_, f.ref, err = GetRepoSetup(ctx, imageRef, pullSecret)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to retrieve manifest %s: %w", imageRef, err)
+	}
+	f.ref.ID = f.digest
+	return digest.Digest(f.digest), f.ref, nil
+}
+
+func (f *fakeRegistryClientImageMetadataProvider) GetMetadata(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, []distribution.Descriptor, distribution.BlobStore, error) {
+	return f.result, []distribution.Descriptor{}, nil, nil
+}
+
+type FakeManifest struct{}
+
+func (f *fakeManifest) References() []distribution.Descriptor { return []distribution.Descriptor{} }
+func (f *fakeManifest) Payload() (string, []byte, error)      { return f.mediaType, []byte{}, nil }
 
 func TestFindMatchingManifest(t *testing.T) {
 	deserializedManifestList1 := &manifestlist.DeserializedManifestList{
@@ -198,48 +247,123 @@ func TestFindMatchingManifest(t *testing.T) {
 
 func TestIsMultiArchManifestList(t *testing.T) {
 	pullSecretBytes := []byte("{\"auths\":{\"quay.io\":{\"auth\":\"\",\"email\":\"\"}}}")
-
 	testCases := []struct {
 		name                   string
 		image                  string
 		pullSecretBytes        []byte
+		mediaType              string
+		manifests              []manifestlist.ManifestDescriptor
 		expectedMultiArchImage bool
 		expectErr              bool
 	}{
 		{
 			name:                   "Check an amd64 image; no err",
 			image:                  "quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64",
+			mediaType:              ManifestMediaType,
 			pullSecretBytes:        pullSecretBytes,
 			expectedMultiArchImage: false,
 			expectErr:              false,
+			manifests: []manifestlist.ManifestDescriptor{
+				{
+					Descriptor: distribution.Descriptor{
+						MediaType: ManifestMediaType,
+						Digest:    "sha256:70fb4524d21e1b6c08477eb5d1ca2cf282b3270b1d008f70dd7e1cf13d8ba4ce",
+					},
+					Platform: manifestlist.PlatformSpec{
+						Architecture: ArchitectureAMD64,
+						OS:           LinuxOS,
+					},
+				},
+			},
 		},
 		{
 			name:                   "Check a ppc64le image; no err",
 			image:                  "quay.io/openshift-release-dev/ocp-release:4.16.11-ppc64le",
+			mediaType:              ManifestMediaType,
 			pullSecretBytes:        pullSecretBytes,
 			expectedMultiArchImage: false,
 			expectErr:              false,
+			manifests: []manifestlist.ManifestDescriptor{
+				{
+					Descriptor: distribution.Descriptor{
+						MediaType: ManifestMediaType,
+						Digest:    "sha256:70fb4524d21e1b6c08477eb5d1ca2cf282b3270b1d008f70dd7e1cf13d8ba4ce",
+					},
+					Platform: manifestlist.PlatformSpec{
+						Architecture: ArchitecturePPC64LE,
+						OS:           LinuxOS,
+					},
+				},
+			},
 		},
 		{
 			name:                   "Check a multi-arch image; no err",
 			image:                  "quay.io/openshift-release-dev/ocp-release:4.16.11-multi",
+			mediaType:              ManifestListMediaType,
 			pullSecretBytes:        pullSecretBytes,
 			expectedMultiArchImage: true,
 			expectErr:              false,
+			manifests: []manifestlist.ManifestDescriptor{
+				{
+					Descriptor: distribution.Descriptor{
+						MediaType: ManifestListMediaType,
+						Digest:    "sha256:70fb4524d21e1b6c08477eb5d1ca2cf282b3270b1d008f70dd7e1cf13d8ba4ce",
+					},
+					Platform: manifestlist.PlatformSpec{
+						Architecture: ArchitectureAMD64,
+						OS:           LinuxOS,
+					},
+				},
+				{
+					Descriptor: distribution.Descriptor{
+						MediaType: ManifestListMediaType,
+						Digest:    "sha256:70fb4524d21e1b6c08477eb5d1ca2cf282b3270b1d008f70dd7e1cf13d8ba4ce",
+					},
+					Platform: manifestlist.PlatformSpec{
+						Architecture: ArchitecturePPC64LE,
+						OS:           LinuxOS,
+					},
+				},
+			},
 		},
 		{
 			name:                   "Bad pull secret; err",
 			image:                  "quay.io/openshift-release-dev/ocp-release:4.16.11-ppc64le",
+			mediaType:              ManifestMediaType,
 			pullSecretBytes:        []byte(""),
 			expectedMultiArchImage: false,
 			expectErr:              true,
+			manifests: []manifestlist.ManifestDescriptor{
+				{
+					Descriptor: distribution.Descriptor{
+						MediaType: ManifestMediaType,
+						Digest:    "sha256:70fb4524d21e1b6c08477eb5d1ca2cf282b3270b1d008f70dd7e1cf13d8ba4ce",
+					},
+					Platform: manifestlist.PlatformSpec{
+						Architecture: ArchitecturePPC64LE,
+						OS:           LinuxOS,
+					},
+				},
+			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			isMultiArchImage, err := IsMultiArchManifestList(context.TODO(), tc.image, tc.pullSecretBytes)
+			deserializeFunc := func(payload []byte) (*manifestlist.DeserializedManifestList, error) {
+				return &manifestlist.DeserializedManifestList{
+					ManifestList: manifestlist.ManifestList{
+						Manifests: tc.manifests,
+					},
+				}, nil
+			}
+			ctx := context.WithValue(context.Background(), DeserializeFuncName, deserializeFunc)
+			imageMetadataProvider := &fakeRegistryClientImageMetadataProvider{
+				mediaType: tc.mediaType,
+			}
+
+			isMultiArchImage, err := IsMultiArchManifestList(ctx, tc.image, tc.pullSecretBytes, imageMetadataProvider)
 			if tc.expectErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/support/util/fakeimagemetadataprovider/fakeimagemetadataprovider.go
+++ b/support/util/fakeimagemetadataprovider/fakeimagemetadataprovider.go
@@ -2,14 +2,63 @@ package fakeimagemetadataprovider
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/docker/distribution"
+	"github.com/opencontainers/go-digest"
+	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
+	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
 )
 
-type FakeImageMetadataProvider struct {
-	Result *dockerv1client.DockerImageConfig
+type FakeImageMetadataProvider interface {
+	ImageMetadata(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, error)
+	GetManifest(ctx context.Context, imageRef string, pullSecret []byte) (distribution.Manifest, error)
+	GetDigest(ctx context.Context, imageRef string, pullSecret []byte) (digest.Digest, *reference.DockerImageReference, error)
 }
 
-func (f *FakeImageMetadataProvider) ImageMetadata(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, error) {
+func (f *FakeRegistryClientImageMetadataProvider) ImageMetadata(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, error) {
 	return f.Result, nil
+}
+
+func (f *FakeManifest) References() []distribution.Descriptor { return []distribution.Descriptor{} }
+func (f *FakeManifest) Payload() (string, []byte, error)      { return f.MediaType, []byte{}, nil }
+
+type FakeRegistryClientImageMetadataProvider struct {
+	MediaType string
+	Result    *dockerv1client.DockerImageConfig
+	Manifest  FakeManifest
+	Digest    string
+	Ref       *reference.DockerImageReference
+}
+type FakeManifest struct {
+	MediaType string
+}
+
+func (f *FakeRegistryClientImageMetadataProvider) GetManifest(ctx context.Context, imageRef string, pullSecret []byte) (distribution.Manifest, error) {
+	_, _, err := registryclient.GetRepoSetup(ctx, imageRef, pullSecret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve manifest %s: %w", imageRef, err)
+	}
+	return &FakeManifest{
+		f.MediaType,
+	}, nil
+}
+
+func (f *FakeRegistryClientImageMetadataProvider) GetDigest(ctx context.Context, imageRef string, pullSecret []byte) (digest.Digest, *reference.DockerImageReference, error) {
+	var err error
+	_, f.Ref, err = registryclient.GetRepoSetup(ctx, imageRef, pullSecret)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to retrieve manifest %s: %w", imageRef, err)
+	}
+	f.Ref.ID = f.Digest
+	return digest.Digest(f.Digest), f.Ref, nil
+}
+
+func (f *FakeRegistryClientImageMetadataProvider) GetMetadata(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, []distribution.Descriptor, distribution.BlobStore, error) {
+	return f.Result, []distribution.Descriptor{}, nil, nil
+}
+
+func (f *FakeRegistryClientImageMetadataProvider) GetOverride(ctx context.Context, imageRef string, pullSecret []byte) (*reference.DockerImageReference, error) {
+	return f.Ref, nil
 }

--- a/support/util/imagemetadata_test.go
+++ b/support/util/imagemetadata_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"github.com/opencontainers/go-digest"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
 )
 
@@ -80,5 +81,257 @@ func TestGetRegistryOverrides(t *testing.T) {
 			g.Expect(err != nil).To(Equal(tc.expectAnErr))
 			g.Expect(overrideFound).To(Equal(tc.overrideFound))
 		})
+	}
+}
+
+func TestGetManifest(t *testing.T) {
+	ctx := context.TODO()
+	pullSecret := []byte("{}")
+
+	testsCases := []struct {
+		name           string
+		imageRef       string
+		pullSecret     []byte
+		expectedErr    bool
+		validateCache  bool
+		expectedDigest digest.Digest
+	}{
+		{
+			name:        "if failed to parse image reference",
+			imageRef:    "invalid-image-ref",
+			pullSecret:  pullSecret,
+			expectedErr: true,
+		},
+		{
+			name:        "Pull x86 manifest",
+			imageRef:    "quay.io/openshift-release-dev/ocp-release:4.16.12-x86_64",
+			pullSecret:  pullSecret,
+			expectedErr: false,
+		},
+		{
+			name:           "Pull x86 manifest from cache",
+			imageRef:       "quay.io/openshift-release-dev/ocp-release:4.16.12-x86_64",
+			pullSecret:     pullSecret,
+			expectedErr:    false,
+			validateCache:  true,
+			expectedDigest: "sha256:2a50e5d5267916078145731db740bbc85ee764e1a194715fd986ab5bf9a3414e",
+		},
+		{
+			name:           "Pull Multiarch manifest",
+			imageRef:       "quay.io/openshift-release-dev/ocp-release:4.16.12-multi",
+			pullSecret:     pullSecret,
+			expectedErr:    false,
+			validateCache:  true,
+			expectedDigest: "sha256:727276732f03d8d5a2374efa3d01fb0ed9f65b32488b862e9a9d2ff4cde89ff6",
+		},
+	}
+
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			provider := &RegistryClientImageMetadataProvider{
+				OpenShiftImageRegistryOverrides: map[string][]string{},
+			}
+
+			manifest, err := provider.GetManifest(ctx, tc.imageRef, tc.pullSecret)
+			if tc.expectedErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(manifest).NotTo(BeNil())
+			}
+
+			if tc.validateCache {
+				_, exists := manifestsCache.Get(tc.expectedDigest)
+				g.Expect(exists).To(BeTrue())
+			}
+		})
+	}
+}
+func TestGetDigest(t *testing.T) {
+	ctx := context.TODO()
+	pullSecret := []byte("{}")
+
+	testsCases := []struct {
+		name           string
+		imageRef       string
+		pullSecret     []byte
+		expectedErr    bool
+		validateCache  bool
+		expectedDigest digest.Digest
+	}{
+		{
+			name:        "if failed to parse image reference",
+			imageRef:    "invalid-image-ref",
+			pullSecret:  pullSecret,
+			expectedErr: true,
+		},
+		{
+			name:           "Multiaarch image digest",
+			imageRef:       "quay.io/openshift-release-dev/ocp-release:4.16.12-multi",
+			pullSecret:     pullSecret,
+			expectedErr:    false,
+			validateCache:  true,
+			expectedDigest: "sha256:727276732f03d8d5a2374efa3d01fb0ed9f65b32488b862e9a9d2ff4cde89ff6",
+		},
+		{
+			name:           "amd64 Image digest is found in cache",
+			imageRef:       "quay.io/openshift-release-dev/ocp-release:4.16.12-x86_64",
+			pullSecret:     pullSecret,
+			expectedErr:    false,
+			validateCache:  true,
+			expectedDigest: "sha256:2a50e5d5267916078145731db740bbc85ee764e1a194715fd986ab5bf9a3414e",
+		},
+		{
+			name:           "amd64 Image digest, recover from cache",
+			imageRef:       "quay.io/openshift-release-dev/ocp-release:4.16.12-x86_64",
+			pullSecret:     pullSecret,
+			expectedErr:    false,
+			validateCache:  true,
+			expectedDigest: "sha256:2a50e5d5267916078145731db740bbc85ee764e1a194715fd986ab5bf9a3414e",
+		},
+		{
+			name:           "Image with digest and not tag",
+			imageRef:       "quay.io/openshift-release-dev/ocp-release@sha256:e96047c50caf0aaffeaf7ed0fe50bd3f574ad347cd0f588a56b876f79cc29d3e",
+			pullSecret:     pullSecret,
+			expectedErr:    false,
+			validateCache:  true,
+			expectedDigest: "sha256:e96047c50caf0aaffeaf7ed0fe50bd3f574ad347cd0f588a56b876f79cc29d3e",
+		},
+	}
+
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			provider := &RegistryClientImageMetadataProvider{
+				OpenShiftImageRegistryOverrides: map[string][]string{},
+			}
+
+			digest, ref, err := provider.GetDigest(ctx, tc.imageRef, tc.pullSecret)
+			if tc.expectedErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(digest).To(Equal(tc.expectedDigest))
+				g.Expect(ref).NotTo(BeNil())
+			}
+
+			if tc.validateCache {
+				_, exists := digestCache.Get(tc.imageRef)
+				g.Expect(exists).To(BeTrue())
+			}
+		})
+	}
+}
+func TestSeekOverride(t *testing.T) {
+	testsCases := []struct {
+		name           string
+		overrides      map[string][]string
+		imageRef       reference.DockerImageReference
+		expectedImgRef *reference.DockerImageReference
+	}{
+		{
+			name:      "if no overrides are provided",
+			overrides: map[string][]string{},
+			imageRef: reference.DockerImageReference{
+				Registry:  "quay.io",
+				Name:      "ocp-release",
+				Namespace: "openshift-release-dev",
+				Tag:       "4.15.0-rc.0-multi",
+			},
+			expectedImgRef: &reference.DockerImageReference{
+				Registry:  "quay.io",
+				Name:      "ocp-release",
+				Namespace: "openshift-release-dev",
+				Tag:       "4.15.0-rc.0-multi",
+			},
+		},
+		{
+			name:      "if registry override exact coincidence is found",
+			overrides: fakeOverrides(),
+			imageRef: reference.DockerImageReference{
+				Registry:  "quay.io",
+				Name:      "ocp-release",
+				Namespace: "openshift-release-dev",
+				Tag:       "4.15.0-rc.0-multi",
+			},
+			expectedImgRef: &reference.DockerImageReference{
+				Registry:  "myregistry1.io",
+				Name:      "ocp-release",
+				Namespace: "openshift-release-dev",
+				Tag:       "4.15.0-rc.0-multi",
+			},
+		},
+		{
+			name:      "if registry override partial coincidence is found",
+			overrides: fakeOverrides(),
+			imageRef: reference.DockerImageReference{
+				Registry:  "quay.io",
+				Name:      "mce-image",
+				Namespace: "mce",
+				Tag:       "latest",
+			},
+			expectedImgRef: &reference.DockerImageReference{
+				Registry:  "myregistry.io",
+				Name:      "mce-image",
+				Namespace: "mce",
+				Tag:       "latest",
+			},
+		},
+		{
+			name:      "if registry override coincidence is not found",
+			overrides: fakeOverrides(),
+			imageRef: reference.DockerImageReference{
+				Registry:  "quay.io",
+				Name:      "testimage",
+				Namespace: "test-namespace",
+				Tag:       "latest",
+			},
+			expectedImgRef: &reference.DockerImageReference{
+				Registry:  "quay.io",
+				Name:      "testimage",
+				Namespace: "test-namespace",
+				Tag:       "latest",
+			},
+		},
+		{
+			name:      "if failed to find registry override",
+			overrides: fakeOverrides(),
+			imageRef: reference.DockerImageReference{
+				Registry:  "quay.io",
+				Name:      "cnv-image",
+				Namespace: "cnv",
+				Tag:       "latest",
+			},
+			expectedImgRef: &reference.DockerImageReference{
+				Registry:  "quay.io",
+				Name:      "cnv-image",
+				Namespace: "cnv",
+				Tag:       "latest",
+			},
+		},
+	}
+
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.TODO()
+			g := NewGomegaWithT(t)
+			imgRef := seekOverride(ctx, tc.overrides, tc.imageRef)
+			g.Expect(imgRef).To(Equal(tc.expectedImgRef))
+		})
+	}
+}
+
+func fakeOverrides() map[string][]string {
+	return map[string][]string{
+		"quay.io/openshift-release-dev/ocp-release": {
+			"myregistry1.io/openshift-release-dev/ocp-release",
+			"myregistry2.io/openshift-release-dev/ocp-release",
+		},
+		"quay.io/mce": {
+			"myregistry.io/mce",
+		},
 	}
 }

--- a/support/util/networking.go
+++ b/support/util/networking.go
@@ -117,7 +117,7 @@ func GetAdvertiseAddress(hcp *hyperv1.HostedControlPlane, ipv4DefaultAddress, ip
 	var err error
 
 	if len(hcp.Spec.Networking.ServiceNetwork) > 0 {
-		ipv4, err = IsIPv4(hcp.Spec.Networking.ServiceNetwork[0].CIDR.String())
+		ipv4, err = IsIPv4CIDR(hcp.Spec.Networking.ServiceNetwork[0].CIDR.String())
 	} else {
 		ipv4 = true
 	}

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -291,19 +291,28 @@ func ConvertImageRegistryOverrideStringToMap(envVar string) map[string][]string 
 	return imageRegistryOverrides
 }
 
-// IsIPv4 function parse the CIDR and get the IPNet struct if the IPNet.IP cannot be converted to 4bytes format,
-// the function returns nil, if it's an IPv6 it will return nil.
-func IsIPv4(cidr string) (bool, error) {
-	_, ipnet, err := net.ParseCIDR(cidr)
+// IsIPv4CIDR checks if the input string is an IPv4 CIDR.
+func IsIPv4CIDR(input string) (bool, error) {
+	_, ipnet, err := net.ParseCIDR(input)
 	if err != nil {
-		return false, fmt.Errorf("error validating the incoming CIDR %s: %v", cidr, err)
+		return false, fmt.Errorf("error parsing input '%s': not a valid CIDR", input)
 	}
-
 	if ipnet.IP.To4() != nil {
 		return true, nil
-	} else {
-		return false, nil
 	}
+	return false, nil
+}
+
+// IsIPv4Address checks if the input string is an IPv4 address.
+func IsIPv4Address(input string) (bool, error) {
+	ip := net.ParseIP(input)
+	if ip == nil {
+		return false, fmt.Errorf("error parsing input '%s': not a valid IP address", input)
+	}
+	if ip.To4() != nil {
+		return true, nil
+	}
+	return false, nil
 }
 
 // FirstUsableIP returns the first usable IP in both, IPv4 and IPv6 stacks.

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -398,7 +398,7 @@ func DetermineHostedClusterPayloadArch(ctx context.Context, c client.Client, hc 
 		return "", fmt.Errorf("expected %s key in pull secret", corev1.DockerConfigJsonKey)
 	}
 
-	isMultiArchReleaseImage, err := registryclient.IsMultiArchManifestList(ctx, hc.Spec.Release.Image, pullSecretBytes)
+	isMultiArchReleaseImage, err := registryclient.IsMultiArchManifestList(ctx, hc.Spec.Release.Image, pullSecretBytes, imageMetadataProvider)
 	if err != nil {
 		return "", fmt.Errorf("failed to determine if release image multi-arch: %w", err)
 	}

--- a/support/util/util_test.go
+++ b/support/util/util_test.go
@@ -260,57 +260,6 @@ func testDecompressFuncErr(t *testing.T, payload []byte) {
 	g.Expect(out.String()).To(BeEmpty(), "should be an empty string")
 }
 
-func TestIsIPv4(t *testing.T) {
-	type args struct {
-		cidrs []string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    bool
-		wantErr bool
-	}{
-		{
-			name: "When an ipv4 CIDR is checked by isIPv4, it should return true",
-			args: args{
-				cidrs: []string{"192.168.1.35/24", "0.0.0.0/0", "127.0.0.1/24"},
-			},
-			want:    true,
-			wantErr: false,
-		},
-		{
-			name: "When an ipv6 CIDR is checked by isIPv4, it should return false",
-			args: args{
-				cidrs: []string{"2001::/17", "2001:db8::/62", "::/0", "2000::/3"},
-			},
-			want:    false,
-			wantErr: false,
-		},
-		{
-			name: "When a non valid CIDR is checked by isIPv4, it should return an error and false",
-			args: args{
-				cidrs: []string{"192.168.35/68"},
-			},
-			want:    false,
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			for _, cidr := range tt.args.cidrs {
-				got, err := IsIPv4(cidr)
-				if (err != nil) != tt.wantErr {
-					t.Errorf("isIPv4() error = %v, wantErr %v", err, tt.wantErr)
-					return
-				}
-				if got != tt.want {
-					t.Errorf("isIPv4() = %v, want %v", got, tt.want)
-				}
-			}
-		})
-	}
-}
-
 func TestFirstUsableIP(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -737,6 +686,86 @@ func TestDetermineHostedClusterPayloadArch(t *testing.T) {
 				g.Expect(err).To(BeNil())
 				g.Expect(payloadType).To(Equal(tc.expectedPayloadType))
 			}
+		})
+	}
+}
+
+func TestIsIPv4CIDR(t *testing.T) {
+	tests := []struct {
+		input       string
+		expected    bool
+		expectError bool
+	}{
+		// Valid IPv4 CIDRs
+		{"192.168.1.0/24", true, false},
+		{"10.0.0.0/8", true, false},
+
+		// Valid IPv6 CIDRs
+		{"2001:db8::/32", false, false},
+		{"fd00::/8", false, false},
+
+		// Invalid inputs
+		{"invalid", false, true},
+		{"192.168.1.1/33", false, true},  // Invalid CIDR prefix
+		{"", false, true},                // Empty input
+		{"1234::5678::/64", false, true}, // Malformed IP
+
+		// Edge cases
+		{"0.0.0.0/0", true, false},
+		{"255.255.255.255/32", true, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			g := NewWithT(t)
+			result, err := IsIPv4CIDR(test.input)
+			if test.expectError {
+				g.Expect(err).To(HaveOccurred(), "Expected an error for input '%s'", test.input)
+			} else {
+				g.Expect(err).ToNot(HaveOccurred(), "Did not expect an error for input '%s'", test.input)
+			}
+
+			g.Expect(result).To(Equal(test.expected), "Unexpected result for input '%s'", test.input)
+		})
+	}
+}
+
+func TestIsIPv4Address(t *testing.T) {
+	tests := []struct {
+		input       string
+		expected    bool
+		expectError bool
+	}{
+		// Valid IPv4 addresses
+		{"192.168.1.1", true, false},
+		{"10.0.0.1", true, false},
+
+		// Valid IPv6 addresses
+		{"2001:db8::1", false, false},
+		{"fd00::1", false, false},
+
+		// Invalid inputs
+		{"invalid", false, true},
+		{"192.168.1.256", false, true}, // Invalid IPv4 address
+		{"", false, true},              // Empty input
+		{"1234::5678::1", false, true}, // Malformed IP
+
+		// Edge cases
+		{"0.0.0.0", true, false},
+		{"255.255.255.255", true, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			g := NewWithT(t)
+			result, err := IsIPv4Address(test.input)
+			if test.expectError {
+				g.Expect(err).To(HaveOccurred(), "Expected an error for input '%s'", test.input)
+			} else {
+				g.Expect(err).ToNot(HaveOccurred(), "Did not expect an error for input '%s'", test.input)
+			}
+
+			g.Expect(result).To(Equal(test.expected), "Unexpected result for input '%s'", test.input)
 		})
 	}
 }

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -390,11 +390,11 @@ func WaitForImageRollout(t *testing.T, ctx context.Context, client crclient.Clie
 				Status: metav1.ConditionFalse,
 			}),
 			func(hostedCluster *hyperv1.HostedCluster) (done bool, reasons string, err error) {
-				if wanted, got := image, ptr.Deref(hostedCluster.Status.Version, hyperv1.ClusterVersionStatus{}).Desired.Image; wanted != got {
-					return false, fmt.Sprintf("wanted HostedCluster to desire image %s, got %s", wanted, got), nil
-				}
 				if len(ptr.Deref(hostedCluster.Status.Version, hyperv1.ClusterVersionStatus{}).History) == 0 {
 					return false, "HostedCluster has no version history", nil
+				}
+				if wanted, got := hostedCluster.Status.Version.History[0].Version, ptr.Deref(hostedCluster.Status.Version, hyperv1.ClusterVersionStatus{}).Desired.Version; wanted != got {
+					return false, fmt.Sprintf("wanted HostedCluster to desired version %s, got %s", wanted, got), nil
 				}
 				if wanted, got := hostedCluster.Status.Version.Desired.Image, hostedCluster.Status.Version.History[0].Image; wanted != got {
 					return false, fmt.Sprintf("desired image %s doesn't match most recent image in history %s", wanted, got), nil


### PR DESCRIPTION
The issue with the MultiArch check is that it's recovering the manifests without passing through ImageMetadaProvider. I've added a new method to that which recovers the requested manifest and adds it to a new LRU Cache.

To pass the ImageMetadataProvider to the RegistryClient, implies to fall in a import cycle issue, so a new interface was created called ManifestProvider, which implement the same GetManifest methods as the original does.

**Which issue(s) this PR fixes**:
Fixes:
- [OCPBUGS-44655](https://issues.redhat.com/browse/OCPBUGS-44655) - HO issue determining the cluster payload arch does not checks the ICSP/IDMS
- [OCPBUGS-43083](https://issues.redhat.com/browse/OCPBUGS-43083) - Pods cannot connect to apiserver in IPv6 disconnected hosted cluster

**Issues Solved**
- [x] Detecting MultiArch cannot get the right manifest (original GetManifests is not using the ImageMetadataProvider) 
  - Implemented GetManifests method inside of ImageMetadataProvider
- [x] ImageMetadataProvider does not understand the IDMS with only the domain (exact match works fine
  - Patched GetOverrideImages to understand IDMS namespace wildcards 
- [x] CVO is being override by a EnvVar and not getting the digest from OCP release
  - Implemented GetDigest method inside of ImageMetadataProvider 
- [x] CVO deployment’s payload-script does not contain EOF
- [x] IPv6 does not work, nodes cannot join the KAS
  - The `IsIPv4` function now accepts IPAddresses instead of only CIDRs.