### PR TITLE
CNTRLPLANE-187: Remove MachineIdentityID from Azure HyperShift API

### DIFF
--- a/api/hypershift/v1beta1/azure.go
+++ b/api/hypershift/v1beta1/azure.go
@@ -97,20 +97,6 @@ type AzureNodePoolPlatform struct {
 	// If not specified, then Boot diagnostics will be disabled.
 	// +optional
 	Diagnostics *Diagnostics `json:"diagnostics,omitempty"`
-
-	// machineIdentityID is a user-assigned identity assigned to the VMs used to authenticate with Azure services. The
-	// identify is expected to exist under the same resource group as HostedCluster.Spec.Platform.Azure.ResourceGroupName. This
-	// user assigned identity is expected to have the Contributor role assigned to it and scoped to the resource group
-	// under HostedCluster.Spec.Platform.Azure.ResourceGroupName.
-	//
-	// If this field is not supplied, the Service Principal credentials will be written to a file on the disk of each VM
-	// in order to be accessible by the cloud provider; the aforementioned credentials provided are the same ones as
-	// HostedCluster.Spec.Platform.Azure.Credentials. However, this is less secure than using a managed identity.
-	//
-	// TODO: What is the valid character set for this field? What about minimum and maximum lengths?
-	//
-	// +optional
-	MachineIdentityID string `json:"machineIdentityID,omitempty"`
 }
 
 // AzureVMImage represents the different types of boot image sources that can be provided for an Azure VM.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
@@ -732,17 +732,6 @@ spec:
                             and forbidden otherwise
                           rule: 'has(self.type) && self.type == ''AzureMarketplace''
                             ?  has(self.azureMarketplace) : !has(self.azureMarketplace)'
-                      machineIdentityID:
-                        description: |
-                          machineIdentityID is a user-assigned identity assigned to the VMs used to authenticate with Azure services. The
-                          identify is expected to exist under the same resource group as HostedCluster.Spec.Platform.Azure.ResourceGroupName. This
-                          user assigned identity is expected to have the Contributor role assigned to it and scoped to the resource group
-                          under HostedCluster.Spec.Platform.Azure.ResourceGroupName.
-
-                          If this field is not supplied, the Service Principal credentials will be written to a file on the disk of each VM
-                          in order to be accessible by the cloud provider; the aforementioned credentials provided are the same ones as
-                          HostedCluster.Spec.Platform.Azure.Credentials. However, this is less secure than using a managed identity.
-                        type: string
                       osDisk:
                         description: |-
                           osDisk provides configuration for the OS disk for the nodepool.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
@@ -732,17 +732,6 @@ spec:
                             and forbidden otherwise
                           rule: 'has(self.type) && self.type == ''AzureMarketplace''
                             ?  has(self.azureMarketplace) : !has(self.azureMarketplace)'
-                      machineIdentityID:
-                        description: |
-                          machineIdentityID is a user-assigned identity assigned to the VMs used to authenticate with Azure services. The
-                          identify is expected to exist under the same resource group as HostedCluster.Spec.Platform.Azure.ResourceGroupName. This
-                          user assigned identity is expected to have the Contributor role assigned to it and scoped to the resource group
-                          under HostedCluster.Spec.Platform.Azure.ResourceGroupName.
-
-                          If this field is not supplied, the Service Principal credentials will be written to a file on the disk of each VM
-                          in order to be accessible by the cloud provider; the aforementioned credentials provided are the same ones as
-                          HostedCluster.Spec.Platform.Azure.Credentials. However, this is less secure than using a managed identity.
-                        type: string
                       osDisk:
                         description: |-
                           osDisk provides configuration for the OS disk for the nodepool.

