### PR TITLE
CNTRLPLANE-216: Add KubeAPIExteralName api

### DIFF
--- a/Dockerfile.control-plane
+++ b/Dockerfile.control-plane
@@ -26,3 +26,4 @@ LABEL io.openshift.hypershift.control-plane-operator-applies-management-kas-netw
 LABEL io.openshift.hypershift.restricted-psa=true
 LABEL io.openshift.hypershift.control-plane-pki-operator-signs-csrs=true
 LABEL io.openshift.hypershift.hosted-cluster-config-operator-reports-node-count=true
+LABEL io.openshift.hypershift.control-plane-operator-supports-kas-custom-kubeconfig=true

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -37,3 +37,4 @@ LABEL io.openshift.hypershift.control-plane-operator-applies-management-kas-netw
 LABEL io.openshift.hypershift.restricted-psa=true
 LABEL io.openshift.hypershift.control-plane-pki-operator-signs-csrs=true
 LABEL io.openshift.hypershift.hosted-cluster-config-operator-reports-node-count=true
+LABEL io.openshift.hypershift.control-plane-operator-supports-kas-custom-kubeconfig=true

--- a/api/hypershift/v1beta1/hosted_controlplane.go
+++ b/api/hypershift/v1beta1/hosted_controlplane.go
@@ -115,6 +115,20 @@ type HostedControlPlaneSpec struct {
 	// +optional
 	KubeConfig *KubeconfigSecretRef `json:"kubeconfig,omitempty"`
 
+	// kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+	// When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+	// If it's set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+	// The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+	// This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+	// access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+	// for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+	//
+	// +kubebuilder:validation:XValidation:rule=`self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')`,message="kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)"
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:example: "api.example.com"
+	// +optional
+	KubeAPIServerDNSName string `json:"kubeAPIServerDNSName,omitempty"`
+
 	// Services defines metadata about how control plane services are published
 	// in the management cluster.
 	// +kubebuilder:validation:MaxItems=6
@@ -313,6 +327,15 @@ type HostedControlPlaneStatus struct {
 	// KubeConfig is a reference to the secret containing the default kubeconfig
 	// for this control plane.
 	KubeConfig *KubeconfigSecretRef `json:"kubeConfig,omitempty"`
+
+	// customKubeconfig references an external custom kubeconfig secret.
+	// This field is populated in the status when a custom kubeconfig secret has been generated
+	// for the hosted cluster. It contains the name and key of the secret located in the
+	// hostedCluster namespace. This field is only populated when kubeApiExternalName is set.
+	// If this field is removed during a day 2 operation, the referenced secret will be deleted
+	// and this field will be removed from the hostedCluster status.
+	// +optional
+	CustomKubeconfig *KubeconfigSecretRef `json:"customKubeconfig,omitempty"`
 
 	// KubeadminPassword is a reference to the secret containing the initial kubeadmin password
 	// for the guest cluster.

--- a/api/hypershift/v1beta1/zz_generated.deepcopy.go
+++ b/api/hypershift/v1beta1/zz_generated.deepcopy.go
@@ -1505,6 +1505,11 @@ func (in *HostedClusterStatus) DeepCopyInto(out *HostedClusterStatus) {
 		*out = new(corev1.LocalObjectReference)
 		**out = **in
 	}
+	if in.CustomKubeconfig != nil {
+		in, out := &in.CustomKubeconfig, &out.CustomKubeconfig
+		*out = new(corev1.LocalObjectReference)
+		**out = **in
+	}
 	if in.KubeadminPassword != nil {
 		in, out := &in.KubeadminPassword, &out.KubeadminPassword
 		*out = new(corev1.LocalObjectReference)
@@ -1726,6 +1731,11 @@ func (in *HostedControlPlaneStatus) DeepCopyInto(out *HostedControlPlaneStatus) 
 	}
 	if in.KubeConfig != nil {
 		in, out := &in.KubeConfig, &out.KubeConfig
+		*out = new(KubeconfigSecretRef)
+		**out = **in
+	}
+	if in.CustomKubeconfig != nil {
+		in, out := &in.CustomKubeconfig, &out.CustomKubeconfig
 		*out = new(KubeconfigSecretRef)
 		**out = **in
 	}

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -2393,6 +2393,21 @@ spec:
                   rule: self == oldSelf
                 - message: issuerURL must be a valid absolute URL
                   rule: isURL(self)
+              kubeAPIServerDNSName:
+                description: |-
+                  kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+                  When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+                  If it's set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+                  The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+                  This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+                  access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+                  for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+                  This API endpoint only works in OCP version 4.19 or later. Older versions will result in a no-op.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)
+                  rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
               labels:
                 additionalProperties:
                   type: string
@@ -4833,6 +4848,22 @@ spec:
                 - host
                 - port
                 type: object
+              customKubeconfig:
+                description: |-
+                  CustomKubeconfig is a local secret reference to the external custom kubeconfig.
+                  Once the hypershift operator sets this status field, it will generate a secret with the specified name containing a kubeconfig within the `HostedCluster` namespace.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               ignitionEndpoint:
                 description: |-
                   IgnitionEndpoint is the endpoint injected in the ign config userdata.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -2434,6 +2434,21 @@ spec:
                   rule: self == oldSelf
                 - message: issuerURL must be a valid absolute URL
                   rule: isURL(self)
+              kubeAPIServerDNSName:
+                description: |-
+                  kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+                  When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+                  If it's set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+                  The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+                  This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+                  access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+                  for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+                  This API endpoint only works in OCP version 4.19 or later. Older versions will result in a no-op.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)
+                  rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
               labels:
                 additionalProperties:
                   type: string
@@ -4866,6 +4881,22 @@ spec:
                 - host
                 - port
                 type: object
+              customKubeconfig:
+                description: |-
+                  CustomKubeconfig is a local secret reference to the external custom kubeconfig.
+                  Once the hypershift operator sets this status field, it will generate a secret with the specified name containing a kubeconfig within the `HostedCluster` namespace.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               ignitionEndpoint:
                 description: |-
                   IgnitionEndpoint is the endpoint injected in the ign config userdata.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -2389,6 +2389,21 @@ spec:
                   rule: self == oldSelf
                 - message: issuerURL must be a valid absolute URL
                   rule: isURL(self)
+              kubeAPIServerDNSName:
+                description: |-
+                  kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+                  When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+                  If it's set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+                  The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+                  This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+                  access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+                  for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+                  This API endpoint only works in OCP version 4.19 or later. Older versions will result in a no-op.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)
+                  rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
               labels:
                 additionalProperties:
                   type: string
@@ -4846,6 +4861,22 @@ spec:
                 - host
                 - port
                 type: object
+              customKubeconfig:
+                description: |-
+                  CustomKubeconfig is a local secret reference to the external custom kubeconfig.
+                  Once the hypershift operator sets this status field, it will generate a secret with the specified name containing a kubeconfig within the `HostedCluster` namespace.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               ignitionEndpoint:
                 description: |-
                   IgnitionEndpoint is the endpoint injected in the ign config userdata.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -2410,6 +2410,21 @@ spec:
                   rule: self == oldSelf
                 - message: issuerURL must be a valid absolute URL
                   rule: isURL(self)
+              kubeAPIServerDNSName:
+                description: |-
+                  kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+                  When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+                  If it's set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+                  The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+                  This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+                  access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+                  for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+                  This API endpoint only works in OCP version 4.19 or later. Older versions will result in a no-op.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)
+                  rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
               labels:
                 additionalProperties:
                   type: string
@@ -4842,6 +4857,22 @@ spec:
                 - host
                 - port
                 type: object
+              customKubeconfig:
+                description: |-
+                  CustomKubeconfig is a local secret reference to the external custom kubeconfig.
+                  Once the hypershift operator sets this status field, it will generate a secret with the specified name containing a kubeconfig within the `HostedCluster` namespace.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               ignitionEndpoint:
                 description: |-
                   IgnitionEndpoint is the endpoint injected in the ign config userdata.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -2631,6 +2631,21 @@ spec:
                   rule: self == oldSelf
                 - message: issuerURL must be a valid absolute URL
                   rule: isURL(self)
+              kubeAPIServerDNSName:
+                description: |-
+                  kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+                  When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+                  If it's set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+                  The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+                  This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+                  access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+                  for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+                  This API endpoint only works in OCP version 4.19 or later. Older versions will result in a no-op.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)
+                  rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
               labels:
                 additionalProperties:
                   type: string
@@ -5063,6 +5078,22 @@ spec:
                 - host
                 - port
                 type: object
+              customKubeconfig:
+                description: |-
+                  CustomKubeconfig is a local secret reference to the external custom kubeconfig.
+                  Once the hypershift operator sets this status field, it will generate a secret with the specified name containing a kubeconfig within the `HostedCluster` namespace.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               ignitionEndpoint:
                 description: |-
                   IgnitionEndpoint is the endpoint injected in the ign config userdata.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -2407,6 +2407,21 @@ spec:
                   rule: self == oldSelf
                 - message: issuerURL must be a valid absolute URL
                   rule: isURL(self)
+              kubeAPIServerDNSName:
+                description: |-
+                  kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+                  When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+                  If it's set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+                  The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+                  This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+                  access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+                  for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+                  This API endpoint only works in OCP version 4.19 or later. Older versions will result in a no-op.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)
+                  rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
               labels:
                 additionalProperties:
                   type: string
@@ -4839,6 +4854,22 @@ spec:
                 - host
                 - port
                 type: object
+              customKubeconfig:
+                description: |-
+                  CustomKubeconfig is a local secret reference to the external custom kubeconfig.
+                  Once the hypershift operator sets this status field, it will generate a secret with the specified name containing a kubeconfig within the `HostedCluster` namespace.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               ignitionEndpoint:
                 description: |-
                   IgnitionEndpoint is the endpoint injected in the ign config userdata.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -2541,6 +2541,21 @@ spec:
                   rule: self == oldSelf
                 - message: issuerURL must be a valid absolute URL
                   rule: isURL(self)
+              kubeAPIServerDNSName:
+                description: |-
+                  kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+                  When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+                  If it's set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+                  The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+                  This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+                  access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+                  for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+                  This API endpoint only works in OCP version 4.19 or later. Older versions will result in a no-op.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)
+                  rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
               labels:
                 additionalProperties:
                   type: string
@@ -4973,6 +4988,22 @@ spec:
                 - host
                 - port
                 type: object
+              customKubeconfig:
+                description: |-
+                  CustomKubeconfig is a local secret reference to the external custom kubeconfig.
+                  Once the hypershift operator sets this status field, it will generate a secret with the specified name containing a kubeconfig within the `HostedCluster` namespace.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               ignitionEndpoint:
                 description: |-
                   IgnitionEndpoint is the endpoint injected in the ign config userdata.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -2389,6 +2389,21 @@ spec:
                   rule: self == oldSelf
                 - message: issuerURL must be a valid absolute URL
                   rule: isURL(self)
+              kubeAPIServerDNSName:
+                description: |-
+                  kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+                  When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+                  If it's set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+                  The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+                  This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+                  access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+                  for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+                  This API endpoint only works in OCP version 4.19 or later. Older versions will result in a no-op.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)
+                  rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
               labels:
                 additionalProperties:
                   type: string
@@ -5309,6 +5324,22 @@ spec:
                 - host
                 - port
                 type: object
+              customKubeconfig:
+                description: |-
+                  CustomKubeconfig is a local secret reference to the external custom kubeconfig.
+                  Once the hypershift operator sets this status field, it will generate a secret with the specified name containing a kubeconfig within the `HostedCluster` namespace.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               ignitionEndpoint:
                 description: |-
                   IgnitionEndpoint is the endpoint injected in the ign config userdata.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -2287,6 +2287,20 @@ spec:
                   default value is kubernetes.default.svc, which only works for in-cluster
                   validation.
                 type: string
+              kubeAPIServerDNSName:
+                description: |-
+                  kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+                  When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+                  If it's set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+                  The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+                  This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+                  access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+                  for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)
+                  rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
               kubeconfig:
                 description: KubeConfig specifies the name and key for the kubeconfig
                   secret
@@ -4653,6 +4667,23 @@ spec:
                 required:
                 - host
                 - port
+                type: object
+              customKubeconfig:
+                description: |-
+                  customKubeconfig references an external custom kubeconfig secret.
+                  This field is populated in the status when a custom kubeconfig secret has been generated
+                  for the hosted cluster. It contains the name and key of the secret located in the
+                  hostedCluster namespace. This field is only populated when kubeApiExternalName is set.
+                  If this field is removed during a day 2 operation, the referenced secret will be deleted
+                  and this field will be removed from the hostedCluster status.
+                properties:
+                  key:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - key
+                - name
                 type: object
               externalManagedControlPlane:
                 default: true

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -2328,6 +2328,20 @@ spec:
                   default value is kubernetes.default.svc, which only works for in-cluster
                   validation.
                 type: string
+              kubeAPIServerDNSName:
+                description: |-
+                  kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+                  When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+                  If it's set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+                  The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+                  This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+                  access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+                  for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)
+                  rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
               kubeconfig:
                 description: KubeConfig specifies the name and key for the kubeconfig
                   secret
@@ -4686,6 +4700,23 @@ spec:
                 required:
                 - host
                 - port
+                type: object
+              customKubeconfig:
+                description: |-
+                  customKubeconfig references an external custom kubeconfig secret.
+                  This field is populated in the status when a custom kubeconfig secret has been generated
+                  for the hosted cluster. It contains the name and key of the secret located in the
+                  hostedCluster namespace. This field is only populated when kubeApiExternalName is set.
+                  If this field is removed during a day 2 operation, the referenced secret will be deleted
+                  and this field will be removed from the hostedCluster status.
+                properties:
+                  key:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - key
+                - name
                 type: object
               externalManagedControlPlane:
                 default: true

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -2283,6 +2283,20 @@ spec:
                   default value is kubernetes.default.svc, which only works for in-cluster
                   validation.
                 type: string
+              kubeAPIServerDNSName:
+                description: |-
+                  kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+                  When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+                  If it's set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+                  The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+                  This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+                  access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+                  for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)
+                  rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
               kubeconfig:
                 description: KubeConfig specifies the name and key for the kubeconfig
                   secret
@@ -4666,6 +4680,23 @@ spec:
                 required:
                 - host
                 - port
+                type: object
+              customKubeconfig:
+                description: |-
+                  customKubeconfig references an external custom kubeconfig secret.
+                  This field is populated in the status when a custom kubeconfig secret has been generated
+                  for the hosted cluster. It contains the name and key of the secret located in the
+                  hostedCluster namespace. This field is only populated when kubeApiExternalName is set.
+                  If this field is removed during a day 2 operation, the referenced secret will be deleted
+                  and this field will be removed from the hostedCluster status.
+                properties:
+                  key:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - key
+                - name
                 type: object
               externalManagedControlPlane:
                 default: true

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -2304,6 +2304,20 @@ spec:
                   default value is kubernetes.default.svc, which only works for in-cluster
                   validation.
                 type: string
+              kubeAPIServerDNSName:
+                description: |-
+                  kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+                  When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+                  If it's set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+                  The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+                  This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+                  access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+                  for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)
+                  rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
               kubeconfig:
                 description: KubeConfig specifies the name and key for the kubeconfig
                   secret
@@ -4662,6 +4676,23 @@ spec:
                 required:
                 - host
                 - port
+                type: object
+              customKubeconfig:
+                description: |-
+                  customKubeconfig references an external custom kubeconfig secret.
+                  This field is populated in the status when a custom kubeconfig secret has been generated
+                  for the hosted cluster. It contains the name and key of the secret located in the
+                  hostedCluster namespace. This field is only populated when kubeApiExternalName is set.
+                  If this field is removed during a day 2 operation, the referenced secret will be deleted
+                  and this field will be removed from the hostedCluster status.
+                properties:
+                  key:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - key
+                - name
                 type: object
               externalManagedControlPlane:
                 default: true

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -2525,6 +2525,20 @@ spec:
                   default value is kubernetes.default.svc, which only works for in-cluster
                   validation.
                 type: string
+              kubeAPIServerDNSName:
+                description: |-
+                  kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+                  When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+                  If it's set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+                  The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+                  This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+                  access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+                  for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)
+                  rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
               kubeconfig:
                 description: KubeConfig specifies the name and key for the kubeconfig
                   secret
@@ -4883,6 +4897,23 @@ spec:
                 required:
                 - host
                 - port
+                type: object
+              customKubeconfig:
+                description: |-
+                  customKubeconfig references an external custom kubeconfig secret.
+                  This field is populated in the status when a custom kubeconfig secret has been generated
+                  for the hosted cluster. It contains the name and key of the secret located in the
+                  hostedCluster namespace. This field is only populated when kubeApiExternalName is set.
+                  If this field is removed during a day 2 operation, the referenced secret will be deleted
+                  and this field will be removed from the hostedCluster status.
+                properties:
+                  key:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - key
+                - name
                 type: object
               externalManagedControlPlane:
                 default: true

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -2301,6 +2301,20 @@ spec:
                   default value is kubernetes.default.svc, which only works for in-cluster
                   validation.
                 type: string
+              kubeAPIServerDNSName:
+                description: |-
+                  kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+                  When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+                  If it's set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+                  The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+                  This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+                  access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+                  for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)
+                  rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
               kubeconfig:
                 description: KubeConfig specifies the name and key for the kubeconfig
                   secret
@@ -4659,6 +4673,23 @@ spec:
                 required:
                 - host
                 - port
+                type: object
+              customKubeconfig:
+                description: |-
+                  customKubeconfig references an external custom kubeconfig secret.
+                  This field is populated in the status when a custom kubeconfig secret has been generated
+                  for the hosted cluster. It contains the name and key of the secret located in the
+                  hostedCluster namespace. This field is only populated when kubeApiExternalName is set.
+                  If this field is removed during a day 2 operation, the referenced secret will be deleted
+                  and this field will be removed from the hostedCluster status.
+                properties:
+                  key:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - key
+                - name
                 type: object
               externalManagedControlPlane:
                 default: true

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -2435,6 +2435,20 @@ spec:
                   default value is kubernetes.default.svc, which only works for in-cluster
                   validation.
                 type: string
+              kubeAPIServerDNSName:
+                description: |-
+                  kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+                  When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+                  If it's set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+                  The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+                  This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+                  access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+                  for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)
+                  rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
               kubeconfig:
                 description: KubeConfig specifies the name and key for the kubeconfig
                   secret
@@ -4793,6 +4807,23 @@ spec:
                 required:
                 - host
                 - port
+                type: object
+              customKubeconfig:
+                description: |-
+                  customKubeconfig references an external custom kubeconfig secret.
+                  This field is populated in the status when a custom kubeconfig secret has been generated
+                  for the hosted cluster. It contains the name and key of the secret located in the
+                  hostedCluster namespace. This field is only populated when kubeApiExternalName is set.
+                  If this field is removed during a day 2 operation, the referenced secret will be deleted
+                  and this field will be removed from the hostedCluster status.
+                properties:
+                  key:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - key
+                - name
                 type: object
               externalManagedControlPlane:
                 default: true

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -2283,6 +2283,20 @@ spec:
                   default value is kubernetes.default.svc, which only works for in-cluster
                   validation.
                 type: string
+              kubeAPIServerDNSName:
+                description: |-
+                  kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+                  When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+                  If it's set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+                  The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+                  This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+                  access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+                  for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)
+                  rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
               kubeconfig:
                 description: KubeConfig specifies the name and key for the kubeconfig
                   secret
@@ -5129,6 +5143,23 @@ spec:
                 required:
                 - host
                 - port
+                type: object
+              customKubeconfig:
+                description: |-
+                  customKubeconfig references an external custom kubeconfig secret.
+                  This field is populated in the status when a custom kubeconfig secret has been generated
+                  for the hosted cluster. It contains the name and key of the secret located in the
+                  hostedCluster namespace. This field is only populated when kubeApiExternalName is set.
+                  If this field is removed during a day 2 operation, the referenced secret will be deleted
+                  and this field will be removed from the hostedCluster status.
+                properties:
+                  key:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - key
+                - name
                 type: object
               externalManagedControlPlane:
                 default: true

--- a/client/applyconfiguration/hypershift/v1beta1/hostedclusterspec.go
+++ b/client/applyconfiguration/hypershift/v1beta1/hostedclusterspec.go
@@ -33,6 +33,7 @@ type HostedClusterSpecApplyConfiguration struct {
 	UpdateService                    *v1.URL                                              `json:"updateService,omitempty"`
 	Channel                          *string                                              `json:"channel,omitempty"`
 	Platform                         *PlatformSpecApplyConfiguration                      `json:"platform,omitempty"`
+	KubeAPIServerDNSName             *string                                              `json:"kubeAPIServerDNSName,omitempty"`
 	ControllerAvailabilityPolicy     *hypershiftv1beta1.AvailabilityPolicy                `json:"controllerAvailabilityPolicy,omitempty"`
 	InfrastructureAvailabilityPolicy *hypershiftv1beta1.AvailabilityPolicy                `json:"infrastructureAvailabilityPolicy,omitempty"`
 	DNS                              *DNSSpecApplyConfiguration                           `json:"dns,omitempty"`
@@ -119,6 +120,14 @@ func (b *HostedClusterSpecApplyConfiguration) WithChannel(value string) *HostedC
 // If called multiple times, the Platform field is set to the value of the last call.
 func (b *HostedClusterSpecApplyConfiguration) WithPlatform(value *PlatformSpecApplyConfiguration) *HostedClusterSpecApplyConfiguration {
 	b.Platform = value
+	return b
+}
+
+// WithKubeAPIServerDNSName sets the KubeAPIServerDNSName field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the KubeAPIServerDNSName field is set to the value of the last call.
+func (b *HostedClusterSpecApplyConfiguration) WithKubeAPIServerDNSName(value string) *HostedClusterSpecApplyConfiguration {
+	b.KubeAPIServerDNSName = &value
 	return b
 }
 

--- a/client/applyconfiguration/hypershift/v1beta1/hostedclusterstatus.go
+++ b/client/applyconfiguration/hypershift/v1beta1/hostedclusterstatus.go
@@ -28,6 +28,7 @@ import (
 type HostedClusterStatusApplyConfiguration struct {
 	Version                  *ClusterVersionStatusApplyConfiguration `json:"version,omitempty"`
 	KubeConfig               *v1.LocalObjectReference                `json:"kubeconfig,omitempty"`
+	CustomKubeconfig         *v1.LocalObjectReference                `json:"customKubeconfig,omitempty"`
 	KubeadminPassword        *v1.LocalObjectReference                `json:"kubeadminPassword,omitempty"`
 	IgnitionEndpoint         *string                                 `json:"ignitionEndpoint,omitempty"`
 	ControlPlaneEndpoint     *APIEndpointApplyConfiguration          `json:"controlPlaneEndpoint,omitempty"`
@@ -56,6 +57,14 @@ func (b *HostedClusterStatusApplyConfiguration) WithVersion(value *ClusterVersio
 // If called multiple times, the KubeConfig field is set to the value of the last call.
 func (b *HostedClusterStatusApplyConfiguration) WithKubeConfig(value v1.LocalObjectReference) *HostedClusterStatusApplyConfiguration {
 	b.KubeConfig = &value
+	return b
+}
+
+// WithCustomKubeconfig sets the CustomKubeconfig field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the CustomKubeconfig field is set to the value of the last call.
+func (b *HostedClusterStatusApplyConfiguration) WithCustomKubeconfig(value v1.LocalObjectReference) *HostedClusterStatusApplyConfiguration {
+	b.CustomKubeconfig = &value
 	return b
 }
 

--- a/client/applyconfiguration/hypershift/v1beta1/hostedcontrolplanespec.go
+++ b/client/applyconfiguration/hypershift/v1beta1/hostedcontrolplanespec.go
@@ -43,6 +43,7 @@ type HostedControlPlaneSpecApplyConfiguration struct {
 	InfrastructureAvailabilityPolicy *hypershiftv1beta1.AvailabilityPolicy                `json:"infrastructureAvailabilityPolicy,omitempty"`
 	FIPS                             *bool                                                `json:"fips,omitempty"`
 	KubeConfig                       *KubeconfigSecretRefApplyConfiguration               `json:"kubeconfig,omitempty"`
+	KubeAPIServerDNSName             *string                                              `json:"kubeAPIServerDNSName,omitempty"`
 	Services                         []ServicePublishingStrategyMappingApplyConfiguration `json:"services,omitempty"`
 	AuditWebhook                     *corev1.LocalObjectReference                         `json:"auditWebhook,omitempty"`
 	Etcd                             *EtcdSpecApplyConfiguration                          `json:"etcd,omitempty"`
@@ -200,6 +201,14 @@ func (b *HostedControlPlaneSpecApplyConfiguration) WithFIPS(value bool) *HostedC
 // If called multiple times, the KubeConfig field is set to the value of the last call.
 func (b *HostedControlPlaneSpecApplyConfiguration) WithKubeConfig(value *KubeconfigSecretRefApplyConfiguration) *HostedControlPlaneSpecApplyConfiguration {
 	b.KubeConfig = value
+	return b
+}
+
+// WithKubeAPIServerDNSName sets the KubeAPIServerDNSName field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the KubeAPIServerDNSName field is set to the value of the last call.
+func (b *HostedControlPlaneSpecApplyConfiguration) WithKubeAPIServerDNSName(value string) *HostedControlPlaneSpecApplyConfiguration {
+	b.KubeAPIServerDNSName = &value
 	return b
 }
 

--- a/client/applyconfiguration/hypershift/v1beta1/hostedcontrolplanestatus.go
+++ b/client/applyconfiguration/hypershift/v1beta1/hostedcontrolplanestatus.go
@@ -36,6 +36,7 @@ type HostedControlPlaneStatusApplyConfiguration struct {
 	ReleaseImage                   *string                                 `json:"releaseImage,omitempty"`
 	LastReleaseImageTransitionTime *v1.Time                                `json:"lastReleaseImageTransitionTime,omitempty"`
 	KubeConfig                     *KubeconfigSecretRefApplyConfiguration  `json:"kubeConfig,omitempty"`
+	CustomKubeconfig               *KubeconfigSecretRefApplyConfiguration  `json:"customKubeconfig,omitempty"`
 	KubeadminPassword              *corev1.LocalObjectReference            `json:"kubeadminPassword,omitempty"`
 	Conditions                     []metav1.ConditionApplyConfiguration    `json:"conditions,omitempty"`
 	Platform                       *PlatformStatusApplyConfiguration       `json:"platform,omitempty"`
@@ -125,6 +126,14 @@ func (b *HostedControlPlaneStatusApplyConfiguration) WithLastReleaseImageTransit
 // If called multiple times, the KubeConfig field is set to the value of the last call.
 func (b *HostedControlPlaneStatusApplyConfiguration) WithKubeConfig(value *KubeconfigSecretRefApplyConfiguration) *HostedControlPlaneStatusApplyConfiguration {
 	b.KubeConfig = value
+	return b
+}
+
+// WithCustomKubeconfig sets the CustomKubeconfig field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the CustomKubeconfig field is set to the value of the last call.
+func (b *HostedControlPlaneStatusApplyConfiguration) WithCustomKubeconfig(value *KubeconfigSecretRefApplyConfiguration) *HostedControlPlaneStatusApplyConfiguration {
+	b.CustomKubeconfig = value
 	return b
 }
 

--- a/cmd/cluster/core/dump.go
+++ b/cmd/cluster/core/dump.go
@@ -12,11 +12,6 @@ import (
 	"strings"
 	"time"
 
-	configv1 "github.com/openshift/api/config/v1"
-	imagev1 "github.com/openshift/api/image/v1"
-	routev1 "github.com/openshift/api/route/v1"
-	securityv1 "github.com/openshift/api/security/v1"
-	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1beta1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	scheduling "github.com/openshift/hypershift/api/scheduling/v1alpha1"
 	"github.com/openshift/hypershift/cmd/log"
@@ -27,6 +22,12 @@ import (
 	hyperapi "github.com/openshift/hypershift/support/api"
 	supportforwarder "github.com/openshift/hypershift/support/forwarder"
 	supportutil "github.com/openshift/hypershift/support/util"
+
+	configv1 "github.com/openshift/api/config/v1"
+	imagev1 "github.com/openshift/api/image/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	securityv1 "github.com/openshift/api/security/v1"
+	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1beta1"
 
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"

--- a/cmd/cluster/core/dump.go
+++ b/cmd/cluster/core/dump.go
@@ -12,6 +12,11 @@ import (
 	"strings"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
+	imagev1 "github.com/openshift/api/image/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	securityv1 "github.com/openshift/api/security/v1"
+	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1beta1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	scheduling "github.com/openshift/hypershift/api/scheduling/v1alpha1"
 	"github.com/openshift/hypershift/cmd/log"
@@ -20,13 +25,8 @@ import (
 	"github.com/openshift/hypershift/hypershift-operator/controllers/sharedingress"
 	kvinfra "github.com/openshift/hypershift/kubevirtexternalinfra"
 	hyperapi "github.com/openshift/hypershift/support/api"
+	supportforwarder "github.com/openshift/hypershift/support/forwarder"
 	supportutil "github.com/openshift/hypershift/support/util"
-
-	configv1 "github.com/openshift/api/config/v1"
-	imagev1 "github.com/openshift/api/image/v1"
-	routev1 "github.com/openshift/api/route/v1"
-	securityv1 "github.com/openshift/api/security/v1"
-	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1beta1"
 
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -183,21 +183,11 @@ func dumpGuestCluster(ctx context.Context, opts *DumpOptions) error {
 
 	target := opts.ArtifactDir + "/hostedcluster-" + opts.Name
 
-	kubeAPIServerPodList := &corev1.PodList{}
-	if err := c.List(ctx, kubeAPIServerPodList, client.InNamespace(cpNamespace), client.MatchingLabels{"app": "kube-apiserver", hyperv1.ControlPlaneComponentLabel: "kube-apiserver"}); err != nil {
-		return fmt.Errorf("failed to list kube-apiserver pods in control plane namespace: %w", err)
+	podToForward, err := supportforwarder.GetRunningKubeAPIServerPod(ctx, c, cpNamespace)
+	if err != nil {
+		return fmt.Errorf("failed to get running kube-apiserver pod for guest cluster: %w", err)
 	}
-	var podToForward *corev1.Pod
-	for i := range kubeAPIServerPodList.Items {
-		pod := &kubeAPIServerPodList.Items[i]
-		if pod.Status.Phase == corev1.PodRunning {
-			podToForward = pod
-			break
-		}
-	}
-	if podToForward == nil {
-		return fmt.Errorf("did not find running kube-apiserver pod for guest cluster")
-	}
+
 	restConfig, err := util.GetConfig()
 	if err != nil {
 		return fmt.Errorf("failed to get a config for management cluster: %w", err)
@@ -214,7 +204,7 @@ func dumpGuestCluster(ctx context.Context, opts *DumpOptions) error {
 		return fmt.Errorf("failed to get a kubernetes client: %w", err)
 	}
 	forwarderOutput := &bytes.Buffer{}
-	forwarder := portForwarder{
+	forwarder := supportforwarder.PortForwarder{
 		Namespace: podToForward.Namespace,
 		PodName:   podToForward.Name,
 		Config:    restConfig,

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
@@ -2870,6 +2870,21 @@ spec:
                   rule: self == oldSelf
                 - message: issuerURL must be a valid absolute URL
                   rule: isURL(self)
+              kubeAPIServerDNSName:
+                description: |-
+                  kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+                  When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+                  If it's set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+                  The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+                  This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+                  access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+                  for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+                  This API endpoint only works in OCP version 4.19 or later. Older versions will result in a no-op.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)
+                  rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
               labels:
                 additionalProperties:
                   type: string
@@ -5815,6 +5830,22 @@ spec:
                 - host
                 - port
                 type: object
+              customKubeconfig:
+                description: |-
+                  CustomKubeconfig is a local secret reference to the external custom kubeconfig.
+                  Once the hypershift operator sets this status field, it will generate a secret with the specified name containing a kubeconfig within the `HostedCluster` namespace.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               ignitionEndpoint:
                 description: |-
                   IgnitionEndpoint is the endpoint injected in the ign config userdata.

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
@@ -2807,6 +2807,21 @@ spec:
                   rule: self == oldSelf
                 - message: issuerURL must be a valid absolute URL
                   rule: isURL(self)
+              kubeAPIServerDNSName:
+                description: |-
+                  kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+                  When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+                  If it's set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+                  The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+                  This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+                  access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+                  for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+                  This API endpoint only works in OCP version 4.19 or later. Older versions will result in a no-op.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)
+                  rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
               labels:
                 additionalProperties:
                   type: string
@@ -5247,6 +5262,22 @@ spec:
                 - host
                 - port
                 type: object
+              customKubeconfig:
+                description: |-
+                  CustomKubeconfig is a local secret reference to the external custom kubeconfig.
+                  Once the hypershift operator sets this status field, it will generate a secret with the specified name containing a kubeconfig within the `HostedCluster` namespace.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               ignitionEndpoint:
                 description: |-
                   IgnitionEndpoint is the endpoint injected in the ign config userdata.

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
@@ -2852,6 +2852,21 @@ spec:
                   rule: self == oldSelf
                 - message: issuerURL must be a valid absolute URL
                   rule: isURL(self)
+              kubeAPIServerDNSName:
+                description: |-
+                  kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+                  When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+                  If it's set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+                  The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+                  This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+                  access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+                  for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+                  This API endpoint only works in OCP version 4.19 or later. Older versions will result in a no-op.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)
+                  rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
               labels:
                 additionalProperties:
                   type: string
@@ -5797,6 +5812,22 @@ spec:
                 - host
                 - port
                 type: object
+              customKubeconfig:
+                description: |-
+                  CustomKubeconfig is a local secret reference to the external custom kubeconfig.
+                  Once the hypershift operator sets this status field, it will generate a secret with the specified name containing a kubeconfig within the `HostedCluster` namespace.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               ignitionEndpoint:
                 description: |-
                   IgnitionEndpoint is the endpoint injected in the ign config userdata.

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
@@ -2764,6 +2764,20 @@ spec:
                   default value is kubernetes.default.svc, which only works for in-cluster
                   validation.
                 type: string
+              kubeAPIServerDNSName:
+                description: |-
+                  kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+                  When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+                  If it's set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+                  The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+                  This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+                  access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+                  for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)
+                  rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
               kubeconfig:
                 description: KubeConfig specifies the name and key for the kubeconfig
                   secret
@@ -5635,6 +5649,23 @@ spec:
                 required:
                 - host
                 - port
+                type: object
+              customKubeconfig:
+                description: |-
+                  customKubeconfig references an external custom kubeconfig secret.
+                  This field is populated in the status when a custom kubeconfig secret has been generated
+                  for the hosted cluster. It contains the name and key of the secret located in the
+                  hostedCluster namespace. This field is only populated when kubeApiExternalName is set.
+                  If this field is removed during a day 2 operation, the referenced secret will be deleted
+                  and this field will be removed from the hostedCluster status.
+                properties:
+                  key:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - key
+                - name
                 type: object
               externalManagedControlPlane:
                 default: true

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
@@ -2701,6 +2701,20 @@ spec:
                   default value is kubernetes.default.svc, which only works for in-cluster
                   validation.
                 type: string
+              kubeAPIServerDNSName:
+                description: |-
+                  kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+                  When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+                  If it's set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+                  The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+                  This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+                  access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+                  for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)
+                  rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
               kubeconfig:
                 description: KubeConfig specifies the name and key for the kubeconfig
                   secret
@@ -5067,6 +5081,23 @@ spec:
                 required:
                 - host
                 - port
+                type: object
+              customKubeconfig:
+                description: |-
+                  customKubeconfig references an external custom kubeconfig secret.
+                  This field is populated in the status when a custom kubeconfig secret has been generated
+                  for the hosted cluster. It contains the name and key of the secret located in the
+                  hostedCluster namespace. This field is only populated when kubeApiExternalName is set.
+                  If this field is removed during a day 2 operation, the referenced secret will be deleted
+                  and this field will be removed from the hostedCluster status.
+                properties:
+                  key:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - key
+                - name
                 type: object
               externalManagedControlPlane:
                 default: true

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
@@ -2746,6 +2746,20 @@ spec:
                   default value is kubernetes.default.svc, which only works for in-cluster
                   validation.
                 type: string
+              kubeAPIServerDNSName:
+                description: |-
+                  kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+                  When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+                  If it's set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+                  The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+                  This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+                  access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+                  for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)
+                  rule: self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')
               kubeconfig:
                 description: KubeConfig specifies the name and key for the kubeconfig
                   secret
@@ -5617,6 +5631,23 @@ spec:
                 required:
                 - host
                 - port
+                type: object
+              customKubeconfig:
+                description: |-
+                  customKubeconfig references an external custom kubeconfig secret.
+                  This field is populated in the status when a custom kubeconfig secret has been generated
+                  for the hosted cluster. It contains the name and key of the secret located in the
+                  hostedCluster namespace. This field is only populated when kubeApiExternalName is set.
+                  If this field is removed during a day 2 operation, the referenced secret will be deleted
+                  and this field will be removed from the hostedCluster status.
+                properties:
+                  key:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - key
+                - name
                 type: object
               externalManagedControlPlane:
                 default: true

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -739,7 +739,8 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		meta.SetStatusCondition(&hostedControlPlane.Status.Conditions, condition)
 	}
 
-	kubeconfig := manifests.KASExternalKubeconfigSecret(hostedControlPlane.Namespace, hostedControlPlane.Spec.KubeConfig)
+	// Admin Kubeconfig
+	kubeconfig := manifests.KASAdminKubeconfigSecret(hostedControlPlane.Namespace, hostedControlPlane.Spec.KubeConfig)
 	if err := r.Get(ctx, client.ObjectKeyFromObject(kubeconfig), kubeconfig); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return reconcile.Result{}, err
@@ -749,9 +750,14 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 			Name: kubeconfig.Name,
 			Key:  DefaultAdminKubeconfigKey,
 		}
+
 		if hostedControlPlane.Spec.KubeConfig != nil {
 			hostedControlPlane.Status.KubeConfig.Key = hostedControlPlane.Spec.KubeConfig.Key
 		}
+	}
+
+	if err := setKASCustomKubeconfigStatus(ctx, hostedControlPlane, r.Client); err != nil {
+		return reconcile.Result{}, err
 	}
 
 	explicitOauthConfig := hostedControlPlane.Spec.Configuration != nil && hostedControlPlane.Spec.Configuration.OAuth != nil
@@ -3008,12 +3014,33 @@ func (r *HostedControlPlaneReconciler) reconcileKubeAPIServer(ctx context.Contex
 		return fmt.Errorf("failed to reconcile localhost kubeconfig secret: %w", err)
 	}
 
-	externalKubeconfigSecret := manifests.KASExternalKubeconfigSecret(hcp.Namespace, hcp.Spec.KubeConfig)
-	if _, err := createOrUpdate(ctx, r, externalKubeconfigSecret, func() error {
-		if !util.IsPublicHCP(hcp) && !util.IsRouteKAS(hcp) {
-			return kas.ReconcileExternalKubeconfigSecret(externalKubeconfigSecret, clientCertSecret, rootCA, p.OwnerRef, p.InternalURL(), p.ExternalKubeconfigKey())
+	// Generate the new KASCustomKubeconfig secret if the KubeAPIServerDNSName is set
+	kasCustomKubeconfigSecret := manifests.KASCustomKubeconfigSecret(hcp.Namespace, nil)
+	if len(hcp.Spec.KubeAPIServerDNSName) > 0 {
+		newRootCA, err := includeServingCertificates(ctx, r.Client, hcp, rootCA)
+		if err != nil {
+			return fmt.Errorf("failed to include serving certificates: %w", err)
 		}
-		return kas.ReconcileExternalKubeconfigSecret(externalKubeconfigSecret, clientCertSecret, rootCA, p.OwnerRef, p.ExternalURL(), p.ExternalKubeconfigKey())
+
+		if _, err := createOrUpdate(ctx, r, kasCustomKubeconfigSecret, func() error {
+			return kas.ReconcileKASCustomKubeconfigSecret(kasCustomKubeconfigSecret, clientCertSecret, newRootCA, p.OwnerRef, p.CustomExternalURL(), p.KASCustomKubeconfigKey())
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile custom external kubeconfig secret: %w", err)
+		}
+	} else {
+		// Cleanup the new kasCustomKubeconfigSecret secret if the KubeAPIServerDNSName is removed
+		if _, err := util.DeleteIfNeeded(ctx, r.Client, kasCustomKubeconfigSecret); err != nil {
+			return fmt.Errorf("failed to delete customKubeconfig status from HCP object: %w", err)
+		}
+	}
+
+	// Renamed the old externalKubeconfigSecret to adminKubeconfigSecret
+	adminKubeconfigSecret := manifests.KASAdminKubeconfigSecret(hcp.Namespace, hcp.Spec.KubeConfig)
+	if _, err := createOrUpdate(ctx, r, adminKubeconfigSecret, func() error {
+		if !util.IsPublicHCP(hcp) && !util.IsRouteKAS(hcp) {
+			return kas.ReconcileKASCustomKubeconfigSecret(adminKubeconfigSecret, clientCertSecret, rootCA, p.OwnerRef, p.InternalURL(), p.ExternalKubeconfigKey())
+		}
+		return kas.ReconcileKASCustomKubeconfigSecret(adminKubeconfigSecret, clientCertSecret, rootCA, p.OwnerRef, p.ExternalURL(), p.ExternalKubeconfigKey())
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile external kubeconfig secret: %w", err)
 	}
@@ -5571,7 +5598,7 @@ func (r *HostedControlPlaneReconciler) validateAzureKMSConfig(ctx context.Contex
 }
 
 func (r *HostedControlPlaneReconciler) GetGuestClusterClient(ctx context.Context, hcp *hyperv1.HostedControlPlane) (*kubernetes.Clientset, error) {
-	kubeconfigSecret := manifests.KASExternalKubeconfigSecret(hcp.Namespace, hcp.Spec.KubeConfig)
+	kubeconfigSecret := manifests.KASAdminKubeconfigSecret(hcp.Namespace, hcp.Spec.KubeConfig)
 	if err := r.Get(ctx, client.ObjectKeyFromObject(kubeconfigSecret), kubeconfigSecret); err != nil {
 		return nil, err
 	}
@@ -5675,4 +5702,55 @@ func (r *HostedControlPlaneReconciler) verifyResourceGroupLocationsMatch(ctx con
 		return fmt.Errorf("the locations of the resource groups do not match - vnet location: %v; network security group location: %v; managed resource group location: %v", ptr.Deref(vnet.Location, ""), ptr.Deref(nsg.Location, ""), ptr.Deref(rg.Location, ""))
 	}
 	return nil
+}
+
+func setKASCustomKubeconfigStatus(ctx context.Context, hcp *hyperv1.HostedControlPlane, c client.Client) error {
+	customKubeconfig := manifests.KASCustomKubeconfigSecret(hcp.Namespace, nil)
+	if err := c.Get(ctx, client.ObjectKeyFromObject(customKubeconfig), customKubeconfig); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get custom kubeconfig secret: %w", err)
+		}
+	}
+
+	if len(hcp.Spec.KubeAPIServerDNSName) > 0 {
+		// Reconcile custom kubeconfig status
+		hcp.Status.CustomKubeconfig = &hyperv1.KubeconfigSecretRef{
+			Name: customKubeconfig.Name,
+			Key:  DefaultAdminKubeconfigKey,
+		}
+	} else {
+		// Cleanning up custom kubeconfig status
+		hcp.Status.CustomKubeconfig = nil
+	}
+
+	return nil
+}
+
+// includeServingCertificates includes additional serving certificates into the provided root CA ConfigMap.
+// It retrieves the named certificates specified in the HostedControlPlane's APIServer configuration and appends
+// their contents to the "ca.crt" entry in the root CA ConfigMap.
+func includeServingCertificates(ctx context.Context, c client.Client, hcp *hyperv1.HostedControlPlane, rootCA *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	var tlsCRT string
+	newRootCA := rootCA.DeepCopy()
+
+	if hcp.Spec.Configuration != nil && hcp.Spec.Configuration.APIServer != nil && len(hcp.Spec.Configuration.APIServer.ServingCerts.NamedCertificates) > 0 {
+		for _, servingCert := range hcp.Spec.Configuration.APIServer.ServingCerts.NamedCertificates {
+			newCRT := &corev1.Secret{}
+			if err := c.Get(ctx, client.ObjectKey{Namespace: hcp.Namespace, Name: servingCert.ServingCertificate.Name}, newCRT); err != nil {
+				return nil, fmt.Errorf("failed to get serving certificate secret: %w", err)
+			}
+
+			if len(tlsCRT) <= 0 {
+				tlsCRT = newRootCA.Data["tls.crt"]
+			}
+
+			tlsCRT = fmt.Sprintf("%s\n%s", tlsCRT, string(newCRT.Data["tls.crt"]))
+		}
+
+		if len(tlsCRT) > 0 {
+			newRootCA.Data["tls.crt"] = tlsCRT
+		}
+	}
+
+	return newRootCA, nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -5741,14 +5741,14 @@ func includeServingCertificates(ctx context.Context, c client.Client, hcp *hyper
 			}
 
 			if len(tlsCRT) <= 0 {
-				tlsCRT = newRootCA.Data["tls.crt"]
+				tlsCRT = newRootCA.Data["ca.crt"]
 			}
 
 			tlsCRT = fmt.Sprintf("%s\n%s", tlsCRT, string(newCRT.Data["tls.crt"]))
 		}
 
 		if len(tlsCRT) > 0 {
-			newRootCA.Data["tls.crt"] = tlsCRT
+			newRootCA.Data["ca.crt"] = tlsCRT
 		}
 	}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -1512,6 +1512,172 @@ func TestReconcileHCPRouterServices(t *testing.T) {
 	}
 }
 
+func TestSetKASCustomKubeconfigStatus(t *testing.T) {
+	hcp := sampleHCP(t)
+	pullSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: hcp.Namespace, Name: "pull-secret"}}
+	c := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(hcp, pullSecret).WithStatusSubresource(&hyperv1.HostedControlPlane{}).Build()
+	ctx := ctrl.LoggerInto(context.Background(), zapr.NewLogger(zaptest.NewLogger(t)))
+
+	tests := []struct {
+		name                 string
+		KubeAPIServerDNSName string
+		expectedStatus       *hyperv1.KubeconfigSecretRef
+	}{
+		{
+			name:                 "KubeAPIServerDNSName is empty",
+			KubeAPIServerDNSName: "",
+			expectedStatus:       nil,
+		},
+		{
+			name:                 "KubeAPIServerDNSName has a valid value",
+			KubeAPIServerDNSName: "testapi.example.com",
+			expectedStatus: &hyperv1.KubeconfigSecretRef{
+				Name: "custom-admin-kubeconfig",
+				Key:  "kubeconfig",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			hcp.Spec.KubeAPIServerDNSName = tc.KubeAPIServerDNSName
+
+			err := setKASCustomKubeconfigStatus(ctx, hcp, c)
+			g.Expect(err).To(BeNil(), fmt.Errorf("error setting custom kubeconfig status failed: %v", err))
+			g.Expect(hcp.Status.CustomKubeconfig).To(Equal(tc.expectedStatus))
+		})
+	}
+}
+
+func TestIncludeServingCertificates(t *testing.T) {
+	ctx := context.Background()
+	hcp := sampleHCP(t)
+	rootCA := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "root-ca",
+			Namespace: hcp.Namespace,
+		},
+		Data: map[string]string{
+			"tls.crt": "root-ca-cert",
+		},
+	}
+
+	tests := []struct {
+		name           string
+		servingCerts   *configv1.APIServerServingCerts
+		servingSecrets []*corev1.Secret
+		expectedCert   string
+		expectError    bool
+	}{
+		{
+			name:         "APIServer servingCerts is nil",
+			servingCerts: &configv1.APIServerServingCerts{},
+			expectedCert: "root-ca-cert",
+		},
+		{
+			name: "APIServer servingCerts configuration with one named certificates",
+			servingCerts: &configv1.APIServerServingCerts{
+				NamedCertificates: []configv1.APIServerNamedServingCert{
+					{
+						ServingCertificate: configv1.SecretNameReference{
+							Name: "serving-cert-1",
+						},
+					},
+				},
+			},
+			servingSecrets: []*corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "serving-cert-1",
+						Namespace: hcp.Namespace,
+					},
+					Data: map[string][]byte{
+						"tls.crt": []byte("cert-1"),
+					},
+				},
+			},
+			expectedCert: "root-ca-cert\ncert-1",
+		},
+		{
+			name: "APIServer servingCerts configuration with multiple named certificates",
+			servingCerts: &configv1.APIServerServingCerts{
+				NamedCertificates: []configv1.APIServerNamedServingCert{
+					{
+						ServingCertificate: configv1.SecretNameReference{
+							Name: "serving-cert-1",
+						},
+					},
+					{
+						ServingCertificate: configv1.SecretNameReference{
+							Name: "serving-cert-2",
+						},
+					},
+				},
+			},
+			servingSecrets: []*corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "serving-cert-1",
+						Namespace: hcp.Namespace,
+					},
+					Data: map[string][]byte{
+						"tls.crt": []byte("cert-1"),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "serving-cert-2",
+						Namespace: hcp.Namespace,
+					},
+					Data: map[string][]byte{
+						"tls.crt": []byte("cert-2"),
+					},
+				},
+			},
+			expectedCert: "root-ca-cert\ncert-1\ncert-2",
+		},
+		{
+			name: "APIServer servingCerts configuration with missing named certificate",
+			servingCerts: &configv1.APIServerServingCerts{
+				NamedCertificates: []configv1.APIServerNamedServingCert{
+					{
+						ServingCertificate: configv1.SecretNameReference{
+							Name: "missing-cert",
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			hcp.Spec.Configuration = &hyperv1.ClusterConfiguration{
+				APIServer: &configv1.APIServerSpec{
+					ServingCerts: *tc.servingCerts,
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().WithObjects(rootCA).Build()
+			for _, secret := range tc.servingSecrets {
+				fakeClient.Create(ctx, secret)
+			}
+
+			newRootCA, err := includeServingCertificates(ctx, fakeClient, hcp, rootCA)
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(newRootCA.Data["tls.crt"]).To(Equal(tc.expectedCert))
+			}
+		})
+	}
+}
+
 type fakeMessageCollector struct {
 	msg string
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -1664,7 +1664,7 @@ func TestIncludeServingCertificates(t *testing.T) {
 
 			fakeClient := fake.NewClientBuilder().WithObjects(rootCA).Build()
 			for _, secret := range tc.servingSecrets {
-				fakeClient.Create(ctx, secret)
+				_ = fakeClient.Create(ctx, secret)
 			}
 
 			newRootCA, err := includeServingCertificates(ctx, fakeClient, hcp, rootCA)

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -1559,7 +1559,7 @@ func TestIncludeServingCertificates(t *testing.T) {
 			Namespace: hcp.Namespace,
 		},
 		Data: map[string]string{
-			"tls.crt": "root-ca-cert",
+			"ca.crt": "root-ca-cert",
 		},
 	}
 
@@ -1672,7 +1672,7 @@ func TestIncludeServingCertificates(t *testing.T) {
 				g.Expect(err).To(HaveOccurred())
 			} else {
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(newRootCA.Data["tls.crt"]).To(Equal(tc.expectedCert))
+				g.Expect(newRootCA.Data["ca.crt"]).To(Equal(tc.expectedCert))
 			}
 		})
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kubeconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kubeconfig.go
@@ -52,7 +52,7 @@ func ReconcileLocalhostKubeconfigSecret(secret, cert *corev1.Secret, ca *corev1.
 	return pki.ReconcileKubeConfig(secret, cert, ca, localhostURL, "", manifests.KubeconfigScopeLocal, ownerRef)
 }
 
-func ReconcileExternalKubeconfigSecret(secret, cert *corev1.Secret, ca *corev1.ConfigMap, ownerRef config.OwnerRef, externalURL, secretKey string) error {
+func ReconcileKASCustomKubeconfigSecret(secret, cert *corev1.Secret, ca *corev1.ConfigMap, ownerRef config.OwnerRef, externalURL, secretKey string) error {
 	return pki.ReconcileKubeConfig(secret, cert, ca, externalURL, secretKey, manifests.KubeconfigScopeExternal, ownerRef)
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/kas.go
@@ -72,7 +72,20 @@ func HCCOKubeconfigSecret(controlPlaneNamespace string) *corev1.Secret {
 	}
 }
 
-func KASExternalKubeconfigSecret(controlPlaneNamespace string, ref *hyperv1.KubeconfigSecretRef) *corev1.Secret {
+func KASCustomKubeconfigSecret(controlPlaneNamespace string, ref *hyperv1.KubeconfigSecretRef) *corev1.Secret {
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "custom-admin-kubeconfig",
+			Namespace: controlPlaneNamespace,
+		},
+	}
+	if ref != nil {
+		s.Name = ref.Name
+	}
+	return s
+}
+
+func KASAdminKubeconfigSecret(controlPlaneNamespace string, ref *hyperv1.KubeconfigSecretRef) *corev1.Secret {
 	s := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "admin-kubeconfig",

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -20,6 +20,15 @@ func RootCASecret(ns string) *corev1.Secret { return secretFor(ns, "root-ca") }
 
 func CSRSignerCASecret(ns string) *corev1.Secret { return secretFor(ns, "cluster-signer-ca") }
 
+func KASExternalCAConfigMap(name string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "openshift-config",
+		},
+	}
+}
+
 func RootCAConfigMap(ns string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-apiserver/custom-admin-kubeconfig.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-apiserver/custom-admin-kubeconfig.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    hypershift.openshift.io/kubeconfig: external
+  name: custom-admin-kubeconfig
+  namespace: HCP_NAMESPACE
+type: Opaque

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/component.go
@@ -6,6 +6,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms"
 	"github.com/openshift/hypershift/support/azureutil"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	hyperutils "github.com/openshift/hypershift/support/util"
 )
 
 const (
@@ -51,6 +52,11 @@ func NewComponent() component.ControlPlaneComponent {
 		WithManifestAdapter(
 			"local-kubeconfig.yaml",
 			component.WithAdaptFunction(adaptLocalhostKubeconfigSecret),
+		).
+		WithManifestAdapter(
+			"custom-admin-kubeconfig.yaml",
+			component.WithAdaptFunction(adaptCustomAdminKubeconfigSecret),
+			component.WithPredicate(enableIfCustomKubeconfig),
 		).
 		WithManifestAdapter(
 			"external-admin-kubeconfig.yaml",
@@ -116,4 +122,9 @@ func enableAzureKMSSecretProvider(cpContext component.WorkloadContext) bool {
 		return azureutil.IsAroHCP()
 	}
 	return false
+}
+
+// enableIfCustomKubeconfig is a helper predicate for the common use case of enabling a resource when a KubeAPICustomKubeconfig is specified.
+func enableIfCustomKubeconfig(cpContext component.WorkloadContext) bool {
+	return hyperutils.EnableIfCustomKubeconfig(cpContext.HCP)
 }

--- a/docs/content/how-to/aws/define-custom-kube-api-name.md
+++ b/docs/content/how-to/aws/define-custom-kube-api-name.md
@@ -1,0 +1,35 @@
+---
+title: Define Custom KubeAPI Name
+---
+
+## What is this for?
+
+`KubeAPICustomName` is a spec field used to declare a custom Kubernetes API URI. To make this work, you simply need to define the URI (e.g., `api.example.com`) in the `HostedCluster` object.
+
+## How does this work?
+
+- This can be defined both during day-1 (initial setup) and day-2 (post-deployment updates).
+- The CPO (ControlPlaneOperator) controllers will create a new kubeconfig stored in the HCP namespace. This kubeconfig will be based on certificates and named `custom-admin-kubeconfig`.
+- The certificates are generated from the root CA, with their expiration and renewal managed by the `HostedControlPlane`.
+- The CPO will report a new kubeconfig, called `CustomKubeconfig`, in the `HostedControlPlane`. This kubeconfig will use the new server defined in the `KubeAPICustomName` field.
+- This custom kubeconfig will also be referenced in the `HostedCluster` object under the status field as `CustomKubeconfig`.
+- A new secret, named `{HOSTEDCLUSTER_NAME}-custom-admin-kubeconfig`, will be created in the `HostedCluster` namespace. This secret can be used to easily access the HostedCluster API server.
+
+!!! NOTE
+    This does not directly affect the dataplane, so no rollouts are expected to occur.
+
+- If you remove this field from the spec, all newly generated secrets and the `CustomKubeconfig` reference will be removed from the cluster and from the status field.
+
+## Additional Notes
+
+This other field called `CustomKubeConfig` is optional and can only be used if `KubeAPICustomName` is not empty. When set, it triggers the generation of a secret with the specified name containing a kubeconfig within the `HostedCluster` namespace. This kubeconfig will also be referenced in the `HostedCluster.status` as `customkubeconfig`. If removed during day-2 operations, all related secrets and status references will also be deleted:
+
+- This action will not cause a NodePool rollout, ensuring zero impact on customers.
+- The `HostedControlPlane` object will receive the changes progressed by the Hypershift Operator and delete the corresponding field.
+- The `.status.customkubeconfig` will be removed from both `HostedCluster` and `HostedControlPlane` objects.
+- The secret in the `HostedControlPlane` namespace, named `custom-admin-kubeconfig`, will be deleted.
+- The secret in the `HostedCluster` namespace, named `{HOSTEDCLUSTER_NAME}-custom-admin-kubeconfig`, will also be deleted.
+
+
+
+

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -275,6 +275,25 @@ and is used to configure platform specific behavior.</p>
 </tr>
 <tr>
 <td>
+<code>kubeAPIServerDNSName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+If it&rsquo;s set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+This API endpoint only works in OCP version 4.19 or later. Older versions will result in a no-op.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>controllerAvailabilityPolicy</code></br>
 <em>
 <a href="#hypershift.openshift.io/v1beta1.AvailabilityPolicy">
@@ -5145,6 +5164,25 @@ and is used to configure platform specific behavior.</p>
 </tr>
 <tr>
 <td>
+<code>kubeAPIServerDNSName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+If it&rsquo;s set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+This API endpoint only works in OCP version 4.19 or later. Older versions will result in a no-op.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>controllerAvailabilityPolicy</code></br>
 <em>
 <a href="#hypershift.openshift.io/v1beta1.AvailabilityPolicy">
@@ -5603,6 +5641,21 @@ for the cluster.</p>
 </tr>
 <tr>
 <td>
+<code>customKubeconfig</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
+Kubernetes core/v1.LocalObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CustomKubeconfig is a local secret reference to the external custom kubeconfig.
+Once the hypershift operator sets this status field, it will generate a secret with the specified name containing a kubeconfig within the <code>HostedCluster</code> namespace.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>kubeadminPassword</code></br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#localobjectreference-v1-core">
@@ -5943,6 +5996,24 @@ KubeconfigSecretRef
 <td>
 <em>(Optional)</em>
 <p>KubeConfig specifies the name and key for the kubeconfig secret</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>kubeAPIServerDNSName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+If it&rsquo;s set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.</p>
 </td>
 </tr>
 <tr>
@@ -6334,6 +6405,25 @@ KubeconfigSecretRef
 <td>
 <p>KubeConfig is a reference to the secret containing the default kubeconfig
 for this control plane.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>customKubeconfig</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1beta1.KubeconfigSecretRef">
+KubeconfigSecretRef
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>customKubeconfig references an external custom kubeconfig secret.
+This field is populated in the status when a custom kubeconfig secret has been generated
+for the hosted cluster. It contains the name and key of the secret located in the
+hostedCluster namespace. This field is only populated when kubeApiExternalName is set.
+If this field is removed during a day 2 operation, the referenced secret will be deleted
+and this field will be removed from the hostedCluster status.</p>
 </td>
 </tr>
 <tr>

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
     - how-to/aws/etc-backup-restore.md
     - how-to/aws/disaster-recovery.md
     - how-to/aws/shared-vpc.md
+    - how-to/aws/define-custom-kube-api-name.md
     - 'Other SDN providers': how-to/aws/other-sdn-providers.md
     - 'Troubleshooting':
         - how-to/aws/troubleshooting/index.md

--- a/hypershift-operator/controllers/manifests/manifests.go
+++ b/hypershift-operator/controllers/manifests/manifests.go
@@ -34,6 +34,15 @@ func KubeConfigSecret(hostedClusterNamespace string, hostedClusterName string) *
 	}
 }
 
+func KubeConfigExternalSecret(hostedClusterNamespace string, hostedClusterName string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: hostedClusterNamespace,
+			Name:      hostedClusterName + "-custom-admin-kubeconfig",
+		},
+	}
+}
+
 func KubeadminPasswordSecret(hostedClusterNamespace string, hostedClusterName string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/support/forwarder/forwarder.go
+++ b/support/forwarder/forwarder.go
@@ -1,18 +1,22 @@
-// source: https://github.com/openshift/oc/blob/bc2163c506ff27cda7ab907a715aeb1815389ead/pkg/cli/rsync/forwarder.go
-package core
+package forwarder
 
 import (
+	"context"
+	"fmt"
 	"io"
 	"net/http"
 
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // portForwarder starts port forwarding to a given pod
-type portForwarder struct {
+type PortForwarder struct {
 	Namespace string
 	PodName   string
 	Client    kubernetes.Interface
@@ -23,7 +27,7 @@ type portForwarder struct {
 
 // ForwardPorts will forward a set of ports from a pod, the stopChan will stop the forwarding
 // when it's closed or receives a struct{}
-func (f *portForwarder) ForwardPorts(ports []string, stopChan <-chan struct{}) error {
+func (f *PortForwarder) ForwardPorts(ports []string, stopChan <-chan struct{}) error {
 	req := f.Client.CoreV1().RESTClient().Post().
 		Resource("pods").
 		Namespace(f.Namespace).
@@ -49,4 +53,23 @@ func (f *portForwarder) ForwardPorts(ports []string, stopChan <-chan struct{}) e
 	case err = <-errChan:
 		return err
 	}
+}
+
+func GetRunningKubeAPIServerPod(ctx context.Context, kbClient crclient.Client, cpNamespace string) (*corev1.Pod, error) {
+	kubeAPIServerPodList := &corev1.PodList{}
+	if err := kbClient.List(ctx, kubeAPIServerPodList, crclient.InNamespace(cpNamespace), crclient.MatchingLabels{"app": "kube-apiserver", hyperv1.ControlPlaneComponentLabel: "kube-apiserver"}); err != nil {
+		return nil, fmt.Errorf("failed to list kube-apiserver pods in control plane namespace: %w", err)
+	}
+	var podToForward *corev1.Pod
+	for i := range kubeAPIServerPodList.Items {
+		pod := &kubeAPIServerPodList.Items[i]
+		if pod.Status.Phase == corev1.PodRunning {
+			podToForward = pod
+			break
+		}
+	}
+	if podToForward == nil {
+		return nil, fmt.Errorf("did not find running kube-apiserver pod for guest cluster")
+	}
+	return podToForward, nil
 }

--- a/support/forwarder/forwarder.go
+++ b/support/forwarder/forwarder.go
@@ -7,11 +7,13 @@ import (
 	"net/http"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
+
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/support/forwarder/forwarder_test.go
+++ b/support/forwarder/forwarder_test.go
@@ -5,13 +5,14 @@ import (
 	"strings"
 	"testing"
 
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 )
 
 func TestGetRunningKubeAPIServerPod(t *testing.T) {

--- a/support/forwarder/forwarder_test.go
+++ b/support/forwarder/forwarder_test.go
@@ -1,0 +1,134 @@
+package forwarder
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+)
+
+func TestGetRunningKubeAPIServerPod(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	tests := []struct {
+		name        string
+		pods        []client.Object
+		cpNamespace string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "successfully find running kube-apiserver pod",
+			pods: []client.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kube-apiserver-1",
+						Namespace: "test-namespace",
+						Labels: map[string]string{
+							"app":                              "kube-apiserver",
+							hyperv1.ControlPlaneComponentLabel: "kube-apiserver",
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+			},
+			cpNamespace: "test-namespace",
+			wantErr:     false,
+		},
+		{
+			name: "no running kube-apiserver pod found",
+			pods: []client.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kube-apiserver-1",
+						Namespace: "test-namespace",
+						Labels: map[string]string{
+							"app":                              "kube-apiserver",
+							hyperv1.ControlPlaneComponentLabel: "kube-apiserver",
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodPending,
+					},
+				},
+			},
+			cpNamespace: "test-namespace",
+			wantErr:     true,
+			errContains: "did not find running kube-apiserver pod",
+		},
+		{
+			name: "no kube-apiserver pods found",
+			pods: []client.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "other-pod",
+						Namespace: "test-namespace",
+					},
+				},
+			},
+			cpNamespace: "test-namespace",
+			wantErr:     true,
+			errContains: "did not find running kube-apiserver pod",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tt.pods...).
+				Build()
+
+			got, err := GetRunningKubeAPIServerPod(context.Background(), fakeClient, tt.cpNamespace)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error but got none")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("expected error containing %q, got %v", tt.errContains, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if got == nil {
+				t.Error("expected pod but got nil")
+				return
+			}
+
+			if got.Status.Phase != corev1.PodRunning {
+				t.Errorf("expected pod phase to be Running, got %v", got.Status.Phase)
+			}
+
+			if got.Namespace != tt.cpNamespace {
+				t.Errorf("expected pod namespace to be %q, got %q", tt.cpNamespace, got.Namespace)
+			}
+
+			// Verify required labels
+			requiredLabels := map[string]string{
+				"app":                              "kube-apiserver",
+				hyperv1.ControlPlaneComponentLabel: "kube-apiserver",
+			}
+			for key, value := range requiredLabels {
+				if got.Labels[key] != value {
+					t.Errorf("expected pod to have label %q=%q, got %q", key, value, got.Labels[key])
+				}
+			}
+		})
+	}
+}

--- a/support/globalconfig/infrastructure.go
+++ b/support/globalconfig/infrastructure.go
@@ -36,6 +36,9 @@ func ReconcileInfrastructure(infra *configv1.Infrastructure, hcp *hyperv1.Hosted
 	}
 
 	infra.Status.APIServerURL = fmt.Sprintf("https://%s:%d", apiServerAddress, apiServerPort)
+	if len(hcp.Spec.KubeAPIServerDNSName) > 0 {
+		infra.Status.APIServerURL = fmt.Sprintf("https://%s:%d", hcp.Spec.KubeAPIServerDNSName, apiServerPort)
+	}
 	infra.Status.EtcdDiscoveryDomain = BaseDomain(hcp)
 	infra.Status.InfrastructureName = hcp.Spec.InfraID
 	infra.Status.ControlPlaneTopology = configv1.ExternalTopologyMode

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -681,4 +681,14 @@ func HostFromURL(addr string) (string, error) {
 		return "", fmt.Errorf("missing host name in URL(%s)", addr)
 	}
 	return hostName, nil
+
+}
+
+// EnableIfCustomKubeconfig returns true if the hosted control plane has a custom kubeconfig defined
+func EnableIfCustomKubeconfig(hcp *hyperv1.HostedControlPlane) bool {
+	if len(hcp.Spec.KubeAPIServerDNSName) > 0 {
+		return true
+	}
+
+	return false
 }

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -686,9 +686,5 @@ func HostFromURL(addr string) (string, error) {
 
 // EnableIfCustomKubeconfig returns true if the hosted control plane has a custom kubeconfig defined
 func EnableIfCustomKubeconfig(hcp *hyperv1.HostedControlPlane) bool {
-	if len(hcp.Spec.KubeAPIServerDNSName) > 0 {
-		return true
-	}
-
-	return false
+	return len(hcp.Spec.KubeAPIServerDNSName) > 0
 }

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -879,6 +879,51 @@ func TestOnCreateAPIUX(t *testing.T) {
 					},
 				},
 			},
