### PR TITLE
NO-JIRA: ho: watch AWSEndpointServices

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -246,6 +246,7 @@ func (r *HostedClusterReconciler) managedResources() []client.Object {
 	managedResources := []client.Object{
 		&capiaws.AWSCluster{},
 		&hyperv1.HostedControlPlane{},
+		&hyperv1.AWSEndpointService{},
 		&capiv1.Cluster{},
 		&appsv1.Deployment{},
 		&prometheusoperatorv1.PodMonitor{},

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -1447,7 +1447,7 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 	for _, resource := range r.managedResources() {
 		resourceType := fmt.Sprintf("%T", resource)
 		switch resourceType {
-		case "*v1.Endpoints", "*v1.Job", "*v1.StatefulSet", "*v1beta1.NodePool":
+		case "*v1.Endpoints", "*v1.Job", "*v1.StatefulSet", "*v1beta1.NodePool", "*v1beta1.AWSEndpointService":
 			// We watch Endpoints for changes to the kubernetes Endpoint in the default namespace
 			// but never create an Endpoints resource
 
@@ -1456,6 +1456,8 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 			// We don't create a StatefulSet but we watch them for etcd health check and recovery
 
 			// We watch NodePools but don't create them
+
+			// We watch AWSEndpointServices to propagate conditions to the HostedCluster
 			continue
 		}
 		watchedResources.Insert(resourceType)


### PR DESCRIPTION
https://github.com/openshift/hypershift/pull/2278 added code for propagating the conditions on the `AWSEndpointService` up to the `HostedCluster`.  However, the `HostedClusterReconciler` does not watch the `AWSEndpointService` type and thus can miss updates to the conditions.

This PR adds `AWSEndpointService` to the `managedResources` that are watched by the `HostedClusterReconciler`.

cc @muraee 