### PR TITLE
PODAUTO-303: Re enable karpenter e2e

### DIFF
--- a/cmd/infra/aws/destroy_iam.go
+++ b/cmd/infra/aws/destroy_iam.go
@@ -166,6 +166,9 @@ func (o *DestroyIAMOptions) DestroyOIDCResources(ctx context.Context, iamClient 
 	if err := o.DestroyOIDCRole(iamClient, "kms-provider", false); err != nil {
 		return err
 	}
+	if err := o.DestroyOIDCRole(iamClient, "karpenter", false); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1882,6 +1882,7 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 		hyperv1.KubeAPIServerMaximumRequestsInFlight,
 		hyperv1.KubeAPIServerMaximumMutatingRequestsInFlight,
 		hyperv1.DisableIgnitionServerAnnotation,
+		hyperv1.AWSMachinePublicIPs,
 	}
 	for _, key := range mirroredAnnotations {
 		val, hasVal := hcluster.Annotations[key]

--- a/hypershift-operator/controllers/hostedcluster/karpenter.go
+++ b/hypershift-operator/controllers/hostedcluster/karpenter.go
@@ -21,9 +21,12 @@ import (
 	"github.com/openshift/hypershift/support/upsert"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (r *HostedClusterReconciler) reconcileKarpenterOperator(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane, hypershiftOperatorImage, controlPlaneOperatorImage string) error {
@@ -71,41 +74,61 @@ spec:
 			Namespace: hcluster.Namespace,
 		},
 	}
-	_, err = createOrUpdate(ctx, r.Client, nodePool, func() error {
-		nodePool.Spec = hyperv1.NodePoolSpec{
-			ClusterName: hcluster.Name,
-			Replicas:    ptr.To(int32(0)),
-			Release:     hcluster.Spec.Release,
-			Config: []corev1.LocalObjectReference{
-				{
-					Name: taintConfigName,
+	spec := hyperv1.NodePoolSpec{
+		ClusterName: hcluster.Name,
+		Replicas:    ptr.To(int32(0)),
+		Release:     hcluster.Spec.Release,
+		Config: []corev1.LocalObjectReference{
+			{
+				Name: taintConfigName,
+			},
+		},
+		Management: hyperv1.NodePoolManagement{
+			UpgradeType: hyperv1.UpgradeTypeReplace,
+			Replace: &hyperv1.ReplaceUpgrade{
+				Strategy: hyperv1.UpgradeStrategyRollingUpdate,
+				RollingUpdate: &hyperv1.RollingUpdate{
+					MaxUnavailable: ptr.To(intstr.FromInt(0)),
+					MaxSurge:       ptr.To(intstr.FromInt(1)),
 				},
 			},
-			Management: hyperv1.NodePoolManagement{
-				UpgradeType: hyperv1.UpgradeTypeReplace,
-				Replace: &hyperv1.ReplaceUpgrade{
-					Strategy: hyperv1.UpgradeStrategyRollingUpdate,
-					RollingUpdate: &hyperv1.RollingUpdate{
-						MaxUnavailable: ptr.To(intstr.FromInt(0)),
-						MaxSurge:       ptr.To(intstr.FromInt(1)),
+			AutoRepair: false,
+		},
+		Platform: hyperv1.NodePoolPlatform{
+			Type: hyperv1.AWSPlatform,
+			AWS: &hyperv1.AWSNodePoolPlatform{
+				InstanceType: "m5.large",
+				Subnet: hyperv1.AWSResourceReference{
+					// TODO(alberto): this is just to pass cel.
+					// Setting an ID instead of filter would break publicAndPrivate topology because the AWSEndpointService won't find the subnet.
+					// We'll move to generate the userdata for karpenter programatically.
+					Filters: []hyperv1.Filter{
+						{
+							Name:   "subnet-none",
+							Values: []string{"none"},
+						},
 					},
 				},
-				AutoRepair: false,
 			},
-			Platform: hyperv1.NodePoolPlatform{
-				Type: hyperv1.AWSPlatform,
-				AWS: &hyperv1.AWSNodePoolPlatform{
-					InstanceType: "m5.large",
-					Subnet: hyperv1.AWSResourceReference{
-						ID: ptr.To("subnet-none"),
-					},
-				},
-			},
+		},
+	}
+
+	if err := r.Client.Get(ctx, crclient.ObjectKeyFromObject(nodePool), nodePool); err != nil {
+		if apierrors.IsNotFound(err) {
+			nodePool.Spec = spec
+			if err := r.Client.Create(ctx, nodePool); err != nil {
+				return fmt.Errorf("failed to create NodePool: %w", err)
+			}
+		} else {
+			return err
 		}
-		return nil
-	})
+	}
+
+	original := nodePool.DeepCopy()
+	nodePool.Spec = spec
+	err = r.Client.Patch(ctx, nodePool, crclient.MergeFrom(original))
 	if err != nil {
-		return fmt.Errorf("failed to create configmap: %w", err)
+		return fmt.Errorf("failed to patch NodePool: %w", err)
 	}
 	// TODO(alberto): Ensure deletion if autoNode is disabled.
 

--- a/karpenter-operator/controllers/karpenter/karpenter_controller.go
+++ b/karpenter-operator/controllers/karpenter/karpenter_controller.go
@@ -288,6 +288,9 @@ func (r *Reconciler) reconcileEC2NodeClassDefault(ctx context.Context, userDataS
 				},
 			},
 		}
+		if hcp.Annotations[hyperv1.AWSMachinePublicIPs] == "true" {
+			ec2NodeClass.Object["spec"].(map[string]interface{})["associatePublicIPAddress"] = true
+		}
 		return nil
 	})
 	if err != nil {

--- a/karpenter-operator/controllers/karpenter/manifests.go
+++ b/karpenter-operator/controllers/karpenter/manifests.go
@@ -21,11 +21,15 @@ import (
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	karpenterName = "karpenter"
+)
+
 func KarpenterDeployment(namespace string) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      "karpenter",
+			Name:      karpenterName,
 		},
 	}
 }
@@ -34,7 +38,7 @@ func KarpenterServiceAccount(controlPlaneNamespace string) *corev1.ServiceAccoun
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: controlPlaneNamespace,
-			Name:      "karpenter",
+			Name:      karpenterName,
 		},
 	}
 }
