### PR TITLE
OCPBUGS-52223: refactor aws identity health check into new controller

### DIFF
--- a/control-plane-operator/controllers/healthcheck/aws.go
+++ b/control-plane-operator/controllers/healthcheck/aws.go
@@ -1,0 +1,72 @@
+package healthcheck
+
+import (
+	"context"
+	"fmt"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func awsHealthCheckIdentityProvider(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
+	ec2Client, _ := hostedcontrolplane.GetEC2Client()
+	if ec2Client == nil {
+		return nil
+	}
+
+	// We try to interact with cloud provider to see validate is operational.
+	if _, err := ec2Client.DescribeVpcEndpointsWithContext(ctx, &ec2.DescribeVpcEndpointsInput{}); err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			// When awsErr.Code() is WebIdentityErr it's likely to be an external issue, e.g. the idp resource was deleted.
+			// We don't set awsErr.Message() in the condition as it might contain aws requests IDs that would make the condition be updated in loop.
+			if awsErr.Code() == "WebIdentityErr" {
+				condition := metav1.Condition{
+					Type:               string(hyperv1.ValidAWSIdentityProvider),
+					ObservedGeneration: hcp.Generation,
+					Status:             metav1.ConditionFalse,
+					Message:            awsErr.Code(),
+					Reason:             hyperv1.InvalidIdentityProvider,
+				}
+				meta.SetStatusCondition(&hcp.Status.Conditions, condition)
+				return fmt.Errorf("error health checking AWS identity provider: %s %s", awsErr.Code(), awsErr.Message())
+			}
+
+			condition := metav1.Condition{
+				Type:               string(hyperv1.ValidAWSIdentityProvider),
+				ObservedGeneration: hcp.Generation,
+				Status:             metav1.ConditionUnknown,
+				Message:            awsErr.Code(),
+				Reason:             hyperv1.AWSErrorReason,
+			}
+			meta.SetStatusCondition(&hcp.Status.Conditions, condition)
+			return fmt.Errorf("error health checking AWS identity provider: %s %s", awsErr.Code(), awsErr.Message())
+		}
+
+		condition := metav1.Condition{
+			Type:               string(hyperv1.ValidAWSIdentityProvider),
+			ObservedGeneration: hcp.Generation,
+			Status:             metav1.ConditionUnknown,
+			Message:            err.Error(),
+			Reason:             hyperv1.StatusUnknownReason,
+		}
+		meta.SetStatusCondition(&hcp.Status.Conditions, condition)
+		return fmt.Errorf("error health checking AWS identity provider: %w", err)
+	}
+
+	condition := metav1.Condition{
+		Type:               string(hyperv1.ValidAWSIdentityProvider),
+		ObservedGeneration: hcp.Generation,
+		Status:             metav1.ConditionTrue,
+		Message:            hyperv1.AllIsWellMessage,
+		Reason:             hyperv1.AsExpectedReason,
+	}
+	meta.SetStatusCondition(&hcp.Status.Conditions, condition)
+
+	return nil
+}

