### PR TITLE
NO-JIRA: Allow multiple yaml def in a file for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
         stages: [pre-commit]
       - id: check-yaml
         name: Check yaml syntax
+        args: [--allow-multiple-documents]
         stages: [pre-commit]
       - id: trailing-whitespace
         name: Trim all whitespace from end of lines


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows multiple yaml definitions to be specified within a single yaml file in the pre-commit check for yaml syntax. The check defaults to only one yaml definition per yaml file without this PR.

Here's an example of what happens without this commit:
```
Check for merge conflict strings.........................................Passed
Check yaml syntax........................................................Failed
- hook id: check-yaml
- exit code: 1
expected a single document in the stream
  in "cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_create_with_a_ure_marketplace_image.yaml", line 1, column 1
but found another document
  in "cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_create_with_a_ure_marketplace_image.yaml", line 8, column 1
...
```

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.