### PR TITLE
OSASINFRA-3733: deploy ORC on release payload >= 4.19

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
@@ -138,8 +138,12 @@ func GetPlatform(ctx context.Context, hcluster *hyperv1.HostedCluster, releasePr
 			if err != nil {
 				return nil, fmt.Errorf("failed to retrieve orc image: %w", err)
 			}
+			payloadVersion, err = imgUtil.GetPayloadVersion(ctx, releaseProvider, hcluster, pullSecretBytes)
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch payload version: %w", err)
+			}
 		}
-		platform = openstack.New(capiImageProvider, orcImage)
+		platform = openstack.New(capiImageProvider, orcImage, payloadVersion)
 	default:
 		return nil, fmt.Errorf("unsupported platform: %s", hcluster.Spec.Platform.Type)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

ORC was added to the release payload in 4.19 so we don't want to
install it in 4.18.
