### PR TITLE
NO-JIRA: Revert 'Relax networking cel validation for IBMCloud'

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -385,9 +385,7 @@ type Capabilities struct {
 // +kubebuilder:validation:XValidation:rule=`self.platform.type == "Azure" ? self.services.exists(s, s.service == "Konnectivity" && s.servicePublishingStrategy.type == "Route" && s.servicePublishingStrategy.route.hostname != "") : true`,message="Azure platform requires Konnectivity Route service with a hostname to be defined"
 // +kubebuilder:validation:XValidation:rule=`self.platform.type == "Azure" ? self.services.exists(s, s.service == "Ignition" && s.servicePublishingStrategy.type == "Route" && s.servicePublishingStrategy.route.hostname != "") : true`,message="Azure platform requires Ignition Route service with a hostname to be defined"
 // +kubebuilder:validation:XValidation:rule=`has(self.issuerURL) || !has(self.serviceAccountSigningKey)`,message="If serviceAccountSigningKey is set, issuerURL must be set"
-// TODO(alberto): Use CEL cidr library for all these validation when all management clusters are >= 1.31.
-// TODO(alberto): Move this down to the networking section when IBMCloud has finished valid input migration.
-// +kubebuilder:validation:XValidation:rule=`(self.platform.type == "IBMCloud" || !has(self.networking.machineNetwork) && self.networking.clusterNetwork.all(c, self.networking.serviceNetwork.all(s, c.cidr != s.cidr)) || (has(self.networking.machineNetwork) && (self.networking.machineNetwork.all(m, self.networking.clusterNetwork.all(c, m.cidr != c.cidr)) && self.networking.machineNetwork.all(m, self.networking.serviceNetwork.all(s, m.cidr != s.cidr)) && self.networking.clusterNetwork.all(c, self.networking.serviceNetwork.all(s, c.cidr != s.cidr)))))`,message="CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork must be unique and non-overlapping"
+
 type HostedClusterSpec struct {
 	// release specifies the desired OCP release payload for all the hosted cluster components.
 	// This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
@@ -892,6 +890,9 @@ type DNSSpec struct {
 // clusterNetworking specifies network configuration for a cluster.
 // All CIDRs must be unique. Additional validation to check for CIDRs overlap and consistent network stack is performed by the controllers.
 // Failing that validation will result in the HostedCluster being degraded and the validConfiguration condition being false.
+// TODO this is available in vanilla kube from 1.31 API servers and in Openshift from 4.16.
+// TODO(alberto): Use CEL cidr library for all these validation when all management clusters are >= 1.31.
+// +kubebuilder:validation:XValidation:rule="(!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s, c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m, self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m, self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c, self.serviceNetwork.all(s, c.cidr != s.cidr)))))",message="CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork must be unique and non-overlapping"
 type ClusterNetworking struct {
 	// machineNetwork is the list of IP address pools for machines.
 	// This might be used among other things to generate appropriate networking security groups in some clouds providers.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -2538,6 +2538,14 @@ spec:
                         once set.
                       rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
+                    must be unique and non-overlapping
+                  rule: (!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s,
+                    c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m,
+                    self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m,
+                    self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c,
+                    self.serviceNetwork.all(s, c.cidr != s.cidr)))))
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -4092,14 +4100,6 @@ spec:
                 != "") : true'
             - message: If serviceAccountSigningKey is set, issuerURL must be set
               rule: has(self.issuerURL) || !has(self.serviceAccountSigningKey)
