### PR TITLE
PODAUTO-302: Relax cel rule for karpenter role to be required in an ec2NodeClass

### DIFF
--- a/karpenter-operator/controllers/karpenter/assets/adjust-cel.sh
+++ b/karpenter-operator/controllers/karpenter/assets/adjust-cel.sh
@@ -11,6 +11,7 @@ yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.ami
     {"message": "expected only \"id\" to be set", "rule": "!self.exists(x, has(x.alias) || has(x.tags) || has(x.name) || has(x.owner))"}]' -i ${SCRIPT_DIR}/karpenter.k8s.aws_ec2nodeclasses.yaml
 
 # since amiSelectorTerms is no longer required, top level validations need to be removed accordingly.
-yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.x-kubernetes-validations = [
-    {"message": "must specify exactly one of ['role', 'instanceProfile']", "rule": "(has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))"},
-    {"message": "changing from 'instanceProfile' to 'role' is not supported. You must delete and recreate this node class if you want to change this.", "rule": "(has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))"}]' -i ${SCRIPT_DIR}/karpenter.k8s.aws_ec2nodeclasses.yaml
+yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.x-kubernetes-validations = []' -i ${SCRIPT_DIR}/karpenter.k8s.aws_ec2nodeclasses.yaml
+
+# additionally, role is no longer requierd to be set, and can be set by cluster-admin.
+yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.role."x-kubernetes-validations" = [{"message": "role cannot be empty", "rule": "self != '\'''\''"}]' -i ${SCRIPT_DIR}/karpenter.k8s.aws_ec2nodeclasses.yaml

--- a/karpenter-operator/controllers/karpenter/assets/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/karpenter-operator/controllers/karpenter/assets/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -452,8 +452,6 @@ spec:
                   x-kubernetes-validations:
                     - message: role cannot be empty
                       rule: self != ''
-                    - message: immutable field changed
-                      rule: self == oldSelf
                 securityGroupSelectorTerms:
                   description: SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.
                   items:
@@ -551,11 +549,7 @@ spec:
                   type: string
               required: []
               type: object
-              x-kubernetes-validations:
-                - message: must specify exactly one of [role, instanceProfile]
-                  rule: (has(self.role) && !has(self.instanceProfile)) || (!has(self.role) && has(self.instanceProfile))
-                - message: changing from instanceProfile to role is not supported. You must delete and recreate this node class if you want to change this.
-                  rule: (has(oldSelf.role) && has(self.role)) || (has(oldSelf.instanceProfile) && has(self.instanceProfile))
+              x-kubernetes-validations: []
             status:
               description: EC2NodeClassStatus contains the resolved state of the EC2NodeClass
               properties:

--- a/karpenter-operator/controllers/karpenter/karpenter_controller.go
+++ b/karpenter-operator/controllers/karpenter/karpenter_controller.go
@@ -340,7 +340,6 @@ func (r *Reconciler) reconcileEC2NodeClassDefault(ctx context.Context, userDataS
 
 	op, err := r.CreateOrUpdate(ctx, r.GuestClient, ec2NodeClass, func() error {
 		ec2NodeClass.Spec = awskarpenterv1.EC2NodeClassSpec{
-			Role:      "KarpenterNodeRole-agl", // TODO(alberto): set a convention for this e.g. openshift-karpenter-infraID
 			UserData:  ptr.To(string(userDataSecret.Data["value"])),
 			AMIFamily: ptr.To("Custom"),
 			AMISelectorTerms: []awskarpenterv1.AMISelectorTerm{

--- a/karpenter-operator/controllers/karpenter/karpenter_controller_test.go
+++ b/karpenter-operator/controllers/karpenter/karpenter_controller_test.go
@@ -89,7 +89,6 @@ func TestReconcileEC2NodeClassDefault(t *testing.T) {
 			}
 
 			// Verify basic fields
-			g.Expect(got.Spec.Role).To(Equal("KarpenterNodeRole-agl"), "role = %v, want KarpenterNodeRole-agl", got.Spec.Role)
 			g.Expect(got.Spec.UserData).To(HaveValue(Equal("test-userdata")), "userData = %v, want test-userdata", got.Spec.UserData)
 			g.Expect(got.Spec.AMIFamily).To(HaveValue(Equal("Custom")), "amiFamily = %v, want Custom", got.Spec.AMIFamily)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In a hosted cluster with `autonode`, the role passed to the default `EC2NodeClass` that are given to instances/nodes are not required for instances to join the cluster. This PR relaxes the cel rule that requires the `role` field to be present in the EC2NodeClass custom resource and allows it to be changed.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes https://issues.redhat.com/browse/PODAUTO-302

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.