### PR TITLE
HOSTEDCP-1542: Implement Workload Identity in Azure for Data Plane Components Part 4

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
@@ -440,6 +440,14 @@ func buildHCCContainerMain(image, hcpName, openShiftVersion, kubeVersion string,
 				},
 			)
 		}
+		if len(os.Getenv("MANAGED_SERVICE")) > 0 {
+			c.Env = append(c.Env,
+				corev1.EnvVar{
+					Name:  "MANAGED_SERVICE",
+					Value: os.Getenv("MANAGED_SERVICE"),
+				})
+		}
+
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
 	}
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/rbac.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/rbac.go
@@ -200,3 +200,35 @@ func UserOAuthClusterRoleBinding() *rbacv1.ClusterRoleBinding {
 		},
 	}
 }
+
+func AzureDiskCSIDriverNodeServiceAccountRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "system:openshift:openshift-cluster-csi-drivers:azure-disk-csi-driver-node-sa",
+		},
+	}
+}
+
+func AzureDiskCSIDriverNodeServiceAccountRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "system:openshift:openshift-cluster-csi-drivers:azure-disk-csi-driver-node-sa",
+		},
+	}
+}
+
+func AzureFileCSIDriverNodeServiceAccountRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "system:serviceaccount:openshift-cluster-csi-drivers:azure-file-csi-driver-node-sa",
+		},
+	}
+}
+
+func AzureFileCSIDriverNodeServiceAccountRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "system:serviceaccount:openshift-cluster-csi-drivers:azure-file-csi-driver-node-sa",
+		},
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
@@ -632,3 +632,89 @@ func ReconcileUserOAuthClusterRole(r *rbacv1.ClusterRole) error {
 	}
 	return nil
 }
