### PR TITLE
NOJIRA: openstack: ORC won't delete the image after HostedCluster deletion

### DIFF
--- a/api/hypershift/v1beta1/openstack.go
+++ b/api/hypershift/v1beta1/openstack.go
@@ -17,7 +17,7 @@ const (
 
 	// PruneRetentionPolicy is the default policy for handling OpenStack Glance Images
 	// when the HostedCluster is deleted.
-	DefaultImageRetentionPolicy RetentionPolicy = PruneRetentionPolicy
+	DefaultImageRetentionPolicy RetentionPolicy = OrphanRetentionPolicy
 )
 
 func (p *RetentionPolicy) String() string {
@@ -165,9 +165,9 @@ type OpenStackPlatformSpec struct {
 
 	// imageRetentionPolicy defines the policy for handling resources associated with the image
 	// when the cluster is deleted.
-	// The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
-	// behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
-	// HostedCluster deletion.
+	// The default (set by the Nodepool controller) is to orphan the image so that it can be
+	// used by other clusters. If the image is no longer needed, it can be manually deleted.
+	// If the image is set to be pruned, it will be deleted when the cluster is deleted.
 	// It is defined at the HostedCluster level and will be used for all nodepools images
 	// so there is no conflict between different ORC objects.
 	// On day 2 operations, if this field is changed, the corresponding ORC object will be updated

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -4005,9 +4005,9 @@ spec:
                         description: |-
                           imageRetentionPolicy defines the policy for handling resources associated with the image
                           when the cluster is deleted.
-                          The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
-                          behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
-                          HostedCluster deletion.
+                          The default (set by the Nodepool controller) is to orphan the image so that it can be
+                          used by other clusters. If the image is no longer needed, it can be manually deleted.
+                          If the image is set to be pruned, it will be deleted when the cluster is deleted.
                           It is defined at the HostedCluster level and will be used for all nodepools images
                           so there is no conflict between different ORC objects.
                           On day 2 operations, if this field is changed, the corresponding ORC object will be updated

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -3890,9 +3890,9 @@ spec:
                         description: |-
                           imageRetentionPolicy defines the policy for handling resources associated with the image
                           when the cluster is deleted.
-                          The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
-                          behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
-                          HostedCluster deletion.
+                          The default (set by the Nodepool controller) is to orphan the image so that it can be
+                          used by other clusters. If the image is no longer needed, it can be manually deleted.
+                          If the image is set to be pruned, it will be deleted when the cluster is deleted.
                           It is defined at the HostedCluster level and will be used for all nodepools images
                           so there is no conflict between different ORC objects.
                           On day 2 operations, if this field is changed, the corresponding ORC object will be updated

--- a/cmd/cluster/openstack/create.go
+++ b/cmd/cluster/openstack/create.go
@@ -47,7 +47,7 @@ func bindCoreOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
 	flags.StringVar(&opts.OpenStackExternalNetworkID, "openstack-external-network-id", opts.OpenStackExternalNetworkID, "ID of the OpenStack external network (optional)")
 	flags.StringVar(&opts.OpenStackIngressFloatingIP, "openstack-ingress-floating-ip", opts.OpenStackIngressFloatingIP, "An available floating IP in your OpenStack cluster that will be associated with the OpenShift ingress port (optional)")
 	flags.StringSliceVar(&opts.OpenStackDNSNameservers, "openstack-dns-nameservers", opts.OpenStackDNSNameservers, "List of DNS nameservers to use for the cluster (optional)")
-	flags.Var(&opts.OpenStackImageRetentionPolicy, "openstack-image-retention-policy", "OpenStack Glance Image retention policy. Valid values are 'Orphan' and 'Prune'. By default images are pruned. (optional)")
+	flags.Var(&opts.OpenStackImageRetentionPolicy, "openstack-image-retention-policy", "OpenStack Glance Image retention policy. Valid values are 'Orphan' and 'Prune'. By default images are orphaned. (optional)")
 }
 
 type RawCreateOptions struct {

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
@@ -4537,9 +4537,9 @@ spec:
                         description: |-
                           imageRetentionPolicy defines the policy for handling resources associated with the image
                           when the cluster is deleted.
-                          The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
-                          behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
-                          HostedCluster deletion.
+                          The default (set by the Nodepool controller) is to orphan the image so that it can be
+                          used by other clusters. If the image is no longer needed, it can be manually deleted.
+                          If the image is set to be pruned, it will be deleted when the cluster is deleted.
                           It is defined at the HostedCluster level and will be used for all nodepools images
                           so there is no conflict between different ORC objects.
                           On day 2 operations, if this field is changed, the corresponding ORC object will be updated

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
@@ -4519,9 +4519,9 @@ spec:
                         description: |-
                           imageRetentionPolicy defines the policy for handling resources associated with the image
                           when the cluster is deleted.
-                          The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
-                          behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
-                          HostedCluster deletion.
+                          The default (set by the Nodepool controller) is to orphan the image so that it can be
+                          used by other clusters. If the image is no longer needed, it can be manually deleted.
+                          If the image is set to be pruned, it will be deleted when the cluster is deleted.
                           It is defined at the HostedCluster level and will be used for all nodepools images
                           so there is no conflict between different ORC objects.
                           On day 2 operations, if this field is changed, the corresponding ORC object will be updated

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
@@ -4422,9 +4422,9 @@ spec:
                         description: |-
                           imageRetentionPolicy defines the policy for handling resources associated with the image
                           when the cluster is deleted.
-                          The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
-                          behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
-                          HostedCluster deletion.
+                          The default (set by the Nodepool controller) is to orphan the image so that it can be
+                          used by other clusters. If the image is no longer needed, it can be manually deleted.
+                          If the image is set to be pruned, it will be deleted when the cluster is deleted.
                           It is defined at the HostedCluster level and will be used for all nodepools images
                           so there is no conflict between different ORC objects.
                           On day 2 operations, if this field is changed, the corresponding ORC object will be updated

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
@@ -4404,9 +4404,9 @@ spec:
                         description: |-
                           imageRetentionPolicy defines the policy for handling resources associated with the image
                           when the cluster is deleted.
-                          The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
-                          behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
-                          HostedCluster deletion.
+                          The default (set by the Nodepool controller) is to orphan the image so that it can be
+                          used by other clusters. If the image is no longer needed, it can be manually deleted.
+                          If the image is set to be pruned, it will be deleted when the cluster is deleted.
                           It is defined at the HostedCluster level and will be used for all nodepools images
                           so there is no conflict between different ORC objects.
                           On day 2 operations, if this field is changed, the corresponding ORC object will be updated

--- a/docs/content/how-to/openstack/hostedcluster.md
+++ b/docs/content/how-to/openstack/hostedcluster.md
@@ -14,7 +14,7 @@ Here are the available options specific to the OpenStack platform:
 | `--openstack-node-additional-port`      | Attach additional ports to nodes. Params: `network-id`, `vnic-type`, `disable-port-security`, `address-pairs`. | No       |               |
 | `--openstack-node-availability-zone`    | Availability zone for the nodepool                                                           | No       |               |
 | `--openstack-node-flavor`               | Flavor for the nodepool                                                                      | Yes      |               |
-| `--openstack-image-retention-policy`    | OpenStack Glance Image retention policy. Valid values are 'Orphan' and 'Prune'.              | No       | `Prune`       |
+| `--openstack-image-retention-policy`    | OpenStack Glance Image retention policy. Valid values are 'Orphan' and 'Prune'.              | No       | `Orphan`       |
 | `--openstack-node-image-name`           | Image name for the nodepool                                                                  | No       |               |
 | `--openstack-dns-nameservers`           | List of DNS server addresses that will be provided when creating the subnet                  | No       |               |
 
@@ -90,8 +90,8 @@ hcp create cluster openstack \
 
     When not providing the `--openstack-node-image-name` flag, the latest RHCOS image will be used.
     ORC will handle the RHCOS image lifecycle by downloading the image from the OpenShift mirror and deleting it when it's no longer needed.
-    If you want ORC to not delete the image, you can create the HostedCluster with the following option: `--openstack-image-retention-policy=Orphan`.
-    This will prevent ORC from deleting the image resource.
+    If you want ORC to delete the image when the cluster is deleted, you can create the HostedCluster with the following
+    option: `--openstack-image-retention-policy=Prune`.
 
 After a few moments we should see our hosted control plane pods up and running:
 

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -9461,9 +9461,9 @@ RetentionPolicy
 <em>(Optional)</em>
 <p>imageRetentionPolicy defines the policy for handling resources associated with the image
 when the cluster is deleted.
-The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
-behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
-HostedCluster deletion.
+The default (set by the Nodepool controller) is to orphan the image so that it can be
+used by other clusters. If the image is no longer needed, it can be manually deleted.
+If the image is set to be pruned, it will be deleted when the cluster is deleted.
 It is defined at the HostedCluster level and will be used for all nodepools images
 so there is no conflict between different ORC objects.
 On day 2 operations, if this field is changed, the corresponding ORC object will be updated
@@ -10666,7 +10666,7 @@ creating new nodes and deleting the old ones.</p>
 <th>Description</th>
 </tr>
 </thead>
-<tbody><tr><td><p>&#34;Prune&#34;</p></td>
+<tbody><tr><td><p>&#34;Orphan&#34;</p></td>
 <td><p>PruneRetentionPolicy is the default policy for handling OpenStack Glance Images
 when the HostedCluster is deleted.</p>
 </td>

--- a/hypershift-operator/controllers/nodepool/openstack.go
+++ b/hypershift-operator/controllers/nodepool/openstack.go
@@ -3,7 +3,6 @@ package nodepool
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/nodepool/openstack"
@@ -30,7 +29,7 @@ func (r *NodePoolReconciler) setOpenStackConditions(ctx context.Context, nodePoo
 			})
 			return fmt.Errorf("couldn't discover an OpenStack Image for release image: %w", err)
 		}