-            - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
-                must be unique and non-overlapping
-              rule: (self.platform.type == "IBMCloud" || !has(self.networking.machineNetwork)
-                && self.networking.clusterNetwork.all(c, self.networking.serviceNetwork.all(s,
-                c.cidr != s.cidr)) || (has(self.networking.machineNetwork) && (self.networking.machineNetwork.all(m,
-                self.networking.clusterNetwork.all(c, m.cidr != c.cidr)) && self.networking.machineNetwork.all(m,
-                self.networking.serviceNetwork.all(s, m.cidr != s.cidr)) && self.networking.clusterNetwork.all(c,
-                self.networking.serviceNetwork.all(s, c.cidr != s.cidr)))))
           status:
             description: Status is the latest observed status of the HostedCluster.
             properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AROHCPManagedIdentities.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AROHCPManagedIdentities.yaml
@@ -2534,6 +2534,14 @@ spec:
                         once set.
                       rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
+                    must be unique and non-overlapping
+                  rule: (!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s,
+                    c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m,
+                    self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m,
+                    self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c,
+                    self.serviceNetwork.all(s, c.cidr != s.cidr)))))
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -4723,14 +4731,6 @@ spec:
                 != "") : true'
             - message: If serviceAccountSigningKey is set, issuerURL must be set
               rule: has(self.issuerURL) || !has(self.serviceAccountSigningKey)
-            - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
-                must be unique and non-overlapping
-              rule: (self.platform.type == "IBMCloud" || !has(self.networking.machineNetwork)
-                && self.networking.clusterNetwork.all(c, self.networking.serviceNetwork.all(s,
-                c.cidr != s.cidr)) || (has(self.networking.machineNetwork) && (self.networking.machineNetwork.all(m,
-                self.networking.clusterNetwork.all(c, m.cidr != c.cidr)) && self.networking.machineNetwork.all(m,
-                self.networking.serviceNetwork.all(s, m.cidr != s.cidr)) && self.networking.clusterNetwork.all(c,
-                self.networking.serviceNetwork.all(s, c.cidr != s.cidr)))))
           status:
             description: Status is the latest observed status of the HostedCluster.
             properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -2579,6 +2579,14 @@ spec:
                         once set.
                       rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
+                    must be unique and non-overlapping
+                  rule: (!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s,
+                    c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m,
+                    self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m,
+                    self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c,
+                    self.serviceNetwork.all(s, c.cidr != s.cidr)))))
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -4125,14 +4133,6 @@ spec:
                 != "") : true'
             - message: If serviceAccountSigningKey is set, issuerURL must be set
               rule: has(self.issuerURL) || !has(self.serviceAccountSigningKey)
-            - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
-                must be unique and non-overlapping
-              rule: (self.platform.type == "IBMCloud" || !has(self.networking.machineNetwork)
-                && self.networking.clusterNetwork.all(c, self.networking.serviceNetwork.all(s,
-                c.cidr != s.cidr)) || (has(self.networking.machineNetwork) && (self.networking.machineNetwork.all(m,
-                self.networking.clusterNetwork.all(c, m.cidr != c.cidr)) && self.networking.machineNetwork.all(m,
-                self.networking.serviceNetwork.all(s, m.cidr != s.cidr)) && self.networking.clusterNetwork.all(c,
-                self.networking.serviceNetwork.all(s, c.cidr != s.cidr)))))
           status:
             description: Status is the latest observed status of the HostedCluster.
             properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DisableClusterCapabilities.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DisableClusterCapabilities.yaml
@@ -2562,6 +2562,14 @@ spec:
                         once set.
                       rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
+                    must be unique and non-overlapping
+                  rule: (!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s,
+                    c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m,
+                    self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m,
+                    self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c,
+                    self.serviceNetwork.all(s, c.cidr != s.cidr)))))
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -4108,14 +4116,6 @@ spec:
                 != "") : true'
             - message: If serviceAccountSigningKey is set, issuerURL must be set
               rule: has(self.issuerURL) || !has(self.serviceAccountSigningKey)
