### PR TITLE
OCPBUGS-48519: fix overwriting PKI operator HCP conditions

### DIFF
--- a/control-plane-pki-operator/certrotationcontroller/certrotationcontroller.go
+++ b/control-plane-pki-operator/certrotationcontroller/certrotationcontroller.go
@@ -132,7 +132,7 @@ func NewCertRotationController(
 			},
 		},
 		eventRecorder,
-		clienthelpers.NewHostedControlPlaneStatusReporter(hostedControlPlane.Name, hostedControlPlane.Namespace, hypershiftClient),
+		clienthelpers.NewHostedControlPlaneStatusReporter(hostedControlPlane.Name, hostedControlPlane.Namespace, rotatorName, hypershiftClient),
 	)
 	ret.certRotators = append(ret.certRotators, certRotator)
 
@@ -190,7 +190,7 @@ func NewCertRotationController(
 			},
 		},
 		eventRecorder,
-		clienthelpers.NewHostedControlPlaneStatusReporter(hostedControlPlane.Name, hostedControlPlane.Namespace, hypershiftClient),
+		clienthelpers.NewHostedControlPlaneStatusReporter(hostedControlPlane.Name, hostedControlPlane.Namespace, sreRotatorName, hypershiftClient),
 	)
 	ret.certRotators = append(ret.certRotators, sreCertRotator)
 

--- a/control-plane-pki-operator/clienthelpers/conditions.go
+++ b/control-plane-pki-operator/clienthelpers/conditions.go
@@ -16,10 +16,11 @@ import (
 	clientgoapplyconfig "k8s.io/client-go/applyconfigurations/meta/v1"
 )
 
-func NewHostedControlPlaneStatusReporter(name, namespace string, client hypershiftv1beta1client.HostedControlPlanesGetter) *HostedControlPlaneStatusReporter {
+func NewHostedControlPlaneStatusReporter(name, namespace, rotator string, client hypershiftv1beta1client.HostedControlPlanesGetter) *HostedControlPlaneStatusReporter {
 	return &HostedControlPlaneStatusReporter{
 		namespace: namespace,
 		name:      name,
+		rotator:   rotator,
 		client:    client,
 	}
 }
@@ -27,6 +28,9 @@ func NewHostedControlPlaneStatusReporter(name, namespace string, client hypershi
 type HostedControlPlaneStatusReporter struct {
 	// namespace, name identify the HostedControlPlane we report to
 	namespace, name string
+
+	// name of the rotating controller
+	rotator string
 
 	client hypershiftv1beta1client.HostedControlPlanesGetter
 }
@@ -43,7 +47,7 @@ func (h *HostedControlPlaneStatusReporter) Report(ctx context.Context, condition
 		newCondition.Message = syncErr.Error()
 	}
 
-	return UpdateHostedControlPlaneStatusCondition(ctx, newCondition, h.namespace, h.name, "cert-rotation-controller", h.client)
+	return UpdateHostedControlPlaneStatusCondition(ctx, newCondition, h.namespace, h.name, h.rotator+"-cert-rotation-controller", h.client)
 }
 
 var _ certrotation.StatusReporter = (*HostedControlPlaneStatusReporter)(nil)


### PR DESCRIPTION
The PKI operator is responsible for setting two conditions on the HostedControlPlane: `CertRotation_CustomerAdminKubeconfigSigner_Degraded` and `CertRotation_SREAdminKubeconfigSigner_Degraded`.  There are two different controllers that each update one of these conditions.

However, both controllers use the same `manager` in the `managedFields`.  The kube-apiserver assumes that, for a particular `manager`, _all_ conditions that the manager owns will be included in any update.  If the condition is not present, the kube-apiserver assumes the manager intent to be removal of the condition.

This results in a situation where the two controllers are removing the others condition.

This fixes the issue by using a unique `manager` name per controller so that the kube-apiserver doesn't remove the condition added by the other controller.