### PR TITLE
OCPBUGS-45182: Disable openstack-manila-csi-controllerplugin crash detection in e2e

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -518,6 +518,11 @@ func EnsureNoCrashingPods(t *testing.T, ctx context.Context, client crclient.Cli
 				continue
 			}
 
+			// Temporary workaround for https://issues.redhat.com/browse/OCPBUGS-45182
+			if strings.HasPrefix(pod.Name, "openstack-manila-csi-controllerplugin-") {
+				continue
+			}
+
 			// Temporary workaround for https://issues.redhat.com/browse/CNV-40820
 			if strings.HasPrefix(pod.Name, "kubevirt-csi") {
 				continue


### PR DESCRIPTION
**What this PR does / why we need it**:

Whether it's on a Standalone OCP cluster or in a HostedCluster, we have a race condition
for Manila CSI with the NFS driver.
The result is openstack-manila-csi-controllerplugin crashes but eventually stabilizes after a restart.
We will solve the race condition.
For now we need to disable crash detection of openstack-manila-csi-controllerplugin to unblock the presubmit jobs.
