### PR TITLE
NO-JIRA: set diskStorageAccountType in aks e2e

### DIFF
--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -160,6 +160,7 @@ spec:
         type: ImageID
       machineIdentityID: fakeMachineIdentityID
       osDisk:
+        diskStorageAccountType: Premium_LRS
         sizeGiB: 120
       subnetID: fakeSubnetID
       vmSize: Standard_D4s_v3

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_ones.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_ones.yaml
@@ -161,6 +161,7 @@ spec:
         type: ImageID
       machineIdentityID: fakeMachineIdentityID
       osDisk:
+        diskStorageAccountType: Premium_LRS
         sizeGiB: 120
       subnetID: fakeSubnetID
       vmSize: Standard_D4s_v3
@@ -193,6 +194,7 @@ spec:
         type: ImageID
       machineIdentityID: fakeMachineIdentityID
       osDisk:
+        diskStorageAccountType: Premium_LRS
         sizeGiB: 120
       subnetID: fakeSubnetID
       vmSize: Standard_D4s_v3

--- a/cmd/nodepool/azure/create.go
+++ b/cmd/nodepool/azure/create.go
@@ -47,7 +47,8 @@ type RawAzurePlatformCreateOptions struct {
 func DefaultOptions() *RawAzurePlatformCreateOptions {
 	return &RawAzurePlatformCreateOptions{
 		AzurePlatformCreateOptions: &AzurePlatformCreateOptions{
-			DiskSize: 120,
+			DiskSize:               120,
+			DiskStorageAccountType: string(hyperv1.DiskStorageAccountTypesPremiumLRS),
 		},
 		AzureMarketPlaceImageInfo: &AzureMarketPlaceImageInfo{},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

- setting diskSotrageAccountType so that if the validation on the nodepool for this changes it will be caught in the e2e


**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.