### PR TITLE
NO-JIRA: add watch permission to SecretProviderClass in ARO

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -1273,6 +1273,7 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 					"list",
 					"create",
 					"update",
+					"watch",
 				},
 			})
 	}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2997,6 +2997,7 @@ func reconcileControlPlaneOperatorRole(role *rbacv1.Role, enableCVOManagementClu
 					"list",
 					"create",
 					"update",
+					"watch",
 				},
 			})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

fixes operator errors like:
> [operator-5cdcbcb4b7-4v2l2 operator] E0205 13:52:52.869331       1 reflector.go:158] "Unhandled Error" err="[sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:106](http://sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:106): Failed to watch *v1.SecretProviderClass: unknown (get [secretproviderclasses.secrets-store.csi.x-k8s.io](http://secretproviderclasses.secrets-store.csi.x-k8s.io/))" logger="UnhandledError"

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.