### PR TITLE
OCPBUGS-44929: e2e: fix manila CSI operator

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1913,7 +1913,7 @@ func EnsureSATokenNotMountedUnlessNecessary(t *testing.T, ctx context.Context, c
 				"openstack-cinder-csi-driver-controller",
 				"openstack-cinder-csi-driver-operator",
 				"manila-csi-driver-controller",
-				"openstack-manila-csi-driver-operator",
+				"manila-csi-driver-operator",
 			)
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The name of the operator pod is `manila-csi-driver-operator`.
This will fix e2e for `e2e-openstack`.