@@ -43,7 +47,7 @@ func KarpenterRole(controlPlaneNamespace string) *rbacv1.Role {
 	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: controlPlaneNamespace,
-			Name:      "karpenter",
+			Name:      karpenterName,
 		},
 	}
 }
@@ -52,14 +56,14 @@ func KarpenterRoleBinding(controlPlaneNamespace string) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: controlPlaneNamespace,
-			Name:      "karpenter",
+			Name:      karpenterName,
 		},
 	}
 }
 
 func karpenterSelector() map[string]string {
 	return map[string]string{
-		"karpenter": "karpenter",
+		"app": karpenterName,
 	}
 }
 
@@ -70,6 +74,20 @@ func ReconcileKarpenterDeployment(deployment *appsv1.Deployment,
 	availabilityProberImage, tokenMinterImage string,
 	setDefaultSecurityContext bool,
 	ownerRef config.OwnerRef) error {
+
+	// Preserve existing resource requirements.
+	karpenterResources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("60Mi"),
+			corev1.ResourceCPU:    resource.MustParse("10m"),
+		},
+	}
+	mainContainer := util.FindContainer(karpenterName, deployment.Spec.Template.Spec.Containers)
+	if mainContainer != nil {
+		if len(mainContainer.Resources.Requests) > 0 || len(mainContainer.Resources.Limits) > 0 {
+			karpenterResources = mainContainer.Resources
+		}
+	}
 
 	deployment.Spec = appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
