### PR TITLE
NO-JIRA: switch to resource.k8s.io/v1beta1 after kube 1.32 rebase

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -215,7 +215,7 @@ func generateConfig(p KubeAPIServerConfigParams) *kcpv1.KubeAPIServerConfig {
 			runtimeConfig = append(runtimeConfig, "admissionregistration.k8s.io/v1beta1=true")
 		}
 		if gate == "DynamicResourceAllocation=true" {
-			runtimeConfig = append(runtimeConfig, "resource.k8s.io/v1alpha3=true")
+			runtimeConfig = append(runtimeConfig, "resource.k8s.io/v1beta1=true")
 		}
 	}
 	args.Set("runtime-config", runtimeConfig...)


### PR DESCRIPTION
This fix is required to unblock the payload jobs

Replicates https://github.com/openshift/cluster-kube-apiserver-operator/pull/1777/commits/dea2e4fb8faafda391789ed662916854f15b8dff