### PR TITLE
OCPBUGS-51364: Remove scaledown APIs from Backup/Restore procedure

### DIFF
--- a/docs/content/how-to/disaster-recovery/backup-and-restore-oadp.md
+++ b/docs/content/how-to/disaster-recovery/backup-and-restore-oadp.md
@@ -158,54 +158,54 @@ Once you create any of these DPA objects, several pods will be instantiated in t
 ## Backup and Upload
 === "**AWS and Bare Metal**"
     ### Data Plane workloads backup
-    
+
     !!! Note
-    
+
         If the workloads in the Data Plane are not crucial for you, it's safe to skip this step.
-    
+
     If you need to backup the applications running under the HostedCluster, it's advisable to follow [the official documentation for backup and restore of OpenShift applications](https://docs.openshift.com/container-platform/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html)
-    
+
     The steps will indeed be quite similar:
-    
+
     - Deploy the OADP operator from OLM.
       - Create the DPA (Data Protection Application), with a manifest similar to the one provided earlier. It might be beneficial to adjust the `Prefix` or/and `Bucket` fields to keep the ControlPlane and DataPlane backups separated.
       - Create the backup manifest. This step varies depending on the complexity of the workloads in the Data Plane. It's essential to thoroughly examine how to back up the PersistentVolumes, the backend used, and ensure compatibility with our storage provisioner.
-      
+
       We recommend checking if your workloads contain Persistent Volumes and if our StorageClass is compatible with CSI Volume Snapshots, which is one of the simplest ways to handle this aspect.