--- a/control-plane-operator/controllers/healthcheck/healthcheck_controller.go
+++ b/control-plane-operator/controllers/healthcheck/healthcheck_controller.go
@@ -1,0 +1,100 @@
+package healthcheck
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-logr/logr"
+)
+
+const (
+	successRequeueInterval = 5 * time.Minute
+	failureRequeueInterval = 30 * time.Second
+)
+
+type HealthCheckUpdater struct {
+	client.Client
+	HostedControlPlane client.ObjectKey
+
+	log logr.Logger
+}
+
+func (hcu *HealthCheckUpdater) SetupWithManager(mgr ctrl.Manager) error {
+	return mgr.Add(hcu)
+}
+
+func (hcu *HealthCheckUpdater) Start(ctx context.Context) error {
+	hcu.log = ctrl.LoggerFrom(ctx).WithName("health-check-updater")
+	hcu.log.Info("Starting health check updater")
+	ticker := time.NewTicker(failureRequeueInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			err := hcu.update(ctx)
+			if err != nil {
+				hcu.log.Error(err, "Failure occurred during health checks")
+				ticker.Reset(failureRequeueInterval)
+			} else {
+				hcu.log.Info("Health checks succeeded")
+				ticker.Reset(successRequeueInterval)
+			}
+		}
+	}
+}
+
+func (hcu *HealthCheckUpdater) update(ctx context.Context) error {
+	hcu.log.Info("Updating health checks")
+
+	hostedControlPlane := &hyperv1.HostedControlPlane{}
+	err := hcu.Client.Get(ctx, hcu.HostedControlPlane, hostedControlPlane)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get HostedControlPlane: %w", err)
+	}
+
+	// Return early if deleting
+	if !hostedControlPlane.DeletionTimestamp.IsZero() {
+		return nil
+	}
+
+	originalHostedControlPlane := hostedControlPlane.DeepCopy()
+
+	errs := []error{}
+
+	// Call generic health checks
+
+	// Call platform-specific health checks
+	if hostedControlPlane.Spec.Platform.Type == hyperv1.AWSPlatform {
+		// This is the best effort ping to the identity provider
+		// that enables access from the operator to the cloud provider resources.
+		if err := awsHealthCheckIdentityProvider(ctx, hostedControlPlane); err != nil {
+			errs = append(errs, err)
+		}
+
+	}
+
+	// Update the status
+	if err := hcu.Client.Status().Patch(ctx, hostedControlPlane, client.MergeFromWithOptions(originalHostedControlPlane, client.MergeFromWithOptimisticLock{})); err != nil {
+		return fmt.Errorf("failed to update status: %w", err)
+	}
+
+	err = utilerrors.NewAggregate(errs)
+	if len(errs) > 0 {
+		return fmt.Errorf("some health checks failed: %w", err)
+	}
+	return nil
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -218,7 +218,7 @@ func (r *HostedControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager, create
 
 	r.reconcileInfrastructureStatus = r.defaultReconcileInfrastructureStatus
 
-	r.ec2Client, r.awsSession = getEC2Client()
+	r.ec2Client, r.awsSession = GetEC2Client()
 
 	if r.IsCPOV2 {
 		r.registerComponents()
@@ -265,7 +265,7 @@ func (r *HostedControlPlaneReconciler) registerComponents() {
 	)
 }
 
-func getEC2Client() (ec2iface.EC2API, *session.Session) {
+func GetEC2Client() (ec2iface.EC2API, *session.Session) {
 	// AWS_SHARED_CREDENTIALS_FILE and AWS_REGION envvar should be set in operator deployment
 	// when reconciling an AWS hosted control plane
 	if os.Getenv("AWS_SHARED_CREDENTIALS_FILE") != "" {
@@ -361,14 +361,6 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	originalHostedControlPlane := hostedControlPlane.DeepCopy()
-	// This is the best effort ping to the identity provider
-	// that enables access from the operator to the cloud provider resources.
-	healthCheckIdentityProvider(ctx, hostedControlPlane)
-	// We want to ensure the healthCheckIdentityProvider condition is in status before we go through the deletion timestamp path.
-	if err := r.Client.Status().Patch(ctx, hostedControlPlane, client.MergeFromWithOptions(originalHostedControlPlane, client.MergeFromWithOptimisticLock{})); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
-	}
-	originalHostedControlPlane = hostedControlPlane.DeepCopy()
 
 	// Return early if deleted
 	if !hostedControlPlane.DeletionTimestamp.IsZero() {
@@ -5137,70 +5129,6 @@ func (r *HostedControlPlaneReconciler) reconcileClusterStorageOperator(ctx conte
 	// TODO: create custom kubeconfig to the guest cluster + RBAC
 
 	return nil
-}
-
-func healthCheckIdentityProvider(ctx context.Context, hcp *hyperv1.HostedControlPlane) {
-	if hcp.Spec.Platform.AWS == nil {
-		return
-	}
-
-	log := ctrl.LoggerFrom(ctx)
-
-	ec2Client, _ := getEC2Client()
-	if ec2Client == nil {
-		return
-	}
-
-	// We try to interact with cloud provider to see validate is operational.
-	if _, err := ec2Client.DescribeVpcEndpointsWithContext(ctx, &ec2.DescribeVpcEndpointsInput{}); err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
-			// When awsErr.Code() is WebIdentityErr it's likely to be an external issue, e.g. the idp resource was deleted.
-			// We don't set awsErr.Message() in the condition as it might contain aws requests IDs that would make the condition be updated in loop.
-			if awsErr.Code() == "WebIdentityErr" {
-				condition := metav1.Condition{
-					Type:               string(hyperv1.ValidAWSIdentityProvider),
-					ObservedGeneration: hcp.Generation,
-					Status:             metav1.ConditionFalse,
-					Message:            awsErr.Code(),
-					Reason:             hyperv1.InvalidIdentityProvider,
-				}
-				meta.SetStatusCondition(&hcp.Status.Conditions, condition)
-				log.Info("Error health checking AWS identity provider", awsErr.Code(), awsErr.Message())
-				return
-			}
-
-			condition := metav1.Condition{
-				Type:               string(hyperv1.ValidAWSIdentityProvider),
-				ObservedGeneration: hcp.Generation,
-				Status:             metav1.ConditionUnknown,
-				Message:            awsErr.Code(),
-				Reason:             hyperv1.AWSErrorReason,
-			}
-			meta.SetStatusCondition(&hcp.Status.Conditions, condition)
-			log.Info("Error health checking AWS identity provider", awsErr.Code(), awsErr.Message())
-			return
-		}
-
-		condition := metav1.Condition{
-			Type:               string(hyperv1.ValidAWSIdentityProvider),
-			ObservedGeneration: hcp.Generation,
-			Status:             metav1.ConditionUnknown,
-			Message:            err.Error(),
-			Reason:             hyperv1.StatusUnknownReason,
-		}
-		meta.SetStatusCondition(&hcp.Status.Conditions, condition)
-		log.Info("Error health checking AWS identity provider", "error", err)
-		return
-	}
-
-	condition := metav1.Condition{
-		Type:               string(hyperv1.ValidAWSIdentityProvider),
-		ObservedGeneration: hcp.Generation,
-		Status:             metav1.ConditionTrue,
-		Message:            hyperv1.AllIsWellMessage,
-		Reason:             hyperv1.AsExpectedReason,
-	}
-	meta.SetStatusCondition(&hcp.Status.Conditions, condition)
 }
 
 func (r *HostedControlPlaneReconciler) reconcileDefaultSecurityGroup(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -11,6 +11,7 @@ import (
 	availabilityprober "github.com/openshift/hypershift/availability-prober"
 	hyperclient "github.com/openshift/hypershift/client/clientset/clientset"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/awsprivatelink"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/healthcheck"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator"
@@ -458,6 +459,14 @@ func NewStartCommand() *cobra.Command {
 			ImageMetadataProvider:                   imageMetaDataProvider,
 		}).SetupWithManager(mgr, upsert.New(enableCIDebugOutput).CreateOrUpdate); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "hosted-control-plane")
+			os.Exit(1)
+		}
+
+		if err := (&healthcheck.HealthCheckUpdater{
+			Client:             mgr.GetClient(),
+			HostedControlPlane: crclient.ObjectKey{Namespace: hcp.Namespace, Name: hcp.Name},
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "health-check-updater")
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
The cloud provider health check runs every time through the HCP reconcile loop and result in ~800k calls to `DescribeVpcEndpoints` per day in our CI.  This is 25-30% of our total AWS API call volume in our CI account and is contributing to API throttling.

xref
Add identity provider health check https://github.com/openshift/hypershift/pull/1913
Requeue HCP always https://github.com/openshift/hypershift/pull/2408

This PR refactors the health check into its own controller to achieve two goals:
1) Do health checks periodically, even HCP is not changing.  This is already done because with requeue the HCP as a hack to deal with unwatchable changes i.e. AWS LB stuff, however, I think we want to refactor this as well in a follow-on PR so we can stop requeuing the HCP on reconcile success.
2) Aggressively limit how often the health check is done in both the failure and success cases (30s for failure, 5m for success)

We could refactor this in a different way where the code remains in the HCP reconciler, but we just record a `lastAWSIdentityCheckTime` and skip if the reconcile was triggered in less time than some `delayAWSIdentityCheckDuration`.  This only works if we always requeue the HCP, even on reconcile success, which we currently do.