### PR TITLE
OCPBUGS-48169: Adjust the multi-arch check logic to skip the check when the payload …

### DIFF
--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -649,7 +649,11 @@ func (opts *RawCreateOptions) Validate(ctx context.Context) (*ValidatedCreateOpt
 			return nil, fmt.Errorf("could not retrieve kube clientset: %w", err)
 		}
 		if err := validateMgmtClusterAndNodePoolCPUArchitectures(ctx, opts, kc, &hyperutil.RegistryClientImageMetadataProvider{}); err != nil {
-			return nil, err
+			if strings.Contains(err.Error(), "failed to retrieve manifest") {
+				opts.Log.Info("WARNING: Unable to access the payload, skipping the Architectures check.", "error", err.Error())
+			} else {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it:**
In many disconnected environments, the execution environment may not have access to the payload image. Adjust the multi-arch check logic to skip the check when the payload is inaccessible.

**Which issue(s) this PR fixes**
Fixes [OCPBUGS-47715](https://issues.redhat.com/browse/OCPBUGS-47715)

**Checklist**

[x] Subject and description added to both, commit and PR.
[x] Relevant issues have been referenced.
[x] This change includes unit tests.
[ ] This change includes docs.