### PR TITLE
CNTRLPLANE-244: Enable initial GitHub Action jobs

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,16 @@
+name: codespell
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  codespell:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run Codespell with annotations
+        uses: codespell-project/actions-codespell@v2.1
+        with:
+          skip: ./hack/tools/bin/codespell_dist,./docs/site/*,./vendor/*,./api/vendor/*,./hack/tools/vendor/*,./api/hypershift/v1alpha1/*,./support/thirdparty/*,./docs/content/reference/*,./hack/tools/bin/*,./cmd/install/assets/*,./go.sum,./hack/workspace/go.work.sum,./api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests,./hack/tools/go.mod,./hack/tools/go.sum
+          ignore_words_file: .codespellignore

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,19 @@
+name: golangci-lint
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Go environment
+        uses: actions/setup-go@v5.3.0
+        with:
+          go-version-file: go.mod
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6.5.0
+        with:
+          args: --timeout=15m --config=.golangci.yml --issues-exit-code=0

--- a/.github/workflows/make-verify.yml
+++ b/.github/workflows/make-verify.yml
@@ -1,0 +1,17 @@
+name: make-verify
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  make-verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Go environment
+        uses: actions/setup-go@v5.3.0
+        with:
+          go-version-file: go.mod
+      - name: Run make verify
+        run: make verify

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,0 +1,29 @@
+name: unit-test
+on:
+  pull_request:
+    branches:
+      - main
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  unit-test:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Go environment
+        uses: actions/setup-go@v5.3.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Run unit tests
+        run: go test -race -parallel=$(nproc) -count=1 -timeout=15m -coverprofile cover.out -covermode=atomic -coverpkg=./... ./...
+      - name: Check test coverage
+        uses: vladopajic/go-test-coverage@v2.12.0
+        continue-on-error: true
+        with:
+          profile: cover.out
+          config: .testcoverage.yml

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -1,0 +1,55 @@
+# (mandatory)
+# Path to coverage profile file (output of `go test -coverprofile` command).
+#
+# For cases where there are many coverage profiles, such as when running
+# unit tests and integration tests separately, you can combine all those
+# profiles into one. In this case, the profile should have a comma-separated list
+# of profile files, e.g., 'cover_unit.out,cover_integration.out'.
+profile: cover.out
+
+# (optional; but recommended to set)
+# When specified reported file paths will not contain local prefix in the output.
+local-prefix: "github.com/openshift/hypershift"
+
+# Holds coverage thresholds percentages, values should be in range [0-100].
+threshold:
+  # (optional; default 0)
+  # Minimum coverage percentage required for individual files.
+  file: 70
+
+  # (optional; default 0)
+  # Minimum coverage percentage required for each package.
+  package: 80
+
+  # (optional; default 0)
+  # Minimum overall project coverage percentage required.
+  total: 95
+
+# Holds regexp rules which will override thresholds for matched files or packages
+# using their paths.
+#
+# First rule from this list that matches file or package is going to apply
+# new threshold to it. If project has multiple rules that match same path,
+# override rules should be listed in order from specific to more general rules.
+override:
+  # Increase coverage threshold to 100% for `foo` package
+  # (default is 80, as configured above in this example).
+  - path: ^pkg/lib/foo$
+    threshold: 100
+
+# Holds regexp rules which will exclude matched files or packages
+# from coverage statistics.
+exclude:
+  # Exclude files or packages matching their paths
+  paths:
+    - \.pb\.go$    # excludes all protobuf generated files
+    - ^pkg/bar     # exclude package `pkg/bar`
+
+# File name of go-test-coverage breakdown file, which can be used to
+# analyze coverage difference.
+breakdown-file-name: ''
+
+diff:
+  # File name of go-test-coverage breakdown file which will be used to
+  # report coverage difference.
+  base-breakdown-file-name: ''

--- a/support/controlplane-component/controlplane-component.go
+++ b/support/controlplane-component/controlplane-component.go
@@ -53,7 +53,7 @@ type ControlPlaneContext struct {
 	SetDefaultSecurityContext bool
 	// EnableCIDebugOutput enable extra debug logs.
 	EnableCIDebugOutput bool
-	// MetricsSet  specifies which metrics to use in the service/pod-monitors.
+	// MetricsSet specifies which metrics to use in the service/pod-monitors.
 	MetricsSet metrics.MetricsSet
 
 	// This is needed for the generic unit test, so we can always generate a fixture for the components deployment/statefulset.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables an initial set of GitHub Action jobs including: codespell, golangci-lint, verify, and unit testing

**Which issue(s) this PR fixes**:
A part of [CNTRLPLANE-244](https://issues.redhat.com/browse/CNTRLPLANE-244)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.