### PR TITLE
OCPBUGS-52331: CPO v2: rollout workloads on any changes to mounted configmaps/secrets

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/catalog-operator/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/catalog-operator/zz_fixture_TestControlPlaneComponents.yaml
@@ -26,6 +26,7 @@ spec:
     metadata:
       annotations:
         alpha.image.policy.openshift.io/resolve-names: '*'
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/catalog-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/catalog-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -26,6 +26,7 @@ spec:
     metadata:
       annotations:
         alpha.image.policy.openshift.io/resolve-names: '*'
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/certified-operators-catalog/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/certified-operators-catalog/zz_fixture_TestControlPlaneComponents.yaml
@@ -29,6 +29,7 @@ spec:
       annotations:
         alpha.image.policy.openshift.io/resolve-names: '*'
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: utilities,catalog-content
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/certified-operators-catalog/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/certified-operators-catalog/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -29,6 +29,7 @@ spec:
       annotations:
         alpha.image.policy.openshift.io/resolve-names: '*'
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: utilities,catalog-content
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-aws/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-aws/zz_fixture_TestControlPlaneComponents.yaml
@@ -26,6 +26,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token
+        component.hypershift.openshift.io/config-hash: 53b6605a
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-aws/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-aws/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -26,6 +26,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token
+        component.hypershift.openshift.io/config-hash: 53b6605a
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-azure/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-azure/zz_fixture_TestControlPlaneComponents.yaml
@@ -25,6 +25,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: b49c626f
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-azure/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-azure/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -25,6 +25,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: b49c626f
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-kubevirt/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-kubevirt/zz_fixture_TestControlPlaneComponents.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: b833e1fe
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-kubevirt/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-kubevirt/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: b833e1fe
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-openstack/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-openstack/zz_fixture_TestControlPlaneComponents.yaml
@@ -26,6 +26,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: 1cdcee0c
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-openstack/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-openstack/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -26,6 +26,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: 1cdcee0c
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-powervs/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-powervs/zz_fixture_TestControlPlaneComponents.yaml
@@ -24,6 +24,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: 774b434c
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-powervs/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-powervs/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -24,6 +24,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: 774b434c
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-credential-operator/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-credential-operator/zz_fixture_TestControlPlaneComponents.yaml
@@ -25,6 +25,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: 741638a5741638a5741638a5741638a5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-credential-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-credential-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -25,6 +25,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: 741638a5741638a5741638a5741638a5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/zz_fixture_TestControlPlaneComponents.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-image-registry-operator/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-image-registry-operator/zz_fixture_TestControlPlaneComponents.yaml
@@ -26,6 +26,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token,apiserver-token
+        component.hypershift.openshift.io/config-hash: 87ecf31a
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-image-registry-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-image-registry-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -26,6 +26,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token,apiserver-token
+        component.hypershift.openshift.io/config-hash: 87ecf31a
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/zz_fixture_TestControlPlaneComponents.yaml
@@ -26,6 +26,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: configs,client-token
+        component.hypershift.openshift.io/config-hash: 87ecf31a
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       creationTimestamp: null

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -26,6 +26,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: configs,client-token
+        component.hypershift.openshift.io/config-hash: 87ecf31a
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       creationTimestamp: null

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-node-tuning-operator/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-node-tuning-operator/zz_fixture_TestControlPlaneComponents.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       creationTimestamp: null

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-node-tuning-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-node-tuning-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       creationTimestamp: null

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-policy-controller/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-policy-controller/zz_fixture_TestControlPlaneComponents.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: 640be845
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-policy-controller/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-policy-controller/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: 4fc3adce
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/zz_fixture_TestControlPlaneComponents.yaml
@@ -24,6 +24,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -24,6 +24,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents.yaml
@@ -30,6 +30,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: payload,update-payloads
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -30,6 +30,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: payload,update-payloads
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/community-operators-catalog/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/community-operators-catalog/zz_fixture_TestControlPlaneComponents.yaml
@@ -29,6 +29,7 @@ spec:
       annotations:
         alpha.image.policy.openshift.io/resolve-names: '*'
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: utilities,catalog-content
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/community-operators-catalog/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/community-operators-catalog/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -29,6 +29,7 @@ spec:
       annotations:
         alpha.image.policy.openshift.io/resolve-names: '*'
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: utilities,catalog-content
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/zz_fixture_TestControlPlaneComponents.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/zz_fixture_TestControlPlaneComponents.yaml
@@ -25,6 +25,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       creationTimestamp: null

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -25,6 +25,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       creationTimestamp: null

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/dns-operator/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/dns-operator/zz_fixture_TestControlPlaneComponents.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: 741638a5741638a5741638a5741638a5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       creationTimestamp: null

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/dns-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/dns-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: 741638a5741638a5741638a5741638a5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       creationTimestamp: null

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents.yaml
@@ -26,6 +26,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -26,6 +26,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/zz_fixture_TestControlPlaneComponents.yaml
@@ -25,6 +25,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -25,6 +25,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/zz_fixture_TestControlPlaneComponents.yaml
@@ -26,6 +26,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token
+        component.hypershift.openshift.io/config-hash: 741638a5741638a5741638a5741638a5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       creationTimestamp: null

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -26,6 +26,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token
+        component.hypershift.openshift.io/config-hash: 741638a5741638a5741638a5741638a5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       creationTimestamp: null

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: bootstrap-manifests,logs
-        component.hypershift.openshift.io/config-hash: 19dc307e1d8949e252ebd36aac833046
+        component.hypershift.openshift.io/config-hash: 19dc307e1d8949e2360eec7552ebd36a741638a5741638a5741638a5741638a58a2366b5ac833046c825c12fe7e69167
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: bootstrap-manifests,logs
-        component.hypershift.openshift.io/config-hash: 19dc307e1d8949e252ebd36af1967855
+        component.hypershift.openshift.io/config-hash: 19dc307e1d8949e2360eec7552ebd36a741638a5741638a5741638a5741638a58a2366b5c825c12fe7e69167f1967855
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: logs,certs
-        component.hypershift.openshift.io/config-hash: "1252551421580954"
+        component.hypershift.openshift.io/config-hash: 1252551487ecf31a87ecf31acb8019bfd6265674
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: logs,certs
-        component.hypershift.openshift.io/config-hash: "1252551421580954"
+        component.hypershift.openshift.io/config-hash: 1252551487ecf31a87ecf31acb8019bfd6265674
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cert-work
-        component.hypershift.openshift.io/config-hash: 022a8a3a
+        component.hypershift.openshift.io/config-hash: 022a8a3acb8019bf
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cert-work
-        component.hypershift.openshift.io/config-hash: 022a8a3a
+        component.hypershift.openshift.io/config-hash: 022a8a3acb8019bf
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-csi-controller/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-csi-controller/zz_fixture_TestControlPlaneComponents.yaml
@@ -25,6 +25,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
+        component.hypershift.openshift.io/config-hash: 741638a5741638a5741638a5741638a5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-csi-controller/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-csi-controller/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -25,6 +25,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
+        component.hypershift.openshift.io/config-hash: 741638a5741638a5741638a5741638a5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/machine-approver/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/machine-approver/zz_fixture_TestControlPlaneComponents.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: a53d18cd
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/machine-approver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/machine-approver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: a53d18cd
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/zz_fixture_TestControlPlaneComponents.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: logs
-        component.hypershift.openshift.io/config-hash: 4ebc1fdd
+        component.hypershift.openshift.io/config-hash: 19dc307e3b105d444ebc1fdd60b54b1d741638a5a0dd232cbcc341c5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: logs
-        component.hypershift.openshift.io/config-hash: 4ebc1fdd
+        component.hypershift.openshift.io/config-hash: 19dc307e3b105d444ebc1fdd60b54b1d741638a5a0dd232cbcc341c5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-collect-profiles/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-collect-profiles/zz_fixture_TestControlPlaneComponents.yaml
@@ -20,6 +20,7 @@ spec:
       template:
         metadata:
           annotations:
