### PR TITLE
HOSTEDCP-2226: Add ValidatingAdmissionPolicy for karpenter EC2NodeClass CRD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,10 @@ hypershift-operator:
 karpenter-operator:
 	$(GO_BUILD_RECIPE) -o $(OUT_DIR)/karpenter-operator ./karpenter-operator
 
+.PHONY: karpenter-api
+karpenter-api:
+	./karpenter-operator/controllers/karpenter/assets/adjust-cel.sh
+
 .PHONY: control-plane-operator
 control-plane-operator:
 	$(GO_BUILD_RECIPE) -o $(OUT_DIR)/control-plane-operator ./control-plane-operator

--- a/karpenter-operator/controllers/karpenter/assets/adjust-cel.sh
+++ b/karpenter-operator/controllers/karpenter/assets/adjust-cel.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# remove amiSelectorTerms, securityGroupSelectorTerms, subnetSelectorTerms required validation.
+yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.required = []' -i ${SCRIPT_DIR}/karpenter.k8s.aws_ec2nodeclasses.yaml
+
+yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.amiFamily.enum = ["Custom"]' -i ${SCRIPT_DIR}/karpenter.k8s.aws_ec2nodeclasses.yaml
+
+yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.amiSelectorTerms.x-kubernetes-validations = [
+    {"message": "expected only \"id\" to be set", "rule": "!self.exists(x, has(x.alias) || has(x.tags) || has(x.name) || has(x.owner))"}]' -i ${SCRIPT_DIR}/karpenter.k8s.aws_ec2nodeclasses.yaml
+
+# since amiSelectorTerms is no longer required, top level validations need to be removed accordingly.
+yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.x-kubernetes-validations = [
+    {"message": "must specify exactly one of ['role', 'instanceProfile']", "rule": "(has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))"},
+    {"message": "changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.", "rule": "(has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))"}]' -i ${SCRIPT_DIR}/karpenter.k8s.aws_ec2nodeclasses.yaml

--- a/karpenter-operator/controllers/karpenter/assets/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/karpenter-operator/controllers/karpenter/assets/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -66,12 +66,7 @@ spec:
                     NOTE: We ignore the AMIFamily for hashing here because we hash the AMIFamily dynamically by using the alias using
                     the AMIFamily() helper function
                   enum:
-                    - AL2
-                    - AL2023
-                    - Bottlerocket
                     - Custom
-                    - Windows2019
-                    - Windows2022
                   type: string
                 amiSelectorTerms:
                   description: AMISelectorTerms is a list of or ami selector terms. The terms are ORed.
@@ -127,14 +122,8 @@ spec:
                   minItems: 1
                   type: array
                   x-kubernetes-validations:
-                    - message: expected at least one, got none, ['tags', 'id', 'name', 'alias']
-                      rule: self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))
-                    - message: '''id'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
-                      rule: '!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))'
-                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms'
-                      rule: '!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))'
-                    - message: '''alias'' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms'
-                      rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                    - message: expected only "id" to be set
+                      rule: '!self.exists(x, has(x.alias) || has(x.tags) || has(x.name) || has(x.owner))'
                 associatePublicIPAddress:
                   description: AssociatePublicIPAddress controls if public IP addresses are assigned to instances that are launched with the nodeclass.
                   type: boolean
@@ -560,28 +549,13 @@ spec:
                     It must be in the appropriate format based on the AMIFamily in use. Karpenter will merge certain fields into
                     this UserData to ensure nodes are being provisioned with the correct configuration.
                   type: string
-              required:
-                - amiSelectorTerms
-                - securityGroupSelectorTerms
-                - subnetSelectorTerms
+              required: []
               type: object
               x-kubernetes-validations:
-                - message: must specify exactly one of ['role', 'instanceProfile']
+                - message: must specify exactly one of [role, instanceProfile]
                   rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
-                - message: changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.
+                - message: changing from instanceProfile to role is not supported. You must delete and recreate this node class if you want to change this.
                   rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
-                - message: if set, amiFamily must be 'AL2' or 'Custom' when using an AL2 alias
-                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2'') : true)'
-                - message: if set, amiFamily must be 'AL2023' or 'Custom' when using an AL2023 alias
-                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''al2023'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''AL2023'') : true)'
-                - message: if set, amiFamily must be 'Bottlerocket' or 'Custom' when using a Bottlerocket alias
-                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''bottlerocket'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Bottlerocket'') : true)'
-                - message: if set, amiFamily must be 'Windows2019' or 'Custom' when using a Windows2019 alias
-                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2019'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2019'') : true)'
-                - message: if set, amiFamily must be 'Windows2022' or 'Custom' when using a Windows2022 alias
-                  rule: '!has(self.amiFamily) || (self.amiSelectorTerms.exists(x, has(x.alias) && x.alias.find(''^[^@]+'') == ''windows2022'') ? (self.amiFamily == ''Custom'' || self.amiFamily == ''Windows2022'') : true)'
-                - message: must specify amiFamily if amiSelectorTerms does not contain an alias
-                  rule: 'self.amiSelectorTerms.exists(x, has(x.alias)) ? true : has(self.amiFamily)'
             status:
               description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
               properties:


### PR DESCRIPTION
**What this PR does / why we need it**:
- Add ValidatingAdmissionPolicy for karpenter EC2NodeClass CRD to prevent updates to managed fields
- Relax CEL validations for EC2NodeClass CRD
- Default subnetSelectorTerms and securityGroupSelectorTerms if not set

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.