### PR TITLE
PODAUTO-324: PODAUTO-325: Allow autonode to run upstream karpenter core e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,6 +321,14 @@ run-operator-locally-aws-dev:
 verify-codespell: codespell ## Verify codespell.
 	@$(CODESPELL) --count --ignore-words=./.codespellignore --skip="./hack/tools/bin/codespell_dist,./docs/site/*,./vendor/*,./api/vendor/*,./hack/tools/vendor/*,./api/hypershift/v1alpha1/*,./support/thirdparty/*,./docs/content/reference/*,./hack/tools/bin/*,./cmd/install/assets/*,./go.sum,./hack/workspace/go.work.sum,./api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests,./hack/tools/go.mod,./hack/tools/go.sum"
 
+## Run Karpenter upstream e2e tests. Requires:
+# - KARPENTER_CORE_DIR to be set to the path of the karpenter-core repository
+# - current context to be set to a hosted cluster with AutoNode enabled.
+# - an annotation to be applied to the HCP to stop reconcillation (hypershift.openshift.io/karpenter-core-e2e-override=true)
+.PHONY: karpenter-upstream-e2e
+karpenter-upstream-e2e:
+	./karpenter-operator/e2e/upstream-e2e.sh
+
 ## --------------------------------------
 ## Tooling Binaries
 ## --------------------------------------

