### PR TITLE
NO-JIRA: add assignServicePrincipal check before assignign roles to WI

### DIFF
--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -255,7 +255,7 @@ func (o *CreateInfraOptions) Run(ctx context.Context, l logr.Logger) (*CreateInf
 		}
 	}
 
-	if o.DataPlaneIdentitiesFile != "" {
+	if o.DataPlaneIdentitiesFile != "" && o.AssignServicePrincipalRoles {
 		managedRG := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", subscriptionID, resourceGroupName)
 
 		dataPlaneIdentitiesRaw, err := os.ReadFile(o.DataPlaneIdentitiesFile)

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3757,7 +3757,7 @@ func (r *HostedControlPlaneReconciler) reconcileClusterNetworkOperator(ctx conte
 func (r *HostedControlPlaneReconciler) cleanupClusterNetworkOperatorResources(ctx context.Context, hcp *hyperv1.HostedControlPlane, hasRouteCap bool) error {
 	if restartAnnotation, ok := hcp.Annotations[hyperv1.RestartDateAnnotation]; ok {
 		// CNO manages overall multus-admission-controller deployment. CPO manages restarts.
-		// TODO: why is this not doen in CNO?
+		// TODO: why is this not done in CNO?
 		multusDeployment := manifests.MultusAdmissionControllerDeployment(hcp.Namespace)
 		if err := cno.SetRestartAnnotationAndPatch(ctx, r.Client, multusDeployment, restartAnnotation); err != nil {
 			return fmt.Errorf("failed to restart multus admission controller: %w", err)

--- a/hypershift-operator/controllers/hostedcluster/karpenter.go
+++ b/hypershift-operator/controllers/hostedcluster/karpenter.go
@@ -101,7 +101,7 @@ spec:
 				Subnet: hyperv1.AWSResourceReference{
 					// TODO(alberto): this is just to pass cel.
 					// Setting an ID instead of filter would break publicAndPrivate topology because the AWSEndpointService won't find the subnet.
-					// We'll move to generate the userdata for karpenter programatically.
+					// We'll move to generate the userdata for karpenter programmatically.
 					Filters: []hyperv1.Filter{
 						{
 							Name:   "subnet-none",

--- a/test/e2e/karpenter_test.go
+++ b/test/e2e/karpenter_test.go
@@ -75,14 +75,14 @@ func TestKarpenter(t *testing.T) {
 
 		// Wait for Karpenter Nodes to go away.
 		_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, guestClient, hostedCluster.Spec.Platform.Type, 0, nodeLabels)
-		t.Logf("Waiting for Karpenter Nodes to dissapear")
+		t.Logf("Waiting for Karpenter Nodes to disappear")
 
 		// TODO(alberto): increase coverage:
 		// - Karpenter operator plumbing, e.g:
 		// -- validate the CRDs are installed
 		// -- validate the default class is created and has expected values
 		// -- validate admin can't modify fields owned by the service, e.g. ami.
-		// - Karpenter functionallity:
+		// - Karpenter functionality:
 		// -- Drift and Upgrades
 	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We should check if the assignServicePrincipal option has been set before assigning service principal roles using az cli. This causes a dependency on AZ cli when executing this command which can cause issues in CI.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.