### PR TITLE
OCPBUGS-48794: Adds contributor role over VNET for Cloud Provider

### DIFF
--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -831,7 +831,7 @@ func assignServicePrincipalRoles(subscriptionID, managedResourceGroupName, nsgRe
 
 	switch component {
 	case cloudProvider:
-		scopes = append(scopes, nsgRG)
+		scopes = append(scopes, nsgRG, vnetRG)
 	case ingress:
 		scopes = append(scopes, vnetRG, dnsZoneRG)
 	case cpo:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the contributor role over VNET for Cloud Provider.

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-48794](https://issues.redhat.com/browse/OCPBUGS-48794)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.