### PR TITLE
PODAUTO-318: Implement HCP karpenter deletion

### DIFF
--- a/karpenter-operator/controllers/karpenter/karpenter_controller_test.go
+++ b/karpenter-operator/controllers/karpenter/karpenter_controller_test.go
@@ -18,8 +18,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	karpenterapis "sigs.k8s.io/karpenter/pkg/apis"
+	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+
+	"github.com/go-logr/logr/testr"
 )
 
 func TestReconcileEC2NodeClassDefault(t *testing.T) {
@@ -194,6 +200,172 @@ func TestGetUserDataSecret(t *testing.T) {
 			g.Expect(secret).NotTo(BeNil())
 
 			g.Expect(secret.Name).To(Equal("newer-secret"))
+		})
+	}
+}
+
+func TestKarpenterDeletion(t *testing.T) {
+	g := NewWithT(t)
+	scheme := runtime.NewScheme()
+	g.Expect(hyperv1.AddToScheme(scheme)).To(Succeed())
+	karpenterGroupVersion := schema.GroupVersion{Group: karpenterapis.Group, Version: "v1"}
+	scheme.AddKnownTypes(karpenterGroupVersion, &karpenterv1.NodeClaim{})
+	scheme.AddKnownTypes(karpenterGroupVersion, &karpenterv1.NodeClaimList{})
+	scheme.AddKnownTypes(karpenterGroupVersion, &karpenterv1.NodePool{})
+	scheme.AddKnownTypes(karpenterGroupVersion, &karpenterv1.NodePoolList{})
+
+	testCases := []struct {
+		name                                string
+		hcp                                 *hyperv1.HostedControlPlane
+		objects                             []client.Object
+		expectedNodePools                   int
+		eventuallyKarpenterFinalizerRemoved bool
+	}{
+		{
+			name: "when hcp is deleted, remove karpenter finalizer",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-hcp",
+					DeletionTimestamp: &metav1.Time{
+						Time: time.Now(),
+					},
+					Finalizers: []string{
+						karpenterFinalizer,
+						"some-other-finalizer",
+					},
+				},
+			},
+			objects:                             []client.Object{},
+			expectedNodePools:                   0,
+			eventuallyKarpenterFinalizerRemoved: true,
+		},
+		{
+			name: "when hcp is deleted, delete karpenter NodePools and remove karpenter finalizer",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-hcp",
+					DeletionTimestamp: &metav1.Time{
+						Time: time.Now(),
+					},
+					Finalizers: []string{
+						karpenterFinalizer,
+						"some-other-finalizer",
+					},
+				},
+			},
+			objects: []client.Object{
+				&karpenterv1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-nodepool-1",
+					},
+				},
+				&karpenterv1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-nodepool-2",
+					},
+				},
+			},
+			expectedNodePools:                   0,
+			eventuallyKarpenterFinalizerRemoved: true,
+		},
+		{
+			name: "when hcp is deleted, should not remove karpenter finalizer if karpenter NodePools still exist",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-hcp",
+					DeletionTimestamp: &metav1.Time{
+						Time: time.Now(),
+					},
+					Finalizers: []string{
+						karpenterFinalizer,
+						"some-other-finalizer",
+					},
+				},
+			},
+			objects: func() []client.Object {
+				nodepool := &karpenterv1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-nodepool-1",
+					},
+				}
+				nodepool.SetFinalizers([]string{"some-finalizer"}) // this prevents the nodepool from being deleted
+				return []client.Object{nodepool}
+			}(),
+			expectedNodePools:                   1,
+			eventuallyKarpenterFinalizerRemoved: false,
+		},
+		{
+			name: "when hcp is deleted, should not remove karpenter finalizer if karpenter NodeClaims still exist",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-hcp",
+					DeletionTimestamp: &metav1.Time{
+						Time: time.Now(),
+					},
+					Finalizers: []string{
+						karpenterFinalizer,
+						"some-other-finalizer",
+					},
+				},
+			},
+			objects: []client.Object{
+				&karpenterv1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-nodepool-1",
+					},
+				},
+				&karpenterv1.NodeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-nodeclaim-1",
+					},
+				},
+			},
+			expectedNodePools:                   0,
+			eventuallyKarpenterFinalizerRemoved: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeManagementClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tc.hcp).
+				Build()
+
+			fakeGuestClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tc.objects...).
+				Build()
+
+			r := &Reconciler{
+				ManagementClient: fakeManagementClient,
+				GuestClient:      fakeGuestClient,
+			}
+
+			ctx := log.IntoContext(context.Background(), testr.New(t))
+
+			// first reconcile should initiate deletions
+			_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(tc.hcp)})
+			g.Expect(err).NotTo(HaveOccurred())
+
+			// second reconcile will attempt to remove finalizers
+			_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(tc.hcp)})
+			g.Expect(err).NotTo(HaveOccurred())
+
+			// verify finalizers
+			hcp, err := r.getHCP(ctx)
+			g.Expect(err).NotTo(HaveOccurred())
+			if tc.eventuallyKarpenterFinalizerRemoved {
+				g.Expect(hcp.Finalizers).NotTo(ContainElement(karpenterFinalizer))
+			} else {
+				g.Expect(hcp.Finalizers).To(ContainElement(karpenterFinalizer))
+			}
+
+			// check if the expected amount of nodepools still exist
+			nodePoolList := &karpenterv1.NodePoolList{}
+			err = fakeGuestClient.List(ctx, nodePoolList)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(nodePoolList.Items).To(HaveLen(tc.expectedNodePools))
 		})
 	}
 }

