### PR TITLE
OCPBUGS-52417: [release-4.18] refactor aws identity health check into new controller

### DIFF
--- a/control-plane-operator/controllers/healthcheck/aws.go
+++ b/control-plane-operator/controllers/healthcheck/aws.go
@@ -1,0 +1,72 @@
+package healthcheck
+
+import (
+	"context"
+	"fmt"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func awsHealthCheckIdentityProvider(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
+	ec2Client, _ := hostedcontrolplane.GetEC2Client()
+	if ec2Client == nil {
+		return nil
+	}
+
+	// We try to interact with cloud provider to see validate is operational.
+	if _, err := ec2Client.DescribeVpcEndpointsWithContext(ctx, &ec2.DescribeVpcEndpointsInput{}); err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			// When awsErr.Code() is WebIdentityErr it's likely to be an external issue, e.g. the idp resource was deleted.
+			// We don't set awsErr.Message() in the condition as it might contain aws requests IDs that would make the condition be updated in loop.
+			if awsErr.Code() == "WebIdentityErr" {
+				condition := metav1.Condition{
+					Type:               string(hyperv1.ValidAWSIdentityProvider),
+					ObservedGeneration: hcp.Generation,
+					Status:             metav1.ConditionFalse,
+					Message:            awsErr.Code(),
+					Reason:             hyperv1.InvalidIdentityProvider,
+				}
+				meta.SetStatusCondition(&hcp.Status.Conditions, condition)
+				return fmt.Errorf("error health checking AWS identity provider: %s %s", awsErr.Code(), awsErr.Message())
+			}
+
+			condition := metav1.Condition{
+				Type:               string(hyperv1.ValidAWSIdentityProvider),
+				ObservedGeneration: hcp.Generation,
+				Status:             metav1.ConditionUnknown,
+				Message:            awsErr.Code(),
+				Reason:             hyperv1.AWSErrorReason,
+			}
+			meta.SetStatusCondition(&hcp.Status.Conditions, condition)
+			return fmt.Errorf("error health checking AWS identity provider: %s %s", awsErr.Code(), awsErr.Message())
+		}
+
+		condition := metav1.Condition{
+			Type:               string(hyperv1.ValidAWSIdentityProvider),
+			ObservedGeneration: hcp.Generation,
+			Status:             metav1.ConditionUnknown,
+			Message:            err.Error(),
+			Reason:             hyperv1.StatusUnknownReason,
+		}
+		meta.SetStatusCondition(&hcp.Status.Conditions, condition)
+		return fmt.Errorf("error health checking AWS identity provider: %w", err)
+	}
+
+	condition := metav1.Condition{
+		Type:               string(hyperv1.ValidAWSIdentityProvider),
+		ObservedGeneration: hcp.Generation,
+		Status:             metav1.ConditionTrue,
+		Message:            hyperv1.AllIsWellMessage,
+		Reason:             hyperv1.AsExpectedReason,
+	}
+	meta.SetStatusCondition(&hcp.Status.Conditions, condition)
+
+	return nil
+}

