### PR TITLE
OCPBUGS-48626: openstack: add DNS option to CLI

### DIFF
--- a/docs/content/how-to/openstack/hostedcluster.md
+++ b/docs/content/how-to/openstack/hostedcluster.md
@@ -15,6 +15,7 @@ Here are the available options specific to the OpenStack platform:
 | `--openstack-node-availability-zone`| Availability zone for the nodepool                                                        | No       |               |
 | `--openstack-node-flavor`        | Flavor for the nodepool                                                                      | Yes      |               |
 | `--openstack-node-image-name`    | Image name for the nodepool                                                                  | Yes      |               |
+| `--openstack-dns-nameservers`    | List of DNS server addresses that will be provided when creating the subnet                  | No       |               |
 
 Below is an example of how to create a cluster using environment variables and the `hcp` cli tool.
 
@@ -55,6 +56,9 @@ export CLOUDS_YAML="$HOME/clouds.yaml"
 # SSH Key for the nodepool VMs
 export SSH_KEY="$HOME/.ssh/id_rsa.pub"
 
+# DNS nameserver for the subnet
+export DNS_NAMESERVERS="1.1.1.1"
+
 hcp create cluster openstack \
 --name $CLUSTER_NAME \
 --base-domain $BASE_DOMAIN \
@@ -66,7 +70,8 @@ hcp create cluster openstack \
 --openstack-external-network-id $EXTERNAL_NETWORK_ID \
 --openstack-node-image-name $IMAGE_NAME \
 --openstack-node-flavor $FLAVOR \
---openstack-ingress-floating-ip $INGRESS_FLOATING_IP
+--openstack-ingress-floating-ip $INGRESS_FLOATING_IP \
+--openstack-dns-nameservers $DNS_NAMESERVERS
 ```
 
 !!! note

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -137,6 +137,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.ConfigurableClusterOptions.OpenStackNodeAvailabilityZone, "e2e.openstack-node-availability-zone", "", "The availability zone to use for OpenStack nodes")
 	flag.StringVar(&globalOpts.ConfigurableClusterOptions.OpenStackNodeFlavor, "e2e.openstack-node-flavor", "", "The flavor to use for OpenStack nodes")
 	flag.StringVar(&globalOpts.ConfigurableClusterOptions.OpenStackNodeImageName, "e2e.openstack-node-image-name", "", "The image name to use for OpenStack nodes")
+	flag.Var(&globalOpts.ConfigurableClusterOptions.OpenStackDNSNameservers, "e2e.openstack-dns-nameservers", "List of DNS nameservers to use for the cluster")
 
 	// PowerVS specific flags
 	flag.BoolVar(&globalOpts.ConfigurableClusterOptions.PowerVSPER, "e2e-powervs-power-edge-router", false, "Enabling this flag will utilize Power Edge Router solution via transit gateway instead of cloud connection to create a connection between PowerVS and VPC")

--- a/test/e2e/util/options.go
+++ b/test/e2e/util/options.go
@@ -128,6 +128,7 @@ type ConfigurableClusterOptions struct {
 	OpenStackNodeAvailabilityZone         string
 	OpenStackNodeFlavor                   string
 	OpenStackNodeImageName                string
+	OpenStackDNSNameservers               stringSliceVar
 	PowerVSCloudConnection                string
 	PowerVSCloudInstanceID                string
 	PowerVSMemory                         int
@@ -229,6 +230,7 @@ func (p *Options) DefaultOpenStackOptions() hypershiftopenstack.RawCreateOptions
 				AvailabityZone: p.ConfigurableClusterOptions.OpenStackNodeAvailabilityZone,
 			},
 		},
+		OpenStackDNSNameservers: p.ConfigurableClusterOptions.OpenStackDNSNameservers,
 	}
 
 	return opts


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow the users to provide the DNS nameservers that will be used when
creating the OpenStack subnets.
In some environments where DNS forwarding is not enabled, the subnet
needs to have DNS nameservers for external resolution, otherwise the
Nodepools won't be able to e.g. reach the ignition endpoint.

This was already possible before by rendering the HostedCluster spec
first but now it's possible to do it via the CLI for a better UX, since
this option might be used by a majority of our customers.