-            - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
-                must be unique and non-overlapping
-              rule: (self.platform.type == "IBMCloud" || !has(self.networking.machineNetwork)
-                && self.networking.clusterNetwork.all(c, self.networking.serviceNetwork.all(s,
-                c.cidr != s.cidr)) || (has(self.networking.machineNetwork) && (self.networking.machineNetwork.all(m,
-                self.networking.clusterNetwork.all(c, m.cidr != c.cidr)) && self.networking.machineNetwork.all(m,
-                self.networking.serviceNetwork.all(s, m.cidr != s.cidr)) && self.networking.clusterNetwork.all(c,
-                self.networking.serviceNetwork.all(s, c.cidr != s.cidr)))))
           status:
             description: Status is the latest observed status of the HostedCluster.
             properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -2555,6 +2555,14 @@ spec:
                         once set.
                       rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
+                    must be unique and non-overlapping
+                  rule: (!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s,
+                    c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m,
+                    self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m,
+                    self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c,
+                    self.serviceNetwork.all(s, c.cidr != s.cidr)))))
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -4101,14 +4109,6 @@ spec:
                 != "") : true'
             - message: If serviceAccountSigningKey is set, issuerURL must be set
               rule: has(self.issuerURL) || !has(self.serviceAccountSigningKey)
-            - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
-                must be unique and non-overlapping
-              rule: (self.platform.type == "IBMCloud" || !has(self.networking.machineNetwork)
-                && self.networking.clusterNetwork.all(c, self.networking.serviceNetwork.all(s,
-                c.cidr != s.cidr)) || (has(self.networking.machineNetwork) && (self.networking.machineNetwork.all(m,
-                self.networking.clusterNetwork.all(c, m.cidr != c.cidr)) && self.networking.machineNetwork.all(m,
-                self.networking.serviceNetwork.all(s, m.cidr != s.cidr)) && self.networking.clusterNetwork.all(c,
-                self.networking.serviceNetwork.all(s, c.cidr != s.cidr)))))
           status:
             description: Status is the latest observed status of the HostedCluster.
             properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -2776,6 +2776,14 @@ spec:
                         once set.
                       rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
+                    must be unique and non-overlapping
+                  rule: (!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s,
+                    c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m,
+                    self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m,
+                    self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c,
+                    self.serviceNetwork.all(s, c.cidr != s.cidr)))))
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -4322,14 +4330,6 @@ spec:
                 != "") : true'
             - message: If serviceAccountSigningKey is set, issuerURL must be set
               rule: has(self.issuerURL) || !has(self.serviceAccountSigningKey)
-            - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
-                must be unique and non-overlapping
-              rule: (self.platform.type == "IBMCloud" || !has(self.networking.machineNetwork)
-                && self.networking.clusterNetwork.all(c, self.networking.serviceNetwork.all(s,
-                c.cidr != s.cidr)) || (has(self.networking.machineNetwork) && (self.networking.machineNetwork.all(m,
-                self.networking.clusterNetwork.all(c, m.cidr != c.cidr)) && self.networking.machineNetwork.all(m,
-                self.networking.serviceNetwork.all(s, m.cidr != s.cidr)) && self.networking.clusterNetwork.all(c,
-                self.networking.serviceNetwork.all(s, c.cidr != s.cidr)))))
           status:
             description: Status is the latest observed status of the HostedCluster.
             properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -2552,6 +2552,14 @@ spec:
                         once set.
                       rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
+                    must be unique and non-overlapping
+                  rule: (!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s,
+                    c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m,
+                    self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m,
+                    self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c,
+                    self.serviceNetwork.all(s, c.cidr != s.cidr)))))
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -4098,14 +4106,6 @@ spec:
                 != "") : true'
             - message: If serviceAccountSigningKey is set, issuerURL must be set
               rule: has(self.issuerURL) || !has(self.serviceAccountSigningKey)
