### PR TITLE
OCPBUGS-50860: Skip hashing configuration.image.imageStreamImportMode

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/mcs/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/mcs/params.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/backwardcompat"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/globalconfig"
-	"github.com/openshift/hypershift/support/util"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -47,7 +47,8 @@ func NewMCSParams(hcp *hyperv1.HostedControlPlane, rootCA, pullSecret *corev1.Se
 	image := globalconfig.ImageConfig()
 	globalconfig.ReconcileImageConfig(image, hcp)
 
-	hcConfigurationHash, err := util.HashStruct(hcp.Spec.Configuration)
+	// Some fields in the ClusterConfiguration have changes that are not backwards compatible with older versions of the CPO.
+	hcConfigurationHash, err := backwardcompat.GetBackwardCompatibleConfigHash(hcp.Spec.Configuration)
 	if err != nil {
 		return &MCSParams{}, fmt.Errorf("failed to hash HCP configuration: %w", err)
 	}

--- a/hypershift-operator/controllers/nodepool/token.go
+++ b/hypershift-operator/controllers/nodepool/token.go
@@ -9,6 +9,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
+	"github.com/openshift/hypershift/support/backwardcompat"
 	"github.com/openshift/hypershift/support/globalconfig"
 	"github.com/openshift/hypershift/support/upsert"
 	supportutil "github.com/openshift/hypershift/support/util"
@@ -101,7 +102,9 @@ func NewToken(ctx context.Context, configGenerator *ConfigGenerator, cpoCapabili
 	// This inconsistency was introduced by https://github.com/openshift/hypershift/pull/3795
 	// See reconcileTokenSecret and https://github.com/openshift/hypershift/pull/4057 for more info on how this is used.
 	// This is kept like this for now to contain the scope of the refactor and avoid backward compatibility issues.
-	hcConfigurationHash, err := supportutil.HashStruct(configGenerator.hostedCluster.Spec.Configuration)
+
+	// Some fields in the ClusterConfiguration have changes that are not backwards compatible with older versions of the CPO.
+	hcConfigurationHash, err := backwardcompat.GetBackwardCompatibleConfigHash(configGenerator.hostedCluster.Spec.Configuration)
 	if err != nil {
 		return nil, fmt.Errorf("failed to hash HostedCluster configuration: %w", err)
 	}

--- a/support/backwardcompat/backwardcompat.go
+++ b/support/backwardcompat/backwardcompat.go
@@ -1,0 +1,27 @@
+package backwardcompat
+
+import (
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+	supportutil "github.com/openshift/hypershift/support/util"
+)
+
+const ImageStreamImportModeField = "imageStreamImportMode"
+
+// GetBackwardCompatibleConfigString returns a ClusterConfiguration which is backward-compatible with older CPO versions
+func GetBackwardCompatibleConfigString(stringData string) string {
+	// This PR https://github.com/openshift/api/pull/1928 introduced a string field which has no omitempty tag.
+	// This results in our mashaling transparently changing. This produces a different configuration Hash.
+	// This drops the field when it shows up as empty in the mashaled string to keep backward compatibility.
+	// Implementing this at the marshal operation level might result in undesired impact as we might potentially modify other fields and ordering is not deterministic
+	return supportutil.RemoveEmptyJSONField(stringData, ImageStreamImportModeField)
+}
+
+// GetBackwardCompatibleConfigHash returns a hash of ClusterConfiguration which is backward-compatible with CPO versions that doesn't
+// hash the ImageSpec.
+func GetBackwardCompatibleConfigHash(config *v1beta1.ClusterConfiguration) (string, error) {
+	// This PR https://github.com/openshift/api/pull/1928 introduced a string field which has no omitempty tag.
+	// This results in our mashaling transparently changing. This produces a different configuration Hash.
+	// We need to drop the field when it shows up as empty in the marshaled string to keep backward compatibility.
+	// Implementing this at the marshal operation level might result in undesired impact as we might potentially modify other fields and ordering is not deterministic
+	return supportutil.HashStructWithJSONMapper(config, supportutil.NewOmitFieldIfEmptyJSONMapper(ImageStreamImportModeField))
+}

--- a/support/backwardcompat/backwardcompat_test.go
+++ b/support/backwardcompat/backwardcompat_test.go
@@ -1,0 +1,91 @@
+package backwardcompat
+
+import (
+	"testing"
+
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/util"
+
+	v1 "github.com/openshift/api/config/v1"
+)
+
+func TestGetBackwardCompatibleConfigHash(t *testing.T) {
+	tests := []struct {
+		name                   string
+		input                  v1beta1.ClusterConfiguration
+		expectedHashedJSONE    string
+		requiresBackwardCompat bool
+	}{
+		{
+			name: "test config without an image",
+			input: v1beta1.ClusterConfiguration{
+				Proxy: &v1.ProxySpec{
+					HTTPProxy: "http://proxy.example.com",
+				},
+			},
+			expectedHashedJSONE: `{"proxy":{"httpProxy":"http://proxy.example.com"}}`,
+		},
+		{
+			name: "test config with an image and no imageStreamImportMode",
+			input: v1beta1.ClusterConfiguration{
+				Proxy: &v1.ProxySpec{
+					HTTPProxy: "http://proxy.example.com",
+				},
+				Image: &v1.ImageSpec{
+					RegistrySources: v1.RegistrySources{
+						InsecureRegistries: []string{"registry.example.com"},
+					},
+				},
+			},
+			expectedHashedJSONE:    `{"image":{"additionalTrustedCA":{"name":""},"registrySources":{"insecureRegistries":["registry.example.com"]}},"proxy":{"httpProxy":"http://proxy.example.com","trustedCA":{"name":""}}}`,
+			requiresBackwardCompat: true,
+		},
+		{
+			name: "test config with an image and imageStreamImportMode",
+			input: v1beta1.ClusterConfiguration{
+				Proxy: &v1.ProxySpec{
+					HTTPProxy: "http://proxy.example.com",
+				},
+				Image: &v1.ImageSpec{
+					RegistrySources: v1.RegistrySources{
+						InsecureRegistries: []string{"registry.example.com"},
+					},
+					ImageStreamImportMode: "",
+				},
+			},
+			expectedHashedJSONE:    `{"image":{"additionalTrustedCA":{"name":""},"registrySources":{"insecureRegistries":["registry.example.com"]}},"proxy":{"httpProxy":"http://proxy.example.com","trustedCA":{"name":""}}}`,
+			requiresBackwardCompat: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withoutBackwardCompat, err := util.HashStructWithJSONMapper(tt.input, nil)
+			if err != nil {
+				t.Errorf("error hashing without backward compatibility: %v", err)
+				return
+			}
+			withBackwardCompat, err := GetBackwardCompatibleConfigHash(&tt.input)
+			if err != nil {
+				t.Errorf("GetBackwardCompatibleConfigHash() error = %v", err)
+				return
+			}
+			if !tt.requiresBackwardCompat && withoutBackwardCompat != withBackwardCompat {
+				t.Errorf("GetBackwardCompatibleConfigHash() = %v, want %v", withBackwardCompat, withoutBackwardCompat)
+			} else if tt.requiresBackwardCompat {
+				if withoutBackwardCompat == withBackwardCompat {
+					t.Errorf("GetBackwardCompatibleConfigHash() = %v, want %v", withBackwardCompat, withoutBackwardCompat)
+				} else {
+					want, err := util.HashBytes([]byte(tt.expectedHashedJSONE))
+					if err != nil {
+						t.Errorf("error hashing wanted config: %v", err)
+						return
+					}
+					if withBackwardCompat != want {
+						t.Errorf("GetBackwardCompatibleConfigHash() = %v, want %v", withBackwardCompat, want)
+					}
+				}
+			}
+
+		})
+	}
+}

--- a/support/util/util_test.go
+++ b/support/util/util_test.go
@@ -771,3 +771,94 @@ func TestIsIPv4Address(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoveEmptyJSONField(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		field    string
+		expected string
+	}{
+		{
+			name:     "Remove empty field from JSON - at the end",
+			input:    `{"field1": "value1", "field2": ""}`,
+			field:    "field2",
+			expected: `{"field1": "value1"}`,
+		},
+		{
+			name:     "Remove empty field from JSON - at the beginning",
+			input:    `{"field1": "", "field2": "value2"}`,
+			field:    "field1",
+			expected: `{"field2": "value2"}`,
+		},
+		{
+			name:     "Remove empty field from JSON - in the middle",
+			input:    `{"field1": "value1", "field2": "", "field3": "value3"}`,
+			field:    "field2",
+			expected: `{"field1": "value1", "field3": "value3"}`,
+		},
+		{
+			name:     "Remove empty field from JSON - without spaces - at the beginning",
+			input:    `{"field1":"","field2":"value2"}`,
+			field:    "field1",
+			expected: `{"field2":"value2"}`,
+		},
+		{
+			name:     "Remove empty field from JSON - without spaces - in the middle",
+			input:    `{"field1":"value1","field2":"","field3":"value3"}`,
+			field:    "field2",
+			expected: `{"field1":"value1","field3":"value3"}`,
+		},
+		{
+			name:     "Remove empty field from JSON - without spaces - at the end",
+			input:    `{"field1":"value1","field2":""}`,
+			field:    "field2",
+			expected: `{"field1":"value1"}`,
+		},
+
+		{
+			name:     "Keep non-empty field from JSON",
+			input:    `{"field1": "value1", "field2": "value2"}`,
+			field:    "field2",
+			expected: `{"field1": "value1", "field2": "value2"}`,
+		},
+		{
+			name:     "Remove non-existent field from JSON returns the same JSON",
+			input:    `{"field1": "value1"}`,
+			field:    "field2",
+			expected: `{"field1": "value1"}`,
+		},
+		{
+			name:     "Empty JSON returns empty JSON",
+			input:    `{}`,
+			field:    "field1",
+			expected: `{}`,
+		},
+		{
+			name:     "Empty JSON returns empty JSON - empty field",
+			input:    `{}`,
+			field:    "",
+			expected: `{}`,
+		},
+		{
+			name:     "Remove nested empty field from JSON",
+			input:    `{"field1": "value1", "field2": {"field3": ""}}`,
+			field:    "field3",
+			expected: `{"field1": "value1", "field2": {}}`,
+		},
+		{
+			name:     "Remove nested empty field from JSON - in the middle",
+			input:    `{"field1": "value1", "field2": {"field3": "value3", "field4": "value4", "field5": ""}}`,
+			field:    "field5",
+			expected: `{"field1": "value1", "field2": {"field3": "value3", "field4": "value4"}}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result := RemoveEmptyJSONField(test.input, test.field)
+			g.Expect(result).To(Equal(test.expected))
+		})
+	}
+}

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -1269,6 +1269,19 @@ func TestCreateClusterCustomConfig(t *testing.T) {
 
 	clusterOpts := globalOpts.DefaultClusterOptions(t)
 
+	clusterOpts.BeforeApply = func(o crclient.Object) {
+		switch hc := o.(type) {
+		case *hyperv1.HostedCluster:
+			hc.Spec.Configuration = &hyperv1.ClusterConfiguration{
+				Image: &configv1.ImageSpec{
+					RegistrySources: configv1.RegistrySources{
+						BlockedRegistries: []string{"badregistry.io"},
+					},
+				},
+			}
+		}
+	}
+
 	// find kms key ARN using alias
 	kmsKeyArn, err := e2eutil.GetKMSKeyArn(clusterOpts.AWSPlatform.Credentials.AWSCredentialsFile, clusterOpts.AWSPlatform.Region, globalOpts.ConfigurableClusterOptions.AWSKmsKeyAlias)
 	if err != nil || kmsKeyArn == nil {
@@ -1308,6 +1321,13 @@ func TestCreateClusterCustomConfigV2(t *testing.T) {
 				obj.Annotations = make(map[string]string)
 			}
 			obj.Annotations[hyperv1.ControlPlaneOperatorV2Annotation] = "true"
+			obj.Spec.Configuration = &hyperv1.ClusterConfiguration{
+				Image: &configv1.ImageSpec{
+					RegistrySources: configv1.RegistrySources{
+						BlockedRegistries: []string{"badregistry.io"},
+					},
+				},
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

- Skip the hashing of the `spec.configuration.image.imageStreamImportMode` field as older CPO versions don't see that field yet and if we hash it then the HO and CPO hashes will never match.
- Add a `CreateClusterWithImageConfiguration` e2e test that validates the cluster creation would fail without the hashing skipping 


>[!NOTE]
>First, I pushed the `CreateClusterWithImageConfiguration` test first without the fix to verify it's going to fail and catch the bug, and indeed it did.
>
>- [Failed Job](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_hypershift/5651/pull-ci-openshift-hypershift-main-e2e-aws-4-18/1891765234188685312/artifacts/e2e-aws-4-18/hypershift-aws-run-e2e-external/artifacts/TestCreateClusterWithImageConfiguration/)
>- [ignition-server-logs ](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_hypershift/5651/pull-ci-openshift-hypershift-main-e2e-aws-4-18/1891765234188685312/artifacts/e2e-aws-4-18/hypershift-aws-run-e2e-external/artifacts/TestCreateClusterWithImageConfiguration/namespaces/e2e-clusters-jd6tw-example-g5xv7/core/pods/logs/ignition-server-7d54c5fbbb-6dklc-ignition-server.log)
>```
>{"level":"error","ts":"2025-02-18T09:52:49Z","msg":"Reconciler error","controller":"secret","controllerGroup":"","controllerKind":"Secret","Secret":{"name":"token-example-g5xv7-us-east-1b-15d0c3a1","namespace":"e2e-clusters-jd6tw-example-g5xv7"},"namespace":"e2e-clusters-jd6tw-example-g5xv7","name":"token-example-g5xv7-us-east-1b-15d0c3a1","reconcileID":"b15397db-2c76-47e8-b3ba-e1696612099c","error":"failed to generate payload: error getting ignition payload: machine-config-server configmap is out of date, waiting for update 90058cc5 != c3711dfa","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/hypershift/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:324\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/hypershift/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:261\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/hypershift/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:222"}
>2025/02/18 09:52:51 User Agent: Ignition/2.18.0. Requested: /ignition
>2025/02/18 09:52:51 Token not found
>{"level":"debug","ts":"2025-02-18T09:52:51Z","logger":"events","msg":"Token not found in cache","type":"Warning","object":{"kind":"Secret","namespace":"e2e-clusters-jd6tw-example-g5xv7","name":"token-example-g5xv7-us-east-1a-15d0c3a1","apiVersion":"v1"},"reason":"GetPayloadFailed"}
>2025/02/18 09:52:51 User Agent: Ignition/2.18.0. Requested: /ignition
>2025/02/18 09:52:51 Token not found
>{"level":"debug","ts":"2025-02-18T09:52:51Z","logger":"events","msg":"Token not found in cache","type":"Warning","object":{"kind":"Secret","namespace":"e2e-clusters-jd6tw-example-g5xv7","name":"token-example-g5xv7-us-east-1b-15d0c3a1","apiVersion":"v1"},"reason":"GetPayloadFailed"}
>2025/02/18 09:52:56 User Agent: Ignition/2.18.0. Requested: /ignition
>```




**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes OCPBUGS-50860

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.