### PR TITLE
NO-JIRA: Bump Golang to 1.23

### DIFF
--- a/Containerfile.control-plane
+++ b/Containerfile.control-plane
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23.4 AS builder
 
 WORKDIR /hypershift
 

--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23.4 AS builder
 
 WORKDIR /hypershift
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/hypershift/api
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/openshift/api v0.0.0-20241114175301-1d987ad446cf

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/hypershift
 
-go 1.22.5
+go 1.23.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,8 +1,6 @@
 module github.com/openshift-hive/hypershift/hack/tools
 
-go 1.22.1
-
-toolchain go1.23.0
+go 1.23.0
 
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0

--- a/hack/workspace/go.work
+++ b/hack/workspace/go.work
@@ -1,4 +1,6 @@
-go 1.22.5
+go 1.23.0
+
+toolchain go1.23.1
 
 use (
 	./hypershift

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -854,7 +854,7 @@ github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/control
 ## explicit; go 1.12
 github.com/openshift/custom-resource-status/conditions/v1
 # github.com/openshift/hypershift/api v0.0.0-20240604072534-cd2d5291e2b7 => ./api
-## explicit; go 1.22.0
+## explicit; go 1.23.0
 github.com/openshift/hypershift/api/certificates
 github.com/openshift/hypershift/api/certificates/v1alpha1
 github.com/openshift/hypershift/api/hypershift/v1beta1


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR 
- bumps Golang to 1.23 for the main go.mod, API go.mod, and hack/tools/go.mod
- updates the RHTAP Dockerfiles to Golang v1.23

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.