### PR TITLE
[release-4.18] OCPBUGS-46666: Correctly Reconcile CSO CSI Secrets for Managed Azure Deployments

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go
@@ -109,6 +109,7 @@ type AzureConfig struct {
 	SubscriptionID               string `json:"subscriptionId"`
 	AADClientID                  string `json:"aadClientId"`
 	AADClientSecret              string `json:"aadClientSecret"`
+	AADClientCertPath            string `json:"aadClientCertPath"`
 	ResourceGroup                string `json:"resourceGroup"`
 	Location                     string `json:"location"`
 	VnetName                     string `json:"vnetName"`

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -4949,29 +4949,47 @@ func (r *HostedControlPlaneReconciler) reconcileCSISnapshotControllerOperator(ct
 func (r *HostedControlPlaneReconciler) reconcileClusterStorageOperator(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider, userReleaseImageProvider *imageprovider.SimpleReleaseImageProvider, createOrUpdate upsert.CreateOrUpdateFN) error {
 	params := storage.NewParams(hcp, userReleaseImageProvider.Version(), releaseImageProvider, userReleaseImageProvider, r.SetDefaultSecurityContext)
 
-	if hcp.Spec.Platform.Type == hyperv1.AzurePlatform {
+	if hyperazureutil.IsAroHCP() {
+		// Reconcile SecretProviderClasses
+		azureDiskSecretProviderClass := manifests.ManagedAzureSecretProviderClass(config.ManagedAzureDiskCSISecretStoreProviderClassName, hcp.Namespace)
+		if _, err := createOrUpdate(ctx, r, azureDiskSecretProviderClass, func() error {
+			secretproviderclass.ReconcileManagedAzureSecretProviderClass(azureDiskSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Disk.CertificateName)
+			return nil
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile Azure Disk Secret Provider Class: %w", err)
+		}
+
+		azureFileSecretProviderClass := manifests.ManagedAzureSecretProviderClass(config.ManagedAzureFileCSISecretStoreProviderClassName, hcp.Namespace)
+		if _, err := createOrUpdate(ctx, r, azureFileSecretProviderClass, func() error {
+			secretproviderclass.ReconcileManagedAzureSecretProviderClass(azureFileSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.File.CertificateName)
+			return nil
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile Azure File Secret Provider Class: %w", err)
+		}
+
+		// Get the credentials secret so we can retrieve the tenant ID for the configuration
 		credentialsSecret := manifests.AzureCredentialInformation(hcp.Namespace)
 		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
 			return fmt.Errorf("failed to get Azure credentials secret: %w", err)
 		}
+		tenantID := string(credentialsSecret.Data["AZURE_TENANT_ID"])
 
-		// Reconcile the Azure Disk configuration secret
-		// TODO this just copies the cloud provider secret at the moment. There will be a follow-on PR to provide
-		// different credentials for Azure Disk and Azure File (right below).
+		// Reconcile the secret needed for azure-disk-csi-controller
 		// This is related to https://github.com/openshift/csi-operator/pull/290.
-		azureDiskConfigSecret := manifests.AzureDiskConfigWithCredentials(hcp.Namespace)
-		if _, err := createOrUpdate(ctx, r, azureDiskConfigSecret, func() error {
-			return azure.ReconcileCloudConfigWithCredentials(azureDiskConfigSecret, hcp, credentialsSecret)
+		azureDiskCSISecret := manifests.AzureDiskConfigWithCredentials(hcp.Namespace)
+		if _, err := createOrUpdate(ctx, r, azureDiskCSISecret, func() error {
+			return storage.ReconcileAzureDiskCSISecret(azureDiskCSISecret, hcp, tenantID)
 		}); err != nil {
-			return fmt.Errorf("failed to reconcile Azure disk config: %w", err)
+			return fmt.Errorf("failed to reconcile Azure Disk CSI config: %w", err)
 		}
 
-		// Reconcile the Azure File configuration secret
-		azureFileConfigSecret := manifests.AzureFileConfigWithCredentials(hcp.Namespace)
-		if _, err := createOrUpdate(ctx, r, azureFileConfigSecret, func() error {
-			return azure.ReconcileCloudConfigWithCredentials(azureFileConfigSecret, hcp, credentialsSecret)
+		// Reconcile the secret needed for azure-disk-csi-controller
+		// This is related to https://github.com/openshift/csi-operator/pull/290.
+		azureFileCSISecret := manifests.AzureFileConfigWithCredentials(hcp.Namespace)
+		if _, err := createOrUpdate(ctx, r, azureDiskCSISecret, func() error {
+			return storage.ReconcileAzureFileCSISecret(azureFileCSISecret, hcp, tenantID)
 		}); err != nil {
-			return fmt.Errorf("failed to reconcile Azure disk config: %w", err)
+			return fmt.Errorf("failed to reconcile Azure File CSI config: %w", err)
 		}
 	}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -4986,7 +4986,7 @@ func (r *HostedControlPlaneReconciler) reconcileClusterStorageOperator(ctx conte
 		// Reconcile the secret needed for azure-disk-csi-controller
 		// This is related to https://github.com/openshift/csi-operator/pull/290.
 		azureFileCSISecret := manifests.AzureFileConfigWithCredentials(hcp.Namespace)
-		if _, err := createOrUpdate(ctx, r, azureDiskCSISecret, func() error {
+		if _, err := createOrUpdate(ctx, r, azureFileCSISecret, func() error {
 			return storage.ReconcileAzureFileCSISecret(azureFileCSISecret, hcp, tenantID)
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile Azure File CSI config: %w", err)

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/azure.go
@@ -1,0 +1,63 @@
+package storage
+
+import (
+	"encoding/json"
+	"fmt"
+	"path"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
+	hypershiftconfig "github.com/openshift/hypershift/support/config"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// initializeAzureCSIControllerConfig initializes an AzureConfig object which will be used to populate the secrets
+// needed by azure-disk-csi-controller and azure-file-csi-controller.
+func initializeAzureCSIControllerConfig(hcp *hyperv1.HostedControlPlane, tenantID string) azure.AzureConfig {
+	azureConfig := azure.AzureConfig{
+		Cloud:          hcp.Spec.Platform.Azure.Cloud,
+		TenantID:       tenantID,
+		SubscriptionID: hcp.Spec.Platform.Azure.SubscriptionID,
+		ResourceGroup:  hcp.Spec.Platform.Azure.ResourceGroupName,
+		Location:       hcp.Spec.Platform.Azure.Location,
+	}
+
+	return azureConfig
+}
+
+// ReconcileAzureDiskCSISecret reconciles the configuration for the secret as expected by azure-disk-csi-controller
+func ReconcileAzureDiskCSISecret(secret *corev1.Secret, hcp *hyperv1.HostedControlPlane, tenantID string) error {
+	config := initializeAzureCSIControllerConfig(hcp, tenantID)
+	config.AADClientID = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Disk.ClientID
+	config.AADClientCertPath = path.Join(hypershiftconfig.ManagedAzureCertificatePath, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Disk.CertificateName)
+
+	serializedConfig, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to serialize cloudconfig: %w", err)
+	}
+
+	if secret.Data == nil {
+		secret.Data = map[string][]byte{}
+	}
+	secret.Data[azure.CloudConfigKey] = serializedConfig
+	return nil
+}
+
+// ReconcileAzureFileCSISecret reconciles the configuration for the secret as expected by azure-file-csi-controller
+func ReconcileAzureFileCSISecret(secret *corev1.Secret, hcp *hyperv1.HostedControlPlane, tenantID string) error {
+	config := initializeAzureCSIControllerConfig(hcp, tenantID)
+	config.AADClientID = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.File.ClientID
+	config.AADClientCertPath = path.Join(hypershiftconfig.ManagedAzureCertificatePath, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.File.CertificateName)
+
+	serializedConfig, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to serialize cloudconfig: %w", err)
+	}
+
+	if secret.Data == nil {
+		secret.Data = map[string][]byte{}
+	}
+	secret.Data[azure.CloudConfigKey] = serializedConfig
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual backport of https://github.com/openshift/hypershift/pull/5311

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes [OCPBUGS-46666](https://issues.redhat.com/browse/OCPBUGS-46666)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.