### PR TITLE
NO-JIRA: e2e: don't skip mirrorconfigs on OSP

### DIFF
--- a/test/e2e/nodepool_mirrorconfigs_test.go
+++ b/test/e2e/nodepool_mirrorconfigs_test.go
@@ -60,9 +60,6 @@ func NewMirrorConfigsTest(ctx context.Context, mgmtClient crclient.Client, hoste
 func (mc *MirrorConfigsTest) Setup(t *testing.T) {
 	t.Log("Starting test MirrorConfigsTest")
 
-	if globalOpts.Platform == hyperv1.OpenStackPlatform {
-		t.Skip("test is being skipped for OpenStack platform until https://issues.redhat.com/browse/OSASINFRA-3566 is addressed")
-	}
 	if e2eutil.IsLessThan(e2eutil.Version418) {
 		t.Skip("test only applicable for 4.18+")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This was a bad copy paste but this test should not be skipped on
OpenStack.
