### PR TITLE
OCPBUGS-44314: Consistently look up and dial cloud API hostnames

### DIFF
--- a/support/konnectivityproxy/dialer.go
+++ b/support/konnectivityproxy/dialer.go
@@ -265,7 +265,7 @@ func (p *konnectivityProxy) DialContext(ctx context.Context, network string, req
 	}
 	log.V(4).Info("Host and port determined", "requestHost", requestHost, "requestPort", requestPort)
 	// return a dial direct function which respects any proxy environment settings
-	if p.connectDirectlyToCloudAPIs && p.IsCloudAPI(requestHost) {
+	if p.IsCloudAPI(requestHost) {
 		p.log.V(4).Info("Host name is cloud API, dialing through mgmt cluster proxy if present")
 		return p.dialDirectWithProxy(network, requestAddress)
 	}
@@ -389,6 +389,14 @@ func (f *syncBool) set(valueToSet bool) {
 // IBMCLOUD: https://cloud.ibm.com/apidocs/iam-identity-token-api#endpoints
 func (p *konnectivityProxy) IsCloudAPI(host string) bool {
 	log := p.log.WithName("konnectivityProxy.IsCloudAPI")
+	if !p.connectDirectlyToCloudAPIs {
+		// If not connecting directly to cloud APIs, we should not
+		// make any distinction between regular hostnames and cloud hostnames.
+		// This is used by both the dialer and the resolver in determining how
+		// to access cloud api hostnames when connectDirectlyToCloudAPIs is set
+		// to true.
+		return false
+	}
 	log.V(4).Info("Determining whether host is cloud API", "host", host)
 	if p.excludeCloudHosts.Has(host) {
 		log.V(4).Info("Host is in the list of exclude hosts, returning false")


### PR DESCRIPTION
**What this PR does / why we need it**:
Before this commit, the konnectivity proxy dialer relied on the connectDirectlyToCloudAPIs boolean to determine whether it should connect directly to hostnames that matched the known cloud API suffixes. However, the resolver used by the dialer was always doing a control plane resolve of the hostnames with cloud API suffixes regardless of the connectDirectlyToCloudAPIs setting. This commit updates the behavior so that both dialer and resolver connect to cloud APIs in the same way.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [OCPBUGS-44314](https://issues.redhat.com/browse/OCPBUGS-44314)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.