-    
+
     As a standard approach to maintain consistency in the backup layer for the Hosted Control Plane, we will utilize [`Kopia`](https://docs.openshift.com/container-platform/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-about-kopia.html) as the backend tool for data snapshots, along with [`File System Backup`](https://docs.openshift.com/container-platform/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.html). However, it's possible that your workloads may benefit from a different approach that better aligns with your specific use case.
-    
+
     !!! Important
-    
+
         The backup of the workloads residing in the Data Plane falls outside the scope of this documentation. Please refer to the official Openshift-ADP backup documentation for further details. Additional links and information can be found in the [References](#References) section.
-    
+
     Once we have completed the backup of the Data Plane layer, we can proceed with the backup of the Hosted Control Plane (HCP).
-    
+
     ### Manual actions before backup
-    
+
     Before deploying the `backup` manifest, several actions are required:
-    
-    - Scale down the NodePool to 0 replicas.
-    
-        ```bash
-        oc --kubeconfig <MGMT-CLUSTER-KUBECONFIG> scale nodepool -n <HOSTEDCLUSTER NAMESPACE> <NODEPOOL NAME> --replicas 0
-        ```
-        
-        This will make the HostedCluster nodes to come back to the Infraenv in the Bare Metal provider or the instance deletion in the other ones.
-        
+
     - Pause the HostedCluster and NodePools.
-        
+
         ```bash
         oc --kubeconfig <MGMT-CLUSTER-KUBECONFIG> patch hostedcluster -n <HOSTEDCLUSTER NAMESPACE> <HOSTEDCLUSTER NAME> --type json -p '[{"op": "add", "path": "/spec/pausedUntil", "value": "true"}]'
         oc --kubeconfig <MGMT-CLUSTER-KUBECONFIG> patch nodepool -n <HOSTEDCLUSTER NAMESPACE> <NODEPOOL NAME> --type json -p '[{"op": "add", "path": "/spec/pausedUntil", "value": "true"}]'
         ```
-        
+
         This will allow the controller to halt modifications over the ETCD.
-        
+
+    - Scale down the NodePool to 0 replicas.
+
+        ```bash
+        oc --kubeconfig <MGMT-CLUSTER-KUBECONFIG> scale nodepool -n <HOSTEDCLUSTER NAMESPACE> <NODEPOOL NAME> --replicas 0
+        ```
+
+        This will make the HostedCluster nodes to come back to the Infraenv in the Bare Metal provider or the instance deletion in the other ones.
+
     ### Control Plane backup
-        
+
     Now, we will apply the backup manifest. Here is how it looks like:
-        
+
     ```yaml
     ---
     apiVersion: velero.io/v1
@@ -253,32 +253,32 @@ Once you create any of these DPA objects, several pods will be instantiated in t
       datamover: "velero"
       defaultVolumesToFsBackup: true
     ```
-        
+
     We will emphasize the most important fields:
-    
+
     - These two fields enable the CSI VolumeSnapshots to be automatically uploaded to the remote cloud storage.
-    
+
     ```yaml
     snapshotMoveData: true
     datamover: "velero"
     ```
-    
+
     - This particular field is crucial if you utilize a combination of CSI Volume Snapshot and fs-backup. It designates fs-backup as the default method for Persistent Volume backup. If you wish to continue using CSI Volume Snapshot (within the same backup manifest), you will need to add an annotation to the desired pods, including the PVs `backup.velero.io/backup-volumes-excludes=<pvc-name>`. Further information can be found [here](https://velero.io/docs/latest/file-system-backup/#using-the-opt-out-approach).
-    
+
     ```yaml
     defaultVolumesToFsBackup: true
     ```
-    
+
     - This field selects the namespaces from which objects will be backed up. They should include namespaces from both the HostedCluster (in the example `clusters`) and the HostedControlPlane (in the example `clusters-hosted`).
-    
+
     ```yaml
     includedNamespaces:
     - clusters
     - clusters-hosted
     ```
-    
+
     Once you apply the manifest, you can monitor the backup process in two places: the backup object status and the Velero logs. Please refer to the [Watching](#watching) section for more information.
-    
+
     The backup process is considered complete when the `status.phase` is `Completed`.
 
 === "**KubeVirt**"
@@ -288,9 +288,9 @@ Once you create any of these DPA objects, several pods will be instantiated in t
         The restore may only be done on the same management cluster where the backup was created.
 
     Backup of a hosted cluster, running on a KubeVirt platform may be done on a running hosted cluster, and there is no
-    need to pause it. 
-    
-    The backup will contain the hosted control plane components, the hosted cluster ETCD, and the data stored on the 
+    need to pause it.
+
+    The backup will contain the hosted control plane components, the hosted cluster ETCD, and the data stored on the
     hosted cluster PVCs.
 
     The backup will not contain the KubeVirt VMs, used as worker nodes, and they will be automatically recreated after
@@ -343,24 +343,24 @@ Once you create any of these DPA objects, several pods will be instantiated in t
       defaultVolumesToFsBackup: false
     ```
     We will emphasize the most important fields:
-    
+
     - These two fields enable the CSI VolumeSnapshots to be automatically uploaded to the remote cloud storage.
-    
+
         ```yaml
         snapshotMoveData: true
         datamover: "velero"
         ```
-    
-    - We don't want to use this feature. This will allow us to safely backup the PVCs we want 
-    
+
+    - We don't want to use this feature. This will allow us to safely backup the PVCs we want
+
         ```yaml
         defaultVolumesToFsBackup: false
         ```
-    
+
     - This field selects the namespaces from which objects will be backed up. They should include namespaces from both
       the HostedCluster (in the example `clusters`) and the HostedControlPlane (in the example `clusters-hosted`).
-      
-    
+
+
         ```yaml
         includedNamespaces:
         - clusters
@@ -369,20 +369,20 @@ Once you create any of these DPA objects, several pods will be instantiated in t
 
     !!! hint
         By default, the HostedControlPlane namespace is `clusters-<hosted cluster name>`.
-    
-    - The boot image of the KubeVirt VMs, that are used as the hosted cluster nodes, are stored in huge PVCs. We don't 
-      need these PVCs because the VMs are going to be recreated as new VMs. We want tilter these PVCs out of the backup 
+
+    - The boot image of the KubeVirt VMs, that are used as the hosted cluster nodes, are stored in huge PVCs. We don't
+      need these PVCs because the VMs are going to be recreated as new VMs. We want tilter these PVCs out of the backup
       to gain meaningful reduce in backup time and storage size. We'll filter these PVC using this label selector:
-   
+
         ```yaml
         labelSelector:
           matchExpressions:
           - key: 'hypershift.openshift.io/is-kubevirt-rhcos'
             operator: 'DoesNotExist'
         ```
-    
+
     Once you apply the manifest, you can monitor the backup process in two places: the backup object status and the Velero logs. Please refer to the [Watching](#watching) section for more information.
-    
+
     The backup process is considered complete when the `status.phase` is `Completed`.
 
 ## Restore
@@ -440,26 +440,26 @@ The restoration process is considered complete once the `status.phase` is `Compl
 === "**AWS and Bare Metal**"
 
     Now, we need to undo the actions taken before the backup phase:
-    
+
     - Revert the controllers' reconciliation state to unpaused.
-    
+
     ```bash
     oc --kubeconfig <MGMT-CLUSTER-KUBECONFIG> patch hostedcluster -n <HOSTEDCLUSTER NAMESPACE> <HOSTEDCLUSTER NAME> --type json -p '[{"op": "add", "path": "/spec/pausedUntil", "value": "false"}]'
     oc --kubeconfig <MGMT-CLUSTER-KUBECONFIG> patch nodepool -n <HOSTEDCLUSTER NAMESPACE> <NODEPOOL NAME> --type json -p '[{"op": "add", "path": "/spec/pausedUntil", "value": "false"}]'
     ```
-    
+
     !!! Important
-    
+
         **(For BareMetal Provider)** After some time in the BareMetal case, you will see Agents popping up. This indicates that the nodes have been booted up (which depends on the BareMetalHosts that you backed up). If you don't see those agents appearing, try recreating the BareMetalHosts in the proper namespace. This ensures that the Agents will appear. Then, you can rescale the node pool as follows:
-    
+
     - Scale back the Nodepool/s to the desired number of replicas.
-    
+
     ```bash
     oc --kubeconfig <MGMT-CLUSTER-KUBECONFIG> scale nodepool -n <HOSTEDCLUSTER NAMESPACE> <NODEPOOL NAME> --replicas X
     ```
-    
+
     After some time, the nodes will join the cluster, and the Hosted Cluster will be back online.
-    
+
     Following that, you will need to restore the Data Plane workloads if applicable to your use case.
 
 === "**KubeVirt**"

--- a/docs/content/how-to/disaster-recovery/etcd-recovery.md
+++ b/docs/content/how-to/disaster-recovery/etcd-recovery.md
@@ -27,7 +27,7 @@ To disable this default behavior, install HyperShift with `--enable-etcd-recover
 Execute into a running etcd pod:
 
 ```
-$ oc rsh -n ${CONTROL_PLANE_NAMESPACE} -c etcd etcd-0 
+$ oc rsh -n ${CONTROL_PLANE_NAMESPACE} -c etcd etcd-0
 ```
 
 Setup the etcdctl environment:
@@ -93,15 +93,7 @@ CONTROL_PLANE_NAMESPACE="${CLUSTER_NAMESPACE}-${CLUSTER_NAME}"
 oc patch -n ${CLUSTER_NAMESPACE} hostedclusters/${CLUSTER_NAME} -p '{"spec":{"pausedUntil":"true"}}' --type=merge
 ```
 
-2. Scale down API servers:
-
-```
-oc scale -n ${CONTROL_PLANE_NAMESPACE} deployment/kube-apiserver --replicas=0
-oc scale -n ${CONTROL_PLANE_NAMESPACE} deployment/openshift-apiserver --replicas=0
-oc scale -n ${CONTROL_PLANE_NAMESPACE} deployment/openshift-oauth-apiserver --replicas=0
-```
-
-3. Take a snapshot of etcd data using one of the following methods:
+2. Take a snapshot of etcd data using one of the following methods:
 
     a. Use a previously backed up snapshot
 
@@ -115,41 +107,41 @@ oc scale -n ${CONTROL_PLANE_NAMESPACE} deployment/openshift-oauth-apiserver --re
 
         # 1. take a snapshot of its database and save it locally
         # Set ETCD_POD to the name of the pod that is available
-        ETCD_POD=etcd-0 
+        ETCD_POD=etcd-0
         oc exec -n ${CONTROL_PLANE_NAMESPACE} -c etcd -t ${ETCD_POD} -- env ETCDCTL_API=3 /usr/bin/etcdctl \
         --cacert /etc/etcd/tls/etcd-ca/ca.crt \
         --cert /etc/etcd/tls/client/etcd-client.crt \
         --key /etc/etcd/tls/client/etcd-client.key \
         --endpoints=https://localhost:2379 \
         snapshot save /var/lib/snapshot.db
-    
+
         # 2. Verify that the snapshot is good
         oc exec -n ${CONTROL_PLANE_NAMESPACE} -c etcd -t ${ETCD_POD} -- env ETCDCTL_API=3 /usr/bin/etcdctl -w table snapshot status /var/lib/snapshot.db
-        
+
         # 3. Make a local copy of the snapshot
         oc cp -c etcd ${CONTROL_PLANE_NAMESPACE}/${ETCD_POD}:/var/lib/snapshot.db /tmp/etcd.snapshot.db
         ```
-    
+
     c. Make a copy of the snapshot db from etcd persistent storage:
 
        ```
        # List etcd pods
-       oc get -n ${CONTROL_PLANE_NAMESPACE} pods -l app=etcd 
+       oc get -n ${CONTROL_PLANE_NAMESPACE} pods -l app=etcd
 
-       # Find a pod that is running and set its name as the value of ETCD_POD 
+       # Find a pod that is running and set its name as the value of ETCD_POD
        ETCD_POD=etcd-0
 
        # Copy the snapshot db from it
        oc cp -c etcd ${CONTROL_PLANE_NAMESPACE}/${ETCD_POD}:/var/lib/data/member/snap/db /tmp/etcd.snapshot.db
        ```
 
-4. Scale down the etcd statefulset:
+3. Scale down the etcd statefulset:
 
 ```
-oc scale -n ${CONTROL_PLANE_NAMESPACE} statefulset/etcd --replicas=0 
+oc scale -n ${CONTROL_PLANE_NAMESPACE} statefulset/etcd --replicas=0
 ```
 
-5. Delete volumes for 2nd and 3rd members:
+4. Delete volumes for 2nd and 3rd members:
 ```
 oc delete -n ${CONTROL_PLANE_NAMESPACE} pvc/data-etcd-1 pvc/data-etcd-2
 ```
@@ -202,7 +194,7 @@ EOF
 
 ```
 # Wait for the etcd-data pod to start running
-oc get -n ${CONTROL_PLANE_NAMESPACE} pods -l app=etcd-data 
+oc get -n ${CONTROL_PLANE_NAMESPACE} pods -l app=etcd-data
 
 # Get the name of the etcd-data pod
 DATA_POD=$(oc get -n ${CONTROL_PLANE_NAMESPACE} pods --no-headers -l app=etcd-data -o name | cut -d/ -f2)
@@ -242,15 +234,7 @@ Wait for the all etcd member pods to come up and report available:
 oc get -n ${CONTROL_PLANE_NAMESPACE} pods -l app=etcd -w
 ```
 
-9. Scale apiservers back up:
-
-```
-oc scale -n ${CONTROL_PLANE_NAMESPACE} deployment/kube-apiserver --replicas=3
-oc scale -n ${CONTROL_PLANE_NAMESPACE} deployment/openshift-apiserver --replicas=3
-oc scale -n ${CONTROL_PLANE_NAMESPACE} deployment/openshift-oauth-apiserver --replicas=3
-```
-
-10. Remove hosted cluster pause:
+9. Remove hosted cluster pause:
 
 ```
 oc patch -n ${CLUSTER_NAMESPACE} hostedclusters/${CLUSTER_NAME} -p '{"spec":{"pausedUntil":""}}' --type=merge


### PR DESCRIPTION
After talking with etcd folks during the backup/restore research for OADP, they mentioned that is not necessary to scale down the APIs, meanwhile the HC is in pause. 

More info here: https://redhat-internal.slack.com/archives/C027U68LP/p1722438193341419