### PR TITLE
CNTRLPLANE-112: Add UserAssignedIdentityCredentials environment variable for OpenShift operators

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -104,22 +104,23 @@ type Images struct {
 }
 
 type Params struct {
-	ReleaseVersion          string
-	AvailabilityProberImage string
-	HostedClusterName       string
-	CAConfigMap             string
-	CAConfigMapKey          string
-	APIServerAddress        string
-	APIServerPort           int32
-	TokenAudience           string
-	Images                  Images
-	OwnerRef                config.OwnerRef
-	DeploymentConfig        config.DeploymentConfig
-	IsPrivate               bool
-	DefaultIngressDomain    string
-	AzureClientID           string
-	AzureTenantID           string
-	AzureCertificateName    string
+	ReleaseVersion           string
+	AvailabilityProberImage  string
+	HostedClusterName        string
+	CAConfigMap              string
+	CAConfigMapKey           string
+	APIServerAddress         string
+	APIServerPort            int32
+	TokenAudience            string
+	Images                   Images
+	OwnerRef                 config.OwnerRef
+	DeploymentConfig         config.DeploymentConfig
+	IsPrivate                bool
+	DefaultIngressDomain     string
+	AzureClientID            string
+	AzureTenantID            string
+	AzureCertificateName     string
+	AzureCredentialsFilepath string
 }
 
 func init() {
@@ -171,6 +172,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 	if azureutil.IsAroHCP() {
 		p.AzureClientID = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Network.ClientID
 		p.AzureCertificateName = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Network.CertificateName
+		p.AzureCredentialsFilepath = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Network.CredentialsSecretName
 	}
 
 	p.DeploymentConfig.AdditionalLabels = map[string]string{
@@ -639,6 +641,10 @@ if [[ -n $sc ]]; then kubectl --kubeconfig $kc delete --ignore-not-found validat
 			corev1.EnvVar{
 				Name:  config.ManagedAzureSecretProviderClassEnvVarKey,
 				Value: config.ManagedAzureNetworkSecretStoreProviderClassName,
+			},
+			corev1.EnvVar{
+				Name:  config.ManagedAzureCredentialsFilePath,
+				Value: params.AzureCredentialsFilepath,
 			},
 		)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -40,21 +40,22 @@ const (
 )
 
 type Params struct {
-	IngressOperatorImage    string
-	IngressCanaryImage      string
-	HAProxyRouterImage      string
-	KubeRBACProxyImage      string
-	ReleaseVersion          string
-	TokenMinterImage        string
-	AvailabilityProberImage string
-	ProxyImage              string
-	Platform                hyperv1.PlatformType
-	DeploymentConfig        config.DeploymentConfig
-	ProxyConfig             *configv1.ProxySpec
-	NoProxy                 string
-	AzureClientID           string
-	AzureTenantID           string
-	AzureCertificateName    string
+	IngressOperatorImage     string
+	IngressCanaryImage       string
+	HAProxyRouterImage       string
+	KubeRBACProxyImage       string
+	ReleaseVersion           string
+	TokenMinterImage         string
+	AvailabilityProberImage  string
+	ProxyImage               string
+	Platform                 hyperv1.PlatformType
+	DeploymentConfig         config.DeploymentConfig
+	ProxyConfig              *configv1.ProxySpec
+	NoProxy                  string
+	AzureClientID            string
+	AzureTenantID            string
+	AzureCertificateName     string
+	AzureCredentialsFilepath string
 }
 
 func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProvider imageprovider.ReleaseImageProvider, userReleaseImageProvider imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool, platform hyperv1.PlatformType) Params {
@@ -71,6 +72,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 	if azureutil.IsAroHCP() {
 		p.AzureClientID = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Ingress.ClientID
 		p.AzureCertificateName = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Ingress.CertificateName
+		p.AzureCredentialsFilepath = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Ingress.CredentialsSecretName
 	}
 
 	if hcp.Spec.Configuration != nil {
@@ -237,7 +239,7 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, platformType hyp
 	// ARO_HCP_CLIENT_CERTIFICATE_PATH.
 	if azureutil.IsAroHCP() {
 		dep.Spec.Template.Spec.Containers[0].Env = append(dep.Spec.Template.Spec.Containers[0].Env,
-			azureutil.CreateEnvVarsForAzureManagedIdentity(params.AzureClientID, params.AzureTenantID, params.AzureCertificateName)...)
+			azureutil.CreateEnvVarsForAzureManagedIdentity(params.AzureClientID, params.AzureTenantID, params.AzureCertificateName, params.AzureCredentialsFilepath)...)
 
 		if dep.Spec.Template.Spec.Containers[0].VolumeMounts == nil {
 			dep.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{}

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
@@ -99,17 +99,18 @@ var (
 )
 
 type Params struct {
-	operatorImage        string
-	tokenMinterImage     string
-	platform             hyperv1.PlatformType
-	issuerURL            string
-	releaseVersion       string
-	registryImage        string
-	prunerImage          string
-	deploymentConfig     config.DeploymentConfig
-	AzureClientID        string
-	AzureTenantID        string
-	AzureCertificateName string
+	operatorImage            string
+	tokenMinterImage         string
+	platform                 hyperv1.PlatformType
+	issuerURL                string
+	releaseVersion           string
+	registryImage            string
+	prunerImage              string
+	deploymentConfig         config.DeploymentConfig
+	AzureClientID            string
+	AzureTenantID            string
+	AzureCertificateName     string
+	AzureCredentialsFilepath string
 }
 
 func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProvider imageprovider.ReleaseImageProvider, userReleaseImageProvider imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) Params {
@@ -152,6 +153,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 	if azureutil.IsAroHCP() {
 		params.AzureClientID = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ImageRegistry.ClientID
 		params.AzureCertificateName = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ImageRegistry.CertificateName
+		params.AzureCredentialsFilepath = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ImageRegistry.CredentialsSecretName
 	}
 
 	params.deploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
@@ -210,7 +212,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, params Params) error {
 	// ARO_HCP_CLIENT_CERTIFICATE_PATH.
 	if azureutil.IsAroHCP() {
 		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env,
-			azureutil.CreateEnvVarsForAzureManagedIdentity(params.AzureClientID, params.AzureTenantID, params.AzureCertificateName)...)
+			azureutil.CreateEnvVarsForAzureManagedIdentity(params.AzureClientID, params.AzureTenantID, params.AzureCertificateName, params.AzureCredentialsFilepath)...)
 
 		if deployment.Spec.Template.Spec.Containers[0].VolumeMounts == nil {
 			deployment.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cno/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cno/deployment.go
@@ -161,6 +161,10 @@ func buildCNOEnvVars(cpContext component.WorkloadContext) ([]corev1.EnvVar, erro
 				Name:  config.ManagedAzureSecretProviderClassEnvVarKey,
 				Value: config.ManagedAzureNetworkSecretStoreProviderClassName,
 			},
+			corev1.EnvVar{
+				Name:  config.ManagedAzureCredentialsFilePath,
+				Value: hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Network.CredentialsSecretName,
+			},
 		)
 	}
 

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -271,7 +271,7 @@ func buildAWSWebIdentityCredentials(roleArn, region string) (string, error) {
 		return "", fmt.Errorf("role arn cannot be empty in AssumeRole credentials")
 	}
 	if region == "" {
-		return "", fmt.Errorf("a region must be specified for cross-partition compatability in AssumeRole credentials")
+		return "", fmt.Errorf("a region must be specified for cross-partition compatibility in AssumeRole credentials")
 	}
 	return fmt.Sprintf(awsCredentialsTemplate, roleArn, region), nil
 }

