### PR TITLE
NO-JIRA: Add `make lint-fix` to pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,12 @@ repos:
           - Dockerfile.control-plane
         description: Ensures the CPO container files stay in sync
         stages: [pre-commit]
+      - id: make-lint-fix
+        name: Sort imports
+        description: Runs `make lint-fix` to sort imports.
+        entry: make lint-fix
+        language: system
+        stages: [pre-commit]
       - id: make-verify
         name: Run make verify
         description: Runs `make verify`.


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit adds `make lint-fix` to the pre-commit hook so imports are automatically sorted by gci before `make verify` is run in the pre-push hook.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.