### PR TITLE
OCPBUGS-53050: Handle multiple mirror entries for source

### DIFF
--- a/support/releaseinfo/registry_image_content_policies.go
+++ b/support/releaseinfo/registry_image_content_policies.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -32,8 +34,13 @@ func (p *ProviderWithOpenShiftImageRegistryOverridesDecorator) Lookup(ctx contex
 				// Attempt to lookup image with mirror registry destination
 				releaseImage, err := p.Delegate.Lookup(ctx, image, pullSecret)
 				if releaseImage != nil {
-					p.mirroredReleaseImage = image
-					return releaseImage, nil
+					// Verify mirror image availability.
+					if _, _, err = registryclient.GetRepoSetup(ctx, image, pullSecret); err == nil {
+						p.mirroredReleaseImage = image
+						return releaseImage, nil
+					}
+					logger.Info("WARNING: The current mirrors image is unavailable, continue Scanning multiple mirrors", "error", err.Error(), "mirror image", image)
+					continue
 				}
 
 				logger.Error(err, "Failed to look up release image using registry mirror", "registry mirror", registryReplacement)

--- a/support/releaseinfo/registry_image_content_policies_test.go
+++ b/support/releaseinfo/registry_image_content_policies_test.go
@@ -2,6 +2,7 @@ package releaseinfo
 
 import (
 	"context"
+	"os"
 	"sync"
 	"testing"
 
@@ -14,7 +15,7 @@ func TestProviderWithOpenShiftImageRegistryOverridesDecorator_Lookup(t *testing.
 	g := NewWithT(t)
 
 	// Create mock resources.
-	mirroredReleaseImage := "mirrored-release-image"
+	mirroredReleaseImage := "quay.io/openshift-release-dev/ocp-release:4.16.13-x86_64"
 	canonicalReleaseImage := "canonical-release-image"
 	releaseImage := &ReleaseImage{
 		ImageStream:    &imagev1.ImageStream{},
@@ -39,8 +40,12 @@ func TestProviderWithOpenShiftImageRegistryOverridesDecorator_Lookup(t *testing.
 		lock: sync.Mutex{},
 	}
 
+	pullSecret, err := os.ReadFile("../../hack/dev/fakePullSecret.json")
+	if err != nil {
+		t.Fatalf("failed to read manifests file: %v", err)
+	}
 	// Call the Lookup method and validate GetMirroredReleaseImage.
-	_, err := provider.Lookup(context.Background(), canonicalReleaseImage, []byte("test-pull-secret"))
+	_, err = provider.Lookup(context.Background(), canonicalReleaseImage, pullSecret)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(provider.GetMirroredReleaseImage()).To(Equal(mirroredReleaseImage))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
According to OCP IDMS, when the current mirror image is unavailable, the system should continue searching for an available mirror image.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/browse/OCPBUGS-53050

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.