### PR TITLE
CNTRLPLANE-265: Enable staticcheck linter in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,9 @@ issues:
         - staticcheck
       text: "SA1019: in.Status.DNSName is deprecated"
     - linters:
+        - staticcheck
+      text: "SA1019: infra.Status.Platform is deprecated: Use platformStatus.type instead"
+    - linters:
         - unused
       text: "const `tuningConfigKey` is unused"
 linters:
@@ -36,7 +39,6 @@ linters:
     - gosimple
     - errcheck
     - govet
-  disable:
     - staticcheck
 linters-settings:
   gci:

--- a/cmd/bastion/aws/create.go
+++ b/cmd/bastion/aws/create.go
@@ -518,7 +518,7 @@ func waitForInstanceRunning(ctx context.Context, logger logr.Logger, ec2Client *
 
 	waitCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
-	err := wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
+	err := wait.PollUntilContextCancel(waitCtx, 5*time.Second, true, func(ctx context.Context) (bool, error) {
 		err := ec2Client.WaitUntilInstanceRunningWithContext(ctx, &ec2.DescribeInstancesInput{
 			InstanceIds: []*string{aws.String(instanceID)},
 		})
@@ -531,7 +531,7 @@ func waitForInstanceRunning(ctx context.Context, logger logr.Logger, ec2Client *
 			return false, fmt.Errorf("error waiting for instance running: %w", err)
 		}
 		return true, nil
-	}, waitCtx.Done())
+	})
 	if err != nil {
 		return "", err
 	}

--- a/cmd/bastion/aws/destroy.go
+++ b/cmd/bastion/aws/destroy.go
@@ -115,7 +115,7 @@ func (o *DestroyBastionOpts) Run(ctx context.Context, logger logr.Logger) error 
 	awsConfig := awsutil.NewConfig()
 	ec2Client := ec2.New(awsSession, awsConfig)
 
