### PR TITLE
METAL-1240: Fix kube-controller-manager and openshift-route-controller-manager services' ipFamilies wrt PreferDualStack policy

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-controller-manager/service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-controller-manager/service.yaml
@@ -6,8 +6,6 @@ metadata:
   name: kube-controller-manager
 spec:
   internalTrafficPolicy: Cluster
-  ipFamilies:
-  - IPv4
   ipFamilyPolicy: PreferDualStack
   ports:
   - name: client

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-route-controller-manager/service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-route-controller-manager/service.yaml
@@ -7,8 +7,6 @@ metadata:
   namespace: HCP_NAMESPACE
 spec:
   internalTrafficPolicy: Cluster
-  ipFamilies:
-  - IPv4
   ipFamilyPolicy: PreferDualStack
   ports:
   - name: https


### PR DESCRIPTION
**What this PR does / why we need it**:
While adding a new ControlPlaneComponent, I came across these 2 errors:

`{"level":"error","ts":"2025-03-13T15:45:22Z","msg":"Reconciler error","controller":"hostedcontrolplane","controllerGroup":"hypershift.openshift.io","controllerKind":"HostedControlPlane","HostedControlPlane":{"name":"my-hcp-cluster","namespace":"clusters-my-hcp-cluster"},"namespace":"clusters-my-hcp-cluster","name":"my-hcp-cluster","reconcileID":"2b7e0124-4ae6-42d2-b368-2d7cfc1252e5","error":"failed to update control plane: [...Service \"kube-controller-manager\" is invalid: spec.ipFamilyPolicy: Invalid value: \"PreferDualStack\": must be 'SingleStack' to release the secondary IP family, Service \"openshift-route-controller-manager\" is invalid: spec.ipFamilyPolicy: Invalid value: \"PreferDualStack\": must be 'SingleStack' to release the secondary IP family,...}`

I could fix this error in two ways: either by removing both Services's spec.ipFamilies field, or by adding IPv6 to both Services's spec.ipFamilies. 

I found this online which helped me reach this solution: https://github.com/kubernetes/kubernetes/issues/123761 
The error seems to be coming from here in k8s: https://github.com/kubernetes/kubernetes/blob/dc3f5ec6ccb9855dfa99f4c1078625df5fdfab6a/pkg/registry/core/service/storage/alloc.go#L184

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.