### PR TITLE
OCPBUGS-44957: Use fleet manager configmaps to determine placeholder pod node antiaffinity

### DIFF
--- a/hypershift-operator/controllers/scheduler/placeholders_test.go
+++ b/hypershift-operator/controllers/scheduler/placeholders_test.go
@@ -45,7 +45,7 @@ func TestPlaceholderCreator_Reconcile(t *testing.T) {
 		config *schedulingv1alpha1.ClusterSizingConfiguration
 
 		listDeployments func(context.Context, ...client.ListOption) (*appsv1.DeploymentList, error)
-		listNodes       func(context.Context, ...client.ListOption) (*corev1.NodeList, error)
+		listConfigMaps  func(context.Context, ...client.ListOption) (*corev1.ConfigMapList, error)
 
 		expected    *appsv1applyconfigurations.DeploymentApplyConfiguration
 		expectedErr bool
@@ -83,8 +83,8 @@ func TestPlaceholderCreator_Reconcile(t *testing.T) {
 			listDeployments: func(_ context.Context, _ ...client.ListOption) (*appsv1.DeploymentList, error) {
 				return &appsv1.DeploymentList{Items: []appsv1.Deployment{}}, nil
 			},
-			listNodes: func(_ context.Context, _ ...client.ListOption) (*corev1.NodeList, error) {
-				return &corev1.NodeList{Items: []corev1.Node{}}, nil
+			listConfigMaps: func(_ context.Context, _ ...client.ListOption) (*corev1.ConfigMapList, error) {
+				return &corev1.ConfigMapList{Items: []corev1.ConfigMap{}}, nil
 			},
 			expected: newDeployment(placeholderNamespace, "small", 0, []string{}),
 		},
@@ -103,8 +103,8 @@ func TestPlaceholderCreator_Reconcile(t *testing.T) {
 					{ObjectMeta: metav1.ObjectMeta{Name: "placeholder-small-0", Labels: map[string]string{"hypershift.openshift.io/hosted-cluster-size": "small"}}},
 				}}, nil
 			},
-			listNodes: func(_ context.Context, _ ...client.ListOption) (*corev1.NodeList, error) {
-				return &corev1.NodeList{Items: []corev1.Node{}}, nil
+			listConfigMaps: func(_ context.Context, _ ...client.ListOption) (*corev1.ConfigMapList, error) {
+				return &corev1.ConfigMapList{Items: []corev1.ConfigMap{}}, nil
 			},
 			expected: newDeployment(placeholderNamespace, "small", 1, []string{}),
 		},
@@ -123,8 +123,8 @@ func TestPlaceholderCreator_Reconcile(t *testing.T) {
 					{ObjectMeta: metav1.ObjectMeta{Name: "placeholder-small-1", Labels: map[string]string{"hypershift.openshift.io/hosted-cluster-size": "small"}}},
 				}}, nil
 			},
-			listNodes: func(_ context.Context, _ ...client.ListOption) (*corev1.NodeList, error) {
-				return &corev1.NodeList{Items: []corev1.Node{}}, nil
+			listConfigMaps: func(_ context.Context, _ ...client.ListOption) (*corev1.ConfigMapList, error) {
+				return &corev1.ConfigMapList{Items: []corev1.ConfigMap{}}, nil
 			},
 			expected: newDeployment(placeholderNamespace, "small", 0, []string{}),
 		},
@@ -144,8 +144,8 @@ func TestPlaceholderCreator_Reconcile(t *testing.T) {
 					{ObjectMeta: metav1.ObjectMeta{Name: "placeholder-small-1", Labels: map[string]string{"hypershift.openshift.io/hosted-cluster-size": "small"}}},
 				}}, nil
 			},
