### PR TITLE
OCPBUGS-42320: Prevent IgnitionServer from flooding the API server with patch requests

### DIFF
--- a/ignition-server/controllers/tokensecret_controller.go
+++ b/ignition-server/controllers/tokensecret_controller.go
@@ -249,12 +249,18 @@ func (r *TokenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	compressedConfig := tokenSecret.Data[TokenSecretConfigKey]
 	config, err := util.DecodeAndDecompress(compressedConfig)
 	if err != nil {
+		errWithFullMsg := fmt.Errorf("failed to decode and decompress config: %w", err)
+		if hasSameReasonAndMessage(tokenSecret, InvalidConfigReason, errWithFullMsg) {
+			return ctrl.Result{}, errWithFullMsg
+		}
+
 		patch := tokenSecret.DeepCopy()
 		patch.Data[TokenSecretReasonKey] = []byte(InvalidConfigReason)
-		patch.Data[TokenSecretMessageKey] = []byte(fmt.Sprintf("Failed to decode and decompress config: %s", err))
+		patch.Data[TokenSecretMessageKey] = []byte(errWithFullMsg.Error())
 		if err := r.Client.Patch(ctx, patch, client.MergeFrom(tokenSecret)); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to patch tokenSecret with payload content: %w", err)
 		}
+
 		return ctrl.Result{}, err
 	}
 
@@ -274,12 +280,20 @@ func (r *TokenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return payload, err
 	}()
 	if err != nil {
+		// This patch could flood the API server, so we should only do it when the reason or message is different from the current one.
+		// More info here: https://issues.redhat.com/browse/OCPBUGS-42320.
+		errWithFullMsg := fmt.Errorf("failed to generate payload: %w", err)
+		if hasSameReasonAndMessage(tokenSecret, InvalidConfigReason, errWithFullMsg) {
+			return ctrl.Result{}, errWithFullMsg
+		}
+
 		patch := tokenSecret.DeepCopy()
 		patch.Data[TokenSecretReasonKey] = []byte(InvalidConfigReason)
-		patch.Data[TokenSecretMessageKey] = []byte(fmt.Sprintf("Failed to generate payload: %s", err))
+		patch.Data[TokenSecretMessageKey] = []byte(errWithFullMsg.Error())
 		if err := r.Client.Patch(ctx, patch, client.MergeFrom(tokenSecret)); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to patch tokenSecret with payload content: %w", err)
 		}
+
 		return ctrl.Result{}, err
 	}
 
@@ -306,6 +320,10 @@ func (r *TokenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	return ctrl.Result{RequeueAfter: ttl/2 - durationDeref(timeLived)}, nil
+}
+
+func hasSameReasonAndMessage(tokenSecret *corev1.Secret, reason string, message error) bool {
+	return string(tokenSecret.Data[TokenSecretReasonKey]) == reason && string(tokenSecret.Data[TokenSecretMessageKey]) == message.Error()
 }
 
 // getTokenIDTimeLived returns the duration a from TokenSecretLastUpdatedTokenIDAnnotation til now.

--- a/ignition-server/controllers/tokensecret_controller_test.go
+++ b/ignition-server/controllers/tokensecret_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -80,7 +81,7 @@ func TestReconcile(t *testing.T) {
 
 				// Validate data for conditions
 				g.Expect(freshSecret.Data[TokenSecretReasonKey]).To(BeEquivalentTo(InvalidConfigReason))
-				g.Expect(freshSecret.Data[TokenSecretMessageKey]).To(BeEquivalentTo("Failed to decode and decompress config: could not initialize gzip reader: illegal base64 data at input byte 3"))
+				g.Expect(freshSecret.Data[TokenSecretMessageKey]).To(BeEquivalentTo("failed to decode and decompress config: could not initialize gzip reader: illegal base64 data at input byte 3"))
 			},
 		},
 		{
@@ -597,6 +598,85 @@ func TestProcessedExpiredToken(t *testing.T) {
 			}
 			err = r.Client.Get(context.Background(), client.ObjectKeyFromObject(secretToFetch), secretToFetch)
 			g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+	}
+}
+
+func TestHasSameReasonAndMessage(t *testing.T) {
+	testCases := []struct {
+		name     string
+		secret   *corev1.Secret
+		reason   string
+		message  error
+		expected bool
+	}{
+		{
+			name: "Reason and message match",
+			secret: &corev1.Secret{
+				Data: map[string][]byte{
+					TokenSecretReasonKey:  []byte("reason1"),
+					TokenSecretMessageKey: []byte("message1"),
+				},
+			},
+			reason:   "reason1",
+			message:  fmt.Errorf("message1"),
+			expected: true,
+		},
+		{
+			name: "Reason does not match",
+			secret: &corev1.Secret{
+				Data: map[string][]byte{
+					TokenSecretReasonKey:  []byte("reason1"),
+					TokenSecretMessageKey: []byte("message1"),
+				},
+			},
+			reason:   "reason2",
+			message:  fmt.Errorf("message1"),
+			expected: false,
+		},
+		{
+			name: "Message does not match",
+			secret: &corev1.Secret{
+				Data: map[string][]byte{
+					TokenSecretReasonKey:  []byte("reason1"),
+					TokenSecretMessageKey: []byte("message1"),
+				},
+			},
+			reason:   "reason1",
+			message:  fmt.Errorf("message2"),
+			expected: false,
+		},
+		{
+			name: "Both reason and message do not match",
+			secret: &corev1.Secret{
+				Data: map[string][]byte{
+					TokenSecretReasonKey:  []byte("reason1"),
+					TokenSecretMessageKey: []byte("message1"),
+				},
+			},
+			reason:   "reason2",
+			message:  fmt.Errorf("message2"),
+			expected: false,
+		},
+		{
+			name: "Reason and message are empty",
+			secret: &corev1.Secret{
+				Data: map[string][]byte{
+					TokenSecretReasonKey:  []byte(""),
+					TokenSecretMessageKey: []byte(""),
+				},
+			},
+			reason:   "",
+			message:  fmt.Errorf(""),
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result := hasSameReasonAndMessage(tc.secret, tc.reason, tc.message)
+			g.Expect(result).To(Equal(tc.expected))
 		})
 	}
 }


### PR DESCRIPTION
This patch addresses the issue of excessive patch attempts in a short period, which could overwhelm the KAS in the control plane.  A new safeguards have been implemented to prevent this scenario which involves a conditional check before executing patch commands that could potentially flood the API.  

**Which issue(s) this PR fixes**:
Fixes #[OCPBUGS-42320](https://issues.redhat.com/browse/OCPBUGS-42320)