--- a/karpenter-operator/controllers/karpenter/assets/adjust-cel.sh
+++ b/karpenter-operator/controllers/karpenter/assets/adjust-cel.sh
@@ -13,5 +13,5 @@ yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.ami
 # since amiSelectorTerms is no longer required, top level validations need to be removed accordingly.
 yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.x-kubernetes-validations = []' -i ${SCRIPT_DIR}/karpenter.k8s.aws_ec2nodeclasses.yaml
 
-# additionally, role is no longer requierd to be set, and can be set by cluster-admin.
+# additionally, role is no longer required to be set, and can be set by cluster-admin.
 yq eval '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.role."x-kubernetes-validations" = [{"message": "role cannot be empty", "rule": "self != '\'''\''"}]' -i ${SCRIPT_DIR}/karpenter.k8s.aws_ec2nodeclasses.yaml

--- a/support/azureutil/azureutil.go
+++ b/support/azureutil/azureutil.go
@@ -190,7 +190,7 @@ func GetKeyVaultAuthorizedUser() string {
 	return os.Getenv(config.AROHCPKeyVaultManagedIdentityClientID)
 }
 
-func CreateEnvVarsForAzureManagedIdentity(azureClientID, azureTenantID, azureCertificateName string) []corev1.EnvVar {
+func CreateEnvVarsForAzureManagedIdentity(azureClientID, azureTenantID, azureCertificateName, azureCredentialsName string) []corev1.EnvVar {
 	return []corev1.EnvVar{
 		{
 			Name:  config.ManagedAzureClientIdEnvVarKey,
@@ -203,6 +203,10 @@ func CreateEnvVarsForAzureManagedIdentity(azureClientID, azureTenantID, azureCer
 		{
 			Name:  config.ManagedAzureCertificatePathEnvVarKey,
 			Value: config.ManagedAzureCertificatePath + azureCertificateName,
+		},
+		{
+			Name:  config.ManagedAzureCredentialsFilePath,
+			Value: azureCredentialsName,
 		},
 	}
 }

--- a/support/azureutil/azureutil_test.go
+++ b/support/azureutil/azureutil_test.go
@@ -180,9 +180,10 @@ func TestIsAroHCP(t *testing.T) {
 
 func TestCreateEnvVarsForAzureManagedIdentity(t *testing.T) {
 	type args struct {
-		azureClientID        string
-		azureTenantID        string
-		azureCertificateName string
+		azureClientID            string
+		azureTenantID            string
+		azureCertificateName     string
+		azureCredentialsFilepath string
 	}
 	tests := []struct {
 		name string
@@ -192,9 +193,10 @@ func TestCreateEnvVarsForAzureManagedIdentity(t *testing.T) {
 		{
 			name: "returns a slice of environment variables with the azure creds",
 			args: args{
-				azureClientID:        "my-client-id",
-				azureTenantID:        "my-tenant-id",
-				azureCertificateName: "my-certificate-name",
+				azureClientID:            "my-client-id",
+				azureTenantID:            "my-tenant-id",
+				azureCertificateName:     "my-certificate-name",
+				azureCredentialsFilepath: "my-credentials-file",
 			},
 			want: []corev1.EnvVar{
 				{
@@ -209,12 +211,16 @@ func TestCreateEnvVarsForAzureManagedIdentity(t *testing.T) {
 					Name:  config.ManagedAzureCertificatePathEnvVarKey,
 					Value: config.ManagedAzureCertificatePath + "my-certificate-name",
 				},
+				{
+					Name:  config.ManagedAzureCredentialsFilePath,
+					Value: "my-credentials-file",
+				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := CreateEnvVarsForAzureManagedIdentity(tt.args.azureClientID, tt.args.azureTenantID, tt.args.azureCertificateName); !reflect.DeepEqual(got, tt.want) {
+			if got := CreateEnvVarsForAzureManagedIdentity(tt.args.azureClientID, tt.args.azureTenantID, tt.args.azureCertificateName, tt.args.azureCredentialsFilepath); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("CreateEnvVarsForAzureManagedIdentity() = %v, want %v", got, tt.want)
 			}
 		})

--- a/support/config/constants.go
+++ b/support/config/constants.go
@@ -59,6 +59,7 @@ const (
 	// management cluster's resource group in Azure.
 	AROHCPKeyVaultManagedIdentityClientID = "ARO_HCP_KEY_VAULT_USER_CLIENT_ID"
 
+	ManagedAzureCredentialsFilePath          = "MANAGED_AZURE_HCP_CREDENTIALS_FILE_PATH"
 	ManagedAzureClientIdEnvVarKey            = "ARO_HCP_MI_CLIENT_ID"
 	ManagedAzureTenantIdEnvVarKey            = "ARO_HCP_TENANT_ID"
 	ManagedAzureCertificatePathEnvVarKey     = "ARO_HCP_CLIENT_CERTIFICATE_PATH"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an environment variable on the deployment of the following operators to specify the file path for the UserAssignedIdentityCredentials: ingress, image registry, and network.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes [CNTRLPLANE-112](https://issues.redhat.com/browse/CNTRLPLANE-112)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.