### PR TITLE
STOR-2281: Remove csi-snapshot-validation-webhook

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/assets/07_deployment-hypershift.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/assets/07_deployment-hypershift.yaml
@@ -25,8 +25,6 @@ spec:
         env:
         - name: OPERAND_IMAGE
           value: quay.io/openshift/origin-csi-snapshot-controller
-        - name: WEBHOOK_IMAGE
-          value: quay.io/openshift/origin-csi-snapshot-validation-webhook
         - name: OPERATOR_IMAGE_VERSION
           value: 0.0.1-snapshot
         - name: OPERAND_IMAGE_VERSION

--- a/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/operator_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/operator_test.go
@@ -29,9 +29,8 @@ func TestReconcileOperatorDeployment(t *testing.T) {
 	}
 	images := map[string]string{
 		"cluster-csi-snapshot-controller-operator": "quay.io/openshift/cluster-csi-snapshot-controller-operator:latest",
-		"token-minter":                    "quay.io/openshift/token-minter:latest",
-		"csi-snapshot-controller":         "quay.io/openshift/csi-snapshot-controller:latest",
-		"csi-snapshot-validation-webhook": "quay.io/openshift/csi-snapshot-validation-webhook:latest",
+		"token-minter":            "quay.io/openshift/token-minter:latest",
+		"csi-snapshot-controller": "quay.io/openshift/csi-snapshot-controller:latest",
 	}
 	deployment := manifests.CSISnapshotControllerOperatorDeployment("test-namespace")
 	imageProvider := imageprovider.NewFromImages(images)

--- a/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/params.go
@@ -12,7 +12,6 @@ import (
 const (
 	snapshotControllerOperatorImageName = "cluster-csi-snapshot-controller-operator"
 	snapshotControllerImageName         = "csi-snapshot-controller"
-	snapshotWebhookImageName            = "csi-snapshot-validation-webhook"
 )
 
 type Params struct {
@@ -35,7 +34,6 @@ func NewParams(
 		OwnerRef:                        config.OwnerRefFrom(hcp),
 		SnapshotControllerOperatorImage: releaseImageProvider.GetImage(snapshotControllerOperatorImageName),
 		SnapshotControllerImage:         releaseImageProvider.GetImage(snapshotControllerImageName),
-		SnapshotWebhookImage:            releaseImageProvider.GetImage(snapshotWebhookImageName),
 		AvailabilityProberImage:         releaseImageProvider.GetImage(util.AvailabilityProberImageName),
 		Version:                         version,
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/testdata/zz_fixture_TestReconcileOperatorDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/snapshotcontroller/testdata/zz_fixture_TestReconcileOperatorDeployment.yaml
@@ -64,8 +64,6 @@ spec:
         env:
         - name: OPERAND_IMAGE
           value: quay.io/openshift/csi-snapshot-controller:latest
-        - name: WEBHOOK_IMAGE
-          value: quay.io/openshift/csi-snapshot-validation-webhook:latest
         - name: OPERATOR_IMAGE_VERSION
           value: 1.0.0
         - name: OPERAND_IMAGE_VERSION

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/zz_fixture_TestControlPlaneComponents.yaml
@@ -68,8 +68,6 @@ spec:
         env:
         - name: OPERAND_IMAGE
           value: csi-snapshot-controller
-        - name: WEBHOOK_IMAGE
-          value: csi-snapshot-validation-webhook
         - name: OPERATOR_IMAGE_VERSION
           value: 4.18.0
         - name: OPERAND_IMAGE_VERSION

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -68,8 +68,6 @@ spec:
         env:
         - name: OPERAND_IMAGE
           value: csi-snapshot-controller
-        - name: WEBHOOK_IMAGE
-          value: csi-snapshot-validation-webhook
         - name: OPERATOR_IMAGE_VERSION
           value: 4.18.0
         - name: OPERAND_IMAGE_VERSION

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/csi-snapshot-controller-operator/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/csi-snapshot-controller-operator/deployment.yaml
@@ -25,8 +25,6 @@ spec:
         env:
         - name: OPERAND_IMAGE
           value: quay.io/openshift/origin-csi-snapshot-controller
-        - name: WEBHOOK_IMAGE
-          value: quay.io/openshift/origin-csi-snapshot-validation-webhook
         - name: OPERATOR_IMAGE_VERSION
           value: 0.0.1-snapshot
         - name: OPERAND_IMAGE_VERSION

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/snapshotcontroller/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/snapshotcontroller/deployment.go
@@ -18,8 +18,6 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 				c.Env[i].Value = cpContext.UserReleaseImageProvider.Version()
 			case "OPERAND_IMAGE":
 				c.Env[i].Value = cpContext.ReleaseImageProvider.GetImage("csi-snapshot-controller")
-			case "WEBHOOK_IMAGE":
-				c.Env[i].Value = cpContext.ReleaseImageProvider.GetImage("csi-snapshot-validation-webhook")
 			}
 		}
 		// We set this so cluster-csi-storage-controller operator knows which User ID to run the csi-snapshot-controller and csi-snapshot-webhook pods as.


### PR DESCRIPTION
**What this PR does / why we need it**:
Removed csi-snapshot-validation-webhook.
Webhook image is no longer used and will not be built on OCP 4.19+.

**Which issue(s) this PR fixes** 
https://issues.redhat.com/browse/STOR-2281

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.