### PR TITLE
HOSTEDCP-2215: Expand pre-commit hooks to check on commit and push

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,6 @@ repos:
         stages: [pre-commit]
         args:
           - --markdown-linebreak-ext=md
-        exclude:  docs/content/reference/api.md
   - repo: local
     hooks:
       - id: make-codespell
@@ -34,4 +33,18 @@ repos:
           - Dockerfile.control-plane
         description: Ensures the CPO container files stay in sync
         stages: [pre-commit]
+      - id: make-verify
+        name: Run make verify
+        description: Runs `make verify`.
+        entry: make verify
+        language: system
+        stages: [pre-push]
+        require_serial: true
+      - id: make-test
+        name: Run make test
+        description: Runs `make test`.
+        entry: make test
+        language: system
+        stages: [ pre-push ]
 exclude: '^vendor/|^hack/tools/vendor/|^api/vendor/'
+fail_fast: true


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR expands upon our current pre-commit hooks:
- all hooks will either run in either the pre-commit stage or pre-push stage
- adds pre-push hooks to run `make verify`

With pre-commit hooks installed, it looks something like this:
```
% pre-commit run           
Check for merge conflict strings.....................Passed
Check yaml syntax....................................Passed
Trim all whitespace from end of lines................Passed
Verify codespell.....................................Passed
Keep cpo-containerfiles-in-sync......................Passed

% git push -f
Run make verify..........................................................Passed
Run make test............................................................Passed
Enumerating objects: 25, done.
...
```

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes [HOSTEDCP-2215](https://issues.redhat.com/browse/HOSTEDCP-2215)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.