-            - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
-                must be unique and non-overlapping
-              rule: (self.platform.type == "IBMCloud" || !has(self.networking.machineNetwork)
-                && self.networking.clusterNetwork.all(c, self.networking.serviceNetwork.all(s,
-                c.cidr != s.cidr)) || (has(self.networking.machineNetwork) && (self.networking.machineNetwork.all(m,
-                self.networking.clusterNetwork.all(c, m.cidr != c.cidr)) && self.networking.machineNetwork.all(m,
-                self.networking.serviceNetwork.all(s, m.cidr != s.cidr)) && self.networking.clusterNetwork.all(c,
-                self.networking.serviceNetwork.all(s, c.cidr != s.cidr)))))
           status:
             description: Status is the latest observed status of the HostedCluster.
             properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -2686,6 +2686,14 @@ spec:
                         once set.
                       rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
+                    must be unique and non-overlapping
+                  rule: (!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s,
+                    c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m,
+                    self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m,
+                    self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c,
+                    self.serviceNetwork.all(s, c.cidr != s.cidr)))))
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -4232,14 +4240,6 @@ spec:
                 != "") : true'
             - message: If serviceAccountSigningKey is set, issuerURL must be set
               rule: has(self.issuerURL) || !has(self.serviceAccountSigningKey)
-            - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
-                must be unique and non-overlapping
-              rule: (self.platform.type == "IBMCloud" || !has(self.networking.machineNetwork)
-                && self.networking.clusterNetwork.all(c, self.networking.serviceNetwork.all(s,
-                c.cidr != s.cidr)) || (has(self.networking.machineNetwork) && (self.networking.machineNetwork.all(m,
-                self.networking.clusterNetwork.all(c, m.cidr != c.cidr)) && self.networking.machineNetwork.all(m,
-                self.networking.serviceNetwork.all(s, m.cidr != s.cidr)) && self.networking.clusterNetwork.all(c,
-                self.networking.serviceNetwork.all(s, c.cidr != s.cidr)))))
           status:
             description: Status is the latest observed status of the HostedCluster.
             properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -2534,6 +2534,14 @@ spec:
                         once set.
                       rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
+                    must be unique and non-overlapping
+                  rule: (!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s,
+                    c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m,
+                    self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m,
+                    self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c,
+                    self.serviceNetwork.all(s, c.cidr != s.cidr)))))
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -4568,14 +4576,6 @@ spec:
                 != "") : true'
             - message: If serviceAccountSigningKey is set, issuerURL must be set
               rule: has(self.issuerURL) || !has(self.serviceAccountSigningKey)
-            - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
-                must be unique and non-overlapping
-              rule: (self.platform.type == "IBMCloud" || !has(self.networking.machineNetwork)
-                && self.networking.clusterNetwork.all(c, self.networking.serviceNetwork.all(s,
-                c.cidr != s.cidr)) || (has(self.networking.machineNetwork) && (self.networking.machineNetwork.all(m,
-                self.networking.clusterNetwork.all(c, m.cidr != c.cidr)) && self.networking.machineNetwork.all(m,
-                self.networking.serviceNetwork.all(s, m.cidr != s.cidr)) && self.networking.clusterNetwork.all(c,
-                self.networking.serviceNetwork.all(s, c.cidr != s.cidr)))))
           status:
             description: Status is the latest observed status of the HostedCluster.
             properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -2442,6 +2442,14 @@ spec:
                         once set.
                       rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
+                    must be unique and non-overlapping
+                  rule: (!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s,
+                    c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m,
+                    self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m,
+                    self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c,
+                    self.serviceNetwork.all(s, c.cidr != s.cidr)))))
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AROHCPManagedIdentities.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AROHCPManagedIdentities.yaml
@@ -2438,6 +2438,14 @@ spec:
                         once set.
                       rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
+                    must be unique and non-overlapping
+                  rule: (!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s,
+                    c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m,
+                    self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m,
+                    self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c,
+                    self.serviceNetwork.all(s, c.cidr != s.cidr)))))
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -2483,6 +2483,14 @@ spec:
                         once set.
                       rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
