### PR TITLE
CNTRLPLANE-25: Fix valid release image update issue

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -949,6 +949,11 @@ func (r *HostedControlPlaneReconciler) update(ctx context.Context, hostedControl
 		}
 	}
 
+	// Get the latest HCP in memory before we patch the status
+	if err = r.Client.Get(ctx, client.ObjectKeyFromObject(hostedControlPlane), hostedControlPlane); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	originalHostedControlPlane := hostedControlPlane.DeepCopy()
 	missingImages := sets.New(releaseImageProvider.GetMissingImages()...).Insert(userReleaseImageProvider.GetMissingImages()...)
 	if missingImages.Len() == 0 {

--- a/hypershift-operator/controllers/hostedcluster/karpenter.go
+++ b/hypershift-operator/controllers/hostedcluster/karpenter.go
@@ -62,7 +62,7 @@ spec:
 	}
 
 	// Managed a NodePool to generate userData for Karpenter instances
-	// TODO(alberto): consider invoking the token library to manage the karpenter userdata programatically,
+	// TODO(alberto): consider invoking the token library to manage the karpenter userdata programmatically,
 	// instead of via NodePool API.
 	nodePool := &hyperv1.NodePool{
 		ObjectMeta: metav1.ObjectMeta{

--- a/karpenter-operator/controllers/karpenter/manifests.go
+++ b/karpenter-operator/controllers/karpenter/manifests.go
@@ -395,7 +395,7 @@ func (r *Reconciler) reconcileKarpenter(ctx context.Context, hcp *hyperv1.Hosted
 
 	// The deployment depends on the kubeconfig being reported.
 	if hcp.Status.KubeConfig != nil {
-		// Resolve the kubeconfig secret for CAPI which is used for karpeneter for convience
+		// Resolve the kubeconfig secret for CAPI which is used for karpeneter for convenience
 		capiKubeConfigSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: hcp.Namespace,

--- a/karpenter-operator/manifests/operator.go
+++ b/karpenter-operator/manifests/operator.go
@@ -342,7 +342,7 @@ func ReconcileKarpenterOperator(ctx context.Context, createOrUpdate upsert.Creat
 
 	// The deployment depends on the kubeconfig being reported.
 	if hcp.Status.KubeConfig != nil {
-		// Resolve the kubeconfig secret for CAPI which is used for karpeneter for convience
+		// Resolve the kubeconfig secret for CAPI which is used for karpeneter for convenience
 		capiKubeConfigSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: hcp.Namespace,

--- a/support/releaseinfo/registryclient/client.go
+++ b/support/releaseinfo/registryclient/client.go
@@ -308,7 +308,7 @@ func IsMultiArchManifestList(ctx context.Context, imageRef string, pullSecret []
 		return false, nil
 	}
 
-	// Default to using the deserializeManifest function, but allow for a custom deserialization function to be passed in the context for testing purposes and avoiding paralelism issues
+	// Default to using the deserializeManifest function, but allow for a custom deserialization function to be passed in the context for testing purposes and avoiding parallelism issues
 	deserializeFunc := deserializeManifest
 	if ctx.Value(DeserializeFuncName) != nil {
 		deserializeFunc = ctx.Value(DeserializeFuncName).(func([]byte) (*manifestlist.DeserializedManifestList, error))

--- a/support/util/imagemetadata.go
+++ b/support/util/imagemetadata.go
@@ -170,7 +170,7 @@ func (r *RegistryClientImageMetadataProvider) GetDigest(ctx context.Context, ima
 
 	composedRef := fmt.Sprintf("%s/%s/%s", ref.Registry, ref.Namespace, ref.NameString())
 
-	// If the overriden image name is in the cache, return early
+	// If the overridden image name is in the cache, return early
 	if imageDigest, exists := digestCache.Get(composedRef); exists {
 		ref.ID = string(imageDigest.(digest.Digest))
 		return imageDigest.(digest.Digest), ref, nil
@@ -400,7 +400,7 @@ func GetRegistryOverrides(ctx context.Context, ref reference.DockerImageReferenc
 	}
 
 	// docker lib, by default will empty the Namespace once we pass an override with just a Namespace
-	// and it will asume that is the Name instead
+	// and it will assume that is the Name instead
 	if sourceRef.Namespace == "" {
 		if sourceRef.Name == ref.Namespace {
 			composedImage := fmt.Sprintf("%s/%s/%s", mirrorRef.Registry, ref.Namespace, ref.NameString())


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request:
- fixes some codespelling errors
- gets the latest HCP into memory before we update the Valid Release Image status

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes [CNTRLPLANE-25](https://issues.redhat.com/browse/CNTRLPLANE-25)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.