### PR TITLE
NO-JIRA: e2e: followup cleanup for OpenStack Manila

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1198,7 +1198,6 @@ func EnsurePodsWithEmptyDirPVsHaveSafeToEvictAnnotations(t *testing.T, ctx conte
 			"redhat-operators-catalog":               "app",
 			"redhat-marketplace-catalog":             "app",
 			"openstack-cinder-csi-driver-controller": "app",
-			"manila-csi-driver-controller":           "app",
 			"openstack-manila-csi":                   "app",
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow-up cleanup.