@@ -121,10 +139,11 @@ func ReconcileKarpenterDeployment(deployment *appsv1.Deployment,
 				},
 				Containers: []corev1.Container{
 					{
-						Name: "karpenter",
+						Name:      karpenterName,
+						Resources: karpenterResources,
 						// TODO(alberto): lifecycle this image.
 						Image:           "public.ecr.aws/karpenter/controller:1.0.7",
-						ImagePullPolicy: corev1.PullAlways,
+						ImagePullPolicy: corev1.PullIfNotPresent,
 						VolumeMounts: []corev1.VolumeMount{
 							{
 								Name:      "target-kubeconfig",
@@ -187,7 +206,7 @@ func ReconcileKarpenterDeployment(deployment *appsv1.Deployment,
 							},
 							{
 								Name:  "CLUSTER_NAME",
-								Value: "none",
+								Value: hcp.Spec.InfraID,
 							},
 						},
 						// Command: []string{""},

--- a/karpenter-operator/main.go
+++ b/karpenter-operator/main.go
@@ -14,7 +14,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/spf13/cobra"
@@ -91,14 +90,6 @@ func run(ctx context.Context) error {
 
 	if err := mgr.Add(managementCluster); err != nil {
 		return fmt.Errorf("failed to add managementCluster to controller runtime manager: %v", err)
-	}
-
-	// Add health check endpoints
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		return fmt.Errorf("failed to setup healthz check: %w", err)
-	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		return fmt.Errorf("failed to setup readyz check: %w", err)
 	}
 
 	r := karpenter.Reconciler{

--- a/karpenter-operator/manifests/operator.go
+++ b/karpenter-operator/manifests/operator.go
@@ -16,7 +16,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	intstr "k8s.io/apimachinery/pkg/util/intstr"
 	k8sutilspointer "k8s.io/utils/ptr"
 
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -64,7 +63,7 @@ func KarpenterOperatorRoleBinding(controlPlaneNamespace string) *rbacv1.RoleBind
 
 func karpenterOperatorSelector() map[string]string {
 	return map[string]string{
-		"karpenter": "karpenter",
+		"app": "karpenter-operator",
 	}
 }
 
@@ -76,6 +75,20 @@ func ReconcileKarpenterOperatorDeployment(deployment *appsv1.Deployment,
 	controlPlaneOperatorImage string,
 	setDefaultSecurityContext bool,
 	ownerRef config.OwnerRef) error {
+
+	// Preserve existing resource requirements.
+	karpenterOperatorResources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("60Mi"),
+			corev1.ResourceCPU:    resource.MustParse("10m"),
+		},
+	}
+	operatorContainer := util.FindContainer(name, deployment.Spec.Template.Spec.Containers)
+	if operatorContainer != nil {
+		if len(operatorContainer.Resources.Requests) > 0 || len(operatorContainer.Resources.Limits) > 0 {
+			karpenterOperatorResources = operatorContainer.Resources
+		}
+	}
 
 	deployment.Spec = appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
@@ -116,9 +129,10 @@ func ReconcileKarpenterOperatorDeployment(deployment *appsv1.Deployment,
 	}
 
 	mainContainer := corev1.Container{
+		Resources:       karpenterOperatorResources,
 		Name:            name,
 		Image:           hypershiftOperatorImage,
-		ImagePullPolicy: corev1.PullAlways,
+		ImagePullPolicy: corev1.PullIfNotPresent,
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      "target-kubeconfig",
@@ -142,45 +156,6 @@ func ReconcileKarpenterOperatorDeployment(deployment *appsv1.Deployment,
 			"--target-kubeconfig=/mnt/kubeconfig/target-kubeconfig",
 			"--namespace=$(MY_NAMESPACE)",
 			"--control-plane-operator-image=" + controlPlaneOperatorImage,
-		},
-		LivenessProbe: &corev1.Probe{
-			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/healthz",
-					Port:   intstr.FromString("http"),
-					Scheme: corev1.URISchemeHTTP,
-				},
-			},
-			InitialDelaySeconds: 60,
-			PeriodSeconds:       60,
-			SuccessThreshold:    1,
-			FailureThreshold:    5,
-			TimeoutSeconds:      5,
-		},
-
-		ReadinessProbe: &corev1.Probe{
-			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/readyz",
-					Port:   intstr.FromString("http"),
-					Scheme: corev1.URISchemeHTTP,
-				},
-			},
-			PeriodSeconds:    10,
-			SuccessThreshold: 1,
-			FailureThreshold: 3,
-			TimeoutSeconds:   5,
-		},
-		Ports: []corev1.ContainerPort{
-			{
-				Name:          "metrics",
-				ContainerPort: 8000,
-			},
-			{
-				Name:          "http",
-				ContainerPort: 8081,
-				Protocol:      corev1.ProtocolTCP,
-			},
 		},
 	}
 

