### PR TITLE
OCPBUGS-51007: test/e2e: fix WaitForImageRollout to actually wait on upgrade case

### DIFF
--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -44,17 +44,12 @@ func TestUpgradeControlPlane(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred(), "failed update hostedcluster image")
 
 		// Wait for the new rollout to be complete
-		e2eutil.WaitForImageRollout(t, ctx, mgtClient, hostedCluster, globalOpts.LatestReleaseImage)
+		e2eutil.WaitForImageRollout(t, ctx, mgtClient, hostedCluster)
 		err = mgtClient.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
 		g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
-
-		// Sanity check the cluster by waiting for the nodes to report ready
-		guestClient = e2eutil.WaitForGuestClient(t, ctx, mgtClient, hostedCluster)
 
 		e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, ctx, mgtClient, guestClient, hostedCluster.Spec.Platform.Type, hostedCluster.Namespace)
 		e2eutil.EnsureNoCrashingPods(t, ctx, mgtClient, hostedCluster)
 		e2eutil.EnsureMachineDeploymentGeneration(t, ctx, mgtClient, hostedCluster, 1)
-		// TODO (cewong): enable this test once the fix for KAS->Kubelet communication has merged
-		// e2eutil.EnsureNodeCommunication(t, ctx, client, hostedCluster)
 	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 }

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -1411,6 +1411,8 @@ func testCreateClusterPrivate(t *testing.T, enableExternalDNS bool) {
 	clusterOpts := globalOpts.DefaultClusterOptions(t)
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
 	clusterOpts.AWSPlatform.EndpointAccess = string(hyperv1.Private)
+	// DO NOT COMMIT
+	clusterOpts.NodePoolReplicas = 0
 	expectGuestKubeconfHostChange := false
 	if !enableExternalDNS {
 		clusterOpts.ExternalDNSDomain = ""
@@ -1418,57 +1420,39 @@ func testCreateClusterPrivate(t *testing.T, enableExternalDNS bool) {
 	}
 
 	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
-		// Private -> publicAndPrivate
-		t.Run("SwitchFromPrivateToPublic", testSwitchFromPrivateToPublic(ctx, mgtClient, hostedCluster, &clusterOpts, expectGuestKubeconfHostChange))
-		// publicAndPrivate -> Private
-		t.Run("SwitchFromPublicToPrivate", testSwitchFromPublicToPrivate(ctx, mgtClient, hostedCluster, &clusterOpts))
+		// Private -> PublicAndPrivate
+		t.Run("SwitchFromPrivateToPublic", testSwitchEndpointAccess(ctx, mgtClient, hostedCluster, hyperv1.PublicAndPrivate, expectGuestKubeconfHostChange))
+		// PublicAndPrivate -> Private
+		t.Run("SwitchFromPublicToPrivate", testSwitchEndpointAccess(ctx, mgtClient, hostedCluster, hyperv1.Private, expectGuestKubeconfHostChange))
+		// Get up to date hostedCluster object before EnsureHostedCluster in after()
+		err := mgtClient.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
+		g.Expect(err).ToNot(HaveOccurred(), "failed to get hostedCluster")
 	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, globalOpts.ServiceAccountSigningKey)
 }
 
