### PR TITLE
OCPBUGS-48688: Add Tenant ID to Azure API & Remove Credentials from CPO

### DIFF
--- a/api/hypershift/v1beta1/azure.go
+++ b/api/hypershift/v1beta1/azure.go
@@ -442,6 +442,11 @@ type AzurePlatformSpec struct {
 	// +kubebuilder:validation:Required
 	// +openshift:enable:FeatureGate=AROHCPManagedIdentities
 	ManagedIdentities AzureResourceManagedIdentities `json:"managedIdentities,omitempty"`
+
+	// tenantID is a unique identifier for the tenant where Azure resources will be created and managed in.
+	//
+	// +required
+	TenantID string `json:"tenantID"`
 }
 
 // ManagedAzureKeyVault is an Azure Key Vault on the management cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -3113,6 +3113,10 @@ spec:
                         x-kubernetes-validations:
                         - message: SubscriptionID is immutable
                           rule: self == oldSelf
+                      tenantID:
+                        description: tenantID is a unique identifier for the tenant
+                          where Azure resources will be created and managed in.
+                        type: string
                       vnetID:
                         description: |-
                           VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
@@ -3133,6 +3137,7 @@ spec:
                     - securityGroupID
                     - subnetID
                     - subscriptionID
+                    - tenantID
                     - vnetID
                     type: object
                   ibmcloud:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AROHCPManagedIdentities.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AROHCPManagedIdentities.yaml
@@ -3368,6 +3368,10 @@ spec:
                         x-kubernetes-validations:
                         - message: SubscriptionID is immutable
                           rule: self == oldSelf
+                      tenantID:
+                        description: tenantID is a unique identifier for the tenant
+                          where Azure resources will be created and managed in.
+                        type: string
                       vnetID:
                         description: |-
                           VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
@@ -3389,6 +3393,7 @@ spec:
                     - securityGroupID
                     - subnetID
                     - subscriptionID
+                    - tenantID
                     - vnetID
                     type: object
                   ibmcloud:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -3154,6 +3154,10 @@ spec:
                         x-kubernetes-validations:
                         - message: SubscriptionID is immutable
                           rule: self == oldSelf
+                      tenantID:
+                        description: tenantID is a unique identifier for the tenant
+                          where Azure resources will be created and managed in.
+                        type: string
                       vnetID:
                         description: |-
                           VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
@@ -3174,6 +3178,7 @@ spec:
                     - securityGroupID
                     - subnetID
                     - subscriptionID
+                    - tenantID
                     - vnetID
                     type: object
                   ibmcloud:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -3130,6 +3130,10 @@ spec:
                         x-kubernetes-validations:
                         - message: SubscriptionID is immutable
                           rule: self == oldSelf
+                      tenantID:
+                        description: tenantID is a unique identifier for the tenant
+                          where Azure resources will be created and managed in.
+                        type: string
                       vnetID:
                         description: |-
                           VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
@@ -3150,6 +3154,7 @@ spec:
                     - securityGroupID
                     - subnetID
                     - subscriptionID
+                    - tenantID
                     - vnetID
                     type: object
                   ibmcloud:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -3351,6 +3351,10 @@ spec:
                         x-kubernetes-validations:
                         - message: SubscriptionID is immutable
                           rule: self == oldSelf
+                      tenantID:
+                        description: tenantID is a unique identifier for the tenant
+                          where Azure resources will be created and managed in.
+                        type: string
                       vnetID:
                         description: |-
                           VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
@@ -3371,6 +3375,7 @@ spec:
                     - securityGroupID
                     - subnetID
                     - subscriptionID
+                    - tenantID
                     - vnetID
                     type: object
                   ibmcloud:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPPodsLabels.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPPodsLabels.yaml
@@ -3122,6 +3122,10 @@ spec:
                         x-kubernetes-validations:
                         - message: SubscriptionID is immutable
                           rule: self == oldSelf
+                      tenantID:
+                        description: tenantID is a unique identifier for the tenant
+                          where Azure resources will be created and managed in.
+                        type: string
                       vnetID:
                         description: |-
                           VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
@@ -3142,6 +3146,7 @@ spec:
                     - securityGroupID
                     - subnetID
                     - subscriptionID
+                    - tenantID
                     - vnetID
                     type: object
                   ibmcloud:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -3127,6 +3127,10 @@ spec:
                         x-kubernetes-validations:
                         - message: SubscriptionID is immutable
                           rule: self == oldSelf
+                      tenantID:
+                        description: tenantID is a unique identifier for the tenant
+                          where Azure resources will be created and managed in.
+                        type: string
                       vnetID:
                         description: |-
                           VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
@@ -3147,6 +3151,7 @@ spec:
                     - securityGroupID
                     - subnetID
                     - subscriptionID
+                    - tenantID
                     - vnetID
                     type: object
                   ibmcloud:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -3261,6 +3261,10 @@ spec:
                         x-kubernetes-validations:
                         - message: SubscriptionID is immutable
                           rule: self == oldSelf
+                      tenantID:
+                        description: tenantID is a unique identifier for the tenant
+                          where Azure resources will be created and managed in.
+                        type: string
                       vnetID:
                         description: |-
                           VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
@@ -3281,6 +3285,7 @@ spec:
                     - securityGroupID
                     - subnetID
                     - subscriptionID
