### PR TITLE
OSASINFRA-3732: openstack: Sync CA cert to new key

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/providerconfig.go
@@ -29,8 +29,16 @@ func ReconcileCloudConfigSecret(platformSpec *hyperv1.OpenStackPlatformSpec, sec
 	config := getCloudConfig(platformSpec, credentialsSecret, caCertData, machineNetwork)
 	if caCertData != nil {
 		secret.Data[CASecretKey] = caCertData
+		// TODO(stephenfin): Both csi-operator (for Manila and Cinder CSI) and
+		// cluster-storage-operator now uses the certs from 'cacert', meaning
+		// this is no longer necessary. It is only kept here temporarily to
+		// ease upgrades. Remove in 4.20+
 		secret.Data[CABundleKey] = caCertData
 	}
+	// TODO(stephenfin): Neither cinder nor manila CSI drivers (as deployed by
+	// csi-operator) consume configuration from this secret: cinder sources it
+	// from the config map, and manila does its own special thing. Remove in
+	// 4.20+
 	secret.Data[CloudConfigKey] = []byte(config)
 
 	return nil

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/providerconfig.go
@@ -28,6 +28,7 @@ func ReconcileCloudConfigSecret(platformSpec *hyperv1.OpenStackPlatformSpec, sec
 	}
 	config := getCloudConfig(platformSpec, credentialsSecret, caCertData, machineNetwork)
 	if caCertData != nil {
+		secret.Data[CASecretKey] = caCertData
 		secret.Data[CABundleKey] = caCertData
 	}
 	secret.Data[CloudConfigKey] = []byte(config)

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/config.go
@@ -45,6 +45,13 @@ func adaptConfig(cpContext component.WorkloadContext, cm *corev1.ConfigMap) erro
 
 	caCertData := GetCACertFromCredentialsSecret(credentialsSecret)
 	if caCertData != nil {
+		// NOTE(stephenfin): While we (OpenStack) would prefer that this used
+		// 'cacert' like everything else, CCCMO expects the CA cert to be found
+		// at 'ca-bundle.pem' since it will combine this cert with an optional
+		// cert bundle. This is done for more platforms that OpenStack so we
+		// don't want to change that. See the below for more information.
+		//
+		// https://github.com/openshift/cluster-cloud-controller-manager-operator/blob/master/docs/dev/trusted_ca_bundle_sync.md
 		cm.Data[CABundleKey] = string(caCertData)
 	}
 

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1569,9 +1569,9 @@ func (r *reconciler) reconcileCloudCredentialSecrets(ctx context.Context, hcp *h
 		caCertData := openstack.GetCACertFromCredentialsSecret(credentialsSecret)
 		errs = append(errs,
 			r.reconcileOpenStackCredentialsSecret(ctx, hcp.Spec.Platform.OpenStack, "openshift-cluster-csi-drivers", "openstack-cloud-credentials", credentialsSecret, caCertData, hcp.Spec.Networking.MachineNetwork),
+			r.reconcileOpenStackCredentialsSecret(ctx, hcp.Spec.Platform.OpenStack, "openshift-cluster-csi-drivers", "manila-cloud-credentials", credentialsSecret, caCertData, hcp.Spec.Networking.MachineNetwork),
 			r.reconcileOpenStackCredentialsSecret(ctx, hcp.Spec.Platform.OpenStack, "openshift-image-registry", "installer-cloud-credentials", credentialsSecret, caCertData, hcp.Spec.Networking.MachineNetwork),
 			r.reconcileOpenStackCredentialsSecret(ctx, hcp.Spec.Platform.OpenStack, "openshift-cloud-network-config-controller", "cloud-credentials", credentialsSecret, caCertData, hcp.Spec.Networking.MachineNetwork),
-			r.reconcileOpenStackCredentialsSecret(ctx, hcp.Spec.Platform.OpenStack, "openshift-cluster-csi-drivers", "manila-cloud-credentials", credentialsSecret, caCertData, hcp.Spec.Networking.MachineNetwork),
 		)
 	case hyperv1.PowerVSPlatform:
 		createPowerVSSecret := func(srcSecret, destSecret *corev1.Secret) error {
@@ -1649,7 +1649,7 @@ func (r *reconciler) reconcileCloudCredentialSecrets(ctx context.Context, hcp *h
 	return errs
 }
 
-// reconcileOpenStackCredentialsSecret is a wrapper used to reconcile the OpenStack cloud config secrets.
+// reconcileOpenStackCredentialsSecret is a wrapper used to reconcile the OpenStack credentials secrets.
 func (r *reconciler) reconcileOpenStackCredentialsSecret(ctx context.Context, platformSpec *hyperv1.OpenStackPlatformSpec, namespace, name string, credentialsSecret *corev1.Secret, caCertData []byte, machineNetwork []hyperv1.MachineNetworkEntry) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

cloud-credential-operator now supports syncing CA certs from the root credential secret to the generated credentials secrets. If necessary, CCO expects the CA cert to be provided in the `cacert` key and will place it in the same location in the generated secrets. Start doing the same in control-plane-operator, which allows us to significantly simplify the assets used in cluster-storage-operator and csi-operator.

Note that we are intentionally *not* changing how CA certs are managed for cluster-cloud-controller-manager-operator. There's a good reason for this, and a note is left inline to that effect.

/hold

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:

Per $subject.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.