--- a/api/karpenter/v1beta1/karpenter_types.go
+++ b/api/karpenter/v1beta1/karpenter_types.go
@@ -5,6 +5,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// KarpenterCoreE2EOverrideAnnotation is an annotation to be applied to a HostedCluster that allows
+	// overriding the default behavior of the Karpenter Operator for upstream Karpenter core E2E testing purposes.
+	KarpenterCoreE2EOverrideAnnotation = "hypershift.openshift.io/karpenter-core-e2e-override"
+)
+
 // Subnet contains resolved Subnet selector values utilized for node launch
 type Subnet struct {
 	// ID of the subnet

--- a/karpenter-operator/controllers/karpenter/karpenter_controller.go
+++ b/karpenter-operator/controllers/karpenter/karpenter_controller.go
@@ -186,8 +186,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
-	if err := r.reconcileOpenshiftEC2NodeClassDefault(ctx, hcp); err != nil {
-		return ctrl.Result{}, err
+	// Don't reconcile if Karpenter E2E override is set.
+	if hcp.Annotations[hyperkarpenterv1.KarpenterCoreE2EOverrideAnnotation] != "true" {
+		if err := r.reconcileOpenshiftEC2NodeClassDefault(ctx, hcp); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	if err := r.reconcileKarpenter(ctx, hcp); err != nil {

--- a/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller.go
+++ b/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller.go
@@ -102,6 +102,10 @@ func (r *EC2NodeClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
+	if hcp.Annotations[hyperkarpenterv1.KarpenterCoreE2EOverrideAnnotation] == "true" {
+		return ctrl.Result{}, nil
+	}
+
 	if err := r.reconcileCRDs(ctx, false); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/karpenter-operator/e2e/adjust-ec2nodeclass.sh
+++ b/karpenter-operator/e2e/adjust-ec2nodeclass.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+FILE=$1
+
+# delete metadata fields
+yq 'del(.metadata.creationTimestamp, .metadata.generation, .metadata.managedFields, .metadata.resourceVersion, .metadata.selfLink, .metadata.uid)' -i "$FILE"
+
+# delete status
+yq 'del(.status)' -i "$FILE"

--- a/karpenter-operator/e2e/default_nodepool.yaml
+++ b/karpenter-operator/e2e/default_nodepool.yaml
@@ -1,0 +1,27 @@
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      expireAfter: Never
+      requirements:
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: default
+disruption:
+  consolidationPolicy: WhenEmptyOrUnderutilized
+  consolidateAfter: Never
+  budgets:
+    - nodes: 100%
+limits:
+  cpu: 1000
+  memory: 1000Gi

--- a/karpenter-operator/e2e/upstream-e2e.sh
+++ b/karpenter-operator/e2e/upstream-e2e.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Prerequisites:
+# 1. This should only run in a guest cluster with autoNode, in a testing environment, and with a valid kubeconfig
+# 2. The HCP should be annotated with hypershift.openshift.io/karpenter-core-e2e-override=true
+# 3. There should exist a default EC2NodeClass in the guest cluster
+# 4. The openshift/kubernetes-sigs-karpenter fork should be cloned somewhere and pointed to by the KARPENTER_CORE_DIR
+
+if [[ -z "$KARPENTER_CORE_DIR" ]]; then
+  echo "KARPENTER_CORE_DIR is not set"
+  exit 1
+fi
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# snapshot the default nodeclass so that the upstream tests can recreate them before each test
+TMPFILE=$(mktemp)
+oc get ec2nodeclasses.karpenter.k8s.aws default -o yaml > "$TMPFILE"
+"$SCRIPT_DIR/adjust-ec2nodeclass.sh" "$TMPFILE"
+
+DEFAULT_NODEPOOL=${KARPENTER_DEFAULT_NODECLASS:-"$SCRIPT_DIR/default_nodepool.yaml"}
+
+CLEANUP=${CLEANUP:-true}
+
+cleanup() {
+  echo "Cleaning up..."
+  for node in $(oc get nodes -o name); do
+    oc adm taint nodes "$node" key:NoSchedule-
+  done
+
+  for cronjob in $(oc get cronjobs -o name); do
+    oc patch "$cronjob" -p '{"spec" : {"suspend" : false }}'
+  done
+
+  oc delete nodepool --all
+  # NOTE: cleanup requires the management cluster to remove the hcp annotation and potentially restart the karpenter-operator
+}
+
+if [[ "$CLEANUP" == "true" ]]; then
+  trap cleanup EXIT
+fi
+
+# tests expect all nodes to be tainted before running:
+# https://github.com/kubernetes-sigs/karpenter/blob/main/test/pkg/environment/common/setup.go#L87
+echo "Tainting all nodes..."
+for node in $(oc get nodes -o name); do
+  oc adm taint nodes "$node" key=value:NoSchedule --overwrite
+done
+
+# pause cronjobs, otherwise suite fails if it detects schedulable pods before each test
+echo "Pausing all running cronjobs..."
+for cronjob in $(oc get cronjobs -o name); do
+  oc patch "$cronjob" -p '{"spec" : {"suspend" : true }}'
+done
+
+# then remove all NodeClasses, VAP, and stray NodePools
+oc delete validatingadmissionpolicies.admissionregistration.k8s.io karpenter.ec2nodeclass.hypershift.io
+oc delete ec2nodeclasses.karpenter.k8s.aws --all --timeout 60s
+oc delete nodepool --all
+
+GO111MODULE=on GOWORK=off go test \
+  -C "$KARPENTER_CORE_DIR" \
+  -count 1 \
+  -timeout 1h \
+  -v \
+  "$KARPENTER_CORE_DIR"/test/suites/$(echo "$TEST_SUITE" | tr A-Z a-z)/... \
+  --ginkgo.focus="${FOCUS}" \
+  --ginkgo.timeout=1h \
+  --ginkgo.grace-period=5m \
+  --ginkgo.vv \
+  --default-nodeclass="$TMPFILE" \
+  --default-nodepool="$DEFAULT_NODEPOOL"

--- a/vendor/github.com/openshift/hypershift/api/karpenter/v1beta1/karpenter_types.go
+++ b/vendor/github.com/openshift/hypershift/api/karpenter/v1beta1/karpenter_types.go
@@ -5,6 +5,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// KarpenterCoreE2EOverrideAnnotation is an annotation to be applied to a HostedCluster that allows
+	// overriding the default behavior of the Karpenter Operator for upstream Karpenter core E2E testing purposes.
+	KarpenterCoreE2EOverrideAnnotation = "hypershift.openshift.io/karpenter-core-e2e-override"
+)
+
 // Subnet contains resolved Subnet selector values utilized for node launch
 type Subnet struct {
 	// ID of the subnet


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a script to run [upstream Karpenter core e2e tests](https://github.com/kubernetes-sigs/karpenter/tree/main/test) with AutoNode and hypershift. This will allow us to re-use tests and confirm that our karpenter-provider satisfies the basic/expected karpenter behaviour. See the JIRA issues or this relevant slack conversation for details on the test plan: https://redhat-internal.slack.com/archives/C02F1J9UJJD/p1739984424557259. This also allows an annotation `hypershift.openshift.io/karpenter-core-e2e-override` to be added to the `HostedCluster` object that allows the karpenter-operator to stop it's deletion in a guest cluster with AutoNode.

We need the annotation because the upstream tests try to recreate NodeClasses before every test, but on the hypershift side, the karpenter-operator prevents the deletion of the NodeClass. The annotation will prevent the controller from reconciling the NodeClasses and VAP which denies deletion of the EC2NodeClass. We then use this annotation during an e2e test run by setting it before running the script.

Note that the script has to be run in the context of the guest cluster. If all goes well, in a followup PR on the release repo, this will be done in separate steps in the prow config in a new hypershift release job that exercises this upstream test.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
fixes [PODAUTO-324](https://issues.redhat.com/browse/PODAUTO-324), fixes [PODAUTO-325](https://issues.redhat.com/browse/PODAUTO-325)
Related to: [PODAUTO-323](https://issues.redhat.com/browse/PODAUTO-323), [PODAUTO-327](https://issues.redhat.com/browse/PODAUTO-327)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.