### PR TITLE
HOSTEDCP-2259: CLI: enable secure proxy creation

### DIFF
--- a/cmd/infra/aws/ec2.go
+++ b/cmd/infra/aws/ec2.go
@@ -448,7 +448,7 @@ func (o *CreateInfraOptions) CreatePrivateRouteTable(l logr.Logger, client ec2if
 	}
 
 	// Everything below this is only needed if direct internet access is used
-	if o.EnableProxy {
+	if o.EnableProxy || o.EnableSecureProxy {
 		return aws.StringValue(routeTable.RouteTableId), nil
 	}
 

--- a/cmd/infra/aws/proxyca.go
+++ b/cmd/infra/aws/proxyca.go
@@ -1,0 +1,44 @@
+package aws
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func fetchProxyCA(publicAddr, privateAddr string, privateKey []byte) (string, error) {
+	signer, err := ssh.ParsePrivateKey(privateKey)
+	if err != nil {
+		log.Fatalf("unable to parse private key: %v", err)
+	}
+
+	config := &ssh.ClientConfig{
+		User: "ec2-user",
+		Auth: []ssh.AuthMethod{
+			// Use the PublicKeys method for remote authentication.
+			ssh.PublicKeys(signer),
+		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+
+	client, err := ssh.Dial("tcp", publicAddr+":22", config)
+	if err != nil {
+		return "", fmt.Errorf("failed to dial: %w", err)
+	}
+	defer client.Close()
+
+	session, err := client.NewSession()
+	if err != nil {
+		return "", fmt.Errorf("failed to create session: %w", err)
+	}
+	defer session.Close()
+
+	var b bytes.Buffer
+	session.Stdout = &b
+	if err := session.Run(fmt.Sprintf("curl -s -x http://%s:3128 http://mitm.it/cert/pem", privateAddr)); err != nil {
+		return "", fmt.Errorf("failed to run curl: %w", err)
+	}
+	return b.String(), nil
+}

--- a/cmd/infra/aws/proxyconfig.go
+++ b/cmd/infra/aws/proxyconfig.go
@@ -1,0 +1,62 @@
+package aws
+
+import "fmt"
+
+const proxyConfigurationScript = `#!/bin/bash
+yum install -y squid
+# By default, squid only allows connect on port 443
+sed -E 's/(^http_access deny CONNECT.*)/#\1/' -i /etc/squid/squid.conf
+systemctl enable --now squid
+
+mkdir -p /home/ec2-user/.ssh
+chmod 0700 /home/ec2-user/.ssh
+echo -e '%s' >/home/ec2-user/.ssh/authorized_keys
+chmod 0600 /home/ec2-user/.ssh/authorized_keys
+chown -R ec2-user:ec2-user /home/ec2-user/.ssh
+`
+
+const secureProxyConfigurationScript = `#!/bin/bash
+curl -OL https://snapshots.mitmproxy.org/7.0.2/mitmproxy-7.0.2-linux.tar.gz
+tar xzvf mitmproxy-7.0.2-linux.tar.gz -C /usr/bin
+cat <<EOF > /usr/bin/run-mitm
+#!/bin/bash
+mitmdump --showhost --ssl-insecure \
+  -p 3128 \
+  --ignore-hosts '.*'
+EOF
+
+chmod +x /usr/bin/run-mitm
+
+cat <<EOF > /lib/systemd/system/mitmproxy.service
+[Unit]
+Description=mitmdump service
+After=network.target
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/bin/run-mitm
+Restart=always
+RestartSec=1
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable mitmproxy
+systemctl start mitmproxy
+
+mkdir -p /home/ec2-user/.ssh
+chmod 0700 /home/ec2-user/.ssh
+echo -e '%s' >/home/ec2-user/.ssh/authorized_keys
+chmod 0600 /home/ec2-user/.ssh/authorized_keys
+chown -R ec2-user:ec2-user /home/ec2-user/.ssh
+`
+
+func proxyConfigScript(isSecure bool, publicSSHKey string) string {
+	if isSecure {
+		return fmt.Sprintf(secureProxyConfigurationScript, publicSSHKey)
+	}
+	return fmt.Sprintf(proxyConfigurationScript, publicSSHKey)
+}

--- a/cmd/util/sshkeys.go
+++ b/cmd/util/sshkeys.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+
+	"github.com/openshift/hypershift/support/certs"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func GenerateSSHKeys() ([]byte, []byte, error) {
+	privateKey, err := rsa.GenerateKey(certs.Reader(), 4096)
+	if err != nil {
+		return nil, nil, err
+	}
+	privateDER := x509.MarshalPKCS1PrivateKey(privateKey)
+	privatePEMBlock := pem.Block{
+		Type:    "RSA PRIVATE KEY",
+		Headers: nil,
+		Bytes:   privateDER,
+	}
+	privatePEM := pem.EncodeToMemory(&privatePEMBlock)
+
+	publicRSAKey, err := ssh.NewPublicKey(&privateKey.PublicKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	publicBytes := ssh.MarshalAuthorizedKey(publicRSAKey)
+
+	return publicBytes, privatePEM, nil
+}

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -2,6 +2,9 @@ package util
 
 import (
 	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ValidateRequiredOption returns a cobra style error message when the flag value is empty
@@ -10,4 +13,30 @@ func ValidateRequiredOption(flag string, value string) error {
 		return fmt.Errorf("required flag(s) \"%s\" not set", flag)
 	}
 	return nil
+}
+
+func SecretResource(namespace, name string) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+func ConfigMapResource(namespace, name string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds '--enable-secure-proxy' flag to 'hypershift create infra aws' and 'hypershift create cluster aws' commands.

The flag is similar to the existing '--enable-proxy' flag, except that it creates a proxy that exposes a ssl endpoint with custom serving certificate.

This is needed to automate testing of secure proxy use cases.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-2259](https://issues.redhat.com/browse/HOSTEDCP-2259)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.