### PR TITLE
OCPBUGS-46354: fix(ho): Add all supported config schemas for NodePool NTO reconcile

### DIFF
--- a/hypershift-operator/controllers/nodepool/nto.go
+++ b/hypershift-operator/controllers/nodepool/nto.go
@@ -11,7 +11,10 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	configv1 "github.com/openshift/api/config/v1"
+	configv1alpha1 "github.com/openshift/api/config/v1alpha1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	"github.com/openshift/api/operator/v1alpha1"
 	performanceprofilev2 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/performanceprofile/v2"
 	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -414,6 +417,9 @@ func BuildMirrorConfigs(ctx context.Context, cg *ConfigGenerator) ([]*MirrorConf
 func getMirrorConfigForManifest(manifest []byte) (*MirrorConfig, error) {
 	scheme := runtime.NewScheme()
 	_ = mcfgv1.Install(scheme)
+	_ = v1alpha1.Install(scheme)
+	_ = configv1.Install(scheme)
+	_ = configv1alpha1.Install(scheme)
 
 	yamlSerializer := serializer.NewSerializerWithOptions(
 		serializer.DefaultMetaFactory, scheme, scheme,


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes [OCPBUGS-46354](https://issues.redhat.com/browse/OCPBUGS-46354)

Observed errors:
```
{"level":"error","ts":"2024-12-07T12:38:02Z","msg":"Failed to reconcile NodePool","controller":"nodepool","controllerGroup":"hypershift.openshift.io","controllerKind":"NodePool","NodePool":{"name":"30734861-mynodepool","namespace":"master"},"namespace":"master","name":"30734861-mynodepool","reconcileID":"a994e171-39d8-4ebe-b36d-d5bf3b32f91c","error":"failed to reconcile NTO: failed to build mirror configs: configmap \"ignition-config-98-ibm-machineconfig-roks-30734861\" yaml document failed validation: error decoding config: no kind \"ImageDigestMirrorSet\" is registered for version \"config.openshift.io/v1\" in scheme \"/hypershift/hypershift-operator/controllers/nodepool/nto.go:415\"","stacktrace":"github.com/openshift/hypershift/hypershift-operator/controllers/nodepool.(*NodePoolReconciler).Reconcile\n\t/hypershift/hypershift-operator/controllers/nodepool/nodepool_controller.go:205\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/hypershift/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/hypershift/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/hypershift/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:261\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/hypershift/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:222"}
{"level":"debug","ts":"2024-12-07T12:38:02Z","logger":"events","msg":"failed to reconcile NTO: failed to build mirror configs: configmap \"ignition-config-98-ibm-machineconfig-roks-30734861\" yaml document failed validation: error decoding config: no kind \"ImageDigestMirrorSet\" is registered for version \"config.openshift.io/v1\" in scheme \"/hypershift/hypershift-operator/controllers/nodepool/nto.go:415\"","type":"Warning","object":{"kind":"NodePool","namespace":"master","name":"30734861-mynodepool","uid":"6890952e-ffe4-4396-8df4-2054dd939a20","apiVersion":"hypershift.openshift.io/v1beta1","resourceVersion":"422964745"},"reason":"ReconcileError"}
{"level":"error","ts":"2024-12-07T12:38:03Z","msg":"Reconciler error","controller":"nodepool","controllerGroup":"hypershift.openshift.io","controllerKind":"NodePool","NodePool":{"name":"30734861-mynodepool","namespace":"master"},"namespace":"master","name":"30734861-mynodepool","reconcileID":"a994e171-39d8-4ebe-b36d-d5bf3b32f91c","error":"failed to reconcile NTO: failed to build mirror configs: configmap \"ignition-config-98-ibm-machineconfig-roks-30734861\" yaml document failed validation: error decoding config: no kind \"ImageDigestMirrorSet\" is registered for version \"config.openshift.io/v1\" in scheme \"/hypershift/hypershift-operator/controllers/nodepool/nto.go:415\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/hypershift/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:324\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/hypershift/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:261\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/hypershift/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:222"}
```

Adding all API schemas based on:
https://github.com/openshift/hypershift/blob/dc7bd6501be1a9a41c16d1a19464e9911262fd89/hypershift-operator/controllers/nodepool/config.go#L263-L266

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes [OCPBUGS-46354](https://issues.redhat.com/browse/OCPBUGS-46354)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.