### PR TITLE
OCPBUGS-37323: MarkPersistentFlagRequired does not work since CLI refactoring

### DIFF
--- a/cmd/cluster/agent/create_test.go
+++ b/cmd/cluster/agent/create_test.go
@@ -21,6 +21,14 @@ func TestCreateCluster(t *testing.T) {
 	certs.UnsafeSeed(1234567890)
 	ctx := framework.InterruptableContext(context.Background())
 
+	tempDir := t.TempDir()
+
+	pullSecretFile := filepath.Join(tempDir, "pull-secret.json")
+
+	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
+		t.Fatalf("failed to write pullSecret: %v", err)
+	}
+
 	for _, testCase := range []struct {
 		name string
 		args []string
@@ -30,6 +38,8 @@ func TestCreateCluster(t *testing.T) {
 			args: []string{
 				"--api-server-address=fakeAddress", // if we don't set it, the machine's IP is looked up, which isn't portable
 				"--render-sensitive",
+				"--name=example",
+				"--pull-secret=" + pullSecretFile,
 			},
 		},
 	} {

--- a/cmd/cluster/agent/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/agent/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -8,7 +8,7 @@ status: {}
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: null
+  .dockerconfigjson: ZmFrZQ==
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/cmd/cluster/aws/create_test.go
+++ b/cmd/cluster/aws/create_test.go
@@ -180,11 +180,14 @@ func TestCreateCluster(t *testing.T) {
 				"--role-arn=fakeRoleARN",
 				"--pull-secret=" + pullSecretFile,
 				"--render-sensitive",
+				"--name=example",
 			},
 		},
 		{
 			name: "default creation flags for cesar",
 			args: []string{
+				"--pull-secret=" + pullSecretFile,
+				"--name=example",
 				"--sts-creds=" + credentialsFile,
 				"--infra-json=" + infraFile,
 				"--iam-json=" + iamFile,
@@ -206,6 +209,7 @@ func TestCreateCluster(t *testing.T) {
 		{
 			name: "minimal with KubeAPIServerDNSName",
 			args: []string{
+				"--name=example",
 				"--sts-creds=" + credentialsFile,
 				"--infra-json=" + infraFile,
 				"--iam-json=" + iamFile,

--- a/cmd/cluster/azure/create_test.go
+++ b/cmd/cluster/azure/create_test.go
@@ -66,6 +66,12 @@ func TestCreateCluster(t *testing.T) {
 		t.Fatalf("failed to write infra: %v", err)
 	}
 
+	pullSecretFile := filepath.Join(tempDir, "pull-secret.json")
+
+	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
+		t.Fatalf("failed to write pullSecret: %v", err)
+	}
+
 	for _, testCase := range []struct {
 		name string
 		args []string
@@ -77,6 +83,8 @@ func TestCreateCluster(t *testing.T) {
 				"--infra-json=" + infraFile,
 				"--rhcos-image=whatever",
 				"--render-sensitive",
+				"--name=example",
+				"--pull-secret=" + pullSecretFile,
 				"--managed-identities-file", filepath.Join(tempDir, "managedIdentities.json"),
 			},
 		},
@@ -95,6 +103,7 @@ func TestCreateCluster(t *testing.T) {
 				"--instance-type=Standard_DS2_v2",
 				"--disk-storage-account-type=Standard_LRS",
 				"--render-sensitive",
+				"--pull-secret=" + pullSecretFile,
 				"--managed-identities-file", filepath.Join(tempDir, "managedIdentities.json"),
 			},
 		},
@@ -115,6 +124,7 @@ func TestCreateCluster(t *testing.T) {
 				"--marketplace-offer=aro4",
 				"--marketplace-sku=aro_414",
 				"--marketplace-version=414.92.2024021",
+				"--pull-secret=" + pullSecretFile,
 				"--managed-identities-file", filepath.Join(tempDir, "managedIdentities.json"),
 			},
 		},
@@ -126,12 +136,16 @@ func TestCreateCluster(t *testing.T) {
 				"--rhcos-image=whatever",
 				"--render-sensitive",
 				"--availability-zones=1,2",
+				"--name=example",
+				"--pull-secret=" + pullSecretFile,
 				"--managed-identities-file", filepath.Join(tempDir, "managedIdentities.json"),
 			},
 		},
 		{
 			name: "with disabled capabilities",
 			args: []string{
+				"--name=example",
+				"--pull-secret=" + pullSecretFile,
 				"--azure-creds=" + credentialsFile,
 				"--infra-json=" + infraFile,
 				"--rhcos-image=whatever",
@@ -143,6 +157,8 @@ func TestCreateCluster(t *testing.T) {
 		{
 			name: "with KubeAPIServerDNSName",
 			args: []string{
+				"--name=example",
+				"--pull-secret=" + pullSecretFile,
 				"--azure-creds=" + credentialsFile,
 				"--infra-json=" + infraFile,
 				"--rhcos-image=whatever",

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_complicated_invocation_from_bryan.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_complicated_invocation_from_bryan.yaml
@@ -8,7 +8,7 @@ status: {}
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: null
+  .dockerconfigjson: ZmFrZQ==
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -8,7 +8,7 @@ status: {}
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: null
+  .dockerconfigjson: ZmFrZQ==
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_KubeAPIServerDNSName.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_KubeAPIServerDNSName.yaml
@@ -8,7 +8,7 @@ status: {}
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: null
+  .dockerconfigjson: ZmFrZQ==
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_ones.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_ones.yaml
@@ -8,7 +8,7 @@ status: {}
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: null
+  .dockerconfigjson: ZmFrZQ==
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_disabled_capabilities.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_disabled_capabilities.yaml
@@ -8,7 +8,7 @@ status: {}
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: null
+  .dockerconfigjson: ZmFrZQ==
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -45,7 +45,6 @@ import (
 func DefaultOptions() *RawCreateOptions {
 	return &RawCreateOptions{
 		Namespace:                      "clusters",
-		Name:                           "example",
 		ControlPlaneAvailabilityPolicy: string(hyperv1.SingleReplica),
 		ServiceCIDR:                    []string{globalconfig.DefaultIPv4ServiceCIDR},
 		ClusterCIDR:                    []string{globalconfig.DefaultIPv4ClusterCIDR},
@@ -626,6 +625,14 @@ type ValidatedCreateOptions struct {
 }
 
 func (opts *RawCreateOptions) Validate(ctx context.Context) (*ValidatedCreateOptions, error) {
+	if opts.Name == "" {
+		return nil, errors.New("--name is required")
+	}
+
+	if opts.PullSecretFile == "" {
+		return nil, errors.New("--pull-secret is required")
+	}
+
 	if opts.Wait && opts.NodePoolReplicas < 1 {
 		return nil, errors.New("--wait requires --node-pool-replicas > 0")
 	}

--- a/cmd/cluster/core/create_test.go
+++ b/cmd/cluster/core/create_test.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -180,6 +182,14 @@ func TestPrototypeResources(t *testing.T) {
 func TestValidate(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()
+	tempDir := t.TempDir()
+
+	pullSecretFile := filepath.Join(tempDir, "pull-secret.json")
+
+	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
+		t.Fatalf("failed to write pullSecret: %v", err)
+	}
+
 	tests := []struct {
 		name        string
 		rawOpts     *RawCreateOptions
@@ -190,6 +200,7 @@ func TestValidate(t *testing.T) {
 			rawOpts: &RawCreateOptions{
 				Name:                       "test-hc",
 				Namespace:                  "test-hc",
+				PullSecretFile:             pullSecretFile,
 				Arch:                       "amd64",
 				DisableClusterCapabilities: []string{"UnsupportedCapability"},
 			},
@@ -200,6 +211,7 @@ func TestValidate(t *testing.T) {
 			rawOpts: &RawCreateOptions{
 				Name:                       "test-hc",
 				Namespace:                  "test-hc",
+				PullSecretFile:             pullSecretFile,
 				Arch:                       "amd64",
 				DisableClusterCapabilities: []string{"ImageRegistry"},
 			},
@@ -210,6 +222,7 @@ func TestValidate(t *testing.T) {
 			rawOpts: &RawCreateOptions{
 				Name:                 "test-hc",
 				Namespace:            "test-hc",
+				PullSecretFile:       pullSecretFile,
 				Arch:                 "amd64",
 				KubeAPIServerDNSName: "INVALID-DNS-NAME.example.com",
 			},
@@ -220,6 +233,7 @@ func TestValidate(t *testing.T) {
 			rawOpts: &RawCreateOptions{
 				Name:                 "test-hc",
 				Namespace:            "test-hc",
+				PullSecretFile:       pullSecretFile,
 				Arch:                 "amd64",
 				KubeAPIServerDNSName: "test-dns-name.example.com",
 			},

--- a/cmd/cluster/kubevirt/create_test.go
+++ b/cmd/cluster/kubevirt/create_test.go
@@ -121,7 +121,14 @@ func TestCreateCluster(t *testing.T) {
 	utilrand.Seed(1234567890)
 	certs.UnsafeSeed(1234567890)
 	ctx := framework.InterruptableContext(context.Background())
+	tempDir := t.TempDir()
 	t.Setenv("FAKE_CLIENT", "true")
+
+	pullSecretFile := filepath.Join(tempDir, "pull-secret.json")
+
+	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
+		t.Fatalf("failed to write pullSecret: %v", err)
+	}
 
 	for _, testCase := range []struct {
 		name string
@@ -131,6 +138,8 @@ func TestCreateCluster(t *testing.T) {
 			name: "minimal flags necessary to render",
 			args: []string{
 				"--render-sensitive",
+				"--name=example",
+				"--pull-secret=" + pullSecretFile,
 			},
 		},
 		{
@@ -156,6 +165,7 @@ func TestCreateCluster(t *testing.T) {
 				"--toleration", "key=key1,value=value1,effect=noSchedule",
 				"--toleration", "key=key2,value=value2,effect=noSchedule",
 				"--render-sensitive",
+				"--pull-secret=" + pullSecretFile,
 			},
 		},
 	} {

--- a/cmd/cluster/kubevirt/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/kubevirt/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -8,7 +8,7 @@ status: {}
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: null
+  .dockerconfigjson: ZmFrZQ==
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/cmd/cluster/kubevirt/testdata/zz_fixture_TestCreateCluster_test_from_dvossel.yaml
+++ b/cmd/cluster/kubevirt/testdata/zz_fixture_TestCreateCluster_test_from_dvossel.yaml
@@ -8,7 +8,7 @@ status: {}
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: null
+  .dockerconfigjson: ZmFrZQ==
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/cmd/cluster/none/create_test.go
+++ b/cmd/cluster/none/create_test.go
@@ -20,6 +20,13 @@ func TestCreateCluster(t *testing.T) {
 	utilrand.Seed(1234567890)
 	certs.UnsafeSeed(1234567890)
 	ctx := framework.InterruptableContext(context.Background())
+	tempDir := t.TempDir()
+
+	pullSecretFile := filepath.Join(tempDir, "pull-secret.json")
+
+	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
+		t.Fatalf("failed to write pullSecret: %v", err)
+	}
 
 	for _, testCase := range []struct {
 		name string
@@ -30,6 +37,8 @@ func TestCreateCluster(t *testing.T) {
 			args: []string{
 				"--external-api-server-address=fakeAddress", // if we don't set it, the machine's IP is looked up, which isn't portable
 				"--render-sensitive",
+				"--name=example",
+				"--pull-secret=" + pullSecretFile,
 			},
 		},
 	} {

--- a/cmd/cluster/none/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/none/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -8,7 +8,7 @@ status: {}
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: null
+  .dockerconfigjson: ZmFrZQ==
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/cmd/cluster/openstack/create_test.go
+++ b/cmd/cluster/openstack/create_test.go
@@ -85,6 +85,7 @@ func TestCreateCluster(t *testing.T) {
 				"--openstack-node-image-name=rhcos",
 				"--pull-secret=" + pullSecretFile,
 				"--render-sensitive",
+				"--name=example",
 			},
 		},
 		{

--- a/cmd/cluster/powervs/create_test.go
+++ b/cmd/cluster/powervs/create_test.go
@@ -84,6 +84,12 @@ func TestCreateCluster(t *testing.T) {
 		t.Fatalf("failed to write infra: %v", err)
 	}
 
+	pullSecretFile := filepath.Join(tempDir, "pull-secret.json")
+
+	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
+		t.Fatalf("failed to write pullSecret: %v", err)
+	}
+
 	for _, testCase := range []struct {
 		name string
 		args []string
@@ -93,6 +99,8 @@ func TestCreateCluster(t *testing.T) {
 			args: []string{
 				"--infra-json=" + infraFile,
 				"--render-sensitive",
+				"--name=example",
+				"--pull-secret=" + pullSecretFile,
 			},
 		},
 	} {

--- a/cmd/cluster/powervs/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/powervs/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -8,7 +8,7 @@ status: {}
 ---
 apiVersion: v1
 data:
-  .dockerconfigjson: null
+  .dockerconfigjson: ZmFrZQ==
 kind: Secret
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
**What this PR does / why we need it**:
Enforces --name and --pull-secret flag requirements to Hypershift create cluster command since omitting them can lead to misconfigured deployments.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-37323](https://issues.redhat.com/browse/OCPBUGS-37323)

[Original closed PR](https://github.com/openshift/hypershift/pull/5618)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.