### PR TITLE
NO-JIRA: CPOv2 token-minter abstraction

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -1642,7 +1642,8 @@ func TestControlPlaneComponents(t *testing.T) {
 				ManagementType: hyperv1.Managed,
 			},
 			Platform: hyperv1.PlatformSpec{
-				AWS: &hyperv1.AWSPlatformSpec{},
+				Type: hyperv1.AWSPlatform,
+				AWS:  &hyperv1.AWSPlatformSpec{},
 				Azure: &hyperv1.AzurePlatformSpec{
 					SubnetID:        "/subscriptions/mySubscriptionID/resourceGroups/myResourceGroupName/providers/Microsoft.Network/virtualNetworks/myVnetName/subnets/mySubnetName",
 					SecurityGroupID: "/subscriptions/mySubscriptionID/resourceGroups/myResourceGroupName/providers/Microsoft.Network/networkSecurityGroups/myNSGName",

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-aws/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-aws/zz_fixture_TestControlPlaneComponents.yaml
@@ -101,9 +101,9 @@ spec:
         - mountPath: /var/run/secrets/openshift/serviceaccount
           name: cloud-token
       - args:
+        - --token-audience=openshift
         - --service-account-namespace=kube-system
         - --service-account-name=kube-controller-manager
-        - --token-audience=openshift
         - --token-file=/var/run/secrets/openshift/serviceaccount/token
         - --kubeconfig=/etc/kubernetes/kubeconfig
         command:
@@ -111,16 +111,16 @@ spec:
         - token-minter
         image: token-minter
         imagePullPolicy: IfNotPresent
-        name: token-minter
+        name: cloud-token-minter
         resources:
           requests:
             cpu: 10m
             memory: 10Mi
         volumeMounts:
-        - mountPath: /var/run/secrets/openshift/serviceaccount
-          name: cloud-token
         - mountPath: /etc/kubernetes
           name: kubeconfig
+        - mountPath: /var/run/secrets/openshift/serviceaccount
+          name: cloud-token
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-aws/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-aws/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -101,9 +101,9 @@ spec:
         - mountPath: /var/run/secrets/openshift/serviceaccount
           name: cloud-token
       - args:
+        - --token-audience=openshift
         - --service-account-namespace=kube-system
         - --service-account-name=kube-controller-manager
-        - --token-audience=openshift
         - --token-file=/var/run/secrets/openshift/serviceaccount/token
         - --kubeconfig=/etc/kubernetes/kubeconfig
         command:
@@ -111,16 +111,16 @@ spec:
         - token-minter
         image: token-minter
         imagePullPolicy: IfNotPresent
-        name: token-minter
+        name: cloud-token-minter
         resources:
           requests:
             cpu: 10m
             memory: 10Mi
         volumeMounts:
-        - mountPath: /var/run/secrets/openshift/serviceaccount
-          name: cloud-token
         - mountPath: /etc/kubernetes
           name: kubeconfig
+        - mountPath: /var/run/secrets/openshift/serviceaccount
+          name: cloud-token
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-image-registry-operator/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-image-registry-operator/zz_fixture_TestControlPlaneComponents.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: client-token,web-identity-token
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token,apiserver-token
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
@@ -123,38 +123,54 @@ spec:
         volumeMounts:
         - mountPath: /etc/certificate/ca
           name: ca-bundle
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: client-token
         - mountPath: /etc/secrets
           name: serving-cert
         - mountPath: /var/run/secrets/openshift/serviceaccount
-          name: web-identity-token
+          name: cloud-token
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: apiserver-token
       - args:
-        - --service-account-namespace
-        - openshift-image-registry
-        - --service-account-name
-        - cluster-image-registry-operator
-        - --token-file
-        - /var/client-token/token
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig
-        - --token-audience
-        - ""
+        - --token-audience=openshift
+        - --service-account-namespace=openshift-image-registry
+        - --service-account-name=cluster-image-registry-operator
+        - --token-file=/var/run/secrets/openshift/serviceaccount/token
+        - --kubeconfig=/etc/kubernetes/kubeconfig
         command:
         - /usr/bin/control-plane-operator
         - token-minter
         image: token-minter
         imagePullPolicy: IfNotPresent
-        name: client-token-minter
+        name: cloud-token-minter
         resources:
           requests:
             cpu: 10m
             memory: 10Mi
         volumeMounts:
-        - mountPath: /var/client-token
-          name: client-token
         - mountPath: /etc/kubernetes
           name: kubeconfig
+        - mountPath: /var/run/secrets/openshift/serviceaccount
+          name: cloud-token
+      - args:
+        - --token-audience=
+        - --service-account-namespace=openshift-image-registry
+        - --service-account-name=cluster-image-registry-operator
+        - --token-file=/var/run/secrets/openshift/serviceaccount/token
+        - --kubeconfig=/etc/kubernetes/kubeconfig
+        command:
+        - /usr/bin/control-plane-operator
+        - token-minter
+        image: token-minter
+        imagePullPolicy: IfNotPresent
+        name: apiserver-token-minter
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes
+          name: kubeconfig
+        - mountPath: /var/run/secrets/openshift/serviceaccount
+          name: apiserver-token
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule
@@ -166,8 +182,6 @@ spec:
         operator: Equal
         value: hcp-namespace
       volumes:
-      - emptyDir: {}
-        name: client-token
       - name: serving-cert
         secret:
           defaultMode: 416
@@ -180,6 +194,10 @@ spec:
         secret:
           defaultMode: 416
           secretName: root-ca
-      - emptyDir: {}
-        name: web-identity-token
+      - emptyDir:
+          medium: Memory
+        name: cloud-token
+      - emptyDir:
+          medium: Memory
+        name: apiserver-token
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-image-registry-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-image-registry-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: client-token,web-identity-token
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token,apiserver-token
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
@@ -123,38 +123,54 @@ spec:
         volumeMounts:
         - mountPath: /etc/certificate/ca
           name: ca-bundle
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: client-token
         - mountPath: /etc/secrets
           name: serving-cert
         - mountPath: /var/run/secrets/openshift/serviceaccount
-          name: web-identity-token
+          name: cloud-token
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: apiserver-token
       - args:
-        - --service-account-namespace
-        - openshift-image-registry
-        - --service-account-name
-        - cluster-image-registry-operator
-        - --token-file
-        - /var/client-token/token
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig
-        - --token-audience
-        - ""
+        - --token-audience=openshift
+        - --service-account-namespace=openshift-image-registry
+        - --service-account-name=cluster-image-registry-operator
+        - --token-file=/var/run/secrets/openshift/serviceaccount/token
+        - --kubeconfig=/etc/kubernetes/kubeconfig
         command:
         - /usr/bin/control-plane-operator
         - token-minter
         image: token-minter
         imagePullPolicy: IfNotPresent
-        name: client-token-minter
+        name: cloud-token-minter
         resources:
           requests:
             cpu: 10m
             memory: 10Mi
         volumeMounts:
-        - mountPath: /var/client-token
-          name: client-token
         - mountPath: /etc/kubernetes
           name: kubeconfig
+        - mountPath: /var/run/secrets/openshift/serviceaccount
+          name: cloud-token
+      - args:
+        - --token-audience=
+        - --service-account-namespace=openshift-image-registry
+        - --service-account-name=cluster-image-registry-operator
+        - --token-file=/var/run/secrets/openshift/serviceaccount/token
+        - --kubeconfig=/etc/kubernetes/kubeconfig
+        command:
+        - /usr/bin/control-plane-operator
+        - token-minter
+        image: token-minter
+        imagePullPolicy: IfNotPresent
+        name: apiserver-token-minter
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes
+          name: kubeconfig
+        - mountPath: /var/run/secrets/openshift/serviceaccount
+          name: apiserver-token
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule
@@ -166,8 +182,6 @@ spec:
         operator: Equal
         value: hcp-namespace
       volumes:
-      - emptyDir: {}
-        name: client-token
       - name: serving-cert
         secret:
           defaultMode: 416
@@ -180,6 +194,10 @@ spec:
         secret:
           defaultMode: 416
           secretName: root-ca
-      - emptyDir: {}
-        name: web-identity-token
+      - emptyDir:
+          medium: Memory
+        name: cloud-token
+      - emptyDir:
+          medium: Memory
+        name: apiserver-token
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/zz_fixture_TestControlPlaneComponents.yaml
@@ -69,7 +69,7 @@ spec:
         - --namespace
         - $(POD_NAMESPACE)
         - --platform-type
-        - ""
+        - AWS
         - --enable-ci-debug-output=false
         - --hosted-control-plane=hcp
         - --konnectivity-address=

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -69,7 +69,7 @@ spec:
         - --namespace
         - $(POD_NAMESPACE)
         - --platform-type
-        - ""
+        - AWS
         - --enable-ci-debug-output=false
         - --hosted-control-plane=hcp
         - --konnectivity-address=

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/zz_fixture_TestControlPlaneComponents.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: serviceaccount-token
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       creationTimestamp: null
@@ -99,10 +99,10 @@ spec:
             memory: 80Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - mountPath: /var/run/secrets/openshift/serviceaccount
-          name: serviceaccount-token
         - mountPath: /etc/kubernetes
           name: service-account-kubeconfig
+        - mountPath: /var/run/secrets/openshift/serviceaccount
+          name: cloud-token
       - args:
         - run
         - --connect-directly-to-cloud-apis=true
@@ -125,6 +125,27 @@ spec:
           name: konnectivity-proxy-cert
         - mountPath: /etc/konnectivity/proxy-ca
           name: konnectivity-proxy-ca
+      - args:
+        - --token-audience=openshift
+        - --service-account-namespace=openshift-ingress-operator
+        - --service-account-name=ingress-operator
+        - --token-file=/var/run/secrets/openshift/serviceaccount/token
+        - --kubeconfig=/etc/kubernetes/kubeconfig
+        command:
+        - /usr/bin/control-plane-operator
+        - token-minter
+        image: token-minter
+        imagePullPolicy: IfNotPresent
+        name: cloud-token-minter
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes
+          name: admin-kubeconfig
+        - mountPath: /var/run/secrets/openshift/serviceaccount
+          name: cloud-token
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -155,8 +176,6 @@ spec:
         secret:
           defaultMode: 416
           secretName: service-network-admin-kubeconfig
-      - emptyDir: {}
-        name: serviceaccount-token
       - name: service-account-kubeconfig
         secret:
           defaultMode: 416
@@ -168,4 +187,7 @@ spec:
       - configMap:
           name: konnectivity-ca-bundle
         name: konnectivity-proxy-ca
+      - emptyDir:
+          medium: Memory
+        name: cloud-token
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: serviceaccount-token
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       creationTimestamp: null
@@ -99,10 +99,10 @@ spec:
             memory: 80Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - mountPath: /var/run/secrets/openshift/serviceaccount
-          name: serviceaccount-token
         - mountPath: /etc/kubernetes
           name: service-account-kubeconfig
+        - mountPath: /var/run/secrets/openshift/serviceaccount
+          name: cloud-token
       - args:
         - run
         - --connect-directly-to-cloud-apis=true
@@ -125,6 +125,27 @@ spec:
           name: konnectivity-proxy-cert
         - mountPath: /etc/konnectivity/proxy-ca
           name: konnectivity-proxy-ca
+      - args:
+        - --token-audience=openshift
+        - --service-account-namespace=openshift-ingress-operator
+        - --service-account-name=ingress-operator
+        - --token-file=/var/run/secrets/openshift/serviceaccount/token
+        - --kubeconfig=/etc/kubernetes/kubeconfig
+        command:
+        - /usr/bin/control-plane-operator
+        - token-minter
+        image: token-minter
+        imagePullPolicy: IfNotPresent
+        name: cloud-token-minter
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes
+          name: admin-kubeconfig
+        - mountPath: /var/run/secrets/openshift/serviceaccount
+          name: cloud-token
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -155,8 +176,6 @@ spec:
         secret:
           defaultMode: 416
           secretName: service-network-admin-kubeconfig
-      - emptyDir: {}
-        name: serviceaccount-token
       - name: service-account-kubeconfig
         secret:
           defaultMode: 416
@@ -168,4 +187,7 @@ spec:
       - configMap:
           name: konnectivity-ca-bundle
         name: konnectivity-proxy-ca
+      - emptyDir:
+          medium: Memory
+        name: cloud-token
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents.yaml
@@ -300,6 +300,29 @@ spec:
         volumeMounts:
         - mountPath: /var/log/kube-apiserver
           name: logs
+      - command:
+        - /usr/bin/aws-pod-identity-webhook
+        - --annotation-prefix=eks.amazonaws.com
+        - --in-cluster=false
+        - --kubeconfig=/var/run/app/kubeconfig/kubeconfig
+        - --logtostderr
+        - --port=4443
+        - --aws-default-region=
+        - --tls-cert=/var/run/app/certs/tls.crt
+        - --tls-key=/var/run/app/certs/tls.key
+        - --token-audience=openshift
+        image: aws-pod-identity-webhook
+        imagePullPolicy: IfNotPresent
+        name: aws-pod-identity-webhook
+        resources:
+          requests:
+            cpu: 10m
+            memory: 25Mi
+        volumeMounts:
+        - mountPath: /var/run/app/certs
+          name: aws-pod-identity-webhook-serving-certs
+        - mountPath: /var/run/app/kubeconfig
+          name: aws-pod-identity-webhook-kubeconfig
       initContainers:
       - args:
         - -c
@@ -483,4 +506,12 @@ spec:
         secret:
           defaultMode: 416
           secretName: konnectivity-cluster
+      - name: aws-pod-identity-webhook-serving-certs
+        secret:
+          defaultMode: 416
+          secretName: aws-pod-identity-webhook-serving-cert
+      - name: aws-pod-identity-webhook-kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: aws-pod-identity-webhook-kubeconfig
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -300,6 +300,29 @@ spec:
         volumeMounts:
         - mountPath: /var/log/kube-apiserver
           name: logs
+      - command:
+        - /usr/bin/aws-pod-identity-webhook
+        - --annotation-prefix=eks.amazonaws.com
+        - --in-cluster=false
+        - --kubeconfig=/var/run/app/kubeconfig/kubeconfig
+        - --logtostderr
+        - --port=4443
+        - --aws-default-region=
+        - --tls-cert=/var/run/app/certs/tls.crt
+        - --tls-key=/var/run/app/certs/tls.key
+        - --token-audience=openshift
+        image: aws-pod-identity-webhook
+        imagePullPolicy: IfNotPresent
+        name: aws-pod-identity-webhook
+        resources:
+          requests:
+            cpu: 10m
+            memory: 25Mi
+        volumeMounts:
+        - mountPath: /var/run/app/certs
+          name: aws-pod-identity-webhook-serving-certs
+        - mountPath: /var/run/app/kubeconfig
+          name: aws-pod-identity-webhook-kubeconfig
       initContainers:
       - args:
         - -c
@@ -484,4 +507,12 @@ spec:
         secret:
           defaultMode: 416
           secretName: konnectivity-cluster
+      - name: aws-pod-identity-webhook-serving-certs
+        secret:
+          defaultMode: 416
+          secretName: aws-pod-identity-webhook-serving-cert
+      - name: aws-pod-identity-webhook-kubeconfig
+        secret:
+          defaultMode: 416
+          secretName: aws-pod-identity-webhook-kubeconfig
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_component.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_component.yaml
@@ -30,6 +30,9 @@ status:
     name: kas-authentication-token-webhook-config
   - group: ""
     kind: Secret
+    name: aws-pod-identity-webhook-kubeconfig
+  - group: ""
+    kind: Secret
     name: bootstrap-kubeconfig
   - group: ""
     kind: Secret

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_component_TechPreviewNoUpgrade.yaml
@@ -30,6 +30,9 @@ status:
     name: kas-authentication-token-webhook-config
   - group: ""
     kind: Secret
+    name: aws-pod-identity-webhook-kubeconfig
+  - group: ""
+    kind: Secret
     name: bootstrap-kubeconfig
   - group: ""
     kind: Secret

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cloud-controller-manager-aws/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cloud-controller-manager-aws/deployment.yaml
@@ -54,29 +54,6 @@ spec:
           name: kubeconfig
         - mountPath: /etc/kubernetes/secrets/cloud-provider
           name: cloud-creds
-        - mountPath: /var/run/secrets/openshift/serviceaccount
-          name: cloud-token
-      - args:
-        - --service-account-namespace=kube-system
-        - --service-account-name=kube-controller-manager
-        - --token-audience=openshift
-        - --token-file=/var/run/secrets/openshift/serviceaccount/token
-        - --kubeconfig=/etc/kubernetes/kubeconfig
-        command:
-        - /usr/bin/control-plane-operator
-        - token-minter
-        image: token-minter
-        imagePullPolicy: IfNotPresent
-        name: token-minter
-        resources:
-          requests:
-            cpu: 10m
-            memory: 10Mi
-        volumeMounts:
-        - mountPath: /var/run/secrets/openshift/serviceaccount
-          name: cloud-token
-        - mountPath: /etc/kubernetes
-          name: kubeconfig
       volumes:
       - name: kubeconfig
         secret:
@@ -94,6 +71,3 @@ spec:
         secret:
           defaultMode: 420
           secretName: cloud-controller-creds
-      - emptyDir:
-          medium: Memory
-        name: cloud-token

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-image-registry-operator/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-image-registry-operator/deployment.yaml
@@ -78,62 +78,10 @@ spec:
         volumeMounts:
         - mountPath: /etc/certificate/ca
           name: ca-bundle
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: client-token
         - mountPath: /etc/secrets
           name: serving-cert
-        - mountPath: /var/run/secrets/openshift/serviceaccount
-          name: web-identity-token
-      - args:
-        - --service-account-namespace
-        - openshift-image-registry
-        - --service-account-name
-        - cluster-image-registry-operator
-        - --token-file
-        - /var/client-token/token
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig
-        command:
-        - /usr/bin/control-plane-operator
-        - token-minter
-        image: token-minter
-        name: client-token-minter
-        resources:
-          requests:
-            cpu: 10m
-            memory: 10Mi
-        volumeMounts:
-        - mountPath: /var/client-token
-          name: client-token
-        - mountPath: /etc/kubernetes
-          name: kubeconfig
-      - args:
-        - --service-account-namespace
-        - openshift-image-registry
-        - --service-account-name
-        - cluster-image-registry-operator
-        - --token-file
-        - /var/run/secrets/openshift/serviceaccount/token
-        - --kubeconfig
-        - /etc/kubernetes/kubeconfig
-        command:
-        - /usr/bin/control-plane-operator
-        - token-minter
-        image: token-minter
-        name: token-minter
-        resources:
-          requests:
-            cpu: 10m
-            memory: 10Mi
-        volumeMounts:
-        - mountPath: /etc/kubernetes
-          name: kubeconfig
-        - mountPath: /var/run/secrets/openshift/serviceaccount
-          name: web-identity-token
       priorityClassName: hypershift-control-plane
       volumes:
-      - emptyDir: {}
-        name: client-token
       - name: serving-cert
         secret:
           defaultMode: 416
@@ -146,5 +94,3 @@ spec:
         secret:
           defaultMode: 416
           secretName: root-ca
-      - emptyDir: {}
-        name: web-identity-token

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/ingress-operator/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/ingress-operator/deployment.yaml
@@ -55,37 +55,8 @@ spec:
             cpu: 10m
             memory: 80Mi
         terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts:
-        - mountPath: /var/run/secrets/openshift/serviceaccount
-          name: serviceaccount-token
-      - args:
-        - --service-account-namespace=openshift-ingress-operator
-        - --service-account-name=ingress-operator
-        - --token-file=/var/run/secrets/openshift/serviceaccount/token
-        - --kubeconfig=/etc/kubernetes/kubeconfig
-        command:
-        - /usr/bin/control-plane-operator
-        - token-minter
-        image: token-minter
-        imagePullPolicy: IfNotPresent
-        name: token-minter
-        ports:
-        - containerPort: 60000
-          name: metrics
-          protocol: TCP
-        resources:
-          requests:
-            cpu: 10m
-            memory: 10Mi
-        volumeMounts:
-        - mountPath: /var/run/secrets/openshift/serviceaccount
-          name: serviceaccount-token
-        - mountPath: /etc/kubernetes
-          name: admin-kubeconfig
       volumes:
       - name: admin-kubeconfig
         secret:
           defaultMode: 416
           secretName: service-network-admin-kubeconfig
-      - emptyDir: {}
-        name: serviceaccount-token

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/aws/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/aws/component.go
@@ -36,6 +36,11 @@ func NewComponent() component.ControlPlaneComponent {
 			"config.yaml",
 			component.WithAdaptFunction(adaptConfig),
 		).
+		InjectTokenMinterContainer(component.TokenMinterContainerOptions{
+			TokenType:               component.CloudToken,
+			ServiceAccountNameSpace: "kube-system",
+			ServiceAccountName:      "kube-controller-manager",
+		}).
 		Build()
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ingressoperator/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ingressoperator/component.go
@@ -12,6 +12,9 @@ import (
 
 const (
 	ComponentName = "ingress-operator"
+
+	serviceAccountName      = "ingress-operator"
+	serviceAccountNamespace = "openshift-ingress-operator"
 )
 
 var _ component.ComponentOptions = &ingressOperator{}
@@ -61,10 +64,16 @@ func NewComponent() component.ControlPlaneComponent {
 			},
 		}).
 		InjectServiceAccountKubeConfig(component.ServiceAccountKubeConfigOpts{
-			Name:          "ingress-operator",
-			Namespace:     "openshift-ingress-operator",
+			Name:          serviceAccountName,
+			Namespace:     serviceAccountNamespace,
 			MountPath:     "/etc/kubernetes",
 			ContainerName: ComponentName,
+		}).
+		InjectTokenMinterContainer(component.TokenMinterContainerOptions{
+			TokenType:               component.CloudToken,
+			ServiceAccountName:      serviceAccountName,
+			ServiceAccountNameSpace: serviceAccountNamespace,
+			KubeconfingVolumeName:   "admin-kubeconfig",
 		}).
 		Build()
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ingressoperator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ingressoperator/deployment.go
@@ -1,7 +1,6 @@
 package ingressoperator
 
 import (
-	"github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
@@ -41,10 +40,6 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 			)
 		}
 	})
