### PR TITLE
HOSTEDCP-2203: Add support for public only AWS clusters

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -347,6 +347,10 @@ const (
 
 	// ControlPlaneOperatorV2EnvVar when set on the CPO deplyoment, enables the new manifest based CPO implementation.
 	ControlPlaneOperatorV2EnvVar = "CPO_V2"
+
+	// AWSMachinePublicIPs, if set to "true", results in an AWS machine template that creates machines with public IPs
+	// WARNING: This option is for development and testing purposes only
+	AWSMachinePublicIPs = "hypershift.openshift.io/aws-machine-public-ips"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -46,6 +46,7 @@ type RawCreateOptions struct {
 	VPCCIDR                      string
 	VPCOwnerCredentials          awsutil.AWSCredentialsOptions
 	PrivateZonesInClusterAccount bool
+	PublicOnly                   bool
 }
 
 // validatedCreateOptions is a private wrapper that enforces a call of Validate() before Complete() can be invoked.
@@ -306,6 +307,13 @@ func (o *CreateOptions) ApplyPlatformSpecifics(cluster *hyperv1.HostedCluster) e
 		}
 	}
 
+	if o.infra.PublicOnly {
+		if cluster.Annotations == nil {
+			cluster.Annotations = map[string]string{}
+		}
+		cluster.Annotations[hyperv1.AWSMachinePublicIPs] = "true"
+	}
+
 	return nil
 }
 
@@ -441,6 +449,7 @@ func CreateInfraOptions(awsOpts *ValidatedCreateOptions, opts *core.CreateOption
 		VPCCIDR:                      awsOpts.VPCCIDR,
 		VPCOwnerCredentialOpts:       awsOpts.VPCOwnerCredentials,
 		PrivateZonesInClusterAccount: awsOpts.PrivateZonesInClusterAccount,
+		PublicOnly:                   awsOpts.PublicOnly,
 	}
 }
 

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws_test.go
@@ -82,7 +82,7 @@ func TestReconcileAWSCluster(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := reconcileAWSCluster(tc.initialAWSCluster, tc.hostedCluster, hyperv1.APIEndpoint{}); err != nil {
+			if err := reconcileAWSCluster(tc.initialAWSCluster, tc.hostedCluster, hyperv1.APIEndpoint{}, nil); err != nil {
 				t.Fatalf("reconcileAWSCluster failed: %v", err)
 			}
 			if diff := cmp.Diff(tc.initialAWSCluster, tc.expectedAWSCluster); diff != "" {

--- a/hypershift-operator/controllers/nodepool/aws.go
+++ b/hypershift-operator/controllers/nodepool/aws.go
@@ -149,6 +149,9 @@ func awsMachineTemplateSpec(infraName string, hostedCluster *hyperv1.HostedClust
 			},
 		},
 	}
+	if hostedCluster.Annotations[hyperv1.AWSMachinePublicIPs] == "true" {
+		awsMachineTemplateSpec.Template.Spec.PublicIP = ptr.To(true)
+	}
 
 	return awsMachineTemplateSpec, nil
 }

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -347,6 +347,10 @@ const (
 
 	// ControlPlaneOperatorV2EnvVar when set on the CPO deplyoment, enables the new manifest based CPO implementation.
 	ControlPlaneOperatorV2EnvVar = "CPO_V2"
+
+	// AWSMachinePublicIPs, if set to "true", results in an AWS machine template that creates machines with public IPs
+	// WARNING: This option is for development and testing purposes only
+	AWSMachinePublicIPs = "hypershift.openshift.io/aws-machine-public-ips"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.


### PR DESCRIPTION


<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
Adds a new flag to create cluster aws and create infra aws that enables the creation of a HostedCluster that only uses public subnets for machines. Adds annotation to HostedCluster to indicate that we want machines to be created in a public subnet and get assigned a public IP.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-2203](https://issues.redhat.com/browse/HOSTEDCP-2203)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.