+                    must be unique and non-overlapping
+                  rule: (!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s,
+                    c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m,
+                    self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m,
+                    self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c,
+                    self.serviceNetwork.all(s, c.cidr != s.cidr)))))
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DisableClusterCapabilities.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DisableClusterCapabilities.yaml
@@ -2466,6 +2466,14 @@ spec:
                         once set.
                       rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
+                    must be unique and non-overlapping
+                  rule: (!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s,
+                    c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m,
+                    self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m,
+                    self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c,
+                    self.serviceNetwork.all(s, c.cidr != s.cidr)))))
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -2459,6 +2459,14 @@ spec:
                         once set.
                       rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
+                    must be unique and non-overlapping
+                  rule: (!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s,
+                    c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m,
+                    self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m,
+                    self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c,
+                    self.serviceNetwork.all(s, c.cidr != s.cidr)))))
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -2680,6 +2680,14 @@ spec:
                         once set.
                       rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
+                    must be unique and non-overlapping
+                  rule: (!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s,
+                    c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m,
+                    self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m,
+                    self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c,
+                    self.serviceNetwork.all(s, c.cidr != s.cidr)))))
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -2456,6 +2456,14 @@ spec:
                         once set.
                       rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
+                    must be unique and non-overlapping
+                  rule: (!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s,
+                    c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m,
+                    self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m,
+                    self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c,
+                    self.serviceNetwork.all(s, c.cidr != s.cidr)))))
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -2590,6 +2590,14 @@ spec:
                         once set.
                       rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
+                    must be unique and non-overlapping
+                  rule: (!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s,
+                    c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m,
+                    self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m,
+                    self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c,
+                    self.serviceNetwork.all(s, c.cidr != s.cidr)))))
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -2438,6 +2438,14 @@ spec:
                         once set.
                       rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
+                    must be unique and non-overlapping
+                  rule: (!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s,
+                    c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m,
+                    self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m,
+                    self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c,
+                    self.serviceNetwork.all(s, c.cidr != s.cidr)))))
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
@@ -3043,6 +3043,14 @@ spec:
                         once set.
                       rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
+                    must be unique and non-overlapping
+                  rule: (!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s,
+                    c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m,
+                    self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m,
+                    self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c,
+                    self.serviceNetwork.all(s, c.cidr != s.cidr)))))
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -5718,14 +5726,6 @@ spec:
                 != "") : true'
             - message: If serviceAccountSigningKey is set, issuerURL must be set
               rule: has(self.issuerURL) || !has(self.serviceAccountSigningKey)
-            - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
-                must be unique and non-overlapping
-              rule: (self.platform.type == "IBMCloud" || !has(self.networking.machineNetwork)
-                && self.networking.clusterNetwork.all(c, self.networking.serviceNetwork.all(s,
-                c.cidr != s.cidr)) || (has(self.networking.machineNetwork) && (self.networking.machineNetwork.all(m,
-                self.networking.clusterNetwork.all(c, m.cidr != c.cidr)) && self.networking.machineNetwork.all(m,
-                self.networking.serviceNetwork.all(s, m.cidr != s.cidr)) && self.networking.clusterNetwork.all(c,
-                self.networking.serviceNetwork.all(s, c.cidr != s.cidr)))))
           status:
             description: Status is the latest observed status of the HostedCluster.
             properties:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
@@ -2952,6 +2952,14 @@ spec:
                         once set.
                       rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
+                    must be unique and non-overlapping
+                  rule: (!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s,
+                    c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m,
+                    self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m,
+                    self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c,
+                    self.serviceNetwork.all(s, c.cidr != s.cidr)))))
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -4506,14 +4514,6 @@ spec:
                 != "") : true'
             - message: If serviceAccountSigningKey is set, issuerURL must be set
               rule: has(self.issuerURL) || !has(self.serviceAccountSigningKey)
