### PR TITLE
NO-JIRA: openstack: fix e2e on 4.18

### DIFF
--- a/test/e2e/nodepool_osp_advanced_test.go
+++ b/test/e2e/nodepool_osp_advanced_test.go
@@ -57,9 +57,9 @@ func (o OpenStackAdvancedTest) Setup(t *testing.T) {
 		t.Skip("test only supported on platform OpenStack")
 	}
 
-	// The features that are being tested here is only available in 4.18+
-	if e2eutil.IsLessThan(e2eutil.Version418) {
-		t.Skip("test only applicable for 4.18+")
+	// The features that are being tested here is only available in 4.19+
+	if e2eutil.IsLessThan(e2eutil.Version419) {
+		t.Skip("test only applicable for 4.19+")
 	}
 }
 

--- a/test/e2e/util/options.go
+++ b/test/e2e/util/options.go
@@ -219,6 +219,11 @@ func (o *Options) DefaultNoneOptions() none.RawCreateOptions {
 }
 
 func (p *Options) DefaultOpenStackOptions() hypershiftopenstack.RawCreateOptions {
+	var imageName string
+	// ORC was introduced in 4.19 so before that we all HostedClusters will use the same image.
+	if IsLessThan(Version419) {
+		imageName = p.ConfigurableClusterOptions.OpenStackNodeImageName
+	}
 	opts := hypershiftopenstack.RawCreateOptions{
 		OpenStackCredentialsFile:   p.ConfigurableClusterOptions.OpenStackCredentialsFile,
 		OpenStackCACertFile:        p.ConfigurableClusterOptions.OpenStackCACertFile,
@@ -227,6 +232,7 @@ func (p *Options) DefaultOpenStackOptions() hypershiftopenstack.RawCreateOptions
 			OpenStackPlatformOptions: &openstacknodepool.OpenStackPlatformOptions{
 				Flavor:         p.ConfigurableClusterOptions.OpenStackNodeFlavor,
 				AvailabityZone: p.ConfigurableClusterOptions.OpenStackNodeAvailabilityZone,
+				ImageName:      imageName,
 			},
 		},
 		OpenStackDNSNameservers: p.ConfigurableClusterOptions.OpenStackDNSNameservers,


### PR DESCRIPTION
**What this PR does / why we need it**:

We introduced ORC in 4.19 but we still need to use the parameter to
provide an image when testing 4.18 since ORC isn't deployed.

