### PR TITLE
NO-JIRA: CAPI-Provider pod stuck on ContainerCreating in Azure AKS cluster

### DIFF
--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -853,7 +853,7 @@ func assignServicePrincipalRoles(subscriptionID, managedResourceGroupName, nsgRe
 	case ciro:
 		role = "8b32b316-c2f5-4ddf-b05b-83dacd2d08b5"
 	case nodePoolMgmt:
-		scopes = append(scopes, vnetRG)
+		scopes = append(scopes, nsgRG, vnetRG)
 		if assignCustomHCPRoles {
 			role = "Azure Red Hat OpenShift NodePool Management Role"
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently when setting up an Azure AKS cluster following the [Hypershift docs](https://hypershift-docs.netlify.app/how-to/azure/create-azure-cluster_on_aks/), CAPI-Provider will get stuck on ContainerCreating, with the pod description showing the following events:
```
  Type     Reason       Age                  From               Message
  ----     ------       ----                 ----               -------
  Normal   Scheduled    12m                  default-scheduler  Successfully assigned clusters-glipcean-hc/capi-provider-78b58f6db-tjljh to aks-nodepool1-42632445-vmss000000
  Warning  FailedMount  106s (x13 over 12m)  kubelet            MountVolume.SetUp failed for volume "svc-kubeconfig" : secret "service-network-admin-kubeconfig" not found
```
After running *oc get hc -A -o yaml*, the following error message can be seen under status: conditions:
```
    - lastTransitionTime: "2025-03-03T14:12:00Z"
      message: |
        failed to get network security group info to verify its location: failed to get network security group: GET https://management.azure.com/subscriptions/<sub_id>/resourceGroups/glipcean-hc-nsg-glipcean-hc-6r97g/providers/Microsoft.Network/networkSecurityGroups/glipcean-hc-glipcean-hc-6r97g-nsg
        --------------------------------------------------------------------------------
        RESPONSE 403: 403 Forbidden
        ERROR CODE: AuthorizationFailed
        --------------------------------------------------------------------------------
        {
          "error": {
            "code": "AuthorizationFailed",
            "message": "The client '<id>' with object id '<id>' does not have authorization to perform action 'Microsoft.Network/networkSecurityGroups/read' over scope '/subscriptions/<sub_id>/resourceGroups/glipcean-hc-nsg-glipcean-hc-6r97g/providers/Microsoft.Network/networkSecurityGroups/glipcean-hc-glipcean-hc-6r97g-nsg' or the scope is invalid. If access was recently granted, please refresh your credentials."
          }
        }
        --------------------------------------------------------------------------------
```
This PR gives the CAPI-Provider the necessary authorisation to run.

[Original Closed PR](https://github.com/openshift/hypershift/pull/5748)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.