### PR TITLE
OCPBUGS-48688: Remove client secret references now Workload Identity is supported

### DIFF
--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -479,12 +479,11 @@ func (o *CreateOptions) GenerateNodePools(constructor core.DefaultNodePoolConstr
 func (o *CreateOptions) GenerateResources() ([]crclient.Object, error) {
 	var objects []crclient.Object
 
+	// This secret is primarily generated because we need a way to pass the tenant ID to the HCP
 	secret := credentialSecret(o.namespace, o.name)
 	secret.Data = map[string][]byte{
 		"AZURE_SUBSCRIPTION_ID": []byte(o.creds.SubscriptionID),
 		"AZURE_TENANT_ID":       []byte(o.creds.TenantID),
-		"AZURE_CLIENT_ID":       []byte(o.creds.ClientID),
-		"AZURE_CLIENT_SECRET":   []byte(o.creds.ClientSecret),
 	}
 	objects = append(objects, secret)
 

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_complicated_invocation_from_bryan.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_complicated_invocation_from_bryan.yaml
@@ -19,8 +19,6 @@ metadata:
 ---
 apiVersion: v1
 data:
-  AZURE_CLIENT_ID: ZmFrZUNsaWVudElE
-  AZURE_CLIENT_SECRET: ZmFrZUNsaWVudFNlY3JldA==
   AZURE_SUBSCRIPTION_ID: ZmFrZVN1YnNjcmlwdGlvbklE
   AZURE_TENANT_ID: ZmFrZVRlbmFudElE
 kind: Secret

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -19,8 +19,6 @@ metadata:
 ---
 apiVersion: v1
 data:
-  AZURE_CLIENT_ID: ZmFrZUNsaWVudElE
-  AZURE_CLIENT_SECRET: ZmFrZUNsaWVudFNlY3JldA==
   AZURE_SUBSCRIPTION_ID: ZmFrZVN1YnNjcmlwdGlvbklE
   AZURE_TENANT_ID: ZmFrZVRlbmFudElE
 kind: Secret

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_ones.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_ones.yaml
@@ -19,8 +19,6 @@ metadata:
 ---
 apiVersion: v1
 data:
-  AZURE_CLIENT_ID: ZmFrZUNsaWVudElE
-  AZURE_CLIENT_SECRET: ZmFrZUNsaWVudFNlY3JldA==
   AZURE_SUBSCRIPTION_ID: ZmFrZVN1YnNjcmlwdGlvbklE
   AZURE_TENANT_ID: ZmFrZVRlbmFudElE
 kind: Secret

--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -838,6 +838,8 @@ func assignServicePrincipalRoles(subscriptionID, managedResourceGroupName, nsgRe
 		scopes = append(scopes, nsgRG, vnetRG)
 	case nodePoolMgmt:
 		scopes = append(scopes, vnetRG)
+	case cncc:
+		scopes = append(scopes, vnetRG)
 	}
 
 	// Assign contributor role to service principal

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go
@@ -105,13 +105,11 @@ func azureConfigWithoutCredentials(hcp *hyperv1.HostedControlPlane, credentialsS
 // Now the source is https://github.com/kubernetes-sigs/cloud-provider-azure/blob/e5d670328a51e31787fc949ddf41a3efcd90d651/examples/out-of-tree/cloud-controller-manager.yaml#L232
 // https://github.com/kubernetes-sigs/cloud-provider-azure/tree/e5d670328a51e31787fc949ddf41a3efcd90d651/pkg/provider/config
 type AzureConfig struct {
-	Cloud                       string `json:"cloud"`
-	TenantID                    string `json:"tenantId"`
-	UseManagedIdentityExtension bool   `json:"useManagedIdentityExtension"`
-	SubscriptionID              string `json:"subscriptionId"`
-	AADClientID                 string `json:"aadClientId"`
-	// TODO HOSTEDCP-1542 - Bryan - drop client secret once we have WorkloadIdentity working
-	AADClientSecret              string `json:"aadClientSecret"`
+	Cloud                        string `json:"cloud"`
+	TenantID                     string `json:"tenantId"`
+	UseManagedIdentityExtension  bool   `json:"useManagedIdentityExtension"`
+	SubscriptionID               string `json:"subscriptionId"`
+	AADClientID                  string `json:"aadClientId"`
 	AADClientCertPath            string `json:"aadClientCertPath"`
 	ResourceGroup                string `json:"resourceGroup"`
 	Location                     string `json:"location"`

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -4420,7 +4420,7 @@ func (r *HostedClusterReconciler) validateAzureConfig(ctx context.Context, hc *h
 	}
 
 	var errs []error
-	for _, expectedKey := range []string{"AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET", "AZURE_SUBSCRIPTION_ID", "AZURE_TENANT_ID"} {
+	for _, expectedKey := range []string{"AZURE_SUBSCRIPTION_ID", "AZURE_TENANT_ID"} {
 		if _, found := credentialsSecret.Data[expectedKey]; !found {
 			errs = append(errs, fmt.Errorf("credentials secret for cluster doesn't have required key %s", expectedKey))
 		}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
@@ -213,8 +213,6 @@ func (a Azure) ReconcileCredentials(ctx context.Context, c client.Client, create
 	// Sync CNCC secret
 	cloudNetworkConfigCreds := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: controlPlaneNamespace, Name: "cloud-network-config-controller-creds"}}
 	secretData := map[string][]byte{
-		"azure_client_id":       azureCredsInfo.Data["AZURE_CLIENT_ID"],
-		"azure_client_secret":   azureCredsInfo.Data["AZURE_CLIENT_SECRET"],
 		"azure_region":          []byte(hcluster.Spec.Platform.Azure.Location),
 		"azure_resource_prefix": []byte(hcluster.Name + "-" + hcluster.Spec.InfraID),
 		"azure_resourcegroup":   []byte(hcluster.Spec.Platform.Azure.ResourceGroupName),


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request removes client secret references for managed Azure since Workload identity is supported now.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes [OCPBUGS-48688](https://issues.redhat.com/browse/OCPBUGS-48688)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.