### PR TITLE
NO-JIRA: Disable Mintmaker gomod manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "gomod": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently we use dependabot to update our dependency. Disable gomod Mintmaker until we agree on how to better align our tools in the future.

References: https://docs.renovatebot.com/modules/manager/#enabling-and-disabling-managers


**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.