### PR TITLE
HOSTEDCP-910: Enable pprof in hosted etcd

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
@@ -408,6 +408,10 @@ fi
 				Name:  "QUOTA_BACKEND_BYTES",
 				Value: strconv.FormatInt(EtcdSTSQuotaBackendSize, 10),
 			},
+			{
+				Name:  "ETCD_ENABLE_PPROF",
+				Value: "true",
+			},
 		}
 		c.Ports = []corev1.ContainerPort{
 			{


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables pprof in hosted etcd, similar to self-managed or not-hypershift openshift deployments, which eases debugging hosted control-planes

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[HOSTEDCP-910](https://issues.redhat.com/browse/HOSTEDCP-910)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.