### PR TITLE
NO-ISSUE: docs/content/how-to/disaster-recovery/etcd-recovery: Explicitly delegate to admin

### DIFF
--- a/docs/content/how-to/disaster-recovery/etcd-recovery.md
+++ b/docs/content/how-to/disaster-recovery/etcd-recovery.md
@@ -16,7 +16,7 @@ If this is enabled, then the HyperShift operator will attempt to recover the hea
 
 The recovery procedure consists of the following:
 * If a member has been removed from the etcd cluster, re-add the missing member by executing the `member add` command
-* Delete the etcd member's pod and pvc
+* The administrator should [delete the etcd member's pod and pvc](#single-node-recovery), after which the HyperShift operator will automatically provision a replacement etcd member Pod and PersistentVolume.
 
 Once this is done, the `reset-member` init container of the removed pod should be able to complete the recovery.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The outgoing line left the responsibility for the deletion ambiguous. Maybe the HyperShift operator had automated that deletion?  Maybe the admin had to manually delete, and the automation was just scoped to post-deletion recovery?  My incoming line is trying to make it clear that it's the latter, and that HyperShift is not involved in the Pod/PVC deletion that initiates recovery, even when `--enable-etcd-recovery` is true.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.