+            component.hypershift.openshift.io/config-hash: fe7dc514
             hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
           creationTimestamp: null
           labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-collect-profiles/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-collect-profiles/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -20,6 +20,7 @@ spec:
       template:
         metadata:
           annotations:
+            component.hypershift.openshift.io/config-hash: fe7dc514
             hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
           creationTimestamp: null
           labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-operator/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-operator/zz_fixture_TestControlPlaneComponents.yaml
@@ -25,6 +25,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -25,6 +25,7 @@ spec:
   template:
     metadata:
       annotations:
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: work-logs,oas-trust-anchor
-        component.hypershift.openshift.io/config-hash: 19dc307e52ebd36aaab823a0
+        component.hypershift.openshift.io/config-hash: 19dc307e52ebd36a829b997baab823a0
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: work-logs,oas-trust-anchor
-        component.hypershift.openshift.io/config-hash: 19dc307e52ebd36aaab823a0
+        component.hypershift.openshift.io/config-hash: 19dc307e52ebd36a829b997baab823a0
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/zz_fixture_TestControlPlaneComponents.yaml
@@ -29,6 +29,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmpfs
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -29,6 +29,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmpfs
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/redhat-marketplace-catalog/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/redhat-marketplace-catalog/zz_fixture_TestControlPlaneComponents.yaml
@@ -28,6 +28,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: utilities,catalog-content
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/redhat-marketplace-catalog/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/redhat-marketplace-catalog/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -28,6 +28,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: utilities,catalog-content
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/redhat-operators-catalog/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/redhat-operators-catalog/zz_fixture_TestControlPlaneComponents.yaml
@@ -29,6 +29,7 @@ spec:
       annotations:
         alpha.image.policy.openshift.io/resolve-names: '*'
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: utilities,catalog-content
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/redhat-operators-catalog/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/redhat-operators-catalog/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -29,6 +29,7 @@ spec:
       annotations:
         alpha.image.policy.openshift.io/resolve-names: '*'
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: utilities,catalog-content
+        component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/component.go
@@ -101,14 +101,13 @@ func NewComponent() component.ControlPlaneComponent {
 			"aws-pod-identity-webhook-kubeconfig.yaml",
 			component.EnableForPlatform(hyperv1.AWSPlatform),
 			component.WithAdaptFunction(adaptAWSPodIdentityWebhookKubeconfigSecret),
+			component.ReconcileExisting(),
 		).
 		WithManifestAdapter(
 			"azure-kms-secretprovider.yaml",
 			component.WithAdaptFunction(kms.AdaptAzureSecretProvider),
 			component.WithPredicate(enableAzureKMSSecretProvider),
 		).
