### PR TITLE
OCPBUGS-48619: Add HostedCluster additional trustbundles to konnectivity-https-proxy

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -2,12 +2,14 @@ package ingressoperator
 
 import (
 	"fmt"
+	"path"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/azureutil"
+	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/proxy"
@@ -32,6 +34,9 @@ const (
 	konnectivityProxyContainerName = "konnectivity-proxy"
 	ingressOperatorMetricsPort     = 60000
 	konnectivityProxyPort          = 8090
+
+	managedTrustBundlePath = "managed-trust-bundle.crt"
+	certsTrustPath         = "/etc/pki/tls/certs"
 )
 
 type Params struct {
@@ -163,6 +168,20 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, platformType hyp
 		{Name: "admin-kubeconfig", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "service-network-admin-kubeconfig", DefaultMode: ptr.To[int32](0640)}}},
 		{Name: "konnectivity-proxy-cert", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: manifests.KonnectivityClientSecret("").Name, DefaultMode: ptr.To[int32](0640)}}},
 		{Name: "konnectivity-proxy-ca", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: manifests.KonnectivityCAConfigMap("").Name}, DefaultMode: ptr.To[int32](0640)}}},
+		{Name: "managed-trust-bundle",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: manifests.TrustedCABundleConfigMap("").Name},
+					DefaultMode:          ptr.To[int32](0640),
+					Items: []corev1.KeyToPath{
+						{
+							Key:  certs.UserCABundleMapKey,
+							Path: managedTrustBundlePath,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	if params.Platform == hyperv1.AWSPlatform {
@@ -261,6 +280,7 @@ func ingressOperatorKonnectivityProxyContainer(proxyImage string, proxyConfig *c
 			{Name: "admin-kubeconfig", MountPath: "/etc/kubernetes"},
 			{Name: "konnectivity-proxy-cert", MountPath: "/etc/konnectivity/proxy-client"},
 			{Name: "konnectivity-proxy-ca", MountPath: "/etc/konnectivity/proxy-ca"},
+			{Name: "managed-trust-bundle", MountPath: path.Join(certsTrustPath, managedTrustBundlePath), SubPath: managedTrustBundlePath},
 		},
 	}
 	if proxyConfig != nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/testdata/zz_fixture_TestReconcileOauthDeploymentNoChanges.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/testdata/zz_fixture_TestReconcileOauthDeploymentNoChanges.yaml
@@ -123,6 +123,9 @@ spec:
           name: konnectivity-proxy-cert
         - mountPath: /etc/kubernetes
           name: kubeconfig
+        - mountPath: /etc/pki/tls/certs/managed-trust-bundle.crt
+          name: managed-trust-bundle
+          subPath: managed-trust-bundle.crt
       - args:
         - -c
         - "\nset -o errexit\nset -o nounset\nset -o pipefail\n\nfunction cleanup()
@@ -194,6 +197,13 @@ spec:
           defaultMode: 416
           name: konnectivity-ca-bundle
         name: konnectivity-proxy-ca
+      - configMap:
+          defaultMode: 416
+          items:
+          - key: ca-bundle.crt
+            path: managed-trust-bundle.crt
+          name: trusted-ca-bundle-managed
+        name: managed-trust-bundle
       - name: oauth-audit-webhook
         secret:
           secretName: test-webhook-audit-secret


### PR DESCRIPTION
**What this PR does / why we need it**:
When using the konnectivity-https-proxy sidecar to communicate through workers, the proxy dials any configured proxy directly and fails to connect if it cannot trust the proxy's serving certificate. This commit adds mounts for the trusted-ca-bundle-managed configmap to sidecar containers that run the konnectivity-https-proxy. The configmap contains the aggregate of .spec.additionalTrustBundle and
.spec.configuration.proxy.trustedCA.

This fixes the issue of the ingress operator not becoming available when using a proxy with a custom certificate.

In addition it propagates any proxy environment variables that are set on the control plane operator to the konnectivity-https-proxy containers. This is needed when the management cluster itself requires a proxy and the proxy container dials an address directly such as when it needs to communicate with a cloud provider endpoint.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-48619](https://issues.redhat.com/browse/OCPBUGS-48619)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.