### PR TITLE
NO-JIRA: Remove WI step for cluster-image-registry-operator

### DIFF
--- a/docs/content/how-to/azure/create-azure-cluster_on_aks.md
+++ b/docs/content/how-to/azure/create-azure-cluster_on_aks.md
@@ -355,13 +355,6 @@ az identity federated-credential create --name "${IMAGE_REGISTRY_MI_NAME}"-fed-i
 --identity-name "${IMAGE_REGISTRY_MI_NAME}" \
 --resource-group "${PERSISTENT_RG_NAME}" \
 --issuer "${OIDC_ISSUER_URL}" \
---subject system:serviceaccount:openshift-image-registry:cluster-image-registry-operator \
---audience openshift
-
-az identity federated-credential create --name "${IMAGE_REGISTRY_MI_NAME}"-fed-id \
---identity-name "${IMAGE_REGISTRY_MI_NAME}" \
---resource-group "${PERSISTENT_RG_NAME}" \
---issuer "${OIDC_ISSUER_URL}" \
 --subject system:serviceaccount:openshift-image-registry:registry \
 --audience openshift
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit removes the workload identity instruction for adding a federated ID for the service account openshift-image-registry:cluster-image-registry-operator.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
N/A

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.