### PR TITLE
HOSTEDCP-2193: allow reuse of SP for e2e

### DIFF
--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -73,8 +73,8 @@ func bindCoreOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
 		flags.StringVar(&opts.KMSCertName, "kms-cert-name", opts.KMSCertName, "The backing certificate name related to the managed identity used in KMS to authenticate to Azure.")
 		flags.StringVar(&opts.KeyVaultInfo.KeyVaultName, "management-key-vault-name", opts.KeyVaultInfo.KeyVaultName, "The name of the management Azure Key Vault where the managed identity certificates are stored.")
 		flags.StringVar(&opts.KeyVaultInfo.KeyVaultTenantID, "management-key-vault-tenant-id", opts.KeyVaultInfo.KeyVaultTenantID, "The tenant ID of the management Azure Key Vault where the managed identity certificates are stored.")
-		flags.StringVar(&opts.MangedIdentitiesFile, "managed-identities-file", opts.MangedIdentitiesFile, "Path to a file containing the managed identities configuration in json format.")
 		flags.StringVar(&opts.DNSZoneRGName, "dns-zone-rg-name", opts.DNSZoneRGName, "The name of the resource group where the DNS Zone resides. This is needed for the ingress controller. This is just the name and not the full ID of the resource group.")
+		flags.StringVar(&opts.ManagedIdentitiesFile, "managed-identities-file", opts.ManagedIdentitiesFile, "Path to a file containing the managed identities configuration in json format.")
 	}
 }
 
@@ -99,8 +99,8 @@ type RawCreateOptions struct {
 	KMSCertName            string
 	TechPreviewEnabled     bool
 	KeyVaultInfo           ManagementKeyVaultInfo
-	MangedIdentitiesFile   string
 	DNSZoneRGName          string
+	ManagedIdentitiesFile  string
 
 	NodePoolOpts *azurenodepool.RawAzurePlatformCreateOptions
 }
@@ -145,15 +145,15 @@ func (o *RawCreateOptions) Validate(_ context.Context, _ *core.CreateOptions) (c
 			return nil, fmt.Errorf("flag --kms-client-id is required when using --kms-cert-name")
 		}
 
-		if o.KeyVaultInfo.KeyVaultName == "" && o.MangedIdentitiesFile == "" {
+		if o.KeyVaultInfo.KeyVaultName == "" && o.ManagedIdentitiesFile == "" {
 			return nil, fmt.Errorf("flag --management-key-vault-name is required")
 		}
 
-		if o.KeyVaultInfo.KeyVaultTenantID == "" && o.MangedIdentitiesFile == "" {
+		if o.KeyVaultInfo.KeyVaultTenantID == "" && o.ManagedIdentitiesFile == "" {
 			return nil, fmt.Errorf("flag --management-key-vault-tenant-id is required")
 		}
 
-		if o.MangedIdentitiesFile == "" && o.KeyVaultInfo.KeyVaultName == "" && o.KeyVaultInfo.KeyVaultTenantID == "" {
+		if o.ManagedIdentitiesFile == "" && o.KeyVaultInfo.KeyVaultName == "" && o.KeyVaultInfo.KeyVaultTenantID == "" {
 			return nil, fmt.Errorf("flag --managed-identities-file  or  ( --management-key-vault-name and --management-key-vault-tenant-id ) are required")
 		}
 	}
@@ -247,15 +247,6 @@ func (o *ValidatedCreateOptions) Complete(ctx context.Context, opts *core.Create
 		return nil, fmt.Errorf("failed to unmarshal --azure-creds file: %w", err)
 	}
 
-	if o.MangedIdentitiesFile != "" {
-		managedIdentitiesRaw, err := os.ReadFile(o.MangedIdentitiesFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read --managed-identities-file %s: %w", o.MangedIdentitiesFile, err)
-		}
-		if err := yaml.Unmarshal(managedIdentitiesRaw, &output.infra.ControlPlaneMIs.ControlPlane); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal --managed-identities-file: %w", err)
-		}
-	}
 	return output, nil
 }
 
