### PR TITLE
[release-4.18] OCPBUGS-52982: Fix audit-logs container to properly handle SIGTERM

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -1013,8 +1013,9 @@ set -o nounset
 set -o pipefail
 
 function cleanup() {
-	kill -- -$$
+	pkill -P $$$
 	wait
+	exit
 }
 trap cleanup SIGTERM
 

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/testdata/zz_fixture_TestReconcileOauthDeploymentNoChanges.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/testdata/zz_fixture_TestReconcileOauthDeploymentNoChanges.yaml
@@ -129,8 +129,8 @@ spec:
       - args:
         - -c
         - "\nset -o errexit\nset -o nounset\nset -o pipefail\n\nfunction cleanup()
-          {\n\tkill -- -$$\n\twait\n}\ntrap cleanup SIGTERM\n\n/usr/bin/tail -c+1
-          -F /var/run/kubernetes/audit.log &\nwait $!\n"
+          {\n\tpkill -P $$$\n\twait\n\texit\n}\ntrap cleanup SIGTERM\n\n/usr/bin/tail
+          -c+1 -F /var/run/kubernetes/audit.log &\nwait $!\n"
         command:
         - /bin/bash
         image: oauthImage

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents.yaml
@@ -264,8 +264,9 @@ spec:
           set -o pipefail
 
           function cleanup() {
-            kill -- -$$
+            pkill -P $$$
             wait
+            exit
           }
           trap cleanup SIGTERM
 

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/zz_fixture_TestControlPlaneComponents.yaml
@@ -138,8 +138,9 @@ spec:
           set -o pipefail
 
           function cleanup() {
-            kill -- -$$
+            pkill -P $$$
             wait
+            exit
           }
           trap cleanup SIGTERM
 

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents.yaml
@@ -144,8 +144,9 @@ spec:
           set -o pipefail
 
           function cleanup() {
-            kill -- -$$
+            pkill -P $$$
             wait
+            exit
           }
           trap cleanup SIGTERM
 

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents.yaml
@@ -147,8 +147,9 @@ spec:
           set -o pipefail
 
           function cleanup() {
-            kill -- -$$
+            pkill -P $$$
             wait
+            exit
           }
           trap cleanup SIGTERM
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-apiserver/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-apiserver/deployment.yaml
@@ -215,8 +215,9 @@ spec:
           set -o pipefail
 
           function cleanup() {
-            kill -- -$$
+            pkill -P $$$
             wait
+            exit
           }
           trap cleanup SIGTERM
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/oauth-openshift/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/oauth-openshift/deployment.yaml
@@ -92,8 +92,9 @@ spec:
           set -o pipefail
 
           function cleanup() {
-            kill -- -$$
+            pkill -P $$$
             wait
+            exit
           }
           trap cleanup SIGTERM
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-apiserver/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-apiserver/deployment.yaml
@@ -98,8 +98,9 @@ spec:
           set -o pipefail
 
           function cleanup() {
-            kill -- -$$
+            pkill -P $$$
             wait
+            exit
           }
           trap cleanup SIGTERM
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-oauth-apiserver/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-oauth-apiserver/deployment.yaml
@@ -99,8 +99,9 @@ spec:
           set -o pipefail
 
           function cleanup() {
-            kill -- -$$
+            pkill -P $$$
             wait
+            exit
           }
           trap cleanup SIGTERM
 


### PR DESCRIPTION
Cherry pick of #5491 on release-4.18.

#5491: Modify audit container for openshift-apiserver,

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```