### PR TITLE
stop using dev mode for loggers

### DIFF
--- a/availability-prober/availability_prober.go
+++ b/availability-prober/availability_prober.go
@@ -57,7 +57,7 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.waitForLabeledPodsGone, "wait-for-labeled-pods-gone", "", "Waits until pods with the specified label is gone from the namespace. Must be in format: namespace/label=selector")
 	cmd.Flags().StringVar(&opts.waitForClusterRolebinding, "wait-for-cluster-rolebinding", "", "Waits until a concrete ClusterRoleBinding is present.")
 
-	log := zap.New(zap.UseDevMode(true), zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
+	log := zap.New(zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
 		o.EncodeTime = zapcore.RFC3339TimeEncoder
 	}))
 

--- a/cmd/log/log.go
+++ b/cmd/log/log.go
@@ -6,6 +6,6 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-var Log = zap.New(zap.UseDevMode(true), func(o *zap.Options) {
+var Log = zap.New(func(o *zap.Options) {
 	o.TimeEncoder = zapcore.RFC3339TimeEncoder
 })

--- a/control-plane-operator/hostedclusterconfigoperator/cmd.go
+++ b/control-plane-operator/hostedclusterconfigoperator/cmd.go
@@ -210,7 +210,7 @@ func (o *HostedClusterConfigOperator) Complete() error {
 }
 
 func (o *HostedClusterConfigOperator) Run(ctx context.Context) error {
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
+	ctrl.SetLogger(zap.New(zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
 		o.EncodeTime = zapcore.RFC3339TimeEncoder
 	})))
 	versions := map[string]string{

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -60,7 +60,7 @@ var (
 )
 
 func main() {
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
+	ctrl.SetLogger(zap.New(zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
 		o.EncodeTime = zapcore.RFC3339TimeEncoder
 	})))
 	basename := filepath.Base(os.Args[0])

--- a/etcd-defrag/main.go
+++ b/etcd-defrag/main.go
@@ -56,7 +56,7 @@ func NewStartCommand() *cobra.Command {
 }
 
 func run(ctx context.Context, opts Options) error {
-	logger := zap.New(zap.UseDevMode(true), zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
+	logger := zap.New(zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
 		o.EncodeTime = zapcore.RFC3339TimeEncoder
 	}))
 	ctrl.SetLogger(logger)

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -78,7 +78,7 @@ import (
 )
 
 func main() {
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
+	ctrl.SetLogger(zap.New(zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
 		o.EncodeTime = zapcore.RFC3339TimeEncoder
 	})))
 

--- a/ignition-server/cmd/run_local_ignitionprovider.go
+++ b/ignition-server/cmd/run_local_ignitionprovider.go
@@ -53,7 +53,7 @@ func NewRunLocalIgnitionProviderCommand() *cobra.Command {
 			<-sigs
 			cancel()
 		}()
-		ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
+		ctrl.SetLogger(zap.New(zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
 			o.EncodeTime = zapcore.RFC3339TimeEncoder
 		})))
 		return opts.Run(ctx)

--- a/ignition-server/cmd/start.go
+++ b/ignition-server/cmd/start.go
@@ -186,7 +186,7 @@ func setUpPayloadStoreReconciler(ctx context.Context, registryOverrides map[stri
 }
 
 func run(ctx context.Context, opts Options) error {
-	logger := zap.New(zap.UseDevMode(true), zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
+	logger := zap.New(zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
 		o.EncodeTime = zapcore.RFC3339TimeEncoder
 	}))
 	ctrl.SetLogger(logger)

--- a/ignition-server/main.go
+++ b/ignition-server/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 func main() {
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
+	ctrl.SetLogger(zap.New(zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
 		o.EncodeTime = zapcore.RFC3339TimeEncoder
 	})))
 

--- a/konnectivity-https-proxy/cmd.go
+++ b/konnectivity-https-proxy/cmd.go
@@ -28,7 +28,6 @@ import (
 
 func NewStartCommand() *cobra.Command {
 	zLogger := zap.New(
-		zap.UseDevMode(true),
 		zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
 			o.EncodeTime = zapcore.RFC3339TimeEncoder
 		}),

--- a/konnectivity-socks5-proxy/main.go
+++ b/konnectivity-socks5-proxy/main.go
@@ -19,7 +19,7 @@ import (
 
 func NewStartCommand() *cobra.Command {
 	l := log.Log.WithName("konnectivity-socks5-proxy")
-	log.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
+	log.SetLogger(zap.New(zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
 		o.EncodeTime = zapcore.RFC3339TimeEncoder
 	})))
 	cmd := &cobra.Command{

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ import (
 )
 
 func main() {
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
+	ctrl.SetLogger(zap.New(zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
 		o.EncodeTime = zapcore.RFC3339TimeEncoder
 	})))
 

--- a/support/upsert/loopdetector.go
+++ b/support/upsert/loopdetector.go
@@ -22,7 +22,7 @@ func newUpdateLoopDetector() *updateLoopDetector {
 	return &updateLoopDetector{
 		hasNoOpUpdate:    sets.String{},
 		updateEventCount: map[string]int{},
-		log: zap.New(zap.UseDevMode(true), zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
+		log: zap.New(zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
 			o.EncodeTime = zapcore.RFC3339TimeEncoder
 		})),
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Removal of `UseDevMode` for loggers for all code excluding test code. Development logging code should not be used for production code.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Stop using DevMode for loggers: https://issues.redhat.com/browse/OCPBUGS-52821
Hypershift issues at scale: https://issues.redhat.com/browse/OCPBUGS-52256

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.