### PR TITLE
OCPBUGS-50606: Fix kubeadmin login failure

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/configoperator/reconcile.go
@@ -142,6 +142,8 @@ func ReconcileRole(role *rbacv1.Role, ownerRef config.OwnerRef, platform hyperv1
 				"get",
 				"list",
 				"watch",
+				"patch",
+				"update",
 			},
 		},
 		{

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
@@ -123,7 +123,7 @@ func ReconcileDeployment(ctx context.Context, client crclient.Client, deployment
 		}
 		delete(deployment.Spec.Template.ObjectMeta.Annotations, KubeadminSecretHashAnnotation)
 	} else {
-		deployment.Spec.Template.ObjectMeta.Annotations[KubeadminSecretHashAnnotation] = util.HashSimple(kubeadminPasswordSecret.Data)
+		deployment.Spec.Template.ObjectMeta.Annotations[KubeadminSecretHashAnnotation] = kubeadminPasswordSecret.Annotations[KubeadminSecretHashAnnotation]
 	}
 
 	deployment.Spec.Template.Spec = corev1.PodSpec{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/hosted-cluster-config-operator/role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/hosted-cluster-config-operator/role.yaml
@@ -79,6 +79,8 @@ rules:
   - get
   - list
   - watch
+  - patch
+  - update
 - apiGroups:
   - cluster.x-k8s.io
   resources:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/component.go
@@ -1,7 +1,6 @@
 package oauth
 
 import (
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
 	oapiv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/oapi"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/util"
@@ -69,7 +68,6 @@ func NewComponent() component.ControlPlaneComponent {
 		).
 		WithDependencies(oapiv2.ComponentName).
 		RolloutOnConfigMapChange("oauth-openshift").
-		RolloutOnSecretChange(common.KubeadminPasswordSecret("").Name).
 		InjectKonnectivityContainer(component.KonnectivityContainerOptions{
 			Mode: component.Dual,
 			Socks5Options: component.Socks5Options{


### PR DESCRIPTION
This fixes the oauth deployment not restarting after kubeadmin-secret is created in the guest cluster by the HCCO. The HCCO now annoates the secret in the HCP namespace once it creates the secret in the guest cluster to signal a restart of the oauth deployment.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.