### PR TITLE
 [release-4.14] OCPBUGS-49405: add ValidIDPConfiguration condition to report IDP config issues

### DIFF
--- a/api/v1beta1/hostedcluster_conditions.go
+++ b/api/v1beta1/hostedcluster_conditions.go
@@ -99,6 +99,11 @@ const (
 	// A failure here may require external user intervention to resolve. E.g. oidc was deleted out of band.
 	ValidOIDCConfiguration ConditionType = "ValidOIDCConfiguration"
 
+	// ValidIDPConfiguration indicates if the Identity Provider configuration is valid.
+	// A failure here may require external user intervention to resolve
+	// e.g. the user-provided IDP configuration provided is invalid or the IDP is not reachable.
+	ValidIDPConfiguration ConditionType = "ValidIDPConfiguration"
+
 	// ValidReleaseImage indicates if the release image set in the spec is valid
 	// for the HostedCluster. For example, this can be set false if the
 	// HostedCluster itself attempts an unsupported version before 4.9 or an

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2846,6 +2846,30 @@ func (r *HostedControlPlaneReconciler) reconcileOAuthServer(ctx context.Context,
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile oauth deployment: %w", err)
 	}
+
+	// Report any IDP configuration errors as a condition on the HCP
+	new := metav1.Condition{
+		Type:    string(hyperv1.ValidIDPConfiguration),
+		Status:  metav1.ConditionTrue,
+		Reason:  "IDPConfigurationValid",
+		Message: "Identity provider configuration is valid",
+	}
+	if _, _, err := oauth.ConvertIdentityProviders(ctx, p.IdentityProviders(), p.OauthConfigOverrides, r, hcp.Namespace); err != nil {
+		// Report the error in a condition on the HCP
+		r.Log.Error(err, "failed to initialize identity providers")
+		new = metav1.Condition{
+			Type:    string(hyperv1.ValidIDPConfiguration),
+			Status:  metav1.ConditionFalse,
+			Reason:  "IDPConfigurationError",
+			Message: fmt.Sprintf("failed to initialize identity providers: %v", err),
+		}
+	}
+	// Update the condition on the HCP if it has changed
+	meta.SetStatusCondition(&hcp.Status.Conditions, new)
+	if err := r.Status().Update(ctx, hcp); err != nil {
+		return fmt.Errorf("failed to update valid IDP configuration condition: %w", err)
+	}
+
 	return nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/config.go
@@ -51,11 +51,9 @@ func ReconcileOAuthServerConfig(ctx context.Context, cm *corev1.ConfigMap, owner
 }
 
 func generateOAuthConfig(ctx context.Context, client crclient.Client, namespace string, params *OAuthConfigParams) (*osinv1.OsinServerConfig, error) {
-	var identityProviders []osinv1.IdentityProvider
-	identityProviders, _, err := convertIdentityProviders(ctx, params.IdentityProviders, params.OauthConfigOverrides, client, namespace)
-	if err != nil {
-		return nil, err
-	}
+	// Ignore the error here since we don't want to fail the deployment if the identity providers are invalid
+	// A condition will be set on the HC to indicate the error
+	identityProviders, _, _ := ConvertIdentityProviders(ctx, params.IdentityProviders, params.OauthConfigOverrides, client, namespace)
 
 	cpath := func(volume, file string) string {
 		dir := volumeMounts.Path(oauthContainerMain().Name, volume)

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
@@ -157,12 +157,13 @@ func ReconcileDeployment(ctx context.Context, client client.Client, deployment *
 
 	deploymentConfig.ApplyTo(deployment)
 	if len(identityProviders) > 0 {
-		_, volumeMountInfo, err := convertIdentityProviders(ctx, identityProviders, providerOverrides, client, deployment.Namespace)
-		if err != nil {
-			return err
+		_, volumeMountInfo, _ := ConvertIdentityProviders(ctx, identityProviders, providerOverrides, client, deployment.Namespace)
+		// Ignore the error here, since we don't want to fail the deployment if the identity providers are invalid
+		// A condition will be set on the HC to indicate the error
+		if len(volumeMountInfo.Volumes) > 0 {
+			deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, volumeMountInfo.Volumes...)
+			deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, volumeMountInfo.VolumeMounts.ContainerMounts(oauthContainerMain().Name)...)
 		}
-		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, volumeMountInfo.Volumes...)
-		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, volumeMountInfo.VolumeMounts.ContainerMounts(oauthContainerMain().Name)...)
 	}
 	globalconfig.ApplyNamedCertificateMounts(oauthContainerMain().Name, oauthNamedCertificateMountPathPrefix, namedCertificates, &deployment.Spec.Template.Spec)
 	util.AvailabilityProber(kas.InClusterKASReadyURL(platformType), availabilityProberImage, &deployment.Spec.Template.Spec)

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/idp_convert.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/idp_convert.go
@@ -84,7 +84,7 @@ func (i *IDPVolumeMountInfo) SecretPath(index int, secretName, field, key string
 	return path.Join(i.VolumeMounts[i.Container][v.Name], key)
 }
 
-func convertIdentityProviders(ctx context.Context, identityProviders []configv1.IdentityProvider, providerOverrides map[string]*ConfigOverride, kclient crclient.Client, namespace string) ([]osinv1.IdentityProvider, *IDPVolumeMountInfo, error) {
+func ConvertIdentityProviders(ctx context.Context, identityProviders []configv1.IdentityProvider, providerOverrides map[string]*ConfigOverride, kclient crclient.Client, namespace string) ([]osinv1.IdentityProvider, *IDPVolumeMountInfo, error) {
 	converted := make([]osinv1.IdentityProvider, 0, len(identityProviders))
 	errs := []error{}
 	volumeMountInfo := &IDPVolumeMountInfo{

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -2981,6 +2981,11 @@ A failure here is unlikely to resolve without the changing user input.</p>
 supported by the underlying management cluster.
 A failure here is unlikely to resolve without the changing user input.</p>
 </td>
+</tr><tr><td><p>&#34;ValidIDPConfiguration&#34;</p></td>
+<td><p>ValidIDPConfiguration indicates if the Identity Provider configuration is valid.
+A failure here may require external user intervention to resolve
+e.g. the user-provided IDP configuration provided is invalid or the IDP is not reachable.</p>
+</td>
 </tr><tr><td><p>&#34;ValidOIDCConfiguration&#34;</p></td>
 <td><p>ValidOIDCConfiguration indicates if an AWS cluster&rsquo;s OIDC condition is
 detected as invalid.

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -682,6 +682,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 			hyperv1.ExternalDNSReachable,
 			hyperv1.ValidHostedControlPlaneConfiguration,
 			hyperv1.ValidReleaseInfo,
+			hyperv1.ValidIDPConfiguration,
 		}
 
 		for _, conditionType := range hcpConditions {


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

Manual backport of #5037

- removed api change from vendor since we didn't vendor hypershift api in 4.
- SetStatusCondition does not return if the condition changed in 4.14 so we unconditionally update the new condition on each reconcile


**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.