### PR TITLE
OCPBUGS-51039: return marshalled dataplane even if assignprincipals is false

### DIFF
--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -255,7 +255,7 @@ func (o *CreateInfraOptions) Run(ctx context.Context, l logr.Logger) (*CreateInf
 		}
 	}
 
-	if o.DataPlaneIdentitiesFile != "" && o.AssignServicePrincipalRoles {
+	if o.DataPlaneIdentitiesFile != "" {
 		managedRG := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", subscriptionID, resourceGroupName)
 
 		dataPlaneIdentitiesRaw, err := os.ReadFile(o.DataPlaneIdentitiesFile)
@@ -266,32 +266,34 @@ func (o *CreateInfraOptions) Run(ctx context.Context, l logr.Logger) (*CreateInf
 			return nil, fmt.Errorf("failed to unmarshal --data-plane-identities-file: %w", err)
 		}
 
-		// Setup Data Plane MI role assignments
-		objectID, err := findObjectId(result.DataPlaneIdentities.ImageRegistryMSIClientID)
-		if err != nil {
-			return nil, err
-		}
-		err = assignRole(objectID, "8b32b316-c2f5-4ddf-b05b-83dacd2d08b5", managedRG)
-		if err != nil {
-			return nil, err
-		}
+		if o.AssignServicePrincipalRoles {
+			// Setup Data Plane MI role assignments
+			objectID, err := findObjectId(result.DataPlaneIdentities.ImageRegistryMSIClientID)
+			if err != nil {
+				return nil, err
+			}
+			err = assignRole(objectID, "8b32b316-c2f5-4ddf-b05b-83dacd2d08b5", managedRG)
+			if err != nil {
+				return nil, err
+			}
 
-		objectID, err = findObjectId(result.DataPlaneIdentities.DiskMSIClientID)
-		if err != nil {
-			return nil, err
-		}
-		err = assignRole(objectID, "5b7237c5-45e1-49d6-bc18-a1f62f400748", managedRG)
-		if err != nil {
-			return nil, err
-		}
+			objectID, err = findObjectId(result.DataPlaneIdentities.DiskMSIClientID)
+			if err != nil {
+				return nil, err
+			}
+			err = assignRole(objectID, "5b7237c5-45e1-49d6-bc18-a1f62f400748", managedRG)
+			if err != nil {
+				return nil, err
+			}
 
-		objectID, err = findObjectId(result.DataPlaneIdentities.FileMSIClientID)
-		if err != nil {
-			return nil, err
-		}
-		err = assignRole(objectID, "0d7aedc0-15fd-4a67-a412-efad370c947e", managedRG)
-		if err != nil {
-			return nil, err
+			objectID, err = findObjectId(result.DataPlaneIdentities.FileMSIClientID)
+			if err != nil {
+				return nil, err
+			}
+			err = assignRole(objectID, "0d7aedc0-15fd-4a67-a412-efad370c947e", managedRG)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently, we don't return the dataplane identities if assignServicePricnipals is false this means that cluster creation will fail as dataplane identities will be missing

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [OCPBUGS-51039](https://issues.redhat.com/browse/OCPBUGS-51039)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.