+
+func ReconcileAzureDiskCSIDriverNodeServiceAccountClusterRole(r *rbacv1.ClusterRole) error {
+	if r.Annotations == nil {
+		r.Annotations = map[string]string{}
+	}
+	r.Annotations["rbac.authorization.kubernetes.io/autoupdate"] = "true"
+	r.Rules = []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+			Verbs:     []string{"get"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"nodes"},
+			Verbs: []string{
+				"get",
+				"list",
+				"patch",
+				"update",
+				"watch",
+			},
+		},
+		{
+			APIGroups: []string{"storage.k8s.io"},
+			Resources: []string{"csinodes"},
+			Verbs:     []string{"get"},
+		},
+	}
+	return nil
+}
+
+func ReconcileAzureDiskCSIDriverNodeServiceAccountClusterRoleBinding(r *rbacv1.ClusterRoleBinding) error {
+	if r.Annotations == nil {
+		r.Annotations = map[string]string{}
+	}
+	r.Annotations["rbac.authorization.kubernetes.io/autoupdate"] = "true"
+	r.RoleRef = rbacv1.RoleRef{
+		APIGroup: rbacv1.SchemeGroupVersion.Group,
+		Kind:     "ClusterRole",
+		Name:     "system:openshift:openshift-cluster-csi-drivers:azure-disk-csi-driver-node-sa",
+	}
+	r.Subjects = []rbacv1.Subject{
+		{
+			Kind:      "ServiceAccount",
+			Name:      "azure-disk-csi-driver-node-sa",
+			Namespace: "openshift-cluster-csi-drivers",
+		},
+	}
+	return nil
+}
+
+func ReconcileAzureFileCSIDriverNodeServiceAccountClusterRole(r *rbacv1.ClusterRole) error {
+	if r.Annotations == nil {
+		r.Annotations = map[string]string{}
+	}
+	r.Annotations["rbac.authorization.kubernetes.io/autoupdate"] = "true"
+	r.Rules = []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+			Verbs:     []string{"get"},
+		},
+	}
+	return nil
+}
+
+func ReconcileAzureFileCSIDriverNodeServiceAccountClusterRoleBinding(r *rbacv1.ClusterRoleBinding) error {
+	if r.Annotations == nil {
+		r.Annotations = map[string]string{}
+	}
+	r.Annotations["rbac.authorization.kubernetes.io/autoupdate"] = "true"
+	r.RoleRef = rbacv1.RoleRef{
+		APIGroup: rbacv1.SchemeGroupVersion.Group,
+		Kind:     "ClusterRole",
+		Name:     "system:serviceaccount:openshift-cluster-csi-drivers:azure-file-csi-driver-node-sa",
+	}
+	r.Subjects = []rbacv1.Subject{
+		{
+			Kind:      "ServiceAccount",
+			Name:      "azure-file-csi-driver-node-sa",
+			Namespace: "openshift-cluster-csi-drivers",
+		},
+	}
+	return nil
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1474,26 +1474,31 @@ func (r *reconciler) reconcileCloudCredentialSecrets(ctx context.Context, hcp *h
 		}
 
 		secretData := map[string][]byte{
-			"azure_client_id":       referenceCredentialsSecret.Data["AZURE_CLIENT_ID"],
-			"azure_client_secret":   referenceCredentialsSecret.Data["AZURE_CLIENT_SECRET"],
-			"azure_region":          []byte(hcp.Spec.Platform.Azure.Location),
-			"azure_resource_prefix": []byte(hcp.Name + "-" + hcp.Spec.InfraID),
-			"azure_resourcegroup":   []byte(hcp.Spec.Platform.Azure.ResourceGroupName),
-			"azure_subscription_id": referenceCredentialsSecret.Data["AZURE_SUBSCRIPTION_ID"],
-			"azure_tenant_id":       referenceCredentialsSecret.Data["AZURE_TENANT_ID"],
+			"azure_federated_token_file": []byte("/var/run/secrets/openshift/serviceaccount/token"),
+			"azure_region":               []byte(hcp.Spec.Platform.Azure.Location),
+			"azure_resource_prefix":      []byte(hcp.Name + "-" + hcp.Spec.InfraID),
+			"azure_resourcegroup":        []byte(hcp.Spec.Platform.Azure.ResourceGroupName),
+			"azure_subscription_id":      referenceCredentialsSecret.Data["AZURE_SUBSCRIPTION_ID"],
+			"azure_tenant_id":            referenceCredentialsSecret.Data["AZURE_TENANT_ID"],
 		}
 
+		// The ingress controller fails if this secret is not provided. The controller runs on the control plane side. In managed azure, we are
+		// overriding the Azure credentials authentication method to always use client certificate authentication. This secret is just created
+		// so that the ingress controller does not fail. The data in the secret is never used by the ingress controller due to the aforementioned
+		// override to use client certificate authentication.
 		ingressCredentialSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-ingress-operator", Name: "cloud-credentials"}}
 		if _, err := r.CreateOrUpdate(ctx, r.client, ingressCredentialSecret, func() error {
+			secretData["azure_client_id"] = []byte("fakeClientID")
 			ingressCredentialSecret.Data = secretData
 			return nil
 		}); err != nil {
-			errs = append(errs, fmt.Errorf("failed tom reconcile guest cluster ingress operator secret: %w", err))
+			errs = append(errs, fmt.Errorf("failed to reconcile guest cluster ingress operator secret: %w", err))
 		}
 
-		csiCredentialSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-cluster-csi-drivers", Name: "azure-disk-credentials"}}
-		if _, err := r.CreateOrUpdate(ctx, r.client, csiCredentialSecret, func() error {
-			csiCredentialSecret.Data = secretData
+		azureDiskCSISecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-cluster-csi-drivers", Name: "azure-disk-credentials"}}
+		if _, err := r.CreateOrUpdate(ctx, r.client, azureDiskCSISecret, func() error {
+			secretData["azure_client_id"] = []byte(hcp.Spec.Platform.Azure.ManagedIdentities.DataPlane.DiskMSIClientID)
+			azureDiskCSISecret.Data = secretData
 			return nil
 		}); err != nil {
 			errs = append(errs, fmt.Errorf("failed to reconcile guest cluster CSI secret: %w", err))
@@ -1501,23 +1506,17 @@ func (r *reconciler) reconcileCloudCredentialSecrets(ctx context.Context, hcp *h
 
 		imageRegistrySecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-image-registry", Name: "installer-cloud-credentials"}}
 		if _, err := r.CreateOrUpdate(ctx, r.client, imageRegistrySecret, func() error {
+			secretData["azure_client_id"] = []byte(hcp.Spec.Platform.Azure.ManagedIdentities.DataPlane.ImageRegistryMSIClientID)
 			imageRegistrySecret.Data = secretData
 			return nil
 		}); err != nil {
 			errs = append(errs, fmt.Errorf("failed to reconcile guest cluster image-registry secret: %w", err))
 		}
 
-		cloudNetworkConfigControllerSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-cloud-network-config-controller", Name: "cloud-credentials"}}
-		if _, err := r.CreateOrUpdate(ctx, r.client, cloudNetworkConfigControllerSecret, func() error {
-			cloudNetworkConfigControllerSecret.Data = secretData
-			return nil
-		}); err != nil {
-			errs = append(errs, fmt.Errorf("failed to reconcile guest cluster cloud-network-config-controller secret: %w", err))
-		}
-
-		csiDriverSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-cluster-csi-drivers", Name: "azure-file-credentials"}}
-		if _, err := r.CreateOrUpdate(ctx, r.client, csiDriverSecret, func() error {
-			csiDriverSecret.Data = secretData
+		azureFileCSISecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-cluster-csi-drivers", Name: "azure-file-credentials"}}
+		if _, err := r.CreateOrUpdate(ctx, r.client, azureFileCSISecret, func() error {
+			secretData["azure_client_id"] = []byte(hcp.Spec.Platform.Azure.ManagedIdentities.DataPlane.FileMSIClientID)
+			azureFileCSISecret.Data = secretData
 			return nil
 		}); err != nil {
 			errs = append(errs, fmt.Errorf("failed to reconcile csi driver secret: %w", err))


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is part 4 of implementing workload identity for data plane components in managed Azure. Specifically this PR only includes changes to the CPO.

The PR for part 3 is - https://github.com/openshift/hypershift/pull/4587.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-1542](https://issues.redhat.com/browse/HOSTEDCP-1542)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.