### PR TITLE
CNTRLPLANE-269: Remove DeploymentConfig usage from cpov2

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/certified-operators-catalog/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/certified-operators-catalog/zz_fixture_TestControlPlaneComponents.yaml
@@ -146,6 +146,8 @@ spec:
           name: utilities
         - mountPath: /extracted-catalog
           name: catalog-content
+      nodeSelector:
+        kubernetes.io/os: linux
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/certified-operators-catalog/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/certified-operators-catalog/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -146,6 +146,8 @@ spec:
           name: utilities
         - mountPath: /extracted-catalog
           name: catalog-content
+      nodeSelector:
+        kubernetes.io/os: linux
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/community-operators-catalog/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/community-operators-catalog/zz_fixture_TestControlPlaneComponents.yaml
@@ -146,6 +146,8 @@ spec:
           name: utilities
         - mountPath: /extracted-catalog
           name: catalog-content
+      nodeSelector:
+        kubernetes.io/os: linux
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/community-operators-catalog/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/community-operators-catalog/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -146,6 +146,8 @@ spec:
           name: utilities
         - mountPath: /extracted-catalog
           name: catalog-content
+      nodeSelector:
+        kubernetes.io/os: linux
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
   name: etcd
   namespace: hcp-namespace
   ownerReferences:
@@ -26,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cluster-state
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
   name: etcd
   namespace: hcp-namespace
   ownerReferences:
@@ -26,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cluster-state
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/featuregate-generator/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/featuregate-generator/zz_fixture_TestControlPlaneComponents.yaml
@@ -2,6 +2,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
   name: featuregate-generator
   namespace: hcp-namespace
   ownerReferences:
@@ -17,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: manifests,work
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/featuregate-generator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/featuregate-generator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -2,6 +2,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
   name: featuregate-generator
   namespace: hcp-namespace
   ownerReferences:
@@ -17,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: manifests,work
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-collect-profiles/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-collect-profiles/zz_fixture_TestControlPlaneComponents.yaml
@@ -2,6 +2,8 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
   name: olm-collect-profiles
   namespace: hcp-namespace
   ownerReferences:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-collect-profiles/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-collect-profiles/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -2,6 +2,8 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   creationTimestamp: null
+  labels:
+    hypershift.openshift.io/managed-by: control-plane-operator
   name: olm-collect-profiles
   namespace: hcp-namespace
   ownerReferences:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/redhat-marketplace-catalog/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/redhat-marketplace-catalog/zz_fixture_TestControlPlaneComponents.yaml
@@ -145,6 +145,8 @@ spec:
           name: utilities
         - mountPath: /extracted-catalog
           name: catalog-content
+      nodeSelector:
+        kubernetes.io/os: linux
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/redhat-marketplace-catalog/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/redhat-marketplace-catalog/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -145,6 +145,8 @@ spec:
           name: utilities
         - mountPath: /extracted-catalog
           name: catalog-content
+      nodeSelector:
+        kubernetes.io/os: linux
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/redhat-operators-catalog/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/redhat-operators-catalog/zz_fixture_TestControlPlaneComponents.yaml
@@ -146,6 +146,8 @@ spec:
           name: utilities
         - mountPath: /extracted-catalog
           name: catalog-content
+      nodeSelector:
+        kubernetes.io/os: linux
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/redhat-operators-catalog/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/redhat-operators-catalog/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -146,6 +146,8 @@ spec:
           name: utilities
         - mountPath: /extracted-catalog
           name: catalog-content
+      nodeSelector:
+        kubernetes.io/os: linux
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule

--- a/support/controlplane-component/cronjob.go
+++ b/support/controlplane-component/cronjob.go
@@ -3,7 +3,6 @@ package controlplanecomponent
 import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
-	"github.com/openshift/hypershift/support/config"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -15,20 +14,13 @@ var _ WorkloadProvider[*batchv1.CronJob] = &cronJobProvider{}
 type cronJobProvider struct {
 }
 
