### PR TITLE
CNTRLPLANE-111: Fix Azure KMS SecretProviderClass volume name

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kms/kms.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kms/kms.go
@@ -43,7 +43,7 @@ func buildVolumeKMSSecretStore(v *corev1.Volume) {
 			Driver:   config.ManagedAzureSecretsStoreCSIDriver,
 			ReadOnly: ptr.To(true),
 			VolumeAttributes: map[string]string{
-				config.ManagedAzureSecretProviderClass: config.ManagedAzureKMSSecretStoreVolumeName,
+				config.ManagedAzureSecretProviderClass: config.ManagedAzureKMSSecretProviderClassName,
 			},
 		},
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms/azure.go
@@ -241,7 +241,7 @@ func buildVolumeKMSSecretStore(v *corev1.Volume) {
 			Driver:   config.ManagedAzureSecretsStoreCSIDriver,
 			ReadOnly: ptr.To(true),
 			VolumeAttributes: map[string]string{
-				config.ManagedAzureSecretProviderClass: config.ManagedAzureKMSSecretStoreVolumeName,
+				config.ManagedAzureSecretProviderClass: config.ManagedAzureKMSSecretProviderClassName,
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the SecretProviderClass name for the volume related to the KMS MIv3 credentials. Previously it was set to the volume name instead of the SecretProviderClass name.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
A part of [CNTRLPLANE-111](https://issues.redhat.com//browse/CNTRLPLANE-111)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.