### PR TITLE
OCPBUGS-49791: Use /livez for kubernetes scheduler liveness probe

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
@@ -56,7 +56,7 @@ func NewKubeSchedulerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 		schedulerContainerMain().Name: {
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/healthz",
+					Path:   "/livez",
 					Port:   intstr.FromInt(schedulerSecurePort),
 					Scheme: corev1.URISchemeHTTPS,
 				},

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents.yaml
@@ -176,7 +176,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
-            path: /healthz
+            path: /livez
             port: 10259
             scheme: HTTPS
           initialDelaySeconds: 60

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -176,7 +176,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
-            path: /healthz
+            path: /livez
             port: 10259
             scheme: HTTPS
           initialDelaySeconds: 60

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-scheduler/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-scheduler/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
-            path: /healthz
+            path: /livez
             port: 10259
             scheme: HTTPS
           initialDelaySeconds: 60


### PR DESCRIPTION
**What this PR does / why we need it**: The scheduler's /livez endpoint is more appropriate for its liveness probe

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #https://issues.redhat.com/browse/OCPBUGS-49791

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.