### PR TITLE
OCPBUGS-45355: CPO fails to reconcile the SecretProviderClass for Image Registry on ARO HCP

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/secretproviderclass.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/secretproviderclass.go
@@ -1,0 +1,15 @@
+package manifests
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	secretsstorev1 "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
+)
+
+func ManagedAzureSecretProviderClass(name, namespace string) *secretsstorev1.SecretProviderClass {
+	return &secretsstorev1.SecretProviderClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/metrics"
@@ -97,14 +98,17 @@ var (
 )
 
 type Params struct {
-	operatorImage    string
-	tokenMinterImage string
-	platform         hyperv1.PlatformType
-	issuerURL        string
-	releaseVersion   string
-	registryImage    string
-	prunerImage      string
-	deploymentConfig config.DeploymentConfig
+	operatorImage        string
+	tokenMinterImage     string
+	platform             hyperv1.PlatformType
+	issuerURL            string
+	releaseVersion       string
+	registryImage        string
+	prunerImage          string
+	deploymentConfig     config.DeploymentConfig
+	AzureClientID        string
+	AzureTenantID        string
+	AzureCertificateName string
 }
 
 func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProvider *imageprovider.ReleaseImageProvider, userReleaseImageProvider *imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) Params {
@@ -143,6 +147,12 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 			},
 		},
 	}
+
+	if azureutil.IsAroHCP() {
+		params.AzureClientID = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ImageRegistry.ClientID
+		params.AzureCertificateName = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ImageRegistry.CertificateName
+	}
+
 	params.deploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
 	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
 		params.deploymentConfig.Scheduling.PriorityClass = hcp.Annotations[hyperv1.ControlPlanePriorityClass]
@@ -191,6 +201,28 @@ func ReconcileDeployment(deployment *appsv1.Deployment, params Params) error {
 				Name:      volumeWebIdentityToken().Name,
 				MountPath: "/var/run/secrets/openshift/serviceaccount",
 			},
+		)
+	}
+	// For managed azure deployments, we pass environment variables so we authenticate with Azure API through certificate
+	// authentication. We also mount the SecretProviderClass for the Secrets Store CSI driver to use; it will grab the
+	// certificate related to the ARO_HCP_MI_CLIENT_ID and mount it as a volume in the ingress pod in the path,
+	// ARO_HCP_CLIENT_CERTIFICATE_PATH.
+	if azureutil.IsAroHCP() {
+		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env,
+			azureutil.CreateEnvVarsForAzureManagedIdentity(params.AzureClientID, params.AzureTenantID, params.AzureCertificateName)...)
+
+		if deployment.Spec.Template.Spec.Containers[0].VolumeMounts == nil {
+			deployment.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{}
+		}
+		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts,
+			azureutil.CreateVolumeMountForAzureSecretStoreProviderClass(config.ManagedAzureImageRegistrySecretStoreVolumeName),
+		)
+
+		if deployment.Spec.Template.Spec.Volumes == nil {
+			deployment.Spec.Template.Spec.Volumes = []corev1.Volume{}
+		}
+		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes,
+			azureutil.CreateVolumeForAzureSecretStoreProviderClass(config.ManagedAzureImageRegistrySecretStoreVolumeName, config.ManagedAzureImageRegistrySecretStoreProviderClassName),
 		)
 	}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/secretproviderclass/secretproviderclass.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/secretproviderclass/secretproviderclass.go
@@ -1,0 +1,44 @@
+package secretproviderclass
+
+import (
+	"fmt"
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/azureutil"
+
+	secretsstorev1 "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
+)
+
+const (
+	objectFormat = `
+array:
+  - |
+    objectName: %s
+    objectType: secret
+`
+)
+
+// ReconcileManagedAzureSecretProviderClass reconciles the Spec of a SecretProviderClass completed with its name, Azure
+// Key Vault setup, and the certificate name it needs to pull from the Key Vault.
+//
+// https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-identity-access?tabs=azure-portal&pivots=access-with-a-user-assigned-managed-identity
+func ReconcileManagedAzureSecretProviderClass(secretProviderClass *secretsstorev1.SecretProviderClass, hcp *hyperv1.HostedControlPlane, certName string) {
+	secretProviderClass.Spec = secretsstorev1.SecretProviderClassSpec{
+		Provider: "azure",
+		Parameters: map[string]string{
+			"usePodIdentity":         "false",
+			"useVMManagedIdentity":   "true",
+			"userAssignedIdentityID": azureutil.GetKeyVaultAuthorizedUser(),
+			"keyvaultName":           hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ManagedIdentitiesKeyVault.Name,
+			"tenantId":               hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ManagedIdentitiesKeyVault.TenantID,
+			"objects":                formatSecretProviderClassObject(certName),
+		},
+	}
+}
+
+// formatSecretProviderClassObject places the certificate name in the appropriate string structure the
+// SecretProviderClass expects for an object. More details here:
+// - https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-identity-access?tabs=azure-portal&pivots=access-with-a-user-assigned-managed-identity#configure-managed-identity
+// - https://secrets-store-csi-driver.sigs.k8s.io/concepts.html?highlight=object#custom-resource-definitions-crds
+func formatSecretProviderClassObject(certName string) string {
+	return fmt.Sprintf(objectFormat, certName)
+}

