### PR TITLE
NO-JIRA: [kubevirt] Skip KubeVirtAdvancedMultinetTest for v4.14 and below

### DIFF
--- a/test/e2e/nodepool_kv_advanced_multinet_test.go
+++ b/test/e2e/nodepool_kv_advanced_multinet_test.go
@@ -49,7 +49,10 @@ func NewKubeVirtAdvancedMultinetTest(ctx context.Context, mgmtClient crclient.Cl
 
 func (k KubeVirtAdvancedMultinetTest) Setup(t *testing.T) {
 	if globalOpts.Platform != hyperv1.KubevirtPlatform {
-		t.Skip("test only supported on platform KubeVirt")
+		t.Skip("test only supported on KubeVirt platform")
+	}
+	if e2eutil.IsLessThan(e2eutil.Version415) {
+		t.Skip("test only supported from version 4.15")
 	}
 
 	t.Log("Starting test KubeVirtAdvancedMultinetTest")


### PR DESCRIPTION
The multiple networks feature in the kubevirt platform has been introduced in 4.15, therefore we need to skip it for the e2e test running against v4.14 and below.

Need it order for https://github.com/openshift/hypershift/pull/5235 to pass CI.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/browse/OCPBUGS-45559

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.