-// ApplyOptionsTo implements WorkloadProvider.
-func (c *cronJobProvider) ApplyOptionsTo(cpContext ControlPlaneContext, object *batchv1.CronJob, oldObject *batchv1.CronJob, deploymentConfig *config.DeploymentConfig) {
-	// preserve existing resource requirements.
-	existingResources := make(map[string]corev1.ResourceRequirements)
-	for _, container := range oldObject.Spec.JobTemplate.Spec.Template.Spec.Containers {
-		existingResources[container.Name] = container.Resources
-	}
-
-	deploymentConfig.Resources = existingResources
-	deploymentConfig.ApplyToCronJob(object)
-}
-
 func (c *cronJobProvider) NewObject() *batchv1.CronJob {
 	return &batchv1.CronJob{}
+}
+
+// SetReplicasAndStrategy implements WorkloadProvider.
+func (d *cronJobProvider) SetReplicasAndStrategy(object *batchv1.CronJob, replicas int32, isRequestServing bool) {
+	// nothing to do.
 }
 
 // LoadManifest implements WorkloadProvider.

--- a/support/controlplane-component/defaults.go
+++ b/support/controlplane-component/defaults.go
@@ -3,6 +3,7 @@ package controlplanecomponent
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 
@@ -14,10 +15,31 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	DefaultSecurityContextUser = 1001
+
+	// This is used by NodeAffinity to prefer/tolerate Nodes.
+	controlPlaneLabelTolerationKey = "hypershift.openshift.io/control-plane"
+	// colocationLabelKey is used by PodAffinity to prefer colocating pods that belong to the same hosted cluster.
+	colocationLabelKey = "hypershift.openshift.io/hosted-control-plane"
+	// Specific cluster weight for soft affinity rule to node.
+	clusterNodeSchedulingAffinityWeight = 100
+	// Generic control plane workload weight for soft affinity rule to node.
+	controlPlaneNodeSchedulingAffinityWeight = clusterNodeSchedulingAffinityWeight / 2
+
+	// managedByLabel can be used to filter deployments.
+	managedByLabel = "hypershift.openshift.io/managed-by"
+	// podSafeToEvictLocalVolumesAnnotation is an annotation denoting the local volumes of a pod that can be safely evicted.
+	// This is needed for the CA operator to make sure it can properly drain the nodes with those volumes.
+	podSafeToEvictLocalVolumesAnnotation = "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes"
 )
 
 var (
@@ -35,25 +57,41 @@ var (
 	}
 )
 
