### PR TITLE
OCPBUGS-46483: Correctly Reconcile CSO CSI Secrets for Managed Azure Deployments

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -5074,7 +5074,7 @@ func (r *HostedControlPlaneReconciler) reconcileClusterStorageOperator(ctx conte
 		// Reconcile the secret needed for azure-disk-csi-controller
 		// This is related to https://github.com/openshift/csi-operator/pull/290.
 		azureFileCSISecret := manifests.AzureFileConfigWithCredentials(hcp.Namespace)
-		if _, err := createOrUpdate(ctx, r, azureDiskCSISecret, func() error {
+		if _, err := createOrUpdate(ctx, r, azureFileCSISecret, func() error {
 			return storage.ReconcileAzureFileCSISecret(azureFileCSISecret, hcp, tenantID)
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile Azure File CSI config: %w", err)

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/azure.go
@@ -3,9 +3,11 @@ package storage
 import (
 	"encoding/json"
 	"fmt"
+	"path"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
+	hypershiftconfig "github.com/openshift/hypershift/support/config"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -28,7 +30,7 @@ func initializeAzureCSIControllerConfig(hcp *hyperv1.HostedControlPlane, tenantI
 func ReconcileAzureDiskCSISecret(secret *corev1.Secret, hcp *hyperv1.HostedControlPlane, tenantID string) error {
 	config := initializeAzureCSIControllerConfig(hcp, tenantID)
 	config.AADClientID = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Disk.ClientID
-	config.AADClientCertPath = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Disk.CertificateName
+	config.AADClientCertPath = path.Join(hypershiftconfig.ManagedAzureCertificatePath, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Disk.CertificateName)
 
 	serializedConfig, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
@@ -46,7 +48,7 @@ func ReconcileAzureDiskCSISecret(secret *corev1.Secret, hcp *hyperv1.HostedContr
 func ReconcileAzureFileCSISecret(secret *corev1.Secret, hcp *hyperv1.HostedControlPlane, tenantID string) error {
 	config := initializeAzureCSIControllerConfig(hcp, tenantID)
 	config.AADClientID = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.File.ClientID
-	config.AADClientCertPath = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.File.CertificateName
+	config.AADClientCertPath = path.Join(hypershiftconfig.ManagedAzureCertificatePath, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.File.CertificateName)
 
 	serializedConfig, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR:
- removes the double reconciliation of the CSO CSI secrets for managed azure deployments. Previous to the managed identity work merging into the HyperShift repo, we were reconciling the CSO CSI secrets with the Cloud Provider information. Once the managed identity work was added, the reconciliation with the Cloud Provider information wasn't removed.
- adds the file path with the certificate name for the CSO CSI secret reconciliation for managed azure deployments.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes ssue(s) this PR fixes :
Fixes # [OCPBUGS-46483](https://issues.redhat.com/browse/OCPBUGS-46483)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.