### PR TITLE
WIP CNTRLPLANE-374: hcco: handle post-install creation of OIDC client secrets

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1126,6 +1126,10 @@ func (r *reconciler) reconcileAuthOIDC(ctx context.Context, hcp *hyperv1.HostedC
 		// Copy OIDCClient Secrets into openshift-config namespace
 		if len(hcp.Spec.Configuration.Authentication.OIDCProviders[0].OIDCClients) > 0 {
 			for _, oidcClient := range hcp.Spec.Configuration.Authentication.OIDCProviders[0].OIDCClients {
+				// If the secret name is empty, we assume the guest cluster admin is going to create this secret manually
+				if oidcClient.ClientSecret.Name == "" {
+					continue
+				}
 				var src corev1.Secret
 				err := r.cpClient.Get(ctx, client.ObjectKey{Namespace: hcp.Namespace, Name: oidcClient.ClientSecret.Name}, &src)
 				if err != nil {

--- a/support/globalconfig/authentication.go
+++ b/support/globalconfig/authentication.go
@@ -1,6 +1,8 @@
 package globalconfig
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -20,5 +22,12 @@ func ReconcileAuthenticationConfiguration(authentication *configv1.Authenticatio
 		authentication.Spec = *config.Authentication
 	}
 	authentication.Spec.ServiceAccountIssuer = issuerURL
+	for i := range authentication.Spec.OIDCProviders {
+		for j, client := range authentication.Spec.OIDCProviders[i].OIDCClients {
+			if client.ClientSecret.Name == "" {
+				authentication.Spec.OIDCProviders[i].OIDCClients[j].ClientSecret.Name = fmt.Sprintf("%s-post-install-client-secret", client.ComponentName)
+			}
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
Avoid error when allowing guest cluster admin to provide OIDC clientSecrets post-install