### PR TITLE
NO-JIRA: Remove issues-exit flag for golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6.5.0
         with:
-          args: --timeout=15m --config=.golangci.yml --issues-exit-code=0
+          args: --timeout=15m --config=.golangci.yml


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the issues-exit flag for golangci-lint. If this flag is set, then the golangci-lint job will return as success even If there are errors.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.