### PR TITLE
OCPBUGS-49724: remove passed in image matching desired image check fr…

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -404,9 +404,6 @@ func WaitForImageRollout(t *testing.T, ctx context.Context, client crclient.Clie
 				Status: metav1.ConditionFalse,
 			}),
 			func(hostedCluster *hyperv1.HostedCluster) (done bool, reasons string, err error) {
-				if wanted, got := image, ptr.Deref(hostedCluster.Status.Version, hyperv1.ClusterVersionStatus{}).Desired.Image; wanted != got {
-					return false, fmt.Sprintf("wanted HostedCluster to desire image %s, got %s", wanted, got), nil
-				}
 				if len(ptr.Deref(hostedCluster.Status.Version, hyperv1.ClusterVersionStatus{}).History) == 0 {
 					return false, "HostedCluster has no version history", nil
 				}


### PR DESCRIPTION
…om WaitForImageRollout


**What this PR does / why we need it**:

- The reported desired image is now the digest of the passed in image which no longer matches the passed in image during the check and can cause the test to fail cluster validation. The remaining check in WaitForImageRollout should be sufficient to consider the image rolloud successfully.


**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [OCPBUGS-49724](https://issues.redhat.com/browse/OCPBUGS-49724)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.