### PR TITLE
NO-JIRA: Add omitempty to CredentialsSecretName 

### DIFF
--- a/api/hypershift/v1beta1/azure.go
+++ b/api/hypershift/v1beta1/azure.go
@@ -501,7 +501,7 @@ type ManagedIdentity struct {
 	// TODO set the validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=127
 	// TODO set validation:Pattern=`^[a-zA-Z0-9-]+$`
-	CredentialsSecretName string `json:"credentialsSecretName"`
+	CredentialsSecretName string `json:"credentialsSecretName,omitempty"`
 }
 
 // ControlPlaneManagedIdentities contains the managed identities on the HCP control plane needing to authenticate with

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -3107,7 +3107,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3171,7 +3170,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3234,7 +3232,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3297,7 +3294,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3360,7 +3356,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3423,7 +3418,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3508,7 +3502,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3572,7 +3565,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -4361,7 +4353,6 @@ spec:
                             required:
                             - certificateName
                             - clientID
-                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -3148,7 +3148,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3212,7 +3211,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3275,7 +3273,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3338,7 +3335,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3401,7 +3397,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3464,7 +3459,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3549,7 +3543,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3613,7 +3606,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -4394,7 +4386,6 @@ spec:
                             required:
                             - certificateName
                             - clientID
-                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DisableClusterCapabilities.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DisableClusterCapabilities.yaml
@@ -3131,7 +3131,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3195,7 +3194,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3258,7 +3256,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3321,7 +3318,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3384,7 +3380,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3447,7 +3442,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3532,7 +3526,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3596,7 +3589,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -4377,7 +4369,6 @@ spec:
                             required:
                             - certificateName
                             - clientID
-                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -3124,7 +3124,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3188,7 +3187,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3251,7 +3249,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3314,7 +3311,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3377,7 +3373,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3440,7 +3435,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3525,7 +3519,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3589,7 +3582,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -4370,7 +4362,6 @@ spec:
                             required:
                             - certificateName
                             - clientID
-                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -3345,7 +3345,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3409,7 +3408,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3472,7 +3470,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3535,7 +3532,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3598,7 +3594,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3661,7 +3656,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3746,7 +3740,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3810,7 +3803,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -4591,7 +4583,6 @@ spec:
                             required:
                             - certificateName
                             - clientID
-                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -3121,7 +3121,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3185,7 +3184,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3248,7 +3246,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3311,7 +3308,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3374,7 +3370,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3437,7 +3432,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3522,7 +3516,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3586,7 +3579,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -4367,7 +4359,6 @@ spec:
                             required:
                             - certificateName
                             - clientID
-                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -3255,7 +3255,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3319,7 +3318,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3382,7 +3380,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3445,7 +3442,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3508,7 +3504,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3571,7 +3566,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3656,7 +3650,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3720,7 +3713,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -4501,7 +4493,6 @@ spec:
                             required:
                             - certificateName
                             - clientID
-                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -3103,7 +3103,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3167,7 +3166,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3230,7 +3228,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3293,7 +3290,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3356,7 +3352,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3419,7 +3414,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3504,7 +3498,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3568,7 +3561,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -4837,7 +4829,6 @@ spec:
                             required:
                             - certificateName
                             - clientID
-                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -2996,7 +2996,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3060,7 +3059,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3123,7 +3121,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3186,7 +3183,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3249,7 +3245,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3312,7 +3307,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3397,7 +3391,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3461,7 +3454,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -4226,7 +4218,6 @@ spec:
                             required:
                             - certificateName
                             - clientID
-                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -3037,7 +3037,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3101,7 +3100,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3164,7 +3162,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3227,7 +3224,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3290,7 +3286,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3353,7 +3348,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3438,7 +3432,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3502,7 +3495,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -4259,7 +4251,6 @@ spec:
                             required:
                             - certificateName
                             - clientID
-                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DisableClusterCapabilities.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DisableClusterCapabilities.yaml
@@ -3020,7 +3020,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3084,7 +3083,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3147,7 +3145,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3210,7 +3207,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3273,7 +3269,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3336,7 +3331,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3421,7 +3415,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3485,7 +3478,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -4242,7 +4234,6 @@ spec:
                             required:
                             - certificateName
                             - clientID
-                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -3013,7 +3013,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3077,7 +3076,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3140,7 +3138,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3203,7 +3200,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3266,7 +3262,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3329,7 +3324,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3414,7 +3408,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3478,7 +3471,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -4235,7 +4227,6 @@ spec:
                             required:
                             - certificateName
                             - clientID
-                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -3234,7 +3234,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3298,7 +3297,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3361,7 +3359,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3424,7 +3421,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3487,7 +3483,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3550,7 +3545,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3635,7 +3629,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3699,7 +3692,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -4456,7 +4448,6 @@ spec:
                             required:
                             - certificateName
                             - clientID
-                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -3010,7 +3010,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3074,7 +3073,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3137,7 +3135,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3200,7 +3197,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3263,7 +3259,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3326,7 +3321,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3411,7 +3405,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3475,7 +3468,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -4232,7 +4224,6 @@ spec:
                             required:
                             - certificateName
                             - clientID