--- a/client/applyconfiguration/hypershift/v1beta1/azurenodepoolplatform.go
+++ b/client/applyconfiguration/hypershift/v1beta1/azurenodepoolplatform.go
@@ -20,14 +20,13 @@ package v1beta1
 // AzureNodePoolPlatformApplyConfiguration represents an declarative configuration of the AzureNodePoolPlatform type for use
 // with apply.
 type AzureNodePoolPlatformApplyConfiguration struct {
-	VMSize            *string                                `json:"vmSize,omitempty"`
-	Image             *AzureVMImageApplyConfiguration        `json:"image,omitempty"`
-	OSDisk            *AzureNodePoolOSDiskApplyConfiguration `json:"osDisk,omitempty"`
-	AvailabilityZone  *string                                `json:"availabilityZone,omitempty"`
-	EncryptionAtHost  *string                                `json:"encryptionAtHost,omitempty"`
-	SubnetID          *string                                `json:"subnetID,omitempty"`
-	Diagnostics       *DiagnosticsApplyConfiguration         `json:"diagnostics,omitempty"`
-	MachineIdentityID *string                                `json:"machineIdentityID,omitempty"`
+	VMSize           *string                                `json:"vmSize,omitempty"`
+	Image            *AzureVMImageApplyConfiguration        `json:"image,omitempty"`
+	OSDisk           *AzureNodePoolOSDiskApplyConfiguration `json:"osDisk,omitempty"`
+	AvailabilityZone *string                                `json:"availabilityZone,omitempty"`
+	EncryptionAtHost *string                                `json:"encryptionAtHost,omitempty"`
+	SubnetID         *string                                `json:"subnetID,omitempty"`
+	Diagnostics      *DiagnosticsApplyConfiguration         `json:"diagnostics,omitempty"`
 }
 
 // AzureNodePoolPlatformApplyConfiguration constructs an declarative configuration of the AzureNodePoolPlatform type for use with
@@ -89,13 +88,5 @@ func (b *AzureNodePoolPlatformApplyConfiguration) WithSubnetID(value string) *Az
 // If called multiple times, the Diagnostics field is set to the value of the last call.
 func (b *AzureNodePoolPlatformApplyConfiguration) WithDiagnostics(value *DiagnosticsApplyConfiguration) *AzureNodePoolPlatformApplyConfiguration {
 	b.Diagnostics = value
-	return b
-}
-
-// WithMachineIdentityID sets the MachineIdentityID field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the MachineIdentityID field is set to the value of the last call.
-func (b *AzureNodePoolPlatformApplyConfiguration) WithMachineIdentityID(value string) *AzureNodePoolPlatformApplyConfiguration {
-	b.MachineIdentityID = &value
 	return b
 }

--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -406,10 +406,9 @@ func (o *CreateOptions) GenerateNodePools(constructor core.DefaultNodePoolConstr
 					EncryptionSetID:        o.DiskEncryptionSetID,
 					DiskStorageAccountType: hyperv1.AzureDiskStorageAccountType(o.DiskStorageAccountType),
 				},
