### PR TITLE
OCPBUGS-50518: Kubernetes API Server apply-bootstrap container does not respect SIGTERM

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -799,6 +799,12 @@ cp /tmp/manifests/* %[1]s
 
 func applyBootstrapManifestsScript(workDir string) string {
 	var script = `#!/bin/sh
+function cleanup() {
+	pkill -P $$$
+	wait
+	exit
+}
+trap cleanup SIGTERM
 while true; do
   if oc apply -f %[1]s; then
     echo "Bootstrap manifests applied successfully."
@@ -814,7 +820,8 @@ while true; do
   sleep 1
 done
 while true; do
-  sleep 1000
+  sleep 1000 &
+  wait $!
 done
 `
 	return fmt.Sprintf(script, workDir)

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents.yaml
@@ -85,6 +85,12 @@ spec:
         - -c
         - |
           #!/bin/sh
+          function cleanup() {
+            pkill -P $$$
+            wait
+            exit
+          }
+          trap cleanup SIGTERM
           while true; do
             if oc apply -f /work; then
               echo "Bootstrap manifests applied successfully."
@@ -100,7 +106,8 @@ spec:
             sleep 1
           done
           while true; do
-            sleep 1000
+            sleep 1000 &
+            wait $!
           done
         command:
         - /bin/bash

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -85,6 +85,12 @@ spec:
         - -c
         - |
           #!/bin/sh
+          function cleanup() {
+            pkill -P $$$
+            wait
+            exit
+          }
+          trap cleanup SIGTERM
           while true; do
             if oc apply -f /work; then
               echo "Bootstrap manifests applied successfully."
@@ -100,7 +106,8 @@ spec:
             sleep 1
           done
           while true; do
-            sleep 1000
+            sleep 1000 &
+            wait $!
           done
         command:
         - /bin/bash

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-apiserver/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-apiserver/deployment.yaml
@@ -24,6 +24,12 @@ spec:
         - -c
         - |
           #!/bin/sh
+          function cleanup() {
+            pkill -P $$$
+            wait
+            exit
+          }
+          trap cleanup SIGTERM
           while true; do
             if oc apply -f /work; then
               echo "Bootstrap manifests applied successfully."
@@ -39,7 +45,8 @@ spec:
             sleep 1
           done
           while true; do
-            sleep 1000
+            sleep 1000 &
+            wait $!
           done
         command:
         - /bin/bash


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
Modify apply-bootstrap container to trap SIGTERM, and handle it correctly before exiting to ensure the container terminates within the specified grace period.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.