### PR TITLE
NO-JIRA: Add CPO container sync check to GitHub Actions

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/setup-go@v5.3.0
         with:
           go-version-file: go.mod
+          cache: false
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6.5.0
         with:

--- a/.github/workflows/make-verify.yml
+++ b/.github/workflows/make-verify.yml
@@ -13,5 +13,6 @@ jobs:
         uses: actions/setup-go@v5.3.0
         with:
           go-version-file: go.mod
+          cache: false
       - name: Run make verify
         run: make verify

--- a/.github/workflows/sync-container-files.yaml
+++ b/.github/workflows/sync-container-files.yaml
@@ -1,0 +1,18 @@
+name: sync cpo container files
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  sync-container-files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Go environment
+        uses: actions/setup-go@v5.3.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Ensure container files in sync
+        run: ./hack/tools/git-hooks/cpo-containerfiles-in-sync.sh ./Containerfile.control-plane ./Dockerfile.control-plane


### PR DESCRIPTION
**What this PR does / why we need it**:
Minor updates to the GitHub Actions. This PR:
- adds the CPO container sync check to GitHub Actions
- disables caching for the make verify and golangci-lint GitHub Actions.Cache was enabled by default and was causing warning errors like - `Warning: Failed to restore: "/usr/bin/tar" failed with error: The process '/usr/bin/tar' failed with exit code 2.`

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
N/A

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.