### PR TITLE
[release-4.18] OCPBUGS-49904: Use /livez for kubernetes scheduler liveness probe

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/scheduler/params.go
@@ -55,7 +55,7 @@ func NewKubeSchedulerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 		schedulerContainerMain().Name: {
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/healthz",
+					Path:   "/livez",
 					Port:   intstr.FromInt(schedulerSecurePort),
 					Scheme: corev1.URISchemeHTTPS,
 				},

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents.yaml
@@ -168,7 +168,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
-            path: /healthz
+            path: /livez
             port: 10259
             scheme: HTTPS
           initialDelaySeconds: 60

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-scheduler/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-scheduler/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         livenessProbe:
           failureThreshold: 5
           httpGet:
-            path: /healthz
+            path: /livez
             port: 10259
             scheme: HTTPS
           initialDelaySeconds: 60


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/hypershift/pull/5546