+                    - tenantID
                     - vnetID
                     type: object
                   ibmcloud:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -3109,6 +3109,10 @@ spec:
                         x-kubernetes-validations:
                         - message: SubscriptionID is immutable
                           rule: self == oldSelf
+                      tenantID:
+                        description: tenantID is a unique identifier for the tenant
+                          where Azure resources will be created and managed in.
+                        type: string
                       vnetID:
                         description: |-
                           VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
@@ -3129,6 +3133,7 @@ spec:
                     - securityGroupID
                     - subnetID
                     - subscriptionID
+                    - tenantID
                     - vnetID
                     type: object
                   ibmcloud:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -3015,6 +3015,10 @@ spec:
                         x-kubernetes-validations:
                         - message: SubscriptionID is immutable
                           rule: self == oldSelf
+                      tenantID:
+                        description: tenantID is a unique identifier for the tenant
+                          where Azure resources will be created and managed in.
+                        type: string
                       vnetID:
                         description: |-
                           VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
@@ -3035,6 +3039,7 @@ spec:
                     - securityGroupID
                     - subnetID
                     - subscriptionID
+                    - tenantID
                     - vnetID
                     type: object
                   ibmcloud:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AROHCPManagedIdentities.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AROHCPManagedIdentities.yaml
@@ -3270,6 +3270,10 @@ spec:
                         x-kubernetes-validations:
                         - message: SubscriptionID is immutable
                           rule: self == oldSelf
+                      tenantID:
+                        description: tenantID is a unique identifier for the tenant
+                          where Azure resources will be created and managed in.
+                        type: string
                       vnetID:
                         description: |-
                           VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
@@ -3291,6 +3295,7 @@ spec:
                     - securityGroupID
                     - subnetID
                     - subscriptionID
+                    - tenantID
                     - vnetID
                     type: object
                   ibmcloud:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -3056,6 +3056,10 @@ spec:
                         x-kubernetes-validations:
                         - message: SubscriptionID is immutable
                           rule: self == oldSelf
+                      tenantID:
+                        description: tenantID is a unique identifier for the tenant
+                          where Azure resources will be created and managed in.
+                        type: string
                       vnetID:
                         description: |-
                           VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
@@ -3076,6 +3080,7 @@ spec:
                     - securityGroupID
                     - subnetID
                     - subscriptionID
+                    - tenantID
                     - vnetID
                     type: object
                   ibmcloud:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -3032,6 +3032,10 @@ spec:
                         x-kubernetes-validations:
                         - message: SubscriptionID is immutable
                           rule: self == oldSelf
+                      tenantID:
+                        description: tenantID is a unique identifier for the tenant
+                          where Azure resources will be created and managed in.
+                        type: string
                       vnetID:
                         description: |-
                           VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
@@ -3052,6 +3056,7 @@ spec:
                     - securityGroupID
                     - subnetID
                     - subscriptionID
+                    - tenantID
                     - vnetID
                     type: object
                   ibmcloud:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -3253,6 +3253,10 @@ spec:
                         x-kubernetes-validations:
                         - message: SubscriptionID is immutable
                           rule: self == oldSelf
+                      tenantID:
+                        description: tenantID is a unique identifier for the tenant
+                          where Azure resources will be created and managed in.
+                        type: string
                       vnetID:
                         description: |-
                           VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
@@ -3273,6 +3277,7 @@ spec:
                     - securityGroupID
                     - subnetID
                     - subscriptionID
+                    - tenantID
                     - vnetID
                     type: object
                   ibmcloud:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -3029,6 +3029,10 @@ spec:
                         x-kubernetes-validations:
                         - message: SubscriptionID is immutable
                           rule: self == oldSelf
+                      tenantID:
+                        description: tenantID is a unique identifier for the tenant
+                          where Azure resources will be created and managed in.
+                        type: string
                       vnetID:
                         description: |-
                           VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
@@ -3049,6 +3053,7 @@ spec:
                     - securityGroupID
                     - subnetID
                     - subscriptionID
+                    - tenantID
                     - vnetID
                     type: object
                   ibmcloud:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -3163,6 +3163,10 @@ spec:
                         x-kubernetes-validations:
                         - message: SubscriptionID is immutable
                           rule: self == oldSelf
+                      tenantID:
+                        description: tenantID is a unique identifier for the tenant
+                          where Azure resources will be created and managed in.
+                        type: string
                       vnetID:
                         description: |-
                           VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
@@ -3183,6 +3187,7 @@ spec:
                     - securityGroupID
                     - subnetID
                     - subscriptionID
+                    - tenantID
                     - vnetID
                     type: object
                   ibmcloud:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -3011,6 +3011,10 @@ spec:
                         x-kubernetes-validations:
                         - message: SubscriptionID is immutable
                           rule: self == oldSelf
+                      tenantID:
+                        description: tenantID is a unique identifier for the tenant
+                          where Azure resources will be created and managed in.
+                        type: string
                       vnetID:
                         description: |-
                           VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
@@ -3031,6 +3035,7 @@ spec:
                     - securityGroupID
                     - subnetID
                     - subscriptionID
+                    - tenantID
                     - vnetID
                     type: object
                   ibmcloud:

