### PR TITLE
OCPBUGS-50915: Disable capi machineset preflights

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3426,6 +3426,7 @@ func reconcileCAPIManagerDeployment(deployment *appsv1.Deployment, hc *hyperv1.H
 							fmt.Sprintf("--leader-elect-lease-duration=%s", config.RecommendedLeaseDuration),
 							fmt.Sprintf("--leader-elect-retry-period=%s", config.RecommendedRetryPeriod),
 							fmt.Sprintf("--leader-elect-renew-deadline=%s", config.RecommendedRenewDeadline),
+							"--feature-gates=MachineSetPreflightChecks=false",
 						},
 						LivenessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{

--- a/hypershift-operator/controllers/nodepool/capi.go
+++ b/hypershift-operator/controllers/nodepool/capi.go
@@ -374,6 +374,8 @@ func (c *CAPI) reconcileMachineDeployment(ctx context.Context, log logr.Logger,
 		machineDeployment.Annotations = map[string]string{}
 	}
 	machineDeployment.Annotations[nodePoolAnnotation] = client.ObjectKeyFromObject(nodePool).String()
+	machineDeployment.Annotations[capiv1.MachineSetSkipPreflightChecksAnnotation] = string(capiv1.MachineSetPreflightCheckAll)
+
 	// Delete any paused annotation
 	delete(machineDeployment.Annotations, capiv1.PausedAnnotation)
 	if machineDeployment.GetLabels() == nil {
@@ -931,6 +933,8 @@ func (c *CAPI) reconcileMachineSet(ctx context.Context,
 		return err
 	}
 	machineSet.Annotations[nodePoolAnnotationMaxUnavailable] = strconv.Itoa(maxUnavailable)
+
+	machineSet.Annotations[capiv1.MachineSetSkipPreflightChecksAnnotation] = string(capiv1.MachineSetPreflightCheckAll)
 
 	// Set selector and template
 	machineSet.Spec.ClusterName = capiClusterName

--- a/hypershift-operator/controllers/nodepool/capi_test.go
+++ b/hypershift-operator/controllers/nodepool/capi_test.go
@@ -1456,6 +1456,8 @@ func TestCAPIReconcile(t *testing.T) {
 				g.Expect(md.Spec.Template.Spec.InfrastructureRef.Name).To(Equal(awsMachineTemplateName))
 				// Check MachineDeployment annotations
 				g.Expect(md.Annotations).To(HaveKeyWithValue(nodePoolAnnotation, "test-namespace/test-nodepool"))
+				// Check skip preflight annotation.
+				g.Expect(md.Annotations).To(HaveKeyWithValue(capiv1.MachineSetSkipPreflightChecksAnnotation, string(capiv1.MachineSetPreflightCheckAll)))
 
 				// Check MachineDeployment spec.
 				g.Expect(md.Spec.Strategy.Type).To(Equal(capiv1.MachineDeploymentStrategyType("RollingUpdate")))


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
This enabled machineset preflights by default https://github.com/kubernetes-sigs/cluster-api/pull/11228

We want to disable this functionality in hcp because of the following reasons:

- MachineSetPreflightCheckControlPlaneIsStable
We currently don't express intent for a version via spec.version but via spec.release
- MachineSetPreflightCheckKubernetesVersionSkew
We preserve our ability to control our skew policy at a higher layer i.e. NodePool API
- MachineSetPreflightCheckKubeadmVersionSkew
We don't run kubeadmin at all.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.