--- a/support/azureutil/azureutil.go
+++ b/support/azureutil/azureutil.go
@@ -217,3 +217,52 @@ func VerifyResourceGroupLocationsMatch(ctx context.Context, hc *hyperv1.HostedCl
 
 	return nil
 }
+
+// IsAroHCP returns true if the managed service environment variable is set to ARO-HCP
+func IsAroHCP() bool {
+	return os.Getenv("MANAGED_SERVICE") == hyperv1.AroHCP
+}
+
+func GetKeyVaultAuthorizedUser() string {
+	return os.Getenv(config.AROHCPKeyVaultManagedIdentityClientID)
+}
+
+func CreateEnvVarsForAzureManagedIdentity(azureClientID, azureTenantID, azureCertificateName string) []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name:  config.ManagedAzureClientIdEnvVarKey,
+			Value: azureClientID,
+		},
+		{
+			Name:  config.ManagedAzureTenantIdEnvVarKey,
+			Value: azureTenantID,
+		},
+		{
+			Name:  config.ManagedAzureCertificatePathEnvVarKey,
+			Value: config.ManagedAzureCertificatePath + azureCertificateName,
+		},
+	}
+}
+
+func CreateVolumeMountForAzureSecretStoreProviderClass(secretStoreVolumeName string) corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      secretStoreVolumeName,
+		MountPath: config.ManagedAzureCertificateMountPath,
+		ReadOnly:  true,
+	}
+}
+
+func CreateVolumeForAzureSecretStoreProviderClass(secretStoreVolumeName, secretProviderClassName string) corev1.Volume {
+	return corev1.Volume{
+		Name: secretStoreVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			CSI: &corev1.CSIVolumeSource{
+				Driver:   config.ManagedAzureSecretsStoreCSIDriver,
+				ReadOnly: ptr.To(true),
+				VolumeAttributes: map[string]string{
+					config.ManagedAzureSecretProviderClass: secretProviderClassName,
+				},
+			},
+		},
+	}
+}

--- a/support/config/constants.go
+++ b/support/config/constants.go
@@ -45,4 +45,39 @@ const (
 	EnableCVOManagementClusterMetricsAccessEnvVar = "ENABLE_CVO_MANAGEMENT_CLUSTER_METRICS_ACCESS"
 
 	AuditWebhookService = "audit-webhook"
+
+	// DefaultMachineNetwork is the default network CIDR for the machine network.
+	DefaultMachineNetwork = "10.0.0.0/16"
+)
+
+// Managed Azure Related Constants
+const (
+	// AROHCPKeyVaultManagedIdentityClientID captures the client ID of the managed identity created on an ARO HCP
+	// management cluster. This managed identity is used to pull secrets and certificates out of Azure Key Vaults in the
+	// management cluster's resource group in Azure.
+	AROHCPKeyVaultManagedIdentityClientID = "ARO_HCP_KEY_VAULT_USER_CLIENT_ID"
+
+	ManagedAzureClientIdEnvVarKey        = "ARO_HCP_MI_CLIENT_ID"
+	ManagedAzureTenantIdEnvVarKey        = "ARO_HCP_TENANT_ID"
+	ManagedAzureCertificatePathEnvVarKey = "ARO_HCP_CLIENT_CERTIFICATE_PATH"
+	ManagedAzureCertificateMountPath     = "/mnt/certs"
+	ManagedAzureCertificatePath          = "/mnt/certs/"
+	ManagedAzureSecretsStoreCSIDriver    = "secrets-store.csi.k8s.io"
+	ManagedAzureSecretProviderClass      = "secretProviderClass"
+
+	ManagedAzureCPOSecretProviderClassName                = "managed-azure-cpo"
+	ManagedAzureCPOSecretStoreVolumeName                  = "cpo-cert"
+	ManagedAzureCloudProviderSecretProviderClassName      = "managed-azure-cloud-provider"
+	ManagedAzureCloudProviderSecretStoreVolumeName        = "cloud-provider-cert"
+	ManagedAzureDiskCSISecretStoreProviderClassName       = "managed-azure-disk-csi"
+	ManagedAzureFileCSISecretStoreProviderClassName       = "managed-azure-file-csi"
+	ManagedAzureImageRegistrySecretStoreProviderClassName = "managed-azure-image-registry"
+	ManagedAzureImageRegistrySecretStoreVolumeName        = "image-registry-cert"
+	ManagedAzureIngressSecretStoreProviderClassName       = "managed-azure-ingress"
+	ManagedAzureIngressSecretStoreVolumeName              = "ingress-cert"
+	ManagedAzureKMSSecretProviderClassName                = "managed-azure-kms"
+	ManagedAzureKMSSecretStoreVolumeName                  = "kms-cert"
+	ManagedAzureNetworkSecretStoreProviderClassName       = "managed-azure-network"
+	ManagedAzureNodePoolMgmtSecretProviderClassName       = "managed-azure-nodepool-management"
+	ManagedAzureNodePoolMgmtSecretStoreVolumeName         = "nodepool-management-cert"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Reconcile the SecretProviderClass for the image registry operator for ARO HCP deployments. The SecretProviderClass is used by the Secrets Store CSI driver to mount a certificate to a volume in the image registry pod deployment.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes OCPBUGS-45355

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.