### PR TITLE
NO-JIRA: Remove TODO comment for AzureProviderConfig

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/azure.go
@@ -5,9 +5,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// AzureProviderConfig is a configMap for azure config.
-// TODO (alberto): can we drop this completely?
-// It has some consumers atm: it's reconciled into guest cluster, ignition local provider. Review them and drop it.
+// AzureProviderConfig is a configMap for Azure cloud config. This is needed for ignition configuration by the
+// machine-config-operator (MCO). https://github.com/openshift/machine-config-operator/blob/fe8353e4ea7e72dfd69105069b870a37a87478ec/pkg/operator/bootstrap.go#L124
 func AzureProviderConfig(ns string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit removes the TODO comment above the AzureProviderConfig function. This ConfigMap is needed for the ignition configuration by the machine-config-operator (MCO).

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.