-
-	if cpContext.HCP.Spec.Platform.Type != v1beta1.AWSPlatform {
-		util.RemoveContainer("token-minter", &deployment.Spec.Template.Spec)
-	}
 
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/registryoperator/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/registryoperator/component.go
@@ -43,6 +43,11 @@ func NewComponent() component.ControlPlaneComponent {
 			component.WithPredicate(isAroHCP),
 		).
 		WithDependencies(oapiv2.ComponentName).
+		InjectTokenMinterContainer(component.TokenMinterContainerOptions{
+			TokenType:               component.CloudAndAPIServerToken,
+			ServiceAccountName:      "cluster-image-registry-operator",
+			ServiceAccountNameSpace: "openshift-image-registry",
+		}).
 		Build()
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/registryoperator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/registryoperator/deployment.go
@@ -1,7 +1,6 @@
 package registryoperator
 
 import (
-	"github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
@@ -44,12 +43,5 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		}
 	})
 
-	util.UpdateContainer("client-token-minter", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
-		c.Args = append(c.Args, "--token-audience", cpContext.HCP.Spec.IssuerURL)
-	})
-
-	if cpContext.HCP.Spec.Platform.Type != v1beta1.AWSPlatform {
-		util.RemoveContainer("token-minter", &deployment.Spec.Template.Spec)
-	}
 	return nil
 }

