### PR TITLE
OCPBUGS-49748: Duplicate hostDevices.name when hostDevices.deviceName has multiple types.

### DIFF
--- a/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
@@ -291,13 +291,15 @@ func virtualMachineTemplateBase(nodePool *hyperv1.NodePool, bootImage BootImage)
 
 	if len(kvPlatform.KubevirtHostDevices) > 0 {
 		hostDevices := []kubevirtv1.HostDevice{}
+		deviceCounter := 1
 		for _, hostDevice := range kvPlatform.KubevirtHostDevices {
 			for i := 1; i <= hostDevice.Count; i++ {
 				kvHostDevice := kubevirtv1.HostDevice{
-					Name:       "hostdevice-" + strconv.Itoa(i),
+					Name:       "hostdevice-" + strconv.Itoa(deviceCounter),
 					DeviceName: hostDevice.DeviceName,
 				}
 				hostDevices = append(hostDevices, kvHostDevice)
+				deviceCounter++
 			}
 
 		}


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
If hostDevices.deviceName has multiple types, the generated hostDevices.name has duplicates.
when
```
apiVersion: hypershift.openshift.io/v1beta1
kind: NodePool
spec:
 platform:
  kubevirt:
   hostDevices:
   - count: 8
     deviceName: nvidia.com/H20
   - count: 4
     deviceName: nvidia.com/NVSwitch
```
VirtualMachine
```
hostDevices:
 - deviceName: nvidia.com/H20
   name :hostdevice-1
 - deviceName: nvidia.com/H20
   name :hostdevice-2
 - deviceName: nvidia.com/H20
   name :hostdevice-3
 - deviceName: nvidia.com/H20
   name :hostdevice-4
 - deviceName: nvidia.com/NVSwitch
   name :hostdevice-1
 - deviceName: nvidia.com/NVSwitch
   name :hostdevice-2   
```

**Which issue(s) this PR fixes**
Fixes # https://issues.redhat.com/browse/OCPBUGS-49748

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.