--- a/control-plane-operator/controllers/healthcheck/healthcheck_controller.go
+++ b/control-plane-operator/controllers/healthcheck/healthcheck_controller.go
@@ -1,0 +1,100 @@
+package healthcheck
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-logr/logr"
+)
+
+const (
+	successRequeueInterval = 5 * time.Minute
+	failureRequeueInterval = 30 * time.Second
+)
+
+type HealthCheckUpdater struct {
+	client.Client
+	HostedControlPlane client.ObjectKey
+
+	log logr.Logger
+}
+
+func (hcu *HealthCheckUpdater) SetupWithManager(mgr ctrl.Manager) error {
+	return mgr.Add(hcu)
+}
+
+func (hcu *HealthCheckUpdater) Start(ctx context.Context) error {
+	hcu.log = ctrl.LoggerFrom(ctx).WithName("health-check-updater")
+	hcu.log.Info("Starting health check updater")
+	ticker := time.NewTicker(failureRequeueInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			err := hcu.update(ctx)
+			if err != nil {
+				hcu.log.Error(err, "Failure occurred during health checks")
+				ticker.Reset(failureRequeueInterval)
+			} else {
+				hcu.log.Info("Health checks succeeded")
+				ticker.Reset(successRequeueInterval)
+			}
+		}
+	}
+}
+
+func (hcu *HealthCheckUpdater) update(ctx context.Context) error {
+	hcu.log.Info("Updating health checks")
+
+	hostedControlPlane := &hyperv1.HostedControlPlane{}
+	err := hcu.Client.Get(ctx, hcu.HostedControlPlane, hostedControlPlane)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get HostedControlPlane: %w", err)
+	}
+
+	// Return early if deleting
+	if !hostedControlPlane.DeletionTimestamp.IsZero() {
+		return nil
+	}
+
+	originalHostedControlPlane := hostedControlPlane.DeepCopy()
+
+	errs := []error{}
+
+	// Call generic health checks
+
+	// Call platform-specific health checks
+	if hostedControlPlane.Spec.Platform.Type == hyperv1.AWSPlatform {
+		// This is the best effort ping to the identity provider
+		// that enables access from the operator to the cloud provider resources.
+		if err := awsHealthCheckIdentityProvider(ctx, hostedControlPlane); err != nil {
+			errs = append(errs, err)
+		}
+
+	}
+
+	// Update the status
+	if err := hcu.Client.Status().Patch(ctx, hostedControlPlane, client.MergeFromWithOptions(originalHostedControlPlane, client.MergeFromWithOptimisticLock{})); err != nil {
+		return fmt.Errorf("failed to update status: %w", err)
+	}
+
+	err = utilerrors.NewAggregate(errs)
+	if len(errs) > 0 {
+		return fmt.Errorf("some health checks failed: %w", err)
+	}
+	return nil
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -197,7 +197,7 @@ func (r *HostedControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager, create
 
 	r.reconcileInfrastructureStatus = r.defaultReconcileInfrastructureStatus
 
-	r.ec2Client, r.awsSession = getEC2Client()
+	r.ec2Client, r.awsSession = GetEC2Client()
 
 	if r.IsCPOV2 {
 		r.registerComponents()
@@ -228,7 +228,7 @@ func (r *HostedControlPlaneReconciler) registerComponents() {
 	)
 }
 
-func getEC2Client() (ec2iface.EC2API, *session.Session) {
+func GetEC2Client() (ec2iface.EC2API, *session.Session) {
 	// AWS_SHARED_CREDENTIALS_FILE and AWS_REGION envvar should be set in operator deployment
 	// when reconciling an AWS hosted control plane
 	if os.Getenv("AWS_SHARED_CREDENTIALS_FILE") != "" {
@@ -324,14 +324,6 @@ func (r *HostedControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	originalHostedControlPlane := hostedControlPlane.DeepCopy()
-	// This is the best effort ping to the identity provider
-	// that enables access from the operator to the cloud provider resources.
-	healthCheckIdentityProvider(ctx, hostedControlPlane)
-	// We want to ensure the healthCheckIdentityProvider condition is in status before we go through the deletion timestamp path.
-	if err := r.Client.Status().Patch(ctx, hostedControlPlane, client.MergeFromWithOptions(originalHostedControlPlane, client.MergeFromWithOptimisticLock{})); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
-	}
-	originalHostedControlPlane = hostedControlPlane.DeepCopy()
 
 	// Return early if deleted
 	if !hostedControlPlane.DeletionTimestamp.IsZero() {
@@ -5087,70 +5079,6 @@ func (r *HostedControlPlaneReconciler) reconcileClusterStorageOperator(ctx conte
 	// TODO: create custom kubeconfig to the guest cluster + RBAC
 
 	return nil
-}
-
-func healthCheckIdentityProvider(ctx context.Context, hcp *hyperv1.HostedControlPlane) {
-	if hcp.Spec.Platform.AWS == nil {
-		return
-	}
-
-	log := ctrl.LoggerFrom(ctx)
-
-	ec2Client, _ := getEC2Client()
-	if ec2Client == nil {
-		return
-	}
-
-	// We try to interact with cloud provider to see validate is operational.
-	if _, err := ec2Client.DescribeVpcEndpointsWithContext(ctx, &ec2.DescribeVpcEndpointsInput{}); err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
-			// When awsErr.Code() is WebIdentityErr it's likely to be an external issue, e.g. the idp resource was deleted.
-			// We don't set awsErr.Message() in the condition as it might contain aws requests IDs that would make the condition be updated in loop.
-			if awsErr.Code() == "WebIdentityErr" {
-				condition := metav1.Condition{
-					Type:               string(hyperv1.ValidAWSIdentityProvider),
-					ObservedGeneration: hcp.Generation,
-					Status:             metav1.ConditionFalse,
-					Message:            awsErr.Code(),
-					Reason:             hyperv1.InvalidIdentityProvider,
-				}
-				meta.SetStatusCondition(&hcp.Status.Conditions, condition)
-				log.Info("Error health checking AWS identity provider", awsErr.Code(), awsErr.Message())
-				return
-			}
-
-			condition := metav1.Condition{
-				Type:               string(hyperv1.ValidAWSIdentityProvider),
-				ObservedGeneration: hcp.Generation,
-				Status:             metav1.ConditionUnknown,
-				Message:            awsErr.Code(),
-				Reason:             hyperv1.AWSErrorReason,
-			}
-			meta.SetStatusCondition(&hcp.Status.Conditions, condition)
-			log.Info("Error health checking AWS identity provider", awsErr.Code(), awsErr.Message())
-			return
-		}
-
-		condition := metav1.Condition{
-			Type:               string(hyperv1.ValidAWSIdentityProvider),
-			ObservedGeneration: hcp.Generation,
-			Status:             metav1.ConditionUnknown,
-			Message:            err.Error(),
-			Reason:             hyperv1.StatusUnknownReason,
-		}
-		meta.SetStatusCondition(&hcp.Status.Conditions, condition)
-		log.Info("Error health checking AWS identity provider", "error", err)
-		return
-	}
-
-	condition := metav1.Condition{
-		Type:               string(hyperv1.ValidAWSIdentityProvider),
-		ObservedGeneration: hcp.Generation,
-		Status:             metav1.ConditionTrue,
-		Message:            hyperv1.AllIsWellMessage,
-		Reason:             hyperv1.AsExpectedReason,
-	}
-	meta.SetStatusCondition(&hcp.Status.Conditions, condition)
 }
 
 func (r *HostedControlPlaneReconciler) reconcileDefaultSecurityGroup(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -10,6 +10,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	availabilityprober "github.com/openshift/hypershift/availability-prober"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/awsprivatelink"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/healthcheck"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator"
 	pkiconfig "github.com/openshift/hypershift/control-plane-pki-operator/config"
@@ -460,6 +461,14 @@ func NewStartCommand() *cobra.Command {
 			ImageMetadataProvider:                   imageMetaDataProvider,
 		}).SetupWithManager(mgr, upsert.New(enableCIDebugOutput).CreateOrUpdate); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "hosted-control-plane")
+			os.Exit(1)
+		}
+
+		if err := (&healthcheck.HealthCheckUpdater{
+			Client:             mgr.GetClient(),
+			HostedControlPlane: crclient.ObjectKey{Namespace: hcp.Namespace, Name: hcp.Name},
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "health-check-updater")
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
Manual pick of https://github.com/openshift/hypershift/pull/5751

Conflict was just import ordering in `main.go`