### PR TITLE
NO-JIRA: add information about checking HO and e2e are from main on latest release branch

### DIFF
--- a/docs/content/contribute/release-process.md
+++ b/docs/content/contribute/release-process.md
@@ -68,6 +68,10 @@ So, we need to check over the Step registry config and make sure that the hypers
 
 [Example Release Repo PR](https://github.com/openshift/release/pull/59120/files)
 
+We should also ensure that the latest release branch is using the Hypershift Operator and e2e from main.
+
+[Example Release Branch PR](https://github.com/openshift/release/pull/60531/files)
+
 ### Notes
 If test platform are testing new OCP releases before the release is cut the hypershift test will fail and block payloads until:
 - There are at least two accepted nightly payloads for the new release.


### PR DESCRIPTION
**What this PR does / why we need it**:
add a part to the doc to remind us to check that the correct version of the HO and e2e are being used on the new release branch after a release cut

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.