### PR TITLE
CNTRLPLANE-244: Add needed Codecov files to HyperShift

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,26 @@
+codecov:
+  notify:
+    require_ci_to_pass: no
+
+coverage:
+  precision: 2
+  round: down
+  range: "20...100"
+
+  status:
+    project: no
+    patch: no
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: no

--- a/Makefile
+++ b/Makefile
@@ -321,6 +321,10 @@ run-operator-locally-aws-dev:
 verify-codespell: codespell ## Verify codespell.
 	@$(CODESPELL) --count --ignore-words=./.codespellignore --skip="./hack/tools/bin/codespell_dist,./docs/site/*,./vendor/*,./api/vendor/*,./hack/tools/vendor/*,./api/hypershift/v1alpha1/*,./support/thirdparty/*,./docs/content/reference/*,./hack/tools/bin/*,./cmd/install/assets/*,./go.sum,./hack/workspace/go.work.sum,./api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests,./hack/tools/go.mod,./hack/tools/go.sum"
 
+.PHONY: coverage
+coverage:
+	hack/codecov.sh
+
 ## --------------------------------------
 ## Tooling Binaries
 ## --------------------------------------

--- a/docs/content/contribute/index.md
+++ b/docs/content/contribute/index.md
@@ -8,9 +8,9 @@ Thanks for your interest in contributing to HyperShift. Here are some guidelines
 ## Prior to Submitting a Pull Request
 1. Prior to committing your code
    1. Install `precommit`. The precommit hooks run on pre-commit and pre-push. The hooks will catch spelling mistakes,
-   make verify issues, unit test issues, and more. 
+   make verify issues, unit test issues, and more.
         1. Instructions for installing `precommit` can be found [here](https://pre-commit.com/#install).
-        2. Tips on using `precommit` hooks in the HyperShift repo cna be found [here](./precommit-hook-help.md).
+        2. Tips on using `precommit` hooks in the HyperShift repo can be found [here](./precommit-hook-help.md).
    2. Run `make pre-commit`. This updates all Golang and API dependencies, builds the source code, builds the e2e tests, verifies source code format, and runs all unit tests. This will help catch issues before committing so that the verify and unit test CI jobs will not fail on your PR.
 2. Before submitting your pull request on GitHub, look at your changes and try to view them from the eyes of a reviewer.
     1. Try to find the aspects that might not immediately make sense for someone else and explain them in the pull request description.

--- a/hack/codecov.sh
+++ b/hack/codecov.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+CI_SERVER_URL=https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test
+COVER_PROFILE=${COVER_PROFILE:-coverage.out}
+JOB_TYPE=${JOB_TYPE:-"local"}
+
+# Default concurrency to four threads. By default it's the number of procs,
+# which seems to be 16 in the CI env. Some consumers' coverage jobs were
+# regularly getting OOM-killed; so do this rather than boost the pod resources
+# unreasonably.
+COV_THREAD_COUNT=${COV_THREAD_COUNT:-4}
+make -C "${REPO_ROOT}" test-unit GO_TEST_FLAGS="-coverprofile=${COVER_PROFILE}.tmp -covermode=atomic -coverpkg=./... -p ${COV_THREAD_COUNT}"
+
+# Remove generated files from coverage profile
+grep -v "zz_generated" "${COVER_PROFILE}.tmp" > "${COVER_PROFILE}"
+rm -f "${COVER_PROFILE}.tmp"
+
+# Configure the git refs and job link based on how the job was triggered via prow
+if [[ "${JOB_TYPE}" == "presubmit" ]]; then
+       echo "detected PR code coverage job for #${PULL_NUMBER}"
+       REF_FLAGS="-P ${PULL_NUMBER} -C ${PULL_PULL_SHA}"
+       JOB_LINK="${CI_SERVER_URL}/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
+elif [[ "${JOB_TYPE}" == "postsubmit" ]]; then
+       echo "detected branch code coverage job for ${PULL_BASE_REF}"
+       REF_FLAGS="-B ${PULL_BASE_REF} -C ${PULL_BASE_SHA}"
+       JOB_LINK="${CI_SERVER_URL}/logs/${JOB_NAME}/${BUILD_ID}"
+elif [[ "${JOB_TYPE}" == "local" ]]; then
+       echo "coverage report available at ${COVER_PROFILE}"
+       exit 0
+else
+       echo "${JOB_TYPE} jobs not supported" >&2
+       exit 1
+fi
+
+# Configure certain internal codecov variables with values from prow.
+export CI_BUILD_URL="${JOB_LINK}"
+export CI_BUILD_ID="${JOB_NAME}"
+export CI_JOB_ID="${BUILD_ID}"
+
+if [[ "${JOB_TYPE}" != "local" ]]; then
+       if [[ -z "${ARTIFACT_DIR:-}" ]] || [[ ! -d "${ARTIFACT_DIR}" ]] || [[ ! -w "${ARTIFACT_DIR}" ]]; then
+              echo '${ARTIFACT_DIR} must be set for non-local jobs, and must point to a writable directory' >&2
+              exit 1
+       fi
+       curl -sS https://codecov.io/bash -o "${ARTIFACT_DIR}/codecov.sh"
+       bash <(cat "${ARTIFACT_DIR}/codecov.sh") -Z -K -f "${COVER_PROFILE}" -r "${REPO_OWNER}/${REPO_NAME}" ${REF_FLAGS}
+else
+       bash <(curl -s https://codecov.io/bash) -Z -K -f "${COVER_PROFILE}" -r "${REPO_OWNER}/${REPO_NAME}" ${REF_FLAGS}
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the needed files to run codecov on HyperShift. See https://github.com/openshift/hive-sops/blob/master/sop/Coverage.md for more information.

**Which issue(s) this PR fixes**:
Part of [CNTRLPLANE-244](https://issues.redhat.com/browse/CNTRLPLANE-244)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.