@@ -541,8 +532,8 @@ func CreateInfraOptions(ctx context.Context, azureOpts *ValidatedCreateOptions, 
 		ManagedIdentityKeyVaultName:     azureOpts.KeyVaultInfo.KeyVaultName,
 		ManagedIdentityKeyVaultTenantID: azureOpts.KeyVaultInfo.KeyVaultTenantID,
 		TechPreviewEnabled:              azureOpts.TechPreviewEnabled,
-		ManagedIdentitiesFile:           azureOpts.MangedIdentitiesFile,
 		DNSZoneRG:                       azureOpts.DNSZoneRGName,
+		ManagedIdentitiesFile:           azureOpts.ManagedIdentitiesFile,
 	}, nil
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -109,6 +109,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackNodeImageName, "e2e.openstack-node-image-name", "", "The image name to use for OpenStack nodes")
 	flag.StringVar(&globalOpts.configurableClusterOptions.OpenStackNodeAvailabilityZone, "e2e.openstack-node-availability-zone", "", "The availability zone to use for OpenStack nodes")
 	flag.StringVar(&globalOpts.configurableClusterOptions.AzureCredentialsFile, "e2e.azure-credentials-file", "", "Path to an Azure credentials file")
+	flag.StringVar(&globalOpts.configurableClusterOptions.AzureManagedIdentitiesFile, "e2e.azure-managed-identities-file", "", "Path to an Azure managed identities file")
 	flag.StringVar(&globalOpts.configurableClusterOptions.ManagementKeyVaultName, "e2e.management-key-vault-name", "", "Name of the Azure Key Vault to use for Certificates")
 	flag.StringVar(&globalOpts.configurableClusterOptions.ManagementKeyVaultTenantId, "e2e.management-key-vault-tenant-id", "", "Tenant ID of the Azure Key Vault to use for Certificates")
 	flag.StringVar(&globalOpts.configurableClusterOptions.AzureLocation, "e2e.azure-location", "eastus", "The location to use for Azure")
@@ -439,6 +440,7 @@ type configurableClusterOptions struct {
 	AzureCredentialsFile          string
 	ManagementKeyVaultName        string
 	ManagementKeyVaultTenantId    string
+	AzureManagedIdentitiesFile    string
 	OpenStackCredentialsFile      string
 	OpenStackCACertFile           string
 	AzureLocation                 string
@@ -641,7 +643,11 @@ func (o *options) DefaultAzureOptions() azure.RawCreateOptions {
 		opts.KeyVaultInfo.KeyVaultTenantID = o.configurableClusterOptions.ManagementKeyVaultTenantId
 	}
 
-	if opts.KeyVaultInfo.KeyVaultName != "" && opts.KeyVaultInfo.KeyVaultTenantID != "" {
+	if o.configurableClusterOptions.AzureManagedIdentitiesFile != "" {
+		opts.ManagedIdentitiesFile = o.configurableClusterOptions.AzureManagedIdentitiesFile
+	}
+
+	if (opts.KeyVaultInfo.KeyVaultName != "" && opts.KeyVaultInfo.KeyVaultTenantID != "") || opts.ManagedIdentitiesFile != "" {
 		opts.TechPreviewEnabled = true
 	}
 

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -248,6 +248,11 @@ func destroyCluster(ctx context.Context, t *testing.T, hc *hyperv1.HostedCluster
 			CredentialsFile: createOpts.AzurePlatform.CredentialsFile,
 			Location:        createOpts.AzurePlatform.Location,
 		}
+
+		if createOpts.AzurePlatform.ManagedIdentitiesFile != "" {
+			opts.AzurePlatform.SkipServicePrincipalDeletion = true
+		}
+
 		return azure.DestroyCluster(ctx, opts)
 	case hyperv1.PowerVSPlatform:
 		opts.PowerVSPlatform = core.PowerVSPlatformDestroyOptions{


### PR DESCRIPTION

**What this PR does / why we need it**:
This or adds a flag that we can use while executing the e2e in ci. The addition of this flag will allow us to pass in precreated SP and certs along with keyvault information that will then be used to populate the control plane managed identities field in the HC.


**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.