### PR TITLE
OCPBUGS-44910: openstack: don't reconcile image registry config during bootstrap

### DIFF
--- a/docs/content/how-to/openstack/create-openstack-cluster.md
+++ b/docs/content/how-to/openstack/create-openstack-cluster.md
@@ -12,7 +12,6 @@ Upon scaling up a NodePool, a Machine will be created, and the CAPI provider wil
 
 * Although the HyperShift Operator with OpenStack support is currently in development and is not intended for production use,
   it is possible to create and manage clusters for development and testing purposes and it's expected to work as described in this document.
-* OpenStack CSI (Cinder and Manila) are not functional yet but are [expected](https://issues.redhat.com/browse/OSASINFRA-3536) to work in the 4.18 release and fully supported in future releases.
 
 ## Prerequisites
 


### PR DESCRIPTION
**What this PR does / why we need it**:

For platforms where cluster-image-registry-operator (CIRO) needs a PVC to be created, bootstrap needs to happen
in CIRO before the registry config is created. For now, this is the case for the OpenStack platform.
If the object exist, we reconcile the registry config for other other fields as it should be fine since the PVC would
exist at this point.

This patch will maintain a list of platforms that require a PVC for CIRO
(OpenStack only for now), check whether an image registry config already
exist and if it does, skip reconcile to let CIRO bootstrap doing it and
creating the needed PVC for CIRO.
