### PR TITLE
OCPBUGS-48506: Set ownership annotations for TLS artifacts

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -1,6 +1,8 @@
 package manifests
 
 import (
+	"github.com/openshift/api/annotations"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -282,7 +284,17 @@ func KonnectivityClusterSecret(ns string) *corev1.Secret {
 
 func KonnectivityClientSecret(ns string) *corev1.Secret { return secretFor(ns, "konnectivity-client") }
 
-func KonnectivityAgentSecret(ns string) *corev1.Secret { return secretFor(ns, "konnectivity-agent") }
+func KonnectivityAgentSecret(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "konnectivity-agent",
+			Namespace: ns,
+			Annotations: map[string]string{
+				annotations.OpenShiftComponent: "HyperShift",
+			},
+		},
+	}
+}
 
 func IngressCert(ns string) *corev1.Secret { return secretFor(ns, "ingress-crt") }
 

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/oauth.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/oauth.go
@@ -1,6 +1,7 @@
 package manifests
 
 import (
+	"github.com/openshift/api/annotations"
 	oauthv1 "github.com/openshift/api/oauth/v1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -13,6 +14,9 @@ func OAuthCABundle() *corev1.ConfigMap {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "oauth-serving-cert",
 			Namespace: "openshift-config-managed",
+			Annotations: map[string]string{
+				annotations.OpenShiftComponent: "apiserver-auth",
+			},
 		},
 	}
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -49,6 +49,7 @@ import (
 	openshiftcpv1 "github.com/openshift/api/openshiftcontrolplane/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 
+	"github.com/openshift/api/annotations"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -442,6 +443,9 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "openshift-kube-apiserver-operator",
 			Name:      "kube-control-plane-signer",
+			Annotations: map[string]string{
+				annotations.OpenShiftComponent: "kube-apiserver",
+			},
 		},
 	}
 	if _, err := r.CreateOrUpdate(ctx, r.client, kubeControlPlaneSignerSecret, func() error {
@@ -456,6 +460,9 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ConfigManagedNamespace,
 			Name:      "kubelet-serving-ca",
+			Annotations: map[string]string{
+				annotations.OpenShiftComponent: "kube-controller-manager",
+			},
 		},
 	}
 	if _, err := r.CreateOrUpdate(ctx, r.client, kubeletServingCAConfigMap, func() error {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -44,12 +44,12 @@ import (
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
 
+	"github.com/openshift/api/annotations"
 	configv1 "github.com/openshift/api/config/v1"
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	openshiftcpv1 "github.com/openshift/api/openshiftcontrolplane/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 
-	"github.com/openshift/api/annotations"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION


<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

The secrets/configmaps used to store TLS artifacts should have the same annotations as self-hosted version to match TLS registry. See https://github.com/openshift/enhancements/blob/master/enhancements/security/tls-artifacts-registry.md for more infotmation

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.