-            - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
-                must be unique and non-overlapping
-              rule: (self.platform.type == "IBMCloud" || !has(self.networking.machineNetwork)
-                && self.networking.clusterNetwork.all(c, self.networking.serviceNetwork.all(s,
-                c.cidr != s.cidr)) || (has(self.networking.machineNetwork) && (self.networking.machineNetwork.all(m,
-                self.networking.clusterNetwork.all(c, m.cidr != c.cidr)) && self.networking.machineNetwork.all(m,
-                self.networking.serviceNetwork.all(s, m.cidr != s.cidr)) && self.networking.clusterNetwork.all(c,
-                self.networking.serviceNetwork.all(s, c.cidr != s.cidr)))))
           status:
             description: Status is the latest observed status of the HostedCluster.
             properties:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
@@ -3025,6 +3025,14 @@ spec:
                         once set.
                       rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
+                    must be unique and non-overlapping
+                  rule: (!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s,
+                    c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m,
+                    self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m,
+                    self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c,
+                    self.serviceNetwork.all(s, c.cidr != s.cidr)))))
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -5700,14 +5708,6 @@ spec:
                 != "") : true'
             - message: If serviceAccountSigningKey is set, issuerURL must be set
               rule: has(self.issuerURL) || !has(self.serviceAccountSigningKey)
-            - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
-                must be unique and non-overlapping
-              rule: (self.platform.type == "IBMCloud" || !has(self.networking.machineNetwork)
-                && self.networking.clusterNetwork.all(c, self.networking.serviceNetwork.all(s,
-                c.cidr != s.cidr)) || (has(self.networking.machineNetwork) && (self.networking.machineNetwork.all(m,
-                self.networking.clusterNetwork.all(c, m.cidr != c.cidr)) && self.networking.machineNetwork.all(m,
-                self.networking.serviceNetwork.all(s, m.cidr != s.cidr)) && self.networking.clusterNetwork.all(c,
-                self.networking.serviceNetwork.all(s, c.cidr != s.cidr)))))
           status:
             description: Status is the latest observed status of the HostedCluster.
             properties:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
@@ -2947,6 +2947,14 @@ spec:
                         once set.
                       rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
+                    must be unique and non-overlapping
+                  rule: (!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s,
+                    c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m,
+                    self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m,
+                    self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c,
+                    self.serviceNetwork.all(s, c.cidr != s.cidr)))))
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
@@ -2856,6 +2856,14 @@ spec:
                         once set.
                       rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
+                    must be unique and non-overlapping
+                  rule: (!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s,
+                    c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m,
+                    self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m,
+                    self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c,
+                    self.serviceNetwork.all(s, c.cidr != s.cidr)))))
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
@@ -2929,6 +2929,14 @@ spec:
                         once set.
                       rule: self == oldSelf
                 type: object
+                x-kubernetes-validations:
+                - message: CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork
+                    must be unique and non-overlapping
+                  rule: (!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s,
+                    c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m,
+                    self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m,
+                    self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c,
+                    self.serviceNetwork.all(s, c.cidr != s.cidr)))))
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -3798,7 +3798,9 @@ field is not used by the plugin, it can be left unset.</p>
 <p>
 <p>clusterNetworking specifies network configuration for a cluster.
 All CIDRs must be unique. Additional validation to check for CIDRs overlap and consistent network stack is performed by the controllers.
-Failing that validation will result in the HostedCluster being degraded and the validConfiguration condition being false.</p>
+Failing that validation will result in the HostedCluster being degraded and the validConfiguration condition being false.
+TODO this is available in vanilla kube from 1.31 API servers and in Openshift from 4.16.
+TODO(alberto): Use CEL cidr library for all these validation when all management clusters are &gt;= 1.31.</p>
 </p>
 <table>
 <thead>
@@ -4964,8 +4966,6 @@ which contain any of the given tags will be excluded from the result.</p>
 <a href="#hypershift.openshift.io/v1beta1.HostedCluster">HostedCluster</a>)
 </p>
 <p>
