### PR TITLE
NO-JIRA: Add GOWORK=off to clients in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ api-docs: $(GENAPIDOCS)
 
 .PHONY: clients
 clients: delegating_client
-	GO=GO111MODULE=on GOFLAGS=-mod=readonly hack/update-codegen.sh
+	GOWORK=off GO=GO111MODULE=on GOFLAGS=-mod=readonly hack/update-codegen.sh
 
 .PHONY: release
 release:


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit adds the GOWORK=off to the `clients` in the Makefile.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes N/A

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.