### PR TITLE
WIP: Update bootstrapping and admission plugin configuration depending on OAuth enablement

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -852,10 +852,12 @@ func invokeAuthBootstrapRenderScript(workDir, payloadVersion, featureGateYaml st
 cd /tmp
 mkdir input output manifests
 
-touch /tmp/manifests/99_feature-gate.yaml
-cat <<EOF >/tmp/manifests/99_feature-gate.yaml
-%[3]s
-EOF
+if [ ! -f /tmp/manifests/99_feature-gate.yaml ]; then
+  touch /tmp/manifests/99_feature-gate.yaml
+  cat <<EOF >/tmp/manifests/99_feature-gate.yaml
+  %[3]s
+  EOF
+fi
 
 /usr/bin/authentication-operator render \
    --asset-output-dir /tmp/output \

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -862,7 +862,7 @@ EOF
    --rendered-manifest-dir=/tmp/manifests \
    --cluster-profile=ibm-cloud-managed \
    --payload-version=%[2]s
-cp /tmp/output/manifests/* %[1]s
+cp /tmp/output/* %[1]s
 cp /tmp/manifests/* %[1]s
 `
 	return fmt.Sprintf(script, workDir, payloadVersion, featureGateYaml)

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -22,17 +22,18 @@ import (
 )
 
 type KubeAPIServerImages struct {
-	ClusterConfigOperator      string `json:"clusterConfigOperator"`
-	CLI                        string `json:"cli"`
-	HyperKube                  string `json:"hyperKube"`
-	IBMCloudKMS                string `json:"ibmcloudKMS"`
-	AWSKMS                     string `json:"awsKMS"`
-	AzureKMS                   string `json:"azureKMS"`
-	Portieris                  string `json:"portieris"`
-	TokenMinterImage           string
-	AWSPodIdentityWebhookImage string
-	KonnectivityServer         string
-	KASBootstrap               string
+	ClusterConfigOperator         string `json:"clusterConfigOperator"`
+	CLI                           string `json:"cli"`
+	HyperKube                     string `json:"hyperKube"`
+	IBMCloudKMS                   string `json:"ibmcloudKMS"`
+	AWSKMS                        string `json:"awsKMS"`
+	AzureKMS                      string `json:"azureKMS"`
+	Portieris                     string `json:"portieris"`
+	TokenMinterImage              string
+	AWSPodIdentityWebhookImage    string
+	KonnectivityServer            string
+	KASBootstrap                  string
+	ClusterAuthenticationOperator string `json:"clusterAuthenticationOperator"`
 }
 
 type KubeAPIServerParams struct {
@@ -115,15 +116,16 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 		DisableProfiling:     util.StringListContains(hcp.Annotations[hyperv1.DisableProfilingAnnotation], manifests.KASDeployment("").Name),
 
 		Images: KubeAPIServerImages{
-			HyperKube:                  releaseImageProvider.GetImage("hyperkube"),
-			CLI:                        releaseImageProvider.GetImage("cli"),
-			ClusterConfigOperator:      releaseImageProvider.GetImage("cluster-config-api"),
-			TokenMinterImage:           releaseImageProvider.GetImage("token-minter"),
-			AWSKMS:                     releaseImageProvider.GetImage("aws-kms-encryption-provider"),
-			AzureKMS:                   releaseImageProvider.GetImage("azure-kms-encryption-provider"),
-			AWSPodIdentityWebhookImage: releaseImageProvider.GetImage("aws-pod-identity-webhook"),
-			KonnectivityServer:         releaseImageProvider.GetImage("apiserver-network-proxy"),
-			KASBootstrap:               releaseImageProvider.GetImage(util.CPOImageName),
+			HyperKube:                     releaseImageProvider.GetImage("hyperkube"),
+			CLI:                           releaseImageProvider.GetImage("cli"),
+			ClusterConfigOperator:         releaseImageProvider.GetImage("cluster-config-api"),
+			TokenMinterImage:              releaseImageProvider.GetImage("token-minter"),
+			AWSKMS:                        releaseImageProvider.GetImage("aws-kms-encryption-provider"),
+			AzureKMS:                      releaseImageProvider.GetImage("azure-kms-encryption-provider"),
+			AWSPodIdentityWebhookImage:    releaseImageProvider.GetImage("aws-pod-identity-webhook"),
+			KonnectivityServer:            releaseImageProvider.GetImage("apiserver-network-proxy"),
+			KASBootstrap:                  releaseImageProvider.GetImage(util.CPOImageName),
+			ClusterAuthenticationOperator: releaseImageProvider.GetImage("cluster-authentication-operator"),
 		},
 		MaxRequestsInflight:         fmt.Sprint(defaultMaxRequestsInflight),
 		MaxMutatingRequestsInflight: fmt.Sprint(defaultMaxMutatingRequestsInflight),


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**: 
- Updates the Kubernetes API server bootstrapping logic to get the `RoleBindingRestriction` CRD from the cluster-authentication-operator's manifest renderer if OAuth is enabled. This is needed so that the Kubernetes API server can start up successfully when the `RoleBindingRestriction` CRD is no longer included in the openshift/api generated payload manifests. See https://github.com/openshift/api/pull/2138
- Disables the `authorization.openshift.io/RestrictSubjectBindings` and `authorization.openshift.io/ValidateRoleBindingRestrictions` admission plugins on the Kubernetes API server if the OAuth is not enabled. This was proposed in https://github.com/openshift/enhancements/pull/1726
**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.