### PR TITLE
OSASINFRA-3685: openstack: tag CAPI resources with InfraID

### DIFF
--- a/docs/content/how-to/openstack/create-openstack-cluster.md
+++ b/docs/content/how-to/openstack/create-openstack-cluster.md
@@ -365,6 +365,11 @@ example                   example         5               5               False 
 example-extra-az          example         2               2               False         False        4.17.0
 ```
 
+## OpenStack resources tagging
+
+The OpenStack resources created by the CAPI provider are tagged with `openshiftClusterID=<infraID>` but additional tags can be added to the resources
+via the `HostedCluster.Spec.Platform.OpenStack.Tags` field when creating the HostedCluster with a given YAML file.
+
 ## Delete a HostedCluster
 
 To delete a HostedCluster:

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack.go
@@ -155,7 +155,11 @@ func reconcileOpenStackClusterSpec(hcluster *hyperv1.HostedCluster, openStackClu
 	openStackClusterSpec.ManagedSecurityGroups = &capo.ManagedSecurityGroups{
 		AllNodesSecurityGroupRules: defaultWorkerSecurityGroupRules(machineNetworksToStrings(machineNetworks)),
 	}
-	openStackClusterSpec.Tags = openStackPlatform.Tags
+
+	// Users are permitted to specify additional tags to be applied to the OpenStack resources
+	// but the default tag will be compliant with the OpenShift Cluster ID.
+	openStackClusterSpec.Tags = []string{"openshiftClusterID=" + hcluster.Spec.InfraID}
+	openStackClusterSpec.Tags = append(openStackClusterSpec.Tags, openStackPlatform.Tags...)
 
 	return nil
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack_test.go
@@ -30,6 +30,7 @@ func TestReconcileOpenStackCluster(t *testing.T) {
 			name: "CAPO provisioned network and subnet",
 			hostedCluster: &hyperv1.HostedCluster{
 				Spec: hyperv1.HostedClusterSpec{
+					InfraID: "cluster-123",
 					Networking: hyperv1.ClusterNetworking{
 						MachineNetwork: []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("10.0.0.0/24")}},
 					},
@@ -71,6 +72,7 @@ func TestReconcileOpenStackCluster(t *testing.T) {
 				ManagedSecurityGroups: &capo.ManagedSecurityGroups{
 					AllNodesSecurityGroupRules: defaultWorkerSecurityGroupRules([]string{"10.0.0.0/24"}),
 				},
+				Tags: []string{"openshiftClusterID=cluster-123"},
 			},
 			wantErr: false,
 		},
@@ -78,6 +80,7 @@ func TestReconcileOpenStackCluster(t *testing.T) {
 			name: "User provided network and subnet by ID on hosted cluster",
 			hostedCluster: &hyperv1.HostedCluster{
 				Spec: hyperv1.HostedClusterSpec{
+					InfraID: "cluster-123",
 					Networking: hyperv1.ClusterNetworking{
 						MachineNetwork: []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}},
 					},
@@ -115,6 +118,7 @@ func TestReconcileOpenStackCluster(t *testing.T) {
 				ManagedSecurityGroups: &capo.ManagedSecurityGroups{
 					AllNodesSecurityGroupRules: defaultWorkerSecurityGroupRules([]string{"192.168.1.0/24"}),
 				},
+				Tags: []string{"openshiftClusterID=cluster-123"},
 			},
 			wantErr: false,
 		},
@@ -122,6 +126,7 @@ func TestReconcileOpenStackCluster(t *testing.T) {
 			name: "User provided network and subnet by tag on hosted cluster",
 			hostedCluster: &hyperv1.HostedCluster{
 				Spec: hyperv1.HostedClusterSpec{
+					InfraID: "cluster-123",
 					Networking: hyperv1.ClusterNetworking{
 						MachineNetwork: []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}},
 					},
@@ -144,6 +149,7 @@ func TestReconcileOpenStackCluster(t *testing.T) {
 									},
 								}},
 							},
+							Tags: []string{"hcp-id=123"},
 						}}}},
 			expectedOpenStackClusterSpec: capo.OpenStackClusterSpec{
 				IdentityRef: capo.OpenStackIdentityReference{
@@ -171,6 +177,7 @@ func TestReconcileOpenStackCluster(t *testing.T) {
 				ManagedSecurityGroups: &capo.ManagedSecurityGroups{
 					AllNodesSecurityGroupRules: defaultWorkerSecurityGroupRules([]string{"192.168.1.0/24"}),
 				},
+				Tags: []string{"openshiftClusterID=cluster-123", "hcp-id=123"},
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
By default, OpenStack resources created by CAPI will be tagged (in the
OpenStack way) with `openshiftClusterID=<infraID>`.

`openshiftClusterID` is a well-known tag prefix in ShiftOnStack IPI.

Additional tags can be added via the `HostedCluster.Spec.Platform.OpenStack.Tags` field
when creating the HostedCluster with a given YAML file.