-				AvailabilityZone:  availabilityZone,
-				SubnetID:          o.infra.SubnetID,
-				MachineIdentityID: o.infra.MachineIdentityID,
-				EncryptionAtHost:  o.EncryptionAtHost,
+				AvailabilityZone: availabilityZone,
+				SubnetID:         o.infra.SubnetID,
+				EncryptionAtHost: o.EncryptionAtHost,
 			}
 
 			if o.EnableEphemeralOSDisk {
@@ -441,11 +440,10 @@ func (o *CreateOptions) GenerateNodePools(constructor core.DefaultNodePoolConstr
 		azureNodePool.Spec.Management.UpgradeType = hyperv1.UpgradeTypeReplace
 	}
 	azureNodePool.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
-		VMSize:            instanceType,
-		Image:             vmImage,
-		SubnetID:          o.infra.SubnetID,
-		MachineIdentityID: o.infra.MachineIdentityID,
-		EncryptionAtHost:  o.EncryptionAtHost,
+		VMSize:           instanceType,
+		Image:            vmImage,
+		SubnetID:         o.infra.SubnetID,
+		EncryptionAtHost: o.EncryptionAtHost,
 		OSDisk: hyperv1.AzureNodePoolOSDisk{
 			SizeGiB:                o.NodePoolOpts.DiskSize,
 			EncryptionSetID:        o.DiskEncryptionSetID,

--- a/cmd/cluster/azure/create_test.go
+++ b/cmd/cluster/azure/create_test.go
@@ -56,7 +56,6 @@ func TestCreateCluster(t *testing.T) {
 		SubnetID:          "fakeSubnetID",
 		BootImageID:       "fakeBootImageID",
 		InfraID:           "fakeInfraID",
-		MachineIdentityID: "fakeMachineIdentityID",
 		SecurityGroupID:   "fakeSecurityGroupID",
 	})
 	if err != nil {

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_complicated_invocation_from_bryan.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_complicated_invocation_from_bryan.yaml
@@ -160,7 +160,6 @@ spec:
       image:
         imageID: fakeBootImageID
         type: ImageID
-      machineIdentityID: fakeMachineIdentityID
       osDisk:
         diskStorageAccountType: Standard_LRS
         persistence: Ephemeral

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_create_with_a_ure_marketplace_image.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_create_with_a_ure_marketplace_image.yaml
@@ -131,7 +131,6 @@ spec:
           sku: aro_414
           version: 414.92.2024021
         type: AzureMarketplace
-      machineIdentityID: fakeMachineIdentityID
       osDisk:
         diskStorageAccountType: Standard_LRS
         persistence: Ephemeral

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -160,7 +160,6 @@ spec:
       image:
         imageID: fakeBootImageID
         type: ImageID
-      machineIdentityID: fakeMachineIdentityID
       osDisk:
         diskStorageAccountType: Premium_LRS
         sizeGiB: 120

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_ones.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_ones.yaml
@@ -161,7 +161,6 @@ spec:
       image:
         imageID: fakeBootImageID
         type: ImageID
-      machineIdentityID: fakeMachineIdentityID
       osDisk:
         diskStorageAccountType: Premium_LRS
         sizeGiB: 120
@@ -194,7 +193,6 @@ spec:
       image:
         imageID: fakeBootImageID
         type: ImageID
-      machineIdentityID: fakeMachineIdentityID
       osDisk:
         diskStorageAccountType: Premium_LRS
         sizeGiB: 120

--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -82,7 +82,6 @@ type CreateInfraOutput struct {
 	SubnetID            string                                 `json:"subnetID"`
 	BootImageID         string                                 `json:"bootImageID"`
 	InfraID             string                                 `json:"infraID"`
-	MachineIdentityID   string                                 `json:"machineIdentityID"`
 	SecurityGroupID     string                                 `json:"securityGroupID"`
 	ControlPlaneMIs     hyperv1.AzureResourceManagedIdentities `json:"controlPlaneMIs"`
 	DataPlaneIdentities hyperv1.DataPlaneManagedIdentities     `json:"dataPlaneIdentities"`

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -735,17 +735,6 @@ spec:
                             and forbidden otherwise
                           rule: 'has(self.type) && self.type == ''AzureMarketplace''
                             ?  has(self.azureMarketplace) : !has(self.azureMarketplace)'
-                      machineIdentityID:
-                        description: |
-                          machineIdentityID is a user-assigned identity assigned to the VMs used to authenticate with Azure services. The
-                          identify is expected to exist under the same resource group as HostedCluster.Spec.Platform.Azure.ResourceGroupName. This
-                          user assigned identity is expected to have the Contributor role assigned to it and scoped to the resource group
-                          under HostedCluster.Spec.Platform.Azure.ResourceGroupName.
-
-                          If this field is not supplied, the Service Principal credentials will be written to a file on the disk of each VM
-                          in order to be accessible by the cloud provider; the aforementioned credentials provided are the same ones as
-                          HostedCluster.Spec.Platform.Azure.Credentials. However, this is less secure than using a managed identity.
-                        type: string
                       osDisk:
                         description: |-
                           osDisk provides configuration for the OS disk for the nodepool.

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -735,17 +735,6 @@ spec:
                             and forbidden otherwise
                           rule: 'has(self.type) && self.type == ''AzureMarketplace''
                             ?  has(self.azureMarketplace) : !has(self.azureMarketplace)'
-                      machineIdentityID:
-                        description: |
-                          machineIdentityID is a user-assigned identity assigned to the VMs used to authenticate with Azure services. The
-                          identify is expected to exist under the same resource group as HostedCluster.Spec.Platform.Azure.ResourceGroupName. This
-                          user assigned identity is expected to have the Contributor role assigned to it and scoped to the resource group
-                          under HostedCluster.Spec.Platform.Azure.ResourceGroupName.
-
-                          If this field is not supplied, the Service Principal credentials will be written to a file on the disk of each VM
-                          in order to be accessible by the cloud provider; the aforementioned credentials provided are the same ones as
-                          HostedCluster.Spec.Platform.Azure.Credentials. However, this is less secure than using a managed identity.
-                        type: string
                       osDisk:
                         description: |-
                           osDisk provides configuration for the OS disk for the nodepool.

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -735,17 +735,6 @@ spec:
                             and forbidden otherwise
                           rule: 'has(self.type) && self.type == ''AzureMarketplace''
                             ?  has(self.azureMarketplace) : !has(self.azureMarketplace)'
-                      machineIdentityID:
-                        description: |
-                          machineIdentityID is a user-assigned identity assigned to the VMs used to authenticate with Azure services. The
-                          identify is expected to exist under the same resource group as HostedCluster.Spec.Platform.Azure.ResourceGroupName. This
-                          user assigned identity is expected to have the Contributor role assigned to it and scoped to the resource group
-                          under HostedCluster.Spec.Platform.Azure.ResourceGroupName.
-
-                          If this field is not supplied, the Service Principal credentials will be written to a file on the disk of each VM
-                          in order to be accessible by the cloud provider; the aforementioned credentials provided are the same ones as
-                          HostedCluster.Spec.Platform.Azure.Credentials. However, this is less secure than using a managed identity.
-                        type: string
                       osDisk:
                         description: |-
                           osDisk provides configuration for the OS disk for the nodepool.

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -3130,25 +3130,6 @@ Diagnostics
 If not specified, then Boot diagnostics will be disabled.</p>
 </td>
 </tr>
-<tr>
-<td>
-<code>machineIdentityID</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>machineIdentityID is a user-assigned identity assigned to the VMs used to authenticate with Azure services. The
-identify is expected to exist under the same resource group as HostedCluster.Spec.Platform.Azure.ResourceGroupName. This
-user assigned identity is expected to have the Contributor role assigned to it and scoped to the resource group
-under HostedCluster.Spec.Platform.Azure.ResourceGroupName.</p>
-<p>If this field is not supplied, the Service Principal credentials will be written to a file on the disk of each VM
-in order to be accessible by the cloud provider; the aforementioned credentials provided are the same ones as
-HostedCluster.Spec.Platform.Azure.Credentials. However, this is less secure than using a managed identity.</p>
-<p>TODO: What is the valid character set for this field? What about minimum and maximum lengths?</p>
-</td>
-</tr>
 </tbody>
 </table>
 ###AzurePlatformSpec { #hypershift.openshift.io/v1beta1.AzurePlatformSpec }

--- a/hypershift-operator/controllers/nodepool/azure.go
+++ b/hypershift-operator/controllers/nodepool/azure.go
@@ -61,13 +61,6 @@ func azureMachineTemplateSpec(nodePool *hyperv1.NodePool) (*capiazure.AzureMachi
 		}
 	}
 
-	if nodePool.Spec.Platform.Azure.MachineIdentityID != "" {
-		azureMachineTemplate.Template.Spec.Identity = capiazure.VMIdentityUserAssigned
-		azureMachineTemplate.Template.Spec.UserAssignedIdentities = []capiazure.UserAssignedIdentity{{
-			ProviderID: nodePool.Spec.Platform.Azure.MachineIdentityID,
-		}}
-	}
-
 	if nodePool.Spec.Platform.Azure.OSDisk.EncryptionSetID != "" {
 		azureMachineTemplate.Template.Spec.OSDisk.ManagedDisk.DiskEncryptionSet = &capiazure.DiskEncryptionSetParameters{
 			ID: nodePool.Spec.Platform.Azure.OSDisk.EncryptionSetID,

--- a/hypershift-operator/controllers/nodepool/azure_test.go
+++ b/hypershift-operator/controllers/nodepool/azure_test.go
@@ -63,7 +63,6 @@ func TestAzureMachineTemplateSpec(t *testing.T) {
 							Marketplace:    nil,
 							ComputeGallery: nil,
 						},
-						Identity:                   "",
 						UserAssignedIdentities:     nil,
 						SystemAssignedIdentityRole: nil,
 						RoleAssignmentName:         "",
@@ -121,7 +120,6 @@ func TestAzureMachineTemplateSpec(t *testing.T) {
 								SizeGiB:                30,
 								DiskStorageAccountType: "Standard_LRS",
 							},
-							MachineIdentityID: "/subscriptions/testSubscriptionID/resourceGroups/testResourceGroupName/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testIdentity",
 						},
 					},
 				},
@@ -139,12 +137,7 @@ func TestAzureMachineTemplateSpec(t *testing.T) {
 							Marketplace:    nil,
 							ComputeGallery: nil,
 						},
-						Identity: "UserAssigned",
-						UserAssignedIdentities: []capiazure.UserAssignedIdentity{
-							{
-								ProviderID: "/subscriptions/testSubscriptionID/resourceGroups/testResourceGroupName/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testIdentity",
-							},
-						},
+						Identity:                   "",
 						SystemAssignedIdentityRole: nil,
 						RoleAssignmentName:         "",
 						OSDisk: capiazure.OSDisk{
@@ -206,7 +199,6 @@ func TestAzureMachineTemplateSpec(t *testing.T) {
 								SizeGiB:                30,
 								DiskStorageAccountType: "Standard_LRS",
 							},
-							MachineIdentityID: "/subscriptions/testSubscriptionID/resourceGroups/testResourceGroupName/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testIdentity",
 						},
 					},
 				},
