### PR TITLE
NO-JIRA: contrib: update route53 zone cleaning utility

### DIFF
--- a/contrib/cleanzones/Dockerfile
+++ b/contrib/cleanzones/Dockerfile
@@ -1,0 +1,5 @@
+FROM docker.io/golang:latest
+WORKDIR /cleanzones
+COPY . .
+RUN go build .
+ENTRYPOINT /cleanzones/cleanzones

--- a/contrib/cleanzones/go.mod
+++ b/contrib/cleanzones/go.mod
@@ -1,0 +1,7 @@
+module github.com/openshift/hypershift/contrib/cleanzones
+
+go 1.22.7
+
+require github.com/aws/aws-sdk-go v1.55.5
+
+require github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/contrib/cleanzones/go.sum
+++ b/contrib/cleanzones/go.sum
@@ -1,0 +1,14 @@
+github.com/aws/aws-sdk-go v1.55.5 h1:KKUZBfBoyqy5d3swXyiC7Q76ic40rYcbqH7qjh59kzU=
+github.com/aws/aws-sdk-go v1.55.5/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/contrib/cleanzones/manifests/01-serviceaccount.yaml
+++ b/contrib/cleanzones/manifests/01-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cleanzones
+  namespace: hypershift

--- a/contrib/cleanzones/manifests/02-cronjob.yaml
+++ b/contrib/cleanzones/manifests/02-cronjob.yaml
@@ -1,0 +1,34 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cleanzones
+  namespace: hypershift
+spec:
+  schedule: "0 0 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: cleanzones
+            image: quay.io/hypershift/cleanzones:latest
+            command: ["/cleanzones/cleanzones"]
+            env:
+            - name: AWS_ROLE_ARN
+              value: "arn:aws:iam::820196288204:role/hypershift-ci-2-cleanzones"
+            - name: AWS_WEB_IDENTITY_TOKEN_FILE
+              value: "/var/run/secrets/openshift/token"
+            imagePullPolicy: Always
+            volumeMounts:
+            - name: token
+              mountPath: /var/run/secrets/openshift
+              readOnly: true
+          restartPolicy: Never
+          serviceAccountName: cleanzones
+          volumes:
+          - name: token
+            projected:
+              sources:
+              - serviceAccountToken:
+                  path: token
+                  audience: openshift

--- a/contrib/cleanzones/role-policy.json
+++ b/contrib/cleanzones/role-policy.json
@@ -1,0 +1,16 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:ListHostedZones",
+                "route53:ListResourceRecordSets",
+                "route53:ChangeResourceRecordSets",
+                "route53:DeleteHostedZone",
+                "ec2:DescribeVpcs"
+            ],
+            "Resource": "*"
+        }
+    ]
+}


### PR DESCRIPTION
This utility is now installed in the `hypershift` namespace of the root CI cluster and a CronJob (daily) to clean up CI related hosted zones and records from the `ci` and `service.ci` zones.  The intent is to be non-disruptive to running tests by extracting the list of infraIDs in-use from the VPC list, then use that to find CI related zones/records that don't match an in-use infraID and remove them.