### PR TITLE
HOSTEDCP-2206: Improve Unit Test Runtime

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
       - id: trailing-whitespace
         args:
           - --markdown-linebreak-ext=md
+        exclude:  docs/content/reference/api.md
   - repo: local
     hooks:
       - id: make-codespell

--- a/docs/content/contribute/index.md
+++ b/docs/content/contribute/index.md
@@ -8,21 +8,21 @@ Thanks for your interest in contributing to HyperShift. Here are some guidelines
 ## Prior to Submitting a Pull Request
 1. Prior to committing your code
    1. Install `precommit`. The HyperShift repo is set up to run `codespell` on your commits through `precommit`. Instructions for installing `precommit` can be found [here](https://pre-commit.com/#install).
-   2. Run `make pre-commit`. This updates all Golang and API dependencies, builds the source code, builds the e2e tests, verifies source code format, and runs all unit tests. This will help catch issues before committing so that the verify and unit test CI jobs will not fail on your PR. 
-2. Before submitting your pull request on GitHub, look at your changes and try to view them from the eyes of a reviewer. 
+   2. Run `make pre-commit`. This updates all Golang and API dependencies, builds the source code, builds the e2e tests, verifies source code format, and runs all unit tests. This will help catch issues before committing so that the verify and unit test CI jobs will not fail on your PR.
+2. Before submitting your pull request on GitHub, look at your changes and try to view them from the eyes of a reviewer.
     1. Try to find the aspects that might not immediately make sense for someone else and explain them in the pull request description.
-3. Keep commits/changes scoped to one thing and as minimal as possible. 
+3. Keep commits/changes scoped to one thing and as minimal as possible.
     1. Always keep refactorings (how we do something) separate from logic changes (what we do).
-    2. If you find additional things along the way that you feel should be improved, do that in a separate pull request. 
+    2. If you find additional things along the way that you feel should be improved, do that in a separate pull request.
     3. This helps ensure that you will get a timely review of your change, as a series of small pull requests is a lot easier to review than one big pull request that changes 10 independent things for independent reasons.
 4. Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit, e.g. `Mark infraID as required` instead of `This patch marks infraID as required`.
     1. This follows Git’s own built-in conventions; see [github.com/openshift/hypershift/pull/485](https://github.com/openshift/hypershift/pull/485) as an example.
 5. Make sure the "Why" and "How" are included in the message of each commit.
 
 ## Creating a Pull Request
-1. For small changes, you can just do the change and submit a pull request with it. 
-2. For bigger changes (more than 200 lines of code diff), do not just do the change but, ask for feedback on the idea and direction of the change first (Either in a GitHub issue or the #project-hypershift channel in the External Red Hat Slack). 
-    1. This avoids situations where big changes are submitted that are then declined or never reviewed, which is frustrating for everyone. 
+1. For small changes, you can just do the change and submit a pull request with it.
+2. For bigger changes (more than 200 lines of code diff), do not just do the change but, ask for feedback on the idea and direction of the change first (Either in a GitHub issue or the #project-hypershift channel in the External Red Hat Slack).
+    1. This avoids situations where big changes are submitted that are then declined or never reviewed, which is frustrating for everyone.
 3. Regardless of the size of the change, always explain how the change will improve the project.
 4. Every PR title must be prefixed with the Jira ticket that is addressing e.g. [https://github.com/openshift/hypershift/pull/2233](https://github.com/openshift/hypershift/pull/2233).
 5. This repository is the base code for the Hypershift Operator and the Control Plane Operator (belongs to the OCP payload) so they might have different release cadence.

--- a/docs/content/contribute/release-process.md
+++ b/docs/content/contribute/release-process.md
@@ -54,7 +54,7 @@ We need to add the latest supported version in the `hypershift` repository. We n
 
 - `support/supportedversion/version.go` which contains the variable called `LatestSupportedVersion`. This one contains, as you can imagine, the Latest supported version. We need to put the new version here.
 - `support/supportedversion/version_test.go` contains the tests for the to validate the Latest version. It should comply with the established contract to support 2 versions prior to the Latest.
- 
+
 [Example Supported Version Bump PR](https://github.com/openshift/hypershift/pull/5146/files)
 
 We also need to bump the base images in our Dockerfiles.
@@ -63,7 +63,7 @@ We also need to bump the base images in our Dockerfiles.
 
 ### [Openshift/Release](https://github.com/openshift/release) Repository
 
-The Step registry config should be updated by Test Platform. However, the Test Platform is not aware of custom configurations of the different version for specifc hypershift tests. 
+The Step registry config should be updated by Test Platform. However, the Test Platform is not aware of custom configurations of the different version for specific hypershift tests.
 So, we need to check over the Step registry config and make sure that the hypershift tests are correctly configured. Below is an example of the necessary changes to the Step registry config after test platform bumps:
 
 [Example Release Repo PR](https://github.com/openshift/release/pull/59120/files)

--- a/docs/content/how-to/agent/create-agent-cluster.md
+++ b/docs/content/how-to/agent/create-agent-cluster.md
@@ -155,7 +155,7 @@ export BASEDOMAIN="krnl.es"
 export PULL_SECRET_FILE=$PWD/pull-secret
 export OCP_RELEASE=4.11.5-x86_64
 export MACHINE_CIDR=192.168.122.0/24
-# Typically the namespace is created by the hypershift-operator 
+# Typically the namespace is created by the hypershift-operator
 # but agent cluster creation generates a capi-provider role that
 # needs the namespace to already exist
 oc create ns ${HOSTED_CONTROL_PLANE_NAMESPACE}
@@ -238,7 +238,7 @@ You can add Agents by manually configuring the machine to boot with the live ISO
 
 ### Manual
 
-The live ISO may be downloaded and used to boot a node (bare-metal or VM). 
+The live ISO may be downloaded and used to boot a node (bare-metal or VM).
 
 On boot, the node will communicate with the assisted-service and register as an Agent in the same namespace as the InfraEnv.
 
@@ -385,9 +385,9 @@ As you can see it was auto-approved. We will repeat this with another two nodes.
 oc -n ${HOSTED_CONTROL_PLANE_NAMESPACE} get agent
 
 NAME                                   CLUSTER   APPROVED   ROLE          STAGE
-4dac1ab2-7dd5-4894-a220-6a3473b67ee6             true       auto-assign   
-d9198891-39f4-4930-a679-65fb142b108b             true       auto-assign 
-da503cf1-a347-44f2-875c-4960ddb04091             true       auto-assign 
+4dac1ab2-7dd5-4894-a220-6a3473b67ee6             true       auto-assign  
+d9198891-39f4-4930-a679-65fb142b108b             true       auto-assign
+da503cf1-a347-44f2-875c-4960ddb04091             true       auto-assign
 ~~~
 
 ## Accessing the HostedCluster
@@ -427,8 +427,8 @@ The ClusterAPI Agent provider will pick two agents randomly that will get assign
 oc -n ${HOSTED_CONTROL_PLANE_NAMESPACE} get agent
 
 NAME                                   CLUSTER         APPROVED   ROLE          STAGE
-4dac1ab2-7dd5-4894-a220-6a3473b67ee6   hypercluster1   true       auto-assign   
-d9198891-39f4-4930-a679-65fb142b108b                   true       auto-assign   
+4dac1ab2-7dd5-4894-a220-6a3473b67ee6   hypercluster1   true       auto-assign  
+d9198891-39f4-4930-a679-65fb142b108b                   true       auto-assign  
 da503cf1-a347-44f2-875c-4960ddb04091   hypercluster1   true       auto-assign
 
 oc -n ${HOSTED_CONTROL_PLANE_NAMESPACE} get agent -o jsonpath='{range .items[*]}BMH: {@.metadata.labels.agent-install\.openshift\.io/bmh} Agent: {@.metadata.name} State: {@.status.debugInfo.state}{"\n"}{end}'
@@ -470,25 +470,25 @@ clusterversion.config.openshift.io/version             False       True         
 
 NAME                                                                           VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
 clusteroperator.config.openshift.io/console                                    4.11.5    False       False         False      11m     RouteHealthAvailable: failed to GET route (https://console-openshift-console.apps.hypercluster1.domain.com): Get "https://console-openshift-console.apps.hypercluster1.domain.com": dial tcp 10.19.3.29:443: connect: connection refused
-clusteroperator.config.openshift.io/csi-snapshot-controller                    4.11.5    True        False         False      10m     
-clusteroperator.config.openshift.io/dns                                        4.11.5    True        False         False      9m16s   
-clusteroperator.config.openshift.io/image-registry                             4.11.5    True        False         False      9m5s    
+clusteroperator.config.openshift.io/csi-snapshot-controller                    4.11.5    True        False         False      10m  
+clusteroperator.config.openshift.io/dns                                        4.11.5    True        False         False      9m16s  
+clusteroperator.config.openshift.io/image-registry                             4.11.5    True        False         False      9m5s  
 clusteroperator.config.openshift.io/ingress                                    4.11.5    True        False         True       39m     The "default" ingress controller reports Degraded=True: DegradedConditions: One or more other status conditions indicate a degraded state: CanaryChecksSucceeding=False (CanaryChecksRepetitiveFailures: Canary route checks for the default ingress controller are failing)
-clusteroperator.config.openshift.io/insights                                   4.11.5    True        False         False      11m     
-clusteroperator.config.openshift.io/kube-apiserver                             4.11.5    True        False         False      40m     
-clusteroperator.config.openshift.io/kube-controller-manager                    4.11.5    True        False         False      40m     
-clusteroperator.config.openshift.io/kube-scheduler                             4.11.5    True        False         False      40m     
-clusteroperator.config.openshift.io/kube-storage-version-migrator              4.11.5    True        False         False      10m     
-clusteroperator.config.openshift.io/monitoring                                 4.11.5    True        False         False      7m38s   
-clusteroperator.config.openshift.io/network                                    4.11.5    True        False         False      11m     
-clusteroperator.config.openshift.io/openshift-apiserver                        4.11.5    True        False         False      40m     
-clusteroperator.config.openshift.io/openshift-controller-manager               4.11.5    True        False         False      40m     
-clusteroperator.config.openshift.io/openshift-samples                          4.11.5    True        False         False      8m54s   
-clusteroperator.config.openshift.io/operator-lifecycle-manager                 4.11.5    True        False         False      40m     
-clusteroperator.config.openshift.io/operator-lifecycle-manager-catalog         4.11.5    True        False         False      40m     
-clusteroperator.config.openshift.io/operator-lifecycle-manager-packageserver   4.11.5    True        False         False      40m     
-clusteroperator.config.openshift.io/service-ca                                 4.11.5    True        False         False      11m     
-clusteroperator.config.openshift.io/storage                                    4.11.5    True        False         False      11m 
+clusteroperator.config.openshift.io/insights                                   4.11.5    True        False         False      11m  
+clusteroperator.config.openshift.io/kube-apiserver                             4.11.5    True        False         False      40m  
+clusteroperator.config.openshift.io/kube-controller-manager                    4.11.5    True        False         False      40m  
+clusteroperator.config.openshift.io/kube-scheduler                             4.11.5    True        False         False      40m  
+clusteroperator.config.openshift.io/kube-storage-version-migrator              4.11.5    True        False         False      10m  
+clusteroperator.config.openshift.io/monitoring                                 4.11.5    True        False         False      7m38s  
+clusteroperator.config.openshift.io/network                                    4.11.5    True        False         False      11m  
+clusteroperator.config.openshift.io/openshift-apiserver                        4.11.5    True        False         False      40m  
+clusteroperator.config.openshift.io/openshift-controller-manager               4.11.5    True        False         False      40m  
+clusteroperator.config.openshift.io/openshift-samples                          4.11.5    True        False         False      8m54s  
+clusteroperator.config.openshift.io/operator-lifecycle-manager                 4.11.5    True        False         False      40m  
+clusteroperator.config.openshift.io/operator-lifecycle-manager-catalog         4.11.5    True        False         False      40m  
+clusteroperator.config.openshift.io/operator-lifecycle-manager-packageserver   4.11.5    True        False         False      40m  
+clusteroperator.config.openshift.io/service-ca                                 4.11.5    True        False         False      11m  
+clusteroperator.config.openshift.io/storage                                    4.11.5    True        False         False      11m
 ~~~
 
 Let's fix the Ingress.
@@ -554,7 +554,7 @@ EOF
 
 #### Step 2 - Get the MetalLB Operator Configured
 
-We will create an `IPAddressPool` with a single IP address and L2Advertisement to advertise the LoadBalancer IPs provided by the `IPAddressPool` via L2. 
+We will create an `IPAddressPool` with a single IP address and L2Advertisement to advertise the LoadBalancer IPs provided by the `IPAddressPool` via L2.
 Since layer 2 mode relies on ARP and NDP, the IP address must be on the same subnet as the network used by the cluster nodes in order for the MetalLB to work.
 more information about metalLB configuration options is available [here](https://metallb.universe.tf/configuration/).
 > **WARN:** Change `INGRESS_IP` env var to match your environments addressing.
@@ -635,26 +635,26 @@ NAME                                         VERSION   AVAILABLE   PROGRESSING  
 clusterversion.config.openshift.io/version   4.11.5    True        False         3m32s   Cluster version is 4.11.5
 
 NAME                                                                           VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
-clusteroperator.config.openshift.io/console                                    4.11.5    True        False         False      3m50s   
-clusteroperator.config.openshift.io/csi-snapshot-controller                    4.11.5    True        False         False      25m     
-clusteroperator.config.openshift.io/dns                                        4.11.5    True        False         False      23m     
-clusteroperator.config.openshift.io/image-registry                             4.11.5    True        False         False      23m     
-clusteroperator.config.openshift.io/ingress                                    4.11.5    True        False         False      53m     
-clusteroperator.config.openshift.io/insights                                   4.11.5    True        False         False      25m     
-clusteroperator.config.openshift.io/kube-apiserver                             4.11.5    True        False         False      54m     
-clusteroperator.config.openshift.io/kube-controller-manager                    4.11.5    True        False         False      54m     
-clusteroperator.config.openshift.io/kube-scheduler                             4.11.5    True        False         False      54m     
-clusteroperator.config.openshift.io/kube-storage-version-migrator              4.11.5    True        False         False      25m     
-clusteroperator.config.openshift.io/monitoring                                 4.11.5    True        False         False      21m     
-clusteroperator.config.openshift.io/network                                    4.11.5    True        False         False      25m     
-clusteroperator.config.openshift.io/openshift-apiserver                        4.11.5    True        False         False      54m     
-clusteroperator.config.openshift.io/openshift-controller-manager               4.11.5    True        False         False      54m     
-clusteroperator.config.openshift.io/openshift-samples                          4.11.5    True        False         False      23m     
-clusteroperator.config.openshift.io/operator-lifecycle-manager                 4.11.5    True        False         False      54m     
-clusteroperator.config.openshift.io/operator-lifecycle-manager-catalog         4.11.5    True        False         False      54m     
-clusteroperator.config.openshift.io/operator-lifecycle-manager-packageserver   4.11.5    True        False         False      54m     
-clusteroperator.config.openshift.io/service-ca                                 4.11.5    True        False         False      25m     
-clusteroperator.config.openshift.io/storage                                    4.11.5    True        False         False      25m     
+clusteroperator.config.openshift.io/console                                    4.11.5    True        False         False      3m50s  
+clusteroperator.config.openshift.io/csi-snapshot-controller                    4.11.5    True        False         False      25m  
+clusteroperator.config.openshift.io/dns                                        4.11.5    True        False         False      23m  
+clusteroperator.config.openshift.io/image-registry                             4.11.5    True        False         False      23m  
+clusteroperator.config.openshift.io/ingress                                    4.11.5    True        False         False      53m  
+clusteroperator.config.openshift.io/insights                                   4.11.5    True        False         False      25m  
+clusteroperator.config.openshift.io/kube-apiserver                             4.11.5    True        False         False      54m  
+clusteroperator.config.openshift.io/kube-controller-manager                    4.11.5    True        False         False      54m  
+clusteroperator.config.openshift.io/kube-scheduler                             4.11.5    True        False         False      54m  
+clusteroperator.config.openshift.io/kube-storage-version-migrator              4.11.5    True        False         False      25m  
+clusteroperator.config.openshift.io/monitoring                                 4.11.5    True        False         False      21m  
+clusteroperator.config.openshift.io/network                                    4.11.5    True        False         False      25m  
+clusteroperator.config.openshift.io/openshift-apiserver                        4.11.5    True        False         False      54m  
+clusteroperator.config.openshift.io/openshift-controller-manager               4.11.5    True        False         False      54m  
+clusteroperator.config.openshift.io/openshift-samples                          4.11.5    True        False         False      23m  
+clusteroperator.config.openshift.io/operator-lifecycle-manager                 4.11.5    True        False         False      54m  
+clusteroperator.config.openshift.io/operator-lifecycle-manager-catalog         4.11.5    True        False         False      54m  
+clusteroperator.config.openshift.io/operator-lifecycle-manager-packageserver   4.11.5    True        False         False      54m  
+clusteroperator.config.openshift.io/service-ca                                 4.11.5    True        False         False      25m  
+clusteroperator.config.openshift.io/storage                                    4.11.5    True        False         False      25m  
 ~~~
 
 ## Enabling Node Auto-Scaling for the Hosted Cluster

--- a/docs/content/how-to/automated-machine-management/scale-to-zero-dataplane.md
+++ b/docs/content/how-to/automated-machine-management/scale-to-zero-dataplane.md
@@ -57,7 +57,7 @@ function annotate_nodes() {
         echo "HC Namespace: ${HC_CLUSTER_NS}"
         echo "HC Clusted Name: ${HC_CLUSTER_NAME}"
         exit 1
-    fi 
+    fi
 
     echo "Annotating Nodes to avoid Draining"
     oc annotate -n ${HC_CLUSTER_NS}-${HC_CLUSTER_NAME} machines --all "machine.cluster.x-k8s.io/exclude-node-draining="

--- a/docs/content/how-to/aws/shared-vpc.md
+++ b/docs/content/how-to/aws/shared-vpc.md
@@ -10,7 +10,7 @@ AWS allows [sharing a VPC's subnets](https://docs.aws.amazon.com/vpc/latest/user
 This enables a use case where network management can be done in a single AWS account, while workloads such as OpenShift clusters exist
 in a separate, satellite account.
 
-Creating a standalone OCP cluster is already [supported in ROSA classic](https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa-shared-vpc-config.html). 
+Creating a standalone OCP cluster is already [supported in ROSA classic](https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa-shared-vpc-config.html).
 
 In hosted clusters, the shared VPC architecture is very similar to standalone OCP. However, hosted clusters require some new resources to be created.
 

--- a/docs/content/how-to/kubevirt/configuring-storage.md
+++ b/docs/content/how-to/kubevirt/configuring-storage.md
@@ -43,7 +43,7 @@ to live migrate and be portable across infra nodes.
 Below is a chart that outlines the current features of KubeVirt CSI as they map
 to the infra cluster's storage class.
 
-| Infra CSI Capability  | Guest CSI Capability               | VM Live Migration Support | Notes                                           | 
+| Infra CSI Capability  | Guest CSI Capability               | VM Live Migration Support | Notes                                           |
 |-----------------------|------------------------------------|---------------------------|-------------------------------------------------|
 | RWX Block             | RWO (Block/Filesystem) RWX (Block) | Supported                 |                                                 |
 | RWO Block             | RWO (Block/Filesystem)             | Not Supported             |                                                 |
@@ -104,7 +104,7 @@ mapping that was configured during cluster creation.
 KubeVirt CSI permits infra VolumeSnapshotClasses to be exposed to the guest
 cluster. Since VolumeSnapshotClasses are tied to a particular provisioner the
 mapping between VolumeSnapshotClasses and StorageClasses needs to expressed to
-hypershift during guest cluster creation. using the `hcp` cli tool and the 
+hypershift during guest cluster creation. using the `hcp` cli tool and the
 `--infra-volumesnapshot-class-mapping` cli argument.
 
 Below is an example of a simple setup with a single infra storage class and a
@@ -128,9 +128,9 @@ hcp create cluster kubevirt \
 --infra-volumesnapshot-class-mapping=infra-vsc1/guest-vsc1
 ```
 
-If you omit the `--infra-storage-class-mapping` and the 
-`--infra-volumesnapshot-class-mapping`. The system will use the default 
-storage class and the default volume snapshot class in the infra cluster. If 
+If you omit the `--infra-storage-class-mapping` and the
+`--infra-volumesnapshot-class-mapping`. The system will use the default
+storage class and the default volume snapshot class in the infra cluster. If
 the default is not set, then the snapshot functionality will not work and the
 snapshot request will never reach ready state. This is because it not possible
 to create a correct snapshot in the infra cluster.
@@ -167,7 +167,7 @@ hcp create cluster kubevirt \
 ```
 
 Since both storage class `infra-sca` and volume snapshot class `infra-vsca`
-are in the same group, this indicates to KubeVirt CSI that they are 
+are in the same group, this indicates to KubeVirt CSI that they are
 compatible and be used to create snapshots of volumes from storage class
 `guest-sca` using the guest volume snapshot class `guest-vsca`. The same
 is true with with the `b` grouping as well. Since `infra-scc` is also in
@@ -178,7 +178,7 @@ snapshot of volumes that use storage class `guest-sca`
 !!! note
 
    KubeVirt CSI passes snapshot requests to the underlying infra. This means
-   that snapshots will only work for compatible volumes. Please ensure the 
+   that snapshots will only work for compatible volumes. Please ensure the
    proper mapping is configured before attempting to create a snapshot in the
    guest cluster.
 

--- a/docs/content/how-to/kubevirt/create-kubevirt-cluster.md
+++ b/docs/content/how-to/kubevirt/create-kubevirt-cluster.md
@@ -33,7 +33,7 @@ places the cli tool within the /usr/local/bin directory.
 !!! note
 
     The command below is the same if you use docker.
-  
+
 ```shell
 podman run --rm --privileged -it -v \
 $PWD:/output docker.io/library/golang:1.20 /bin/bash -c \
@@ -245,7 +245,7 @@ namespace:
 oc get nodepools --namespace clusters
 
 NAME                      CLUSTER         DESIRED NODES   CURRENT NODES   AUTOSCALING   AUTOREPAIR   VERSION   UPDATINGVERSION   UPDATINGCONFIG   MESSAGE
-example                   example         5               5               False         False        4.14.0                                       
+example                   example         5               5               False         False        4.14.0  
 example-extra-cpu         example         2                               False         False                  True              True             Minimum availability requires 2 replicas, current 0 available
 ```
 
@@ -270,7 +270,7 @@ And the nodepool will be in the desired state:
 oc get nodepools --namespace clusters
 
 NAME                      CLUSTER         DESIRED NODES   CURRENT NODES   AUTOSCALING   AUTOREPAIR   VERSION   UPDATINGVERSION   UPDATINGCONFIG   MESSAGE
-example                   example         5               5               False         False        4.14.0                                       
+example                   example         5               5               False         False        4.14.0  
 example-extra-cpu         example         2               2               False         False        4.14.0  
 ```
 

--- a/docs/content/how-to/powervs/create-cluster-powervs.md
+++ b/docs/content/how-to/powervs/create-cluster-powervs.md
@@ -22,7 +22,7 @@ Use the `hypershift create cluster powervs` command:
     RESOURCE_GROUP=ibm-hypershift-dev
     RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release:4.12.0-0.nightly-multi-2022-09-08-131900
     PULL_SECRET="$HOME/pull-secret"
-    
+
     ./bin/hypershift create cluster powervs \
         --name $CLUSTER_NAME \
         --region $REGION \
@@ -44,7 +44,7 @@ where
 * RESOURCE_GROUP is the resource group in IBM Cloud where your infrastructure resources will be created.
 * RELEASE_IMAGE is the latest multi arch release image.
 * PULL_SECRET is a file that contains a valid OpenShift pull secret.
-* node-pool-replicas is worker node count 
+* node-pool-replicas is worker node count
 
 Running this command will create [infra](create-infra-separately.md) and manifests for the hosted cluster and deploys it.
 

--- a/docs/content/how-to/powervs/create-infra-separately.md
+++ b/docs/content/how-to/powervs/create-infra-separately.md
@@ -5,12 +5,12 @@ title: Create PowerVS Infra resources separately
 # Create IBMCloud PowerVS Infra resources separately
 
 The default behavior of the `hypershift create cluster powervs` command is to create cloud infrastructure
-along with the manifests for hosted cluster and apply it. 
+along with the manifests for hosted cluster and apply it.
 
 It is possible to create the cloud infrastructure separately so that the `hypershift create cluster powervs` command can just be used to create the manifests and apply it.
 
 In order to do this, you need to:
-1. [Create PowerVS infrastructure](#creating-the-powervs-infra) 
+1. [Create PowerVS infrastructure](#creating-the-powervs-infra)
 2. [Create cluster](#creating-the-cluster)
 
 ## Creating the PowerVS infra
@@ -54,7 +54,7 @@ where
 
 Running this command should result in the following resources getting created in IBM Cloud:
 
-### PowerVS Cluster Infra Resources 
+### PowerVS Cluster Infra Resources
 
 * 1 VPC with Subnet
 * 1 PowerVS Cloud Instance
@@ -79,7 +79,7 @@ E.g.:
     RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release:4.12.0-0.nightly-multi-2022-09-08-131900
     PULL_SECRET="$HOME/pull-secret"
     INFRA_JSON=infra.json
-    
+
     ./bin/hypershift create cluster powervs \
         --name $CLUSTER_NAME \
         --region $REGION \

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1655,7 +1655,7 @@ addition to any security groups specified in the NodePool.</p>
 ###AWSResourceReference { #hypershift.openshift.io/v1beta1.AWSResourceReference }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.AWSCloudProviderConfig">AWSCloudProviderConfig</a>, 
+<a href="#hypershift.openshift.io/v1beta1.AWSCloudProviderConfig">AWSCloudProviderConfig</a>,
 <a href="#hypershift.openshift.io/v1beta1.AWSNodePoolPlatform">AWSNodePoolPlatform</a>)
 </p>
 <p>
@@ -1704,7 +1704,7 @@ They are applied according to the rules defined by the AWS API:
 ###AWSResourceTag { #hypershift.openshift.io/v1beta1.AWSResourceTag }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.AWSNodePoolPlatform">AWSNodePoolPlatform</a>, 
+<a href="#hypershift.openshift.io/v1beta1.AWSNodePoolPlatform">AWSNodePoolPlatform</a>,
 <a href="#hypershift.openshift.io/v1beta1.AWSPlatformSpec">AWSPlatformSpec</a>)
 </p>
 <p>
@@ -2572,7 +2572,7 @@ string
 ###AvailabilityPolicy { #hypershift.openshift.io/v1beta1.AvailabilityPolicy }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -3398,7 +3398,7 @@ Valid values are ImageID and AzureMarketplace.</p>
 ###ClusterAutoscaling { #hypershift.openshift.io/v1beta1.ClusterAutoscaling }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -3476,7 +3476,7 @@ resources available. The default is -10.</p>
 ###ClusterConfiguration { #hypershift.openshift.io/v1beta1.ClusterConfiguration }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -3701,7 +3701,7 @@ field is not used by the plugin, it can be left unset.</p>
 ###ClusterNetworking { #hypershift.openshift.io/v1beta1.ClusterNetworking }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -3806,7 +3806,7 @@ how the APIServer is exposed inside a hosted cluster node.</p>
 ###ClusterVersionStatus { #hypershift.openshift.io/v1beta1.ClusterVersionStatus }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterStatus">HostedClusterStatus</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterStatus">HostedClusterStatus</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneStatus">HostedControlPlaneStatus</a>)
 </p>
 <p>
@@ -4450,7 +4450,7 @@ ManagedIdentity
 ###DNSSpec { #hypershift.openshift.io/v1beta1.DNSSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -4600,7 +4600,7 @@ and the user is responsible for doing so.</p>
 ###EtcdSpec { #hypershift.openshift.io/v1beta1.EtcdSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -4739,8 +4739,8 @@ string
 ###FilterByNeutronTags { #hypershift.openshift.io/v1beta1.FilterByNeutronTags }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.NetworkFilter">NetworkFilter</a>, 
-<a href="#hypershift.openshift.io/v1beta1.RouterFilter">RouterFilter</a>, 
+<a href="#hypershift.openshift.io/v1beta1.NetworkFilter">NetworkFilter</a>,
+<a href="#hypershift.openshift.io/v1beta1.RouterFilter">RouterFilter</a>,
 <a href="#hypershift.openshift.io/v1beta1.SubnetFilter">SubnetFilter</a>)
 </p>
 <p>
@@ -6372,7 +6372,7 @@ call IBM Cloud KMS APIs</p>
 ###IBMCloudPlatformSpec { #hypershift.openshift.io/v1beta1.IBMCloudPlatformSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.NodePoolPlatform">NodePoolPlatform</a>, 
+<a href="#hypershift.openshift.io/v1beta1.NodePoolPlatform">NodePoolPlatform</a>,
 <a href="#hypershift.openshift.io/v1beta1.PlatformSpec">PlatformSpec</a>)
 </p>
 <p>
@@ -6404,7 +6404,7 @@ github.com/openshift/api/config/v1.IBMCloudProviderType
 ###ImageContentSource { #hypershift.openshift.io/v1beta1.ImageContentSource }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -7096,7 +7096,7 @@ Value of Filesystem is implied when not included in claim spec.</p>
 ###KubevirtPlatformCredentials { #hypershift.openshift.io/v1beta1.KubevirtPlatformCredentials }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.KubeVirtNodePoolStatus">KubeVirtNodePoolStatus</a>, 
+<a href="#hypershift.openshift.io/v1beta1.KubeVirtNodePoolStatus">KubeVirtNodePoolStatus</a>,
 <a href="#hypershift.openshift.io/v1beta1.KubevirtPlatformSpec">KubevirtPlatformSpec</a>)
 </p>
 <p>
@@ -7761,7 +7761,7 @@ is empty.</p>
 ###ManagedIdentity { #hypershift.openshift.io/v1beta1.ManagedIdentity }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.AzureKMSSpec">AzureKMSSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.AzureKMSSpec">AzureKMSSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.ControlPlaneManagedIdentities">ControlPlaneManagedIdentities</a>)
 </p>
 <p>
@@ -7895,7 +7895,7 @@ FilterByNeutronTags
 ###NetworkParam { #hypershift.openshift.io/v1beta1.NetworkParam }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.OpenStackPlatformSpec">OpenStackPlatformSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.OpenStackPlatformSpec">OpenStackPlatformSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.PortSpec">PortSpec</a>)
 </p>
 <p>
@@ -8724,7 +8724,7 @@ assigned when the service is created.</p>
 ###OLMCatalogPlacement { #hypershift.openshift.io/v1beta1.OLMCatalogPlacement }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -9160,7 +9160,7 @@ host: NodePool instances run on user&rsquo;s pre-allocated dedicated hosts.</p>
 ###PlatformSpec { #hypershift.openshift.io/v1beta1.PlatformSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -9290,7 +9290,7 @@ OpenStackPlatformSpec
 ###PlatformStatus { #hypershift.openshift.io/v1beta1.PlatformStatus }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterStatus">HostedClusterStatus</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterStatus">HostedClusterStatus</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneStatus">HostedControlPlaneStatus</a>)
 </p>
 <p>
@@ -9322,7 +9322,7 @@ AWSPlatformStatus
 ###PlatformType { #hypershift.openshift.io/v1beta1.PlatformType }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.NodePoolPlatform">NodePoolPlatform</a>, 
+<a href="#hypershift.openshift.io/v1beta1.NodePoolPlatform">NodePoolPlatform</a>,
 <a href="#hypershift.openshift.io/v1beta1.PlatformSpec">PlatformSpec</a>)
 </p>
 <p>
@@ -9883,7 +9883,7 @@ credentials for image registry operator to get authenticated with ibm cloud.</p>
 ###PowerVSResourceReference { #hypershift.openshift.io/v1beta1.PowerVSResourceReference }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.PowerVSNodePoolPlatform">PowerVSNodePoolPlatform</a>, 
+<a href="#hypershift.openshift.io/v1beta1.PowerVSNodePoolPlatform">PowerVSNodePoolPlatform</a>,
 <a href="#hypershift.openshift.io/v1beta1.PowerVSPlatformSpec">PowerVSPlatformSpec</a>)
 </p>
 <p>
@@ -10027,7 +10027,7 @@ This field is immutable. Once set, It can&rsquo;t be changed.</p>
 ###Release { #hypershift.openshift.io/v1beta1.Release }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.NodePoolSpec">NodePoolSpec</a>)
 </p>
 <p>
@@ -10321,7 +10321,7 @@ RouterFilter
 ###SecretEncryptionSpec { #hypershift.openshift.io/v1beta1.SecretEncryptionSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -10510,7 +10510,7 @@ The specifics of the setup are platform dependent.</p>
 ###ServicePublishingStrategyMapping { #hypershift.openshift.io/v1beta1.ServicePublishingStrategyMapping }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1655,7 +1655,7 @@ addition to any security groups specified in the NodePool.</p>
 ###AWSResourceReference { #hypershift.openshift.io/v1beta1.AWSResourceReference }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.AWSCloudProviderConfig">AWSCloudProviderConfig</a>,
+<a href="#hypershift.openshift.io/v1beta1.AWSCloudProviderConfig">AWSCloudProviderConfig</a>, 
 <a href="#hypershift.openshift.io/v1beta1.AWSNodePoolPlatform">AWSNodePoolPlatform</a>)
 </p>
 <p>
@@ -1704,7 +1704,7 @@ They are applied according to the rules defined by the AWS API:
 ###AWSResourceTag { #hypershift.openshift.io/v1beta1.AWSResourceTag }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.AWSNodePoolPlatform">AWSNodePoolPlatform</a>,
+<a href="#hypershift.openshift.io/v1beta1.AWSNodePoolPlatform">AWSNodePoolPlatform</a>, 
 <a href="#hypershift.openshift.io/v1beta1.AWSPlatformSpec">AWSPlatformSpec</a>)
 </p>
 <p>
@@ -2572,7 +2572,7 @@ string
 ###AvailabilityPolicy { #hypershift.openshift.io/v1beta1.AvailabilityPolicy }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -3398,7 +3398,7 @@ Valid values are ImageID and AzureMarketplace.</p>
 ###ClusterAutoscaling { #hypershift.openshift.io/v1beta1.ClusterAutoscaling }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -3476,7 +3476,7 @@ resources available. The default is -10.</p>
 ###ClusterConfiguration { #hypershift.openshift.io/v1beta1.ClusterConfiguration }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -3701,7 +3701,7 @@ field is not used by the plugin, it can be left unset.</p>
 ###ClusterNetworking { #hypershift.openshift.io/v1beta1.ClusterNetworking }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -3806,7 +3806,7 @@ how the APIServer is exposed inside a hosted cluster node.</p>
 ###ClusterVersionStatus { #hypershift.openshift.io/v1beta1.ClusterVersionStatus }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterStatus">HostedClusterStatus</a>,
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterStatus">HostedClusterStatus</a>, 
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneStatus">HostedControlPlaneStatus</a>)
 </p>
 <p>
@@ -4450,7 +4450,7 @@ ManagedIdentity
 ###DNSSpec { #hypershift.openshift.io/v1beta1.DNSSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -4600,7 +4600,7 @@ and the user is responsible for doing so.</p>
 ###EtcdSpec { #hypershift.openshift.io/v1beta1.EtcdSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -4739,8 +4739,8 @@ string
 ###FilterByNeutronTags { #hypershift.openshift.io/v1beta1.FilterByNeutronTags }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.NetworkFilter">NetworkFilter</a>,
-<a href="#hypershift.openshift.io/v1beta1.RouterFilter">RouterFilter</a>,
+<a href="#hypershift.openshift.io/v1beta1.NetworkFilter">NetworkFilter</a>, 
+<a href="#hypershift.openshift.io/v1beta1.RouterFilter">RouterFilter</a>, 
 <a href="#hypershift.openshift.io/v1beta1.SubnetFilter">SubnetFilter</a>)
 </p>
 <p>
@@ -6372,7 +6372,7 @@ call IBM Cloud KMS APIs</p>
 ###IBMCloudPlatformSpec { #hypershift.openshift.io/v1beta1.IBMCloudPlatformSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.NodePoolPlatform">NodePoolPlatform</a>,
+<a href="#hypershift.openshift.io/v1beta1.NodePoolPlatform">NodePoolPlatform</a>, 
 <a href="#hypershift.openshift.io/v1beta1.PlatformSpec">PlatformSpec</a>)
 </p>
 <p>
@@ -6404,7 +6404,7 @@ github.com/openshift/api/config/v1.IBMCloudProviderType
 ###ImageContentSource { #hypershift.openshift.io/v1beta1.ImageContentSource }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -7096,7 +7096,7 @@ Value of Filesystem is implied when not included in claim spec.</p>
 ###KubevirtPlatformCredentials { #hypershift.openshift.io/v1beta1.KubevirtPlatformCredentials }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.KubeVirtNodePoolStatus">KubeVirtNodePoolStatus</a>,
+<a href="#hypershift.openshift.io/v1beta1.KubeVirtNodePoolStatus">KubeVirtNodePoolStatus</a>, 
 <a href="#hypershift.openshift.io/v1beta1.KubevirtPlatformSpec">KubevirtPlatformSpec</a>)
 </p>
 <p>
@@ -7761,7 +7761,7 @@ is empty.</p>
 ###ManagedIdentity { #hypershift.openshift.io/v1beta1.ManagedIdentity }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.AzureKMSSpec">AzureKMSSpec</a>,
+<a href="#hypershift.openshift.io/v1beta1.AzureKMSSpec">AzureKMSSpec</a>, 
 <a href="#hypershift.openshift.io/v1beta1.ControlPlaneManagedIdentities">ControlPlaneManagedIdentities</a>)
 </p>
 <p>
@@ -7895,7 +7895,7 @@ FilterByNeutronTags
 ###NetworkParam { #hypershift.openshift.io/v1beta1.NetworkParam }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.OpenStackPlatformSpec">OpenStackPlatformSpec</a>,
+<a href="#hypershift.openshift.io/v1beta1.OpenStackPlatformSpec">OpenStackPlatformSpec</a>, 
 <a href="#hypershift.openshift.io/v1beta1.PortSpec">PortSpec</a>)
 </p>
 <p>
@@ -8724,7 +8724,7 @@ assigned when the service is created.</p>
 ###OLMCatalogPlacement { #hypershift.openshift.io/v1beta1.OLMCatalogPlacement }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -9160,7 +9160,7 @@ host: NodePool instances run on user&rsquo;s pre-allocated dedicated hosts.</p>
 ###PlatformSpec { #hypershift.openshift.io/v1beta1.PlatformSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -9290,7 +9290,7 @@ OpenStackPlatformSpec
 ###PlatformStatus { #hypershift.openshift.io/v1beta1.PlatformStatus }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterStatus">HostedClusterStatus</a>,
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterStatus">HostedClusterStatus</a>, 
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneStatus">HostedControlPlaneStatus</a>)
 </p>
 <p>
@@ -9322,7 +9322,7 @@ AWSPlatformStatus
 ###PlatformType { #hypershift.openshift.io/v1beta1.PlatformType }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.NodePoolPlatform">NodePoolPlatform</a>,
+<a href="#hypershift.openshift.io/v1beta1.NodePoolPlatform">NodePoolPlatform</a>, 
 <a href="#hypershift.openshift.io/v1beta1.PlatformSpec">PlatformSpec</a>)
 </p>
 <p>
@@ -9883,7 +9883,7 @@ credentials for image registry operator to get authenticated with ibm cloud.</p>
 ###PowerVSResourceReference { #hypershift.openshift.io/v1beta1.PowerVSResourceReference }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.PowerVSNodePoolPlatform">PowerVSNodePoolPlatform</a>,
+<a href="#hypershift.openshift.io/v1beta1.PowerVSNodePoolPlatform">PowerVSNodePoolPlatform</a>, 
 <a href="#hypershift.openshift.io/v1beta1.PowerVSPlatformSpec">PowerVSPlatformSpec</a>)
 </p>
 <p>
@@ -10027,7 +10027,7 @@ This field is immutable. Once set, It can&rsquo;t be changed.</p>
 ###Release { #hypershift.openshift.io/v1beta1.Release }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
 <a href="#hypershift.openshift.io/v1beta1.NodePoolSpec">NodePoolSpec</a>)
 </p>
 <p>
@@ -10321,7 +10321,7 @@ RouterFilter
 ###SecretEncryptionSpec { #hypershift.openshift.io/v1beta1.SecretEncryptionSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -10510,7 +10510,7 @@ The specifics of the setup are platform dependent.</p>
 ###ServicePublishingStrategyMapping { #hypershift.openshift.io/v1beta1.ServicePublishingStrategyMapping }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>

--- a/support/azureutil/azureutil_test.go
+++ b/support/azureutil/azureutil_test.go
@@ -187,7 +187,7 @@ func TestCreateEnvVarsForAzureManagedIdentity(t *testing.T) {
 		want []corev1.EnvVar
 	}{
 		{
-			name: "returns a slice of environment variables iwth the azure creds",
+			name: "returns a slice of environment variables with the azure creds",
 			args: args{
 				azureClientID:        "my-client-id",
 				azureTenantID:        "my-tenant-id",

--- a/support/controlplane-component/README.md
+++ b/support/controlplane-component/README.md
@@ -34,7 +34,7 @@ EOF
 
 Note that the container image `image-key` will be replaced with the image value corresponding to that key from the release payload if that key exist, and kept as is otherwise.
 
-!!! note 
+!!! note
 
     If your workload is a StatefulSet, create a filed named `statefulset.yaml` containing the StatefulSet's manifest instead!
 
@@ -114,7 +114,7 @@ func NewComponent() component.ControlPlaneComponent {
 }
 ```
 
-!!! note 
+!!! note
 
     use `component.NewStatefulSetComponent()` instead if your components's workload is a StatefulSet.
 

--- a/support/controlplane-component/defaults.go
+++ b/support/controlplane-component/defaults.go
@@ -141,7 +141,7 @@ func (c *controlPlaneWorkload) applyWatchedResourcesAnnotation(cpContext Control
 			hashedData = append(hashedData, util.HashSimple(value))
 		}
 	}
-	// if not sorted, we could get a different value on each reconcilation loop and cause unneeded rollout.
+	// if not sorted, we could get a different value on each reconciliation loop and cause unneeded rollout.
 	slices.Sort(hashedData)
 
 	if podTemplate.Annotations == nil {
@@ -173,7 +173,7 @@ func replaceContainersImageFromPayload(imageProvider imageprovider.ReleaseImageP
 			containers[i].Image = payloadImage
 		} else if key == "cluster-version-operator" {
 			// fallback to hcp releaseImage if "cluster-version-operator" image is not available.
-			// This could happen for example in local dev enviroments if the "OPERATE_ON_RELEASE_IMAGE" env variable is not set.
+			// This could happen for example in local dev environments if the "OPERATE_ON_RELEASE_IMAGE" env variable is not set.
 			containers[i].Image = util.HCPControlPlaneReleaseImage(hcp)
 		}
 	}

--- a/test/e2e/nodepool_kv_advanced_multinet_test.go
+++ b/test/e2e/nodepool_kv_advanced_multinet_test.go
@@ -318,7 +318,7 @@ func (k KubeVirtAdvancedMultinetTest) composeDNSMasqPod(t *testing.T) *corev1.Po
 						"-c",
 						fmt.Sprintf(`set -xe
 dnf install -y iptables dnsmasq procps-ng
-ip a add 192.168.66.1/24 dev %[1]s 
+ip a add 192.168.66.1/24 dev %[1]s
 echo "net.ipv4.ip_forward=1" | tee -a /etc/sysctl.conf
 sysctl -p
 iptables -A FORWARD -i %[1]s -j ACCEPT


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR:
- reduces the unit test runtime by ~90% from my tests locally
- reduces the CI runtime by ~72%*
- fixes some minor codespelling mistakes picked up by `pre-commit` hooks

_\*calculated from 8 runs of this PR vs 8 successful runs of the unit tests without this PR_

---

The majority of the time reduction is due from taking count from 25 to 1. Setting this value to 1 ensures all the unit tests are always run.
```
% go help testflag
...
	-count n
	    Run each test, benchmark, and fuzz seed n times (default 1).
	    If -cpu is set, run n times for each GOMAXPROCS value.
	    Examples are always run once. -count does not apply to
	    fuzz tests matched by -fuzz.
```

This PR also sets the parallel flag on unit tests according to the number of cores on the machine running the test. More info on the parallel flag can be found here:
```
% go help testflag
...
	-parallel n
	    Allow parallel execution of test functions that call t.Parallel, and
	    fuzz targets that call t.Parallel when running the seed corpus.
	    The value of this flag is the maximum number of tests to run
	    simultaneously.
	    While fuzzing, the value of this flag is the maximum number of
	    subprocesses that may call the fuzz function simultaneously, regardless of
	    whether T.Parallel is called.
	    By default, -parallel is set to the value of GOMAXPROCS.
	    Setting -parallel to values higher than GOMAXPROCS may cause degraded
	    performance due to CPU contention, especially when fuzzing.
	    Note that -parallel only applies within a single test binary.
	    The 'go test' command may run tests for different packages
	    in parallel as well, according to the setting of the -p flag
	    (see 'go help build').
```

---

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-2206](https://issues.redhat.com/browse/HOSTEDCP-2206)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.