### PR TITLE
NO-JIRA: speed up image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,7 @@
 bin/
+hack/tools/bin/
+contrib/
+.git/
 .github/
 .tekton/
 .ci-operator.yaml

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -4,9 +4,21 @@ WORKDIR /hypershift
 
 COPY . .
 
+RUN make e2e
+
+# Reuse the same image as builder because we need go command in ci-test-e2e.sh
+# Multi-stage build lets us drop the source code and build cache from the final image
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.19
+
+WORKDIR /hypershift
+
+RUN mkdir -p /hypershift/bin /hypershift/hack
+COPY --from=builder /hypershift/bin/test-e2e /hypershift/bin/test-e2e
+COPY --from=builder /hypershift/bin/test-setup /hypershift//bin/test-setup
+COPY --from=builder /hypershift/hack/ci-test-e2e.sh /hypershift/hack/ci-test-e2e.sh
+
 RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc && \
     dnf install -y https://packages.microsoft.com/config/rhel/9/packages-microsoft-prod.rpm && \
     mv /etc/yum.repos.d/microsoft-prod.repo /etc/yum.repos.art/ci/ && \
-    dnf install -y azure-cli
-
-RUN make e2e
+    dnf install -y azure-cli && \
+    dnf clean all


### PR DESCRIPTION
This PR speeds up the image builds by

* Exclude the `.git` directory in the `COPY . .` for all built images, which saves around 150MB of disk I/O
* Make the `hypershift-tests` image, built with `Dockerfile.e2e`, multi-stage so we don't commit the source tree, intermediate build files, and dnf cache to the final image that needs to be pushed to the CI registry.  This reduces the size of additional layers, on top of the base image, by 75% from ~4GB to ~1GB

Before
```
$ podman history 118e47b22af65211e283c950b65ecc569381cff570990ef03914af5b9fb568b6
ID            CREATED       CREATED BY                                     SIZE        COMMENT
118e47b22af6  2 hours ago   /bin/sh -c #(nop) LABEL "io.openshift.buil...  4.02GB      FROM image-registry.openshift-image-registry.svc:5000/ci-op-vlijyxmd/pipeline@sha256:fe18ab91e42b1653a76a394ee0c9b6081069aff4781c3ecc765fab5ad6fc7c72
0c55494e4022  2 hours ago   /bin/sh -c #(nop) ENV "OPENSHIFT_BUILD_NAM...  0B          
<missing>     2 hours ago   /bin/sh -c make e2e                            0B          
<missing>     2 hours ago   /bin/sh -c rpm --import https://packages.m...  0B          
<missing>     2 hours ago   /bin/sh -c #(nop) COPY dir:8e14329a83dbead...  0B          
<missing>     2 hours ago   /bin/sh -c #(nop) WORKDIR /hypershift          0B          
<missing>     2 hours ago   /bin/sh -c #(nop) ENV "BUILD_LOGLEVEL"="0"     0B          
<missing>     8 hours ago   /bin/sh -c mv -fZ /tmp/ubi.repo /etc/yum.r...  494MB       FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-ci-openshift-golang-builder-latest-rhel9@sha256:80df50e59da51d2583cfc21d6d82b4f5725b20e3b5cf852129451f2be8a45e60
```

After
```
$ podman history d51366c9ebabff1e0aeb1efaad4df34ff06db64c925b73171c976968de1be1ce
ID            CREATED         CREATED BY                                     SIZE        COMMENT
d51366c9ebab  15 minutes ago  /bin/sh -c #(nop) LABEL "io.openshift.buil...  1GB         FROM image-registry.openshift-image-registry.svc:5000/ci-op-j3lpfnxi/pipeline@sha256:fe18ab91e42b1653a76a394ee0c9b6081069aff4781c3ecc765fab5ad6fc7c72
0c55494e4022  16 minutes ago  /bin/sh -c #(nop) ENV "OPENSHIFT_BUILD_NAM...  0B          
<missing>     16 minutes ago  /bin/sh -c rpm --import https://packages.m...  0B          
<missing>     18 minutes ago  /bin/sh -c #(nop) COPY file:363b0f143d8a29...  0B          
<missing>     18 minutes ago  /bin/sh -c #(nop) COPY file:08382bb82bb010...  0B          
<missing>     18 minutes ago  /bin/sh -c #(nop) COPY file:51eb800577418a...  0B          
<missing>     18 minutes ago  /bin/sh -c mkdir -p /hypershift/bin /hyper...  0B          
<missing>     18 minutes ago  /bin/sh -c #(nop) WORKDIR /hypershift          0B          
<missing>     18 minutes ago  /bin/sh -c #(nop) ENV "BUILD_LOGLEVEL"="0"     0B          
<missing>     8 hours ago     /bin/sh -c mv -fZ /tmp/ubi.repo /etc/yum.r...  494MB       FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-ci-openshift-golang-builder-latest-rhel9@sha256:80df50e59da51d2583cfc21d6d82b4f5725b20e3b5cf852129451f2be8a45e60
```