### PR TITLE
HOSTEDCP-2203: Create e2e clusters with public IP instances only

### DIFF
--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -391,6 +391,7 @@ func bindCoreOptions(opts *RawCreateOptions, flags *flag.FlagSet) {
 	flags.BoolVar(&opts.MultiArch, "multi-arch", opts.MultiArch, "If true, this flag indicates the Hosted Cluster will support multi-arch NodePools and will perform additional validation checks to ensure a multi-arch release image or stream was used.")
 	flags.StringVar(&opts.VPCCIDR, "vpc-cidr", opts.VPCCIDR, "The CIDR to use for the cluster VPC (mask must be 16)")
 	flags.BoolVar(&opts.PrivateZonesInClusterAccount, "private-zones-in-cluster-account", opts.PrivateZonesInClusterAccount, "In shared VPC infrastructure, create private hosted zones in cluster account")
+	flags.BoolVar(&opts.PublicOnly, "public-only", opts.PublicOnly, "If true, creates a cluster that does not have private subnets or NAT gateway and assigns public IPs to all instances.")
 
 	_ = flags.MarkDeprecated("multi-arch", "Multi-arch validation is now performed automatically based on the release image and signaled in the HostedCluster.Status.PayloadArch.")
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -580,6 +580,7 @@ func (o *options) DefaultAWSOptions() hypershiftaws.RawCreateOptions {
 		EndpointAccess: o.configurableClusterOptions.AWSEndpointAccess,
 		IssuerURL:      o.IssuerURL,
 		MultiArch:      o.configurableClusterOptions.AWSMultiArch,
+		PublicOnly:     true,
 	}
 	opts.AdditionalTags = append(opts.AdditionalTags, o.additionalTags...)
 	if len(o.configurableClusterOptions.Zone) == 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to save on nat gateway costs, this change will switch the default configuration of AWS hosted clusters created for e2e tests to use public IPs for ec2 instances and communicate through the internet gateway.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-2203](https://issues.redhat.com//browse/HOSTEDCP-2203)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.