### PR TITLE
OCPBUGS-52419: e2e: don't call `WaitForImageRollout` in `executeNodePoolTest`

### DIFF
--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -319,9 +319,6 @@ func executeNodePoolTest(t *testing.T, ctx context.Context, mgmtClient crclient.
 
 	nodes := e2eutil.WaitForReadyNodesByNodePool(t, ctx, hcClient, nodePool, hostedCluster.Spec.Platform.Type)
 
-	// Wait for the rollout to be complete
-	e2eutil.WaitForImageRollout(t, ctx, mgmtClient, hostedCluster)
-
 	// run test validations
 	nodePoolTest.Run(t, *nodePool, nodes)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We don't need to call that function as it's already called where it's
needed, in control_plane_upgrade_test for example.