-func (c *controlPlaneWorkload[T]) defaultOptions(cpContext ControlPlaneContext, podTemplateSpec *corev1.PodTemplateSpec, desiredReplicas *int32) (*config.DeploymentConfig, error) {
-	if _, exist := podTemplateSpec.Annotations[config.NeedMetricsServerAccessLabel]; exist || c.NeedsManagementKASAccess() ||
-		c.Name() == "packageserver" { // TODO: investigate why packageserver needs AutomountServiceAccountToken or set NeedsManagementKASAccess to true.
-		podTemplateSpec.Spec.AutomountServiceAccountToken = ptr.To(true)
-	} else {
-		podTemplateSpec.Spec.AutomountServiceAccountToken = ptr.To(false)
+func (c *controlPlaneWorkload[T]) setDefaultOptions(cpContext ControlPlaneContext, workloadObj T, existingResources map[string]corev1.ResourceRequirements) error {
+	hcp := cpContext.HCP
+
+	labels := workloadObj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[managedByLabel] = "control-plane-operator"
+	workloadObj.SetLabels(labels)
+
+	desiredReplicas := c.workloadProvider.Replicas(workloadObj)
+	replicas := c.defaultReplicas(cpContext.HCP)
+	if desiredReplicas != nil {
+		replicas = *desiredReplicas
 	}
 
+	if debugComponentsSet(hcp).Has(c.Name()) {
+		// scale to 0 if this component is in debug mode.
+		c.workloadProvider.SetReplicasAndStrategy(workloadObj, 0, c.IsRequestServing())
+	} else {
+		c.workloadProvider.SetReplicasAndStrategy(workloadObj, replicas, c.IsRequestServing())
+	}
+
+	podTemplateSpec := c.workloadProvider.PodTemplateSpec(workloadObj)
 	enforceVolumesDefaultMode(&podTemplateSpec.Spec)
 	err := enforceImagePullPolicy(podTemplateSpec.Spec.Containers)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	if err := replaceContainersImageFromPayload(cpContext.ReleaseImageProvider, cpContext.HCP, podTemplateSpec.Spec.Containers); err != nil {
-		return nil, err
+	if err := replaceContainersImageFromPayload(cpContext.ReleaseImageProvider, hcp, podTemplateSpec.Spec.Containers); err != nil {
+		return err
 	}
-	if err := replaceContainersImageFromPayload(cpContext.ReleaseImageProvider, cpContext.HCP, podTemplateSpec.Spec.InitContainers); err != nil {
-		return nil, err
+	if err := replaceContainersImageFromPayload(cpContext.ReleaseImageProvider, hcp, podTemplateSpec.Spec.InitContainers); err != nil {
+		return err
 	}
 
 	if c.serviceAccountKubeConfigOpts != nil {
@@ -69,47 +107,327 @@ func (c *controlPlaneWorkload[T]) defaultOptions(cpContext ControlPlaneContext, 
 	}
 
 	if err := c.applyWatchedResourcesAnnotation(cpContext, podTemplateSpec); err != nil {
-		return nil, err
+		return err
 	}
 
 	if c.availabilityProberOpts != nil {
 		availabilityProberImage := cpContext.ReleaseImageProvider.GetImage(util.AvailabilityProberImageName)
 		util.AvailabilityProber(
-			kas.InClusterKASReadyURL(cpContext.HCP.Spec.Platform.Type), availabilityProberImage,
+			kas.InClusterKASReadyURL(hcp.Spec.Platform.Type), availabilityProberImage,
 			&podTemplateSpec.Spec,
 			util.WithOptions(c.availabilityProberOpts))
 	}
 
-	deploymentConfig := &config.DeploymentConfig{
-		SetDefaultSecurityContext: cpContext.SetDefaultSecurityContext,
-		AdditionalLabels: map[string]string{
-			hyperv1.ControlPlaneComponentLabel: c.Name(),
+	if _, exist := podTemplateSpec.Annotations[config.NeedMetricsServerAccessLabel]; exist || c.NeedsManagementKASAccess() ||
+		c.Name() == "packageserver" { // TODO: investigate why packageserver needs AutomountServiceAccountToken or set NeedsManagementKASAccess to true.
+		podTemplateSpec.Spec.AutomountServiceAccountToken = ptr.To(true)
+	} else {
+		podTemplateSpec.Spec.AutomountServiceAccountToken = ptr.To(false)
+	}
+
+	// set default security context for the pod.
+	// ETCD component is excluded as it fails to create data dir on AKS if we set the default security context.
+	if c.Name() != etcdComponentName && cpContext.SetDefaultSecurityContext {
+		podTemplateSpec.Spec.SecurityContext = &corev1.PodSecurityContext{
+			RunAsUser: ptr.To[int64](DefaultSecurityContextUser),
+		}
+	}
+
+	// preserve existing resource requirements.
+	for idx, container := range podTemplateSpec.Spec.Containers {
+		if res, exist := existingResources[container.Name]; exist {
+			podTemplateSpec.Spec.Containers[idx].Resources = res
+		}
+	}
+
+	// set PriorityClassName
+	podTemplateSpec.Spec.PriorityClassName = priorityClass(c.Name(), hcp)
+	// setNodeSelector sets a nodeSelector passed through the API.
+	// This is useful to e.g ensure control plane pods land in management cluster Infra Nodes.
+	if hcp.Spec.NodeSelector != nil {
+		podTemplateSpec.Spec.NodeSelector = hcp.Spec.NodeSelector
+	}
+
+	c.setLabels(podTemplateSpec, hcp)
+	c.setAnnotations(podTemplateSpec, hcp)
+	c.setControlPlaneIsolation(podTemplateSpec, hcp)
+	c.setColocation(podTemplateSpec, hcp)
+	c.applyRequestsOverrides(podTemplateSpec, hcp)
+	if replicas > 1 && c.MultiZoneSpread() {
+		c.setMultizoneSpread(podTemplateSpec, hcp)
+	}
+
+	return nil
+}
+
+func (c *controlPlaneWorkload[T]) setAnnotations(podTemplate *corev1.PodTemplateSpec, hcp *hyperv1.HostedControlPlane) {
+	if podTemplate.Annotations == nil {
+		podTemplate.Annotations = map[string]string{}
+	}
+
+	podTemplate.Annotations[hyperv1.ReleaseImageAnnotation] = util.HCPControlPlaneReleaseImage(hcp)
+	if restartDate, ok := hcp.Annotations[hyperv1.RestartDateAnnotation]; ok {
+		podTemplate.Annotations[hyperv1.RestartDateAnnotation] = restartDate
+	}
+
+	localStorageVolumes := make([]string, 0)
+	for _, volume := range podTemplate.Spec.Volumes {
+		if volume.EmptyDir != nil || volume.HostPath != nil {
+			localStorageVolumes = append(localStorageVolumes, volume.Name)
+		}
+	}
+
+	if len(localStorageVolumes) > 0 {
+		annotationsVolumes := strings.Join(localStorageVolumes, ",")
+		podTemplate.Annotations[podSafeToEvictLocalVolumesAnnotation] = annotationsVolumes
+	}
+}
+
+func (c *controlPlaneWorkload[T]) setLabels(podTemplate *corev1.PodTemplateSpec, hcp *hyperv1.HostedControlPlane) {
+	if podTemplate.Labels == nil {
+		podTemplate.Labels = map[string]string{}
+	}
+
+	podTemplate.Labels[hyperv1.ControlPlaneComponentLabel] = c.Name()
+	if c.NeedsManagementKASAccess() {
+		podTemplate.Labels[config.NeedManagementKASAccessLabel] = "true"
+	}
+	if c.IsRequestServing() {
+		podTemplate.Labels[hyperv1.RequestServingComponentLabel] = "true"
+	}
+	// set additional Labels
+	maps.Copy(podTemplate.Labels, hcp.Spec.Labels)
+}
+
+// setControlPlaneIsolation configures tolerations and NodeAffinity rules to prefer Nodes with controlPlaneNodeLabel and clusterNodeLabel.
+func (c *controlPlaneWorkload[T]) setControlPlaneIsolation(podTemplate *corev1.PodTemplateSpec, hcp *hyperv1.HostedControlPlane) {
+	isolateAsRequestServing := false
+	if c.IsRequestServing() && hcp.Annotations[hyperv1.TopologyAnnotation] == hyperv1.DedicatedRequestServingComponentsTopology {
+		isolateAsRequestServing = true
+	}
+
+	// set Tolerations
+	podTemplate.Spec.Tolerations = []corev1.Toleration{
+		{
+			Key:      controlPlaneLabelTolerationKey,
+			Operator: corev1.TolerationOpEqual,
+			Value:    "true",
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      hyperv1.HostedClusterLabel,
+			Operator: corev1.TolerationOpEqual,
+			Value:    clusterKey(hcp),
+			Effect:   corev1.TaintEffectNoSchedule,
 		},
 	}
-	deploymentConfig.Scheduling.PriorityClass = getPriorityClass(c.Name(), cpContext.HCP)
-
-	if c.NeedsManagementKASAccess() {
-		deploymentConfig.AdditionalLabels[config.NeedManagementKASAccessLabel] = "true"
+	if isolateAsRequestServing {
+		podTemplate.Spec.Tolerations = append(podTemplate.Spec.Tolerations, corev1.Toleration{
+			Key:      hyperv1.RequestServingComponentLabel,
+			Operator: corev1.TolerationOpEqual,
+			Value:    "true",
+			Effect:   corev1.TaintEffectNoSchedule,
+		})
+	}
+	// set additional Tolerations
+	if len(hcp.Spec.Tolerations) != 0 {
+		podTemplate.Spec.Tolerations = append(podTemplate.Spec.Tolerations, hcp.Spec.Tolerations...)
 	}
 
-	replicas := c.defaultReplicas(cpContext.HCP)
-	if desiredReplicas != nil {
-		replicas = int(*desiredReplicas)
+	// set Affinity
+	if podTemplate.Spec.Affinity == nil {
+		podTemplate.Spec.Affinity = &corev1.Affinity{}
+	}
+	if podTemplate.Spec.Affinity.NodeAffinity == nil {
+		podTemplate.Spec.Affinity.NodeAffinity = &corev1.NodeAffinity{}
+	}
+	podTemplate.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = []corev1.PreferredSchedulingTerm{
+		{
+			Weight: controlPlaneNodeSchedulingAffinityWeight,
+			Preference: corev1.NodeSelectorTerm{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      controlPlaneLabelTolerationKey,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"true"},
+					},
+				},
+			},
+		},
+		{
+			Weight: clusterNodeSchedulingAffinityWeight,
+			Preference: corev1.NodeSelectorTerm{
+				MatchExpressions: []corev1.NodeSelectorRequirement{
+					{
+						Key:      hyperv1.HostedClusterLabel,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{clusterKey(hcp)},
+					},
+				},
+			},
+		},
 	}
 
-	var multiZoneSpreadLabels map[string]string
-	if c.MultiZoneSpread() {
-		multiZoneSpreadLabels = podTemplateSpec.ObjectMeta.Labels
+	if isolateAsRequestServing {
+		nodeSelectorRequirements := []corev1.NodeSelectorRequirement{
+			{
+				Key:      hyperv1.RequestServingComponentLabel,
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{"true"},
+			},
+			{
+				Key:      hyperv1.HostedClusterLabel,
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{clusterKey(hcp)},
+			},
+		}
+
+		var additionalRequestServingNodeSelector map[string]string
+		if hcp.Annotations[hyperv1.RequestServingNodeAdditionalSelectorAnnotation] != "" {
+			additionalRequestServingNodeSelector = util.ParseNodeSelector(hcp.Annotations[hyperv1.RequestServingNodeAdditionalSelectorAnnotation])
+		}
+		for key, value := range additionalRequestServingNodeSelector {
+			nodeSelectorRequirements = append(nodeSelectorRequirements, corev1.NodeSelectorRequirement{
+				Key:      key,
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{value},
+			})
+		}
+
+		podTemplate.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &corev1.NodeSelector{
+			NodeSelectorTerms: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: nodeSelectorRequirements,
+				},
+			},
+		}
+	}
+}
+
+// setColocation sets labels and PodAffinity rules for this deployment so that pods
+// of the deployment will prefer to group with pods of the anchor deployment.
+func (c *controlPlaneWorkload[T]) setColocation(podTemplate *corev1.PodTemplateSpec, hcp *hyperv1.HostedControlPlane) {
+	if podTemplate.Labels == nil {
+		podTemplate.Labels = map[string]string{}
+	}
+	podTemplate.Labels[colocationLabelKey] = clusterKey(hcp)
+
+	if podTemplate.Spec.Affinity == nil {
+		podTemplate.Spec.Affinity = &corev1.Affinity{}
+	}
+	if podTemplate.Spec.Affinity.PodAffinity == nil {
+		podTemplate.Spec.Affinity.PodAffinity = &corev1.PodAffinity{}
+	}
+	podTemplate.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = []corev1.WeightedPodAffinityTerm{
+		{
+			Weight: 100,
+			PodAffinityTerm: corev1.PodAffinityTerm{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						colocationLabelKey: clusterKey(hcp),
+					},
+				},
+				TopologyKey: corev1.LabelHostname,
+			},
+		},
+	}
+}
+
+// SetMultizoneSpread sets PodAntiAffinity with corev1.LabelTopologyZone as the topology key for a given set of labels.
+// This is useful to e.g ensure pods are spread across availability zones.
+// If required is true, the rule is set as RequiredDuringSchedulingIgnoredDuringExecution, otherwise it is set as
+// PreferredDuringSchedulingIgnoredDuringExecution.
+func (c *controlPlaneWorkload[T]) setMultizoneSpread(podTemplate *corev1.PodTemplateSpec, hcp *hyperv1.HostedControlPlane) {
+	multiZoneSpreadLabels := podTemplate.ObjectMeta.Labels
+	multiZoneRequired := true
+	switch hcp.Spec.Platform.Type {
+	// On OpenStack and Kubevirt we can't spread across zones in certain cases
+	// so let's relax the requirement on those platforms.
+	case hyperv1.OpenStackPlatform, hyperv1.KubevirtPlatform:
+		multiZoneRequired = false
 	}
 
-	if c.IsRequestServing() {
-		deploymentConfig.SetRequestServingDefaults(cpContext.HCP, multiZoneSpreadLabels, ptr.To(replicas))
+	if podTemplate.Spec.Affinity == nil {
+		podTemplate.Spec.Affinity = &corev1.Affinity{}
+	}
+	if podTemplate.Spec.Affinity.PodAntiAffinity == nil {
+		podTemplate.Spec.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
+	}
+
+	if multiZoneRequired {
+		podTemplate.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(podTemplate.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
+			corev1.PodAffinityTerm{
+				TopologyKey: corev1.LabelTopologyZone,
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: multiZoneSpreadLabels,
+				},
+			})
 	} else {
-		deploymentConfig.SetDefaults(cpContext.HCP, multiZoneSpreadLabels, ptr.To(replicas))
+		podTemplate.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(podTemplate.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
+			corev1.WeightedPodAffinityTerm{
+				Weight: 100,
+				PodAffinityTerm: corev1.PodAffinityTerm{
+					TopologyKey: corev1.LabelTopologyZone,
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: multiZoneSpreadLabels,
+					},
+				},
+			})
 	}
-	deploymentConfig.SetRestartAnnotation(cpContext.HCP.ObjectMeta)
 
-	return deploymentConfig, nil
+	// set PodAntiAffinity with corev1.LabelHostname as the topology key for a given set of labels.
+	// This is useful to e.g ensure pods are spread across nodes.
+	podTemplate.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(podTemplate.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
+		corev1.PodAffinityTerm{
+			TopologyKey: corev1.LabelHostname,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: multiZoneSpreadLabels,
+			},
+		},
+	)
+}
+
+func (c *controlPlaneWorkload[T]) applyRequestsOverrides(podTemplate *corev1.PodTemplateSpec, hcp *hyperv1.HostedControlPlane) {
+	requestsOverrides := map[string]corev1.ResourceList{}
+	for key, value := range hcp.Annotations {
+		if strings.HasPrefix(key, hyperv1.ResourceRequestOverrideAnnotationPrefix+"/") {
+			keyParts := strings.SplitN(key, "/", 2)
+			deploymentContainerParts := strings.SplitN(keyParts[1], ".", 2)
+			deploymentName, containerName := deploymentContainerParts[0], deploymentContainerParts[1]
+			if deploymentName != c.Name() {
+				continue
+			}
+			requestsOverrides[containerName] = parseResourceRequestOverrideAnnotation(value)
+		}
+	}
+
+	for i, c := range podTemplate.Spec.InitContainers {
+		if res, ok := requestsOverrides[c.Name]; ok {
+			maps.Copy(podTemplate.Spec.InitContainers[i].Resources.Requests, res)
+		}
+	}
+	for i, c := range podTemplate.Spec.Containers {
+		if res, ok := requestsOverrides[c.Name]; ok {
+			maps.Copy(podTemplate.Spec.Containers[i].Resources.Requests, res)
+		}
+	}
+}
+
+func parseResourceRequestOverrideAnnotation(value string) corev1.ResourceList {
+	result := corev1.ResourceList{}
+	resourceRequests := strings.Split(value, ",")
+
+	for _, request := range resourceRequests {
+		requestParts := strings.SplitN(request, "=", 2)
+		quantity, err := resource.ParseQuantity(requestParts[1])
+		if err != nil {
+			// Skip this request if invalid
+			continue
+		}
+		result[corev1.ResourceName(requestParts[0])] = quantity
+	}
+
+	return result
 }
 
 func podConfigMapNames(spec *corev1.PodSpec, excludeNames []string) []string {
@@ -249,7 +567,7 @@ func replaceContainersImageFromPayload(imageProvider imageprovider.ReleaseImageP
 	return nil
 }
 
-func getPriorityClass(componentName string, hcp *hyperv1.HostedControlPlane) string {
+func priorityClass(componentName string, hcp *hyperv1.HostedControlPlane) string {
 	priorityClass := config.DefaultPriorityClass
 	overrideAnnotation := hyperv1.ControlPlanePriorityClass
 
@@ -268,7 +586,7 @@ func getPriorityClass(componentName string, hcp *hyperv1.HostedControlPlane) str
 	return priorityClass
 }
 
-func (c *controlPlaneWorkload[T]) defaultReplicas(hcp *hyperv1.HostedControlPlane) int {
+func (c *controlPlaneWorkload[T]) defaultReplicas(hcp *hyperv1.HostedControlPlane) int32 {
 	if hcp.Spec.ControllerAvailabilityPolicy == hyperv1.SingleReplica {
 		return 1
 	}
@@ -281,4 +599,20 @@ func (c *controlPlaneWorkload[T]) defaultReplicas(hcp *hyperv1.HostedControlPlan
 		return 3
 	}
 	return 2
+}
+
+// debugComponentsSet returns a set of Components to debug based on the
+// debugDeploymentsAnnotation value, indicating the Component should be considered to
+// be in development mode.
+func debugComponentsSet(hcp *hyperv1.HostedControlPlane) sets.Set[string] {
+	val, exists := hcp.Annotations[util.DebugDeploymentsAnnotation]
+	if !exists {
+		return nil
+	}
+	names := strings.Split(val, ",")
+	return sets.New(names...)
+}
+
+func clusterKey(hcp *hyperv1.HostedControlPlane) string {
+	return hcp.Namespace
 }

--- a/support/controlplane-component/job.go
+++ b/support/controlplane-component/job.go
@@ -2,7 +2,6 @@ package controlplanecomponent
 
 import (
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
-	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/util"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -16,20 +15,13 @@ var _ WorkloadProvider[*batchv1.Job] = &jobProvider{}
 type jobProvider struct {
 }
 
-// ApplyOptionsTo implements WorkloadProvider.
-func (c *jobProvider) ApplyOptionsTo(cpContext ControlPlaneContext, object *batchv1.Job, oldObject *batchv1.Job, deploymentConfig *config.DeploymentConfig) {
-	// preserve existing resource requirements.
-	existingResources := make(map[string]corev1.ResourceRequirements)
-	for _, container := range oldObject.Spec.Template.Spec.Containers {
-		existingResources[container.Name] = container.Resources
-	}
-
-	deploymentConfig.Resources = existingResources
-	deploymentConfig.ApplyToJob(object)
-}
-
 func (c *jobProvider) NewObject() *batchv1.Job {
 	return &batchv1.Job{}
+}
+
+// SetReplicasAndStrategy implements WorkloadProvider.
+func (d *jobProvider) SetReplicasAndStrategy(object *batchv1.Job, replicas int32, isRequestServing bool) {
+	// nothing to do.
 }
 
 // LoadManifest implements WorkloadProvider.

--- a/support/upsert/apply.go
+++ b/support/upsert/apply.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openshift/hypershift/support/util"
 
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -102,6 +103,11 @@ func (p *applyProvider) update(ctx context.Context, c crclient.Client, obj crcli
 	switch existingTyped := existing.(type) {
 	case *corev1.ServiceAccount:
 		preserveServiceAccountPullSecrets(existingTyped, obj.(*corev1.ServiceAccount))
+	case *appsv1.Deployment:
+		// Selector field is immutable, always preserve original Selector to avoid hot error loops.
+		if existingTyped.Spec.Selector != nil {
+			obj.(*appsv1.Deployment).Spec.Selector = existingTyped.Spec.Selector
+		}
 	}
 	preserveOriginalMetadata(existing, obj)
 

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1302,6 +1302,7 @@ func EnsurePodsWithEmptyDirPVsHaveSafeToEvictAnnotations(t *testing.T, ctx conte
 		g := NewWithT(t)
 
 		auditedAppList := map[string]string{
+			"etcd":                                   "app",
 			"cloud-controller-manager":               "app",
 			"cloud-credential-operator":              "app",
 			"aws-ebs-csi-driver-controller":          "app",
@@ -1348,6 +1349,12 @@ func EnsurePodsWithEmptyDirPVsHaveSafeToEvictAnnotations(t *testing.T, ctx conte
 		// involved as an string  and separated by comma, to satisfy CA operator contract.
 		// more info here: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node
 		for _, pod := range hcpPods.Items {
+			// skip etcd and feature-gate-generator pods
+			// If added to the list of audited pods,it will fail the e2e check on older release branches since e2e is ran from main.
+			if componentName := pod.Labels["hypershift.openshift.io/control-plane-component"]; componentName == "etcd" || componentName == "featuregate-generator" {
+				continue
+			}
+
 			var labelKey, labelValue string
 			// Go through our audited list looking for the label that matches the pod Labels
 			// Get the key and value and delete the entry from the audited list.


### PR DESCRIPTION
**What this PR does / why we need it**:
This removes the usage of the legacy DeploymentConfig from cpov2 and moves all the PodTemplateSpec defaulting logic to the ControlPlaneComponent. This includes setting annotations, labels, isolation, colocation, spread, etc.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.