### PR TITLE
NO-JIRA: Update OCP max supported version for HO

### DIFF
--- a/support/supportedversion/version.go
+++ b/support/supportedversion/version.go
@@ -17,7 +17,7 @@ import (
 // HyperShift operator.
 // NOTE: The .0 (z release) should be ignored. It's only here to support
 // semver parsing.
-var LatestSupportedVersion = semver.MustParse("4.18.0")
+var LatestSupportedVersion = semver.MustParse("4.19.0")
 var MinSupportedVersion = semver.MustParse("4.14.0")
 
 func GetMinSupportedVersion(hc *hyperv1.HostedCluster) semver.Version {

--- a/test/e2e/util/version.go
+++ b/test/e2e/util/version.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	// y-stream versions supported by e2e in main
+	Version419 = semver.MustParse("4.19.0")
 	Version418 = semver.MustParse("4.18.0")
 	Version417 = semver.MustParse("4.17.0")
 	Version416 = semver.MustParse("4.16.0")
@@ -26,6 +27,7 @@ func init() {
 	// Ensure that the version constants are valid semver versions
 	// This is a compile-time check to ensure that the versions are valid
 	// semver versions.
+	_ = Version419
 	_ = Version418
 	_ = Version417
 	_ = Version416


### PR DESCRIPTION
Updated the max supported version to 4.19

/hold until branch cut