@@ -229,12 +221,7 @@ func TestAzureMachineTemplateSpec(t *testing.T) {
 								ThirdPartyImage: false,
 							},
 						},
-						Identity: "UserAssigned",
-						UserAssignedIdentities: []capiazure.UserAssignedIdentity{
-							{
-								ProviderID: "/subscriptions/testSubscriptionID/resourceGroups/testResourceGroupName/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testIdentity",
-							},
-						},
+						Identity:                   "",
 						SystemAssignedIdentityRole: nil,
 						RoleAssignmentName:         "",
 						OSDisk: capiazure.OSDisk{
@@ -302,7 +289,6 @@ func TestAzureMachineTemplateSpec(t *testing.T) {
 							Diagnostics: &hyperv1.Diagnostics{
 								StorageAccountType: "Managed",
 							},
-							MachineIdentityID: "/subscriptions/testSubscriptionID/resourceGroups/testResourceGroupName/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testIdentity",
 						},
 					},
 				},
@@ -325,12 +311,7 @@ func TestAzureMachineTemplateSpec(t *testing.T) {
 								ThirdPartyImage: false,
 							},
 						},
-						Identity: "UserAssigned",
-						UserAssignedIdentities: []capiazure.UserAssignedIdentity{
-							{
-								ProviderID: "/subscriptions/testSubscriptionID/resourceGroups/testResourceGroupName/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testIdentity",
-							},
-						},
+						Identity:                   "",
 						SystemAssignedIdentityRole: nil,
 						RoleAssignmentName:         "",
 						OSDisk: capiazure.OSDisk{
@@ -404,7 +385,6 @@ func TestAzureMachineTemplateSpec(t *testing.T) {
 									StorageAccountURI: "www.test.com",
 								},
 							},
