### PR TITLE
AUTH-482: set required-scc for openshift workloads

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/daemonset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/daemonset.yaml
@@ -17,6 +17,8 @@ spec:
     metadata:
       labels:
         app: kubevirt-csi-driver
+      annotations:
+        openshift.io/required-scc: privileged
     spec:
       dnsPolicy: ClusterFirst
       priorityClassName: system-node-critical


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
This PR pins `privileged` SCC for the `kubevirt-csi-node` in the `openshift-cluster-csi-drivers` namespace. Pinning ensures the workload explicitly uses the required SCC and prevents unintended security vulnerabilities.

This is part of the ongoing task to ensure SCC pinning for all workloads in platform namespaces .

**Which issue(s) this PR fixes:** 
Fixes [AUTH-482](https://issues.redhat.com/browse/AUTH-482) and [sippy test](https://sippy.dptools.openshift.org/sippy-ng/tests/4.19/analysis?test=%5Bsig-auth%5D%20all%20workloads%20in%20ns%2Fopenshift-cluster-csi-drivers%20must%20set%20the%20%27openshift.io%2Frequired-scc%27%20annotation&filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-auth%5D%20all%20workloads%20in%20ns%2Fopenshift-cluster-csi-drivers%20must%20set%20the%20%27openshift.io%2Frequired-scc%27%20annotation%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22aggregated%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.