### PR TITLE
OCPBUGS-50694: OCPBUGS-50692: Fix IsIPv4 function identifying also addresses instead of CIDRs

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
@@ -40,7 +40,7 @@ func etcdPodSelector() map[string]string {
 
 func NewEtcdParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider *imageprovider.ReleaseImageProvider) (*EtcdParams, error) {
 
-	ipv4, err := hyputils.IsIPv4(hcp.Spec.Networking.ClusterNetwork[0].CIDR.String())
+	ipv4, err := hyputils.IsIPv4CIDR(hcp.Spec.Networking.ClusterNetwork[0].CIDR.String())
 	if err != nil {
 		return nil, fmt.Errorf("error checking the ClusterNetworkCIDR: %v", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/params.go
@@ -84,7 +84,7 @@ func NewPKIParams(hcp *hyperv1.HostedControlPlane,
 	// Even with that, we cannot set more than one AdvertiseAddress so both
 	// are not supported at the same time.
 	// Check this for more info: https://github.com/kubernetes/enhancements/issues/2438
-	ipv4, err := util.IsIPv4(p.ServiceCIDR[0])
+	ipv4, err := util.IsIPv4CIDR(p.ServiceCIDR[0])
 	if err != nil || ipv4 {
 		p.NodeInternalAPIServerIP = util.AdvertiseAddressWithDefault(hcp, config.DefaultAdvertiseIPv4Address)
 	} else {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas/reconcile.go
@@ -29,7 +29,7 @@ func ReconcileKASEndpointSlice(endpointSlice *discoveryv1.EndpointSlice, address
 		endpointSlice.Labels = map[string]string{}
 	}
 	endpointSlice.Labels[discoveryv1.LabelServiceName] = "kubernetes"
-	ipv4, err := util.IsIPv4(address)
+	ipv4, err := util.IsIPv4Address(address)
 	if err != nil || ipv4 {
 		endpointSlice.AddressType = discoveryv1.AddressTypeIPv4
 	} else {

--- a/hypershift-operator/controllers/nodepool/haproxy.go
+++ b/hypershift-operator/controllers/nodepool/haproxy.go
@@ -101,7 +101,7 @@ func (r *NodePoolReconciler) reconcileHAProxyIgnitionConfig(ctx context.Context,
 	}
 
 	// This provides support for HTTP Proxy on IPv6 scenarios
-	ipv4, err := util.IsIPv4(hcluster.Spec.Networking.ServiceNetwork[0].CIDR.String())
+	ipv4, err := util.IsIPv4CIDR(hcluster.Spec.Networking.ServiceNetwork[0].CIDR.String())
 	if err != nil {
 		return "", true, fmt.Errorf("error checking the stack in the first ServiceNetworkCIDR %s: %w", hcluster.Spec.Networking.ServiceNetwork[0].CIDR.String(), err)
 	}

--- a/support/globalconfig/network.go
+++ b/support/globalconfig/network.go
@@ -32,7 +32,7 @@ func ReconcileNetworkConfig(cfg *configv1.Network, hcp *hyperv1.HostedControlPla
 	for _, entry := range hcp.Spec.Networking.ClusterNetwork {
 		hostPrefix := uint32(entry.HostPrefix)
 		if hostPrefix == 0 {
-			ipv4, err := util.IsIPv4(entry.CIDR.String())
+			ipv4, err := util.IsIPv4CIDR(entry.CIDR.String())
 			if err != nil {
 				return fmt.Errorf("the CIDR %s included in the cluster network spec is not valid: %w", entry.CIDR.String(), err)
 			}

--- a/support/util/networking.go
+++ b/support/util/networking.go
@@ -106,7 +106,7 @@ func GetAdvertiseAddress(hcp *hyperv1.HostedControlPlane, ipv4DefaultAddress, ip
 	var err error
 
 	if len(hcp.Spec.Networking.ServiceNetwork) > 0 {
-		ipv4, err = IsIPv4(hcp.Spec.Networking.ServiceNetwork[0].CIDR.String())
+		ipv4, err = IsIPv4CIDR(hcp.Spec.Networking.ServiceNetwork[0].CIDR.String())
 	} else {
 		ipv4 = true
 	}

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -286,19 +286,28 @@ func ConvertImageRegistryOverrideStringToMap(envVar string) map[string][]string 
 	return imageRegistryOverrides
 }
 
-// IsIPv4 function parse the CIDR and get the IPNet struct if the IPNet.IP cannot be converted to 4bytes format,
-// the function returns nil, if it's an IPv6 it will return nil.
-func IsIPv4(cidr string) (bool, error) {
-	_, ipnet, err := net.ParseCIDR(cidr)
+// IsIPv4CIDR checks if the input string is an IPv4 CIDR.
+func IsIPv4CIDR(input string) (bool, error) {
+	_, ipnet, err := net.ParseCIDR(input)
 	if err != nil {
-		return false, fmt.Errorf("error validating the incoming CIDR %s: %v", cidr, err)
+		return false, fmt.Errorf("error parsing input '%s': not a valid CIDR", input)
 	}
-
 	if ipnet.IP.To4() != nil {
 		return true, nil
-	} else {
-		return false, nil
 	}
+	return false, nil
+}
+
+// IsIPv4Address checks if the input string is an IPv4 address.
+func IsIPv4Address(input string) (bool, error) {
+	ip := net.ParseIP(input)
+	if ip == nil {
+		return false, fmt.Errorf("error parsing input '%s': not a valid IP address", input)
+	}
+	if ip.To4() != nil {
+		return true, nil
+	}
+	return false, nil
 }
 
 // FirstUsableIP returns the first usable IP in both, IPv4 and IPv6 stacks.

--- a/support/util/util_test.go
+++ b/support/util/util_test.go
@@ -249,57 +249,6 @@ func testDecompressFuncErr(t *testing.T, payload []byte) {
 	g.Expect(out.String()).To(BeEmpty(), "should be an empty string")
 }
 
-func TestIsIPv4(t *testing.T) {
-	type args struct {
-		cidrs []string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    bool
-		wantErr bool
-	}{
-		{
-			name: "When an ipv4 CIDR is checked by isIPv4, it should return true",
-			args: args{
-				cidrs: []string{"192.168.1.35/24", "0.0.0.0/0", "127.0.0.1/24"},
-			},
-			want:    true,
-			wantErr: false,
-		},
-		{
-			name: "When an ipv6 CIDR is checked by isIPv4, it should return false",
-			args: args{
-				cidrs: []string{"2001::/17", "2001:db8::/62", "::/0", "2000::/3"},
-			},
-			want:    false,
-			wantErr: false,
-		},
-		{
-			name: "When a non valid CIDR is checked by isIPv4, it should return an error and false",
-			args: args{
-				cidrs: []string{"192.168.35/68"},
-			},
-			want:    false,
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			for _, cidr := range tt.args.cidrs {
-				got, err := IsIPv4(cidr)
-				if (err != nil) != tt.wantErr {
-					t.Errorf("isIPv4() error = %v, wantErr %v", err, tt.wantErr)
-					return
-				}
-				if got != tt.want {
-					t.Errorf("isIPv4() = %v, want %v", got, tt.want)
-				}
-			}
-		})
-	}
-}
-
 func TestFirstUsableIP(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -482,6 +431,86 @@ func TestSanitizeIgnitionPayload(t *testing.T) {
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 			}
+		})
+	}
+}
+
+func TestIsIPv4CIDR(t *testing.T) {
+	tests := []struct {
+		input       string
+		expected    bool
+		expectError bool
+	}{
+		// Valid IPv4 CIDRs
+		{"192.168.1.0/24", true, false},
+		{"10.0.0.0/8", true, false},
+
+		// Valid IPv6 CIDRs
+		{"2001:db8::/32", false, false},
+		{"fd00::/8", false, false},
+
+		// Invalid inputs
+		{"invalid", false, true},
+		{"192.168.1.1/33", false, true},  // Invalid CIDR prefix
+		{"", false, true},                // Empty input
+		{"1234::5678::/64", false, true}, // Malformed IP
+
+		// Edge cases
+		{"0.0.0.0/0", true, false},
+		{"255.255.255.255/32", true, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			g := NewWithT(t)
+			result, err := IsIPv4CIDR(test.input)
+			if test.expectError {
+				g.Expect(err).To(HaveOccurred(), "Expected an error for input '%s'", test.input)
+			} else {
+				g.Expect(err).ToNot(HaveOccurred(), "Did not expect an error for input '%s'", test.input)
+			}
+
+			g.Expect(result).To(Equal(test.expected), "Unexpected result for input '%s'", test.input)
+		})
+	}
+}
+
+func TestIsIPv4Address(t *testing.T) {
+	tests := []struct {
+		input       string
+		expected    bool
+		expectError bool
+	}{
+		// Valid IPv4 addresses
+		{"192.168.1.1", true, false},
+		{"10.0.0.1", true, false},
+
+		// Valid IPv6 addresses
+		{"2001:db8::1", false, false},
+		{"fd00::1", false, false},
+
+		// Invalid inputs
+		{"invalid", false, true},
+		{"192.168.1.256", false, true}, // Invalid IPv4 address
+		{"", false, true},              // Empty input
+		{"1234::5678::1", false, true}, // Malformed IP
+
+		// Edge cases
+		{"0.0.0.0", true, false},
+		{"255.255.255.255", true, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			g := NewWithT(t)
+			result, err := IsIPv4Address(test.input)
+			if test.expectError {
+				g.Expect(err).To(HaveOccurred(), "Expected an error for input '%s'", test.input)
+			} else {
+				g.Expect(err).ToNot(HaveOccurred(), "Did not expect an error for input '%s'", test.input)
+			}
+
+			g.Expect(result).To(Equal(test.expected), "Unexpected result for input '%s'", test.input)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The issue deploying IPv6 disconnected clusters happens on the validation of the KASEndpointSlice (https://github.com/openshift/hypershift/blob/main/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas/reconcile.go\#L32). Now that function supports IPv4/IPv6 addresses too, so the workflow is not modified but the validation and configuration of the Kubernetes endpointSlice

**Which issue(s) this PR fixes** :
Fixes #[OCPBUGS-50692](https://issues.redhat.com//browse/OCPBUGS-50692)