-							MachineIdentityID: "/subscriptions/testSubscriptionID/resourceGroups/testResourceGroupName/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testIdentity",
 						},
 					},
 				},
@@ -427,12 +407,7 @@ func TestAzureMachineTemplateSpec(t *testing.T) {
 								ThirdPartyImage: false,
 							},
 						},
-						Identity: "UserAssigned",
-						UserAssignedIdentities: []capiazure.UserAssignedIdentity{
-							{
-								ProviderID: "/subscriptions/testSubscriptionID/resourceGroups/testResourceGroupName/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testIdentity",
-							},
-						},
+						Identity:                   "",
 						SystemAssignedIdentityRole: nil,
 						RoleAssignmentName:         "",
 						OSDisk: capiazure.OSDisk{

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/azure.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/azure.go
@@ -97,20 +97,6 @@ type AzureNodePoolPlatform struct {
 	// If not specified, then Boot diagnostics will be disabled.
 	// +optional
 	Diagnostics *Diagnostics `json:"diagnostics,omitempty"`
-
-	// machineIdentityID is a user-assigned identity assigned to the VMs used to authenticate with Azure services. The
-	// identify is expected to exist under the same resource group as HostedCluster.Spec.Platform.Azure.ResourceGroupName. This
-	// user assigned identity is expected to have the Contributor role assigned to it and scoped to the resource group
-	// under HostedCluster.Spec.Platform.Azure.ResourceGroupName.
-	//
-	// If this field is not supplied, the Service Principal credentials will be written to a file on the disk of each VM
-	// in order to be accessible by the cloud provider; the aforementioned credentials provided are the same ones as
-	// HostedCluster.Spec.Platform.Azure.Credentials. However, this is less secure than using a managed identity.
-	//
-	// TODO: What is the valid character set for this field? What about minimum and maximum lengths?
-	//
-	// +optional
-	MachineIdentityID string `json:"machineIdentityID,omitempty"`
 }
 
 // AzureVMImage represents the different types of boot image sources that can be provided for an Azure VM.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes MachineIdentityID from the Azure HyperShift API, CLI, and NodePool controller. This field is not needed for ARO HCP.

**Which issue(s) this PR fixes**:
Fixes [CNTRLPLANE-187](https://issues.redhat.com/browse/CNTRLPLANE-187)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.