--- a/client/applyconfiguration/hypershift/v1beta1/azureplatformspec.go
+++ b/client/applyconfiguration/hypershift/v1beta1/azureplatformspec.go
@@ -33,6 +33,7 @@ type AzurePlatformSpecApplyConfiguration struct {
 	SubscriptionID    *string                                           `json:"subscriptionID,omitempty"`
 	SecurityGroupID   *string                                           `json:"securityGroupID,omitempty"`
 	ManagedIdentities *AzureResourceManagedIdentitiesApplyConfiguration `json:"managedIdentities,omitempty"`
+	TenantID          *string                                           `json:"tenantID,omitempty"`
 }
 
 // AzurePlatformSpecApplyConfiguration constructs an declarative configuration of the AzurePlatformSpec type for use with
@@ -110,5 +111,13 @@ func (b *AzurePlatformSpecApplyConfiguration) WithSecurityGroupID(value string) 
 // If called multiple times, the ManagedIdentities field is set to the value of the last call.
 func (b *AzurePlatformSpecApplyConfiguration) WithManagedIdentities(value *AzureResourceManagedIdentitiesApplyConfiguration) *AzurePlatformSpecApplyConfiguration {
 	b.ManagedIdentities = value
+	return b
+}
+
+// WithTenantID sets the TenantID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the TenantID field is set to the value of the last call.
+func (b *AzurePlatformSpecApplyConfiguration) WithTenantID(value string) *AzurePlatformSpecApplyConfiguration {
+	b.TenantID = &value
 	return b
 }

