### PR TITLE
[release-4.18] OCPBUGS-52878: Kubernetes API Server apply-bootstrap container does not respect SIGTERM

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -799,6 +799,12 @@ cp /tmp/manifests/* %[1]s
 
 func applyBootstrapManifestsScript(workDir string) string {
 	var script = `#!/bin/sh
+function cleanup() {
+	pkill -P $$$
+	wait
+	exit
+}
+trap cleanup SIGTERM
 while true; do
   if oc apply -f %[1]s; then
     echo "Bootstrap manifests applied successfully."
@@ -814,7 +820,8 @@ while true; do
   sleep 1
 done
 while true; do
-  sleep 1000
+  sleep 1000 &
+  wait $!
 done
 `
 	return fmt.Sprintf(script, workDir)

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents.yaml
@@ -69,6 +69,12 @@ spec:
         - -c
         - |
           #!/bin/sh
+          function cleanup() {
+            pkill -P $$$
+            wait
+            exit
+          }
+          trap cleanup SIGTERM
           while true; do
             if oc apply -f /work; then
               echo "Bootstrap manifests applied successfully."
@@ -84,7 +90,8 @@ spec:
             sleep 1
           done
           while true; do
-            sleep 1000
+            sleep 1000 &
+            wait $!
           done
         command:
         - /bin/bash

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-apiserver/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-apiserver/deployment.yaml
@@ -24,6 +24,12 @@ spec:
         - -c
         - |
           #!/bin/sh
+          function cleanup() {
+            pkill -P $$$
+            wait
+            exit
+          }
+          trap cleanup SIGTERM
           while true; do
             if oc apply -f /work; then
               echo "Bootstrap manifests applied successfully."
@@ -39,7 +45,8 @@ spec:
             sleep 1
           done
           while true; do
-            sleep 1000
+            sleep 1000 &
+            wait $!
           done
         command:
         - /bin/bash


### PR DESCRIPTION
Cherry pick of #5475 on release-4.18.

#5475: Modify the apply-bootstrap container of kube-apiserver to

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```