-		imageName, err := r.reconcileOpenStackImageCR(ctx, r.Client, hcluster, releaseImage, nodePool)
+		imageName, err := r.reconcileOpenStackImageCR(ctx, r.Client, hcluster, controlPlaneNamespace, releaseImage, nodePool)
 		if err != nil {
 			return err
 		}
@@ -56,12 +55,11 @@ func (r *NodePoolReconciler) setOpenStackConditions(ctx context.Context, nodePoo
 // reconcileOpenStackImageCR reconciles the OpenStack Image CR for the given NodePool.
 // An ORC object will be created or updated with the image spec.
 // The image name will be returned.
-func (r *NodePoolReconciler) reconcileOpenStackImageCR(ctx context.Context, client client.Client, hcluster *hyperv1.HostedCluster, release *releaseinfo.ReleaseImage, nodePool *hyperv1.NodePool) (string, error) {
+func (r *NodePoolReconciler) reconcileOpenStackImageCR(ctx context.Context, client client.Client, hcluster *hyperv1.HostedCluster, controlPlaneNamespace string, release *releaseinfo.ReleaseImage, nodePool *hyperv1.NodePool) (string, error) {
 	releaseVersion, err := openstack.OpenStackReleaseImage(release)
 	if err != nil {
 		return "", err
 	}
-	controlPlaneNamespace := fmt.Sprintf("%s-%s", nodePool.Namespace, strings.ReplaceAll(nodePool.Spec.ClusterName, ".", "-"))
 	openstackCluster, err := openstack.GetOpenStackClusterForHostedCluster(ctx, client, hcluster, controlPlaneNamespace)
 	if err != nil {
 		return "", err

--- a/hypershift-operator/controllers/nodepool/openstack/openstack_test.go
+++ b/hypershift-operator/controllers/nodepool/openstack/openstack_test.go
@@ -387,7 +387,7 @@ func TestReconcileOpenStackImageSpec(t *testing.T) {
 						},
 					},
 				},
-				ManagedOptions: &orc.ManagedOptions{OnDelete: orc.OnDeleteDelete},
+				ManagedOptions: &orc.ManagedOptions{OnDelete: orc.OnDeleteDetach},
 			},
 		},
 		{

--- a/test/e2e/util/options.go
+++ b/test/e2e/util/options.go
@@ -220,14 +220,6 @@ func (o *Options) DefaultNoneOptions() none.RawCreateOptions {
 }
 
 func (p *Options) DefaultOpenStackOptions() hypershiftopenstack.RawCreateOptions {
-	var e2eOpenStackImageRetentionPolicy hyperv1.RetentionPolicy
-	if p.ConfigurableClusterOptions.OpenStackImageRetentionPolicy == "" {
-		// Default to orphaning images for e2e tests so they can be reused
-		// across multiple tests.
-		e2eOpenStackImageRetentionPolicy = hyperv1.OrphanRetentionPolicy
-	} else {
-		e2eOpenStackImageRetentionPolicy = p.ConfigurableClusterOptions.OpenStackImageRetentionPolicy
-	}
 	opts := hypershiftopenstack.RawCreateOptions{
 		OpenStackCredentialsFile:   p.ConfigurableClusterOptions.OpenStackCredentialsFile,
 		OpenStackCACertFile:        p.ConfigurableClusterOptions.OpenStackCACertFile,
@@ -239,7 +231,7 @@ func (p *Options) DefaultOpenStackOptions() hypershiftopenstack.RawCreateOptions
 			},
 		},
 		OpenStackDNSNameservers:       p.ConfigurableClusterOptions.OpenStackDNSNameservers,
-		OpenStackImageRetentionPolicy: e2eOpenStackImageRetentionPolicy,
+		OpenStackImageRetentionPolicy: p.ConfigurableClusterOptions.OpenStackImageRetentionPolicy,
 	}
 
 	return opts

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/openstack.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/openstack.go
@@ -17,7 +17,7 @@ const (
 
 	// PruneRetentionPolicy is the default policy for handling OpenStack Glance Images
 	// when the HostedCluster is deleted.
-	DefaultImageRetentionPolicy RetentionPolicy = PruneRetentionPolicy
+	DefaultImageRetentionPolicy RetentionPolicy = OrphanRetentionPolicy
 )
 
 func (p *RetentionPolicy) String() string {
@@ -165,9 +165,9 @@ type OpenStackPlatformSpec struct {
 
 	// imageRetentionPolicy defines the policy for handling resources associated with the image
 	// when the cluster is deleted.
-	// The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
-	// behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
-	// HostedCluster deletion.
+	// The default (set by the Nodepool controller) is to orphan the image so that it can be
+	// used by other clusters. If the image is no longer needed, it can be manually deleted.
+	// If the image is set to be pruned, it will be deleted when the cluster is deleted.
 	// It is defined at the HostedCluster level and will be used for all nodepools images
 	// so there is no conflict between different ORC objects.
 	// On day 2 operations, if this field is changed, the corresponding ORC object will be updated


### PR DESCRIPTION
**What this PR does / why we need it**:

We have introduced a new feature where ORC handles the lifecycle of
OpenStack Glance images for the release image from OpenShift mirrors.
By default, we were deleting the image when the HostedCluster was
deleted.
But this will be problematic when a customer deploys more than one
HostedCluster, and then after the deletion of one of them the image
would have been destroyed, which would be problematic for the other
HostedCluster where a Nodepools couldn't be scaled up for example.

It is safer to orphan the images (with proper documentation that they
are orphaned) and provide an option to let them follow the
HostedCluster's lifecycle when desired (also documented).

The default in ORC is to delete the image once the ORC object is deleted
but this would cause problems for us in Hypershift, so we don't follow
that default.

This patch updates API, code, tests and docs to address that change.
