### PR TITLE
OCPBUGS-48708: correct aro azureFile config and permissions

### DIFF
--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -806,6 +806,8 @@ func assignServicePrincipalRoles(subscriptionID, managedResourceGroupName, nsgRe
 		scopes = append(scopes, vnetRG, dnsZoneRG)
 	case cpo:
 		scopes = append(scopes, nsgRG, vnetRG)
+	case azureFile:
+		scopes = append(scopes, nsgRG, vnetRG)
 	case nodePoolMgmt:
 		scopes = append(scopes, vnetRG)
 	}


### PR DESCRIPTION

**What this PR does / why we need it**:
- Correct ARO file csi driver cloud config and permissions.

**Which issue(s) this PR fixes** 
Fixes # [OCPBUGS-48708](https://issues.redhat.com/browse/OCPBUGS-48708)

**Test record(Manually build the control plane operator image and replcaed in a live cluster verify it works)** 
https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/ocp-common/job/ginkgo-test/285274/console
```console
79 pass, 13 skip (46m1s)
```