### PR TITLE
CNTRLPLANE-112: Enable MIv3 for azure disk csi driver

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go
@@ -111,6 +111,7 @@ type AzureConfig struct {
 	SubscriptionID               string `json:"subscriptionId"`
 	AADClientID                  string `json:"aadClientId"`
 	AADClientCertPath            string `json:"aadClientCertPath"`
+	AADMSIDataPlaneIdentityPath  string `json:"aadMSIDataPlaneIdentityPath"`
 	ResourceGroup                string `json:"resourceGroup"`
 	Location                     string `json:"location"`
 	VnetName                     string `json:"vnetName"`

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -5083,7 +5083,7 @@ func (r *HostedControlPlaneReconciler) reconcileClusterStorageOperator(ctx conte
 		// Reconcile SecretProviderClasses
 		azureDiskSecretProviderClass := manifests.ManagedAzureSecretProviderClass(config.ManagedAzureDiskCSISecretStoreProviderClassName, hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r, azureDiskSecretProviderClass, func() error {
-			secretproviderclass.ReconcileManagedAzureSecretProviderClass(azureDiskSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Disk)
+			secretproviderclass.ReconcileManagedAzureSecretProviderClass(azureDiskSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Disk, true)
 			return nil
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile Azure Disk Secret Provider Class: %w", err)

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/azure.go
@@ -30,8 +30,7 @@ func initializeAzureCSIControllerConfig(hcp *hyperv1.HostedControlPlane, tenantI
 // ReconcileAzureDiskCSISecret reconciles the configuration for the secret as expected by azure-disk-csi-controller
 func ReconcileAzureDiskCSISecret(secret *corev1.Secret, hcp *hyperv1.HostedControlPlane, tenantID string) error {
 	config := initializeAzureCSIControllerConfig(hcp, tenantID)
-	config.AADClientID = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Disk.ClientID
-	config.AADClientCertPath = path.Join(hypershiftconfig.ManagedAzureCertificatePath, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Disk.CertificateName)
+	config.AADMSIDataPlaneIdentityPath = path.Join(hypershiftconfig.ManagedAzureCertificatePath, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Disk.CredentialsSecretName)
 
 	serializedConfig, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/config.go
@@ -116,6 +116,7 @@ type AzureConfig struct {
 	// TODO HOSTEDCP-1542 - Bryan - drop client secret once we have WorkloadIdentity working
 	AADClientSecret              string `json:"aadClientSecret"`
 	AADClientCertPath            string `json:"aadClientCertPath"`
+	AADMSIDataPlaneIdentityPath  string `json:"aadMSIDataPlaneIdentityPath"`
 	ResourceGroup                string `json:"resourceGroup"`
 	Location                     string `json:"location"`
 	VnetName                     string `json:"vnetName"`

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/storage/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/storage/azure.go
@@ -21,13 +21,12 @@ func adaptAzureCSISecret(cpContext component.WorkloadContext, managedIdentity hy
 	azureSpec := cpContext.HCP.Spec.Platform.Azure
 
 	azureConfig := azure.AzureConfig{
-		Cloud:             azureSpec.Cloud,
-		TenantID:          azureSpec.TenantID,
-		SubscriptionID:    azureSpec.SubscriptionID,
-		ResourceGroup:     azureSpec.ResourceGroupName,
-		Location:          azureSpec.Location,
-		AADClientID:       managedIdentity.ClientID,
-		AADClientCertPath: path.Join(hyperconfig.ManagedAzureCertificatePath, managedIdentity.CertificateName),
+		Cloud:                       azureSpec.Cloud,
+		TenantID:                    azureSpec.TenantID,
+		SubscriptionID:              azureSpec.SubscriptionID,
+		ResourceGroup:               azureSpec.ResourceGroupName,
+		Location:                    azureSpec.Location,
+		AADMSIDataPlaneIdentityPath: path.Join(hyperconfig.ManagedAzureCertificatePath, managedIdentity.CredentialsSecretName),
 	}
 
 	var getVnetNameAndResourceGroupErr error
@@ -53,7 +52,7 @@ func adaptAzureCSIDiskSecret(cpContext component.WorkloadContext, secret *corev1
 
 func adaptAzureCSIDiskSecretProvider(cpContext component.WorkloadContext, secretProvider *secretsstorev1.SecretProviderClass) error {
 	managedIdentity := cpContext.HCP.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Disk
-	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, managedIdentity)
+	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, managedIdentity, true)
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request enables managed identity version 3 for azure disk csi driver for managed Azure HCP.

**Which issue(s) this PR fixes**
A part of [CNTRLPLANE-112](https://issues.redhat.com/browse/CNTRLPLANE-112)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.