### PR TITLE
OCPBUGS-51339: [release-4.17] Fix IsProgressing condition in HostedClusters

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3529,31 +3529,19 @@ func (r *HostedControlPlaneReconciler) reconcileClusterVersionOperator(ctx conte
 	if err := r.Get(ctx, client.ObjectKeyFromObject(pullSecret), pullSecret); err != nil {
 		return fmt.Errorf("failed to get pull secret for namespace %s: %w", hcp.Namespace, err)
 	}
-
-	cpRef, err := registryclient.GetCorrectArchImage(ctx, "cluster-version-operator", p.ControlPlaneImage, pullSecret.Data[corev1.DockerConfigJsonKey], r.ImageMetadataProvider)
+	pullSecretBytes := pullSecret.Data[corev1.DockerConfigJsonKey]
+	_, controlPlaneReleaseImageRef, err := r.ImageMetadataProvider.GetDigest(ctx, p.ControlPlaneImage, pullSecretBytes)
 	if err != nil {
-		return fmt.Errorf("failed to parse control plane release image %s: %w", cpRef, err)
+		return fmt.Errorf("failed to get control plane release image digest %s: %w", p.ControlPlaneImage, err)
 	}
-
-	_, cpReleaseImageRef, err := r.ImageMetadataProvider.GetDigest(ctx, cpRef, pullSecret.Data[corev1.DockerConfigJsonKey])
-	if err != nil {
-		return fmt.Errorf("failed to get control plane release image digest %s: %w", cpRef, err)
-	}
-
-	controlPlaneReleaseImage = fmt.Sprintf("%s/%s/%s", cpReleaseImageRef.Registry, cpReleaseImageRef.Namespace, cpReleaseImageRef.NameString())
+	controlPlaneReleaseImage = controlPlaneReleaseImageRef.String()
 
 	if p.ControlPlaneImage != hcp.Spec.ReleaseImage {
-		dpRef, err := registryclient.GetCorrectArchImage(ctx, "cluster-version-operator", hcp.Spec.ReleaseImage, pullSecret.Data[corev1.DockerConfigJsonKey], r.ImageMetadataProvider)
+		_, dataPlaneReleaseImageRef, err := r.ImageMetadataProvider.GetDigest(ctx, hcp.Spec.ReleaseImage, pullSecretBytes)
 		if err != nil {
-			return fmt.Errorf("failed to parse data plane release image %s: %w", dpRef, err)
+			return fmt.Errorf("failed to get release image digest %s: %w", hcp.Spec.ReleaseImage, err)
 		}
-
-		_, dpReleaseImageRef, err := r.ImageMetadataProvider.GetDigest(ctx, dpRef, pullSecret.Data[corev1.DockerConfigJsonKey])
-		if err != nil {
-			return fmt.Errorf("failed to get data plane release image digest %s: %w", dpRef, err)
-		}
-
-		dataPlaneReleaseImage = fmt.Sprintf("%s/%s/%s", dpReleaseImageRef.Registry, dpReleaseImageRef.Namespace, dpReleaseImageRef.NameString())
+		dataPlaneReleaseImage = dataPlaneReleaseImageRef.String()
 	} else {
 		dataPlaneReleaseImage = controlPlaneReleaseImage
 	}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1033,6 +1033,10 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	hcluster.Status.PayloadArch = payloadArch
+	pullSecretBytes, err := hyperutil.GetPullSecretBytes(ctx, r.Client, hcluster)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
 	releaseImage, err := r.lookupReleaseImage(ctx, hcluster, releaseProvider)
 	if err != nil {
@@ -1047,7 +1051,15 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 			Message:            "HostedCluster is at expected version",
 			Reason:             hyperv1.AsExpectedReason,
 		}
-		progressing, err := isProgressing(hcluster, releaseImage)
+		refWithDigest := func() (string, error) {
+			_, ref, err := registryClientImageMetadataProvider.GetDigest(ctx, hcluster.Spec.Release.Image, pullSecretBytes)
+			if err != nil {
+				return "", err
+			}
+			return ref.String(), nil
+		}
+
+		progressing, err := isProgressing(hcluster, releaseImage, refWithDigest)
 		if err != nil {
 			condition.Status = metav1.ConditionFalse
 			condition.Message = err.Error()
@@ -1136,10 +1148,6 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	pullSecretBytes, err := hyperutil.GetPullSecretBytes(ctx, r.Client, hcluster)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
 	controlPlaneOperatorImage, err := GetControlPlaneOperatorImage(ctx, hcluster, releaseProvider, r.HypershiftOperatorImage, pullSecretBytes)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get controlPlaneOperatorImage: %w", err)
@@ -4066,7 +4074,7 @@ func (r *HostedClusterReconciler) validateReleaseImage(ctx context.Context, hc *
 	return supportedversion.IsValidReleaseVersion(&version, currentVersion, &supportedversion.LatestSupportedVersion, &minSupportedVersion, hc.Spec.Networking.NetworkType, hc.Spec.Platform.Type)
 }
 
-func isProgressing(hc *hyperv1.HostedCluster, releaseImage *releaseinfo.ReleaseImage) (bool, error) {
+func isProgressing(hc *hyperv1.HostedCluster, releaseImage *releaseinfo.ReleaseImage, refWithDigest func() (string, error)) (bool, error) {
 	for _, condition := range hc.Status.Conditions {
 		switch string(condition.Type) {
 		case string(hyperv1.SupportedHostedCluster), string(hyperv1.ValidHostedClusterConfiguration), string(hyperv1.ValidReleaseImage), string(hyperv1.ReconciliationActive):
@@ -4081,7 +4089,12 @@ func isProgressing(hc *hyperv1.HostedCluster, releaseImage *releaseinfo.ReleaseI
 		}
 	}
 
-	if hc.Status.Version == nil || hc.Spec.Release.Image != hc.Status.Version.Desired.Image {
+	withDigest, err := refWithDigest()
+	if err != nil {
+		return false, err
+	}
+
+	if hc.Status.Version == nil || (hc.Spec.Release.Image != hc.Status.Version.Desired.Image && withDigest != hc.Status.Version.Desired.Image) {
 		// cluster is doing initial rollout or upgrading
 		return true, nil
 	}

--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -168,7 +168,7 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage str
 		return nil, err
 	}
 
-	mcoComposedImage := fmt.Sprintf("%s/%s/%s", checkedMcoImage.Registry, checkedMcoImage.Namespace, checkedMcoImage.NameString())
+	mcoComposedImage := checkedMcoImage.String()
 	if mcoComposedImage != mcoImage {
 		mcoImage = mcoComposedImage
 		log.Info(fmt.Sprintf("using mirrored %s image %v", component, mcoImage))
@@ -318,7 +318,7 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage str
 			return err
 		}
 
-		ccaComposedImage := fmt.Sprintf("%s/%s/%s", checkedClusterConfigImage.Registry, checkedClusterConfigImage.Namespace, checkedClusterConfigImage.NameString())
+		ccaComposedImage := checkedClusterConfigImage.String()
 		if ccaComposedImage != clusterConfigImage {
 			clusterConfigImage = ccaComposedImage
 			log.Info(fmt.Sprintf("using mirrored %s image %v", clusterConfigComponent, ccaComposedImage))

--- a/support/util/imagemetadata_test.go
+++ b/support/util/imagemetadata_test.go
@@ -150,6 +150,7 @@ func TestGetManifest(t *testing.T) {
 		})
 	}
 }
+
 func TestGetDigest(t *testing.T) {
 	ctx := context.TODO()
 	pullSecret := []byte("{}")
@@ -164,7 +165,7 @@ func TestGetDigest(t *testing.T) {
 	}{
 		{
 			name:        "if failed to parse image reference",
-			imageRef:    "invalid-image-ref",
+			imageRef:    "::invalid-image-ref",
 			pullSecret:  pullSecret,
 			expectedErr: true,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
After #5168, the release image passed to the CVO is an image with a digest (which is needed for offline). Because this doesn't always match the release image specified in the HostedCluster.spec.release.image field, code that relies on comparing the image in CVO status with what's in the spec is now not matching. One effect is that the Progressing condition remains set to "true" even if a HostedCluster has completed provisioning.

This PR makes the following changes in order to fix it:
- Adds code to the HyperShift operator to compare either the image in spec as is or converted to a digest with the image reported by the CVO in status.
- Removes the call to obtain the release image for a specific architecture when obtaining an image with digest for the release.
- Removes code that uses fmt.Sprintf to obtain an image ref string from a docker reference in favor of ref.String() except in places where we can't rely on ref.String() to give us the expected reference.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.