### PR TITLE
CNTRLPLANE-111: Fix KMS MIv3 Issues

### DIFF
--- a/api/hypershift/v1beta1/azure.go
+++ b/api/hypershift/v1beta1/azure.go
@@ -465,15 +465,17 @@ type ManagedIdentity struct {
 	// Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
 	// removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
 	//
+	// +optional
 	// +kubebuilder:validation:XValidation:rule="self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')",message="the client ID of a managed identity must be a valid UUID. It should be 5 groups of hyphen separated hexadecimal characters in the form 8-4-4-4-12."
-	ClientID string `json:"clientID"`
+	ClientID string `json:"clientID,omitempty"`
 
 	// certificateName is the name of the certificate backing the managed identity. This certificate is expected to
 	// reside in an Azure Key Vault on the management cluster.
 	// Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
 	// removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
 	//
-	CertificateName string `json:"certificateName"`
+	// +optional
+	CertificateName string `json:"certificateName,omitempty"`
 
 	// objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
 	// CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -3117,8 +3117,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3180,8 +3178,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3242,8 +3238,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               file:
@@ -3304,8 +3298,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3366,8 +3358,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3428,8 +3418,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3512,8 +3500,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3575,8 +3561,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                             required:
@@ -4363,8 +4347,6 @@ spec:
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                 type: string
                             required:
-                            - certificateName
-                            - clientID
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -3158,8 +3158,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3221,8 +3219,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3283,8 +3279,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               file:
@@ -3345,8 +3339,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3407,8 +3399,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3469,8 +3459,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3553,8 +3541,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3616,8 +3602,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                             required:
@@ -4396,8 +4380,6 @@ spec:
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                 type: string
                             required:
-                            - certificateName
-                            - clientID
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -3138,8 +3138,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3201,8 +3199,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3263,8 +3259,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               file:
@@ -3325,8 +3319,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3387,8 +3379,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3449,8 +3439,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3533,8 +3521,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3596,8 +3582,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                             required:
@@ -4376,8 +4360,6 @@ spec:
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                 type: string
                             required:
-                            - certificateName
-                            - clientID
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DisableClusterCapabilities.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DisableClusterCapabilities.yaml
@@ -3141,8 +3141,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3204,8 +3202,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3266,8 +3262,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               file:
@@ -3328,8 +3322,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3390,8 +3382,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3452,8 +3442,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3536,8 +3524,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3599,8 +3585,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                             required:
@@ -4379,8 +4363,6 @@ spec:
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                 type: string
                             required:
-                            - certificateName
-                            - clientID
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -3134,8 +3134,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3197,8 +3195,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3259,8 +3255,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               file:
@@ -3321,8 +3315,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3383,8 +3375,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3445,8 +3435,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3529,8 +3517,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3592,8 +3578,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                             required:
@@ -4372,8 +4356,6 @@ spec:
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                 type: string
                             required:
-                            - certificateName
-                            - clientID
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -3355,8 +3355,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3418,8 +3416,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3480,8 +3476,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               file:
@@ -3542,8 +3536,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3604,8 +3596,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3666,8 +3656,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3750,8 +3738,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3813,8 +3799,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                             required:
@@ -4593,8 +4577,6 @@ spec:
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                 type: string
                             required:
-                            - certificateName
-                            - clientID
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -3131,8 +3131,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3194,8 +3192,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3256,8 +3252,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               file:
@@ -3318,8 +3312,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3380,8 +3372,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3442,8 +3432,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3526,8 +3514,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3589,8 +3575,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                             required:
@@ -4369,8 +4353,6 @@ spec:
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                 type: string
                             required:
-                            - certificateName
-                            - clientID
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -3265,8 +3265,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3328,8 +3326,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3390,8 +3386,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               file:
@@ -3452,8 +3446,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3514,8 +3506,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3576,8 +3566,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3660,8 +3648,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3723,8 +3709,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                             required:
@@ -4503,8 +4487,6 @@ spec:
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                 type: string
                             required:
-                            - certificateName
-                            - clientID
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -3113,8 +3113,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3176,8 +3174,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3238,8 +3234,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               file:
@@ -3300,8 +3294,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3362,8 +3354,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3424,8 +3414,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3508,8 +3496,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3571,8 +3557,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                             required:
@@ -4839,8 +4823,6 @@ spec:
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                 type: string
                             required:
-                            - certificateName
-                            - clientID
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -3002,8 +3002,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3065,8 +3063,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3127,8 +3123,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               file:
@@ -3189,8 +3183,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3251,8 +3243,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3313,8 +3303,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3397,8 +3385,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3460,8 +3446,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                             required:
@@ -4224,8 +4208,6 @@ spec:
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                 type: string
                             required:
-                            - certificateName
-                            - clientID
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -3043,8 +3043,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3106,8 +3104,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3168,8 +3164,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               file:
@@ -3230,8 +3224,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3292,8 +3284,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3354,8 +3344,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3438,8 +3426,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3501,8 +3487,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                             required:
@@ -4257,8 +4241,6 @@ spec:
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                 type: string
                             required:
-                            - certificateName
-                            - clientID
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -3023,8 +3023,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3086,8 +3084,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3148,8 +3144,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               file:
@@ -3210,8 +3204,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3272,8 +3264,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3334,8 +3324,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3418,8 +3406,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3481,8 +3467,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                             required:
@@ -4237,8 +4221,6 @@ spec:
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                 type: string
                             required:
-                            - certificateName
-                            - clientID
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DisableClusterCapabilities.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DisableClusterCapabilities.yaml
@@ -3026,8 +3026,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3089,8 +3087,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3151,8 +3147,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               file:
@@ -3213,8 +3207,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3275,8 +3267,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3337,8 +3327,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3421,8 +3409,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3484,8 +3470,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                             required:
@@ -4240,8 +4224,6 @@ spec:
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                 type: string
                             required:
-                            - certificateName
-                            - clientID
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -3019,8 +3019,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3082,8 +3080,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3144,8 +3140,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               file:
@@ -3206,8 +3200,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3268,8 +3260,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3330,8 +3320,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3414,8 +3402,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3477,8 +3463,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                             required:
@@ -4233,8 +4217,6 @@ spec:
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                 type: string
                             required:
-                            - certificateName
-                            - clientID
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -3240,8 +3240,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3303,8 +3301,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3365,8 +3361,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               file:
@@ -3427,8 +3421,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3489,8 +3481,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3551,8 +3541,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3635,8 +3623,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3698,8 +3684,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                             required:
@@ -4454,8 +4438,6 @@ spec:
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                 type: string
                             required:
-                            - certificateName
-                            - clientID
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -3016,8 +3016,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3079,8 +3077,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3141,8 +3137,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               file:
@@ -3203,8 +3197,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3265,8 +3257,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3327,8 +3317,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3411,8 +3399,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3474,8 +3460,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                             required:
@@ -4230,8 +4214,6 @@ spec:
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                 type: string
                             required:
-                            - certificateName
-                            - clientID
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -3150,8 +3150,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3213,8 +3211,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3275,8 +3271,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               file:
@@ -3337,8 +3331,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3399,8 +3391,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3461,8 +3451,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3545,8 +3533,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3608,8 +3594,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                             required:
@@ -4364,8 +4348,6 @@ spec:
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                 type: string
                             required:
-                            - certificateName
-                            - clientID
                             - objectEncoding
                             type: object
                         required:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -2998,8 +2998,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3061,8 +3059,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3123,8 +3119,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               file:
@@ -3185,8 +3179,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3247,8 +3239,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3309,8 +3299,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3393,8 +3381,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3456,8 +3442,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                             required:
@@ -4700,8 +4684,6 @@ spec:
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                 type: string
                             required:
-                            - certificateName
-                            - clientID
                             - objectEncoding
                             type: object
                         required:

--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -63,7 +63,7 @@ func bindCoreOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
 	flags.StringVar(&opts.SubnetID, "subnet-id", opts.SubnetID, "The subnet ID where the VMs will be placed.")
 	flags.StringVar(&opts.IssuerURL, "oidc-issuer-url", "", "The OIDC provider issuer URL")
 	flags.StringVar(&opts.ServiceAccountTokenIssuerKeyPath, "sa-token-issuer-private-key-path", "", "The file to the private key for the service account token issuer")
-	flags.StringVar(&opts.KMSUserAssignedCredsFile, "kms-credentials-file", opts.KMSUserAssignedCredsFile, "Path to a file containing the JSON UserAssignedIdentityCredentials used in KMS to authenticate to Azure.")
+	flags.StringVar(&opts.KMSUserAssignedCredsSecretName, "kms-credentials-secret-name", opts.KMSUserAssignedCredsSecretName, "The name of a secret, in Azure KeyVault, containing the JSON UserAssignedIdentityCredentials used in KMS to authenticate to Azure.")
 	flags.StringVar(&opts.DNSZoneRGName, "dns-zone-rg-name", opts.DNSZoneRGName, "The name of the resource group where the DNS Zone resides. This is needed for the ingress controller. This is just the name and not the full ID of the resource group.")
 	flags.StringVar(&opts.ManagedIdentitiesFile, "managed-identities-file", opts.ManagedIdentitiesFile, "Path to a file containing the managed identities configuration in json format.")
 	flags.StringVar(&opts.DataPlaneIdentitiesFile, "data-plane-identities-file", opts.ManagedIdentitiesFile, "Path to a file containing the client IDs of the managed identities for the data plane configured in json format.")
@@ -88,7 +88,7 @@ type RawCreateOptions struct {
 	ResourceGroupTags                map[string]string
 	SubnetID                         string
 	RHCOSImage                       string
-	KMSUserAssignedCredsFile         string
+	KMSUserAssignedCredsSecretName   string
 	TechPreviewEnabled               bool
 	DNSZoneRGName                    string
 	ManagedIdentitiesFile            string
@@ -287,7 +287,7 @@ func (o *CreateOptions) ApplyPlatformSpecifics(cluster *hyperv1.HostedCluster) e
 
 	if o.encryptionKey != nil {
 		cluster.Spec.SecretEncryption.KMS.Azure.KMS = hyperv1.ManagedIdentity{
-			CredentialsSecretName: o.KMSUserAssignedCredsFile,
+			CredentialsSecretName: o.KMSUserAssignedCredsSecretName,
 			ObjectEncoding:        ObjectEncoding,
 		}
 	}

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_complicated_invocation_from_bryan.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_complicated_invocation_from_bryan.yaml
@@ -75,39 +75,23 @@ spec:
       managedIdentities:
         controlPlane:
           cloudProvider:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           controlPlaneOperator:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           disk:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           file:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           imageRegistry:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           ingress:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           managedIdentitiesKeyVault:
             name: ""
             tenantID: ""
           network:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           nodePoolManagement:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
         dataPlane:
           diskMSIClientID: ""

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_create_with_a_ure_marketplace_image.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_create_with_a_ure_marketplace_image.yaml
@@ -42,39 +42,23 @@ spec:
       managedIdentities:
         controlPlane:
           cloudProvider:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           controlPlaneOperator:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           disk:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           file:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           imageRegistry:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           ingress:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           managedIdentitiesKeyVault:
             name: ""
             tenantID: ""
           network:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           nodePoolManagement:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
         dataPlane:
           diskMSIClientID: ""

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -75,39 +75,23 @@ spec:
       managedIdentities:
         controlPlane:
           cloudProvider:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           controlPlaneOperator:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           disk:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           file:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           imageRegistry:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           ingress:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           managedIdentitiesKeyVault:
             name: ""
             tenantID: ""
           network:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           nodePoolManagement:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
         dataPlane:
           diskMSIClientID: ""

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_ones.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_ones.yaml
@@ -75,39 +75,23 @@ spec:
       managedIdentities:
         controlPlane:
           cloudProvider:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           controlPlaneOperator:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           disk:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           file:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           imageRegistry:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           ingress:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           managedIdentitiesKeyVault:
             name: ""
             tenantID: ""
           network:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
           nodePoolManagement:
-            certificateName: ""
-            clientID: ""
             objectEncoding: utf-8
         dataPlane:
           diskMSIClientID: ""

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
@@ -3647,8 +3647,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3710,8 +3708,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3772,8 +3768,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               file:
@@ -3834,8 +3828,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3896,8 +3888,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3958,8 +3948,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -4042,8 +4030,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -4105,8 +4091,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                             required:
@@ -5373,8 +5357,6 @@ spec:
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                 type: string
                             required:
-                            - certificateName
-                            - clientID
                             - objectEncoding
                             type: object
                         required:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
@@ -3531,8 +3531,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3594,8 +3592,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3656,8 +3652,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               file:
@@ -3718,8 +3712,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3780,8 +3772,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3842,8 +3832,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3926,8 +3914,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3989,8 +3975,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                             required:
@@ -4777,8 +4761,6 @@ spec:
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                 type: string
                             required:
-                            - certificateName
-                            - clientID
                             - objectEncoding
                             type: object
                         required:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
@@ -3629,8 +3629,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3692,8 +3690,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3754,8 +3750,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               file:
@@ -3816,8 +3810,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3878,8 +3870,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3940,8 +3930,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -4024,8 +4012,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -4087,8 +4073,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                             required:
@@ -5355,8 +5339,6 @@ spec:
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                 type: string
                             required:
-                            - certificateName
-                            - clientID
                             - objectEncoding
                             type: object
                         required:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
@@ -3532,8 +3532,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3595,8 +3593,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3657,8 +3653,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               file:
@@ -3719,8 +3713,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3781,8 +3773,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3843,8 +3833,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3927,8 +3915,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3990,8 +3976,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                             required:
@@ -5234,8 +5218,6 @@ spec:
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                 type: string
                             required:
-                            - certificateName
-                            - clientID
                             - objectEncoding
                             type: object
                         required:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
@@ -3416,8 +3416,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3479,8 +3477,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3541,8 +3537,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               file:
@@ -3603,8 +3597,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3665,8 +3657,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3727,8 +3717,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3811,8 +3799,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3874,8 +3860,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                             required:
@@ -4638,8 +4622,6 @@ spec:
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                 type: string
                             required:
-                            - certificateName
-                            - clientID
                             - objectEncoding
                             type: object
                         required:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
@@ -3514,8 +3514,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               controlPlaneOperator:
@@ -3577,8 +3575,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               disk:
@@ -3639,8 +3635,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               file:
@@ -3701,8 +3695,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               imageRegistry:
@@ -3763,8 +3755,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               ingress:
@@ -3825,8 +3815,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               managedIdentitiesKeyVault:
@@ -3909,8 +3897,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                               nodePoolManagement:
@@ -3972,8 +3958,6 @@ spec:
                                       See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                     type: string
                                 required:
-                                - certificateName
-                                - clientID
                                 - objectEncoding
                                 type: object
                             required:
@@ -5216,8 +5200,6 @@ spec:
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
                                 type: string
                             required:
-                            - certificateName
-                            - clientID
                             - objectEncoding
                             type: object
                         required:

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -8142,6 +8142,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>clientID is the client ID of a managed identity.
 Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
 removed as part of the MIWI phase 3 work, <a href="https://issues.redhat.com/browse/OCPSTRAT-1856">https://issues.redhat.com/browse/OCPSTRAT-1856</a>.</p>
@@ -8155,6 +8156,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>certificateName is the name of the certificate backing the managed identity. This certificate is expected to
 reside in an Azure Key Vault on the management cluster.
 Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/azure.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/azure.go
@@ -465,15 +465,17 @@ type ManagedIdentity struct {
 	// Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
 	// removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
 	//
+	// +optional
 	// +kubebuilder:validation:XValidation:rule="self.matches('^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$')",message="the client ID of a managed identity must be a valid UUID. It should be 5 groups of hyphen separated hexadecimal characters in the form 8-4-4-4-12."
-	ClientID string `json:"clientID"`
+	ClientID string `json:"clientID,omitempty"`
 
 	// certificateName is the name of the certificate backing the managed identity. This certificate is expected to
 	// reside in an Azure Key Vault on the management cluster.
 	// Deprecated: This field was previously required as part of the MIWI phase 2 work; however, this field will be
 	// removed as part of the MIWI phase 3 work, https://issues.redhat.com/browse/OCPSTRAT-1856.
 	//
-	CertificateName string `json:"certificateName"`
+	// +optional
+	CertificateName string `json:"certificateName,omitempty"`
 
 	// objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
 	// CertificateName. objectEncoding needs to match the encoding format used when the certificate was stored in the


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a few issues when KMS was converted over to MIv3:
- adds omitempty to ClientID and CertificatName in Azure API since these fields are no longer required in managed identity version 3
- renames the KMSUserAssignedCredsFile flag to KMSUserAssignedCredsSecretName. This more accurately represents the   flag's purpose, which is to supply the HC with the name of the secret in Azure Key Vault containing the managed identity needed when using KMS.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
A part of [CNTRLPLANE-111](https://issues.redhat.com//browse/CNTRLPLANE-111)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.