### PR TITLE
OCPBUGS-52323: Make managed-trust-bundle optional

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -181,6 +181,7 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, platformType hyp
 							Path: managedTrustBundlePath,
 						},
 					},
+					Optional: ptr.To(true),
 				},
 			},
 		},

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -565,7 +565,9 @@ func oasVolumeProxyManagedTrustBundle() *corev1.Volume {
 }
 
 func buildOASVolumeProxyManagedTrustBundle(v *corev1.Volume) {
-	v.ConfigMap = &corev1.ConfigMapVolumeSource{}
+	v.ConfigMap = &corev1.ConfigMapVolumeSource{
+		Optional: ptr.To(true),
+	}
 	v.ConfigMap.DefaultMode = ptr.To[int32](0640)
 	v.ConfigMap.Name = manifests.TrustedCABundleConfigMap("").Name
 	v.ConfigMap.Items = []corev1.KeyToPath{

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/deployment.go
@@ -484,7 +484,9 @@ func oauthVolumeProxyManagedTrustBundle() *corev1.Volume {
 }
 
 func buildOAuthVolumeProxyManagedTrustBundle(v *corev1.Volume) {
-	v.ConfigMap = &corev1.ConfigMapVolumeSource{}
+	v.ConfigMap = &corev1.ConfigMapVolumeSource{
+		Optional: ptr.To(true),
+	}
 	v.ConfigMap.DefaultMode = ptr.To[int32](0640)
 	v.ConfigMap.Name = manifests.TrustedCABundleConfigMap("").Name
 	v.ConfigMap.Items = []corev1.KeyToPath{

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/testdata/zz_fixture_TestReconcileOauthDeploymentNoChanges.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/testdata/zz_fixture_TestReconcileOauthDeploymentNoChanges.yaml
@@ -203,6 +203,7 @@ spec:
           - key: ca-bundle.crt
             path: managed-trust-bundle.crt
           name: trusted-ca-bundle-managed
+          optional: true
         name: managed-trust-bundle
       - name: oauth-audit-webhook
         secret:


### PR DESCRIPTION
**What this PR does / why we need it**:

Addresses issue with https://github.com/openshift/hypershift/pull/5667 which made the `managed-trust-bundle` required. However, this breaks folks who bring their own PKI.

https://ibm-argonauts.slack.com/archives/C01C8502FMM/p1741096684745729

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

https://issues.redhat.com/browse/OCPBUGS-52323

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.