### PR TITLE
OCPBUGS-44326: Separate CPO containerfiles

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: trailing-whitespace
+        args:
+          - --markdown-linebreak-ext=md
+  - repo: local
+    hooks:
+      - id: cpo-containerfiles-in-sync
+        name: cpo-containerfiles-in-sync
+        entry: ./hack/tools/git-hooks/cpo-containerfiles-in-sync.sh
+        language: script
+        pass_filenames: false
+        args:
+          - Containerfile.control-plane
+          - Dockerfile.control-plane
+        description: Ensures the CPO container files stay in sync
+exclude: '^vendor/|^hack/tools/vendor/|^api/vendor/'

--- a/Containerfile.control-plane
+++ b/Containerfile.control-plane
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 AS builder
 
 WORKDIR /hypershift
 
@@ -6,7 +6,7 @@ COPY . .
 
 RUN make control-plane-operator control-plane-pki-operator
 
-FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
+FROM registry.redhat.io/rhel9-2-els/rhel:9.2
 COPY --from=builder /hypershift/bin/control-plane-operator /usr/bin/control-plane-operator
 COPY --from=builder /hypershift/bin/control-plane-pki-operator /usr/bin/control-plane-pki-operator
 

--- a/hack/tools/git-hooks/cpo-containerfiles-in-sync.sh
+++ b/hack/tools/git-hooks/cpo-containerfiles-in-sync.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+echo >&2 "Processing " "$@"
+
+eval_cmd=("diff")
+for f in "$@"; do
+  eval_cmd+=("<(sed -e '/^FROM /d' \"$f\")")
+done
+
+eval "${eval_cmd[*]}"


### PR DESCRIPTION
**What this PR does / why we need it**:

ART machinery checks that the FROM images are consistent in the release payload. Since the Control Plane Operator does go in the release payload, the work I did to have the FROM image references be parametrized for Konflux, trips it up.

This PR separates the container files into:
- Containerfile.control-plane: For Konflux, using RH catalog/brew
- Dockerfile.control-plane: For ART/release-payload

To help developers avoid the situation where one changes one but not the other, this commit adds a git pre-commit hook that enforces the only differences to be in the "^FROM" lines.

In order to install this pre-commit hook, one can run:

    pipx install pre-commit
    pre-commit install

Then, any new commit that the developer attempts will have to conform to the new hook (and a couple more I added like no whitespace at the end).

**Which issue(s) this PR fixes**
Fixes #OCPBUGS-44326

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.