--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -270,6 +270,7 @@ func (o *CreateOptions) ApplyPlatformSpecifics(cluster *hyperv1.HostedCluster) e
 		Azure: &hyperv1.AzurePlatformSpec{
 			Credentials:       corev1.LocalObjectReference{Name: credentialSecret(cluster.Namespace, cluster.Name).Name},
 			SubscriptionID:    o.creds.SubscriptionID,
+			TenantID:          o.creds.TenantID,
 			Location:          o.infra.Location,
 			ResourceGroupName: o.infra.ResourceGroupName,
 			VnetID:            o.infra.VNetID,

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_complicated_invocation_from_bryan.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_complicated_invocation_from_bryan.yaml
@@ -111,6 +111,7 @@ spec:
       securityGroupID: fakeSecurityGroupID
       subnetID: fakeSubnetID
       subscriptionID: fakeSubscriptionID
+      tenantID: fakeTenantID
       vnetID: fakeVNetID
     type: Azure
   pullSecret:

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_create_with_a_ure_marketplace_image.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_create_with_a_ure_marketplace_image.yaml
@@ -78,6 +78,7 @@ spec:
       securityGroupID: fakeSecurityGroupID
       subnetID: fakeSubnetID
       subscriptionID: fakeSubscriptionID
+      tenantID: fakeTenantID
       vnetID: fakeVNetID
     type: Azure
   pullSecret:

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -111,6 +111,7 @@ spec:
       securityGroupID: fakeSecurityGroupID
       subnetID: fakeSubnetID
       subscriptionID: fakeSubscriptionID
+      tenantID: fakeTenantID
       vnetID: fakeVNetID
     type: Azure
   pullSecret:

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_ones.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_ones.yaml
@@ -111,6 +111,7 @@ spec:
       securityGroupID: fakeSecurityGroupID
       subnetID: fakeSubnetID
       subscriptionID: fakeSubscriptionID
+      tenantID: fakeTenantID
       vnetID: fakeVNetID
     type: Azure
   pullSecret:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
@@ -3862,6 +3862,10 @@ spec:
                         x-kubernetes-validations:
                         - message: SubscriptionID is immutable
                           rule: self == oldSelf
+                      tenantID:
+                        description: tenantID is a unique identifier for the tenant
+                          where Azure resources will be created and managed in.
+                        type: string
                       vnetID:
                         description: |-
                           VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
@@ -3882,6 +3886,7 @@ spec:
                     - securityGroupID
                     - subnetID
                     - subscriptionID
+                    - tenantID
                     - vnetID
                     type: object
                   ibmcloud:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
@@ -3527,6 +3527,10 @@ spec:
                         x-kubernetes-validations:
                         - message: SubscriptionID is immutable
                           rule: self == oldSelf
+                      tenantID:
+                        description: tenantID is a unique identifier for the tenant
+                          where Azure resources will be created and managed in.
+                        type: string
                       vnetID:
                         description: |-
                           VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
@@ -3547,6 +3551,7 @@ spec:
                     - securityGroupID
                     - subnetID
                     - subscriptionID
+                    - tenantID
                     - vnetID
                     type: object
                   ibmcloud:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
@@ -3844,6 +3844,10 @@ spec:
                         x-kubernetes-validations:
                         - message: SubscriptionID is immutable
                           rule: self == oldSelf
+                      tenantID:
+                        description: tenantID is a unique identifier for the tenant
+                          where Azure resources will be created and managed in.
+                        type: string
                       vnetID:
                         description: |-
                           VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
@@ -3864,6 +3868,7 @@ spec:
                     - securityGroupID
                     - subnetID
                     - subscriptionID
+                    - tenantID
                     - vnetID
                     type: object
                   ibmcloud:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
@@ -3751,6 +3751,10 @@ spec:
                         x-kubernetes-validations:
                         - message: SubscriptionID is immutable
                           rule: self == oldSelf
+                      tenantID:
+                        description: tenantID is a unique identifier for the tenant
+                          where Azure resources will be created and managed in.
+                        type: string
                       vnetID:
                         description: |-
                           VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
@@ -3771,6 +3775,7 @@ spec:
                     - securityGroupID
                     - subnetID
                     - subscriptionID
+                    - tenantID
                     - vnetID
                     type: object
                   ibmcloud:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
@@ -3429,6 +3429,10 @@ spec:
                         x-kubernetes-validations:
                         - message: SubscriptionID is immutable
                           rule: self == oldSelf
+                      tenantID:
+                        description: tenantID is a unique identifier for the tenant
+                          where Azure resources will be created and managed in.
+                        type: string
                       vnetID:
                         description: |-
                           VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
@@ -3449,6 +3453,7 @@ spec:
                     - securityGroupID
                     - subnetID
                     - subscriptionID
+                    - tenantID
                     - vnetID
                     type: object
                   ibmcloud:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
@@ -3733,6 +3733,10 @@ spec:
                         x-kubernetes-validations:
                         - message: SubscriptionID is immutable
                           rule: self == oldSelf
+                      tenantID:
+                        description: tenantID is a unique identifier for the tenant
+                          where Azure resources will be created and managed in.
+                        type: string
                       vnetID:
                         description: |-
                           VnetID is the ID of an existing VNET to use in creating VMs. The VNET can exist in a different resource group
@@ -3753,6 +3757,7 @@ spec:
                     - securityGroupID
                     - subnetID
                     - subscriptionID
+                    - tenantID
                     - vnetID
                     type: object
                   ibmcloud:

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go
@@ -17,8 +17,8 @@ const (
 )
 
 // ReconcileCloudConfig reconciles as expected by Nodes Kubelet.
-func ReconcileCloudConfig(cm *corev1.ConfigMap, hcp *hyperv1.HostedControlPlane, credentialsSecret *corev1.Secret) error {
-	cfg, err := azureConfigWithoutCredentials(hcp, credentialsSecret)
+func ReconcileCloudConfig(cm *corev1.ConfigMap, hcp *hyperv1.HostedControlPlane) error {
+	cfg, err := azureConfigWithoutCredentials(hcp)
 	if err != nil {
 		return err
 	}
@@ -37,8 +37,8 @@ func ReconcileCloudConfig(cm *corev1.ConfigMap, hcp *hyperv1.HostedControlPlane,
 }
 
 // ReconcileCloudConfigWithCredentials reconciles as expected by KAS/KCM.
-func ReconcileCloudConfigWithCredentials(secret *corev1.Secret, hcp *hyperv1.HostedControlPlane, credentialsSecret *corev1.Secret) error {
-	cfg, err := azureConfigWithoutCredentials(hcp, credentialsSecret)
+func ReconcileCloudConfigWithCredentials(secret *corev1.Secret, hcp *hyperv1.HostedControlPlane) error {
+	cfg, err := azureConfigWithoutCredentials(hcp)
 	if err != nil {
 		return err
 	}
@@ -60,7 +60,7 @@ func ReconcileCloudConfigWithCredentials(secret *corev1.Secret, hcp *hyperv1.Hos
 	return nil
 }
 
-func azureConfigWithoutCredentials(hcp *hyperv1.HostedControlPlane, credentialsSecret *corev1.Secret) (AzureConfig, error) {
+func azureConfigWithoutCredentials(hcp *hyperv1.HostedControlPlane) (AzureConfig, error) {
 	subnetName, err := azureutil.GetSubnetNameFromSubnetID(hcp.Spec.Platform.Azure.SubnetID)
 	if err != nil {
 		return AzureConfig{}, fmt.Errorf("failed to determine subnet name from SubnetID: %w", err)
@@ -78,7 +78,7 @@ func azureConfigWithoutCredentials(hcp *hyperv1.HostedControlPlane, credentialsS
 
 	azureConfig := AzureConfig{
 		Cloud:                        hcp.Spec.Platform.Azure.Cloud,
-		TenantID:                     string(credentialsSecret.Data["AZURE_TENANT_ID"]),
+		TenantID:                     hcp.Spec.Platform.Azure.TenantID,
 		UseManagedIdentityExtension:  true,
 		SubscriptionID:               hcp.Spec.Platform.Azure.SubscriptionID,
 		ResourceGroup:                hcp.Spec.Platform.Azure.ResourceGroupName,

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -892,14 +892,7 @@ func (r *HostedControlPlaneReconciler) validateConfigAndClusterCapabilities(ctx 
 	}
 
 	if hyperazureutil.IsAroHCP() {
-		credentialsSecret := manifests.AzureCredentialInformation(hcp.Namespace)
-		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
-			return fmt.Errorf("failed to get Azure credentials secret: %w", err)
-		}
-
-		tenantID := string(credentialsSecret.Data["AZURE_TENANT_ID"])
-
-		if err := verifyResourceGroupLocationsMatch(ctx, hcp, tenantID); err != nil {
+		if err := verifyResourceGroupLocationsMatch(ctx, hcp); err != nil {
 			return err
 		}
 	}
@@ -2743,15 +2736,10 @@ func (r *HostedControlPlaneReconciler) reconcileCloudProviderConfig(ctx context.
 			return fmt.Errorf("failed to reconcile aws provider config: %w", err)
 		}
 	case hyperv1.AzurePlatform:
-		credentialsSecret := manifests.AzureCredentialInformation(hcp.Namespace)
-		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
-			return fmt.Errorf("failed to get Azure credentials secret: %w", err)
-		}
-
 		// We need different configs for KAS/KCM and Kubelet in Nodes
 		cfg := manifests.AzureProviderConfig(hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r, cfg, func() error {
-			return azure.ReconcileCloudConfig(cfg, hcp, credentialsSecret)
+			return azure.ReconcileCloudConfig(cfg, hcp)
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile Azure cloud config: %w", err)
 		}
@@ -2759,7 +2747,7 @@ func (r *HostedControlPlaneReconciler) reconcileCloudProviderConfig(ctx context.
 		// Reconcile the Cloud Provider configuration secret
 		withSecrets := manifests.AzureProviderConfigWithCredentials(hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r, withSecrets, func() error {
-			return azure.ReconcileCloudConfigWithCredentials(withSecrets, hcp, credentialsSecret)
+			return azure.ReconcileCloudConfigWithCredentials(withSecrets, hcp)
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile Azure cloud config with credentials: %w", err)
 		}
@@ -3727,12 +3715,7 @@ func (r *HostedControlPlaneReconciler) reconcileClusterNetworkOperator(ctx conte
 			return fmt.Errorf("failed to reconcile ingressoperator secret provider class: %w", err)
 		}
 
-		credentialsSecret := manifests.AzureCredentialInformation(hcp.Namespace)
-		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
-			return fmt.Errorf("failed to get Azure credentials secret: %w", err)
-		}
-
-		p.AzureTenantID = string(credentialsSecret.Data["AZURE_TENANT_ID"])
+		p.AzureTenantID = hcp.Spec.Platform.Azure.TenantID
 	}
 
 	sa := manifests.ClusterNetworkOperatorServiceAccount(hcp.Namespace)
@@ -3896,12 +3879,7 @@ func (r *HostedControlPlaneReconciler) reconcileIngressOperator(ctx context.Cont
 			return fmt.Errorf("failed to reconcile ingress operator secret provider class: %w", err)
 		}
 
-		credentialsSecret := manifests.AzureCredentialInformation(hcp.Namespace)
-		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
-			return fmt.Errorf("failed to get Azure credentials secret: %w", err)
-		}
-
-		p.AzureTenantID = string(credentialsSecret.Data["AZURE_TENANT_ID"])
+		p.AzureTenantID = hcp.Spec.Platform.Azure.TenantID
 	}
 
 	if _, exists := hcp.Annotations[hyperv1.DisablePKIReconciliationAnnotation]; !exists {
@@ -4269,12 +4247,7 @@ func (r *HostedControlPlaneReconciler) reconcileImageRegistryOperator(ctx contex
 			return fmt.Errorf("failed to reconcile image registry operator secret provider class: %w", err)
 		}
 
-		credentialsSecret := manifests.AzureCredentialInformation(hcp.Namespace)
-		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
-			return fmt.Errorf("failed to get Azure credentials secret: %w", err)
-		}
-
-		params.AzureTenantID = string(credentialsSecret.Data["AZURE_TENANT_ID"])
+		params.AzureTenantID = hcp.Spec.Platform.Azure.TenantID
 	}
 
 	deployment := manifests.ImageRegistryOperatorDeployment(hcp.Namespace)
@@ -4885,12 +4858,7 @@ func (r *HostedControlPlaneReconciler) reconcileCloudControllerManager(ctx conte
 			return fmt.Errorf("failed to reconcile azure cloud provider secret provider class: %w", err)
 		}
 
-		// Retrieve the credentials secret to get the tenant ID
-		credentialsSecret := manifests.AzureCredentialInformation(hcp.Namespace)
-		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
-			return fmt.Errorf("failed to get Azure credentials secret: %w", err)
-		}
-		p.TenantID = string(credentialsSecret.Data["AZURE_TENANT_ID"])
+		p.TenantID = hcp.Spec.Platform.Azure.TenantID
 
 		// Reconcile the CCM Deployment
 		deployment := azure.CCMDeployment(hcp.Namespace)
@@ -5128,12 +5096,7 @@ func (r *HostedControlPlaneReconciler) reconcileClusterStorageOperator(ctx conte
 			return fmt.Errorf("failed to reconcile Azure File Secret Provider Class: %w", err)
 		}
 
-		// Get the credentials secret so we can retrieve the tenant ID for the configuration
-		credentialsSecret := manifests.AzureCredentialInformation(hcp.Namespace)
-		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
-			return fmt.Errorf("failed to get Azure credentials secret: %w", err)
-		}
-		tenantID := string(credentialsSecret.Data["AZURE_TENANT_ID"])
+		tenantID := hcp.Spec.Platform.Azure.TenantID
 
 		// Reconcile the secret needed for azure-disk-csi-controller
 		// This is related to https://github.com/openshift/csi-operator/pull/290.
@@ -5614,20 +5577,6 @@ func (r *HostedControlPlaneReconciler) validateAzureKMSConfig(ctx context.Contex
 	}
 	azureKmsSpec := hcp.Spec.SecretEncryption.KMS.Azure
 
-	credentialsSecret := manifests.AzureCredentialInformation(hcp.Namespace)
-	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
-		condition := metav1.Condition{
-			Type:               string(hyperv1.ValidAzureKMSConfig),
-			ObservedGeneration: hcp.Generation,
-			Status:             metav1.ConditionUnknown,
-			Message:            fmt.Sprintf("failed to get azure credentials secret: %v", err),
-			Reason:             hyperv1.StatusUnknownReason,
-		}
-		meta.SetStatusCondition(&hcp.Status.Conditions, condition)
-		return
-	}
-	tenantID := string(credentialsSecret.Data["AZURE_TENANT_ID"])
-
 	// Retrieve the KMS certificate
 	certPath := config.ManagedAzureCertificateMountPath + hcp.Spec.SecretEncryption.KMS.Azure.KMS.CertificateName
 	certsContent, err := os.ReadFile(certPath)
@@ -5674,7 +5623,7 @@ func (r *HostedControlPlaneReconciler) validateAzureKMSConfig(ctx context.Contex
 	options := &azidentity.ClientCertificateCredentialOptions{
 		SendCertificateChain: true,
 	}
-	cred, err := azidentity.NewClientCertificateCredential(tenantID, hcp.Spec.SecretEncryption.KMS.Azure.KMS.ClientID, parsedCertificate, key, options)
+	cred, err := azidentity.NewClientCertificateCredential(hcp.Spec.Platform.Azure.TenantID, hcp.Spec.SecretEncryption.KMS.Azure.KMS.ClientID, parsedCertificate, key, options)
 	if err != nil {
 		conditions.SetFalseCondition(hcp, hyperv1.ValidAzureKMSConfig, hyperv1.InvalidAzureCredentialsReason,
 			fmt.Sprintf("failed to obtain azure client credential: %v", err))
@@ -5778,7 +5727,7 @@ func doesOpenShiftTrustedCABundleConfigMapForCPOExist(ctx context.Context, c cli
 }
 
 // verifyResourceGroupLocationsMatch verifies the locations match for the VNET, network security group, and managed resource groups
-func verifyResourceGroupLocationsMatch(ctx context.Context, hcp *hyperv1.HostedControlPlane, tenantID string) error {
+func verifyResourceGroupLocationsMatch(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
 	// Retrieve the CPO certificate
 	certPath := config.ManagedAzureCertificatePath + hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ControlPlaneOperator.CertificateName
 	certsContent, err := os.ReadFile(certPath)
@@ -5795,7 +5744,7 @@ func verifyResourceGroupLocationsMatch(ctx context.Context, hcp *hyperv1.HostedC
 	options := &azidentity.ClientCertificateCredentialOptions{
 		SendCertificateChain: true,
 	}
-	creds, err := azidentity.NewClientCertificateCredential(tenantID, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ControlPlaneOperator.ClientID, parsedCertificate, key, options)
+	creds, err := azidentity.NewClientCertificateCredential(hcp.Spec.Platform.Azure.TenantID, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ControlPlaneOperator.ClientID, parsedCertificate, key, options)
 	if err != nil {
 		return fmt.Errorf("failed to create azure creds to verify resource group locations: %v", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -1644,9 +1644,6 @@ func TestControlPlaneComponents(t *testing.T) {
 					SubnetID:        "/subscriptions/mySubscriptionID/resourceGroups/myResourceGroupName/providers/Microsoft.Network/virtualNetworks/myVnetName/subnets/mySubnetName",
 					SecurityGroupID: "/subscriptions/mySubscriptionID/resourceGroups/myResourceGroupName/providers/Microsoft.Network/networkSecurityGroups/myNSGName",
 					VnetID:          "/subscriptions/mySubscriptionID/resourceGroups/myResourceGroupName/providers/Microsoft.Network/virtualNetworks/myVnetName",
-					Credentials: corev1.LocalObjectReference{
-						Name: "fake-cloud-credentials-secret",
-					},
 				},
 				OpenStack: &hyperv1.OpenStackPlatformSpec{
 					IdentityRef: hyperv1.OpenStackIdentityReference{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/config.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/secretproviderclass"
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/config"
@@ -12,7 +11,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	secretsstorev1 "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
 )
 
@@ -61,11 +59,6 @@ func azureConfig(cpContext component.WorkloadContext, withCredentials bool) (Azu
 	hcp := cpContext.HCP
 	azureplatform := hcp.Spec.Platform.Azure
 
-	credentialsSecret := manifests.AzureCredentialInformation(hcp.Namespace)
-	if err := cpContext.Client.Get(cpContext, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
-		return AzureConfig{}, fmt.Errorf("failed to get Azure credentials secret: %w", err)
-	}
-
 	subnetName, err := azureutil.GetSubnetNameFromSubnetID(azureplatform.SubnetID)
 	if err != nil {
 		return AzureConfig{}, fmt.Errorf("failed to determine subnet name from SubnetID: %w", err)
@@ -83,7 +76,7 @@ func azureConfig(cpContext component.WorkloadContext, withCredentials bool) (Azu
 
 	azureConfig := AzureConfig{
 		Cloud:                        azureplatform.Cloud,
-		TenantID:                     string(credentialsSecret.Data["AZURE_TENANT_ID"]),
+		TenantID:                     azureplatform.TenantID,
 		UseManagedIdentityExtension:  true,
 		SubscriptionID:               azureplatform.SubscriptionID,
 		ResourceGroup:                azureplatform.ResourceGroupName,

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cno/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cno/deployment.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
@@ -16,8 +15,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/blang/semver"
 )
@@ -147,11 +144,6 @@ func buildCNOEnvVars(cpContext component.WorkloadContext) ([]corev1.EnvVar, erro
 	// For ARO HCP deployments, we pass the env variable for the SecretProviderClass for the Secrets Store CSI driver
 	// to use on the CNCC deployment.
 	if azureutil.IsAroHCP() {
-		credentialsSecret := manifests.AzureCredentialInformation(hcp.Namespace)
-		if err := cpContext.Client.Get(cpContext, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
-			return nil, fmt.Errorf("failed to get Azure credentials secret: %w", err)
-		}
-
 		cnoEnv = append(cnoEnv,
 			corev1.EnvVar{
 				Name:  config.ManagedAzureClientIdEnvVarKey,
@@ -159,7 +151,7 @@ func buildCNOEnvVars(cpContext component.WorkloadContext) ([]corev1.EnvVar, erro
 			},
 			corev1.EnvVar{
 				Name:  config.ManagedAzureTenantIdEnvVarKey,
-				Value: string(credentialsSecret.Data["AZURE_TENANT_ID"]),
+				Value: hcp.Spec.Platform.Azure.TenantID,
 			},
 			corev1.EnvVar{
 				Name:  config.ManagedAzureCertificateNameEnvVarKey,

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/storage/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/storage/azure.go
@@ -6,7 +6,6 @@ import (
 	"path"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/secretproviderclass"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure"
 	hyperazureutil "github.com/openshift/hypershift/support/azureutil"
@@ -15,23 +14,15 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	secretsstorev1 "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
 )
 
 func adaptAzureCSISecret(cpContext component.WorkloadContext, managedIdentity hyperv1.ManagedIdentity, secret *corev1.Secret) error {
-	// Get the credentials secret so we can retrieve the tenant ID for the configuration
-	credentialsSecret := manifests.AzureCredentialInformation(cpContext.HCP.Namespace)
-	if err := cpContext.Client.Get(cpContext, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
-		return fmt.Errorf("failed to get Azure credentials secret: %w", err)
-	}
-
-	tenantID := string(credentialsSecret.Data["AZURE_TENANT_ID"])
 	azureSpec := cpContext.HCP.Spec.Platform.Azure
 
 	azureConfig := azure.AzureConfig{
 		Cloud:             azureSpec.Cloud,
-		TenantID:          tenantID,
+		TenantID:          azureSpec.TenantID,
 		SubscriptionID:    azureSpec.SubscriptionID,
 		ResourceGroup:     azureSpec.ResourceGroupName,
 		Location:          azureSpec.Location,

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1468,18 +1468,13 @@ func (r *reconciler) reconcileCloudCredentialSecrets(ctx context.Context, hcp *h
 			}
 		}
 	case hyperv1.AzurePlatform:
-		referenceCredentialsSecret := cpomanifests.AzureCredentialInformation(hcp.Namespace)
-		if err := r.cpClient.Get(ctx, client.ObjectKeyFromObject(referenceCredentialsSecret), referenceCredentialsSecret); err != nil {
-			return []error{fmt.Errorf("failed to get cloud credentials secret in hcp namespace: %w", err)}
-		}
-
 		secretData := map[string][]byte{
 			"azure_federated_token_file": []byte("/var/run/secrets/openshift/serviceaccount/token"),
 			"azure_region":               []byte(hcp.Spec.Platform.Azure.Location),
 			"azure_resource_prefix":      []byte(hcp.Name + "-" + hcp.Spec.InfraID),
 			"azure_resourcegroup":        []byte(hcp.Spec.Platform.Azure.ResourceGroupName),
-			"azure_subscription_id":      referenceCredentialsSecret.Data["AZURE_SUBSCRIPTION_ID"],
-			"azure_tenant_id":            referenceCredentialsSecret.Data["AZURE_TENANT_ID"],
+			"azure_subscription_id":      []byte(hcp.Spec.Platform.Azure.SubscriptionID),
+			"azure_tenant_id":            []byte(hcp.Spec.Platform.Azure.TenantID),
 		}
 
 		// The ingress controller fails if this secret is not provided. The controller runs on the control plane side. In managed azure, we are

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -3296,6 +3296,17 @@ AzureResourceManagedIdentities
 authenticate with Azure&rsquo;s API.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>tenantID</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>tenantID is a unique identifier for the tenant where Azure resources will be created and managed in.</p>
+</td>
+</tr>
 </tbody>
 </table>
 ###AzureResourceManagedIdentities { #hypershift.openshift.io/v1beta1.AzureResourceManagedIdentities }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -4128,7 +4128,7 @@ func (r *HostedClusterReconciler) validateConfigAndClusterCapabilities(ctx conte
 		errs = append(errs, err)
 	}
 
-	if err := r.validateAzureConfig(ctx, hc); err != nil {
+	if err := r.validateAzureConfig(hc); err != nil {
 		errs = append(errs, err)
 	}
 
@@ -4401,7 +4401,7 @@ func (r *HostedClusterReconciler) validatePublishingStrategyMapping(hc *hyperv1.
 	return nil
 }
 
-func (r *HostedClusterReconciler) validateAzureConfig(ctx context.Context, hc *hyperv1.HostedCluster) error {
+func (r *HostedClusterReconciler) validateAzureConfig(hc *hyperv1.HostedCluster) error {
 	if hc.Spec.Platform.Type != hyperv1.AzurePlatform {
 		return nil
 	}
@@ -4411,23 +4411,7 @@ func (r *HostedClusterReconciler) validateAzureConfig(ctx context.Context, hc *h
 		return errors.New("azurecluster needs .spec.platform.azure to be filled")
 	}
 
-	// Verify the credentials secret contains the data fields we expect
-	credentialsSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
-		Namespace: hc.Namespace,
-		Name:      hc.Spec.Platform.Azure.Credentials.Name,
-	}}
-	if err := r.Get(ctx, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
-		return fmt.Errorf("failed to get credentials secret for cluster: %w", err)
-	}
-
-	var errs []error
-	for _, expectedKey := range []string{"AZURE_SUBSCRIPTION_ID", "AZURE_TENANT_ID"} {
-		if _, found := credentialsSecret.Data[expectedKey]; !found {
-			errs = append(errs, fmt.Errorf("credentials secret for cluster doesn't have required key %s", expectedKey))
-		}
-	}
-
-	return utilerrors.NewAggregate(errs)
+	return nil
 }
 
 func (r *HostedClusterReconciler) validateAgentConfig(ctx context.Context, hc *hyperv1.HostedCluster) error {

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
@@ -59,7 +59,7 @@ func (a Azure) ReconcileCAPIInfraCR(
 	}
 
 	if _, err := createOrUpdate(ctx, c, azureClusterIdentity, func() error {
-		return reconcileAzureClusterIdentity(ctx, c, hcluster, azureClusterIdentity, controlPlaneNamespace)
+		return reconcileAzureClusterIdentity(hcluster, azureClusterIdentity, controlPlaneNamespace)
 	}); err != nil {
 		return nil, fmt.Errorf("failed to reconcile Azure cluster identity: %w", err)
 	}
@@ -216,8 +216,8 @@ func (a Azure) ReconcileCredentials(ctx context.Context, c client.Client, create
 		"azure_region":          []byte(hcluster.Spec.Platform.Azure.Location),
 		"azure_resource_prefix": []byte(hcluster.Name + "-" + hcluster.Spec.InfraID),
 		"azure_resourcegroup":   []byte(hcluster.Spec.Platform.Azure.ResourceGroupName),
-		"azure_subscription_id": azureCredsInfo.Data["AZURE_SUBSCRIPTION_ID"],
-		"azure_tenant_id":       azureCredsInfo.Data["AZURE_TENANT_ID"],
+		"azure_subscription_id": []byte(hcluster.Spec.Platform.Azure.SubscriptionID),
+		"azure_tenant_id":       []byte(hcluster.Spec.Platform.Azure.TenantID),
 	}
 	if _, err := createOrUpdate(ctx, c, cloudNetworkConfigCreds, func() error {
 		cloudNetworkConfigCreds.Data = secretData
@@ -274,15 +274,10 @@ func reconcileAzureCluster(azureCluster *capiazure.AzureCluster, hcluster *hyper
 	return nil
 }
 
-func reconcileAzureClusterIdentity(ctx context.Context, c client.Client, hc *hyperv1.HostedCluster, azureClusterIdentity *capiazure.AzureClusterIdentity, controlPlaneNamespace string) error {
-	credentialsSecret := manifests.AzureCredentialInformation(controlPlaneNamespace)
-	if err := c.Get(ctx, client.ObjectKeyFromObject(credentialsSecret), credentialsSecret); err != nil {
-		return fmt.Errorf("failed to get Azure credentials secret: %w", err)
-	}
-
+func reconcileAzureClusterIdentity(hc *hyperv1.HostedCluster, azureClusterIdentity *capiazure.AzureClusterIdentity, controlPlaneNamespace string) error {
 	azureClusterIdentity.Spec = capiazure.AzureClusterIdentitySpec{
 		ClientID: hc.Spec.Platform.Azure.ManagedIdentities.ControlPlane.NodePoolManagement.ClientID,
-		TenantID: string(credentialsSecret.Data["AZURE_TENANT_ID"]),
+		TenantID: hc.Spec.Platform.Azure.TenantID,
 		CertPath: config.ManagedAzureCertificatePath + hc.Spec.Platform.Azure.ManagedIdentities.ControlPlane.NodePoolManagement.CertificateName,
 		Type:     capiazure.ServicePrincipalCertificate,
 		AllowedNamespaces: &capiazure.AllowedNamespaces{

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/azure.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/azure.go
@@ -442,6 +442,11 @@ type AzurePlatformSpec struct {
 	// +kubebuilder:validation:Required
 	// +openshift:enable:FeatureGate=AROHCPManagedIdentities
 	ManagedIdentities AzureResourceManagedIdentities `json:"managedIdentities,omitempty"`
+
+	// tenantID is a unique identifier for the tenant where Azure resources will be created and managed in.
+	//
+	// +required
+	TenantID string `json:"tenantID"`
 }
 
 // ManagedAzureKeyVault is an Azure Key Vault on the management cluster.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR:
- exposes a field for the tenant ID in the Azure API. This value was originally captured in the Credentials field of the Azure API, but that field will be removed in a future commit
- updates the CLI and the HyperShift Operator (HO) to use Tenant ID directly from the HC Azure API spec rather than the previous Credentials secret. References to the Credentials secret, in the CLI and HO, were also removed in this commit
- updates control plane operator (CPO) to use Tenant ID directly from the HC Azure API spec rather than the previous Credentials secret. References to the Credentials secret, CPO, were also removed in this commit

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.