### PR TITLE
OCPBUGS-48152: Fix mirror reference image name when ID is set

### DIFF
--- a/support/util/imagemetadata.go
+++ b/support/util/imagemetadata.go
@@ -414,7 +414,9 @@ func GetRegistryOverrides(ctx context.Context, ref reference.DockerImageReferenc
 	}
 
 	if ref.Namespace == sourceRef.Namespace && ref.Name == sourceRef.Name {
-		composedImage := fmt.Sprintf("%s/%s/%s", mirrorRef.Registry, mirrorRef.Namespace, ref.NameString())
+		mirrorRef.ID = ref.ID
+		mirrorRef.Tag = ref.Tag
+		composedImage := fmt.Sprintf("%s/%s/%s", mirrorRef.Registry, mirrorRef.Namespace, mirrorRef.NameString())
 		composedRef, err := reference.Parse(composedImage)
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to parse composed image reference (exact match) %q: %w", source, err)

--- a/support/util/imagemetadata_test.go
+++ b/support/util/imagemetadata_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -312,6 +313,38 @@ func TestSeekOverride(t *testing.T) {
 				Tag:       "latest",
 			},
 		},
+		{
+			name:      "if registry override exact coincidence is found, and using ID",
+			overrides: fakeOverrides(),
+			imageRef: reference.DockerImageReference{
+				Registry:  "registry.build01.ci.openshift.org",
+				Name:      "release",
+				Namespace: "ci-op-p2mqdwjp",
+				ID:        "sha256:ba93b7791accfb38e76634edbc815d596ebf39c3d4683a001f8286b3e122ae69",
+			},
+			expectedImgRef: &reference.DockerImageReference{
+				Registry:  "virthost.ostest.test.metalkube.org:5000",
+				Name:      "local-release-image",
+				Namespace: "localimages",
+				ID:        "sha256:ba93b7791accfb38e76634edbc815d596ebf39c3d4683a001f8286b3e122ae69",
+			},
+		},
+		{
+			name:      "if registry override partial coincidence is found, and using ID",
+			overrides: fakeOverrides(),
+			imageRef: reference.DockerImageReference{
+				Registry:  "quay.io",
+				Name:      "mce-image",
+				Namespace: "mce",
+				ID:        "sha256:ba93b7791accfb38e76634edbc815d596ebf39c3d4683a001f8286b3e122ae69",
+			},
+			expectedImgRef: &reference.DockerImageReference{
+				Registry:  "myregistry.io",
+				Name:      "mce-image",
+				Namespace: "mce",
+				ID:        "sha256:ba93b7791accfb38e76634edbc815d596ebf39c3d4683a001f8286b3e122ae69",
+			},
+		},
 	}
 
 	for _, tc := range testsCases {
@@ -319,7 +352,7 @@ func TestSeekOverride(t *testing.T) {
 			ctx := context.TODO()
 			g := NewGomegaWithT(t)
 			imgRef := seekOverride(ctx, tc.overrides, tc.imageRef)
-			g.Expect(imgRef).To(Equal(tc.expectedImgRef))
+			g.Expect(imgRef).To(Equal(tc.expectedImgRef), fmt.Sprintf("Expected image reference to be equal to: %v, \nbut got: %v", tc.expectedImgRef, imgRef))
 		})
 	}
 }
@@ -332,6 +365,12 @@ func fakeOverrides() map[string][]string {
 		},
 		"quay.io/mce": {
 			"myregistry.io/mce",
+		},
+		"registry.build01.ci.openshift.org/ci-op-p2mqdwjp/release": {
+			"virthost.ostest.test.metalkube.org:5000/localimages/local-release-image",
+		},
+		"registry.ci.openshift.org/ocp/4.18-2025-01-04-031500": {
+			"virthost.ostest.test.metalkube.org:5000/localimages/local-release-image",
 		},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**: When an imageName is set with the SHA256 and the ICSP/IDMS does not contain a Tag but an ID, the reference image name is using the original name instead of the mirror one. This PR fixes that situation.

**Which issue(s) this PR fixes** :
Fixes #[OCPBUGS-48152](https://issues.redhat.com/browse/OCPBUGS-48152)