### PR TITLE
OCPBUGS-51007: test/e2e: fix WaitForImageRollout to actually wait on upgrade case

### DIFF
--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -44,12 +44,9 @@ func TestUpgradeControlPlane(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred(), "failed update hostedcluster image")
 
 		// Wait for the new rollout to be complete
-		e2eutil.WaitForImageRollout(t, ctx, mgtClient, hostedCluster, globalOpts.LatestReleaseImage)
+		e2eutil.WaitForImageRollout(t, ctx, mgtClient, hostedCluster)
 		err = mgtClient.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
 		g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
-
-		// Sanity check the cluster by waiting for the nodes to report ready
-		guestClient = e2eutil.WaitForGuestClient(t, ctx, mgtClient, hostedCluster)
 
 		e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, ctx, mgtClient, guestClient, hostedCluster.Spec.Platform.Type, hostedCluster.Namespace)
 		e2eutil.EnsureNoCrashingPods(t, ctx, mgtClient, hostedCluster)

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -320,7 +320,7 @@ func executeNodePoolTest(t *testing.T, ctx context.Context, mgmtClient crclient.
 	nodes := e2eutil.WaitForReadyNodesByNodePool(t, ctx, hcClient, nodePool, hostedCluster.Spec.Platform.Type)
 
 	// Wait for the rollout to be complete
-	e2eutil.WaitForImageRollout(t, ctx, mgmtClient, hostedCluster, globalOpts.LatestReleaseImage)
+	e2eutil.WaitForImageRollout(t, ctx, mgmtClient, hostedCluster)
 
 	// run test validations
 	nodePoolTest.Run(t, *nodePool, nodes)


### PR DESCRIPTION
The general idea of the fix is to detect the case where the HC image has been changed but that change has not yet propagated to HostedCluster status via ClusterVersion status.

The PR detects this by recording the CompletionTime of the latest rollout in the version history when WaitForImageRollout is first called, immediately after the image is changed on the HostedCluster.

As long as the latest rollout in the version history continues to match this recorded time, the update has not yet propagated through ClusterVersion and to the HostedCluster status. Once the propagation occurs, the latest entry in the version history will be Partial until the rollout completes, for which there is an existing block.

Changes:
* Ignore the latest entries in the version history if the `CompletionTime` was before we changed the HC release image.
* drop `image` from `WaitForImageRollout()` signature since it is actually not used and also makes it clear that not waiting on anything to match the HC release image.
* add assertions to `TestCreateClusterPrivate` that actually test if the API endpoint is transitioning between private and public. Calling `ValidatePublicCluster or ValidatePrivateCluster` did not do this.


Closed https://github.com/openshift/hypershift/pull/5664 because I pushed the branch directly to `openshift` org :man_facepalming: 