### PR TITLE
NO-JIRA: Remove OpenStack workaround for Ingress Floating IP

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile.go
@@ -10,7 +10,6 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -89,11 +88,9 @@ func ReconcileDefaultIngressController(ingressController *operatorv1.IngressCont
 				Scope: loadBalancerScope,
 				ProviderParameters: &operatorv1.ProviderLoadBalancerParameters{
 					Type: operatorv1.OpenStackLoadBalancerProvider,
-					// TODO(emilien): add the field once bumped openshift/api and also remove `ReconcileDefaultIngressControllerWithUnstructured`.
-					// https://github.com/openshift/hypershift/pull/4927
-					// OpenStack: &operatorv1.OpenStackLoadBalancerParameters{
-					// 	FloatingIP: loadBalancerIP,
-					// },
+					OpenStack: &operatorv1.OpenStackLoadBalancerParameters{
+						FloatingIP: loadBalancerIP,
+					},
 				},
 			},
 		}
@@ -113,32 +110,6 @@ func ReconcileDefaultIngressController(ingressController *operatorv1.IngressCont
 			Type:    operatorv1.PrivateStrategyType,
 			Private: &operatorv1.PrivateStrategy{},
 		}
-	}
-	return nil
-}
-
-// ReconcileDefaultIngressControllerWithUnstructured reconciles the default ingress controller with an unstructured object
-// that has custom fields set per platform.
-func ReconcileOpenStackDefaultIngressController(ingressController *unstructured.Unstructured, ingressSubdomain string, replicas int32, isPrivate bool, loadBalancerScope operatorv1.LoadBalancerScope, loadBalancerIP string) error {
-	// If ingress controller already exists, skip reconciliation to allow day-2 configuration
-	if ingressController.GetResourceVersion() != "" {
-		return nil
-	}
-
-	unstructured.SetNestedField(ingressController.Object, ingressSubdomain, "spec", "domain")
-	unstructured.SetNestedField(ingressController.Object, string(operatorv1.LoadBalancerServiceStrategyType), "spec", "endpointPublishingStrategy", "type")
-	unstructured.SetNestedField(ingressController.Object, int64(replicas), "spec", "replicas")
-
-	unstructured.SetNestedField(ingressController.Object, string(loadBalancerScope), "spec", "endpointPublishingStrategy", "loadBalancer", "scope")
-	unstructured.SetNestedField(ingressController.Object, string(operatorv1.OpenStackLoadBalancerProvider), "spec", "endpointPublishingStrategy", "loadBalancer", "providerParameters", "type")
-	if loadBalancerIP != "" {
-		unstructured.SetNestedField(ingressController.Object, loadBalancerIP, "spec", "endpointPublishingStrategy", "loadBalancer", "providerParameters", "openstack", "floatingIP")
-	}
-	unstructured.SetNestedField(ingressController.Object, manifests.IngressDefaultIngressControllerCert().Name, "spec", "defaultCertificate", "name")
-
-	if isPrivate {
-		unstructured.SetNestedField(ingressController.Object, operatorv1.PrivateStrategyType, "spec", "endpointPublishingStrategy", "type")
-		unstructured.SetNestedMap(ingressController.Object, map[string]interface{}{}, "spec", "endpointPublishingStrategy", "private")
 	}
 	return nil
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/ingress.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/ingress.go
@@ -6,7 +6,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func IngressDefaultIngressController() *operatorv1.IngressController {
@@ -16,16 +15,6 @@ func IngressDefaultIngressController() *operatorv1.IngressController {
 			Namespace: "openshift-ingress-operator",
 		},
 	}
-}
-
-func IngressDefaultIngressControllerAsUnstructured() *unstructured.Unstructured {
-	src := IngressDefaultIngressController()
-	obj := &unstructured.Unstructured{}
-	obj.SetAPIVersion(operatorv1.GroupVersion.String())
-	obj.SetKind("IngressController")
-	obj.SetName(src.Name)
-	obj.SetNamespace(src.Namespace)
-	return obj
 }
 
 func IngressDefaultIngressControllerCert() *corev1.Secret {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1005,23 +1005,11 @@ func (r *reconciler) reconcileRBAC(ctx context.Context) error {
 func (r *reconciler) reconcileIngressController(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
 	var errs []error
 	p := ingress.NewIngressParams(hcp)
-
-	// This is a workaround until we bump openshift/api which has the floatingIP field in the IngessControllerSpec
-	// TODO (cewong): Remove this when updated openshift/api is vendored
-	if hcp.Spec.Platform.Type == hyperv1.OpenStackPlatform {
-		ingressController := manifests.IngressDefaultIngressControllerAsUnstructured()
-		if _, err := r.CreateOrUpdate(ctx, r.client, ingressController, func() error {
-			return ingress.ReconcileOpenStackDefaultIngressController(ingressController, p.IngressSubdomain, p.Replicas, p.IsPrivate, p.LoadBalancerScope, p.LoadBalancerIP)
-		}); err != nil {
-			errs = append(errs, fmt.Errorf("failed to reconcile openstack default ingress controller: %w", err))
-		}
-	} else {
-		ingressController := manifests.IngressDefaultIngressController()
-		if _, err := r.CreateOrUpdate(ctx, r.client, ingressController, func() error {
-			return ingress.ReconcileDefaultIngressController(ingressController, p.IngressSubdomain, p.PlatformType, p.Replicas, p.IBMCloudUPI, p.IsPrivate, p.AWSNLB, p.LoadBalancerScope, p.LoadBalancerIP)
-		}); err != nil {
-			errs = append(errs, fmt.Errorf("failed to reconcile default ingress controller: %w", err))
-		}
+	ingressController := manifests.IngressDefaultIngressController()
+	if _, err := r.CreateOrUpdate(ctx, r.client, ingressController, func() error {
+		return ingress.ReconcileDefaultIngressController(ingressController, p.IngressSubdomain, p.PlatformType, p.Replicas, p.IBMCloudUPI, p.IsPrivate, p.AWSNLB, p.LoadBalancerScope, p.LoadBalancerIP)
+	}); err != nil {
+		errs = append(errs, fmt.Errorf("failed to reconcile default ingress controller: %w", err))
 	}
 
 	sourceCert := cpomanifests.IngressCert(hcp.Namespace)


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove some technical debt around the Ingress Floating IP reconcile for the OpenStack platform.
