### PR TITLE
CNTRLPLANE-112: Enable image registry to use managed identity v3 

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -4252,7 +4252,7 @@ func (r *HostedControlPlaneReconciler) reconcileImageRegistryOperator(ctx contex
 	if hyperazureutil.IsAroHCP() {
 		imageRegistrySecretProviderClass := manifests.ManagedAzureSecretProviderClass(config.ManagedAzureImageRegistrySecretStoreProviderClassName, hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r, imageRegistrySecretProviderClass, func() error {
-			secretproviderclass.ReconcileManagedAzureSecretProviderClass(imageRegistrySecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ImageRegistry)
+			secretproviderclass.ReconcileManagedAzureSecretProviderClass(imageRegistrySecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ImageRegistry, true)
 			return nil
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile image registry operator secret provider class: %w", err)

--- a/support/azureutil/azureutil.go
+++ b/support/azureutil/azureutil.go
@@ -206,7 +206,7 @@ func CreateEnvVarsForAzureManagedIdentity(azureClientID, azureTenantID, azureCer
 		},
 		{
 			Name:  config.ManagedAzureCredentialsFilePath,
-			Value: azureCredentialsName,
+			Value: config.ManagedAzureCertificatePath + azureCredentialsName,
 		},
 	}
 }

--- a/support/azureutil/azureutil_test.go
+++ b/support/azureutil/azureutil_test.go
@@ -213,7 +213,7 @@ func TestCreateEnvVarsForAzureManagedIdentity(t *testing.T) {
 				},
 				{
 					Name:  config.ManagedAzureCredentialsFilePath,
-					Value: "my-credentials-file",
+					Value: config.ManagedAzureCertificatePath + "my-credentials-file",
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables image registry to use managed identity v3 

**Which issue(s) this PR fixes**:
Part of [CNTRLPLANE-112](https://issues.redhat.com/browse/CNTRLPLANE-112)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.