### PR TITLE
CNTRLPLANE-112: Enable MIv3 for CNO/CNCC on managed Azure

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3714,13 +3714,11 @@ func (r *HostedControlPlaneReconciler) reconcileClusterNetworkOperator(ctx conte
 	if hyperazureutil.IsAroHCP() {
 		cnccSecretProviderClass := manifests.ManagedAzureSecretProviderClass(config.ManagedAzureNetworkSecretStoreProviderClassName, hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r, cnccSecretProviderClass, func() error {
-			secretproviderclass.ReconcileManagedAzureSecretProviderClass(cnccSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Network)
+			secretproviderclass.ReconcileManagedAzureSecretProviderClass(cnccSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Network, true)
 			return nil
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile ingressoperator secret provider class: %w", err)
 		}
-
-		p.AzureTenantID = hcp.Spec.Platform.Azure.TenantID
 	}
 
 	sa := manifests.ClusterNetworkOperatorServiceAccount(hcp.Namespace)

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cno/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cno/azure.go
@@ -9,6 +9,6 @@ import (
 
 func adaptAzureSecretProvider(cpContext component.WorkloadContext, secretProvider *secretsstorev1.SecretProviderClass) error {
 	managedIdentity := cpContext.HCP.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Network
-	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, managedIdentity)
+	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, managedIdentity, true)
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cno/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cno/deployment.go
@@ -141,22 +141,11 @@ func buildCNOEnvVars(cpContext component.WorkloadContext) ([]corev1.EnvVar, erro
 		})
 	}
 
-	// For ARO HCP deployments, we pass the env variable for the SecretProviderClass for the Secrets Store CSI driver
-	// to use on the CNCC deployment.
+	// For managed Azure deployments, we pass the env variables for:
+	// - the SecretProviderClass for the Secrets Store CSI driver to use on the CNCC deployment
+	// - the filepath of the credentials
 	if azureutil.IsAroHCP() {
 		cnoEnv = append(cnoEnv,
-			corev1.EnvVar{
-				Name:  config.ManagedAzureClientIdEnvVarKey,
-				Value: hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Network.ClientID,
-			},
-			corev1.EnvVar{
-				Name:  config.ManagedAzureTenantIdEnvVarKey,
-				Value: hcp.Spec.Platform.Azure.TenantID,
-			},
-			corev1.EnvVar{
-				Name:  config.ManagedAzureCertificateNameEnvVarKey,
-				Value: hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Network.CertificateName,
-			},
 			corev1.EnvVar{
 				Name:  config.ManagedAzureSecretProviderClassEnvVarKey,
 				Value: config.ManagedAzureNetworkSecretStoreProviderClassName,

--- a/support/config/constants.go
+++ b/support/config/constants.go
@@ -65,7 +65,6 @@ const (
 	ManagedAzureClientIdEnvVarKey            = "ARO_HCP_MI_CLIENT_ID"
 	ManagedAzureTenantIdEnvVarKey            = "ARO_HCP_TENANT_ID"
 	ManagedAzureCertificatePathEnvVarKey     = "ARO_HCP_CLIENT_CERTIFICATE_PATH"
-	ManagedAzureCertificateNameEnvVarKey     = "ARO_HCP_CLIENT_CERTIFICATE_NAME"
 	ManagedAzureSecretProviderClassEnvVarKey = "ARO_HCP_SECRET_PROVIDER_CLASS"
 	ManagedAzureCertificateMountPath         = "/mnt/certs"
 	ManagedAzureCertificatePath              = "/mnt/certs/"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables managed identity version 3 for cluster network operator (CNO) and cloud network configuration controller (CNCC) for managed azure.

**Which issue(s) this PR fixes**:
Fixes [CNTRLPLANE-112](https://issues.redhat.com/browse/CNTRLPLANE-112)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.