### PR TITLE
CNTRLPLANE-1961: feat(nodepool): Add ImageTagMirrorSet support

### DIFF
--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -126,13 +126,18 @@ type NodePoolSpec struct {
 	AutoScaling *NodePoolAutoScaling `json:"autoScaling,omitempty"`
 
 	// config is a list of references to ConfigMaps containing serialized
-	// MachineConfig resources to be injected into the ignition configurations of
-	// nodes in the NodePool. The MachineConfig API schema is defined here:
+	// MachineConfig or select OpenShift Config resources to be injected into
+	// the ignition configurations of nodes in the NodePool.
 	//
-	// https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185
+	// The MachineConfig API schema is defined here:
+	// https://github.com/openshift/api/blob/caf97963ed302881f01e67b791ae4efc6bcf723c/machineconfiguration/v1/types.go#L290
+	//
+	// The OpenShift Config API schemas are defined here:
+	// https://github.com/openshift/api/tree/master/config/v1
 	//
 	// Each ConfigMap must have a single key named "config" whose value is the YML
-	// with one or more serialized machineconfiguration.openshift.io resources:
+	// with one or more serialized machineconfiguration.openshift.io or select
+	// config.openshift.io resources:
 	//
 	// * KubeletConfig
 	// * ContainerRuntimeConfig
@@ -140,6 +145,7 @@ type NodePoolSpec struct {
 	// * ClusterImagePolicy
 	// * ImageContentSourcePolicy
 	// * ImageDigestMirrorSet
+	// * ImageTagMirrorSet
 	//
 	// This is validated in the backend and signaled back via validMachineConfig condition.
 	// Changing this field will trigger a NodePool rollout.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
@@ -134,13 +134,18 @@ spec:
               config:
                 description: |-
                   config is a list of references to ConfigMaps containing serialized
-                  MachineConfig resources to be injected into the ignition configurations of
-                  nodes in the NodePool. The MachineConfig API schema is defined here:
+                  MachineConfig or select OpenShift Config resources to be injected into
+                  the ignition configurations of nodes in the NodePool.
 
-                  https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185
+                  The MachineConfig API schema is defined here:
+                  https://github.com/openshift/api/blob/caf97963ed302881f01e67b791ae4efc6bcf723c/machineconfiguration/v1/types.go#L290
+
+                  The OpenShift Config API schemas are defined here:
+                  https://github.com/openshift/api/tree/master/config/v1
 
                   Each ConfigMap must have a single key named "config" whose value is the YML
-                  with one or more serialized machineconfiguration.openshift.io resources:
+                  with one or more serialized machineconfiguration.openshift.io or select
+                  config.openshift.io resources:
 
                   * KubeletConfig
                   * ContainerRuntimeConfig
@@ -148,6 +153,7 @@ spec:
                   * ClusterImagePolicy
                   * ImageContentSourcePolicy
                   * ImageDigestMirrorSet
+                  * ImageTagMirrorSet
 
                   This is validated in the backend and signaled back via validMachineConfig condition.
                   Changing this field will trigger a NodePool rollout.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
@@ -134,13 +134,18 @@ spec:
               config:
                 description: |-
                   config is a list of references to ConfigMaps containing serialized
-                  MachineConfig resources to be injected into the ignition configurations of
-                  nodes in the NodePool. The MachineConfig API schema is defined here:
+                  MachineConfig or select OpenShift Config resources to be injected into
+                  the ignition configurations of nodes in the NodePool.
 
-                  https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185
+                  The MachineConfig API schema is defined here:
+                  https://github.com/openshift/api/blob/caf97963ed302881f01e67b791ae4efc6bcf723c/machineconfiguration/v1/types.go#L290
+
+                  The OpenShift Config API schemas are defined here:
+                  https://github.com/openshift/api/tree/master/config/v1
 
                   Each ConfigMap must have a single key named "config" whose value is the YML
-                  with one or more serialized machineconfiguration.openshift.io resources:
+                  with one or more serialized machineconfiguration.openshift.io or select
+                  config.openshift.io resources:
 
                   * KubeletConfig
                   * ContainerRuntimeConfig
@@ -148,6 +153,7 @@ spec:
                   * ClusterImagePolicy
                   * ImageContentSourcePolicy
                   * ImageDigestMirrorSet
+                  * ImageTagMirrorSet
 
                   This is validated in the backend and signaled back via validMachineConfig condition.
                   Changing this field will trigger a NodePool rollout.

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -137,13 +137,18 @@ spec:
               config:
                 description: |-
                   config is a list of references to ConfigMaps containing serialized
-                  MachineConfig resources to be injected into the ignition configurations of
-                  nodes in the NodePool. The MachineConfig API schema is defined here:
+                  MachineConfig or select OpenShift Config resources to be injected into
+                  the ignition configurations of nodes in the NodePool.
 
-                  https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185
+                  The MachineConfig API schema is defined here:
+                  https://github.com/openshift/api/blob/caf97963ed302881f01e67b791ae4efc6bcf723c/machineconfiguration/v1/types.go#L290
+
+                  The OpenShift Config API schemas are defined here:
+                  https://github.com/openshift/api/tree/master/config/v1
 
                   Each ConfigMap must have a single key named "config" whose value is the YML
-                  with one or more serialized machineconfiguration.openshift.io resources:
+                  with one or more serialized machineconfiguration.openshift.io or select
+                  config.openshift.io resources:
 
                   * KubeletConfig
                   * ContainerRuntimeConfig
@@ -151,6 +156,7 @@ spec:
                   * ClusterImagePolicy
                   * ImageContentSourcePolicy
                   * ImageDigestMirrorSet
+                  * ImageTagMirrorSet
 
                   This is validated in the backend and signaled back via validMachineConfig condition.
                   Changing this field will trigger a NodePool rollout.

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -137,13 +137,18 @@ spec:
               config:
                 description: |-
                   config is a list of references to ConfigMaps containing serialized
-                  MachineConfig resources to be injected into the ignition configurations of
-                  nodes in the NodePool. The MachineConfig API schema is defined here:
+                  MachineConfig or select OpenShift Config resources to be injected into
+                  the ignition configurations of nodes in the NodePool.
 
-                  https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185
+                  The MachineConfig API schema is defined here:
+                  https://github.com/openshift/api/blob/caf97963ed302881f01e67b791ae4efc6bcf723c/machineconfiguration/v1/types.go#L290
+
+                  The OpenShift Config API schemas are defined here:
+                  https://github.com/openshift/api/tree/master/config/v1
 
                   Each ConfigMap must have a single key named "config" whose value is the YML
-                  with one or more serialized machineconfiguration.openshift.io resources:
+                  with one or more serialized machineconfiguration.openshift.io or select
+                  config.openshift.io resources:
 
                   * KubeletConfig
                   * ContainerRuntimeConfig
@@ -151,6 +156,7 @@ spec:
                   * ClusterImagePolicy
                   * ImageContentSourcePolicy
                   * ImageDigestMirrorSet
+                  * ImageTagMirrorSet
 
                   This is validated in the backend and signaled back via validMachineConfig condition.
                   Changing this field will trigger a NodePool rollout.

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -137,13 +137,18 @@ spec:
               config:
                 description: |-
                   config is a list of references to ConfigMaps containing serialized
-                  MachineConfig resources to be injected into the ignition configurations of
-                  nodes in the NodePool. The MachineConfig API schema is defined here:
+                  MachineConfig or select OpenShift Config resources to be injected into
+                  the ignition configurations of nodes in the NodePool.
 
-                  https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185
+                  The MachineConfig API schema is defined here:
+                  https://github.com/openshift/api/blob/caf97963ed302881f01e67b791ae4efc6bcf723c/machineconfiguration/v1/types.go#L290
+
+                  The OpenShift Config API schemas are defined here:
+                  https://github.com/openshift/api/tree/master/config/v1
 
                   Each ConfigMap must have a single key named "config" whose value is the YML
-                  with one or more serialized machineconfiguration.openshift.io resources:
+                  with one or more serialized machineconfiguration.openshift.io or select
+                  config.openshift.io resources:
 
                   * KubeletConfig
                   * ContainerRuntimeConfig
@@ -151,6 +156,7 @@ spec:
                   * ClusterImagePolicy
                   * ImageContentSourcePolicy
                   * ImageDigestMirrorSet
+                  * ImageTagMirrorSet
 
                   This is validated in the backend and signaled back via validMachineConfig condition.
                   Changing this field will trigger a NodePool rollout.

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -798,11 +798,15 @@ autoscaling is mutually exclusive with replicas. If replicas is set, this field 
 </td>
 <td>
 <p>config is a list of references to ConfigMaps containing serialized
-MachineConfig resources to be injected into the ignition configurations of
-nodes in the NodePool. The MachineConfig API schema is defined here:</p>
-<p><a href="https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185">https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185</a></p>
+MachineConfig or select OpenShift Config resources to be injected into
+the ignition configurations of nodes in the NodePool.</p>
+<p>The MachineConfig API schema is defined here:
+<a href="https://github.com/openshift/api/blob/caf97963ed302881f01e67b791ae4efc6bcf723c/machineconfiguration/v1/types.go#L290">https://github.com/openshift/api/blob/caf97963ed302881f01e67b791ae4efc6bcf723c/machineconfiguration/v1/types.go#L290</a></p>
+<p>The OpenShift Config API schemas are defined here:
+<a href="https://github.com/openshift/api/tree/master/config/v1">https://github.com/openshift/api/tree/master/config/v1</a></p>
 <p>Each ConfigMap must have a single key named &ldquo;config&rdquo; whose value is the YML
-with one or more serialized machineconfiguration.openshift.io resources:</p>
+with one or more serialized machineconfiguration.openshift.io or select
+config.openshift.io resources:</p>
 <ul>
 <li>KubeletConfig</li>
 <li>ContainerRuntimeConfig</li>
@@ -810,6 +814,7 @@ with one or more serialized machineconfiguration.openshift.io resources:</p>
 <li>ClusterImagePolicy</li>
 <li>ImageContentSourcePolicy</li>
 <li>ImageDigestMirrorSet</li>
+<li>ImageTagMirrorSet</li>
 </ul>
 <p>This is validated in the backend and signaled back via validMachineConfig condition.
 Changing this field will trigger a NodePool rollout.</p>
@@ -8425,11 +8430,15 @@ autoscaling is mutually exclusive with replicas. If replicas is set, this field 
 </td>
 <td>
 <p>config is a list of references to ConfigMaps containing serialized
-MachineConfig resources to be injected into the ignition configurations of
-nodes in the NodePool. The MachineConfig API schema is defined here:</p>
-<p><a href="https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185">https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185</a></p>
+MachineConfig or select OpenShift Config resources to be injected into
+the ignition configurations of nodes in the NodePool.</p>
+<p>The MachineConfig API schema is defined here:
+<a href="https://github.com/openshift/api/blob/caf97963ed302881f01e67b791ae4efc6bcf723c/machineconfiguration/v1/types.go#L290">https://github.com/openshift/api/blob/caf97963ed302881f01e67b791ae4efc6bcf723c/machineconfiguration/v1/types.go#L290</a></p>
+<p>The OpenShift Config API schemas are defined here:
+<a href="https://github.com/openshift/api/tree/master/config/v1">https://github.com/openshift/api/tree/master/config/v1</a></p>
 <p>Each ConfigMap must have a single key named &ldquo;config&rdquo; whose value is the YML
-with one or more serialized machineconfiguration.openshift.io resources:</p>
+with one or more serialized machineconfiguration.openshift.io or select
+config.openshift.io resources:</p>
 <ul>
 <li>KubeletConfig</li>
 <li>ContainerRuntimeConfig</li>
@@ -8437,6 +8446,7 @@ with one or more serialized machineconfiguration.openshift.io resources:</p>
 <li>ClusterImagePolicy</li>
 <li>ImageContentSourcePolicy</li>
 <li>ImageDigestMirrorSet</li>
+<li>ImageTagMirrorSet</li>
 </ul>
 <p>This is validated in the backend and signaled back via validMachineConfig condition.
 Changing this field will trigger a NodePool rollout.</p>

--- a/hypershift-operator/controllers/nodepool/config.go
+++ b/hypershift-operator/controllers/nodepool/config.go
@@ -287,6 +287,7 @@ func (cg *ConfigGenerator) defaultAndValidateConfigManifest(manifest []byte) ([]
 		}
 	case *v1alpha1.ImageContentSourcePolicy:
 	case *configv1.ImageDigestMirrorSet:
+	case *configv1.ImageTagMirrorSet:
 	case *configv1alpha1.ClusterImagePolicy:
 	case *mcfgv1.KubeletConfig:
 		obj.Spec.MachineConfigPoolSelector = &metav1.LabelSelector{

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -126,13 +126,18 @@ type NodePoolSpec struct {
 	AutoScaling *NodePoolAutoScaling `json:"autoScaling,omitempty"`
 
 	// config is a list of references to ConfigMaps containing serialized
-	// MachineConfig resources to be injected into the ignition configurations of
-	// nodes in the NodePool. The MachineConfig API schema is defined here:
+	// MachineConfig or select OpenShift Config resources to be injected into
+	// the ignition configurations of nodes in the NodePool.
 	//
-	// https://github.com/openshift/machine-config-operator/blob/18963e4f8fe66e8c513ca4b131620760a414997f/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L185
+	// The MachineConfig API schema is defined here:
+	// https://github.com/openshift/api/blob/caf97963ed302881f01e67b791ae4efc6bcf723c/machineconfiguration/v1/types.go#L290
+	//
+	// The OpenShift Config API schemas are defined here:
+	// https://github.com/openshift/api/tree/master/config/v1
 	//
 	// Each ConfigMap must have a single key named "config" whose value is the YML
-	// with one or more serialized machineconfiguration.openshift.io resources:
+	// with one or more serialized machineconfiguration.openshift.io or select
+	// config.openshift.io resources:
 	//
 	// * KubeletConfig
 	// * ContainerRuntimeConfig
@@ -140,6 +145,7 @@ type NodePoolSpec struct {
 	// * ClusterImagePolicy
 	// * ImageContentSourcePolicy
 	// * ImageDigestMirrorSet
+	// * ImageTagMirrorSet
 	//
 	// This is validated in the backend and signaled back via validMachineConfig condition.
 	// Changing this field will trigger a NodePool rollout.


### PR DESCRIPTION
**What this PR does / why we need it**:
Add ImageTagMirrorSet support for NodePool configs.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.