### PR TITLE
OCPBUGS-44967: Pass only the certificate name for CNO deployment

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -622,11 +622,20 @@ if [[ -n $sc ]]; then kubectl --kubeconfig $kc delete --ignore-not-found validat
 	// to use on the CNCC deployment.
 	if azureutil.IsAroHCP() {
 		dep.Spec.Template.Spec.Containers[0].Env = append(dep.Spec.Template.Spec.Containers[0].Env,
-			azureutil.CreateEnvVarsForAzureManagedIdentity(params.AzureClientID, params.AzureTenantID, params.AzureCertificateName)...)
-
-		dep.Spec.Template.Spec.Containers[0].Env = append(dep.Spec.Template.Spec.Containers[0].Env,
 			corev1.EnvVar{
-				Name:  "ARO_HCP_SECRET_PROVIDER_CLASS",
+				Name:  config.ManagedAzureClientIdEnvVarKey,
+				Value: params.AzureClientID,
+			},
+			corev1.EnvVar{
+				Name:  config.ManagedAzureTenantIdEnvVarKey,
+				Value: params.AzureTenantID,
+			},
+			corev1.EnvVar{
+				Name:  config.ManagedAzureCertificateNameEnvVarKey,
+				Value: params.AzureCertificateName,
+			},
+			corev1.EnvVar{
+				Name:  config.ManagedAzureSecretProviderClassEnvVarKey,
 				Value: config.ManagedAzureNetworkSecretStoreProviderClassName,
 			},
 		)

--- a/support/config/constants.go
+++ b/support/config/constants.go
@@ -61,13 +61,15 @@ const (
 	// management cluster's resource group in Azure.
 	AROHCPKeyVaultManagedIdentityClientID = "ARO_HCP_KEY_VAULT_USER_CLIENT_ID"
 
-	ManagedAzureClientIdEnvVarKey        = "ARO_HCP_MI_CLIENT_ID"
-	ManagedAzureTenantIdEnvVarKey        = "ARO_HCP_TENANT_ID"
-	ManagedAzureCertificatePathEnvVarKey = "ARO_HCP_CLIENT_CERTIFICATE_PATH"
-	ManagedAzureCertificateMountPath     = "/mnt/certs"
-	ManagedAzureCertificatePath          = "/mnt/certs/"
-	ManagedAzureSecretsStoreCSIDriver    = "secrets-store.csi.k8s.io"
-	ManagedAzureSecretProviderClass      = "secretProviderClass"
+	ManagedAzureClientIdEnvVarKey            = "ARO_HCP_MI_CLIENT_ID"
+	ManagedAzureTenantIdEnvVarKey            = "ARO_HCP_TENANT_ID"
+	ManagedAzureCertificatePathEnvVarKey     = "ARO_HCP_CLIENT_CERTIFICATE_PATH"
+	ManagedAzureCertificateNameEnvVarKey     = "ARO_HCP_CLIENT_CERTIFICATE_NAME"
+	ManagedAzureSecretProviderClassEnvVarKey = "ARO_HCP_SECRET_PROVIDER_CLASS"
+	ManagedAzureCertificateMountPath         = "/mnt/certs"
+	ManagedAzureCertificatePath              = "/mnt/certs/"
+	ManagedAzureSecretsStoreCSIDriver        = "secrets-store.csi.k8s.io"
+	ManagedAzureSecretProviderClass          = "secretProviderClass"
 
 	ManagedAzureCPOSecretProviderClassName                = "managed-azure-cpo"
 	ManagedAzureCPOSecretStoreVolumeName                  = "cpo-cert"


### PR DESCRIPTION
**What this PR does / why we need it**:
Pass only the certificate name for the CNO deployment for managed Azure.
CNO uses its own certificate path here, https://github.com/openshift/cluster-network-operator/blob/7736bfe37f1276f771fcef03077f6d840eb6b862/pkg/network/cloud_network.go#L23.
This is combined with the certificate name here, https://github.com/openshift/cluster-network-operator/blob/7736bfe37f1276f771fcef03077f6d840eb6b862/pkg/network/cloud_network.go#L111.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes OCPBUGS-44967

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.