### PR TITLE
CNTRLPLANE-109: Update Azure API for Phase 3 Managed Identity Work

### DIFF
--- a/api/hypershift/v1beta1/azure.go
+++ b/api/hypershift/v1beta1/azure.go
@@ -489,6 +489,20 @@ type ManagedIdentity struct {
 	// +kubebuilder:validation:Enum:=utf-8;hex;base64
 	// +kubebuilder:default:="utf-8"
 	ObjectEncoding ObjectEncodingFormat `json:"objectEncoding"`
+
+	// credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+	// format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+	// ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+	//
+	// More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+	//
+	// credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+	// credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+	//
+	// TODO set the validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=127
+	// TODO set validation:Pattern=`^[a-zA-Z0-9-]+$`
+	CredentialsSecretName string `json:"credentialsSecretName"`
 }
 
 // ControlPlaneManagedIdentities contains the managed identities on the HCP control plane needing to authenticate with

--- a/api/hypershift/v1beta1/azure.go
+++ b/api/hypershift/v1beta1/azure.go
@@ -463,15 +463,17 @@ type AzureResourceManagedIdentities struct {
 // used, by an HCP component, to authenticate with the Azure API.
 type ManagedIdentity struct {
 	// clientID is the client ID of a managed identity.
+	// Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+	// removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
 	//
 	// +kubebuilder:validation:XValidation:rule="self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')",message="the client ID of a managed identity must be a valid UUID. It should be 5 groups of hyphen separated hexadecimal characters in the form 8-4-4-4-12."
-	// +kubebuilder:validation:Required
 	ClientID string `json:"clientID"`
 
 	// certificateName is the name of the certificate backing the managed identity. This certificate is expected to
 	// reside in an Azure Key Vault on the management cluster.
+	// Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+	// removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
 	//
-	// +kubebuilder:validation:Required
 	CertificateName string `json:"certificateName"`
 
 	// objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AROHCPManagedIdentities.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AROHCPManagedIdentities.yaml
@@ -3051,10 +3051,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3062,6 +3066,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3087,6 +3103,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3098,10 +3115,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3109,6 +3130,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3134,6 +3167,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3144,10 +3178,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3155,6 +3193,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3180,6 +3230,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3190,10 +3241,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3201,6 +3256,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3226,6 +3293,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3236,10 +3304,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3247,6 +3319,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3272,6 +3356,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3282,10 +3367,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3293,6 +3382,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3318,6 +3419,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3350,10 +3452,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3361,6 +3467,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3386,6 +3504,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3397,10 +3516,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3408,6 +3531,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3433,6 +3568,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -4162,16 +4298,32 @@ spec:
                                 description: |-
                                   certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                   reside in an Azure Key Vault on the management cluster.
+                                  Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                  removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                 type: string
                               clientID:
-                                description: clientID is the client ID of a managed
-                                  identity.
+                                description: |-
+                                  clientID is the client ID of a managed identity.
+                                  Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                  removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                 type: string
                                 x-kubernetes-validations:
                                 - message: the client ID of a managed identity must
                                     be a valid UUID. It should be 5 groups of hyphen
                                     separated hexadecimal characters in the form 8-4-4-4-12.
                                   rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                              credentialsSecretName:
+                                description: |
+                                  credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                  format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                  ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                  More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                  credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                  credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                maxLength: 127
+                                type: string
                               objectEncoding:
                                 allOf:
                                 - enum:
@@ -4197,6 +4349,7 @@ spec:
                             required:
                             - certificateName
                             - clientID
+                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AROHCPManagedIdentities.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AROHCPManagedIdentities.yaml
@@ -2940,10 +2940,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -2951,6 +2955,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -2976,6 +2992,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -2987,10 +3004,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -2998,6 +3019,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3023,6 +3056,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3033,10 +3067,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3044,6 +3082,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3069,6 +3119,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3079,10 +3130,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3090,6 +3145,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3115,6 +3182,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3125,10 +3193,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3136,6 +3208,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3161,6 +3245,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3171,10 +3256,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3182,6 +3271,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3207,6 +3308,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3239,10 +3341,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3250,6 +3356,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3275,6 +3393,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3286,10 +3405,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3297,6 +3420,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3322,6 +3457,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -4027,16 +4163,32 @@ spec:
                                 description: |-
                                   certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                   reside in an Azure Key Vault on the management cluster.
+                                  Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                  removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                 type: string
                               clientID:
-                                description: clientID is the client ID of a managed
-                                  identity.
+                                description: |-
+                                  clientID is the client ID of a managed identity.
+                                  Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                  removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                 type: string
                                 x-kubernetes-validations:
                                 - message: the client ID of a managed identity must
                                     be a valid UUID. It should be 5 groups of hyphen
                                     separated hexadecimal characters in the form 8-4-4-4-12.
                                   rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                              credentialsSecretName:
+                                description: |
+                                  credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                  format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                  ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                  More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                  credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                  credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                maxLength: 127
+                                type: string
                               objectEncoding:
                                 allOf:
                                 - enum:
@@ -4062,6 +4214,7 @@ spec:
                             required:
                             - certificateName
                             - clientID
+                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/client/applyconfiguration/hypershift/v1beta1/managedidentity.go
+++ b/client/applyconfiguration/hypershift/v1beta1/managedidentity.go
@@ -24,9 +24,10 @@ import (
 // ManagedIdentityApplyConfiguration represents an declarative configuration of the ManagedIdentity type for use
 // with apply.
 type ManagedIdentityApplyConfiguration struct {
-	ClientID        *string                       `json:"clientID,omitempty"`
-	CertificateName *string                       `json:"certificateName,omitempty"`
-	ObjectEncoding  *v1beta1.ObjectEncodingFormat `json:"objectEncoding,omitempty"`
+	ClientID              *string                       `json:"clientID,omitempty"`
+	CertificateName       *string                       `json:"certificateName,omitempty"`
+	ObjectEncoding        *v1beta1.ObjectEncodingFormat `json:"objectEncoding,omitempty"`
+	CredentialsSecretName *string                       `json:"credentialsSecretName,omitempty"`
 }
 
 // ManagedIdentityApplyConfiguration constructs an declarative configuration of the ManagedIdentity type for use with
@@ -56,5 +57,13 @@ func (b *ManagedIdentityApplyConfiguration) WithCertificateName(value string) *M
 // If called multiple times, the ObjectEncoding field is set to the value of the last call.
 func (b *ManagedIdentityApplyConfiguration) WithObjectEncoding(value v1beta1.ObjectEncodingFormat) *ManagedIdentityApplyConfiguration {
 	b.ObjectEncoding = &value
+	return b
+}
+
+// WithCredentialsSecretName sets the CredentialsSecretName field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the CredentialsSecretName field is set to the value of the last call.
+func (b *ManagedIdentityApplyConfiguration) WithCredentialsSecretName(value string) *ManagedIdentityApplyConfiguration {
+	b.CredentialsSecretName = &value
 	return b
 }

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_complicated_invocation_from_bryan.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_complicated_invocation_from_bryan.yaml
@@ -77,26 +77,32 @@ spec:
           cloudProvider:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           controlPlaneOperator:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           disk:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           file:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           imageRegistry:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           ingress:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           managedIdentitiesKeyVault:
             name: ""
@@ -104,10 +110,12 @@ spec:
           network:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           nodePoolManagement:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
         dataPlane:
           diskMSIClientID: ""

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_create_with_a_ure_marketplace_image.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_create_with_a_ure_marketplace_image.yaml
@@ -44,26 +44,32 @@ spec:
           cloudProvider:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           controlPlaneOperator:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           disk:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           file:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           imageRegistry:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           ingress:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           managedIdentitiesKeyVault:
             name: ""
@@ -71,10 +77,12 @@ spec:
           network:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           nodePoolManagement:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
         dataPlane:
           diskMSIClientID: ""

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -77,26 +77,32 @@ spec:
           cloudProvider:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           controlPlaneOperator:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           disk:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           file:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           imageRegistry:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           ingress:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           managedIdentitiesKeyVault:
             name: ""
@@ -104,10 +110,12 @@ spec:
           network:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           nodePoolManagement:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
         dataPlane:
           diskMSIClientID: ""

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_ones.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_ones.yaml
@@ -77,26 +77,32 @@ spec:
           cloudProvider:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           controlPlaneOperator:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           disk:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           file:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           imageRegistry:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           ingress:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           managedIdentitiesKeyVault:
             name: ""
@@ -104,10 +110,12 @@ spec:
           network:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
           nodePoolManagement:
             certificateName: ""
             clientID: ""
+            credentialsSecretName: ""
             objectEncoding: ""
         dataPlane:
           diskMSIClientID: ""

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
@@ -3532,10 +3532,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3543,6 +3547,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3568,6 +3584,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3579,10 +3596,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3590,6 +3611,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3615,6 +3648,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3625,10 +3659,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3636,6 +3674,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3661,6 +3711,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3671,10 +3722,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3682,6 +3737,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3707,6 +3774,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3717,10 +3785,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3728,6 +3800,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3753,6 +3837,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3763,10 +3848,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3774,6 +3863,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3799,6 +3900,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3831,10 +3933,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3842,6 +3948,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3867,6 +3985,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3878,10 +3997,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3889,6 +4012,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3914,6 +4049,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -5130,16 +5266,32 @@ spec:
                                 description: |-
                                   certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                   reside in an Azure Key Vault on the management cluster.
+                                  Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                  removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                 type: string
                               clientID:
-                                description: clientID is the client ID of a managed
-                                  identity.
+                                description: |-
+                                  clientID is the client ID of a managed identity.
+                                  Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                  removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                 type: string
                                 x-kubernetes-validations:
                                 - message: the client ID of a managed identity must
                                     be a valid UUID. It should be 5 groups of hyphen
                                     separated hexadecimal characters in the form 8-4-4-4-12.
                                   rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                              credentialsSecretName:
+                                description: |
+                                  credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                  format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                  ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                  More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                  credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                  credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                maxLength: 127
+                                type: string
                               objectEncoding:
                                 allOf:
                                 - enum:
@@ -5165,6 +5317,7 @@ spec:
                             required:
                             - certificateName
                             - clientID
+                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
@@ -3514,10 +3514,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3525,6 +3529,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3550,6 +3566,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3561,10 +3578,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3572,6 +3593,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3597,6 +3630,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3607,10 +3641,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3618,6 +3656,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3643,6 +3693,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3653,10 +3704,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3664,6 +3719,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3689,6 +3756,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3699,10 +3767,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3710,6 +3782,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3735,6 +3819,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3745,10 +3830,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3756,6 +3845,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3781,6 +3882,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3813,10 +3915,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3824,6 +3930,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3849,6 +3967,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3860,10 +3979,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3871,6 +3994,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3896,6 +4031,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -5112,16 +5248,32 @@ spec:
                                 description: |-
                                   certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                   reside in an Azure Key Vault on the management cluster.
+                                  Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                  removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                 type: string
                               clientID:
-                                description: clientID is the client ID of a managed
-                                  identity.
+                                description: |-
+                                  clientID is the client ID of a managed identity.
+                                  Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                  removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                 type: string
                                 x-kubernetes-validations:
                                 - message: the client ID of a managed identity must
                                     be a valid UUID. It should be 5 groups of hyphen
                                     separated hexadecimal characters in the form 8-4-4-4-12.
                                   rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                              credentialsSecretName:
+                                description: |
+                                  credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                  format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                  ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                  More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                  credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                  credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                maxLength: 127
+                                type: string
                               objectEncoding:
                                 allOf:
                                 - enum:
@@ -5147,6 +5299,7 @@ spec:
                             required:
                             - certificateName
                             - clientID
+                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
@@ -3421,10 +3421,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3432,6 +3436,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3457,6 +3473,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3468,10 +3485,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3479,6 +3500,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3504,6 +3537,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3514,10 +3548,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3525,6 +3563,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3550,6 +3600,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3560,10 +3611,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3571,6 +3626,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3596,6 +3663,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3606,10 +3674,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3617,6 +3689,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3642,6 +3726,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3652,10 +3737,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3663,6 +3752,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3688,6 +3789,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3720,10 +3822,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3731,6 +3837,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3756,6 +3874,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3767,10 +3886,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3778,6 +3901,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3803,6 +3938,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -4995,16 +5131,32 @@ spec:
                                 description: |-
                                   certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                   reside in an Azure Key Vault on the management cluster.
+                                  Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                  removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                 type: string
                               clientID:
-                                description: clientID is the client ID of a managed
-                                  identity.
+                                description: |-
+                                  clientID is the client ID of a managed identity.
+                                  Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                  removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                 type: string
                                 x-kubernetes-validations:
                                 - message: the client ID of a managed identity must
                                     be a valid UUID. It should be 5 groups of hyphen
                                     separated hexadecimal characters in the form 8-4-4-4-12.
                                   rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                              credentialsSecretName:
+                                description: |
+                                  credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                  format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                  ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                  More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                  credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                  credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                maxLength: 127
+                                type: string
                               objectEncoding:
                                 allOf:
                                 - enum:
@@ -5030,6 +5182,7 @@ spec:
                             required:
                             - certificateName
                             - clientID
+                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
@@ -3403,10 +3403,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3414,6 +3418,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3439,6 +3455,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3450,10 +3467,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3461,6 +3482,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3486,6 +3519,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3496,10 +3530,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3507,6 +3545,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3532,6 +3582,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3542,10 +3593,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3553,6 +3608,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3578,6 +3645,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3588,10 +3656,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3599,6 +3671,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3624,6 +3708,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3634,10 +3719,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3645,6 +3734,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3670,6 +3771,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3702,10 +3804,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3713,6 +3819,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3738,6 +3856,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3749,10 +3868,14 @@ spec:
                                     description: |-
                                       certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                       reside in an Azure Key Vault on the management cluster.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                   clientID:
-                                    description: clientID is the client ID of a managed
-                                      identity.
+                                    description: |-
+                                      clientID is the client ID of a managed identity.
+                                      Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                      removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                     type: string
                                     x-kubernetes-validations:
                                     - message: the client ID of a managed identity
@@ -3760,6 +3883,18 @@ spec:
                                         of hyphen separated hexadecimal characters
                                         in the form 8-4-4-4-12.
                                       rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                                  credentialsSecretName:
+                                    description: |
+                                      credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                      format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                      ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                      More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                      credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                      credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                    maxLength: 127
+                                    type: string
                                   objectEncoding:
                                     allOf:
                                     - enum:
@@ -3785,6 +3920,7 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
+                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -4977,16 +5113,32 @@ spec:
                                 description: |-
                                   certificateName is the name of the certificate backing the managed identity. This certificate is expected to
                                   reside in an Azure Key Vault on the management cluster.
+                                  Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                  removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                 type: string
                               clientID:
-                                description: clientID is the client ID of a managed
-                                  identity.
+                                description: |-
+                                  clientID is the client ID of a managed identity.
+                                  Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+                                  removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
                                 type: string
                                 x-kubernetes-validations:
                                 - message: the client ID of a managed identity must
                                     be a valid UUID. It should be 5 groups of hyphen
                                     separated hexadecimal characters in the form 8-4-4-4-12.
                                   rule: self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')
+                              credentialsSecretName:
+                                description: |
+                                  credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+                                  format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+                                  ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+
+                                  More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+
+                                  credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+                                  credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+                                maxLength: 127
+                                type: string
                               objectEncoding:
                                 allOf:
                                 - enum:
@@ -5012,6 +5164,7 @@ spec:
                             required:
                             - certificateName
                             - clientID
+                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -7972,7 +7972,9 @@ string
 </em>
 </td>
 <td>
-<p>clientID is the client ID of a managed identity.</p>
+<p>clientID is the client ID of a managed identity.
+Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+removed as part of the MIWI phase 3 work, <a href="https://issues.redhat.com/browse/OCPSTRAT-1856">https://issues.redhat.com/browse/OCPSTRAT-1856</a>.</p>
 </td>
 </tr>
 <tr>
@@ -7984,7 +7986,9 @@ string
 </td>
 <td>
 <p>certificateName is the name of the certificate backing the managed identity. This certificate is expected to
-reside in an Azure Key Vault on the management cluster.</p>
+reside in an Azure Key Vault on the management cluster.
+Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+removed as part of the MIWI phase 3 work, <a href="https://issues.redhat.com/browse/OCPSTRAT-1856">https://issues.redhat.com/browse/OCPSTRAT-1856</a>.</p>
 </td>
 </tr>
 <tr>
@@ -8004,6 +8008,24 @@ unsuccessfully be read by the Secrets CSI driver and an error will occur. This e
 SecretProviderClass custom resource related to the managed identity.</p>
 <p>The default value is utf-8.</p>
 <p>See this for more info - <a href="https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md">https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>credentialsSecretName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.</p>
+<p>More info on this struct can be found here - <a href="https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156">https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156</a>.</p>
+<p>credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+credentialsSecretName must also be unique within the Azure Key Vault. See more details here - <a href="https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/">https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/</a>.</p>
+<p>TODO set the validation:MinLength=1
+TODO set validation:Pattern=<code>^[a-zA-Z0-9-]+$</code></p>
 </td>
 </tr>
 </tbody>

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/azure.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/azure.go
@@ -463,15 +463,17 @@ type AzureResourceManagedIdentities struct {
 // used, by an HCP component, to authenticate with the Azure API.
 type ManagedIdentity struct {
 	// clientID is the client ID of a managed identity.
+	// Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+	// removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
 	//
 	// +kubebuilder:validation:XValidation:rule="self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')",message="the client ID of a managed identity must be a valid UUID. It should be 5 groups of hyphen separated hexadecimal characters in the form 8-4-4-4-12."
-	// +kubebuilder:validation:Required
 	ClientID string `json:"clientID"`
 
 	// certificateName is the name of the certificate backing the managed identity. This certificate is expected to
 	// reside in an Azure Key Vault on the management cluster.
+	// Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
+	// removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
 	//
-	// +kubebuilder:validation:Required
 	CertificateName string `json:"certificateName"`
 
 	// objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
@@ -487,6 +489,20 @@ type ManagedIdentity struct {
 	// +kubebuilder:validation:Enum:=utf-8;hex;base64
 	// +kubebuilder:default:="utf-8"
 	ObjectEncoding ObjectEncodingFormat `json:"objectEncoding"`
+
+	// credentialsSecretName is the name of an Azure Key Vault secret. This field assumes the secret contains the JSON
+	// format of a UserAssignedIdentityCredentials struct. At a minimum, the secret needs to contain the ClientId,
+	// ClientSecret, AuthenticationEndpoint, NotBefore, and NotAfter, and TenantId.
+	//
+	// More info on this struct can be found here - https://github.com/Azure/msi-dataplane/blob/63fb37d3a1aaac130120624674df795d2e088083/pkg/dataplane/internal/generated_client.go#L156.
+	//
+	// credentialsSecretName must be between 1 and 127 characters and use only alphanumeric characters and hyphens.
+	// credentialsSecretName must also be unique within the Azure Key Vault. See more details here - https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.KeyVault.SecretName/.
+	//
+	// TODO set the validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=127
+	// TODO set validation:Pattern=`^[a-zA-Z0-9-]+$`
+	CredentialsSecretName string `json:"credentialsSecretName"`
 }
 
 // ControlPlaneManagedIdentities contains the managed identities on the HCP control plane needing to authenticate with


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull requests begins the phase 3 managed identity work for ARO HCP. This pull request:
- relaxes the API requirement to have a ClientID and CertificateName for any ManagedIdentity
- adds the CredentialsSecretName field which contains the name of the secret that contains the JSON format of a UserAssignedIdentityCredentials struct

Relaxing the previous API requirements should allow the HO to continue to work with phase 2 managed identity work as phase 3 work continues. In a later PR, ClientID and CertificateName will be removed and CredentialsSecretName will be required.

**Which issue(s) this PR fixes**:
Fixes [CNTRLPLANE-109](https://issues.redhat.com/browse/CNTRLPLANE-109)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.