### PR TITLE
CNTRLPLANE-325: rootless containerized builds

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,2 +1,15 @@
-FROM squidfunk/mkdocs-material:9
-RUN pip install mkdocs-mermaid2-plugin mkdocs-glightbox setuptools==70.0.0 zipp==3.19.1
+FROM registry.fedoraproject.org/fedora-minimal:41
+
+RUN dnf install -y python-pip \
+  && dnf clean all \
+  && useradd docs
+
+WORKDIR /home/docs
+USER docs
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt \
+  && mkdir /home/docs/hypershift
+
+WORKDIR /home/docs/hypershift
+ENTRYPOINT [ "/home/docs/.local/bin/mkdocs" ]

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,5 +1,6 @@
-IMG ?= quay.io/hypershift/mkdocs-material:latest
-RUNTIME ?= docker
+RUNTIME ?= $(shell sh ../hack/utils.sh get_container_engine)
+VERSION := $(shell awk -f image-version.awk requirements.txt)
+IMG ?= quay.io/hypershift/mkdocs-material:$(VERSION)
 
 .PHONY: build
 build:
@@ -7,11 +8,18 @@ build:
 
 .PHONY: build-containerized
 build-containerized:
-	$(RUNTIME) run --rm -it -v ${PWD}:/docs:z $(IMG) build
+	$(RUNTIME) volume create --ignore hypershift-docs-site
+	$(RUNTIME) run --rm -it \
+		-v ${PWD}:/home/docs/hypershift:Z \
+		-v hypershift-docs-site:/home/docs/hypershift/site \
+		$(IMG) build --strict
 
 .PHONY: serve-containerized
 serve-containerized:
-	$(RUNTIME) run --rm -it -p 8000:8000 -v ${PWD}:/docs $(IMG) serve --dev-addr 0.0.0.0:8000
+	$(RUNTIME) run --rm -it -p 8000:8000 \
+		-v ${PWD}:/home/docs/hypershift:Z \
+		-v hypershift-docs-site:/home/docs/hypershift/site \
+		$(IMG) serve --dev-addr 0.0.0.0:8000
 
 .PHONY: image
 image:
@@ -19,4 +27,4 @@ image:
 
 .PHONY: push
 push:
-	$(RUNTIME) push $(IMG)
+        $(RUNTIME) push $(IMG)

--- a/docs/image-version.awk
+++ b/docs/image-version.awk
@@ -1,0 +1,1 @@
+BEGIN { FS = " |==="}; /mkdocs-material/{print $2}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
-mkdocs==1.6.1
-mkdocs-material==9.6.6
-mkdocs-mermaid2-plugin==1.2.1
-mkdocs-glightbox==0.4.0
+mkdocs-material===9.6.8
+mkdocs-mermaid2-plugin===1.2.1
+mkdocs-glightbox===0.4.0


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes the containerized builds to:
* Use the same container runtime detection as the main repository makefile.
* Changes from the docker mkdocs-material image to a fedora-minimal based one.
* Introduces the usage of a volume for the site build not to pollute the repository
* Makes the containerized versions respect the versions in requirements.txt
* Bumps requirements.txt.
* Changes the build mode to --strict, to prevent warnings from creeping in.

**Which issue(s) this PR fixes**
Fixes #[CNTRLPLANE-325](https://issues.redhat.com//browse/CNTRLPLANE-325)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.