### PR TITLE
CNTRLPLANE-26: Disable building HO for s390x platform on PR

### DIFF
--- a/.tekton/hypershift-operator-main-pull-request.yaml
+++ b/.tekton/hypershift-operator-main-pull-request.yaml
@@ -206,34 +206,6 @@ spec:
             workspace: workspace-arm64
           - name: basic-auth
             workspace: git-auth
-      - name: clone-repository-s390x
-        params:
-          - name: url
-            value: $(params.git-url)
-          - name: revision
-            value: $(params.revision)
-        runAfter:
-          - init
-        taskRef:
-          kind: Task
-          params:
-            - name: name
-              value: git-clone
-            - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-git-clone:0.1@sha256:a3e22f57fbf8398fbe93fbeeb38e03756cd073182d6d109fe8e8cde57b561603
-            - name: kind
-              value: task
-          resolver: bundles
-        when:
-          - input: $(tasks.init.results.build)
-            operator: in
-            values:
-              - "true"
-        workspaces:
-          - name: output
-            workspace: workspace-s390x
-          - name: basic-auth
-            workspace: git-auth
       - name: clone-repository-ppc64le
         params:
           - name: url
@@ -357,43 +329,6 @@ spec:
         workspaces:
           - name: source
             workspace: workspace-arm64
-      - name: build-container-s390x
-        params:
-          - name: IMAGE
-            value: $(params.output-image)-s390x
-          - name: DOCKERFILE
-            value: $(params.dockerfile)
-          - name: CONTEXT
-            value: $(params.path-context)
-          - name: HERMETIC
-            value: $(params.hermetic)
-          - name: PREFETCH_INPUT
-            value: $(params.prefetch-input)
-          - name: IMAGE_EXPIRES_AFTER
-            value: $(params.image-expires-after)
-          - name: COMMIT_SHA
-            value: $(tasks.clone-repository.results.commit)
-          - name: PLATFORM
-            value: linux/s390x
-        runAfter:
-          - clone-repository-s390x
-        taskRef:
-          params:
-            - name: name
-              value: buildah-remote
-            - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.2@sha256:27d07dbe1d3b6b612cd0a68eb4974791e9a91af2df98c43b9810b5b9f7ca573c
-            - name: kind
-              value: task
-          resolver: bundles
-        when:
-          - input: $(tasks.init.results.build)
-            operator: in
-            values:
-              - "true"
-        workspaces:
-          - name: source
-            workspace: workspace-s390x
 
       - name: build-container-ppc64le
         params:
@@ -442,12 +377,10 @@ spec:
             value:
               - $(tasks.build-container-amd64.results.IMAGE_URL)@$(tasks.build-container-amd64.results.IMAGE_DIGEST)
               - $(tasks.build-container-arm64.results.IMAGE_URL)@$(tasks.build-container-arm64.results.IMAGE_DIGEST)
-              - $(tasks.build-container-s390x.results.IMAGE_URL)@$(tasks.build-container-s390x.results.IMAGE_DIGEST)
               - $(tasks.build-container-ppc64le.results.IMAGE_URL)@$(tasks.build-container-ppc64le.results.IMAGE_DIGEST)
         runAfter:
           - build-container-amd64
           - build-container-arm64
-          - build-container-s390x
           - build-container-ppc64le
         taskRef:
           params:
@@ -591,17 +524,6 @@ spec:
               storage: 1Gi
         status: {}
     - name: workspace-arm64
-      volumeClaimTemplate:
-        metadata:
-          creationTimestamp: null
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-        status: {}
-    - name: workspace-s390x
       volumeClaimTemplate:
         metadata:
           creationTimestamp: null


### PR DESCRIPTION
**What this PR does / why we need it**:
Due to capacity issues in s390x environment, we're instructed to stop building images on PR for s390x


**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.