### PR TITLE
NO-JIRA: Revert E2E test change which validates the CVO Image propagation

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -390,11 +390,11 @@ func WaitForImageRollout(t *testing.T, ctx context.Context, client crclient.Clie
 				Status: metav1.ConditionFalse,
 			}),
 			func(hostedCluster *hyperv1.HostedCluster) (done bool, reasons string, err error) {
+				if wanted, got := image, ptr.Deref(hostedCluster.Status.Version, hyperv1.ClusterVersionStatus{}).Desired.Image; wanted != got {
+					return false, fmt.Sprintf("wanted HostedCluster to desire image %s, got %s", wanted, got), nil
+				}
 				if len(ptr.Deref(hostedCluster.Status.Version, hyperv1.ClusterVersionStatus{}).History) == 0 {
 					return false, "HostedCluster has no version history", nil
-				}
-				if wanted, got := hostedCluster.Status.Version.History[0].Version, ptr.Deref(hostedCluster.Status.Version, hyperv1.ClusterVersionStatus{}).Desired.Version; wanted != got {
-					return false, fmt.Sprintf("wanted HostedCluster to desired version %s, got %s", wanted, got), nil
 				}
 				if wanted, got := hostedCluster.Status.Version.Desired.Image, hostedCluster.Status.Version.History[0].Image; wanted != got {
 					return false, fmt.Sprintf("desired image %s doesn't match most recent image in history %s", wanted, got), nil


### PR DESCRIPTION
This is reverting a small change done in https://github.com/openshift/hypershift/pull/5168 in order to fix the Upgrade tests on E2E. `hostedCluster.Status.Version` is mirrored up from the CVO and doesn't propagate immediately, so we need to verify the image we pass to `WaitForImageRollout` is present in the status before we check any other thing.

https://github.com/openshift/hypershift/pull/5168/files#diff-cebde6b83b4b372162b2c6a22710a4ab0b1838576120535593a66a3a9bdfc170