### PR TITLE
OCPBUGS-49913: Honor proxy vars in the util insecure http client

### DIFF
--- a/support/util/util.go
+++ b/support/util/util.go
@@ -212,6 +212,7 @@ func ResolveDNSHostname(ctx context.Context, hostName string) error {
 func InsecureHTTPClient() *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

Honor proxy vars in the util insecure http client.

When replacing the default transport, we need to set the proxy field to net.http.ProxyFromEnvironment to honor proxy env vars. Otherwise, no proxy will be used if the *_PROXY env vars are set.

Here's the documentation of the `Proxy` field 

```go
	// Proxy specifies a function to return a proxy for a given
	// Request. If the function returns a non-nil error, the
	// request is aborted with the provided error.
	//
	// The proxy type is determined by the URL scheme. "http",
	// "https", "socks5", and "socks5h" are supported. If the scheme is empty,
	// "http" is assumed.
	// "socks5" is treated the same as "socks5h".
	//
	// If the proxy URL contains a userinfo subcomponent,
	// the proxy request will pass the username and password
	// in a Proxy-Authorization header.
	//
	// If Proxy is nil or returns a nil *URL, no proxy is used.
	Proxy func(*Request) (*url.URL, error)
```


**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.