--- a/support/controlplane-component/README.md
+++ b/support/controlplane-component/README.md
@@ -279,4 +279,21 @@ func NewComponent() component.ControlPlaneComponent {
 }
 ```
 
+### Tokens
+
+If your component requires access to the cloud or kube-apiserver. It requires a serviceAccount token in the guest cluster. This can be provided by the token-minter sidecar container which you can automatically inject into your deployment as follows:
+
+```go hl_lines="5 9"
+// control-plane-operator/controllers/hostedcontrolplane/v2/mycomponent/component.go
+
+func NewComponent() component.ControlPlaneComponent {
+	return component.NewDeploymentComponent(ComponentName, &MyComponent{}).
+        InjectTokenMinterContainer(component.TokenMinterContainerOptions{
+			TokenType:               component.Cloud, // mint token for cloud access, possible values: Cloud, KubeAPIServerToken or CloudAndAPIServerToken.
+			ServiceAccountName:      "my-serivceaccount",
+			ServiceAccountNameSpace: "my-serivceaccount-namespace",
+		}).
+		Build()
+}
+
 See [controlPlaneWorkloadBuilder](/support/controlplane-component/builder.go) for all available options

--- a/support/controlplane-component/builder.go
+++ b/support/controlplane-component/builder.go
@@ -91,6 +91,13 @@ func (b *controlPlaneWorkloadBuilder[T]) InjectAvailabilityProberContainer(opts 
 	return b
 }
 