-	return wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
+	return wait.PollUntilContextCancel(ctx, 5*time.Second, true, func(ctx context.Context) (bool, error) {
 		err := destroyBastion(ctx, logger, ec2Client, infraID)
 		if err != nil {
 			if !awsutil.IsErrorRetryable(err) {
@@ -125,7 +125,7 @@ func (o *DestroyBastionOpts) Run(ctx context.Context, logger logr.Logger) error 
 			return false, nil
 		}
 		return true, nil
-	}, ctx.Done())
+	})
 }
 
 func destroyBastion(ctx context.Context, logger logr.Logger, ec2Client *ec2.EC2, infraID string) error {

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -559,7 +559,7 @@ func apply(ctx context.Context, l logr.Logger, infraID string, objects []crclien
 
 	if waitForRollout {
 		l.Info("Waiting for cluster rollout")
-		return wait.PollInfiniteWithContext(ctx, 30*time.Second, func(ctx context.Context) (bool, error) {
+		return wait.PollUntilContextCancel(ctx, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 			hostedCluster := hostedCluster.DeepCopy()
 			if err := client.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster); err != nil {
 				return false, fmt.Errorf("failed to get hostedcluster %s: %w", crclient.ObjectKeyFromObject(hostedCluster), err)

--- a/cmd/infra/aws/destroy.go
+++ b/cmd/infra/aws/destroy.go
@@ -181,7 +181,7 @@ func (o *DestroyInfraOptions) Run(ctx context.Context) error {
 		infraCtx = ctx
 	}
 
-	return wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
+	return wait.PollUntilContextCancel(infraCtx, 5*time.Second, true, func(context.Context) (bool, error) {
 		err := o.DestroyInfra(infraCtx)
 		if err != nil {
 			if !awsutil.IsErrorRetryable(err) {
@@ -191,7 +191,7 @@ func (o *DestroyInfraOptions) Run(ctx context.Context) error {
 			return false, nil
 		}
 		return true, nil
-	}, infraCtx.Done())
+	})
 }
 
 func (o *DestroyInfraOptions) DestroyInfra(ctx context.Context) error {

--- a/cmd/infra/aws/destroy_iam.go
+++ b/cmd/infra/aws/destroy_iam.go
@@ -71,7 +71,7 @@ func NewDestroyIAMCommand() *cobra.Command {
 }
 
 func (o *DestroyIAMOptions) Run(ctx context.Context) error {
-	return wait.PollImmediateUntil(5*time.Second, func() (bool, error) {
+	return wait.PollUntilContextCancel(ctx, 5*time.Second, true, func(ctx context.Context) (bool, error) {
 		err := o.DestroyIAM(ctx)
 		if err != nil {
 			if !awsutil.IsErrorRetryable(err) {
@@ -81,7 +81,7 @@ func (o *DestroyIAMOptions) Run(ctx context.Context) error {
 			return false, nil
 		}
 		return true, nil
-	}, ctx.Done())
+	})
 }
 
 func (o *DestroyIAMOptions) DestroyIAM(ctx context.Context) error {

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -414,7 +414,7 @@ func WaitUntilAvailable(ctx context.Context, opts Options) (*appsv1.Deployment, 
 
 	deployment := getOperatorDeployment(opts)
 	fmt.Printf("Waiting for deployment %q in namespace %q rollout for operator...\n", deployment.Name, deployment.Namespace)
-	err = wait.PollImmediateUntilWithContext(waitCtx, 2*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(waitCtx, 2*time.Second, true, func(ctx context.Context) (bool, error) {
 		if err := client.Get(ctx, crclient.ObjectKeyFromObject(deployment), deployment); err != nil {
 			return false, err
 		}
@@ -449,7 +449,7 @@ func WaitUntilAvailable(ctx context.Context, opts Options) (*appsv1.Deployment, 
 	if opts.Development {
 		return deployment, nil
 	}
-	err = wait.PollImmediateUntilWithContext(waitCtx, 2*time.Second, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextCancel(waitCtx, 2*time.Second, true, func(ctx context.Context) (bool, error) {
 		endpoints := operatorEndpoints(opts)
 		if err := client.Get(ctx, crclient.ObjectKeyFromObject(endpoints), endpoints); err != nil {
 			if apierrors.IsNotFound(err) {

--- a/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kcm/deployment_test.go
@@ -42,7 +42,7 @@ func TestKCMArgs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			args := kcmArgs(tc.p)
 
-			seen := sets.String{}
+			seen := sets.New[string]()
 			for _, arg := range args {
 				key := strings.Split(arg, "=")[0]
 				if allowedDuplicateArgs.Has(key) {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -2017,7 +2017,7 @@ func (r *reconciler) destroyCloudResources(ctx context.Context, hcp *hyperv1.Hos
 		} else {
 			reason = "RemainingCloudResources"
 			status = metav1.ConditionFalse
-			message = fmt.Sprintf("Remaining resources: %s", strings.Join(remaining.List(), ","))
+			message = fmt.Sprintf("Remaining resources: %s", strings.Join(remaining.UnsortedList(), ","))
 		}
 	}
 	resourcesDestroyedCond := &metav1.Condition{
@@ -2043,9 +2043,9 @@ func (r *reconciler) destroyCloudResources(ctx context.Context, hcp *hyperv1.Hos
 	}
 }
 
-func (r *reconciler) ensureCloudResourcesDestroyed(ctx context.Context, hcp *hyperv1.HostedControlPlane) (sets.String, error) {
+func (r *reconciler) ensureCloudResourcesDestroyed(ctx context.Context, hcp *hyperv1.HostedControlPlane) (sets.Set[string], error) {
 	log := ctrl.LoggerFrom(ctx)
-	remaining := sets.NewString()
+	remaining := sets.New[string]()
 	log.Info("Ensuring resource creation is blocked in cluster")
 	if err := r.ensureResourceCreationIsBlocked(ctx); err != nil {
 		return remaining, err

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -329,7 +330,7 @@ func NewStartCommand() *cobra.Command {
 			return "", fmt.Errorf("couldn't locate operator container on deployment")
 		}
 
-		if err := wait.PollImmediate(5*time.Second, 30*time.Second, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 			hostedClusterConfigOperatorImage, err = lookupOperatorImage(hostedClusterConfigOperatorImage)
 			if err != nil {
 				return false, err

--- a/dnsresolver/cmd.go
+++ b/dnsresolver/cmd.go
@@ -30,7 +30,7 @@ func NewCommand() *cobra.Command {
 }
 
 func resolveDNS(ctx context.Context, hostName string) error {
-	err := wait.PollImmediateWithContext(ctx, time.Second, 10*time.Minute, func(ctx context.Context) (done bool, err error) {
+	err := wait.PollUntilContextTimeout(ctx, time.Second, 10*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		ips, err := net.DefaultResolver.LookupIPAddr(ctx, hostName)
 		if err == nil && len(ips) > 0 {
 			fmt.Printf("Address %s resolved to %s\n", hostName, ips[0].String())

--- a/etcd-defrag/etcddefrag_controller.go
+++ b/etcd-defrag/etcddefrag_controller.go
@@ -201,10 +201,12 @@ func (r *DefragController) runDefrag(ctx context.Context) error {
 			successfulDefrags++
 
 			// Give cluster time to recover before we move to the next member.
-			if err := wait.Poll(
+			if err := wait.PollUntilContextTimeout(
+				ctx,
 				pollWaitDuration,
 				pollTimeoutDuration,
-				func() (bool, error) {
+				true,
+				func(ctx context.Context) (bool, error) {
 					// Ensure defragmentation attempts have clear observable signal.
 					r.log.Info("Sleeping to allow cluster to recover before defragging next member", "waiting", r.defragWaitDuration)
 					time.Sleep(r.defragWaitDuration)

--- a/hypershift-operator/controllers/nodepool/capi.go
+++ b/hypershift-operator/controllers/nodepool/capi.go
@@ -385,8 +385,6 @@ func (c *CAPI) reconcileMachineDeployment(ctx context.Context, log logr.Logger,
 	// However, since we don't run the webhook, CAPI updates the machinedeployment
 	// after it has been created with defaults.
 	machineDeployment.Spec.MinReadySeconds = ptr.To[int32](0)
-	machineDeployment.Spec.RevisionHistoryLimit = ptr.To[int32](1)
-	machineDeployment.Spec.ProgressDeadlineSeconds = ptr.To[int32](600)
 
 	machineDeployment.Spec.ClusterName = capiClusterName
 	if machineDeployment.Spec.Selector.MatchLabels == nil {

--- a/hypershift-operator/controllers/nodepool/capi_test.go
+++ b/hypershift-operator/controllers/nodepool/capi_test.go
@@ -918,12 +918,6 @@ func TestReconcileMachineHealthCheck(t *testing.T) {
 			o.SetAnnotations(a)
 		}
 	}
-	withMaxUnhealthy := func(value string) func(*capiv1.MachineHealthCheck) {
-		return func(mhc *capiv1.MachineHealthCheck) {
-			maxUnhealthy := intstr.Parse(value)
-			mhc.Spec.MaxUnhealthy = &maxUnhealthy
-		}
-	}
 	withTimeout := func(d time.Duration) func(*capiv1.MachineHealthCheck) {
 		return func(mhc *capiv1.MachineHealthCheck) {
 			for i := range mhc.Spec.UnhealthyConditions {
@@ -1006,24 +1000,6 @@ func TestReconcileMachineHealthCheck(t *testing.T) {
 			hc:       hostedcluster(withNodeStartupTimeoutOverride("foo")),
 			np:       nodepool(),
 			expected: healthcheck(),
-		},
-		{
-			name:     "maxunhealthy override in hc",
-			hc:       hostedcluster(withMaxUnhealthyOverride("10%")),
-			np:       nodepool(),
-			expected: healthcheck(withMaxUnhealthy("10%")),
-		},
-		{
-			name:     "maxunhealthy override in np",
-			hc:       hostedcluster(),
-			np:       nodepool(withMaxUnhealthyOverride("5")),
-			expected: healthcheck(withMaxUnhealthy("5")),
-		},
-		{
-			name:     "maxunhealthy override in both, np takes precedence",
-			hc:       hostedcluster(withMaxUnhealthyOverride("10%")),
-			np:       nodepool(withMaxUnhealthyOverride("5")),
-			expected: healthcheck(withMaxUnhealthy("5")),
 		},
 		{
 			name:     "invalid maxunhealthy override value, default is preserved",
@@ -1422,10 +1398,6 @@ func TestCAPIReconcile(t *testing.T) {
 					CreateOrUpdateProvider: upsert.New(false),
 				},
 				capiClusterName: capiClusterName,
-			}
-
-			if tt.expectedError {
-				// TODO(alberto): use WithObjectTracker() / WithInterceptorFuncs() to mock error paths.
 			}
 
 			// Make sure the templates are populates in the control plane namespace

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -253,7 +253,7 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 		return "", fmt.Errorf("couldn't locate operator container on deployment")
 	}
 	var operatorImage string
-	if err := wait.PollImmediate(5*time.Second, 30*time.Second, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 		operatorImage, err = lookupOperatorImage(opts.ControlPlaneOperatorImage)
 		if err != nil {
 			return false, err

--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -659,7 +659,7 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage, cu
 			Timeout: 5 * time.Second,
 		}
 		var payload []byte
-		err = wait.PollUntilWithContext(ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+		err = wait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
 			req, err := http.NewRequestWithContext(ctx, "GET", "http://localhost:22626/config/master", nil)
 			if err != nil {
 				return false, fmt.Errorf("error building http request: %w", err)

--- a/konnectivity-https-proxy/cmd.go
+++ b/konnectivity-https-proxy/cmd.go
@@ -187,7 +187,7 @@ func connectDialFunc(log logr.Logger, httpProxy *goproxy.ProxyHttpServer, proxyU
 		// send it through the dialer directly.
 		if (connectDirectlyToCloudAPIs && isCloudAPI(host)) || proxyURL == nil {
 			log.V(4).Info("Host is cloud API or should not use a proxy with it, dialing directly through konnectivity")
-			return httpProxy.Tr.Dial(network, addr)
+			return httpProxy.Tr.Dial(network, addr) //nolint:staticcheck
 		}
 		log.V(4).Info("Using proxy to dial", "proxy", proxyURL)
 		return defaultDial(network, addr)

--- a/pkg/etcdcli/etcdcli.go
+++ b/pkg/etcdcli/etcdcli.go
@@ -3,7 +3,7 @@ package etcdcli
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"os"
 	"strings"
@@ -57,14 +57,13 @@ func NewEtcdClient(endpointsFunc func() ([]string, error), eventRecorder events.
 // newEtcdClientWithClientOpts allows customization of the etcd client using ClientOptions. All clients must be manually
 // closed by the caller with Close().
 func newEtcdClientWithClientOpts(endpoints []string, skipConnectionTest bool, opts ...ClientOption) (*clientv3.Client, error) {
-	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, os.Stderr))
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, os.Stderr))
 	clientOpts, err := newClientOpts(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("error during clientOpts: %w", err)
 	}
 
 	dialOptions := []grpc.DialOption{
-		grpc.WithBlock(), // block until the underlying connection is up
 		grpc.WithChainUnaryInterceptor(grpcprom.UnaryClientInterceptor),
 		grpc.WithChainStreamInterceptor(grpcprom.StreamClientInterceptor),
 	}

--- a/support/config/deployment.go
+++ b/support/config/deployment.go
@@ -44,7 +44,7 @@ type DeploymentConfig struct {
 	ReadinessProbes           ReadinessProbes
 	StartupProbes             StartupProbes
 	Resources                 ResourcesSpec
-	DebugDeployments          sets.String
+	DebugDeployments          sets.Set[string]
 	ResourceRequestOverrides  ResourceOverrides
 	IsolateAsRequestServing   bool
 	RevisionHistoryLimit      int
@@ -479,7 +479,7 @@ func (c *DeploymentConfig) SetDefaults(hcp *hyperv1.HostedControlPlane, multiZon
 	} else {
 		c.Replicas = *replicas
 	}
-	c.DebugDeployments = debugDeployments(hcp)
+	c.DebugDeployments = sets.New(debugDeployments(hcp).UnsortedList()...)
 	c.ResourceRequestOverrides = resourceRequestOverrides(hcp)
 	c.RevisionHistoryLimit = 2
 
@@ -538,11 +538,11 @@ func parseResourceRequestOverrideAnnotation(key, value string, overrides Resourc
 // debugDeployments returns a set of deployments to debug based on the
 // debugDeploymentsAnnotation value, indicating the deployment should be considered to
 // be in development mode.
-func debugDeployments(hc *hyperv1.HostedControlPlane) sets.String {
+func debugDeployments(hc *hyperv1.HostedControlPlane) sets.Set[string] {
 	val, exists := hc.Annotations[util.DebugDeploymentsAnnotation]
 	if !exists {
 		return nil
 	}
 	names := strings.Split(val, ",")
-	return sets.NewString(names...)
+	return sets.New(names...)
 }

--- a/support/thirdparty/kubernetes/pkg/credentialprovider/config.go
+++ b/support/thirdparty/kubernetes/pkg/credentialprovider/config.go
@@ -21,7 +21,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 )
 
@@ -49,7 +49,7 @@ type DockerConfigEntry struct {
 func ReadSpecificDockerConfigJSONFile(filePath string) (cfg DockerConfig, err error) {
 	var contents []byte
 
-	if contents, err = ioutil.ReadFile(filePath); err != nil {
+	if contents, err = os.ReadFile(filePath); err != nil {
 		return nil, err
 	}
 

--- a/support/thirdparty/library-go/pkg/image/registryclient/client.go
+++ b/support/thirdparty/library-go/pkg/image/registryclient/client.go
@@ -379,7 +379,7 @@ func isTemporaryHTTPError(err error) (time.Duration, bool) {
 	}
 	switch t := err.(type) {
 	case net.Error:
-		return time.Second, t.Temporary() || t.Timeout()
+		return time.Second, t.Timeout()
 	case errcode.ErrorCoder:
 		// note: we explicitly do not check errcode.ErrorCodeUnknown because that is used in
 		// a wide range of scenarios to convey "generic error", not "retryable error"

--- a/support/upsert/loopdetector.go
+++ b/support/upsert/loopdetector.go
@@ -20,7 +20,7 @@ import (
 
 func newUpdateLoopDetector() *updateLoopDetector {
 	return &updateLoopDetector{
-		hasNoOpUpdate:    sets.String{},
+		hasNoOpUpdate:    sets.New[string](),
 		updateEventCount: map[string]int{},
 		log: zap.New(zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
 			o.EncodeTime = zapcore.RFC3339TimeEncoder
@@ -43,7 +43,7 @@ func updateLoopThreshold(o runtime.Object) int {
 }
 
 type updateLoopDetector struct {
-	hasNoOpUpdate    sets.String
+	hasNoOpUpdate    sets.Set[string]
 	lock             sync.RWMutex
 	updateEventCount map[string]int
 	log              logr.Logger

--- a/test/e2e/util/node.go
+++ b/test/e2e/util/node.go
@@ -30,7 +30,7 @@ func EnsureNodeCommunication(t *testing.T, ctx context.Context, client crclient.
 
 		// Mulham: konnectivity-agent pod is not available immediately after switching from private to public.
 		// This simply adds retries to solve that.
-		err = wait.PollImmediateWithContext(ctx, 10*time.Second, 5*time.Minute, func(ctx context.Context) (done bool, err error) {
+		err = wait.PollUntilContextTimeout(ctx, 10*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 			podList, err := guestClient.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{LabelSelector: "app=konnectivity-agent"})
 			if err != nil || len(podList.Items) == 0 {
 				return false, nil

--- a/test/e2e/util/oauth.go
+++ b/test/e2e/util/oauth.go
@@ -125,7 +125,7 @@ func WaitForOAuthToken(t *testing.T, ctx context.Context, oauthRoute *routev1.Ro
 	}
 
 	var access_token string
-	err = wait.PollImmediateWithContext(ctx, time.Second, time.Minute*2, func(ctx context.Context) (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, time.Second, time.Minute*2, true, func(ctx context.Context) (done bool, err error) {
 		resp, err := httpClient.Do(request)
 		if err != nil {
 			t.Logf("Waiting for OAuth token request to succeed")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR:
- enables the last default linter in golangci-lint: staticcheck
- fixes all the issues discovered by staticcheck

**Which issue(s) this PR fixes**:
[CNTRLPLANE-265](https://issues.redhat.com//browse/CNTRLPLANE-265)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.