### PR TITLE
OCPBUGS-49609: Split binary builds

### DIFF
--- a/Containerfile.control-plane
+++ b/Containerfile.control-plane
@@ -4,7 +4,8 @@ WORKDIR /hypershift
 
 COPY . .
 
-RUN make control-plane-operator control-plane-pki-operator
+RUN make control-plane-operator \
+  && make control-plane-pki-operator
 
 FROM registry.redhat.io/rhel9-2-els/rhel:9.2
 COPY --from=builder /hypershift/bin/control-plane-operator /usr/bin/control-plane-operator

--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -4,29 +4,25 @@ WORKDIR /hypershift
 
 COPY . .
 
-RUN make build
+RUN make hypershift \
+  && make hypershift-operator \
+  && make product-cli \
+  && make karpenter-operator
 
 FROM registry.redhat.io/rhel9-4-els/rhel:9.4
 COPY --from=builder /hypershift/bin/hypershift \
                     /hypershift/bin/hcp \
                     /hypershift/bin/hypershift-operator \
-                    /hypershift/bin/control-plane-operator \
-                    /hypershift/bin/control-plane-pki-operator \
+                    /hypershift/bin/karpenter-operator \
      /usr/bin/
-
-RUN cd /usr/bin && \
-  ln -s control-plane-operator ignition-server && \
-  ln -s control-plane-operator konnectivity-socks5-proxy && \
-  ln -s control-plane-operator availability-prober && \
-  ln -s control-plane-operator token-minter
 
 ENTRYPOINT ["/usr/bin/hypershift"]
 
 LABEL name="multicluster-engine/hypershift-operator"
 LABEL description="HyperShift Operator is an operator to manage the lifecycle of Hosted Clusters"
 LABEL summary="HyperShift Operator"
-LABEL url="https://catalog.redhat.com/software/containers/multicluster-engine/hypershift-rhel8-operator/"
-LABEL version=4.16
+LABEL url="https://catalog.redhat.com/software/containers/multicluster-engine/hypershift-rhel9-operator/"
+LABEL version=4.19
 LABEL com.redhat.component="multicluster-engine-hypershift-operator"
 LABEL io.k8s.description="HyperShift Operator"
 LABEL io.k8s.display-name="hypershift-operator"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,10 @@ WORKDIR /hypershift
 
 COPY . .
 
-RUN make hypershift hypershift-operator product-cli karpenter-operator
+RUN make hypershift \
+  && make hypershift-operator \
+  && make product-cli \
+  && make karpenter-operator
 
 FROM registry.access.redhat.com/ubi9:latest
 COPY --from=builder /hypershift/bin/hypershift \

--- a/Dockerfile.control-plane
+++ b/Dockerfile.control-plane
@@ -4,7 +4,8 @@ WORKDIR /hypershift
 
 COPY . .
 
-RUN make control-plane-operator control-plane-pki-operator
+RUN make control-plane-operator \
+  && make control-plane-pki-operator
 
 FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
 COPY --from=builder /hypershift/bin/control-plane-operator /usr/bin/control-plane-operator


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR aims to alleviate the memory issues that occur when building binaries due to memory exhaustion, likely caused by the AzureSDK imports.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-49609

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.