### PR TITLE
OCPBUGS-51375: use registryOverrides when automaitcally retrieving catalog images for hosted control plane

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
@@ -21,7 +21,6 @@ import (
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/metrics"
-	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
 	"github.com/openshift/hypershift/support/util"
 )
 
@@ -122,7 +121,7 @@ func findTagReference(tags []imagev1.TagReference, name string) *imagev1.TagRefe
 	return nil
 }
 
-func GetCatalogImages(ctx context.Context, hcp hyperv1.HostedControlPlane, pullSecret []byte, digestLister registryclient.DigestListerFN, imageMetadataProvider util.ImageMetadataProvider) (map[string]string, error) {
+func GetCatalogImages(ctx context.Context, hcp hyperv1.HostedControlPlane, pullSecret []byte, imageMetadataProvider util.ImageMetadataProvider, registryOverrides map[string][]string) (map[string]string, error) {
 	imageRef := hcp.Spec.ReleaseImage
 	imageConfig, _, _, err := imageMetadataProvider.GetMetadata(ctx, imageRef, pullSecret)
 	if err != nil {
@@ -134,17 +133,38 @@ func GetCatalogImages(ctx context.Context, hcp hyperv1.HostedControlPlane, pullS
 		return nil, fmt.Errorf("invalid OpenShift release version format: %s", imageConfig.Config.Labels["io.openshift.release"])
 	}
 
-	//check catalogs of last 4 supported version incase new version is not available
-	supportedVersions := 4
-	for i := 0; i < supportedVersions; i++ {
-		_, err = digestLister(ctx, fmt.Sprintf("registry.redhat.io/redhat/certified-operator-index:v%d.%d", version.Major, version.Minor), pullSecret)
-		if err == nil {
-			break
+	registries := []string{
+		"registry.redhat.io/redhat",
+	}
+	if len(registryOverrides) > 0 {
+		for registrySource, registryDest := range registryOverrides {
+			if registries[0] == registrySource {
+				registries = registryDest
+				break
+			}
 		}
-		//manifest unknown error is expected if the image is not available.
-		//If the all supported versions are checked and the image is still not available, return the error
-		if !strings.Contains(err.Error(), "manifest unknown") {
-			return nil, err
+	}
+
+	//check catalogs of last 4 supported version in case new version is not available
+	supportedVersions := 4
+	imageRegistry := ""
+	for i := 0; i < supportedVersions; i++ {
+		for _, registry := range registries {
+			testImage := fmt.Sprintf("%s/certified-operator-index:v%d.%d", registry, version.Major, version.Minor)
+
+			_, dockerImage, err := imageMetadataProvider.GetDigest(ctx, testImage, pullSecret)
+			if err == nil {
+				imageRegistry = fmt.Sprintf("%s/%s", dockerImage.Registry, dockerImage.Namespace)
+				break
+			}
+
+			// Manifest unknown error is expected if the image is not available.
+			if !strings.Contains(err.Error(), "manifest unknown") {
+				return nil, err // Return if it's an unexpected error
+			}
+		}
+		if imageRegistry != "" {
+			break
 		}
 		if i == supportedVersions-1 {
 			return nil, fmt.Errorf("failed to get image digest for 4 previous versions of certified-operator-index: %w", err)
@@ -153,21 +173,21 @@ func GetCatalogImages(ctx context.Context, hcp hyperv1.HostedControlPlane, pullS
 	}
 
 	operators := map[string]string{
-		"certified-operators": fmt.Sprintf("registry.redhat.io/redhat/certified-operator-index:v%d.%d", version.Major, version.Minor),
-		"community-operators": fmt.Sprintf("registry.redhat.io/redhat/community-operator-index:v%d.%d", version.Major, version.Minor),
-		"redhat-marketplace":  fmt.Sprintf("registry.redhat.io/redhat/redhat-marketplace-index:v%d.%d", version.Major, version.Minor),
-		"redhat-operators":    fmt.Sprintf("registry.redhat.io/redhat/redhat-operator-index:v%d.%d", version.Major, version.Minor),
+		"certified-operators": fmt.Sprintf("%s/certified-operator-index:v%d.%d", imageRegistry, version.Major, version.Minor),
+		"community-operators": fmt.Sprintf("%s/community-operator-index:v%d.%d", imageRegistry, version.Major, version.Minor),
+		"redhat-marketplace":  fmt.Sprintf("%s/redhat-marketplace-index:v%d.%d", imageRegistry, version.Major, version.Minor),
+		"redhat-operators":    fmt.Sprintf("%s/redhat-operator-index:v%d.%d", imageRegistry, version.Major, version.Minor),
 	}
 
 	return operators, nil
 }
 
-func ReconcileCatalogsImageStream(imageStream *imagev1.ImageStream, ownerRef config.OwnerRef, isImageRegistryOverrides map[string][]string, catalogImages map[string]string) error {
+func ReconcileCatalogsImageStream(imageStream *imagev1.ImageStream, ownerRef config.OwnerRef, catalogImages map[string]string) error {
 	imageStream.Spec.LookupPolicy.Local = true
 	if imageStream.Spec.Tags == nil {
 		imageStream.Spec.Tags = []imagev1.TagReference{}
 	}
-	for name, image := range getCatalogToImageWithISImageRegistryOverrides(catalogImages, isImageRegistryOverrides) {
+	for name, image := range catalogImages {
 		tagRef := findTagReference(imageStream.Spec.Tags, name)
 		if tagRef == nil {
 			imageStream.Spec.Tags = append(imageStream.Spec.Tags, imagev1.TagReference{

--- a/control-plane-operator/hostedclusterconfigoperator/cmd.go
+++ b/control-plane-operator/hostedclusterconfigoperator/cmd.go
@@ -240,10 +240,21 @@ func (o *HostedClusterConfigOperator) Run(ctx context.Context) error {
 		kubevirtInfraConfig = cpConfig
 	}
 
-	var imageRegistryOverrides map[string][]string
+	imageRegistryOverrides := map[string][]string{}
 	openShiftImgOverrides, ok := os.LookupEnv("OPENSHIFT_IMG_OVERRIDES")
 	if ok {
 		imageRegistryOverrides = util.ConvertImageRegistryOverrideStringToMap(openShiftImgOverrides)
+	}
+	if len(o.registryOverrides) > 0 {
+		if imageRegistryOverrides == nil {
+			imageRegistryOverrides = map[string][]string{}
+		}
+		for registry, override := range o.registryOverrides {
+			if _, exists := imageRegistryOverrides[registry]; !exists {
+				imageRegistryOverrides[registry] = []string{}
+			}
+			imageRegistryOverrides[registry] = append(imageRegistryOverrides[registry], override)
+		}
 	}
 
 	releaseProvider := &releaseinfo.ProviderWithOpenShiftImageRegistryOverridesDecorator{
@@ -303,7 +314,7 @@ func (o *HostedClusterConfigOperator) Run(ctx context.Context) error {
 		OAuthPort:             o.OAuthPort,
 		OperateOnReleaseImage: os.Getenv("OPERATE_ON_RELEASE_IMAGE"),
 		EnableCIDebugOutput:   o.enableCIDebugOutput,
-		ImageMetaDataProvider: *imageMetaDataProvider,
+		ImageMetaDataProvider: imageMetaDataProvider,
 	}
 	configmetrics.Register(mgr.GetCache())
 	return operatorConfig.Start(ctx)

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm/params.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm/params.go
@@ -6,7 +6,6 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/olm"
-	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
 	"github.com/openshift/hypershift/support/util"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -19,8 +18,9 @@ type OperatorLifecycleManagerParams struct {
 	OLMCatalogPlacement     hyperv1.OLMCatalogPlacement
 }
 
-func NewOperatorLifecycleManagerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, pullSecret *corev1.Secret, digestLister registryclient.DigestListerFN, imageMetadataProvider util.ImageMetadataProvider) (*OperatorLifecycleManagerParams, error) {
-	catalogImages, err := olm.GetCatalogImages(ctx, *hcp, pullSecret.Data[corev1.DockerConfigJsonKey], digestLister, imageMetadataProvider)
+func NewOperatorLifecycleManagerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, pullSecret *corev1.Secret, imageMetadataProvider util.ImageMetadataProvider) (*OperatorLifecycleManagerParams, error) {
+	isImageRegistryOverrides := util.ConvertImageRegistryOverrideStringToMap(hcp.Annotations[hyperv1.OLMCatalogsISRegistryOverridesAnnotation])
+	catalogImages, err := olm.GetCatalogImages(ctx, *hcp, pullSecret.Data[corev1.DockerConfigJsonKey], imageMetadataProvider, isImageRegistryOverrides)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get catalog images: %w", err)
 	}

--- a/control-plane-operator/hostedclusterconfigoperator/operator/config.go
+++ b/control-plane-operator/hostedclusterconfigoperator/operator/config.go
@@ -28,7 +28,6 @@ import (
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/labelenforcingclient"
 	"github.com/openshift/hypershift/support/releaseinfo"
-	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
 
@@ -73,8 +72,7 @@ type HostedClusterConfigOperatorConfig struct {
 	OAuthPort                    int32
 	OperateOnReleaseImage        string
 	EnableCIDebugOutput          bool
-	ListDigestsFN                registryclient.DigestListerFN
-	ImageMetaDataProvider        util.RegistryClientImageMetadataProvider
+	ImageMetaDataProvider        util.ImageMetadataProvider
 
 	kubeClient kubeclient.Interface
 }

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -391,6 +391,18 @@ func NewStartCommand() *cobra.Command {
 			imageRegistryOverrides = util.ConvertImageRegistryOverrideStringToMap(openShiftImgOverrides)
 		}
 
+		if len(registryOverrides) > 0 {
+			if imageRegistryOverrides == nil {
+				imageRegistryOverrides = map[string][]string{}
+			}
+			for registry, override := range registryOverrides {
+				if _, exists := imageRegistryOverrides[registry]; !exists {
+					imageRegistryOverrides[registry] = []string{}
+				}
+				imageRegistryOverrides[registry] = append(imageRegistryOverrides[registry], override)
+			}
+		}
+
 		coreReleaseProvider := &releaseinfo.StaticProviderDecorator{
 			Delegate: &releaseinfo.CachedProvider{
 				Inner: &releaseinfo.RegistryClientProvider{},

--- a/docs/content/contribute/index.md
+++ b/docs/content/contribute/index.md
@@ -6,21 +6,26 @@ title: Contribute to HyperShift
 Thanks for your interest in contributing to HyperShift. Here are some guidelines that help make the process more straightforward for everyone.
 
 ## Prior to Submitting a Pull Request
-1. Prior to committing your code, run `make pre-commit`. This updates all Golang and API dependencies, builds the source code, builds the e2e tests, verifies source code format, and runs all unit tests. This will help catch issues before committing so that the verify and unit test CI jobs will not fail on your PR. 
-2. Before submitting your pull request on GitHub, look at your changes and try to view them from the eyes of a reviewer. 
+1. Prior to committing your code
+   1. Install `precommit`. The precommit hooks run on pre-commit and pre-push. The hooks will catch spelling mistakes,
+   make verify issues, unit test issues, and more.
+        1. Instructions for installing `precommit` can be found [here](https://pre-commit.com/#install).
+        2. Tips on using `precommit` hooks in the HyperShift repo can be found [here](./precommit-hook-help.md).
+   2. Run `make pre-commit`. This updates all Golang and API dependencies, builds the source code, builds the e2e tests, verifies source code format, and runs all unit tests. This will help catch issues before committing so that the verify and unit test CI jobs will not fail on your PR.
+2. Before submitting your pull request on GitHub, look at your changes and try to view them from the eyes of a reviewer.
     1. Try to find the aspects that might not immediately make sense for someone else and explain them in the pull request description.
-3. Keep commits/changes scoped to one thing and as minimal as possible. 
+3. Keep commits/changes scoped to one thing and as minimal as possible.
     1. Always keep refactorings (how we do something) separate from logic changes (what we do).
-    2. If you find additional things along the way that you feel should be improved, do that in a separate pull request. 
+    2. If you find additional things along the way that you feel should be improved, do that in a separate pull request.
     3. This helps ensure that you will get a timely review of your change, as a series of small pull requests is a lot easier to review than one big pull request that changes 10 independent things for independent reasons.
 4. Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit, e.g. `Mark infraID as required` instead of `This patch marks infraID as required`.
     1. This follows Git’s own built-in conventions; see [github.com/openshift/hypershift/pull/485](https://github.com/openshift/hypershift/pull/485) as an example.
 5. Make sure the "Why" and "How" are included in the message of each commit.
 
 ## Creating a Pull Request
-1. For small changes, you can just do the change and submit a pull request with it. 
-2. For bigger changes (more than 200 lines of code diff), do not just do the change but, ask for feedback on the idea and direction of the change first (Either in a GitHub issue or the #project-hypershift channel in the External Red Hat Slack). 
-    1. This avoids situations where big changes are submitted that are then declined or never reviewed, which is frustrating for everyone. 
+1. For small changes, you can just do the change and submit a pull request with it.
+2. For bigger changes (more than 200 lines of code diff), do not just do the change but, ask for feedback on the idea and direction of the change first (Either in a GitHub issue or the #project-hypershift channel in the External Red Hat Slack).
+    1. This avoids situations where big changes are submitted that are then declined or never reviewed, which is frustrating for everyone.
 3. Regardless of the size of the change, always explain how the change will improve the project.
 4. Every PR title must be prefixed with the Jira ticket that is addressing e.g. [https://github.com/openshift/hypershift/pull/2233](https://github.com/openshift/hypershift/pull/2233).
 5. This repository is the base code for the Hypershift Operator and the Control Plane Operator (belongs to the OCP payload) so they might have different release cadence.

--- a/support/releaseinfo/registryclient/client.go
+++ b/support/releaseinfo/registryclient/client.go
@@ -16,7 +16,6 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/registry/client/transport"
-	"github.com/opencontainers/go-digest"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -437,26 +436,3 @@ func GetCorrectArchImage(ctx context.Context, component string, imageRef string,
 
 	return imageRef, nil
 }
-
-func GetListDigest(ctx context.Context, imageRef string, pullSecret []byte) (digest.Digest, error) {
-	repo, dockerImageRef, err := GetRepoSetup(ctx, imageRef, pullSecret)
-	if err != nil {
-		return "", fmt.Errorf("failed to get repo setup: %v", err)
-	}
-
-	var srcDigest digest.Digest
-	if len(dockerImageRef.ID) > 0 {
-		srcDigest = digest.Digest(dockerImageRef.ID)
-	} else if len(dockerImageRef.Tag) > 0 {
-		desc, err := repo.Tags(ctx).Get(ctx, dockerImageRef.Tag)
-		if err != nil {
-			return "", err
-		}
-		srcDigest = desc.Digest
-	} else {
-		return "", fmt.Errorf("no tag or digest specified")
-	}
-	return srcDigest, nil
-}
-
-type DigestListerFN = func(ctx context.Context, image string, pullSecret []byte) (digest.Digest, error)


### PR DESCRIPTION
Were changing to use registryOverrides when retrieving catalog images as some users may be mirroring to private registries

OCPBUGS-49825: add a new fakeImageMetaDataProvider for HCCO resources.go

Switch from passing in a fakeDigest func during the resource_test.go fror olmReconcile to using a fakeImageMetaDataProvider to simplify the code

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/browse/OCPBUGS-51375

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.