-			listNodes: func(_ context.Context, _ ...client.ListOption) (*corev1.NodeList, error) {
-				return &corev1.NodeList{Items: []corev1.Node{}}, nil
+			listConfigMaps: func(_ context.Context, _ ...client.ListOption) (*corev1.ConfigMapList, error) {
+				return &corev1.ConfigMapList{Items: []corev1.ConfigMap{}}, nil
 			},
 		},
 	} {
@@ -153,7 +153,7 @@ func TestPlaceholderCreator_Reconcile(t *testing.T) {
 			r := &placeholderCreator{
 				placeholderLister: &placeholderLister{
 					listDeployments: testCase.listDeployments,
-					listNodes:       testCase.listNodes,
+					listConfigMaps:  testCase.listConfigMaps,
 				},
 			}
 			action, err := r.reconcile(ctx, testCase.config)
@@ -185,7 +185,7 @@ func TestPlaceholderUpdater_Reconcile(t *testing.T) {
 		config     *schedulingv1alpha1.ClusterSizingConfiguration
 		deployment *appsv1.Deployment
 
-		listNodes func(context.Context, ...client.ListOption) (*corev1.NodeList, error)
+		listConfigMaps func(context.Context, ...client.ListOption) (*corev1.ConfigMapList, error)
 
 		delete      bool
 		expected    *appsv1applyconfigurations.DeploymentApplyConfiguration
@@ -324,12 +324,12 @@ func TestPlaceholderUpdater_Reconcile(t *testing.T) {
 				},
 				Status: validConfigStatus,
 			},
-			listNodes: func(_ context.Context, _ ...client.ListOption) (*corev1.NodeList, error) {
-				return &corev1.NodeList{Items: []corev1.Node{
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{OSDFleetManagerPairedNodesLabel: "first"}}},
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{OSDFleetManagerPairedNodesLabel: "first"}}},
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{OSDFleetManagerPairedNodesLabel: "second"}}},
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{OSDFleetManagerPairedNodesLabel: "second"}}},
+			listConfigMaps: func(_ context.Context, _ ...client.ListOption) (*corev1.ConfigMapList, error) {
+				return &corev1.ConfigMapList{Items: []corev1.ConfigMap{
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{pairLabelKey: "first"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{pairLabelKey: "first"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{pairLabelKey: "second"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{pairLabelKey: "second"}}},
 				}}, nil
 			},
 			expected: newDeployment(placeholderNamespace, "small", 1, []string{"first", "second"}),
@@ -372,12 +372,12 @@ func TestPlaceholderUpdater_Reconcile(t *testing.T) {
 				},
 				Status: validConfigStatus,
 			},
-			listNodes: func(_ context.Context, _ ...client.ListOption) (*corev1.NodeList, error) {
-				return &corev1.NodeList{Items: []corev1.Node{
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{OSDFleetManagerPairedNodesLabel: "first"}}},
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{OSDFleetManagerPairedNodesLabel: "first"}}},
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{OSDFleetManagerPairedNodesLabel: "second"}}},
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{OSDFleetManagerPairedNodesLabel: "second"}}},
+			listConfigMaps: func(_ context.Context, _ ...client.ListOption) (*corev1.ConfigMapList, error) {
+				return &corev1.ConfigMapList{Items: []corev1.ConfigMap{
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{pairLabelKey: "first"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{pairLabelKey: "first"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{pairLabelKey: "second"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{pairLabelKey: "second"}}},
 				}}, nil
 			},
 			expected: newDeployment(placeholderNamespace, "small", 1, []string{"first", "second"}),
@@ -420,12 +420,12 @@ func TestPlaceholderUpdater_Reconcile(t *testing.T) {
 				},
 				Status: validConfigStatus,
 			},
-			listNodes: func(_ context.Context, _ ...client.ListOption) (*corev1.NodeList, error) {
-				return &corev1.NodeList{Items: []corev1.Node{
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{OSDFleetManagerPairedNodesLabel: "first"}}},
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{OSDFleetManagerPairedNodesLabel: "first"}}},
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{OSDFleetManagerPairedNodesLabel: "second"}}},
-					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{OSDFleetManagerPairedNodesLabel: "second"}}},
+			listConfigMaps: func(_ context.Context, _ ...client.ListOption) (*corev1.ConfigMapList, error) {
+				return &corev1.ConfigMapList{Items: []corev1.ConfigMap{
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{pairLabelKey: "first"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{pairLabelKey: "first"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{pairLabelKey: "second"}}},
+					{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{pairLabelKey: "second"}}},
 				}}, nil
 			},
 		},
@@ -433,7 +433,7 @@ func TestPlaceholderUpdater_Reconcile(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			r := &placeholderUpdater{
 				placeholderLister: &placeholderLister{
-					listNodes: testCase.listNodes,
+					listConfigMaps: testCase.listConfigMaps,
 				},
 			}
 			shouldDelete, action, err := r.reconcile(ctx, testCase.deployment, testCase.config)


### PR DESCRIPTION
**What this PR does / why we need it**:
Before this commit, the placeholder controller looked at nodes with hosted cluster labels to determine which fleet manager labels it should exclude for placeholders. However, in the case when a hostedcluster control plane is cleaned up, but the HostedCluster CR itself has not been deleted due to the controlplane namespace not getting cleaned up, there are no longer any nodes with the hostedcluster label, but the hostedcluster is still associated with a particular pair label. Placeholder pods are not prevented from landing on nodes with this same pair label. These nodes cannot be used to allocate to a new HostedCluster because they are still associated with previous HostedCluster. This change modifies the placeholder controller to use the pair association configmaps in the placeholder namespace to determine which pair labels to avoid. This makes it consistent with the scheduler which also looks at the same configmaps to determine whether a fleetmanager pair label is available to use for a new cluster.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-44957](https://issues.redhat.com/browse/OCPBUGS-44957)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.