### PR TITLE
CNTRLPLANE-35: skip EnsureValidatingAdmissionPoliciesExists/EnsureVal…

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1283,7 +1283,7 @@ func EnsureAdmissionPolicies(t *testing.T, ctx context.Context, mgmtClient crcli
 	}
 	guestClient := WaitForGuestClient(t, ctx, mgmtClient, hc)
 	t.Run("EnsureValidatingAdmissionPoliciesExists", func(t *testing.T) {
-		AtLeast(t, Version418)
+		CPOAtLeast(t, Version418, hc)
 		g := NewWithT(t)
 		t.Log("Checking that all ValidatingAdmissionPolicies are present")
 		var validatingAdmissionPolicies k8sadmissionv1beta1.ValidatingAdmissionPolicyList
@@ -1309,7 +1309,7 @@ func EnsureAdmissionPolicies(t *testing.T, ctx context.Context, mgmtClient crcli
 		}
 	})
 	t.Run("EnsureValidatingAdmissionPoliciesCheckDeniedRequests", func(t *testing.T) {
-		AtLeast(t, Version418)
+		CPOAtLeast(t, Version418, hc)
 		g := NewWithT(t)
 		t.Log("Checking Denied KAS Requests for ValidatingAdmissionPolicies")
 		apiServer := &configv1.APIServer{

--- a/test/e2e/util/version.go
+++ b/test/e2e/util/version.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/releaseinfo"
 
 	"github.com/blang/semver"
@@ -57,6 +58,17 @@ func SetReleaseImageVersion(ctx context.Context, latestReleaseImage string, pull
 
 func AtLeast(t *testing.T, version semver.Version) {
 	if releaseVersion.LT(version) {
+		t.Skipf("Only tested in %s and later", version)
+	}
+}
+
+func CPOAtLeast(t *testing.T, version semver.Version, hc *hyperv1.HostedCluster) {
+	if hc.Status.Version == nil || hc.Status.Version.Desired.Version == "" {
+		t.Logf("Desired version is not set on the HostedCluster using latestReleaseImage: %s", releaseVersion)
+		AtLeast(t, version)
+	}
+	cpoVersion := semver.MustParse(hc.Status.Version.Desired.Version)
+	if cpoVersion.LT(version) {
 		t.Skipf("Only tested in %s and later", version)
 	}
 }


### PR DESCRIPTION
…idatingAdmissionPoliciesCheckDeniedRequests based on HC CPO version

We need to skip based on the HC CPO version because when running minor upgrade tests we dont want to use the latest release image version as this would give innacurate test results

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [CNTRLPLANE-35](https://issues.redhat.com/browse/CNTRLPLANE-35)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.