+			{
+				name: "when kubeAPIServerDNSName is not valid it should fail",
+				file: "hostedcluster-base.yaml",
+				validations: []struct {
+					name                   string
+					mutateInput            func(*hyperv1.HostedCluster)
+					expectedErrorSubstring string
+				}{
+					{
+						name: "when kubeAPIServerDNSName has invalid chars it should fail",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.KubeAPIServerDNSName = "@foo"
+						},
+						expectedErrorSubstring: "kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)",
+					},
+					{
+						name: "when kubeAPIServerDNSName is a valid hierarchical domain with two levels it should pass",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.KubeAPIServerDNSName = "foo.bar"
+						},
+						expectedErrorSubstring: "",
+					},
+					{
+						name: "when kubeAPIServerDNSName is a valid hierarchical domain it with 3 levels should pass",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.KubeAPIServerDNSName = "123.foo.bar"
+						},
+						expectedErrorSubstring: "",
+					},
+					{
+						name: "when kubeAPIServerDNSName is a single subdomain it should pass",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.KubeAPIServerDNSName = "foo"
+						},
+						expectedErrorSubstring: "",
+					},
+					{
+						name: "when kubeAPIServerDNSName is empty it should pass",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.KubeAPIServerDNSName = ""
+						},
+						expectedErrorSubstring: "",
+					},
+				},
+			},
 		}
 
 		for _, tc := range testCases {

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -1374,6 +1374,7 @@ func TestCreateClusterCustomConfig(t *testing.T) {
 
 		// ensure image registry component is disabled
 		e2eutil.EnsureImageRegistryCapabilityDisabled(ctx, t, g, mgtClient, hostedCluster)
+		e2eutil.EnsureKubeAPIDNSName(t, ctx, mgtClient, hostedCluster)
 	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, "custom-config", globalOpts.ServiceAccountSigningKey)
 }
 

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hosted_controlplane.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hosted_controlplane.go
@@ -115,6 +115,20 @@ type HostedControlPlaneSpec struct {
 	// +optional
 	KubeConfig *KubeconfigSecretRef `json:"kubeconfig,omitempty"`
 
+	// kubeAPIServerDNSName specifies a desired DNS name to resolve to the KAS.
+	// When set, the controller will automatically generate a secret with kubeconfig and expose it in the hostedCluster Status.customKubeconfig field.
+	// If it's set or removed day 2, the kubeconfig generated secret will be created, recreated or deleted.
+	// The DNS entries should be resolvable from the cluster, so this should be manually configured in the DNS provider.
+	// This field works in conjunction with configuration.APIServer.ServingCerts.NamedCertificates to enable
+	// access to the API server via a custom domain name. The NamedCertificates provide the TLS certificates
+	// for the custom domain, while this field triggers the generation of a kubeconfig that uses those certificates.
+	//
+	// +kubebuilder:validation:XValidation:rule=`self == "" || self.matches('^(?:(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}|[a-zA-Z0-9-]+)$')`,message="kubeAPIServerDNSName must be a valid URL name (e.g., api.example.com)"
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:example: "api.example.com"
+	// +optional
+	KubeAPIServerDNSName string `json:"kubeAPIServerDNSName,omitempty"`
+
 	// Services defines metadata about how control plane services are published
 	// in the management cluster.
 	// +kubebuilder:validation:MaxItems=6
@@ -313,6 +327,15 @@ type HostedControlPlaneStatus struct {
 	// KubeConfig is a reference to the secret containing the default kubeconfig
 	// for this control plane.
 	KubeConfig *KubeconfigSecretRef `json:"kubeConfig,omitempty"`
+
+	// customKubeconfig references an external custom kubeconfig secret.
+	// This field is populated in the status when a custom kubeconfig secret has been generated
+	// for the hosted cluster. It contains the name and key of the secret located in the
+	// hostedCluster namespace. This field is only populated when kubeApiExternalName is set.
+	// If this field is removed during a day 2 operation, the referenced secret will be deleted
+	// and this field will be removed from the hostedCluster status.
+	// +optional
+	CustomKubeconfig *KubeconfigSecretRef `json:"customKubeconfig,omitempty"`
 
 	// KubeadminPassword is a reference to the secret containing the initial kubeadmin password
 	// for the guest cluster.

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/zz_generated.deepcopy.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/zz_generated.deepcopy.go
@@ -1505,6 +1505,11 @@ func (in *HostedClusterStatus) DeepCopyInto(out *HostedClusterStatus) {
 		*out = new(corev1.LocalObjectReference)
 		**out = **in
 	}
+	if in.CustomKubeconfig != nil {
+		in, out := &in.CustomKubeconfig, &out.CustomKubeconfig
+		*out = new(corev1.LocalObjectReference)
+		**out = **in
+	}
 	if in.KubeadminPassword != nil {
 		in, out := &in.KubeadminPassword, &out.KubeadminPassword
 		*out = new(corev1.LocalObjectReference)
@@ -1726,6 +1731,11 @@ func (in *HostedControlPlaneStatus) DeepCopyInto(out *HostedControlPlaneStatus) 
 	}
 	if in.KubeConfig != nil {
 		in, out := &in.KubeConfig, &out.KubeConfig
+		*out = new(KubeconfigSecretRef)
+		**out = **in
+	}
+	if in.CustomKubeconfig != nil {
+		in, out := &in.CustomKubeconfig, &out.CustomKubeconfig
 		*out = new(KubeconfigSecretRef)
 		**out = **in
 	}


### PR DESCRIPTION
This new API autogenerate a new kubeconfig based on a desired url and managed by HCP.

**What this PR does / why we need it**:
The current implementation of HCP to define the KAS address is using the ServicePublishingType, where you can define a  hostname and that, will customize the API and API-INT interfaces where all the kubeconfigs (excepts the ones pointing to local) are pointing to. This makes the customization rigid and customers are asking for more flexibility.

This PR adds a new API which creates a new Kubeconfig (certificate based) pointing to the desired address. With this new API you can:

- Modify the address day-1 and day-2 without affectation of the DataPlane (No rollout expected)
- Generation of a new Kubeconfig based on certificates (managed by HCP)
- The HC and HCP are in sync about this new Kubeconfig and reported in the status as `customKubeconfig`
- The target of this new API are the scenarios of Public and PublicAndPrivate

> ⚠️ **IMPORTANT!** The external DNSs URL where you plan to point to and you will specify it in this new API, should be properly configured in order to makes this work.

**Which issue(s) this PR fixes**:
- Fixes #[HOSTEDCP-1960](https://issues.redhat.com/browse/HOSTEDCP-1960)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.