### PR TITLE
CNTRLPLANE-221: specify region in AWS credentials for operator-roles

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -985,6 +985,7 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 							NodePoolManagementARN:   "node-pool-management-arn",
 							ControlPlaneOperatorARN: "control-plane-operator-arn",
 						},
+						Region: "us-east-1",
 					},
 				},
 				Release: hyperv1.Release{


### PR DESCRIPTION
**What this PR does / why we need it**:

specify cloud region in the AWS credentials profile for AssumeRoleWithWebIdentity passed to HCP operator roles (e.g. KAS kms-provider) when the HCP is deployed in a region that lies in the AWS govcloud partition. This is necessary because if the credentials don't specify a GovCloud partition in the profile, then a session is built pointing to the default non-GovCloud regions, and that client will be unable to see and authenticate to OIDC providers inside the GovCloud partition. See the ticket for specific error details and examples against the KubeAPIServer's kms-provider

**Which issue(s) this PR fixes**
Fixes #[CNTRLPLANE-221](https://issues.redhat.com//browse/CNTRLPLANE-221)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.