-<p>TODO(alberto): Use CEL cidr library for all these validation when all management clusters are &gt;= 1.31.
-TODO(alberto): Move this down to the networking section when IBMCloud has finished valid input migration.</p>
 </p>
 <table>
 <thead>

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -385,9 +385,7 @@ type Capabilities struct {
 // +kubebuilder:validation:XValidation:rule=`self.platform.type == "Azure" ? self.services.exists(s, s.service == "Konnectivity" && s.servicePublishingStrategy.type == "Route" && s.servicePublishingStrategy.route.hostname != "") : true`,message="Azure platform requires Konnectivity Route service with a hostname to be defined"
 // +kubebuilder:validation:XValidation:rule=`self.platform.type == "Azure" ? self.services.exists(s, s.service == "Ignition" && s.servicePublishingStrategy.type == "Route" && s.servicePublishingStrategy.route.hostname != "") : true`,message="Azure platform requires Ignition Route service with a hostname to be defined"
 // +kubebuilder:validation:XValidation:rule=`has(self.issuerURL) || !has(self.serviceAccountSigningKey)`,message="If serviceAccountSigningKey is set, issuerURL must be set"
-// TODO(alberto): Use CEL cidr library for all these validation when all management clusters are >= 1.31.
-// TODO(alberto): Move this down to the networking section when IBMCloud has finished valid input migration.
-// +kubebuilder:validation:XValidation:rule=`(self.platform.type == "IBMCloud" || !has(self.networking.machineNetwork) && self.networking.clusterNetwork.all(c, self.networking.serviceNetwork.all(s, c.cidr != s.cidr)) || (has(self.networking.machineNetwork) && (self.networking.machineNetwork.all(m, self.networking.clusterNetwork.all(c, m.cidr != c.cidr)) && self.networking.machineNetwork.all(m, self.networking.serviceNetwork.all(s, m.cidr != s.cidr)) && self.networking.clusterNetwork.all(c, self.networking.serviceNetwork.all(s, c.cidr != s.cidr)))))`,message="CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork must be unique and non-overlapping"
+
 type HostedClusterSpec struct {
 	// release specifies the desired OCP release payload for all the hosted cluster components.
 	// This includes those components running management side like the Kube API Server and the CVO but also the operands which land in the hosted cluster data plane like the ingress controller, ovn agents, etc.
@@ -892,6 +890,9 @@ type DNSSpec struct {
 // clusterNetworking specifies network configuration for a cluster.
 // All CIDRs must be unique. Additional validation to check for CIDRs overlap and consistent network stack is performed by the controllers.
 // Failing that validation will result in the HostedCluster being degraded and the validConfiguration condition being false.
+// TODO this is available in vanilla kube from 1.31 API servers and in Openshift from 4.16.
+// TODO(alberto): Use CEL cidr library for all these validation when all management clusters are >= 1.31.
+// +kubebuilder:validation:XValidation:rule="(!has(self.machineNetwork) && self.clusterNetwork.all(c, self.serviceNetwork.all(s, c.cidr != s.cidr)) || (has(self.machineNetwork) && (self.machineNetwork.all(m, self.clusterNetwork.all(c, m.cidr != c.cidr)) && self.machineNetwork.all(m, self.serviceNetwork.all(s, m.cidr != s.cidr)) && self.clusterNetwork.all(c, self.serviceNetwork.all(s, c.cidr != s.cidr)))))",message="CIDR ranges in machineNetwork, clusterNetwork, and serviceNetwork must be unique and non-overlapping"
 type ClusterNetworking struct {
 	// machineNetwork is the list of IP address pools for machines.
 	// This might be used among other things to generate appropriate networking security groups in some clouds providers.


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a revert of https://github.com/openshift/hypershift/pull/5258/commits/c7ee48dc34d9302461f6d507e80ee47c449adbb5 to reinforce CEL validation for IBMCloud.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.