### PR TITLE
HOSTEDCP-2176: Enable unused & ineffassign linters in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,13 +31,13 @@ issues:
 linters:
   enable:
     - gci
+    - unused
+    - ineffassign
   disable:
     - errcheck
     - gosimple
     - govet
-    - ineffassign
     - staticcheck
-    - unused
 linters-settings:
   gci:
     sections:

--- a/cmd/infra/aws/destroy.go
+++ b/cmd/infra/aws/destroy.go
@@ -292,7 +292,6 @@ func (o *DestroyInfraOptions) DestroyS3Buckets(ctx context.Context, client s3ifa
 			if err != nil {
 				if aerr, ok := err.(awserr.Error); ok && aerr.Code() == s3.ErrCodeNoSuchBucket {
 					o.Log.Info("S3 Bucket already deleted", "name", *bucket.Name)
-					err = nil
 				} else {
 					errs = append(errs, err)
 				}

--- a/pkg/etcdcli/helpers.go
+++ b/pkg/etcdcli/helpers.go
@@ -204,7 +204,6 @@ func NewFakeEtcdClient(members []*etcdserverpb.Member, opts ...FakeClientOption)
 }
 
 type FakeClientOptions struct {
-	client          *clientv3.Client
 	unhealthyMember int
 	healthyMember   int
 	status          []*clientv3.StatusResponse

--- a/support/thirdparty/kubernetes/pkg/credentialprovider/config.go
+++ b/support/thirdparty/kubernetes/pkg/credentialprovider/config.go
@@ -22,14 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
-	"path/filepath"
 	"strings"
-	"sync"
-)
-
-const (
-	maxReadLength = 10 * 1 << 20 // 10MB
 )
 
 // DockerConfigJSON represents ~/.docker/config.json file info
@@ -51,19 +44,6 @@ type DockerConfigEntry struct {
 	Password string
 	Email    string
 }
-
-var (
-	preferredPathLock sync.Mutex
-	preferredPath     = ""
-	workingDirPath    = ""
-	homeDirPath, _    = os.UserHomeDir()
-	rootDirPath       = "/"
-	homeJSONDirPath   = filepath.Join(homeDirPath, ".docker")
-	rootJSONDirPath   = filepath.Join(rootDirPath, ".docker")
-
-	configFileName     = ".dockercfg"
-	configJSONFileName = "config.json"
-)
 
 // ReadSpecificDockerConfigJSONFile attempts to read docker configJSON from a given file path.
 func ReadSpecificDockerConfigJSONFile(filePath string) (cfg DockerConfig, err error) {

--- a/support/thirdparty/library-go/pkg/image/registryclient/client.go
+++ b/support/thirdparty/library-go/pkg/image/registryclient/client.go
@@ -347,8 +347,6 @@ func (c *Context) repositoryTransport(t http.RoundTripper, registry *url.URL, re
 	return c.cachedTransport(t, c.scopes(repoName))
 }
 
-var nowFn = time.Now
-
 type retryRepository struct {
 	distribution.Repository
 

--- a/support/util/imagemetadata.go
+++ b/support/util/imagemetadata.go
@@ -128,12 +128,6 @@ func (r *RegistryClientImageMetadataProvider) GetOverride(ctx context.Context, i
 		return nil, fmt.Errorf("failed to parse image reference %q: %w", imageRef, err)
 	}
 
-	// There are no ICSPs/IDMSs to process.
-	// That means the image reference should be pulled from the external registry
-	if len(r.OpenShiftImageRegistryOverrides) == 0 {
-		ref = &parsedImageRef
-	}
-
 	ref = seekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef)
 
 	return ref, nil

--- a/test/e2e/nodepool_nto_constants.go
+++ b/test/e2e/nodepool_nto_constants.go
@@ -1,7 +1,5 @@
 package e2e
 
 const (
-	tuningConfigKey          = "tuning"
-	nodePoolNsNameAnnotation = "hypershift.openshift.io/nodePool"
-	nodePoolNameLabel        = "hypershift.openshift.io/nodePool"
+	tuningConfigKey = "tuning"
 )

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -198,7 +198,7 @@ func WaitForGuestClient(t *testing.T, ctx context.Context, client crclient.Clien
 	if IsLessThan(Version415) {
 		// SelfSubjectReview API is only available in 4.15+
 		// Use the old method to check if the API server is up
-		err = wait.PollImmediateWithContext(ctx, 35*time.Second, 30*time.Minute, func(ctx context.Context) (done bool, err error) {
+		err = wait.PollUntilContextTimeout(ctx, 35*time.Second, 30*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 			_, err = crclient.New(guestConfig, crclient.Options{Scheme: scheme})
 			if err != nil {
 				t.Logf("attempt to connect failed: %s", err)
@@ -206,6 +206,9 @@ func WaitForGuestClient(t *testing.T, ctx context.Context, client crclient.Clien
 			}
 			return true, nil
 		})
+		if err != nil {
+			t.Fatalf("failed to connect to guest cluster: %v", err)
+		}
 	} else {
 		EventuallyObject(t, ctx, "a successful connection to the guest API server",
 			func(ctx context.Context) (*authenticationv1.SelfSubjectReview, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR:
- This commit enables unused and ineffassign in golangci-lint, which checks Go code for unused constants, variables, functions and types and ineffectual assignments respectively.
- Fixes the errrors found by those linters.

**Which issue(s) this PR fixes**:
Fixes [HOSTEDCP-2176](https://issues.redhat.com/browse/HOSTEDCP-2176)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.