### PR TITLE
OCPBUGS-45600: override OpenShiftPodSecurityAdmission featue gate to false for HCP components

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: bootstrap-manifests,logs
-        component.hypershift.openshift.io/config-hash: 19dc307e1d8949e23415eb666c8157cb
+        component.hypershift.openshift.io/config-hash: 19dc307e1d8949e23415eb66926e10aa
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents.yaml
@@ -113,7 +113,6 @@ spec:
         - --service-cluster-ip-range=
         - --tls-min-version=VersionTLS12
         - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
-        - --feature-gates=OpenShiftPodSecurityAdmission=true
         - --feature-gates=ExternalCloudProvider=true
         - --feature-gates=ExternalCloudProviderAzure=true
         - --feature-gates=ExternalCloudProviderGCP=true
@@ -186,6 +185,7 @@ spec:
         - --feature-gates=EventedPLEG=false
         - --feature-gates=TranslateStreamCloseWebsocketRequests=false
         - --feature-gates=VolumeGroupSnapshot=false
+        - --feature-gates=OpenShiftPodSecurityAdmission=false
         command:
         - hyperkube
         - kube-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents.yaml
@@ -87,7 +87,6 @@ spec:
         - -v=2
         - --tls-min-version=VersionTLS12
         - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
-        - --feature-gates=OpenShiftPodSecurityAdmission=true
         - --feature-gates=ExternalCloudProvider=true
         - --feature-gates=ExternalCloudProviderAzure=true
         - --feature-gates=ExternalCloudProviderGCP=true
@@ -160,6 +159,7 @@ spec:
         - --feature-gates=EventedPLEG=false
         - --feature-gates=TranslateStreamCloseWebsocketRequests=false
         - --feature-gates=VolumeGroupSnapshot=false
+        - --feature-gates=OpenShiftPodSecurityAdmission=false
         command:
         - hyperkube
         - kube-scheduler

--- a/support/config/featuregates.go
+++ b/support/config/featuregates.go
@@ -19,12 +19,22 @@ func FeatureGates(fg configv1.FeatureGateSelection) []string {
 			return nil
 		}
 		for _, fgDescription := range fs.Enabled {
+			if fgDescription.FeatureGateAttributes.Name == features.FeatureGateOpenShiftPodSecurityAdmission {
+				// OpenShiftPodSecurityAdmission is a special case, authoritatively disabled below for now
+				continue
+			}
 			enabled = append(enabled, fgDescription.FeatureGateAttributes.Name)
 		}
 		for _, fgDescription := range fs.Disabled {
+			if fgDescription.FeatureGateAttributes.Name == features.FeatureGateOpenShiftPodSecurityAdmission {
+				// OpenShiftPodSecurityAdmission is a special case, authoritatively disabled below for now
+				continue
+			}
 			disabled = append(disabled, fgDescription.FeatureGateAttributes.Name)
 		}
 	}
+	// OpenShiftPodSecurityAdmission is a special case, it is always disabled for now
+	disabled = append(disabled, features.FeatureGateOpenShiftPodSecurityAdmission)
 	for _, e := range enabled {
 		result = append(result, fmt.Sprintf("%s=true", e))
 	}


### PR DESCRIPTION
Follow on to #5566

Discovered that, while the FeatureGate cluster config within the guest cluster shows that `OpenshiftPodSecurityAdmission` feature gate is disabled, we do not use that for the feature gate configuration of components on the HCP.

In the guest cluster, we use the cluster-config-operator to set the FeatureGate status based on the feature set (the right thing to do).

For the HCP, we decode the feature gates ourselves from the vendored openshift/api (the wrong thing to do).  Our vendored o/api currently has `OpenshiftPodSecurityAdmission` in the Default FeatureSet so it is being set to true for the cluster-policy-controller running in the HCP.

This results in the `pod-security.kubernetes.io/enforce` being authoritatively set all the time, rendering the KAS config defaults inert.