-                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -3144,7 +3144,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3208,7 +3207,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3271,7 +3269,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3334,7 +3331,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3397,7 +3393,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3460,7 +3455,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3545,7 +3539,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3609,7 +3602,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -4366,7 +4358,6 @@ spec:
                             required:
                             - certificateName
                             - clientID
-                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -2992,7 +2992,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3056,7 +3055,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3119,7 +3117,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3182,7 +3179,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3245,7 +3241,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3308,7 +3303,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3393,7 +3387,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3457,7 +3450,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -4702,7 +4694,6 @@ spec:
                             required:
                             - certificateName
                             - clientID
-                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_complicated_invocation_from_bryan.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_complicated_invocation_from_bryan.yaml
@@ -77,32 +77,26 @@ spec:
           cloudProvider:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           controlPlaneOperator:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           disk:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           file:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           imageRegistry:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           ingress:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           managedIdentitiesKeyVault:
             name: ""
@@ -110,12 +104,10 @@ spec:
           network:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           nodePoolManagement:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
         dataPlane:
           diskMSIClientID: ""

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_create_with_a_ure_marketplace_image.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_create_with_a_ure_marketplace_image.yaml
@@ -44,32 +44,26 @@ spec:
           cloudProvider:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           controlPlaneOperator:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           disk:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           file:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           imageRegistry:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           ingress:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           managedIdentitiesKeyVault:
             name: ""
@@ -77,12 +71,10 @@ spec:
           network:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           nodePoolManagement:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
         dataPlane:
           diskMSIClientID: ""

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -77,32 +77,26 @@ spec:
           cloudProvider:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           controlPlaneOperator:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           disk:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           file:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           imageRegistry:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           ingress:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           managedIdentitiesKeyVault:
             name: ""
@@ -110,12 +104,10 @@ spec:
           network:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           nodePoolManagement:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
         dataPlane:
           diskMSIClientID: ""

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_ones.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_ones.yaml
@@ -77,32 +77,26 @@ spec:
           cloudProvider:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           controlPlaneOperator:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           disk:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           file:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           imageRegistry:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           ingress:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           managedIdentitiesKeyVault:
             name: ""
@@ -110,12 +104,10 @@ spec:
           network:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
           nodePoolManagement:
             certificateName: ""
             clientID: ""
-            credentialsSecretName: ""
             objectEncoding: utf-8
         dataPlane:
           diskMSIClientID: ""

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
@@ -3612,7 +3612,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3676,7 +3675,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3739,7 +3737,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3802,7 +3799,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3865,7 +3861,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3928,7 +3923,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -4013,7 +4007,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -4077,7 +4070,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -5346,7 +5338,6 @@ spec:
                             required:
                             - certificateName
                             - clientID
-                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
@@ -3521,7 +3521,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3585,7 +3584,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3648,7 +3646,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3711,7 +3708,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3774,7 +3770,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3837,7 +3832,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3922,7 +3916,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3986,7 +3979,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -4775,7 +4767,6 @@ spec:
                             required:
                             - certificateName
                             - clientID
-                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
@@ -3594,7 +3594,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3658,7 +3657,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3721,7 +3719,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3784,7 +3781,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3847,7 +3843,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3910,7 +3905,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3995,7 +3989,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -4059,7 +4052,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -5328,7 +5320,6 @@ spec:
                             required:
                             - certificateName
                             - clientID
-                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
@@ -3501,7 +3501,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3565,7 +3564,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3628,7 +3626,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3691,7 +3688,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3754,7 +3750,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3817,7 +3812,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3902,7 +3896,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3966,7 +3959,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -5211,7 +5203,6 @@ spec:
                             required:
                             - certificateName
                             - clientID
-                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
@@ -3410,7 +3410,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3474,7 +3473,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3537,7 +3535,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3600,7 +3597,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3663,7 +3659,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3726,7 +3721,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3811,7 +3805,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3875,7 +3868,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -4640,7 +4632,6 @@ spec:
                             required:
                             - certificateName
                             - clientID
-                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
@@ -3483,7 +3483,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3547,7 +3546,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3610,7 +3608,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               file:
@@ -3673,7 +3670,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3736,7 +3732,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3799,7 +3794,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3884,7 +3878,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3948,7 +3941,6 @@ spec:
                                 required:
                                 - certificateName
                                 - clientID
-                                - credentialsSecretName
                                 - objectEncoding
                                 type: object
                             required:
@@ -5193,7 +5185,6 @@ spec:
                             required:
                             - certificateName
                             - clientID
-                            - credentialsSecretName
                             - objectEncoding
                             type: object
                         required:

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/azure.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/azure.go
@@ -501,7 +501,7 @@ type ManagedIdentity struct {
 	// TODO set the validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=127
 	// TODO set validation:Pattern=`^[a-zA-Z0-9-]+$`
-	CredentialsSecretName string `json:"credentialsSecretName"`
+	CredentialsSecretName string `json:"credentialsSecretName,omitempty"`
 }
 
 // ControlPlaneManagedIdentities contains the managed identities on the HCP control plane needing to authenticate with


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds omitempty to CredentialsSecretName for Azure HC API. Without this commit, HO installs are failing on the CS side for ARO HCP since MIv3 isn't enabled.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.