--- a/test/e2e/assets/karpenter-nodepool.yaml
+++ b/test/e2e/assets/karpenter-nodepool.yaml
@@ -1,0 +1,22 @@
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: on-demand
+spec:
+  template:
+    spec:
+      requirements:
+      - key: node.kubernetes.io/instance-type
+        operator: In
+        values:
+        # - g4dn.xlarge
+        # - m5.4xlarge
+        # - c5.xlarge
+        - t3.large
+      - key: karpenter.sh/capacity-type
+        operator: In
+        values: ["on-demand"]
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: default

--- a/test/e2e/assets/karpenter-workloads.yaml
+++ b/test/e2e/assets/karpenter-workloads.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-app
+  namespace: default
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web-app
+  template:
+    metadata:
+      labels:
+        app: web-app
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: web-app
+              topologyKey: "kubernetes.io/hostname"    
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 2000
+      containers:
+      - image: quay.io/openshift/origin-pod:4.19.0
+        name: web-app
+        resources:
+          requests:
+            cpu: "1"
+            memory: 256M
+        securityContext:
+          allowPrivilegeEscalation: false
+      nodeSelector:
+        node.kubernetes.io/instance-type: "t3.large"

--- a/test/e2e/karpenter_test.go
+++ b/test/e2e/karpenter_test.go
@@ -1,0 +1,84 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+func TestKarpenter(t *testing.T) {
+	e2eutil.AtLeast(t, e2eutil.Version419)
+	if globalOpts.Platform != hyperv1.AWSPlatform {
+		t.Skip("test only supported on platform AWS")
+	}
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(testContext)
+	defer cancel()
+
+	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts.AWSPlatform.AutoNode = true
+
+	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+		guestClient := e2eutil.WaitForGuestClient(t, ctx, mgtClient, hostedCluster)
+
+		// Unmarshal Karpenter NodePool.
+		karpenterNodePool := &unstructured.Unstructured{}
+		yamlFile, err := content.ReadFile(fmt.Sprintf("assets/%s", "karpenter-nodepool.yaml"))
+		g.Expect(err).NotTo(HaveOccurred())
+		err = yaml.Unmarshal(yamlFile, karpenterNodePool)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// Unmarshal workloads.
+		workLoads := &unstructured.Unstructured{}
+		yamlFile, err = content.ReadFile(fmt.Sprintf("assets/%s", "karpenter-workloads.yaml"))
+		g.Expect(err).NotTo(HaveOccurred())
+		err = yaml.Unmarshal(yamlFile, workLoads)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// Apply both Karpenter NodePool and workloads.
+		defer guestClient.Delete(ctx, karpenterNodePool)
+		defer guestClient.Delete(ctx, workLoads)
+		g.Expect(guestClient.Create(ctx, karpenterNodePool)).To(Succeed())
+		t.Logf("Created Karpenter NodePool")
+		g.Expect(guestClient.Create(ctx, workLoads)).To(Succeed())
+		t.Logf("Created workloads")
+
+		// Wait for Karpenter Nodes.
+		nodeLabels := map[string]string{
+			"node.kubernetes.io/instance-type": "t3.large",
+			"karpenter.sh/nodepool":            karpenterNodePool.GetName(),
+		}
+
+		t.Logf("Waiting for Karpenter Nodes to come up")
+		_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, guestClient, hostedCluster.Spec.Platform.Type, 3, nodeLabels)
+
+		// Delete both Karpenter NodePool and workloads.
+		g.Expect(guestClient.Delete(ctx, karpenterNodePool)).To(Succeed())
+		t.Logf("Deleted Karpenter NodePool")
+		g.Expect(guestClient.Delete(ctx, workLoads)).To(Succeed())
+		t.Logf("Delete workloads")
+
+		// Wait for Karpenter Nodes to go away.
+		_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, guestClient, hostedCluster.Spec.Platform.Type, 0, nodeLabels)
+		t.Logf("Waiting for Karpenter Nodes to dissapear")
+
+		// TODO(alberto): increase coverage:
+		// - Karpenter operator plumbing, e.g:
+		// -- validate the CRDs are installed
+		// -- validate the default class is created and has expected values
+		// -- validate admin can't modify fields owned by the service, e.g. ami.
+		// - Karpenter functionallity:
+		// -- Drift and Upgrades
+	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
+}

