### PR TITLE
OCPBUGS-49825: use registryOverrides when automaitcally retrieving catalog images for hosted control plane

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -99,7 +98,6 @@ import (
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/releaseinfo"
-	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
 	"github.com/openshift/hypershift/support/secretproviderclass"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
 	"github.com/openshift/hypershift/support/upsert"
@@ -165,8 +163,7 @@ const (
 )
 
 var (
-	olmCatalogImagesOnce sync.Once
-	catalogImages        map[string]string
+	catalogImages map[string]string
 )
 
 type HostedControlPlaneReconciler struct {
@@ -3999,23 +3996,16 @@ func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx con
 				return fmt.Errorf("failed to get pull secret for namespace %s: %w", hcp.Namespace, err)
 			}
 
-			var getCatalogImagesErr error
-			olmCatalogImagesOnce.Do(func() {
-				catalogImages, err = olm.GetCatalogImages(ctx, *hcp, pullSecret.Data[corev1.DockerConfigJsonKey], registryclient.GetListDigest, r.ImageMetadataProvider)
-				if err != nil {
-					getCatalogImagesErr = err
-					return
-				}
-			})
-			if getCatalogImagesErr != nil {
-				return fmt.Errorf("failed to get catalog images: %w", getCatalogImagesErr)
+			catalogImages, err = olm.GetCatalogImages(ctx, *hcp, pullSecret.Data[corev1.DockerConfigJsonKey], r.ImageMetadataProvider, isImageRegistryOverrides)
+			if err != nil {
+				return fmt.Errorf("failed to get catalog images: %w", err)
 			}
 
 			if r.ManagementClusterCapabilities.Has(capabilities.CapabilityImageStream) {
 				catalogsImageStream := manifests.CatalogsImageStream(hcp.Namespace)
 				if !overrideImages {
 					if _, err := createOrUpdate(ctx, r, catalogsImageStream, func() error {
-						return olm.ReconcileCatalogsImageStream(catalogsImageStream, p.OwnerRef, isImageRegistryOverrides, catalogImages)
+						return olm.ReconcileCatalogsImageStream(catalogsImageStream, p.OwnerRef, catalogImages)
 					}); err != nil {
 						return fmt.Errorf("failed to reconcile catalogs image stream: %w", err)
 					}
@@ -4032,22 +4022,11 @@ func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx con
 							return fmt.Errorf("failed to parse catalog image %s: %w", catalog, err)
 						}
 
-						if len(isImageRegistryOverrides) > 0 {
-							for registrySource, registryDest := range isImageRegistryOverrides {
-								if strings.Contains(imageRef.Exact(), registrySource) {
-									imageRef, err = reference.Parse(strings.Replace(imageRef.Exact(), registrySource, registryDest[0], 1))
-									if err != nil {
-										return fmt.Errorf("failed to parse registry override image %s: %w", registryDest[0], err)
-									}
-								}
-							}
-						}
-
-						listDigest, err := registryclient.GetListDigest(ctx, imageRef.Exact(), pullSecret.Data[corev1.DockerConfigJsonKey])
+						digest, _, err := r.ImageMetadataProvider.GetDigest(ctx, imageRef.Exact(), pullSecret.Data[corev1.DockerConfigJsonKey])
 						if err != nil {
 							return fmt.Errorf("failed to get manifest for image %s: %v", imageRef.Exact(), err)
 						}
-						imageRef.ID = listDigest.String()
+						imageRef.ID = digest.String()
 
 						catalogOverrides := map[string]*string{
 							"redhat-operators":    &p.RedHatOperatorsCatalogImageOverride,

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1019,7 +1019,6 @@ func (r *HostedControlPlaneReconciler) reconcileCPOV2(ctx context.Context, hcp *
 		MetricsSet:                r.MetricsSet,
 		EnableCIDebugOutput:       r.EnableCIDebugOutput,
 		ImageMetadataProvider:     r.ImageMetadataProvider,
-		DigestLister:              registryclient.GetListDigest,
 	}
 
 	var errs []error

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -68,7 +68,6 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/go-logr/zapr"
-	"github.com/opencontainers/go-digest"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -1676,9 +1675,6 @@ func TestControlPlaneComponents(t *testing.T) {
 				},
 			},
 			Manifest: fakeimagemetadataprovider.FakeManifest{},
-		},
-		DigestLister: func(ctx context.Context, image string, pullSecret []byte) (digest.Digest, error) {
-			return "", nil
 		},
 		HCP:           hcp,
 		SkipPredicate: true,

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
@@ -12,7 +12,6 @@ import (
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/metrics"
-	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
 	"github.com/openshift/hypershift/support/util"
 
 	imagev1 "github.com/openshift/api/image/v1"
@@ -123,7 +122,7 @@ func findTagReference(tags []imagev1.TagReference, name string) *imagev1.TagRefe
 	return nil
 }
 
-func GetCatalogImages(ctx context.Context, hcp hyperv1.HostedControlPlane, pullSecret []byte, digestLister registryclient.DigestListerFN, imageMetadataProvider util.ImageMetadataProvider) (map[string]string, error) {
+func GetCatalogImages(ctx context.Context, hcp hyperv1.HostedControlPlane, pullSecret []byte, imageMetadataProvider util.ImageMetadataProvider, registryOverrides map[string][]string) (map[string]string, error) {
 	imageRef := hcp.Spec.ReleaseImage
 	imageConfig, _, _, err := imageMetadataProvider.GetMetadata(ctx, imageRef, pullSecret)
 	if err != nil {
@@ -135,17 +134,38 @@ func GetCatalogImages(ctx context.Context, hcp hyperv1.HostedControlPlane, pullS
 		return nil, fmt.Errorf("invalid OpenShift release version format: %s", imageConfig.Config.Labels["io.openshift.release"])
 	}
 
+	registries := []string{
+		"registry.redhat.io/redhat",
+	}
+	if len(registryOverrides) > 0 {
+		for registrySource, registryDest := range registryOverrides {
+			if registries[0] == registrySource {
+				registries = registryDest
+				break
+			}
+		}
+	}
+
 	//check catalogs of last 4 supported version in case new version is not available
 	supportedVersions := 4
+	imageRegistry := ""
 	for i := 0; i < supportedVersions; i++ {
-		_, err = digestLister(ctx, fmt.Sprintf("registry.redhat.io/redhat/certified-operator-index:v%d.%d", version.Major, version.Minor), pullSecret)
-		if err == nil {
-			break
+		for _, registry := range registries {
+			testImage := fmt.Sprintf("%s/certified-operator-index:v%d.%d", registry, version.Major, version.Minor)
+
+			_, dockerImage, err := imageMetadataProvider.GetDigest(ctx, testImage, pullSecret)
+			if err == nil {
+				imageRegistry = fmt.Sprintf("%s/%s", dockerImage.Registry, dockerImage.Namespace)
+				break
+			}
+
+			// Manifest unknown error is expected if the image is not available.
+			if !strings.Contains(err.Error(), "manifest unknown") {
+				return nil, err // Return if it's an unexpected error
+			}
 		}
-		//manifest unknown error is expected if the image is not available.
-		//If the all supported versions are checked and the image is still not available, return the error
-		if !strings.Contains(err.Error(), "manifest unknown") {
-			return nil, err
+		if imageRegistry != "" {
+			break
 		}
 		if i == supportedVersions-1 {
 			return nil, fmt.Errorf("failed to get image digest for 4 previous versions of certified-operator-index: %w", err)
@@ -154,21 +174,21 @@ func GetCatalogImages(ctx context.Context, hcp hyperv1.HostedControlPlane, pullS
 	}
 
 	operators := map[string]string{
-		"certified-operators": fmt.Sprintf("registry.redhat.io/redhat/certified-operator-index:v%d.%d", version.Major, version.Minor),
-		"community-operators": fmt.Sprintf("registry.redhat.io/redhat/community-operator-index:v%d.%d", version.Major, version.Minor),
-		"redhat-marketplace":  fmt.Sprintf("registry.redhat.io/redhat/redhat-marketplace-index:v%d.%d", version.Major, version.Minor),
-		"redhat-operators":    fmt.Sprintf("registry.redhat.io/redhat/redhat-operator-index:v%d.%d", version.Major, version.Minor),
+		"certified-operators": fmt.Sprintf("%s/certified-operator-index:v%d.%d", imageRegistry, version.Major, version.Minor),
+		"community-operators": fmt.Sprintf("%s/community-operator-index:v%d.%d", imageRegistry, version.Major, version.Minor),
+		"redhat-marketplace":  fmt.Sprintf("%s/redhat-marketplace-index:v%d.%d", imageRegistry, version.Major, version.Minor),
+		"redhat-operators":    fmt.Sprintf("%s/redhat-operator-index:v%d.%d", imageRegistry, version.Major, version.Minor),
 	}
 
 	return operators, nil
 }
 
-func ReconcileCatalogsImageStream(imageStream *imagev1.ImageStream, ownerRef config.OwnerRef, isImageRegistryOverrides map[string][]string, catalogImages map[string]string) error {
+func ReconcileCatalogsImageStream(imageStream *imagev1.ImageStream, ownerRef config.OwnerRef, catalogImages map[string]string) error {
 	imageStream.Spec.LookupPolicy.Local = true
 	if imageStream.Spec.Tags == nil {
 		imageStream.Spec.Tags = []imagev1.TagReference{}
 	}
-	for name, image := range getCatalogToImageWithISImageRegistryOverrides(catalogImages, isImageRegistryOverrides) {
+	for name, image := range catalogImages {
 		tagRef := findTagReference(imageStream.Spec.Tags, name)
 		if tagRef == nil {
 			imageStream.Spec.Tags = append(imageStream.Spec.Tags, imagev1.TagReference{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm/params.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm/params.go
@@ -6,7 +6,6 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/olm"
-	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
 	"github.com/openshift/hypershift/support/util"
 
 	corev1 "k8s.io/api/core/v1"
@@ -20,8 +19,9 @@ type OperatorLifecycleManagerParams struct {
 	OLMCatalogPlacement     hyperv1.OLMCatalogPlacement
 }
 
-func NewOperatorLifecycleManagerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, pullSecret *corev1.Secret, digestLister registryclient.DigestListerFN, imageMetadataProvider util.ImageMetadataProvider) (*OperatorLifecycleManagerParams, error) {
-	catalogImages, err := olm.GetCatalogImages(ctx, *hcp, pullSecret.Data[corev1.DockerConfigJsonKey], digestLister, imageMetadataProvider)
+func NewOperatorLifecycleManagerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, pullSecret *corev1.Secret, imageMetadataProvider util.ImageMetadataProvider) (*OperatorLifecycleManagerParams, error) {
+	isImageRegistryOverrides := util.ConvertImageRegistryOverrideStringToMap(hcp.Annotations[hyperv1.OLMCatalogsISRegistryOverridesAnnotation])
+	catalogImages, err := olm.GetCatalogImages(ctx, *hcp, pullSecret.Data[corev1.DockerConfigJsonKey], imageMetadataProvider, isImageRegistryOverrides)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get catalog images: %w", err)
 	}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -42,7 +42,6 @@ import (
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/globalconfig"
 	"github.com/openshift/hypershift/support/releaseinfo"
-	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
 
@@ -105,8 +104,6 @@ var (
 	// only once.
 	deleteDNSOperatorDeploymentOnce sync.Once
 	deleteCVORemovedResourcesOnce   sync.Once
-	olmCatalogImagesOnce            sync.Once
-	p                               *olm.OperatorLifecycleManagerParams
 )
 
 const azureCCMScript = `
@@ -139,8 +136,7 @@ type reconciler struct {
 	oauthPort                 int32
 	versions                  map[string]string
 	operateOnReleaseImage     string
-	ImageMetaDataProvider     util.RegistryClientImageMetadataProvider
-	registryclient.DigestListerFN
+	ImageMetaDataProvider     util.ImageMetadataProvider
 }
 
 // eventHandler is the handler used throughout. As this controller reconciles all kind of different resources
@@ -196,7 +192,6 @@ func Setup(ctx context.Context, opts *operator.HostedClusterConfigOperatorConfig
 		oauthPort:                 opts.OAuthPort,
 		versions:                  opts.Versions,
 		operateOnReleaseImage:     opts.OperateOnReleaseImage,
-		DigestListerFN:            registryclient.GetListDigest,
 		ImageMetaDataProvider:     opts.ImageMetaDataProvider,
 	}})
 	if err != nil {
@@ -646,7 +641,7 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 	}
 
 	log.Info("reconciling olm resources")
-	errs = append(errs, r.reconcileOLM(ctx, hcp, pullSecret, r.DigestListerFN)...)
+	errs = append(errs, r.reconcileOLM(ctx, hcp, pullSecret)...)
 
 	log.Info("reconciling kubelet configs")
 	if err := r.reconcileKubeletConfig(ctx); err != nil {
@@ -1664,7 +1659,7 @@ func (r *reconciler) reconcileOperatorHub(ctx context.Context, operatorHub *conf
 	return nil
 }
 
-func (r *reconciler) reconcileOLM(ctx context.Context, hcp *hyperv1.HostedControlPlane, pullSecret *corev1.Secret, digestLister registryclient.DigestListerFN) []error {
+func (r *reconciler) reconcileOLM(ctx context.Context, hcp *hyperv1.HostedControlPlane, pullSecret *corev1.Secret) []error {
 	var errs []error
 
 	operatorHub := manifests.OperatorHub()
@@ -1693,14 +1688,10 @@ func (r *reconciler) reconcileOLM(ctx context.Context, hcp *hyperv1.HostedContro
 		}
 	}
 
-	olmCatalogImagesOnce.Do(func() {
-		var err error
-		p, err = olm.NewOperatorLifecycleManagerParams(ctx, hcp, pullSecret, digestLister, &r.ImageMetaDataProvider)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to create OperatorLifecycleManagerParams: %w", err))
-			return
-		}
-	})
+	p, err := olm.NewOperatorLifecycleManagerParams(ctx, hcp, pullSecret, r.ImageMetaDataProvider)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("failed to create OperatorLifecycleManagerParams: %w", err))
+	}
 
 	// Check if the defaultSources are disabled
 	if err := r.client.Get(ctx, client.ObjectKeyFromObject(operatorHub), operatorHub); err != nil {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift/hypershift/support/globalconfig"
 	fakereleaseprovider "github.com/openshift/hypershift/support/releaseinfo/fake"
 	supportutil "github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/util/fakeimagemetadataprovider"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -36,8 +37,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	"github.com/opencontainers/go-digest"
 )
 
 type testClient struct {
@@ -134,19 +133,14 @@ var cpObjects = []client.Object{
 // for the initial objects.
 func TestReconcileErrorHandling(t *testing.T) {
 	// get initial number of creates with no get errors
+	imageMetaDataProvider := fakeimagemetadataprovider.FakeRegistryClientImageMetadataProviderHCCO{}
+
 	var totalCreates int
 	{
 		fakeClient := &testClient{
 			Client: fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(initialObjects...).WithStatusSubresource(&configv1.Infrastructure{}).Build(),
 		}
 		uncachedClient := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects().Build()
-
-		fakeDigestLister := func(ctx context.Context, image string, pullSecret []byte) (digest.Digest, error) {
-			return "", nil
-		}
-		imageMetaDataProvider := supportutil.RegistryClientImageMetadataProvider{
-			OpenShiftImageRegistryOverrides: map[string][]string{},
-		}
 
 		r := &reconciler{
 			client:                 fakeClient,
@@ -158,8 +152,7 @@ func TestReconcileErrorHandling(t *testing.T) {
 			hcpName:                "foo",
 			hcpNamespace:           "bar",
 			releaseProvider:        &fakereleaseprovider.FakeReleaseProvider{},
-			DigestListerFN:         fakeDigestLister,
-			ImageMetaDataProvider:  imageMetaDataProvider,
+			ImageMetaDataProvider:  &imageMetaDataProvider,
 		}
 		_, err := r.Reconcile(context.Background(), controllerruntime.Request{})
 		if err != nil {
@@ -183,6 +176,7 @@ func TestReconcileErrorHandling(t *testing.T) {
 			hcpName:                "foo",
 			hcpNamespace:           "bar",
 			releaseProvider:        &fakereleaseprovider.FakeReleaseProvider{},
+			ImageMetaDataProvider:  &imageMetaDataProvider,
 		}
 		r.Reconcile(context.Background(), controllerruntime.Request{})
 		if totalCreates-fakeClient.getErrorCount != fakeClient.createCount {
@@ -201,9 +195,7 @@ func TestReconcileOLM(t *testing.T) {
 	ctx := context.Background()
 	pullSecret := fakePullSecret()
 
-	fakeDigestLister := func(ctx context.Context, image string, pullSecret []byte) (digest.Digest, error) {
-		return "", nil
-	}
+	imageMetaDataProvider := fakeimagemetadataprovider.FakeRegistryClientImageMetadataProviderHCCO{}
 
 	testCases := []struct {
 		name                string
@@ -289,14 +281,15 @@ func TestReconcileOLM(t *testing.T) {
 		cpClient:               cpClient,
 		CreateOrUpdateProvider: &simpleCreateOrUpdater{},
 		rootCA:                 "fake",
+		ImageMetaDataProvider:  &imageMetaDataProvider,
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			errs = append(errs, r.reconcileOLM(ctx, hcp, pullSecret, fakeDigestLister)...)
+			errs = append(errs, r.reconcileOLM(ctx, hcp, pullSecret)...)
 			hcp.Spec.Configuration = tc.hcpClusterConfig
 			hcp.Spec.OLMCatalogPlacement = tc.olmCatalogPlacement
-			errs = append(errs, r.reconcileOLM(ctx, hcp, pullSecret, fakeDigestLister)...)
+			errs = append(errs, r.reconcileOLM(ctx, hcp, pullSecret)...)
 			g.Expect(errs).To(BeEmpty(), "unexpected errors")
 			hcOpHub := manifests.OperatorHub()
 			err := r.client.Get(ctx, client.ObjectKeyFromObject(hcOpHub), hcOpHub)

--- a/control-plane-operator/hostedclusterconfigoperator/operator/config.go
+++ b/control-plane-operator/hostedclusterconfigoperator/operator/config.go
@@ -11,7 +11,6 @@ import (
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/labelenforcingclient"
 	"github.com/openshift/hypershift/support/releaseinfo"
-	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
 
@@ -74,8 +73,7 @@ type HostedClusterConfigOperatorConfig struct {
 	OAuthPort                    int32
 	OperateOnReleaseImage        string
 	EnableCIDebugOutput          bool
-	ListDigestsFN                registryclient.DigestListerFN
-	ImageMetaDataProvider        util.RegistryClientImageMetadataProvider
+	ImageMetaDataProvider        util.ImageMetadataProvider
 
 	kubeClient kubeclient.Interface
 }

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -389,6 +389,18 @@ func NewStartCommand() *cobra.Command {
 			imageRegistryOverrides = util.ConvertImageRegistryOverrideStringToMap(openShiftImgOverrides)
 		}
 
+		if len(registryOverrides) > 0 {
+			if imageRegistryOverrides == nil {
+				imageRegistryOverrides = map[string][]string{}
+			}
+			for registry, override := range registryOverrides {
+				if _, exists := imageRegistryOverrides[registry]; !exists {
+					imageRegistryOverrides[registry] = []string{}
+				}
+				imageRegistryOverrides[registry] = append(imageRegistryOverrides[registry], override)
+			}
+		}
+
 		coreReleaseProvider := &releaseinfo.StaticProviderDecorator{
 			Delegate: &releaseinfo.CachedProvider{
 				Inner: &releaseinfo.RegistryClientProvider{},

--- a/docs/content/contribute/index.md
+++ b/docs/content/contribute/index.md
@@ -8,9 +8,9 @@ Thanks for your interest in contributing to HyperShift. Here are some guidelines
 ## Prior to Submitting a Pull Request
 1. Prior to committing your code
    1. Install `precommit`. The precommit hooks run on pre-commit and pre-push. The hooks will catch spelling mistakes,
-   make verify issues, unit test issues, and more. 
+   make verify issues, unit test issues, and more.
         1. Instructions for installing `precommit` can be found [here](https://pre-commit.com/#install).
-        2. Tips on using `precommit` hooks in the HyperShift repo cna be found [here](./precommit-hook-help.md).
+        2. Tips on using `precommit` hooks in the HyperShift repo can be found [here](./precommit-hook-help.md).
    2. Run `make pre-commit`. This updates all Golang and API dependencies, builds the source code, builds the e2e tests, verifies source code format, and runs all unit tests. This will help catch issues before committing so that the verify and unit test CI jobs will not fail on your PR.
 2. Before submitting your pull request on GitHub, look at your changes and try to view them from the eyes of a reviewer.
     1. Try to find the aspects that might not immediately make sense for someone else and explain them in the pull request description.

--- a/support/controlplane-component/controlplane-component.go
+++ b/support/controlplane-component/controlplane-component.go
@@ -11,7 +11,6 @@ import (
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/metrics"
-	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
 
@@ -47,8 +46,6 @@ type ControlPlaneContext struct {
 	UserReleaseImageProvider imageprovider.ReleaseImageProvider
 	// ImageMetadataProvider returns metadata for a given release image using the given pull secret.
 	ImageMetadataProvider util.ImageMetadataProvider
-	// DigestLister function returns the digest for a given release image using the given pull secret.
-	DigestLister registryclient.DigestListerFN
 
 	// InfraStatus contains all the information about the Hosted cluster's infra services.
 	InfraStatus infra.InfrastructureStatus
@@ -56,7 +53,7 @@ type ControlPlaneContext struct {
 	SetDefaultSecurityContext bool
 	// EnableCIDebugOutput enable extra debug logs.
 	EnableCIDebugOutput bool
-	// MetricsSet  sepcifies which metrics to use in the service/pod-monitors.
+	// MetricsSet  specifies which metrics to use in the service/pod-monitors.
 	MetricsSet metrics.MetricsSet
 
 	// This is needed for the generic unit test, so we can always generate a fixture for the components deployment/statefulset.
@@ -72,7 +69,6 @@ type WorkloadContext struct {
 	ReleaseImageProvider     imageprovider.ReleaseImageProvider
 	UserReleaseImageProvider imageprovider.ReleaseImageProvider
 	ImageMetadataProvider    util.ImageMetadataProvider
-	DigestLister             registryclient.DigestListerFN
 
 	InfraStatus               infra.InfrastructureStatus
 	SetDefaultSecurityContext bool
@@ -92,7 +88,6 @@ func (cp *ControlPlaneContext) workloadContext() WorkloadContext {
 		EnableCIDebugOutput:       cp.EnableCIDebugOutput,
 		MetricsSet:                cp.MetricsSet,
 		ImageMetadataProvider:     cp.ImageMetadataProvider,
-		DigestLister:              cp.DigestLister,
 	}
 }
 

--- a/support/controlplane-component/deployment.go
+++ b/support/controlplane-component/deployment.go
@@ -15,7 +15,7 @@ import (
 )
 
 type WorkloadProvider[T client.Object] interface {
-	// NewObject returns a new object of the generic type. This is useful when gettting/deleting the workload.
+	// NewObject returns a new object of the generic type. This is useful when getting/deleting the workload.
 	NewObject() T
 	// LoadManifest know how to load the correct workload manifest and return a workload object of the correct type.
 	LoadManifest(componentName string) (T, error)
@@ -24,7 +24,7 @@ type WorkloadProvider[T client.Object] interface {
 	PodTemplateSpec(object T) *corev1.PodTemplateSpec
 	// PodTemplateSpec knows how to extract replicas field from the given workload object.
 	Replicas(object T) *int32
-	// ApplyOptionsTo knows how to apply the gived deploymentConfig options to the given workload object.
+	// ApplyOptionsTo knows how to apply the given deploymentConfig options to the given workload object.
 	// TODO(Mulham): remove all usage of deploymentConfig in cpov2 and remove this function eventually.
 	ApplyOptionsTo(cpContext ControlPlaneContext, object T, oldObject T, deploymentConfig *config.DeploymentConfig)
 

--- a/support/releaseinfo/registryclient/client.go
+++ b/support/releaseinfo/registryclient/client.go
@@ -27,7 +27,6 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/registry/client/transport"
-	"github.com/opencontainers/go-digest"
 )
 
 const (
@@ -439,26 +438,3 @@ func GetCorrectArchImage(ctx context.Context, component string, imageRef string,
 
 	return imageRef, nil
 }
-
-func GetListDigest(ctx context.Context, imageRef string, pullSecret []byte) (digest.Digest, error) {
-	repo, dockerImageRef, err := GetRepoSetup(ctx, imageRef, pullSecret)
-	if err != nil {
-		return "", fmt.Errorf("failed to get repo setup: %v", err)
-	}
-
-	var srcDigest digest.Digest
-	if len(dockerImageRef.ID) > 0 {
-		srcDigest = digest.Digest(dockerImageRef.ID)
-	} else if len(dockerImageRef.Tag) > 0 {
-		desc, err := repo.Tags(ctx).Get(ctx, dockerImageRef.Tag)
-		if err != nil {
-			return "", err
-		}
-		srcDigest = desc.Digest
-	} else {
-		return "", fmt.Errorf("no tag or digest specified")
-	}
-	return srcDigest, nil
-}
-
-type DigestListerFN = func(ctx context.Context, image string, pullSecret []byte) (digest.Digest, error)

--- a/support/util/fakeimagemetadataprovider/fakeimagemetadataprovider.go
+++ b/support/util/fakeimagemetadataprovider/fakeimagemetadataprovider.go
@@ -8,6 +8,9 @@ import (
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
 
+	"github.com/openshift/api/image/docker10"
+
+	"github.com/blang/semver"
 	"github.com/docker/distribution"
 	"github.com/opencontainers/go-digest"
 )
@@ -62,4 +65,39 @@ func (f *FakeRegistryClientImageMetadataProvider) GetMetadata(ctx context.Contex
 
 func (f *FakeRegistryClientImageMetadataProvider) GetOverride(ctx context.Context, imageRef string, pullSecret []byte) (*reference.DockerImageReference, error) {
 	return f.Ref, nil
+}
+
+type FakeRegistryClientImageMetadataProviderHCCO struct {
+}
+
+func (f *FakeRegistryClientImageMetadataProviderHCCO) GetDigest(ctx context.Context, imageRef string, pullSecret []byte) (digest.Digest, *reference.DockerImageReference, error) {
+	dockerImageRef := &reference.DockerImageReference{
+		Registry:  "registry.redhat.io",
+		Namespace: "redhat",
+	}
+	return "", dockerImageRef, nil
+}
+
+func (f *FakeRegistryClientImageMetadataProviderHCCO) ImageMetadata(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, error) {
+	return &dockerv1client.DockerImageConfig{}, nil
+}
+
+func (f *FakeRegistryClientImageMetadataProviderHCCO) GetManifest(ctx context.Context, imageRef string, pullSecret []byte) (distribution.Manifest, error) {
+	return &FakeManifest{}, nil
+}
+
+func (f *FakeRegistryClientImageMetadataProviderHCCO) GetMetadata(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, []distribution.Descriptor, distribution.BlobStore, error) {
+	imageConfig := &dockerv1client.DockerImageConfig{
+		Config: &docker10.DockerConfig{
+			Labels: map[string]string{
+				"io.openshift.release": semver.MustParse("4.18.0").String(),
+			},
+		},
+	}
+
+	return imageConfig, []distribution.Descriptor{}, nil, nil
+}
+
+func (f *FakeRegistryClientImageMetadataProviderHCCO) GetOverride(ctx context.Context, imageRef string, pullSecret []byte) (*reference.DockerImageReference, error) {
+	return &reference.DockerImageReference{}, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

- We should use the registry overrides if provided when automatically retrieving the latest available catalog images, this can cause trouble when the pullsecret doesn't give access to the default redhat registry expected ie 'registry.redhat.io/redhat'

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.