### PR TITLE
NO-JIRA: Create token Secret for dev cluster explicitly

### DIFF
--- a/contrib/ci/dev-namespace-template.yaml
+++ b/contrib/ci/dev-namespace-template.yaml
@@ -14,6 +14,14 @@ objects:
   metadata:
     name: ${NAME}-dev
     namespace: ${NAME}
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: ${NAME}-dev-token
+    namespace: ${NAME}
+  annotations:
+    kubernetes.io/service-account.name: ${NAME}-dev
+  type: kubernetes.io/service-account-token
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
   metadata:


### PR DESCRIPTION
Needs to be created manually because:
Prior to OpenShift Container Platform 4.16, a long-lived service account API token secret was also generated for each service account that was created. Starting with OpenShift Container Platform 4.16, this service account API token secret is no longer created.

Related [Slack discussion](https://redhat-internal.slack.com/archives/G01QS0P2F6W/p1738329844270039?thread_ts=1738239053.859029&cid=G01QS0P2F6W)

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
With the new version of OpenShift, the Secret/Token is not created automatically.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:


**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.