+// InjectTokenMinterContainer will injecta sidecar container which mints ServiceAccount tokens in the tenant cluster for the given named service account,
+// and then make it available for the main container with a volume mount.
+func (b *controlPlaneWorkloadBuilder[T]) InjectTokenMinterContainer(opts TokenMinterContainerOptions) *controlPlaneWorkloadBuilder[T] {
+	b.workload.tokenMinterContainerOpts = &opts
+	return b
+}
+
 // InjectServiceAccountKubeConfig will cause the generation of a secret with a kubeconfig using certificates for the given named service account
 // and the volume mounts for that secret within the given mountPath.
 func (b *controlPlaneWorkloadBuilder[T]) InjectServiceAccountKubeConfig(opts ServiceAccountKubeConfigOpts) *controlPlaneWorkloadBuilder[T] {

--- a/support/controlplane-component/controlplane-component.go
+++ b/support/controlplane-component/controlplane-component.go
@@ -124,6 +124,8 @@ type controlPlaneWorkload[T client.Object] struct {
 	konnectivityContainerOpts *KonnectivityContainerOptions
 	// if provided, availabilityProber container and required volumes will be injected into the deployment/statefulset.
 	availabilityProberOpts *util.AvailabilityProberOpts
+	// if provided, token-minter container and required volumes will be injected into the deployment/statefulset.
+	tokenMinterContainerOpts *TokenMinterContainerOptions
 	// serviceAccountKubeConfigOpts will cause the generation of a secret with a kubeconfig using certificates for the given named service account
 	// and the volume mounts for that secret within the given mountPath.
 	serviceAccountKubeConfigOpts *ServiceAccountKubeConfigOpts

--- a/support/controlplane-component/defaults.go
+++ b/support/controlplane-component/defaults.go
@@ -61,6 +61,10 @@ func (c *controlPlaneWorkload[T]) defaultOptions(cpContext ControlPlaneContext, 
 		c.konnectivityContainerOpts.injectKonnectivityContainer(cpContext, &podTemplateSpec.Spec)
 	}
 
+	if c.tokenMinterContainerOpts != nil {
+		c.tokenMinterContainerOpts.injectTokenMinterContainer(cpContext, &podTemplateSpec.Spec)
+	}
+
 	if c.availabilityProberOpts != nil {
 		availabilityProberImage := cpContext.ReleaseImageProvider.GetImage(util.AvailabilityProberImageName)
 		util.AvailabilityProber(

--- a/support/controlplane-component/token-minter-container.go
+++ b/support/controlplane-component/token-minter-container.go
@@ -1,0 +1,140 @@
+package controlplanecomponent
+
+import (
+	"fmt"
+	"path"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/util"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	cloudTokenFileMountPath   = "/var/run/secrets/openshift/serviceaccount"
+	kubeAPITokenFileMountPath = "/var/run/secrets/kubernetes.io/serviceaccount"
+)
+
+type TokenType string
+
+const (
+	CloudToken         TokenType = "cloud"
+	KubeAPIServerToken TokenType = "apiserver"
+
+	// CloudAndAPIServerToken will inject 2 token-minter containers, one using minting a token for cloud and the other minting a token for kube-apiserver access.
+	CloudAndAPIServerToken TokenType = "cloud-and-apiserver"
+)
+
+// TokenMinterContainerOptions defines the options for token-minter sidecar container which mints ServiceAccount tokens in the tenant cluster for the given named service account,
+// and then make it available for the main container with a volume mount.
+type TokenMinterContainerOptions struct {
+	// TokenType defines the token purpose, either to grant cloud access, kube-apiserver access to both.
+	TokenType TokenType
+	// ServiceAccountName is the name of the service account for which to mint a token.
+	ServiceAccountName string
+	// ServiceAccountNameSpace is the namespace of the service account for which to mint a token.
+	ServiceAccountNameSpace string
+
+	// KubeconfingVolumeName is the volume name which contains the kubeconfig to use mint the token in the target cluster.
+	// defaults to 'kubeconfig'
+	KubeconfingVolumeName string
+	// OneShot, if true, will cause the token-minter container to exit after minting the token.
+	OneShot bool
+}
+
+func (opts TokenMinterContainerOptions) injectTokenMinterContainer(cpContext ControlPlaneContext, podSpec *corev1.PodSpec) {
+	if opts.TokenType == "" || opts.ServiceAccountName == "" || opts.ServiceAccountNameSpace == "" {
+		// programmer error.
+		panic("tokenTarget, ServiceAccountName and ServiceAccountNameSpace must be specified!")
+	}
+	image := cpContext.ReleaseImageProvider.GetImage("token-minter")
+
+	// we only mint cloud tokens for AWS.
+	if (opts.TokenType == CloudToken || opts.TokenType == CloudAndAPIServerToken) &&
+		cpContext.HCP.Spec.Platform.Type == hyperv1.AWSPlatform {
+		tokenVolume := opts.buildVolume(string(CloudToken))
+		podSpec.Volumes = append(podSpec.Volumes, tokenVolume)
+
+		podSpec.Containers = append(podSpec.Containers, opts.buildContainer(cpContext.HCP, CloudToken, image, tokenVolume))
+
+		podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, corev1.VolumeMount{
+			Name:      tokenVolume.Name,
+			MountPath: cloudTokenFileMountPath,
+		})
+	}
+
+	if opts.TokenType == KubeAPIServerToken || opts.TokenType == CloudAndAPIServerToken {
+		tokenVolume := opts.buildVolume(string(KubeAPIServerToken))
+		podSpec.Volumes = append(podSpec.Volumes, tokenVolume)
+
+		podSpec.Containers = append(podSpec.Containers, opts.buildContainer(cpContext.HCP, KubeAPIServerToken, image, tokenVolume))
+
+		podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, corev1.VolumeMount{
+			Name:      tokenVolume.Name,
+			MountPath: kubeAPITokenFileMountPath,
+		})
+	}
+}
+
+func (opts TokenMinterContainerOptions) buildContainer(hcp *hyperv1.HostedControlPlane, tokenType TokenType, image string, tokenVolume corev1.Volume) corev1.Container {
+	tokenFileMountPath := "/var/run/secrets/openshift/serviceaccount"
+	kubeconfigMountPath := "/etc/kubernetes"
+
+	var audience string
+	if tokenType == CloudToken {
+		audience = "openshift"
+	} else if tokenType == KubeAPIServerToken {
+		audience = hcp.Spec.IssuerURL
+	}
+	args := []string{
+		fmt.Sprintf("--token-audience=%s", audience),
+		fmt.Sprintf("--service-account-namespace=%s", opts.ServiceAccountNameSpace),
+		fmt.Sprintf("--service-account-name=%s", opts.ServiceAccountName),
+		fmt.Sprintf("--token-file=%s", path.Join(tokenFileMountPath, "token")),
+		fmt.Sprintf("--kubeconfig=%s", path.Join(kubeconfigMountPath, util.KubeconfigKey)),
+	}
+	if opts.OneShot {
+		args = append(args, "--oneshot")
+	}
+
+	kubeconfingVolumeName := opts.KubeconfingVolumeName
+	if kubeconfingVolumeName == "" {
+		kubeconfingVolumeName = "kubeconfig"
+	}
+
+	container := corev1.Container{
+		Name:            fmt.Sprintf("%s-token-minter", tokenType),
+		Image:           image,
+		Command:         []string{"/usr/bin/control-plane-operator", "token-minter"},
+		Args:            args,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("10Mi"),
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      kubeconfingVolumeName,
+				MountPath: kubeconfigMountPath,
+			},
+			{
+				Name:      tokenVolume.Name,
+				MountPath: tokenFileMountPath,
+			},
+		},
+	}
+
+	return container
+}
+
+func (opts TokenMinterContainerOptions) buildVolume(namePrefix string) corev1.Volume {
+	return corev1.Volume{
+		Name: fmt.Sprintf("%s-token", namePrefix),
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory},
+		},
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds automation in CPOv2 that allows component to request a `token-minter` container to be injected programmatically instead of having it explicitly defined in the yaml manifest.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.