--- a/karpenter-operator/main.go
+++ b/karpenter-operator/main.go
@@ -83,6 +83,8 @@ func run(ctx context.Context) error {
 	metav1.AddToGroupVersion(scheme, karpanterGroupVersion)
 	scheme.AddKnownTypes(karpanterGroupVersion, &karpenterv1.NodeClaim{})
 	scheme.AddKnownTypes(karpanterGroupVersion, &karpenterv1.NodeClaimList{})
+	scheme.AddKnownTypes(karpanterGroupVersion, &karpenterv1.NodePool{})
+	scheme.AddKnownTypes(karpanterGroupVersion, &karpenterv1.NodePoolList{})
 
 	managementCluster, err := cluster.New(managementKubeconfig, func(opt *cluster.Options) {
 		opt.Cache = cache.Options{

--- a/test/e2e/karpenter_test.go
+++ b/test/e2e/karpenter_test.go
@@ -77,6 +77,18 @@ func TestKarpenter(t *testing.T) {
 		_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, guestClient, hostedCluster.Spec.Platform.Type, 0, nodeLabels)
 		t.Logf("Waiting for Karpenter Nodes to disappear")
 
+		karpenterNodePool.SetResourceVersion("")
+		workLoads.SetResourceVersion("")
+
+		// Leave dangling resources, and hope the teardown is not blocked, else the test will fail.
+		g.Expect(guestClient.Create(ctx, karpenterNodePool)).To(Succeed())
+		t.Logf("Created Karpenter NodePool")
+		g.Expect(guestClient.Create(ctx, workLoads)).To(Succeed())
+		t.Logf("Created workloads")
+
+		t.Logf("Waiting for Karpenter Nodes to come up")
+		_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, guestClient, hostedCluster.Spec.Platform.Type, 3, nodeLabels)
+
 		// TODO(alberto): increase coverage:
 		// - Karpenter operator plumbing, e.g:
 		// -- validate the CRDs are installed


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit implements supporting cascading deletion of karpenter provisioned nodes upon deletion of a hosted control plane. Also modifies the current Karpenter e2e test to test deletion of an HCP is not blocked by karpenter nodes, and adds a unit test.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes https://issues.redhat.com/browse/PODAUTO-318

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.