### PR TITLE
OCPBUGS-49370: openstack: update CAPI provider deployment spec

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack.go
@@ -194,7 +194,6 @@ func (a OpenStack) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _
 					Args: []string{
 						"--namespace=$(MY_NAMESPACE)",
 						"--leader-elect",
-						"--metrics-bind-addr=127.0.0.1:8080",
 						"--v=2",
 					},
 					Resources: corev1.ResourceRequirements{


### PR DESCRIPTION
**What this PR does / why we need it**:

`metrics-bind-addr` was deprecated and is currently removed, we should
stop using it so we can bump the version of CAPI and CAPO.
