### PR TITLE
OCPBUGS-48117: Fix disconnected GetRegistryOverrides

### DIFF
--- a/support/util/imagemetadata.go
+++ b/support/util/imagemetadata.go
@@ -414,8 +414,7 @@ func GetRegistryOverrides(ctx context.Context, ref reference.DockerImageReferenc
 	}
 
 	if ref.Namespace == sourceRef.Namespace && ref.Name == sourceRef.Name {
-		composedImage := fmt.Sprintf("%s/%s/%s", mirrorRef.Registry, mirrorRef.Namespace, ref.NameString())
-		composedRef, err := reference.Parse(composedImage)
+		composedRef, err := reference.Parse(mirror)
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to parse composed image reference (exact match) %q: %w", source, err)
 		}


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
In some environments, the name source/mirror for the payload image in ICSP/IDMS is inconsistent, so we need to adjust the logic in this part.
icsp config
```
- mirrors:
    - virthost.ostest.test.metalkube.org:5000/localimages/local-release-image
  source: registry.build01.ci.openshift.org/ci-op-p2mqdwjp/release
- mirrors:
    - virthost.ostest.test.metalkube.org:5000/localimages/local-release-image
  source: registry.ci.openshift.org/ocp/4.18-2025-01-04-031500
{"level":"info","ts":"2025-01-05T13:55:14Z","msg":"debug---1","controller":"hostedcluster","controllerGroup":"hypershift.openshift.io","controllerKind":"HostedCluster","HostedCluster":{"name":"4abd3e713877d8639ca1","namespace":"local-cluster"},"namespace":"local-cluster","name":"4abd3e713877d8639ca1","reconcileID":"b2b36e7e-b782-408d-b7c2-cf67887e2c06","OpenShiftImageRegistryOverrides":{"brew.registry.redhat.io":["virthost.ostest.test.metalkube.org:6002"],"quay.io/hypershift":["virthost.ostest.test.metalkube.org:6001/hypershift"],"quay.io/olmqe":["virthost.ostest.test.metalkube.org:6001/olmqe"],"quay.io/openshift-qe-optional-operators":["virthost.ostest.test.metalkube.org:6001/openshift-qe-optional-operators"],"quay.io/openshifttest":["virthost.ostest.test.metalkube.org:6001/openshifttest"],"registry-proxy.engineering.redhat.com":["virthost.ostest.test.metalkube.org:6002"],"registry.build01.ci.openshift.org/ci-op-p2mqdwjp/release":["virthost.ostest.test.metalkube.org:5000/localimages/local-release-image"],"registry.ci.openshift.org/ocp/4.18-2025-01-04-031500":["virthost.ostest.test.metalkube.org:5000/localimages/local-release-image"],"registry.redhat.io":["virthost.ostest.test.metalkube.org:6002"],"registry.stage.redhat.io":["virthost.ostest.test.metalkube.org:6002"]}}
{"level":"info","ts":"2025-01-05T13:55:14Z","msg":"debug---2","controller":"hostedcluster","controllerGroup":"hypershift.openshift.io","controllerKind":"HostedCluster","HostedCluster":{"name":"4abd3e713877d8639ca1","namespace":"local-cluster"},"namespace":"local-cluster","name":"4abd3e713877d8639ca1","reconcileID":"b2b36e7e-b782-408d-b7c2-cf67887e2c06","parsedImageRef":"registry.ci.openshift.org/ocp/4.18-2025-01-04-031500@sha256:ba93b7791accfb38e76634edbc815d596ebf39c3d4683a001f8286b3e122ae69"}
{"level":"info","ts":"2025-01-05T13:55:14Z","msg":"debug---3","controller":"hostedcluster","controllerGroup":"hypershift.openshift.io","controllerKind":"HostedCluster","HostedCluster":{"name":"4abd3e713877d8639ca1","namespace":"local-cluster"},"namespace":"local-cluster","name":"4abd3e713877d8639ca1","reconcileID":"b2b36e7e-b782-408d-b7c2-cf67887e2c06","ref":"virthost.ostest.test.metalkube.org:5000/localimages/4.18-2025-01-04-031500@sha256:ba93b7791accfb38e76634edbc815d596ebf39c3d4683a001f8286b3e122ae69"}
```
error log
```
    - lastTransitionTime: "2025-01-05T13:55:14Z"
      message: 'failed to get controlPlaneOperatorImageLabels: failed to look up image
        metadata for registry.ci.openshift.org/ocp/4.18-2025-01-04-031500@sha256:ba93b7791accfb38e76634edbc815d596ebf39c3d4683a001f8286b3e122ae69:
        failed to obtain root manifest for registry.ci.openshift.org/ocp/4.18-2025-01-04-031500@sha256:ba93b7791accfb38e76634edbc815d596ebf39c3d4683a001f8286b3e122ae69:
        manifest unknown: manifest unknown'
      observedGeneration: 2
      reason: ReconciliationError
      status: "False"
      type: ReconciliationSucceeded

```
test job:
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/60159/rehearse-60159-periodic-ci-openshift-hypershift-release-4.18-periodics-mce-e2e-agent-disconnected-ovn-ipv6-metal3-conformance/1876256251864682496

**Which issue(s) this PR fixes** 
https://issues.redhat.com/browse/OCPBUGS-48117

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.