### PR TITLE
[release-4.14] OCPBUGS-50700: add region to AWS creds passed to operators managed by CPO

### DIFF
--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
@@ -206,8 +206,6 @@ func (r *AWSEndpointServiceReconciler) SetupWithManager(mgr ctrl.Manager) error 
 	awsConfig := aws.NewConfig()
 	r.ec2Client = ec2.New(awsSession, awsConfig)
 	route53Config := aws.NewConfig()
-	// Hardcode region for route53 config
-	route53Config.Region = aws.String("us-east-1")
 	r.route53Client = route53.New(awsSession, route53Config)
 
 	return nil

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -67,8 +67,14 @@ import (
 )
 
 const (
-	ControllerName       = "resources"
-	SecretHashAnnotation = "hypershift.openshift.io/kubeadmin-secret-hash"
+	ControllerName         = "resources"
+	SecretHashAnnotation   = "hypershift.openshift.io/kubeadmin-secret-hash"
+	awsCredentialsTemplate = `[default]
+role_arn = %s
+web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
+sts_regional_endpoints = regional
+region = %s
+`
 )
 
 var (
@@ -1186,16 +1192,24 @@ func (r *reconciler) reconcileUserCertCABundle(ctx context.Context, hcp *hyperv1
 	return nil
 }
 
-const awsCredentialsTemplate = `[default]
-role_arn = %s
-web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
-sts_regional_endpoints = regional
-`
+func buildAWSWebIdentityCredentials(roleArn, region string) (string, error) {
+	if roleArn == "" {
+		return "", fmt.Errorf("role arn cannot be empty in AssumeRole credentials")
+	}
+	if region == "" {
+		return "", fmt.Errorf("a region must be specified for cross-partition compatibility in AssumeRole credentials")
+	}
+	return fmt.Sprintf(awsCredentialsTemplate, roleArn, region), nil
+}
 
 func (r *reconciler) reconcileCloudCredentialSecrets(ctx context.Context, hcp *hyperv1.HostedControlPlane, log logr.Logger) []error {
 	var errs []error
 	switch hcp.Spec.Platform.Type {
 	case hyperv1.AWSPlatform:
+		var region string
+		if hcp.Spec.Platform.AWS != nil {
+			region = hcp.Spec.Platform.AWS.Region
+		}
 		syncSecret := func(secret *corev1.Secret, arn string) error {
 			ns := &corev1.Namespace{}
 			err := r.client.Get(ctx, client.ObjectKey{Name: secret.Namespace}, ns)
@@ -1206,8 +1220,11 @@ func (r *reconciler) reconcileCloudCredentialSecrets(ctx context.Context, hcp *h
 				}
 				return fmt.Errorf("failed to get secret namespace %s: %w", secret.Namespace, err)
 			}
+			credentials, err := buildAWSWebIdentityCredentials(arn, region)
+			if err != nil {
+				return fmt.Errorf("failed to build cloud credentials secret %s/%s: %w", secret.Namespace, secret.Name, err)
+			}
 			if _, err := r.CreateOrUpdate(ctx, r.client, secret, func() error {
-				credentials := fmt.Sprintf(awsCredentialsTemplate, arn)
 				secret.Data = map[string][]byte{"credentials": []byte(credentials)}
 				secret.Type = corev1.SecretTypeOpaque
 				return nil

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -910,3 +910,60 @@ func compareICSAndIDMS(g *WithT, ics []hyperv1.ImageContentSource, idms *configv
 		}
 	}
 }
+
+func TestBuildAWSWebIdentityCredentials(t *testing.T) {
+	type args struct {
+		roleArn string
+		region  string
+	}
+	type test struct {
+		name    string
+		args    args
+		wantErr bool
+		want    string
+	}
+	tests := []test{
+		{
+			name: "should fail if the role ARN is empty",
+			args: args{
+				roleArn: "",
+				region:  "us-east-1",
+			},
+			wantErr: true,
+		},
+		{
+			name:    "should fail if the region is empty",
+			wantErr: true,
+			args: args{
+				roleArn: "arn:aws:iam::123456789012:role/some-role",
+				region:  "",
+			},
+		},
+		{
+			name:    "should succeed and return the creds template populated with role arn and region otherwise",
+			wantErr: false,
+			args: args{
+				roleArn: "arn:aws:iam::123456789012:role/some-role",
+				region:  "us-east-1",
+			},
+			want: `[default]
+role_arn = arn:aws:iam::123456789012:role/some-role
+web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
+sts_regional_endpoints = regional
+region = us-east-1
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			creds, err := buildAWSWebIdentityCredentials(tt.args.roleArn, tt.args.region)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buildAWSWebIdentityCredentials err = %v, wantErr = %v", err, tt.wantErr)
+				return
+			}
+			if creds != tt.want {
+				t.Errorf("expected creds:\n%s, but got:\n%s", tt.want, creds)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/hypershift/pull/5595

/assign openshift-ci-bot