--- a/test/e2e/karpenter_test.go
+++ b/test/e2e/karpenter_test.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -18,6 +19,9 @@ import (
 
 func TestKarpenter(t *testing.T) {
 	e2eutil.AtLeast(t, e2eutil.Version419)
+	if os.Getenv("TECH_PREVIEW_NO_UPGRADE") != "true" {
+		t.Skipf("Only tested when CI sets TECH_PREVIEW_NO_UPGRADE=true and the Hypershift Operator is installed with --tech-preview-no-upgrade")
+	}
 	if globalOpts.Platform != hyperv1.AWSPlatform {
 		t.Skip("test only supported on platform AWS")
 	}

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -77,6 +77,8 @@ var expectedKasManagementComponents = []string{
 	"cloud-controller-manager",
 	"olm-collect-profiles",
 	"aws-ebs-csi-driver-operator",
+	"karpenter",
+	"karpenter-operator",
 }
 
 func UpdateObject[T crclient.Object](t *testing.T, ctx context.Context, client crclient.Client, original T, mutate func(obj T)) error {
@@ -268,6 +270,10 @@ func WaitForNReadyNodes(t *testing.T, ctx context.Context, client crclient.Clien
 
 func WaitForReadyNodesByNodePool(t *testing.T, ctx context.Context, client crclient.Client, np *hyperv1.NodePool, platform hyperv1.PlatformType, opts ...NodePoolPollOption) []corev1.Node {
 	return WaitForNReadyNodesWithOptions(t, ctx, client, *np.Spec.Replicas, platform, fmt.Sprintf("for NodePool %s/%s", np.Namespace, np.Name), append(opts, WithClientOptions(crclient.MatchingLabelsSelector{Selector: labels.SelectorFromSet(labels.Set{hyperv1.NodePoolLabel: np.Name})}))...)
+}
+
+func WaitForReadyNodesByLabels(t *testing.T, ctx context.Context, client crclient.Client, platform hyperv1.PlatformType, replicas int32, nodeLabels map[string]string) []corev1.Node {
+	return WaitForNReadyNodesWithOptions(t, ctx, client, replicas, platform, "", WithClientOptions(crclient.MatchingLabelsSelector{Selector: labels.SelectorFromSet(labels.Set(nodeLabels))}))
 }
 
 func WaitForNodePoolConfigUpdateComplete(t *testing.T, ctx context.Context, client crclient.Client, np *hyperv1.NodePool) {
@@ -505,6 +511,10 @@ func EnsureNoCrashingPods(t *testing.T, ctx context.Context, client crclient.Cli
 			t.Fatalf("failed to list pods in namespace %s: %v", namespace, err)
 		}
 		for _, pod := range podList.Items {
+			// TODO: Figure out why Karpenter needs restaring some times https://issues.redhat.com/browse/HOSTEDCP-2254.
+			if strings.HasPrefix(pod.Name, "karpenter") {
+				continue
+			}
 			// TODO: Figure out why Route kind does not exist when ingress-operator first starts
 			if strings.HasPrefix(pod.Name, "ingress-operator-") {
 				continue
@@ -1160,6 +1170,8 @@ func EnsurePodsWithEmptyDirPVsHaveSafeToEvictAnnotations(t *testing.T, ctx conte
 			"redhat-marketplace-catalog":             "app",
 			"openstack-cinder-csi-driver-controller": "app",
 			"openstack-manila-csi":                   "app",
+			"karpenter":                              "app",
+			"karpenter-operator":                     "app",
 		}
 
 		hcpPods := &corev1.PodList{}


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
https://github.com/openshift/hypershift/pull/5404 introduced e2e for karpenter

https://github.com/openshift/hypershift/pull/5461 reverted it because it was breaking periodics which run the HO without --tech-preview-no-upgrade

This PR re-enable the test with a check to only run when CI sets TECH_PREVIEW_NO_UPGRADE=true and the Hypershift Operator is installed with --tech-preview-no-upgrade

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.