### PR TITLE
[release-4.18] OCPBUGS-49819: Add ObjectEncoding to the Azure API and SecretProviderClass Reconciliation in the CPO

### DIFF
--- a/api/hypershift/v1beta1/azure.go
+++ b/api/hypershift/v1beta1/azure.go
@@ -440,6 +440,10 @@ type AzurePlatformSpec struct {
 	TenantID string `json:"tenantID"`
 }
 
+// ObjectEncodingFormat is the type of encoding for an Azure Key Vault secret
+// +kubebuilder:validation:Enum:=utf-8;hex;base64
+type ObjectEncodingFormat string
+
 // ManagedAzureKeyVault is an Azure Key Vault on the management cluster.
 type ManagedAzureKeyVault struct {
 	// name is the name of the Azure Key Vault on the management cluster.
@@ -483,6 +487,20 @@ type ManagedIdentity struct {
 	//
 	// +kubebuilder:validation:Required
 	CertificateName string `json:"certificateName"`
+
+	// objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+	// CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+	// Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+	// unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+	// SecretProviderClass custom resource related to the managed identity.
+	//
+	// The default value is utf-8.
+	//
+	// See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+	//
+	// +kubebuilder:validation:Enum:=utf-8;hex;base64
+	// +kubebuilder:default:="utf-8"
+	ObjectEncoding ObjectEncodingFormat `json:"objectEncoding"`
 }
 
 // ControlPlaneManagedIdentities contains the managed identities on the HCP control plane needing to authenticate with

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AROHCPManagedIdentities.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AROHCPManagedIdentities.yaml
@@ -3032,9 +3032,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               controlPlaneOperator:
                                 description: controlPlaneOperator is a pre-existing
@@ -3056,9 +3079,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               disk:
                                 description: diskClientID is a pre-existing managed
@@ -3079,9 +3125,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               file:
                                 description: fileClientID is a pre-existing managed
@@ -3102,9 +3171,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               imageRegistry:
                                 description: imageRegistry is a pre-existing managed
@@ -3125,9 +3217,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               ingress:
                                 description: ingress is a pre-existing managed identity
@@ -3148,9 +3263,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
                                 description: |-
@@ -3193,9 +3331,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               nodePoolManagement:
                                 description: nodePoolManagement is a pre-existing
@@ -3217,9 +3378,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                             required:
                             - cloudProvider
@@ -3958,9 +4142,32 @@ spec:
                                     be a valid UUID. It should be 5 groups of hyphen
                                     separated hexadecimal characters in the form 8-4-4-4-12.
                                   rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                              objectEncoding:
+                                allOf:
+                                - enum:
+                                  - utf-8
+                                  - hex
+                                  - base64
+                                - enum:
+                                  - utf-8
+                                  - hex
+                                  - base64
+                                default: utf-8
+                                description: |-
+                                  objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                  CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                  Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                  unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                  SecretProviderClass custom resource related to the managed identity.
+
+                                  The default value is utf-8.
+
+                                  See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                type: string
                             required:
                             - certificateName
                             - clientID
+                            - objectEncoding
                             type: object
                         required:
                         - activeKey

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AROHCPManagedIdentities.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AROHCPManagedIdentities.yaml
@@ -2934,9 +2934,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               controlPlaneOperator:
                                 description: controlPlaneOperator is a pre-existing
@@ -2958,9 +2981,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               disk:
                                 description: diskClientID is a pre-existing managed
@@ -2981,9 +3027,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               file:
                                 description: fileClientID is a pre-existing managed
@@ -3004,9 +3073,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               imageRegistry:
                                 description: imageRegistry is a pre-existing managed
@@ -3027,9 +3119,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               ingress:
                                 description: ingress is a pre-existing managed identity
@@ -3050,9 +3165,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
                                 description: |-
@@ -3095,9 +3233,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               nodePoolManagement:
                                 description: nodePoolManagement is a pre-existing
@@ -3119,9 +3280,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                             required:
                             - cloudProvider
@@ -3836,9 +4020,32 @@ spec:
                                     be a valid UUID. It should be 5 groups of hyphen
                                     separated hexadecimal characters in the form 8-4-4-4-12.
                                   rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                              objectEncoding:
+                                allOf:
+                                - enum:
+                                  - utf-8
+                                  - hex
+                                  - base64
+                                - enum:
+                                  - utf-8
+                                  - hex
+                                  - base64
+                                default: utf-8
+                                description: |-
+                                  objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                  CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                  Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                  unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                  SecretProviderClass custom resource related to the managed identity.
+
+                                  The default value is utf-8.
+
+                                  See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                type: string
                             required:
                             - certificateName
                             - clientID
+                            - objectEncoding
                             type: object
                         required:
                         - activeKey

--- a/client/applyconfiguration/hypershift/v1beta1/managedidentity.go
+++ b/client/applyconfiguration/hypershift/v1beta1/managedidentity.go
@@ -17,11 +17,16 @@ limitations under the License.
 
 package v1beta1
 
+import (
+	v1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+)
+
 // ManagedIdentityApplyConfiguration represents an declarative configuration of the ManagedIdentity type for use
 // with apply.
 type ManagedIdentityApplyConfiguration struct {
-	ClientID        *string `json:"clientID,omitempty"`
-	CertificateName *string `json:"certificateName,omitempty"`
+	ClientID        *string                       `json:"clientID,omitempty"`
+	CertificateName *string                       `json:"certificateName,omitempty"`
+	ObjectEncoding  *v1beta1.ObjectEncodingFormat `json:"objectEncoding,omitempty"`
 }
 
 // ManagedIdentityApplyConfiguration constructs an declarative configuration of the ManagedIdentity type for use with
@@ -43,5 +48,13 @@ func (b *ManagedIdentityApplyConfiguration) WithClientID(value string) *ManagedI
 // If called multiple times, the CertificateName field is set to the value of the last call.
 func (b *ManagedIdentityApplyConfiguration) WithCertificateName(value string) *ManagedIdentityApplyConfiguration {
 	b.CertificateName = &value
+	return b
+}
+
+// WithObjectEncoding sets the ObjectEncoding field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ObjectEncoding field is set to the value of the last call.
+func (b *ManagedIdentityApplyConfiguration) WithObjectEncoding(value v1beta1.ObjectEncodingFormat) *ManagedIdentityApplyConfiguration {
+	b.ObjectEncoding = &value
 	return b
 }

--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -28,6 +28,11 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+const (
+	SATokenIssuerSecret = "sa-token-issuer-key"
+	ObjectEncoding      = "utf-8"
+)
+
 func DefaultOptions(client crclient.Client, log logr.Logger) (*RawCreateOptions, error) {
 	rawCreateOptions := &RawCreateOptions{
 		Location:           "eastus",
@@ -280,6 +285,16 @@ func (o *CreateOptions) ApplyPlatformSpecifics(cluster *hyperv1.HostedCluster) e
 
 	if o.TechPreviewEnabled {
 		cluster.Spec.Platform.Azure.ManagedIdentities = o.infra.ControlPlaneMIs
+		cluster.Spec.Platform.Azure.ManagedIdentities.DataPlane = o.infra.DataPlaneIdentities
+
+		cluster.Spec.Platform.Azure.ManagedIdentities.ControlPlane.CloudProvider.ObjectEncoding = ObjectEncoding
+		cluster.Spec.Platform.Azure.ManagedIdentities.ControlPlane.NodePoolManagement.ObjectEncoding = ObjectEncoding
+		cluster.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ControlPlaneOperator.ObjectEncoding = ObjectEncoding
+		cluster.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ImageRegistry.ObjectEncoding = ObjectEncoding
+		cluster.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Ingress.ObjectEncoding = ObjectEncoding
+		cluster.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Network.ObjectEncoding = ObjectEncoding
+		cluster.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Disk.ObjectEncoding = ObjectEncoding
+		cluster.Spec.Platform.Azure.ManagedIdentities.ControlPlane.File.ObjectEncoding = ObjectEncoding
 	}
 
 	if o.encryptionKey != nil {
@@ -302,6 +317,7 @@ func (o *CreateOptions) ApplyPlatformSpecifics(cluster *hyperv1.HostedCluster) e
 		cluster.Spec.SecretEncryption.KMS.Azure.KMS = hyperv1.ManagedIdentity{
 			ClientID:        o.KMSClientID,
 			CertificateName: o.KMSCertName,
+			ObjectEncoding:  ObjectEncoding,
 		}
 	}
 

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_complicated_invocation_from_bryan.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_complicated_invocation_from_bryan.yaml
@@ -77,30 +77,38 @@ spec:
           cloudProvider:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           controlPlaneOperator:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           disk:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           file:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           imageRegistry:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           ingress:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           managedIdentitiesKeyVault:
             name: ""
             tenantID: ""
           network:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           nodePoolManagement:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
         dataPlane:
           diskMSIClientID: ""
           fileMSIClientID: ""

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_create_with_a_ure_marketplace_image.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_create_with_a_ure_marketplace_image.yaml
@@ -44,30 +44,38 @@ spec:
           cloudProvider:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           controlPlaneOperator:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           disk:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           file:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           imageRegistry:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           ingress:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           managedIdentitiesKeyVault:
             name: ""
             tenantID: ""
           network:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           nodePoolManagement:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
         dataPlane:
           diskMSIClientID: ""
           fileMSIClientID: ""

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -77,30 +77,38 @@ spec:
           cloudProvider:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           controlPlaneOperator:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           disk:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           file:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           imageRegistry:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           ingress:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           managedIdentitiesKeyVault:
             name: ""
             tenantID: ""
           network:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           nodePoolManagement:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
         dataPlane:
           diskMSIClientID: ""
           fileMSIClientID: ""

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_ones.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_ones.yaml
@@ -77,30 +77,38 @@ spec:
           cloudProvider:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           controlPlaneOperator:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           disk:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           file:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           imageRegistry:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           ingress:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           managedIdentitiesKeyVault:
             name: ""
             tenantID: ""
           network:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
           nodePoolManagement:
             certificateName: ""
             clientID: ""
+            objectEncoding: ""
         dataPlane:
           diskMSIClientID: ""
           fileMSIClientID: ""

--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -73,18 +73,19 @@ type CreateInfraOptions struct {
 }
 
 type CreateInfraOutput struct {
-	BaseDomain        string                                 `json:"baseDomain"`
-	PublicZoneID      string                                 `json:"publicZoneID"`
-	PrivateZoneID     string                                 `json:"privateZoneID"`
-	Location          string                                 `json:"region"`
-	ResourceGroupName string                                 `json:"resourceGroupName"`
-	VNetID            string                                 `json:"vnetID"`
-	SubnetID          string                                 `json:"subnetID"`
-	BootImageID       string                                 `json:"bootImageID"`
-	InfraID           string                                 `json:"infraID"`
-	MachineIdentityID string                                 `json:"machineIdentityID"`
-	SecurityGroupID   string                                 `json:"securityGroupID"`
-	ControlPlaneMIs   hyperv1.AzureResourceManagedIdentities `json:"controlPlaneMIs"`
+	BaseDomain          string                                 `json:"baseDomain"`
+	PublicZoneID        string                                 `json:"publicZoneID"`
+	PrivateZoneID       string                                 `json:"privateZoneID"`
+	Location            string                                 `json:"region"`
+	ResourceGroupName   string                                 `json:"resourceGroupName"`
+	VNetID              string                                 `json:"vnetID"`
+	SubnetID            string                                 `json:"subnetID"`
+	BootImageID         string                                 `json:"bootImageID"`
+	InfraID             string                                 `json:"infraID"`
+	MachineIdentityID   string                                 `json:"machineIdentityID"`
+	SecurityGroupID     string                                 `json:"securityGroupID"`
+	ControlPlaneMIs     hyperv1.AzureResourceManagedIdentities `json:"controlPlaneMIs"`
+	DataPlaneIdentities hyperv1.DataPlaneManagedIdentities     `json:"dataPlaneIdentities"`
 }
 
 func NewCreateCommand() *cobra.Command {

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
@@ -3463,9 +3463,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               controlPlaneOperator:
                                 description: controlPlaneOperator is a pre-existing
@@ -3487,9 +3510,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               disk:
                                 description: diskClientID is a pre-existing managed
@@ -3510,9 +3556,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               file:
                                 description: fileClientID is a pre-existing managed
@@ -3533,9 +3602,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               imageRegistry:
                                 description: imageRegistry is a pre-existing managed
@@ -3556,9 +3648,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               ingress:
                                 description: ingress is a pre-existing managed identity
@@ -3579,9 +3694,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
                                 description: |-
@@ -3624,9 +3762,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               nodePoolManagement:
                                 description: nodePoolManagement is a pre-existing
@@ -3648,9 +3809,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                             required:
                             - cloudProvider
@@ -4876,9 +5060,32 @@ spec:
                                     be a valid UUID. It should be 5 groups of hyphen
                                     separated hexadecimal characters in the form 8-4-4-4-12.
                                   rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                              objectEncoding:
+                                allOf:
+                                - enum:
+                                  - utf-8
+                                  - hex
+                                  - base64
+                                - enum:
+                                  - utf-8
+                                  - hex
+                                  - base64
+                                default: utf-8
+                                description: |-
+                                  objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                  CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                  Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                  unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                  SecretProviderClass custom resource related to the managed identity.
+
+                                  The default value is utf-8.
+
+                                  See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                type: string
                             required:
                             - certificateName
                             - clientID
+                            - objectEncoding
                             type: object
                         required:
                         - activeKey

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
@@ -3463,9 +3463,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               controlPlaneOperator:
                                 description: controlPlaneOperator is a pre-existing
@@ -3487,9 +3510,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               disk:
                                 description: diskClientID is a pre-existing managed
@@ -3510,9 +3556,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               file:
                                 description: fileClientID is a pre-existing managed
@@ -3533,9 +3602,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               imageRegistry:
                                 description: imageRegistry is a pre-existing managed
@@ -3556,9 +3648,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               ingress:
                                 description: ingress is a pre-existing managed identity
@@ -3579,9 +3694,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
                                 description: |-
@@ -3624,9 +3762,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               nodePoolManagement:
                                 description: nodePoolManagement is a pre-existing
@@ -3648,9 +3809,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                             required:
                             - cloudProvider
@@ -4876,9 +5060,32 @@ spec:
                                     be a valid UUID. It should be 5 groups of hyphen
                                     separated hexadecimal characters in the form 8-4-4-4-12.
                                   rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                              objectEncoding:
+                                allOf:
+                                - enum:
+                                  - utf-8
+                                  - hex
+                                  - base64
+                                - enum:
+                                  - utf-8
+                                  - hex
+                                  - base64
+                                default: utf-8
+                                description: |-
+                                  objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                  CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                  Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                  unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                  SecretProviderClass custom resource related to the managed identity.
+
+                                  The default value is utf-8.
+
+                                  See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                type: string
                             required:
                             - certificateName
                             - clientID
+                            - objectEncoding
                             type: object
                         required:
                         - activeKey

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
@@ -3352,9 +3352,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               controlPlaneOperator:
                                 description: controlPlaneOperator is a pre-existing
@@ -3376,9 +3399,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               disk:
                                 description: diskClientID is a pre-existing managed
@@ -3399,9 +3445,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               file:
                                 description: fileClientID is a pre-existing managed
@@ -3422,9 +3491,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               imageRegistry:
                                 description: imageRegistry is a pre-existing managed
@@ -3445,9 +3537,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               ingress:
                                 description: ingress is a pre-existing managed identity
@@ -3468,9 +3583,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
                                 description: |-
@@ -3513,9 +3651,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               nodePoolManagement:
                                 description: nodePoolManagement is a pre-existing
@@ -3537,9 +3698,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                             required:
                             - cloudProvider
@@ -4741,9 +4925,32 @@ spec:
                                     be a valid UUID. It should be 5 groups of hyphen
                                     separated hexadecimal characters in the form 8-4-4-4-12.
                                   rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                              objectEncoding:
+                                allOf:
+                                - enum:
+                                  - utf-8
+                                  - hex
+                                  - base64
+                                - enum:
+                                  - utf-8
+                                  - hex
+                                  - base64
+                                default: utf-8
+                                description: |-
+                                  objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                  CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                  Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                  unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                  SecretProviderClass custom resource related to the managed identity.
+
+                                  The default value is utf-8.
+
+                                  See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                type: string
                             required:
                             - certificateName
                             - clientID
+                            - objectEncoding
                             type: object
                         required:
                         - activeKey

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
@@ -3352,9 +3352,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               controlPlaneOperator:
                                 description: controlPlaneOperator is a pre-existing
@@ -3376,9 +3399,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               disk:
                                 description: diskClientID is a pre-existing managed
@@ -3399,9 +3445,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               file:
                                 description: fileClientID is a pre-existing managed
@@ -3422,9 +3491,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               imageRegistry:
                                 description: imageRegistry is a pre-existing managed
@@ -3445,9 +3537,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               ingress:
                                 description: ingress is a pre-existing managed identity
@@ -3468,9 +3583,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
                                 description: |-
@@ -3513,9 +3651,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                               nodePoolManagement:
                                 description: nodePoolManagement is a pre-existing
@@ -3537,9 +3698,32 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  objectEncoding:
+                                    allOf:
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    - enum:
+                                      - utf-8
+                                      - hex
+                                      - base64
+                                    default: utf-8
+                                    description: |-
+                                      objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                      CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                      Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                      unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                      SecretProviderClass custom resource related to the managed identity.
+
+                                      The default value is utf-8.
+
+                                      See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                    type: string
                                 required:
                                 - certificateName
                                 - clientID
+                                - objectEncoding
                                 type: object
                             required:
                             - cloudProvider
@@ -4741,9 +4925,32 @@ spec:
                                     be a valid UUID. It should be 5 groups of hyphen
                                     separated hexadecimal characters in the form 8-4-4-4-12.
                                   rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                              objectEncoding:
+                                allOf:
+                                - enum:
+                                  - utf-8
+                                  - hex
+                                  - base64
+                                - enum:
+                                  - utf-8
+                                  - hex
+                                  - base64
+                                default: utf-8
+                                description: |-
+                                  objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+                                  CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+                                  Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+                                  unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+                                  SecretProviderClass custom resource related to the managed identity.
+
+                                  The default value is utf-8.
+
+                                  See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                type: string
                             required:
                             - certificateName
                             - clientID
+                            - objectEncoding
                             type: object
                         required:
                         - activeKey

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -1266,6 +1266,7 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 				APIGroups: []string{"secrets-store.csi.x-k8s.io"},
 				Resources: []string{"secretproviderclasses"},
 				Verbs: []string{
+					"get",
 					"list",
 					"create",
 					"update",

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3087,7 +3087,7 @@ func (r *HostedControlPlaneReconciler) reconcileKubeAPIServer(ctx context.Contex
 				// Reconcile the SecretProviderClass
 				kmsSecretProviderClass := manifests.ManagedAzureSecretProviderClass(config.ManagedAzureKMSSecretProviderClassName, hcp.Namespace)
 				if _, err := createOrUpdate(ctx, r, kmsSecretProviderClass, func() error {
-					secretproviderclass.ReconcileManagedAzureSecretProviderClass(kmsSecretProviderClass, hcp, hcp.Spec.SecretEncryption.KMS.Azure.KMS.CertificateName)
+					secretproviderclass.ReconcileManagedAzureSecretProviderClass(kmsSecretProviderClass, hcp, hcp.Spec.SecretEncryption.KMS.Azure.KMS.CertificateName, string(hcp.Spec.SecretEncryption.KMS.Azure.KMS.ObjectEncoding))
 					return nil
 				}); err != nil {
 					return fmt.Errorf("failed to reconcile KMS SecretProviderClass: %w", err)
@@ -3676,7 +3676,7 @@ func (r *HostedControlPlaneReconciler) reconcileClusterNetworkOperator(ctx conte
 	if hyperazureutil.IsAroHCP() {
 		cnccSecretProviderClass := manifests.ManagedAzureSecretProviderClass(config.ManagedAzureNetworkSecretStoreProviderClassName, hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r, cnccSecretProviderClass, func() error {
-			secretproviderclass.ReconcileManagedAzureSecretProviderClass(cnccSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Network.CertificateName)
+			secretproviderclass.ReconcileManagedAzureSecretProviderClass(cnccSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Network.CertificateName, string(hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Network.ObjectEncoding))
 			return nil
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile ingressoperator secret provider class: %w", err)
@@ -3833,7 +3833,7 @@ func (r *HostedControlPlaneReconciler) reconcileIngressOperator(ctx context.Cont
 	if hyperazureutil.IsAroHCP() {
 		ingressSecretProviderClass := manifests.ManagedAzureSecretProviderClass(config.ManagedAzureIngressSecretStoreProviderClassName, hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r, ingressSecretProviderClass, func() error {
-			secretproviderclass.ReconcileManagedAzureSecretProviderClass(ingressSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Ingress.CertificateName)
+			secretproviderclass.ReconcileManagedAzureSecretProviderClass(ingressSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Ingress.CertificateName, string(hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Ingress.ObjectEncoding))
 			return nil
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile ingress operator secret provider class: %w", err)
@@ -4201,7 +4201,7 @@ func (r *HostedControlPlaneReconciler) reconcileImageRegistryOperator(ctx contex
 	if hyperazureutil.IsAroHCP() {
 		imageRegistrySecretProviderClass := manifests.ManagedAzureSecretProviderClass(config.ManagedAzureImageRegistrySecretStoreProviderClassName, hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r, imageRegistrySecretProviderClass, func() error {
-			secretproviderclass.ReconcileManagedAzureSecretProviderClass(imageRegistrySecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ImageRegistry.CertificateName)
+			secretproviderclass.ReconcileManagedAzureSecretProviderClass(imageRegistrySecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ImageRegistry.CertificateName, string(hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ImageRegistry.ObjectEncoding))
 			return nil
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile image registry operator secret provider class: %w", err)
@@ -4812,7 +4812,7 @@ func (r *HostedControlPlaneReconciler) reconcileCloudControllerManager(ctx conte
 		// Reconcile SecretProviderClass
 		azureCloudProviderSecretProviderClass := manifests.ManagedAzureSecretProviderClass(config.ManagedAzureCloudProviderSecretProviderClassName, hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r, azureCloudProviderSecretProviderClass, func() error {
-			secretproviderclass.ReconcileManagedAzureSecretProviderClass(azureCloudProviderSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.CloudProvider.CertificateName)
+			secretproviderclass.ReconcileManagedAzureSecretProviderClass(azureCloudProviderSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.CloudProvider.CertificateName, string(hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.CloudProvider.ObjectEncoding))
 			return nil
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile azure cloud provider secret provider class: %w", err)
@@ -5042,7 +5042,7 @@ func (r *HostedControlPlaneReconciler) reconcileClusterStorageOperator(ctx conte
 		// Reconcile SecretProviderClasses
 		azureDiskSecretProviderClass := manifests.ManagedAzureSecretProviderClass(config.ManagedAzureDiskCSISecretStoreProviderClassName, hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r, azureDiskSecretProviderClass, func() error {
-			secretproviderclass.ReconcileManagedAzureSecretProviderClass(azureDiskSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Disk.CertificateName)
+			secretproviderclass.ReconcileManagedAzureSecretProviderClass(azureDiskSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Disk.CertificateName, string(hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Disk.ObjectEncoding))
 			return nil
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile Azure Disk Secret Provider Class: %w", err)
@@ -5050,7 +5050,7 @@ func (r *HostedControlPlaneReconciler) reconcileClusterStorageOperator(ctx conte
 
 		azureFileSecretProviderClass := manifests.ManagedAzureSecretProviderClass(config.ManagedAzureFileCSISecretStoreProviderClassName, hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r, azureFileSecretProviderClass, func() error {
-			secretproviderclass.ReconcileManagedAzureSecretProviderClass(azureFileSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.File.CertificateName)
+			secretproviderclass.ReconcileManagedAzureSecretProviderClass(azureFileSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.File.CertificateName, string(hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.File.ObjectEncoding))
 			return nil
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile Azure File Secret Provider Class: %w", err)

--- a/control-plane-operator/controllers/hostedcontrolplane/secretproviderclass/secretproviderclass.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/secretproviderclass/secretproviderclass.go
@@ -13,6 +13,7 @@ const (
 array:
   - |
     objectName: %s
+    objectEncoding: %s
     objectType: secret
 `
 )
@@ -21,7 +22,7 @@ array:
 // Key Vault setup, and the certificate name it needs to pull from the Key Vault.
 //
 // https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-identity-access?tabs=azure-portal&pivots=access-with-a-user-assigned-managed-identity
-func ReconcileManagedAzureSecretProviderClass(secretProviderClass *secretsstorev1.SecretProviderClass, hcp *hyperv1.HostedControlPlane, certName string) {
+func ReconcileManagedAzureSecretProviderClass(secretProviderClass *secretsstorev1.SecretProviderClass, hcp *hyperv1.HostedControlPlane, certName, objectEncoding string) {
 	secretProviderClass.Spec = secretsstorev1.SecretProviderClassSpec{
 		Provider: "azure",
 		Parameters: map[string]string{
@@ -30,15 +31,15 @@ func ReconcileManagedAzureSecretProviderClass(secretProviderClass *secretsstorev
 			"userAssignedIdentityID": azureutil.GetKeyVaultAuthorizedUser(),
 			"keyvaultName":           hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ManagedIdentitiesKeyVault.Name,
 			"tenantId":               hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ManagedIdentitiesKeyVault.TenantID,
-			"objects":                formatSecretProviderClassObject(certName),
+			"objects":                formatSecretProviderClassObject(certName, objectEncoding),
 		},
 	}
 }
 
 // formatSecretProviderClassObject places the certificate name in the appropriate string structure the
-// SecretProviderClass expects for an object. More details here:
+// SecretProviderClass expects for an object and specified the objectEncoding. More details here:
 // - https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-identity-access?tabs=azure-portal&pivots=access-with-a-user-assigned-managed-identity#configure-managed-identity
 // - https://secrets-store-csi-driver.sigs.k8s.io/concepts.html?highlight=object#custom-resource-definitions-crds
-func formatSecretProviderClassObject(certName string) string {
-	return fmt.Sprintf(objectFormat, certName)
+func formatSecretProviderClassObject(certName, objectEncoding string) string {
+	return fmt.Sprintf(objectFormat, certName, objectEncoding)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/secretproviderclass/secretproviderclass_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/secretproviderclass/secretproviderclass_test.go
@@ -1,0 +1,50 @@
+package secretproviderclass
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestFormatSecretProviderClassObject(t *testing.T) {
+	testCases := []struct {
+		name           string
+		certName       string
+		objectEncoding string
+		expected       string
+	}{
+		{
+			name:           "default",
+			certName:       "cert",
+			objectEncoding: "base64",
+			expected: `
+array:
+  - |
+    objectName: cert
+    objectEncoding: base64
+    objectType: secret
+`,
+		},
+		{
+			name:           "default",
+			certName:       "cert",
+			objectEncoding: "utf-8",
+			expected: `
+array:
+  - |
+    objectName: cert
+    objectEncoding: utf-8
+    objectType: secret
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			actual := formatSecretProviderClassObject(tc.certName, tc.objectEncoding)
+			g.Expect(actual).To(Equal(tc.expected))
+		})
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/config.go
@@ -51,7 +51,7 @@ func adaptConfigSecret(cpContext component.ControlPlaneContext, secret *corev1.S
 }
 
 func adaptSecretProvider(cpContext component.ControlPlaneContext, secretProvider *secretsstorev1.SecretProviderClass) error {
-	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, cpContext.HCP.Spec.Platform.Azure.ManagedIdentities.ControlPlane.CloudProvider.CertificateName)
+	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, cpContext.HCP.Spec.Platform.Azure.ManagedIdentities.ControlPlane.CloudProvider.CertificateName, string(cpContext.HCP.Spec.Platform.Azure.ManagedIdentities.ControlPlane.CloudProvider.ObjectEncoding))
 	return nil
 }
 

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -7863,6 +7863,25 @@ string
 reside in an Azure Key Vault on the management cluster.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>objectEncoding</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1beta1.ObjectEncodingFormat">
+ObjectEncodingFormat
+</a>
+</em>
+</td>
+<td>
+<p>objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+Azure Key Vault. If objectEncoding doesn&rsquo;t match the encoding format of the certificate, the certificate will
+unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+SecretProviderClass custom resource related to the managed identity.</p>
+<p>The default value is utf-8.</p>
+<p>See this for more info - <a href="https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md">https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md</a></p>
+</td>
+</tr>
 </tbody>
 </table>
 ###MultiQueueSetting { #hypershift.openshift.io/v1beta1.MultiQueueSetting }
@@ -8811,6 +8830,14 @@ the management cluster.</p>
 </td>
 </tr></tbody>
 </table>
+###ObjectEncodingFormat { #hypershift.openshift.io/v1beta1.ObjectEncodingFormat }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1beta1.ManagedIdentity">ManagedIdentity</a>)
+</p>
+<p>
+<p>ObjectEncodingFormat is the type of encoding for an Azure Key Vault secret</p>
+</p>
 ###OpenStackIdentityReference { #hypershift.openshift.io/v1beta1.OpenStackIdentityReference }
 <p>
 (<em>Appears on:</em>

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3055,6 +3055,7 @@ func reconcileControlPlaneOperatorRole(role *rbacv1.Role, enableCVOManagementClu
 				APIGroups: []string{"secrets-store.csi.x-k8s.io"},
 				Resources: []string{"secretproviderclasses"},
 				Verbs: []string{
+					"get",
 					"list",
 					"create",
 					"update",

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1825,7 +1825,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 	case hyperv1.AzurePlatform:
 		cpoSecretProviderClass := cpomanifests.ManagedAzureSecretProviderClass(config.ManagedAzureCPOSecretProviderClassName, hcp.Namespace)
 		if _, err = createOrUpdate(ctx, r, cpoSecretProviderClass, func() error {
-			secretproviderclass.ReconcileManagedAzureSecretProviderClass(cpoSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ControlPlaneOperator.CertificateName)
+			secretproviderclass.ReconcileManagedAzureSecretProviderClass(cpoSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ControlPlaneOperator.CertificateName, string(hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ControlPlaneOperator.ObjectEncoding))
 			return nil
 		}); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile control plane operator secret provider class: %w", err)

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
@@ -78,7 +78,7 @@ func (a Azure) ReconcileCAPIInfraCR(
 		if err := c.Get(ctx, client.ObjectKeyFromObject(hcp), hcp); err != nil {
 			return err
 		}
-		secretproviderclass.ReconcileManagedAzureSecretProviderClass(nodepoolMgmtSecretProviderClass, hcp, hcluster.Spec.Platform.Azure.ManagedIdentities.ControlPlane.NodePoolManagement.CertificateName)
+		secretproviderclass.ReconcileManagedAzureSecretProviderClass(nodepoolMgmtSecretProviderClass, hcp, hcluster.Spec.Platform.Azure.ManagedIdentities.ControlPlane.NodePoolManagement.CertificateName, string(hcluster.Spec.Platform.Azure.ManagedIdentities.ControlPlane.NodePoolManagement.ObjectEncoding))
 		return nil
 	}); err != nil {
 		return nil, fmt.Errorf("failed to reconcile KMS SecretProviderClass: %w", err)

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/azure.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/azure.go
@@ -440,6 +440,10 @@ type AzurePlatformSpec struct {
 	TenantID string `json:"tenantID"`
 }
 
+// ObjectEncodingFormat is the type of encoding for an Azure Key Vault secret
+// +kubebuilder:validation:Enum:=utf-8;hex;base64
+type ObjectEncodingFormat string
+
 // ManagedAzureKeyVault is an Azure Key Vault on the management cluster.
 type ManagedAzureKeyVault struct {
 	// name is the name of the Azure Key Vault on the management cluster.
@@ -483,6 +487,20 @@ type ManagedIdentity struct {
 	//
 	// +kubebuilder:validation:Required
 	CertificateName string `json:"certificateName"`
+
+	// objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
+	// CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the
+	// Azure Key Vault. If objectEncoding doesn't match the encoding format of the certificate, the certificate will
+	// unsuccessfully be read by the Secrets CSI driver and an error will occur. This error will only be visible on the
+	// SecretProviderClass custom resource related to the managed identity.
+	//
+	// The default value is utf-8.
+	//
+	// See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+	//
+	// +kubebuilder:validation:Enum:=utf-8;hex;base64
+	// +kubebuilder:default:="utf-8"
+	ObjectEncoding ObjectEncodingFormat `json:"objectEncoding"`
 }
 
 // ControlPlaneManagedIdentities contains the managed identities on the HCP control plane needing to authenticate with


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual backport of https://github.com/openshift/hypershift/pull/5505

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes [OCPBUGS-49819](https://issues.redhat.com/browse/OCPBUGS-49819)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.