### PR TITLE
OCPBUGS-44236: Use system trust bundle in CPO IDP https client

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/idp_convert.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/idp_convert.go
@@ -685,7 +685,10 @@ func transportForCARef(ctx context.Context, kclient crclient.Client, namespace, 
 	transport := net.SetTransportDefaults(&http.Transport{
 		TLSClientConfig: &tls.Config{},
 	})
-	roots := x509.NewCertPool()
+	roots, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create system cert pool: %w", err)
+	}
 
 	if !skipKonnectivityDialer {
 		var err error

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/idp_convert_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/idp_convert_test.go
@@ -376,7 +376,8 @@ users:
 			g.Expect(gotURL).To(Equal(tc.expectedProxyRequestURL))
 
 			// Validate RootCAs expectations.
-			expectedCertPool := x509.NewCertPool()
+			expectedCertPool, err := x509.SystemCertPool()
+			g.Expect(err).ToNot(HaveOccurred())
 			if tc.hcp.Spec.Configuration != nil {
 				if tc.hcp.Spec.Configuration.Proxy.TrustedCA.Name != "" {
 					expectedCertPool.AppendCertsFromPEM([]byte(fakeProxyCertCADecoded))


### PR DESCRIPTION
**What this PR does / why we need it**:
Before this change, if a custom CA was configured for either the proxy or a particular IDP, the CPO client would get built with an empty bundle that only included the specified CAs but not the system trust bundle. This prevented connections to IDP endpoints with publicly trusted certificates. This changes the https client for IDP endpoins in the CPO to include the system trust bundle in the CAs it trusts.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-44236](https://issues.redhat.com/browse/OCPBUGS-44236)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.