### PR TITLE
NO-JIRA: doc: openstack: update go version

### DIFF
--- a/docs/content/how-to/openstack/prerequisites.md
+++ b/docs/content/how-to/openstack/prerequisites.md
@@ -33,7 +33,7 @@ places the CLI tool within the `/usr/local/bin` directory.
   
 ```shell
 podman run --rm --privileged -it -v \
-$PWD:/output docker.io/library/golang:1.22 /bin/bash -c \
+$PWD:/output docker.io/library/golang:1.23 /bin/bash -c \
 'git clone https://github.com/openshift/hypershift.git && \
 cd hypershift/ && \
 make hypershift product-cli && \


### PR DESCRIPTION
We are now using 1.23 so we need to update the doc or users will have trouble to build the binary.
