### PR TITLE
OCPBUGS-46342: Allow ARM64 arch deployment on Agent platform

### DIFF
--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -79,7 +79,7 @@ type NodePool struct {
 
 // NodePoolSpec is the desired behavior of a NodePool.
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.arch) || has(self.arch)", message="Arch is required once set"
-// +kubebuilder:validation:XValidation:rule="self.arch != 'arm64' || has(self.platform.aws) || has(self.platform.azure)", message="Setting Arch to arm64 is only supported for AWS and Azure"
+// +kubebuilder:validation:XValidation:rule="self.arch != 'arm64' || has(self.platform.aws) || has(self.platform.azure) || has(self.platform.agent)", message="Setting Arch to arm64 is only supported for AWS, Azure and Agent"
 // +kubebuilder:validation:XValidation:rule="!has(self.replicas) || !has(self.autoScaling)", message="Both replicas or autoScaling should not be set"
 type NodePoolSpec struct {
 	// clusterName is the name of the HostedCluster this NodePool belongs to.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
@@ -1310,8 +1310,10 @@ spec:
             x-kubernetes-validations:
             - message: Arch is required once set
               rule: '!has(oldSelf.arch) || has(self.arch)'
-            - message: Setting Arch to arm64 is only supported for AWS and Azure
+            - message: Setting Arch to arm64 is only supported for AWS, Azure and
+                Agent
               rule: self.arch != 'arm64' || has(self.platform.aws) || has(self.platform.azure)
+                || has(self.platform.agent)
             - message: Both replicas or autoScaling should not be set
               rule: '!has(self.replicas) || !has(self.autoScaling)'
           status:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
@@ -1477,8 +1477,10 @@ spec:
             x-kubernetes-validations:
             - message: Arch is required once set
               rule: '!has(oldSelf.arch) || has(self.arch)'
-            - message: Setting Arch to arm64 is only supported for AWS and Azure
+            - message: Setting Arch to arm64 is only supported for AWS, Azure and
+                Agent
               rule: self.arch != 'arm64' || has(self.platform.aws) || has(self.platform.azure)
+                || has(self.platform.agent)
             - message: Both replicas or autoScaling should not be set
               rule: '!has(self.replicas) || !has(self.autoScaling)'
           status:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -1480,8 +1480,10 @@ spec:
             x-kubernetes-validations:
             - message: Arch is required once set
               rule: '!has(oldSelf.arch) || has(self.arch)'
-            - message: Setting Arch to arm64 is only supported for AWS and Azure
+            - message: Setting Arch to arm64 is only supported for AWS, Azure and
+                Agent
               rule: self.arch != 'arm64' || has(self.platform.aws) || has(self.platform.azure)
+                || has(self.platform.agent)
             - message: Both replicas or autoScaling should not be set
               rule: '!has(self.replicas) || !has(self.autoScaling)'
           status:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -1313,8 +1313,10 @@ spec:
             x-kubernetes-validations:
             - message: Arch is required once set
               rule: '!has(oldSelf.arch) || has(self.arch)'
-            - message: Setting Arch to arm64 is only supported for AWS and Azure
+            - message: Setting Arch to arm64 is only supported for AWS, Azure and
+                Agent
               rule: self.arch != 'arm64' || has(self.platform.aws) || has(self.platform.azure)
+                || has(self.platform.agent)
             - message: Both replicas or autoScaling should not be set
               rule: '!has(self.replicas) || !has(self.autoScaling)'
           status:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -1480,8 +1480,10 @@ spec:
             x-kubernetes-validations:
             - message: Arch is required once set
               rule: '!has(oldSelf.arch) || has(self.arch)'
-            - message: Setting Arch to arm64 is only supported for AWS and Azure
+            - message: Setting Arch to arm64 is only supported for AWS, Azure and
+                Agent
               rule: self.arch != 'arm64' || has(self.platform.aws) || has(self.platform.azure)
+                || has(self.platform.agent)
             - message: Both replicas or autoScaling should not be set
               rule: '!has(self.replicas) || !has(self.autoScaling)'
           status:

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -79,7 +79,7 @@ type NodePool struct {
 
 // NodePoolSpec is the desired behavior of a NodePool.
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.arch) || has(self.arch)", message="Arch is required once set"
-// +kubebuilder:validation:XValidation:rule="self.arch != 'arm64' || has(self.platform.aws) || has(self.platform.azure)", message="Setting Arch to arm64 is only supported for AWS and Azure"
+// +kubebuilder:validation:XValidation:rule="self.arch != 'arm64' || has(self.platform.aws) || has(self.platform.azure) || has(self.platform.agent)", message="Setting Arch to arm64 is only supported for AWS, Azure and Agent"
 // +kubebuilder:validation:XValidation:rule="!has(self.replicas) || !has(self.autoScaling)", message="Both replicas or autoScaling should not be set"
 type NodePoolSpec struct {
 	// clusterName is the name of the HostedCluster this NodePool belongs to.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allow the NodePool API to set ARM64 arch to Agent deployments.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-46342](https://issues.redhat.com/browse/OCPBUGS-46342)