-		RolloutOnConfigMapChange("kas-config", "kas-audit-config", "auth-config").
-		RolloutOnSecretChange("kas-secret-encryption-config").
 		Build()
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kcm/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kcm/component.go
@@ -1,7 +1,6 @@
 package kcm
 
 import (
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/util"
 )
@@ -34,7 +33,6 @@ func NewComponent() component.ControlPlaneComponent {
 			"servicemonitor.yaml",
 			component.WithAdaptFunction(adaptServiceMonitor),
 		).
-		RolloutOnConfigMapChange("kcm-config", manifests.RootCAConfigMap("").Name, manifests.ServiceServingCA("").Name).
 		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{}).
 		Build()
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/component.go
@@ -40,7 +40,6 @@ func NewComponent() component.ControlPlaneComponent {
 			"kubeconfig.yaml",
 			component.WithAdaptFunction(adaptKubeconfig),
 		).
-		RolloutOnConfigMapChange("kube-scheduler").
 		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{}).
 		Build()
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oapi/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oapi/component.go
@@ -1,7 +1,6 @@
 package oapi
 
 import (
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	kasv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/kas"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/util"
@@ -50,7 +49,6 @@ func NewComponent() component.ControlPlaneComponent {
 			"pdb.yaml",
 			component.AdaptPodDisruptionBudget(),
 		).
-		RolloutOnConfigMapChange("openshift-apiserver", "openshift-apiserver-audit", manifests.ServiceServingCA("").Name).
 		InjectKonnectivityContainer(component.KonnectivityContainerOptions{
 			Mode: component.HTTPS,
 		}).

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/component.go
@@ -67,7 +67,6 @@ func NewComponent() component.ControlPlaneComponent {
 			component.WithAdaptFunction(adaptErrorTemplateSecret),
 		).
 		WithDependencies(oapiv2.ComponentName).
-		RolloutOnConfigMapChange("oauth-openshift").
 		InjectKonnectivityContainer(component.KonnectivityContainerOptions{
 			Mode: component.Dual,
 			Socks5Options: component.Socks5Options{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/sessionsecrets.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/sessionsecrets.go
@@ -38,12 +38,14 @@ func adaptSessionSecret(cpContext component.WorkloadContext, secret *corev1.Secr
 			return nil
 		}
 	}
-	sessionSecrets := generateSessionSecrets()
-	encodedSessionSecrets := &bytes.Buffer{}
-	if err := api.YamlSerializer.Encode(sessionSecrets, encodedSessionSecrets); err != nil {
-		return fmt.Errorf("cannot encode session secrets: %w", err)
+	if !cpContext.SkipCertificateSigning {
+		sessionSecrets := generateSessionSecrets()
+		encodedSessionSecrets := &bytes.Buffer{}
+		if err := api.YamlSerializer.Encode(sessionSecrets, encodedSessionSecrets); err != nil {
+			return fmt.Errorf("cannot encode session secrets: %w", err)
+		}
+		secret.Data[sessionSecretsFileKey] = encodedSessionSecrets.Bytes()
 	}
-	secret.Data[sessionSecretsFileKey] = encodedSessionSecrets.Bytes()
 	return nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/component.go
@@ -44,7 +44,6 @@ func NewComponent() component.ControlPlaneComponent {
 			component.AdaptPodDisruptionBudget(),
 		).
 		WithDependencies(oapiv2.ComponentName).
-		RolloutOnConfigMapChange("openshift-oauth-apiserver-audit").
 		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{}).
 		Build()
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ocm/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ocm/component.go
@@ -8,8 +8,6 @@ import (
 
 const (
 	ComponentName = "openshift-controller-manager"
-
-	configMapName = "openshift-controller-manager-config"
 )
 
 var _ component.ComponentOptions = &openshiftControllerManager{}
@@ -48,6 +46,5 @@ func NewComponent() component.ControlPlaneComponent {
 			component.DisableIfAnnotationExist(hyperv1.DisableMonitoringServices),
 		).
 		WithDependencies(oapiv2.ComponentName).
-		RolloutOnConfigMapChange(configMapName).
 		Build()
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/component.go
@@ -48,6 +48,5 @@ func NewComponent() component.ControlPlaneComponent {
 			component.DisableIfAnnotationExist(hyperv1.DisableMonitoringServices),
 		).
 		WithDependencies(oapiv2.ComponentName).
-		RolloutOnConfigMapChange(ConfigMapName).
 		Build()
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
@@ -43,7 +43,6 @@ func NewComponent() component.ControlPlaneComponent {
 			component.AdaptPodDisruptionBudget(),
 		).
 		WithDependencies(oapiv2.ComponentName).
-		RolloutOnConfigMapChange("router").
 		Build()
 }
 

--- a/support/controlplane-component/builder.go
+++ b/support/controlplane-component/builder.go
@@ -66,16 +66,6 @@ func (b *controlPlaneWorkloadBuilder[T]) WithManifestAdapter(manifestName string
 	return b
 }
 
-func (b *controlPlaneWorkloadBuilder[T]) RolloutOnSecretChange(name ...string) *controlPlaneWorkloadBuilder[T] {
-	b.workload.rolloutSecretsNames = append(b.workload.rolloutSecretsNames, name...)
-	return b
-}
-
-func (b *controlPlaneWorkloadBuilder[T]) RolloutOnConfigMapChange(name ...string) *controlPlaneWorkloadBuilder[T] {
-	b.workload.rolloutConfigMapsNames = append(b.workload.rolloutSecretsNames, name...)
-	return b
-}
-
 func (b *controlPlaneWorkloadBuilder[T]) WithDependencies(dependencies ...string) *controlPlaneWorkloadBuilder[T] {
 	b.workload.dependencies = append(b.workload.dependencies, dependencies...)
 	return b

--- a/support/controlplane-component/controlplane-component_test.go
+++ b/support/controlplane-component/controlplane-component_test.go
@@ -255,9 +255,9 @@ func componentsFakeObjects() ([]client.Object, error) {
 		},
 	}
 
-	rootCA := manifests.RootCAConfigMap(testComponentNamespace)
-	rootCA.Data = map[string]string{
-		certs.CASignerCertMapKey: "fake",
+	rootCA := manifests.RootCASecret(testComponentNamespace)
+	rootCA.Data = map[string][]byte{
+		certs.CASignerCertMapKey: []byte("fake"),
 	}
 
 	caCfg := certs.CertCfg{IsCA: true, Subject: pkix.Name{CommonName: "root-ca", OrganizationalUnit: []string{"ou"}}}

--- a/support/controlplane-component/defaults_test.go
+++ b/support/controlplane-component/defaults_test.go
@@ -1,0 +1,280 @@
+package controlplanecomponent
+
+import (
+	"sort"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	fuzz "github.com/google/gofuzz"
+)
+
+func cmVolume(name string) corev1.Volume {
+	return corev1.Volume{
+		Name: name,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: name,
+				},
+			},
+		},
+	}
+}
+
+func secretVolume(name string) corev1.Volume {
+	return corev1.Volume{
+		Name: name,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: name,
+			},
+		},
+	}
+}
+
+func emptyDirVolume(name string) corev1.Volume {
+	return corev1.Volume{
+		Name: name,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+}
+
+type projectedVolumeBuilder struct {
+	v corev1.Volume
+}
+
+func (b *projectedVolumeBuilder) volume() corev1.Volume {
+	return b.v
+}
+
+func (b *projectedVolumeBuilder) withSecrets(secretNames ...string) *projectedVolumeBuilder {
+	for _, name := range secretNames {
+		b.v.VolumeSource.Projected.Sources = append(b.v.VolumeSource.Projected.Sources, corev1.VolumeProjection{
+			Secret: &corev1.SecretProjection{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: name,
+				},
+			},
+		})
+	}
+	return b
+}
+
+func (b *projectedVolumeBuilder) withConfigMaps(cmNames ...string) *projectedVolumeBuilder {
+	for _, name := range cmNames {
+		b.v.VolumeSource.Projected.Sources = append(b.v.VolumeSource.Projected.Sources, corev1.VolumeProjection{
+			ConfigMap: &corev1.ConfigMapProjection{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: name,
+				},
+			},
+		})
+	}
+	return b
+}
+
+func (b *projectedVolumeBuilder) withDownardAPI(fields ...string) *projectedVolumeBuilder {
+	for _, field := range fields {
+		b.v.VolumeSource.Projected.Sources = append(b.v.VolumeSource.Projected.Sources, corev1.VolumeProjection{
+			DownwardAPI: &corev1.DownwardAPIProjection{
+				Items: []corev1.DownwardAPIVolumeFile{
+					{
+						Path: field,
+						FieldRef: &corev1.ObjectFieldSelector{
+							APIVersion: "v1",
+							FieldPath:  field,
+						},
+					},
+				},
+			},
+		})
+	}
+	return b
+}
+
+func projectedVolume(volumeName string) *projectedVolumeBuilder {
+	return &projectedVolumeBuilder{
+		v: corev1.Volume{
+			Name: volumeName,
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{},
+			},
+		},
+	}
+}
+
+func TestPodConfigMapNames(t *testing.T) {
+	tests := []struct {
+		name    string
+		podSpec corev1.PodSpec
+		exclude []string
+		expect  []string
+	}{
+		{
+			name: "volumes",
+			podSpec: corev1.PodSpec{
+				Volumes: []corev1.Volume{cmVolume("cm1"), secretVolume("s1"), cmVolume("cm2"), emptyDirVolume("e1")},
+			},
+			expect: []string{"cm1", "cm2"},
+		},
+		{
+			name: "projected",
+			podSpec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					projectedVolume("proj1").
+						withConfigMaps("pcm1", "pcm2").
+						withSecrets("ps1", "ps2").
+						withDownardAPI("f1", "f2").volume(),
+					secretVolume("s1")},
+			},
+			expect: []string{"pcm1", "pcm2"},
+		},
+		{
+			name: "volumes and projected",
+			podSpec: corev1.PodSpec{
+				Volumes: []corev1.Volume{cmVolume("cm1"), cmVolume("cm2"),
+					projectedVolume("proj1").
+						withConfigMaps("pcm3").
+						withSecrets("ps2").volume(),
+					projectedVolume("proj2").
+						withConfigMaps("pcm4").
+						withSecrets("ps3").volume(),
+					secretVolume("s1")},
+			},
+			expect: []string{"cm1", "cm2", "pcm3", "pcm4"},
+		},
+		{
+			name: "volumes and projected with exclusions",
+			podSpec: corev1.PodSpec{
+				Volumes: []corev1.Volume{cmVolume("cm1"), cmVolume("cm2"),
+					projectedVolume("proj1").
+						withConfigMaps("pcm3").
+						withSecrets("ps2").volume(),
+					projectedVolume("proj2").
+						withConfigMaps("pcm4").
+						withSecrets("ps3").volume(),
+					secretVolume("s1")},
+			},
+			exclude: []string{"cm2"},
+			expect:  []string{"cm1", "pcm3", "pcm4"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			result := podConfigMapNames(&test.podSpec, test.exclude)
+			sort.StringSlice(result).Sort()
+			sort.StringSlice(test.expect).Sort()
+			g.Expect(result).To(Equal(test.expect))
+		})
+	}
+}
+
+func TestPodSecretNames(t *testing.T) {
+	tests := []struct {
+		name    string
+		podSpec corev1.PodSpec
+		expect  []string
+	}{
+		{
+			name: "volumes",
+			podSpec: corev1.PodSpec{
+				Volumes: []corev1.Volume{cmVolume("cm1"), secretVolume("s1"), secretVolume("s2"), emptyDirVolume("e3")},
+			},
+			expect: []string{"s1", "s2"},
+		},
+		{
+			name: "projected",
+			podSpec: corev1.PodSpec{
+				Volumes: []corev1.Volume{
+					projectedVolume("pcms1").
+						withConfigMaps("pcm1").
+						withSecrets("ps1").volume(),
+					projectedVolume("pcms2").
+						withConfigMaps("pcm2").
+						withSecrets("ps2").
+						withDownardAPI("f1").volume(),
+					cmVolume("cm1"),
+				},
+			},
+			expect: []string{"ps2", "ps1"},
+		},
+		{
+			name: "volumes and projected",
+			podSpec: corev1.PodSpec{
+				Volumes: []corev1.Volume{secretVolume("s1"), secretVolume("s2"),
+					projectedVolume("pss").withSecrets("ps3").volume(),
+					projectedVolume("pss2").withSecrets("ps4").withConfigMaps("pcm1").volume(),
+					cmVolume("cm1"),
+				},
+			},
+			expect: []string{"s1", "s2", "ps3", "ps4"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			result := podSecretNames(&test.podSpec)
+			sort.StringSlice(result).Sort()
+			sort.StringSlice(test.expect).Sort()
+			g.Expect(result).To(Equal(test.expect))
+		})
+	}
+}
+
+func TestComputeResourceHashConsistency(t *testing.T) {
+	g := NewGomegaWithT(t)
+	for range 10 {
+		hashValue := ""
+		secretData, configMapData := generateResources()
+		for range 100 {
+			result, err := computeResourceHash(_resourceKeys(secretData), _resourceKeys(configMapData),
+				func(name string) (*corev1.Secret, error) {
+					return secretData[name].DeepCopy(), nil
+				},
+				func(name string) (*corev1.ConfigMap, error) {
+					return configMapData[name].DeepCopy(), nil
+				})
+			g.Expect(err).ToNot(HaveOccurred())
+			if hashValue == "" {
+				hashValue = result
+			} else {
+				g.Expect(result).To(Equal(hashValue), "Hash value must remain the same for the same data")
+			}
+		}
+	}
+}
+
+func _resourceKeys[T client.Object](resources map[string]T) []string {
+	result := make([]string, 0, len(resources))
+	for k := range resources {
+		result = append(result, k)
+	}
+	return result
+}
+
+func generateResources() (map[string]*corev1.Secret, map[string]*corev1.ConfigMap) {
+	f := fuzz.New()
+	secrets := map[string]*corev1.Secret{}
+	for range 10 {
+		secret := &corev1.Secret{}
+		f.Fuzz(secret)
+		secrets[secret.Name] = secret
+	}
+	configMaps := map[string]*corev1.ConfigMap{}
+	for range 10 {
+		cm := &corev1.ConfigMap{}
+		f.Fuzz(cm)
+		configMaps[cm.Name] = cm
+	}
+	return secrets, configMaps
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the RolloutOnSecretChange and RolloutOnConfigMapChange functions in favor of taking all configmaps and secrets into consideration when computing a config hash for a given component.

Fixes reconciliation of service account kubeconfig secrets by reading existing values before the adapt function so we don't re-generate a certificate with every reconcile.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-52331](https://issues.redhat.com/browse/OCPBUGS-52331)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.