### PR TITLE
NO-JIRA:reconcile azure creds to a fixed secret in hcp namespace

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2617,7 +2617,7 @@ func (r *HostedControlPlaneReconciler) reconcileCloudProviderConfig(ctx context.
 			return fmt.Errorf("failed to reconcile aws provider config: %w", err)
 		}
 	case hyperv1.AzurePlatform:
-		credentialsSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: hcp.Namespace, Name: hcp.Spec.Platform.Azure.Credentials.Name}}
+		credentialsSecret := manifests.AzureCredentialInformation(hcp.Namespace)
 		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
 			return fmt.Errorf("failed to get Azure credentials secret: %w", err)
 		}
@@ -5242,7 +5242,7 @@ func (r *HostedControlPlaneReconciler) validateAzureKMSConfig(ctx context.Contex
 	}
 	azureKmsSpec := hcp.Spec.SecretEncryption.KMS.Azure
 
-	credentialsSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: hcp.Namespace, Name: hcp.Spec.Platform.Azure.Credentials.Name}}
+	credentialsSecret := manifests.AzureCredentialInformation(hcp.Namespace)
 	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
 		condition := metav1.Condition{
 			Type:               string(hyperv1.ValidAzureKMSConfig),

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/azure.go
@@ -25,3 +25,12 @@ func AzureProviderConfigWithCredentials(ns string) *corev1.Secret {
 		},
 	}
 }
+
+func AzureCredentialInformation(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "azure-credential-information",
+			Namespace: ns,
+		},
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1378,7 +1378,7 @@ func (r *reconciler) reconcileCloudCredentialSecrets(ctx context.Context, hcp *h
 			}
 		}
 	case hyperv1.AzurePlatform:
-		referenceCredentialsSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: hcp.Namespace, Name: hcp.Spec.Platform.Azure.Credentials.Name}}
+		referenceCredentialsSecret := cpomanifests.AzureCredentialInformation(hcp.Namespace)
 		if err := r.cpClient.Get(ctx, client.ObjectKeyFromObject(referenceCredentialsSecret), referenceCredentialsSecret); err != nil {
 			return []error{fmt.Errorf("failed to get cloud credentials secret in hcp namespace: %w", err)}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This is blocking 4.17 aks e2e as it cannot create an HC because the reconcile of cloud credentials is blocking progression as it is unable to find the -cloud-credentials secret in HCP NS as made in the HC NS. In newer releases, we use a fixed secret in the HCP namespace instead so this is copying that behavior.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.