### PR TITLE
CNTRLPLANE-172: cli: azure: allow assigning custom HCP roles

### DIFF
--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -79,6 +79,7 @@ func bindCoreOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
 		flags.StringVar(&opts.ManagedIdentitiesFile, "managed-identities-file", opts.ManagedIdentitiesFile, "Path to a file containing the managed identities configuration in json format.")
 		flags.StringVar(&opts.DataPlaneIdentitiesFile, "data-plane-identities-file", opts.ManagedIdentitiesFile, "Path to a file containing the client IDs of the managed identities for the data plane configured in json format.")
 		flags.BoolVar(&opts.AssignServicePrincipalRoles, "assign-service-principal-roles", opts.AssignServicePrincipalRoles, "Assign the service principal roles to the managed identities.")
+		flags.BoolVar(&opts.AssignCustomHCPRoles, "assign-custom-hcp-roles", opts.AssignCustomHCPRoles, "Assign custom roles to HCP identities")
 	}
 }
 
@@ -106,6 +107,7 @@ type RawCreateOptions struct {
 	ManagedIdentitiesFile            string
 	DataPlaneIdentitiesFile          string
 	AssignServicePrincipalRoles      bool
+	AssignCustomHCPRoles             bool
 	IssuerURL                        string
 	ServiceAccountTokenIssuerKeyPath string
 
@@ -568,6 +570,7 @@ func CreateInfraOptions(ctx context.Context, azureOpts *ValidatedCreateOptions, 
 		ManagedIdentitiesFile:       azureOpts.ManagedIdentitiesFile,
 		DataPlaneIdentitiesFile:     azureOpts.DataPlaneIdentitiesFile,
 		AssignServicePrincipalRoles: azureOpts.AssignServicePrincipalRoles,
+		AssignCustomHCPRoles:        azureOpts.AssignCustomHCPRoles,
 	}, nil
 }
 


### PR DESCRIPTION
A follow on to https://github.com/openshift/hypershift/pull/5469

We don't yet have built-in roles for the HCP components and that process might take a while.

In the meantime, we can exercise the limited permission set in custom roles that are manually created by the user before cluster creation.

The role names are
* `Azure Red Hat OpenShift Control Plane Operator Role` for the CPO
* `Azure Red Hat OpenShift NodePool Management Role` for CAPZ i.e. nodePoolManagement

Once these roles are built-in, we can safely assume the roles always exist and remove this flag.