-func testSwitchFromPrivateToPublic(ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, clusterOpts *e2eutil.PlatformAgnosticOptions, expectGuestKubeconfHostChange bool) func(t *testing.T) {
+func testSwitchEndpointAccess(ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, endpointAccess hyperv1.AWSEndpointAccessType, expectGuestKubeconfHostChange bool) func(t *testing.T) {
 	return func(t *testing.T) {
 		g := NewWithT(t)
 		if globalOpts.Platform != hyperv1.AWSPlatform {
 			t.Skip("test only supported on platform AWS")
 		}
 
-		var (
-			host string
-			err  error
-		)
-		if expectGuestKubeconfHostChange {
-			// Get guest kubeconfig host before switching endpoint access
-			host, err = e2eutil.GetGuestKubeconfigHost(t, ctx, client, hostedCluster)
-			g.Expect(err).ToNot(HaveOccurred(), "failed to get guest kubeconfig host")
-			t.Logf("Found guest kubeconfig host before switching endpoint access: %s", host)
-		}
+		// Get guest kubeconfig host before switching endpoint access
+		host, err := e2eutil.GetGuestKubeconfigHost(t, ctx, client, hostedCluster)
+		g.Expect(err).ToNot(HaveOccurred(), "failed to get guest kubeconfig host")
+		t.Logf("Found guest kubeconfig host before switching endpoint access: %s", host)
 
-		// Switch to PublicAndPrivate endpoint access
+		// Switch endpoint access
 		err = e2eutil.UpdateObject(t, ctx, client, hostedCluster, func(obj *hyperv1.HostedCluster) {
-			obj.Spec.Platform.AWS.EndpointAccess = hyperv1.PublicAndPrivate
+			obj.Spec.Platform.AWS.EndpointAccess = endpointAccess
 		})
 		g.Expect(err).ToNot(HaveOccurred(), "failed to update hostedcluster EndpointAccess")
 
 		if expectGuestKubeconfHostChange {
 			e2eutil.WaitForGuestKubeconfigHostUpdate(t, ctx, client, hostedCluster, host)
+		} else {
+			e2eutil.WaitForGuestKubeconfigHostResolutionUpdate(t, ctx, host, endpointAccess)
 		}
-
-		e2eutil.ValidatePublicCluster(t, ctx, client, hostedCluster, clusterOpts)
 	}
-}
 
-func testSwitchFromPublicToPrivate(ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, clusterOpts *e2eutil.PlatformAgnosticOptions) func(t *testing.T) {
-	return func(t *testing.T) {
-		g := NewWithT(t)
-		if globalOpts.Platform != hyperv1.AWSPlatform {
-			t.Skip("test only supported on platform AWS")
-		}
-
-		err := e2eutil.UpdateObject(t, ctx, client, hostedCluster, func(obj *hyperv1.HostedCluster) {
-			obj.Spec.Platform.AWS.EndpointAccess = hyperv1.Private
-		})
-		g.Expect(err).ToNot(HaveOccurred(), "failed to update hostedcluster EndpointAccess")
-
-		e2eutil.ValidatePrivateCluster(t, ctx, client, hostedCluster, clusterOpts)
-	}
 }

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -320,7 +320,7 @@ func executeNodePoolTest(t *testing.T, ctx context.Context, mgmtClient crclient.
 	nodes := e2eutil.WaitForReadyNodesByNodePool(t, ctx, hcClient, nodePool, hostedCluster.Spec.Platform.Type)
 
 	// Wait for the rollout to be complete
-	e2eutil.WaitForImageRollout(t, ctx, mgmtClient, hostedCluster, globalOpts.LatestReleaseImage)
+	e2eutil.WaitForImageRollout(t, ctx, mgmtClient, hostedCluster)
 
 	// run test validations
 	nodePoolTest.Run(t, *nodePool, nodes)

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"strings"
 	"testing"
@@ -200,7 +201,7 @@ func WaitForGuestClient(t *testing.T, ctx context.Context, client crclient.Clien
 	if IsLessThan(Version415) {
 		// SelfSubjectReview API is only available in 4.15+
 		// Use the old method to check if the API server is up
-		err = wait.PollUntilContextTimeout(ctx, 35*time.Second, 30*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		err = wait.PollUntilContextTimeout(ctx, 35*time.Second, 10*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 			_, err = crclient.New(guestConfig, crclient.Options{Scheme: scheme})
 			if err != nil {
 				t.Logf("attempt to connect failed: %s", err)
@@ -215,7 +216,7 @@ func WaitForGuestClient(t *testing.T, ctx context.Context, client crclient.Clien
 		EventuallyObject(t, ctx, "a successful connection to the guest API server",
 			func(ctx context.Context) (*authenticationv1.SelfSubjectReview, error) {
 				return kubeClient.AuthenticationV1().SelfSubjectReviews().Create(ctx, &authenticationv1.SelfSubjectReview{}, metav1.CreateOptions{})
-			}, nil, WithTimeout(30*time.Minute),
+			}, nil, WithTimeout(10*time.Minute),
 		)
 
 	}
@@ -261,7 +262,39 @@ func WaitForGuestKubeconfigHostUpdate(t *testing.T, ctx context.Context, client 
 		return true, nil
 	})
 	g.Expect(err).NotTo(HaveOccurred(), "failed to wait for guest kubeconfig host update")
-	t.Logf("Guest kubeconfig host switched from %s to %s", oldHost, newHost)
+	t.Logf("kubeconfig host switched from %s to %s", oldHost, newHost)
+}
+
+func WaitForGuestKubeconfigHostResolutionUpdate(t *testing.T, ctx context.Context, uri string, endpointAccess hyperv1.AWSEndpointAccessType) {
+	g := NewWithT(t)
+	visibility := "public"
+	if endpointAccess == hyperv1.Private {
+		visibility = "private"
+	}
+	t.Logf("Waiting for guest kubeconfig host to resolve to %s address", visibility)
+	err := wait.PollUntilContextTimeout(ctx, 15*time.Second, 30*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		host := strings.TrimPrefix(uri, "https://")
+		host = strings.Split(host, ":")[0]
+		ips, err := net.LookupIP(host)
+		if err != nil {
+			t.Logf("failed to resolve guest kubeconfig host: %v", err)
+			return false, nil
+		}
+		ip := ips[0].String()
+		if endpointAccess == hyperv1.Private {
+			if strings.HasPrefix(ip, "10.") {
+				t.Logf("kubeconfig host now resolves to private address")
+				return true, nil
+			}
+		} else {
+			if !strings.HasPrefix(ip, "10.") {
+				t.Logf("kubeconfig host now resolves to public address")
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	g.Expect(err).NotTo(HaveOccurred(), "failed to wait for guest kubeconfig host resolution to update")
 }
 
 func WaitForNReadyNodes(t *testing.T, ctx context.Context, client crclient.Client, n int32, platform hyperv1.PlatformType) []corev1.Node {
@@ -387,8 +420,13 @@ func WaitForNReadyNodesWithOptions(t *testing.T, ctx context.Context, client crc
 	return nodes.Items
 }
 
-func WaitForImageRollout(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, image string) {
-	EventuallyObject(t, ctx, fmt.Sprintf("HostedCluster %s/%s to rollout image %s", hostedCluster.Namespace, hostedCluster.Name, image),
+func WaitForImageRollout(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+	var lastVersionCompletionTime *metav1.Time
+	if hostedCluster.Status.Version != nil &&
+		len(hostedCluster.Status.Version.History) > 0 {
+		lastVersionCompletionTime = hostedCluster.Status.Version.History[0].CompletionTime
+	}
+	EventuallyObject(t, ctx, fmt.Sprintf("HostedCluster %s/%s to rollout", hostedCluster.Namespace, hostedCluster.Name),
 		func(ctx context.Context) (*hyperv1.HostedCluster, error) {
 			hc := &hyperv1.HostedCluster{}
 			err := client.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hc)
@@ -407,13 +445,18 @@ func WaitForImageRollout(t *testing.T, ctx context.Context, client crclient.Clie
 				if len(ptr.Deref(hostedCluster.Status.Version, hyperv1.ClusterVersionStatus{}).History) == 0 {
 					return false, "HostedCluster has no version history", nil
 				}
+				if lastVersionCompletionTime != nil &&
+					hostedCluster.Status.Version.History[0].CompletionTime != nil &&
+					lastVersionCompletionTime.Equal(hostedCluster.Status.Version.History[0].CompletionTime) {
+					return false, "HostedCluster version history has not been updated yet", nil
+				}
 				if wanted, got := hostedCluster.Status.Version.Desired.Image, hostedCluster.Status.Version.History[0].Image; wanted != got {
 					return false, fmt.Sprintf("desired image %s doesn't match most recent image in history %s", wanted, got), nil
 				}
 				if wanted, got := configv1.CompletedUpdate, hostedCluster.Status.Version.History[0].State; wanted != got {
 					return false, fmt.Sprintf("wanted most recent version history to have state %s, has state %s", wanted, got), nil
 				}
-				return true, fmt.Sprintf("image %s rolled out", image), nil
+				return true, "cluster rolled out", nil
 			},
 		},
 		WithTimeout(30*time.Minute),
@@ -1281,6 +1324,7 @@ func EnsureAdmissionPolicies(t *testing.T, ctx context.Context, mgmtClient crcli
 	if !util.IsPublicHC(hc) {
 		return // Admission policies are only validated in public clusters does not worth to test it in private ones.
 	}
+	t.Log("Running EnsureAdmissionPolicies", "endpointAccess", hc.Spec.Platform.AWS.EndpointAccess)
 	guestClient := WaitForGuestClient(t, ctx, mgmtClient, hc)
 	t.Run("EnsureValidatingAdmissionPoliciesExists", func(t *testing.T) {
 		AtLeast(t, Version418)
@@ -1549,7 +1593,7 @@ func ValidatePublicCluster(t *testing.T, ctx context.Context, client crclient.Cl
 
 	// rollout will not complete if there are no worker nodes.
 	if numNodes > 0 {
-		WaitForImageRollout(t, ctx, client, hostedCluster, clusterOpts.ReleaseImage)
+		WaitForImageRollout(t, ctx, client, hostedCluster)
 	}
 
 	err := client.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
@@ -1592,7 +1636,7 @@ func ValidatePrivateCluster(t *testing.T, ctx context.Context, client crclient.C
 	numNodes := clusterOpts.NodePoolReplicas * int32(len(clusterOpts.AWSPlatform.Zones))
 	// rollout will not complete if there are no worker nodes.
 	if numNodes > 0 {
-		WaitForImageRollout(t, ctx, client, hostedCluster, clusterOpts.ReleaseImage)
+		WaitForImageRollout(t, ctx, client, hostedCluster)
 	}
 
 	err := client.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)


### PR DESCRIPTION
The general idea of the fix is to detect the case where the HC image has been changed but that change has not yet propagated to HostedCluster status via ClusterVersion status.

The PR detects this by recording the `CompletionTime` of the latest rollout in the version history when  `WaitForImageRollout` is first called, immediately after the image is changed on the HostedCluster.

As long as the latest rollout in the version history continues to match this recorded time, the update has not yet propagated through ClusterVersion and to the HostedCluster status.  Once the propagation occurs, the latest entry in the version history will be `Partial` until the rollout completes, for which there is an existing block.