### PR TITLE
HOSTEDCP-2176: Enable gosimple and govet linters in golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6.5.0
         with:
-          args: --timeout=15m --config=.golangci.yml --issues-exit-code=0
+          args: --timeout=15m --config=.golangci.yml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,9 +34,9 @@ linters:
     - unused
     - ineffassign
     - gosimple
+    - govet
   disable:
     - errcheck
-    - govet
     - staticcheck
 linters-settings:
   gci:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,9 +33,9 @@ linters:
     - gci
     - unused
     - ineffassign
+    - gosimple
   disable:
     - errcheck
-    - gosimple
     - govet
     - staticcheck
 linters-settings:

--- a/etcd-defrag/etcddefrag_controller.go
+++ b/etcd-defrag/etcddefrag_controller.go
@@ -193,7 +193,7 @@ func (r *DefragController) runDefrag(ctx context.Context) error {
 				// Defrag can timeout if defragmentation takes longer than etcdcli.DefragDialTimeout.
 				r.log.Error(err, "DefragController Defragment Failed", "member", member.Name, "ID", member.ID)
 				errMsg := fmt.Sprintf("failed defrag on member: %s, memberID: %x: %v", member.Name, member.ID, err)
-				errs = append(errs, fmt.Errorf(errMsg))
+				errs = append(errs, fmt.Errorf("%s", errMsg))
 				continue
 			}
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1167,7 +1167,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		validReleaseImage := meta.FindStatusCondition(hcluster.Status.Conditions, string(hyperv1.ValidReleaseImage))
 		if validReleaseImage != nil && validReleaseImage.Status == metav1.ConditionFalse {
 			if validReleaseImage.Reason == hyperv1.SecretNotFoundReason {
-				return ctrl.Result{}, fmt.Errorf(validReleaseImage.Message)
+				return ctrl.Result{}, fmt.Errorf("%s", validReleaseImage.Message)
 			}
 			log.Error(fmt.Errorf("release image is invalid"), "reconciliation is blocked", "message", validReleaseImage.Message)
 			return ctrl.Result{}, nil

--- a/hypershift-operator/controlplaneoperator-overrides/overrides_test.go
+++ b/hypershift-operator/controlplaneoperator-overrides/overrides_test.go
@@ -64,8 +64,8 @@ func TestLoadOverrides(t *testing.T) {
 func fakeOverrides() *CPOOverrides {
 	result := &CPOOverrides{
 		Testing: CPOOverrideTestReleases{
-			Latest:   fmt.Sprintf("quay.io/openshift-release-dev/ocp-release:4.17.9-x86_64"),
-			Previous: fmt.Sprintf("quay.io/openshift-release-dev/ocp-release:4.17.8-x86_64"),
+			Latest:   "quay.io/openshift-release-dev/ocp-release:4.17.9-x86_64",
+			Previous: "quay.io/openshift-release-dev/ocp-release:4.17.8-x86_64",
 		},
 	}
 	for _, minor := range []int{15, 16, 17} {

--- a/pkg/etcdcli/health.go
+++ b/pkg/etcdcli/health.go
@@ -153,10 +153,8 @@ func (h memberHealth) Status() string {
 			switch {
 			case !HasStarted(etcd.Member):
 				status = append(status, fmt.Sprintf("%s has not started", GetMemberNameOrHost(etcd.Member)))
-				break
 			case !etcd.Healthy:
 				status = append(status, fmt.Sprintf("%s is unhealthy", etcd.Member.Name))
-				break
 			}
 		}
 	}
@@ -231,10 +229,7 @@ func GetUnstartedMemberNames(memberHealth []healthCheck) []string {
 
 // HasStarted return true if etcd member has started.
 func HasStarted(member *etcdserverpb.Member) bool {
-	if len(member.ClientURLs) == 0 {
-		return false
-	}
-	return true
+	return len(member.ClientURLs) != 0
 }
 
 // IsQuorumFaultTolerant checks the current etcd cluster and returns true if the cluster can tolerate the
@@ -277,10 +272,7 @@ func IsQuorumFaultTolerantErr(memberHealth []healthCheck) error {
 
 func IsClusterHealthy(memberHealth memberHealth) bool {
 	unhealthyMembers := memberHealth.GetUnhealthyMembers()
-	if len(unhealthyMembers) > 0 {
-		return false
-	}
-	return true
+	return len(unhealthyMembers) == 0
 }
 
 // raftTermsCollector is a Prometheus collector to re-expose raft terms as a counter.

--- a/pkg/etcdcli/helpers.go
+++ b/pkg/etcdcli/helpers.go
@@ -117,15 +117,12 @@ func (f *fakeEtcdClient) MemberHealth(ctx context.Context) (memberHealth, error)
 		// if WithClusterHealth is not passed we default to all healthy
 		case f.opts.healthyMember == 0 && f.opts.unhealthyMember == 0:
 			healthCheck.Healthy = true
-			break
 		case f.opts.healthyMember > 0 && healthy < f.opts.healthyMember:
 			healthCheck.Healthy = true
 			healthy++
-			break
 		case f.opts.unhealthyMember > 0 && unhealthy < f.opts.unhealthyMember:
 			healthCheck.Healthy = false
 			unhealthy++
-			break
 		}
 		memberHealth = append(memberHealth, healthCheck)
 	}

--- a/support/azureutil/azureutil.go
+++ b/support/azureutil/azureutil.go
@@ -131,7 +131,7 @@ func getFullVnetInfo(ctx context.Context, subscriptionID string, vnetResourceGro
 		return armnetwork.VirtualNetworksClientGetResponse{}, fmt.Errorf("virtual network has no name")
 	}
 
-	if vnet.Properties.Subnets == nil || len(vnet.Properties.Subnets) == 0 {
+	if len(vnet.Properties.Subnets) == 0 {
 		return armnetwork.VirtualNetworksClientGetResponse{}, fmt.Errorf("no subnets found for resource group '%s'", vnetResourceGroupName)
 	}
 

--- a/support/globalconfig/imagecontentsource.go
+++ b/support/globalconfig/imagecontentsource.go
@@ -165,9 +165,7 @@ func getImageContentSourcePolicies(ctx context.Context, client client.Client) (m
 		for _, mirror := range item.Spec.RepositoryDigestMirrors {
 			source := mirror.Source
 
-			for n := range mirror.Mirrors {
-				icspRegistryOverrides[source] = append(icspRegistryOverrides[source], mirror.Mirrors[n])
-			}
+			icspRegistryOverrides[source] = append(icspRegistryOverrides[source], mirror.Mirrors...)
 		}
 	}
 

--- a/support/secretproviderclass/secretproviderclass.go
+++ b/support/secretproviderclass/secretproviderclass.go
@@ -26,7 +26,7 @@ array:
 func ReconcileManagedAzureSecretProviderClass(secretProviderClass *secretsstorev1.SecretProviderClass, hcp *hyperv1.HostedControlPlane, managedIdentity hyperv1.ManagedIdentity, isMIv3 ...bool) {
 	// TODO - MIv3 - this if can be removed once CS supports only CredentialsSecret and it can be passed in directly to formatSecretProviderClassObject; also remove isMIv3 once everything has been converted over in 4.19 and 4.18 to MIv3
 	var secretName string
-	if isMIv3 != nil && len(isMIv3) > 0 && isMIv3[0] {
+	if len(isMIv3) > 0 && isMIv3[0] {
 		secretName = managedIdentity.CredentialsSecretName
 	} else {
 		secretName = managedIdentity.CertificateName

--- a/support/thirdparty/library-go/pkg/image/reference/reference.go
+++ b/support/thirdparty/library-go/pkg/image/reference/reference.go
@@ -231,7 +231,6 @@ func IsRegistryDockerHub(registry string) bool {
 // DeepCopyInto writing into out. in must be non-nil.
 func (in *DockerImageReference) DeepCopyInto(out *DockerImageReference) {
 	*out = *in
-	return
 }
 
 // DeepCopy copies the receiver, creating a new DockerImageReference.

--- a/support/thirdparty/oc/pkg/cli/image/manifest/manifest.go
+++ b/support/thirdparty/oc/pkg/cli/image/manifest/manifest.go
@@ -169,9 +169,7 @@ func ProcessManifestList(ctx context.Context, srcDigest digest.Digest, srcManife
 		manifestList := t
 
 		filtered := make([]manifestlist.ManifestDescriptor, 0, len(t.Manifests))
-		for _, manifest := range t.Manifests {
-			filtered = append(filtered, manifest)
-		}
+		filtered = append(filtered, t.Manifests...)
 
 		if len(filtered) == 0 {
 			return nil, nil, "", nil

--- a/support/util/containers.go
+++ b/support/util/containers.go
@@ -99,7 +99,7 @@ func AvailabilityProber(target string, image string, spec *corev1.PodSpec, o ...
 		}
 	}
 	if opts.WaitForInfrastructureResource {
-		availabilityProberContainer.Command = append(availabilityProberContainer.Command, fmt.Sprintf("--wait-for-infrastructure-resource"))
+		availabilityProberContainer.Command = append(availabilityProberContainer.Command, "--wait-for-infrastructure-resource")
 	}
 	if opts.WaitForLabeledPodsGone != "" {
 		availabilityProberContainer.Command = append(availabilityProberContainer.Command, fmt.Sprintf("--wait-for-labeled-pods-gone=%s", opts.WaitForLabeledPodsGone))

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -522,21 +522,13 @@ func PredicatesForHostedClusterAnnotationScoping(r client.Reader) predicate.Pred
 func getHostedClusterScopeAnnotation(obj client.Object, r client.Reader) string {
 	hostedClusterName := ""
 	nodePoolName := ""
-	switch obj.(type) {
+	switch obj := obj.(type) {
 	case *hyperv1.HostedCluster:
-		hc, ok := obj.(*hyperv1.HostedCluster)
-		if !ok {
-			return ""
-		}
-		if hc.GetAnnotations() != nil {
-			return hc.GetAnnotations()[HostedClustersScopeAnnotation]
+		if obj.GetAnnotations() != nil {
+			return obj.GetAnnotations()[HostedClustersScopeAnnotation]
 		}
 	case *hyperv1.NodePool:
-		np, ok := obj.(*hyperv1.NodePool)
-		if !ok {
-			return ""
-		}
-		hostedClusterName = fmt.Sprintf("%s/%s", np.Namespace, np.Spec.ClusterName)
+		hostedClusterName = fmt.Sprintf("%s/%s", obj.Namespace, obj.Spec.ClusterName)
 	default:
 		if obj.GetAnnotations() != nil {
 			nodePoolName = obj.GetAnnotations()["hypershift.openshift.io/nodePool"]

--- a/test/e2e/util/eventually.go
+++ b/test/e2e/util/eventually.go
@@ -176,7 +176,7 @@ func evaluatePredicates[T any](object T, predicates []Predicate[T]) ([]predicate
 			return nil, err
 		}
 		if !done && len(reason) == 0 {
-			panic(fmt.Sprintf("programmer error: predicate returned false with no message"))
+			panic("programmer error: predicate returned false with no message")
 		}
 		results[i] = predicateResult{done: done, reason: reason}
 	}

--- a/test/e2e/util/eventually.go
+++ b/test/e2e/util/eventually.go
@@ -152,7 +152,7 @@ func EventuallyObject[T client.Object](t *testing.T, ctx context.Context, object
 						matches = matches || matcher.Matches(condition)
 					}
 					if matches {
-						t.Logf(condition.String())
+						t.Logf("%s", condition.String())
 					}
 				}
 			}
@@ -332,7 +332,7 @@ func EventuallyObjects[T client.Object](t *testing.T, ctx context.Context, objec
 							matches = matches || matcher.Matches(condition)
 						}
 						if matches {
-							t.Logf(condition.String())
+							t.Logf("%s", condition.String())
 						}
 					}
 				}

--- a/test/e2e/util/hypershift_framework.go
+++ b/test/e2e/util/hypershift_framework.go
@@ -88,7 +88,7 @@ func (h *hypershiftTest) Execute(opts *PlatformAgnosticOptions, platform hyperv1
 		if err := recover(); err != nil {
 			// on a panic, print error and mark test as failed so postTeardown() is skipped
 			// panics from subtests can't be caught by this.
-			h.Errorf(string(debug.Stack()))
+			h.Errorf("%s", string(debug.Stack()))
 		}
 
 		h.teardown(hostedCluster, opts, artifactDir, false)

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -161,7 +161,7 @@ func WaitForGuestKubeConfig(t *testing.T, ctx context.Context, client crclient.C
 					Namespace: hostedCluster.Namespace,
 					Name:      ptr.Deref(hostedCluster.Status.KubeConfig, corev1.LocalObjectReference{}).Name,
 				}
-				return hostedCluster.Status.KubeConfig != nil, fmt.Sprintf("expected a kubeconfig reference in status"), nil
+				return hostedCluster.Status.KubeConfig != nil, "expected a kubeconfig reference in status", nil
 			},
 		},
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR:
- enables gosimple and govet linters in golangci-lint
- fixes all issues found by gosimple and govet

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes [HOSTEDCP-2176](https://issues.redhat.com/browse/HOSTEDCP-2176)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.