### PR TITLE
NO-JIRA: Update-precommit-docs

### DIFF
--- a/docs/content/contribute/contribute-docs.md
+++ b/docs/content/contribute/contribute-docs.md
@@ -9,7 +9,7 @@ HyperShift's documentation is based on [MkDocs](https://www.mkdocs.org) with the
 [Diátaxis Framework](https://diataxis.fr) for content organization and stylistic
 approach.
 
-The documentation site is built and published automatically to [https://hypershift-docs.netlify.app](https://hypershift-docs.netlify.app).
+The documentation site is built and published automatically to [https://hypershift.pages.dev/](https://hypershift.pages.dev/).
 
 ## Overview
 

--- a/docs/content/contribute/index.md
+++ b/docs/content/contribute/index.md
@@ -7,7 +7,10 @@ Thanks for your interest in contributing to HyperShift. Here are some guidelines
 
 ## Prior to Submitting a Pull Request
 1. Prior to committing your code
-   1. Install `precommit`. The HyperShift repo is set up to run `codespell` on your commits through `precommit`. Instructions for installing `precommit` can be found [here](https://pre-commit.com/#install).
+   1. Install `precommit`. The precommit hooks run on pre-commit and pre-push. The hooks will catch spelling mistakes,
+   make verify issues, unit test issues, and more. 
+        1. Instructions for installing `precommit` can be found [here](https://pre-commit.com/#install).
+        2. Tips on using `precommit` hooks in the HyperShift repo cna be found [here](./precommit-hook-help.md).
    2. Run `make pre-commit`. This updates all Golang and API dependencies, builds the source code, builds the e2e tests, verifies source code format, and runs all unit tests. This will help catch issues before committing so that the verify and unit test CI jobs will not fail on your PR.
 2. Before submitting your pull request on GitHub, look at your changes and try to view them from the eyes of a reviewer.
     1. Try to find the aspects that might not immediately make sense for someone else and explain them in the pull request description.

--- a/docs/content/contribute/precommit-hook-help.md
+++ b/docs/content/contribute/precommit-hook-help.md
@@ -1,0 +1,34 @@
+# General Help on Using precommit Hooks in the HyperShift Repo
+precommit hooks are helpful in catching issues prior to any new code or pull request appearing in the HyperShift repo. 
+In the long run, the precommit hooks will help you save time by catching issues that would normally cause the `verify` 
+and `unit` tests fail on your pull request. The following sections will walk you through how to quickly install the 
+hooks, quickly uninstall the hooks, and how to bypass the hooks.
+
+## Installing precommit hooks
+Once you have precommit installed on your machine([see this for more info](https://pre-commit.com/#install)), it's quite simple to install the precommit hooks.
+
+```shell
+% pre-commit install
+pre-commit installed at .git/hooks/pre-commit
+pre-commit installed at .git/hooks/pre-push
+```
+
+The jobs ran at the pre-commit and pre-push stages are defined in the .golangci.yml file at the base of the HyperShift 
+repo.
+
+## Uninstalling precommit hooks
+Sometimes it might be useful to turn off the precommit hooks briefly.
+
+```shell
+% pre-commit uninstall
+pre-commit uninstalled
+pre-push uninstalled
+```
+
+## Bypassing precommit hooks
+Sometimes you may want to bypass the precommit hooks on a `git push` command, for example, if you just updated something really minor, updating your local `main` branch, or just needed to rerun a `go mod tidy` command, etc. To ignore the `pre-push` hooks, just add the `--no-verify` flag to your command.
+
+```shell
+% git push --set-upstream origin remove-autorest --no-verify 
+% git push -f --no-verify
+```


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a precommit helpful tips documentation page to help other users quickly understand how to install, uninstall, and bypass the precommit hooks.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.