### PR TITLE
OCPBUGS-47715: fix disconnected via CLI

### DIFF
--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -649,7 +649,11 @@ func (opts *RawCreateOptions) Validate(ctx context.Context) (*ValidatedCreateOpt
 			return nil, fmt.Errorf("could not retrieve kube clientset: %w", err)
 		}
 		if err := validateMgmtClusterAndNodePoolCPUArchitectures(ctx, opts, kc, &hyperutil.RegistryClientImageMetadataProvider{}); err != nil {
-			return nil, err
+			if strings.Contains(err.Error(), "failed to retrieve manifest") {
+				opts.Log.Info("WARNING: Unable to access the payload, skipping the Architectures check.", "error", err.Error())
+			} else {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
In many disconnected environments, the execution environment may not have access to the payload image. Adjust the multi-arch check logic to skip the check when the payload is inaccessible.

**Which issue(s) this PR fixes**
Fixes [OCPBUGS-47715](https://issues.redhat.com/browse/OCPBUGS-47715)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes unit tests.
- [ ] This change includes docs. 
