### PR TITLE
NO-JIRA: cpov2: switch to resource.k8s.io/v1beta1 after kube 1.32 rebase

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: bootstrap-manifests,logs
-        component.hypershift.openshift.io/config-hash: 19dc307e1d8949e252ebd36aed3cbc1b
+        component.hypershift.openshift.io/config-hash: 19dc307e1d8949e252ebd36a94b32818
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/config.go
@@ -217,7 +217,7 @@ func generateConfig(p KubeAPIServerConfigParams) *kcpv1.KubeAPIServerConfig {
 			runtimeConfig = append(runtimeConfig, "admissionregistration.k8s.io/v1beta1=true")
 		}
 		if gate == "DynamicResourceAllocation=true" {
-			runtimeConfig = append(runtimeConfig, "resource.k8s.io/v1alpha2=true")
+			runtimeConfig = append(runtimeConfig, "resource.k8s.io/v1beta1=true")
 		}
 	}
 	args.Set("runtime-config", runtimeConfig...)


### PR DESCRIPTION
Forgot to update CPOv2 code in https://github.com/openshift/hypershift/pull/5496