### PR TITLE
NO-JIRA: openstack: revert `OpenStackImageRetentionPolicy` + use a unique image name per Hosted Cluster

### DIFF
--- a/api/hypershift/v1beta1/openstack.go
+++ b/api/hypershift/v1beta1/openstack.go
@@ -1,7 +1,5 @@
 package v1beta1
 
-import "fmt"
-
 // PortSecurityPolicy defines whether or not to enable port security on a port.
 type PortSecurityPolicy string
 
@@ -14,31 +12,7 @@ const (
 
 	// PortSecurityDefault uses the default port security policy.
 	PortSecurityDefault PortSecurityPolicy = ""
-
-	// PruneRetentionPolicy is the default policy for handling OpenStack Glance Images
-	// when the HostedCluster is deleted.
-	DefaultImageRetentionPolicy RetentionPolicy = PruneRetentionPolicy
 )
-
-func (p *RetentionPolicy) String() string {
-	return string(*p)
-}
-
-func (p *RetentionPolicy) Set(s string) error {
-	switch s {
-	case string(OrphanRetentionPolicy):
-		*p = OrphanRetentionPolicy
-	case string(PruneRetentionPolicy):
-		*p = PruneRetentionPolicy
-	default:
-		return fmt.Errorf("invalid RetentionPolicy: %s", s)
-	}
-	return nil
-}
-
-func (p *RetentionPolicy) Type() string {
-	return "RetentionPolicy"
-}
 
 type OpenStackNodePoolPlatform struct {
 	// Flavor is the OpenStack flavor to use for the node instances.
@@ -162,20 +136,6 @@ type OpenStackPlatformSpec struct {
 	// +kubebuilder:validation:XValidation:rule="isIP(self)",message="floatingIP must be a valid IPv4 or IPv6 address"
 	// +optional
 	IngressFloatingIP string `json:"ingressFloatingIP,omitempty"`
-
-	// imageRetentionPolicy defines the policy for handling resources associated with the image
-	// when the cluster is deleted.
-	// The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
-	// behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
-	// HostedCluster deletion.
-	// It is defined at the HostedCluster level and will be used for all nodepools images
-	// so there is no conflict between different ORC objects.
-	// On day 2 operations, if this field is changed, the corresponding ORC object will be updated
-	// to reflect the chosen retention policy (prune or orphan) which is translated into ORC format
-	// (either 'delete' or 'detach' in ORC terminology).
-	//
-	// +optional
-	ImageRetentionPolicy RetentionPolicy `json:"imageRetentionPolicy,omitempty"`
 }
 
 // OpenStackIdentityReference is a reference to an infrastructure

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -4001,22 +4001,6 @@ spec:
                         - cloudName
                         - name
                         type: object
-                      imageRetentionPolicy:
-                        description: |-
-                          imageRetentionPolicy defines the policy for handling resources associated with the image
-                          when the cluster is deleted.
-                          The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
-                          behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
-                          HostedCluster deletion.
-                          It is defined at the HostedCluster level and will be used for all nodepools images
-                          so there is no conflict between different ORC objects.
-                          On day 2 operations, if this field is changed, the corresponding ORC object will be updated
-                          to reflect the chosen retention policy (prune or orphan) which is translated into ORC format
-                          (either 'delete' or 'detach' in ORC terminology).
-                        enum:
-                        - Orphan
-                        - Prune
-                        type: string
                       ingressFloatingIP:
                         description: |-
                           IngressFloatingIP is an available floating IP in your OpenStack cluster that will

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -3886,22 +3886,6 @@ spec:
                         - cloudName
                         - name
                         type: object
-                      imageRetentionPolicy:
-                        description: |-
-                          imageRetentionPolicy defines the policy for handling resources associated with the image
-                          when the cluster is deleted.
-                          The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
-                          behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
-                          HostedCluster deletion.
-                          It is defined at the HostedCluster level and will be used for all nodepools images
-                          so there is no conflict between different ORC objects.
-                          On day 2 operations, if this field is changed, the corresponding ORC object will be updated
-                          to reflect the chosen retention policy (prune or orphan) which is translated into ORC format
-                          (either 'delete' or 'detach' in ORC terminology).
-                        enum:
-                        - Orphan
-                        - Prune
-                        type: string
                       ingressFloatingIP:
                         description: |-
                           IngressFloatingIP is an available floating IP in your OpenStack cluster that will

--- a/client/applyconfiguration/hypershift/v1beta1/openstackplatformspec.go
+++ b/client/applyconfiguration/hypershift/v1beta1/openstackplatformspec.go
@@ -17,10 +17,6 @@ limitations under the License.
 
 package v1beta1
 
-import (
-	hypershiftv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
-)
-
 // OpenStackPlatformSpecApplyConfiguration represents an declarative configuration of the OpenStackPlatformSpec type for use
 // with apply.
 type OpenStackPlatformSpecApplyConfiguration struct {
@@ -34,7 +30,6 @@ type OpenStackPlatformSpecApplyConfiguration struct {
 	DisableExternalNetwork *bool                                         `json:"disableExternalNetwork,omitempty"`
 	Tags                   []string                                      `json:"tags,omitempty"`
 	IngressFloatingIP      *string                                       `json:"ingressFloatingIP,omitempty"`
-	ImageRetentionPolicy   *hypershiftv1beta1.RetentionPolicy            `json:"imageRetentionPolicy,omitempty"`
 }
 
 // OpenStackPlatformSpecApplyConfiguration constructs an declarative configuration of the OpenStackPlatformSpec type for use with
@@ -132,13 +127,5 @@ func (b *OpenStackPlatformSpecApplyConfiguration) WithTags(values ...string) *Op
 // If called multiple times, the IngressFloatingIP field is set to the value of the last call.
 func (b *OpenStackPlatformSpecApplyConfiguration) WithIngressFloatingIP(value string) *OpenStackPlatformSpecApplyConfiguration {
 	b.IngressFloatingIP = &value
-	return b
-}
-
-// WithImageRetentionPolicy sets the ImageRetentionPolicy field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the ImageRetentionPolicy field is set to the value of the last call.
-func (b *OpenStackPlatformSpecApplyConfiguration) WithImageRetentionPolicy(value hypershiftv1beta1.RetentionPolicy) *OpenStackPlatformSpecApplyConfiguration {
-	b.ImageRetentionPolicy = &value
 	return b
 }

--- a/cmd/cluster/openstack/create_test.go
+++ b/cmd/cluster/openstack/create_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/testutil"
@@ -309,40 +308,4 @@ func TestExtractCloud(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
-}
-func TestValidateRetentionPolicy(t *testing.T) {
-	testCases := []struct {
-		name          string
-		policy        hyperv1.RetentionPolicy
-		expectedError string
-	}{
-		{
-			name: "empty policy",
-		},
-		{
-			name:          "invalid policy",
-			policy:        "invalid",
-			expectedError: "invalid retention policy: invalid",
-		},
-		{
-			name:   "orphan policy",
-			policy: "Orphan",
-		},
-		{
-			name:   "prune policy",
-			policy: "Prune",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := validateRetentionPolicy(tc.policy)
-			if tc.expectedError == "" {
-				assert.NoError(t, err)
-			} else {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), tc.expectedError)
-			}
-		})
-	}
 }

--- a/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_default_creation_flags.yaml
+++ b/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_default_creation_flags.yaml
@@ -81,7 +81,6 @@ spec:
       identityRef:
         cloudName: openstack
         name: test-cloud-credentials
-      imageRetentionPolicy: Prune
     type: OpenStack
   pullSecret:
     name: test-pull-secret

--- a/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -76,7 +76,6 @@ spec:
       identityRef:
         cloudName: openstack
         name: example-cloud-credentials
-      imageRetentionPolicy: Prune
     type: OpenStack
   pullSecret:
     name: example-pull-secret

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
@@ -4533,22 +4533,6 @@ spec:
                         - cloudName
                         - name
                         type: object
-                      imageRetentionPolicy:
-                        description: |-
-                          imageRetentionPolicy defines the policy for handling resources associated with the image
-                          when the cluster is deleted.
-                          The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
-                          behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
-                          HostedCluster deletion.
-                          It is defined at the HostedCluster level and will be used for all nodepools images
-                          so there is no conflict between different ORC objects.
-                          On day 2 operations, if this field is changed, the corresponding ORC object will be updated
-                          to reflect the chosen retention policy (prune or orphan) which is translated into ORC format
-                          (either 'delete' or 'detach' in ORC terminology).
-                        enum:
-                        - Orphan
-                        - Prune
-                        type: string
                       ingressFloatingIP:
                         description: |-
                           IngressFloatingIP is an available floating IP in your OpenStack cluster that will

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
@@ -4515,22 +4515,6 @@ spec:
                         - cloudName
                         - name
                         type: object
-                      imageRetentionPolicy:
-                        description: |-
-                          imageRetentionPolicy defines the policy for handling resources associated with the image
-                          when the cluster is deleted.
-                          The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
-                          behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
-                          HostedCluster deletion.
-                          It is defined at the HostedCluster level and will be used for all nodepools images
-                          so there is no conflict between different ORC objects.
-                          On day 2 operations, if this field is changed, the corresponding ORC object will be updated
-                          to reflect the chosen retention policy (prune or orphan) which is translated into ORC format
-                          (either 'delete' or 'detach' in ORC terminology).
-                        enum:
-                        - Orphan
-                        - Prune
-                        type: string
                       ingressFloatingIP:
                         description: |-
                           IngressFloatingIP is an available floating IP in your OpenStack cluster that will

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
@@ -4418,22 +4418,6 @@ spec:
                         - cloudName
                         - name
                         type: object
-                      imageRetentionPolicy:
-                        description: |-
-                          imageRetentionPolicy defines the policy for handling resources associated with the image
-                          when the cluster is deleted.
-                          The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
-                          behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
-                          HostedCluster deletion.
-                          It is defined at the HostedCluster level and will be used for all nodepools images
-                          so there is no conflict between different ORC objects.
-                          On day 2 operations, if this field is changed, the corresponding ORC object will be updated
-                          to reflect the chosen retention policy (prune or orphan) which is translated into ORC format
-                          (either 'delete' or 'detach' in ORC terminology).
-                        enum:
-                        - Orphan
-                        - Prune
-                        type: string
                       ingressFloatingIP:
                         description: |-
                           IngressFloatingIP is an available floating IP in your OpenStack cluster that will

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
@@ -4400,22 +4400,6 @@ spec:
                         - cloudName
                         - name
                         type: object
-                      imageRetentionPolicy:
-                        description: |-
-                          imageRetentionPolicy defines the policy for handling resources associated with the image
-                          when the cluster is deleted.
-                          The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
-                          behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
-                          HostedCluster deletion.
-                          It is defined at the HostedCluster level and will be used for all nodepools images
-                          so there is no conflict between different ORC objects.
-                          On day 2 operations, if this field is changed, the corresponding ORC object will be updated
-                          to reflect the chosen retention policy (prune or orphan) which is translated into ORC format
-                          (either 'delete' or 'detach' in ORC terminology).
-                        enum:
-                        - Orphan
-                        - Prune
-                        type: string
                       ingressFloatingIP:
                         description: |-
                           IngressFloatingIP is an available floating IP in your OpenStack cluster that will

--- a/docs/content/how-to/openstack/hostedcluster.md
+++ b/docs/content/how-to/openstack/hostedcluster.md
@@ -14,7 +14,6 @@ Here are the available options specific to the OpenStack platform:
 | `--openstack-node-additional-port`      | Attach additional ports to nodes. Params: `network-id`, `vnic-type`, `disable-port-security`, `address-pairs`. | No       |               |
 | `--openstack-node-availability-zone`    | Availability zone for the nodepool                                                           | No       |               |
 | `--openstack-node-flavor`               | Flavor for the nodepool                                                                      | Yes      |               |
-| `--openstack-image-retention-policy`    | OpenStack Glance Image retention policy. Valid values are 'Orphan' and 'Prune'.              | No       | `Prune`       |
 | `--openstack-node-image-name`           | Image name for the nodepool                                                                  | No       |               |
 | `--openstack-dns-nameservers`           | List of DNS server addresses that will be provided when creating the subnet                  | No       |               |
 

--- a/docs/content/how-to/openstack/hostedcluster.md
+++ b/docs/content/how-to/openstack/hostedcluster.md
@@ -89,9 +89,8 @@ hcp create cluster openstack \
 !!! note
 
     When not providing the `--openstack-node-image-name` flag, the latest RHCOS image will be used.
-    ORC will handle the RHCOS image lifecycle by downloading the image from the OpenShift mirror and deleting it when it's no longer needed.
-    If you want ORC to not delete the image, you can create the HostedCluster with the following option: `--openstack-image-retention-policy=Orphan`.
-    This will prevent ORC from deleting the image resource.
+    ORC will handle the RHCOS image lifecycle by downloading the image from the OpenShift mirror and deleting it when the HostedCluster is deleted.
+    The OpenStack Glance Image will be named like this: `<hosted-cluster-name>-rhcos-<rhcos-version>`.
 
 After a few moments we should see our hosted control plane pods up and running:
 

--- a/docs/content/how-to/openstack/prerequisites.md
+++ b/docs/content/how-to/openstack/prerequisites.md
@@ -81,8 +81,7 @@ Follow this [procedure](etcd-local-storage.md) to leverage a well-known and test
 The user can specify which RHCOS image to use when deploying the node pools
 on OpenStack by uploading the image to the OpenStack cloud. If the image is not
 uploaded to OpenStack, [OpenStack Resource Controller (ORC)](https://github.com/k-orc/openstack-resource-controller) will
-manage the RHCOS image lifecycle by downloading the image from the OpenShift mirror and deleting it when it's no longer needed
-or left as an orphan image that can be re-used by other clusters and deleted when it's no longer needed.
+manage the RHCOS image lifecycle by downloading the image from the OpenShift mirror and deleting it when the HostedCluster is deleted.
 
 Here is an example of how to upload an RHCOS image to OpenStack:
 

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -9448,29 +9448,6 @@ balancer.
 This value must be a valid IPv4 or IPv6 address.</p>
 </td>
 </tr>
-<tr>
-<td>
-<code>imageRetentionPolicy</code></br>
-<em>
-<a href="#hypershift.openshift.io/v1beta1.RetentionPolicy">
-RetentionPolicy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>imageRetentionPolicy defines the policy for handling resources associated with the image
-when the cluster is deleted.
-The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
-behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
-HostedCluster deletion.
-It is defined at the HostedCluster level and will be used for all nodepools images
-so there is no conflict between different ORC objects.
-On day 2 operations, if this field is changed, the corresponding ORC object will be updated
-to reflect the chosen retention policy (prune or orphan) which is translated into ORC format
-(either &lsquo;delete&rsquo; or &lsquo;detach&rsquo; in ORC terminology).</p>
-</td>
-</tr>
 </tbody>
 </table>
 ###OperatorConfiguration { #hypershift.openshift.io/v1beta1.OperatorConfiguration }
@@ -10653,10 +10630,6 @@ creating new nodes and deleting the old ones.</p>
 </table>
 ###RetentionPolicy { #hypershift.openshift.io/v1beta1.RetentionPolicy }
 <p>
-(<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.OpenStackPlatformSpec">OpenStackPlatformSpec</a>)
-</p>
-<p>
 <p>RetentionPolicy defines the policy for handling resources associated with a cluster when the cluster is deleted.</p>
 </p>
 <table>
@@ -10666,11 +10639,7 @@ creating new nodes and deleting the old ones.</p>
 <th>Description</th>
 </tr>
 </thead>
-<tbody><tr><td><p>&#34;Prune&#34;</p></td>
-<td><p>PruneRetentionPolicy is the default policy for handling OpenStack Glance Images
-when the HostedCluster is deleted.</p>
-</td>
-</tr><tr><td><p>&#34;Orphan&#34;</p></td>
+<tbody><tr><td><p>&#34;Orphan&#34;</p></td>
 <td><p>OrphanRetentionPolicy will keep the resources associated with the cluster
 when the cluster is deleted.</p>
 </td>

--- a/hypershift-operator/controllers/nodepool/openstack.go
+++ b/hypershift-operator/controllers/nodepool/openstack.go
@@ -74,7 +74,7 @@ func (r *NodePoolReconciler) reconcileOpenStackImageCR(ctx context.Context, clie
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					// Since there is no code that deletes the ORC image object, the only way the OpenStack Glance image
-					// can be deleted is when the OpenStackCluster CR is deleted and that the imageRetentionPolicy is set to "Prune".
+					// can be deleted is when the OpenStackCluster CR is deleted.
 					// That means Nodepools can share the same image and changing the image of a Nodepool will not affect the other Nodepools.
 					APIVersion: openstackCluster.APIVersion,
 					Kind:       openstackCluster.Kind,

--- a/hypershift-operator/controllers/nodepool/openstack/openstack_test.go
+++ b/hypershift-operator/controllers/nodepool/openstack/openstack_test.go
@@ -333,8 +333,11 @@ func TestReconcileOpenStackImageSpec(t *testing.T) {
 		expectedErrorSubstring string
 	}{
 		{
-			name: "valid configuration with no retention policy",
+			name: "valid configuration",
 			hostedCluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
 				Spec: hyperv1.HostedClusterSpec{
 					Platform: hyperv1.PlatformSpec{
 						OpenStack: &hyperv1.OpenStackPlatformSpec{
@@ -373,7 +376,7 @@ func TestReconcileOpenStackImageSpec(t *testing.T) {
 					CloudName:  "test-cloud",
 				},
 				Resource: &orc.ImageResourceSpec{
-					Name: "rhcos-4.9.0",
+					Name: "test-cluster-rhcos-4.9.0",
 					Content: &orc.ImageContent{
 						ContainerFormat: "bare",
 						DiskFormat:      "qcow2",
@@ -387,165 +390,7 @@ func TestReconcileOpenStackImageSpec(t *testing.T) {
 						},
 					},
 				},
-				ManagedOptions: &orc.ManagedOptions{OnDelete: orc.OnDeleteDelete},
 			},
-		},
-		{
-			name: "valid configuration with orphan retention policy",
-			hostedCluster: &hyperv1.HostedCluster{
-				Spec: hyperv1.HostedClusterSpec{
-					Platform: hyperv1.PlatformSpec{
-						OpenStack: &hyperv1.OpenStackPlatformSpec{
-							IdentityRef: hyperv1.OpenStackIdentityReference{
-								Name:      "test-secret",
-								CloudName: "test-cloud",
-							},
-							ImageRetentionPolicy: hyperv1.OrphanRetentionPolicy,
-						},
-					},
-				},
-			},
-			releaseImage: &releaseinfo.ReleaseImage{
-				StreamMetadata: &releaseinfo.CoreOSStreamMetadata{
-					Architectures: map[string]releaseinfo.CoreOSArchitecture{
-						"x86_64": {
-							Artifacts: map[string]releaseinfo.CoreOSArtifact{
-								"openstack": {
-									Release: "4.9.0",
-									Formats: map[string]map[string]releaseinfo.CoreOSFormat{
-										"qcow2.gz": {
-											"disk": {
-												Location: "https://example.com/image.qcow2.gz",
-												SHA256:   "abcdef1234567890",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			expectedImageSpec: &orc.ImageSpec{
-				CloudCredentialsRef: orc.CloudCredentialsReference{
-					SecretName: "test-secret",
-					CloudName:  "test-cloud",
-				},
-				Resource: &orc.ImageResourceSpec{
-					Name: "rhcos-4.9.0",
-					Content: &orc.ImageContent{
-						ContainerFormat: "bare",
-						DiskFormat:      "qcow2",
-						Download: &orc.ImageContentSourceDownload{
-							URL:        "https://example.com/image.qcow2.gz",
-							Decompress: ptr.To(orc.ImageCompressionGZ),
-							Hash: &orc.ImageHash{
-								Algorithm: "sha256",
-								Value:     "abcdef1234567890",
-							},
-						},
-					},
-				},
-				ManagedOptions: &orc.ManagedOptions{OnDelete: orc.OnDeleteDetach},
-			},
-		},
-		{
-			name: "valid configuration with prune retention policy",
-			hostedCluster: &hyperv1.HostedCluster{
-				Spec: hyperv1.HostedClusterSpec{
-					Platform: hyperv1.PlatformSpec{
-						OpenStack: &hyperv1.OpenStackPlatformSpec{
-							IdentityRef: hyperv1.OpenStackIdentityReference{
-								Name:      "test-secret",
-								CloudName: "test-cloud",
-							},
-							ImageRetentionPolicy: hyperv1.PruneRetentionPolicy,
-						},
-					},
-				},
-			},
-			releaseImage: &releaseinfo.ReleaseImage{
-				StreamMetadata: &releaseinfo.CoreOSStreamMetadata{
-					Architectures: map[string]releaseinfo.CoreOSArchitecture{
-						"x86_64": {
-							Artifacts: map[string]releaseinfo.CoreOSArtifact{
-								"openstack": {
-									Release: "4.9.0",
-									Formats: map[string]map[string]releaseinfo.CoreOSFormat{
-										"qcow2.gz": {
-											"disk": {
-												Location: "https://example.com/image.qcow2.gz",
-												SHA256:   "abcdef1234567890",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			expectedImageSpec: &orc.ImageSpec{
-				CloudCredentialsRef: orc.CloudCredentialsReference{
-					SecretName: "test-secret",
-					CloudName:  "test-cloud",
-				},
-				Resource: &orc.ImageResourceSpec{
-					Name: "rhcos-4.9.0",
-					Content: &orc.ImageContent{
-						ContainerFormat: "bare",
-						DiskFormat:      "qcow2",
-						Download: &orc.ImageContentSourceDownload{
-							URL:        "https://example.com/image.qcow2.gz",
-							Decompress: ptr.To(orc.ImageCompressionGZ),
-							Hash: &orc.ImageHash{
-								Algorithm: "sha256",
-								Value:     "abcdef1234567890",
-							},
-						},
-					},
-				},
-				ManagedOptions: &orc.ManagedOptions{OnDelete: orc.OnDeleteDelete},
-			},
-		},
-		{
-			name: "invalid retention policy",
-			hostedCluster: &hyperv1.HostedCluster{
-				Spec: hyperv1.HostedClusterSpec{
-					Platform: hyperv1.PlatformSpec{
-						OpenStack: &hyperv1.OpenStackPlatformSpec{
-							IdentityRef: hyperv1.OpenStackIdentityReference{
-								Name:      "test-secret",
-								CloudName: "test-cloud",
-							},
-							ImageRetentionPolicy: "invalid",
-						},
-					},
-				},
-			},
-			releaseImage: &releaseinfo.ReleaseImage{
-				StreamMetadata: &releaseinfo.CoreOSStreamMetadata{
-					Architectures: map[string]releaseinfo.CoreOSArchitecture{
-						"x86_64": {
-							Artifacts: map[string]releaseinfo.CoreOSArtifact{
-								"openstack": {
-									Release: "4.9.0",
-									Formats: map[string]map[string]releaseinfo.CoreOSFormat{
-										"qcow2.gz": {
-											"disk": {
-												Location: "https://example.com/image.qcow2.gz",
-												SHA256:   "abcdef1234567890",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			expectedError:          true,
-			expectedErrorSubstring: "unsupported image retention policy",
 		},
 		{
 			name: "release image error",
@@ -557,7 +402,6 @@ func TestReconcileOpenStackImageSpec(t *testing.T) {
 								Name:      "test-secret",
 								CloudName: "test-cloud",
 							},
-							ImageRetentionPolicy: hyperv1.PruneRetentionPolicy,
 						},
 					},
 				},
@@ -672,7 +516,7 @@ func TestClusterImageName(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := ClusterImageName(tc.hostedCluster, tc.releaseImage)
+			result, err := PrefixedClusterImageName(tc.hostedCluster, tc.releaseImage)
 			if tc.expectedError {
 				if err == nil {
 					t.Error("expected error but got nil")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -138,7 +138,6 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.ConfigurableClusterOptions.OpenStackNodeFlavor, "e2e.openstack-node-flavor", "", "The flavor to use for OpenStack nodes")
 	flag.StringVar(&globalOpts.ConfigurableClusterOptions.OpenStackNodeImageName, "e2e.openstack-node-image-name", "", "The image name to use for OpenStack nodes")
 	flag.Var(&globalOpts.ConfigurableClusterOptions.OpenStackDNSNameservers, "e2e.openstack-dns-nameservers", "List of DNS nameservers to use for the cluster")
-	flag.Var(&globalOpts.ConfigurableClusterOptions.OpenStackImageRetentionPolicy, "e2e.openstack-image-retention-policy", "The image retention policy to use for OpenStack nodes. Valid values are 'Orphan' and 'Prune'. When not set, images will be retained indefinitely so that they can be reused by other tests")
 
 	// PowerVS specific flags
 	flag.BoolVar(&globalOpts.ConfigurableClusterOptions.PowerVSPER, "e2e-powervs-power-edge-router", false, "Enabling this flag will utilize Power Edge Router solution via transit gateway instead of cloud connection to create a connection between PowerVS and VPC")

--- a/test/e2e/util/options.go
+++ b/test/e2e/util/options.go
@@ -129,7 +129,6 @@ type ConfigurableClusterOptions struct {
 	OpenStackNodeFlavor                   string
 	OpenStackNodeImageName                string
 	OpenStackDNSNameservers               stringSliceVar
-	OpenStackImageRetentionPolicy         hyperv1.RetentionPolicy
 	PowerVSCloudConnection                string
 	PowerVSCloudInstanceID                string
 	PowerVSMemory                         int
@@ -220,14 +219,6 @@ func (o *Options) DefaultNoneOptions() none.RawCreateOptions {
 }
 
 func (p *Options) DefaultOpenStackOptions() hypershiftopenstack.RawCreateOptions {
-	var e2eOpenStackImageRetentionPolicy hyperv1.RetentionPolicy
-	if p.ConfigurableClusterOptions.OpenStackImageRetentionPolicy == "" {
-		// Default to orphaning images for e2e tests so they can be reused
-		// across multiple tests.
-		e2eOpenStackImageRetentionPolicy = hyperv1.OrphanRetentionPolicy
-	} else {
-		e2eOpenStackImageRetentionPolicy = p.ConfigurableClusterOptions.OpenStackImageRetentionPolicy
-	}
 	opts := hypershiftopenstack.RawCreateOptions{
 		OpenStackCredentialsFile:   p.ConfigurableClusterOptions.OpenStackCredentialsFile,
 		OpenStackCACertFile:        p.ConfigurableClusterOptions.OpenStackCACertFile,
@@ -238,8 +229,7 @@ func (p *Options) DefaultOpenStackOptions() hypershiftopenstack.RawCreateOptions
 				AvailabityZone: p.ConfigurableClusterOptions.OpenStackNodeAvailabilityZone,
 			},
 		},
-		OpenStackDNSNameservers:       p.ConfigurableClusterOptions.OpenStackDNSNameservers,
-		OpenStackImageRetentionPolicy: e2eOpenStackImageRetentionPolicy,
+		OpenStackDNSNameservers: p.ConfigurableClusterOptions.OpenStackDNSNameservers,
 	}
 
 	return opts

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/openstack.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/openstack.go
@@ -1,7 +1,5 @@
 package v1beta1
 
-import "fmt"
-
 // PortSecurityPolicy defines whether or not to enable port security on a port.
 type PortSecurityPolicy string
 
@@ -14,31 +12,7 @@ const (
 
 	// PortSecurityDefault uses the default port security policy.
 	PortSecurityDefault PortSecurityPolicy = ""
-
-	// PruneRetentionPolicy is the default policy for handling OpenStack Glance Images
-	// when the HostedCluster is deleted.
-	DefaultImageRetentionPolicy RetentionPolicy = PruneRetentionPolicy
 )
-
-func (p *RetentionPolicy) String() string {
-	return string(*p)
-}
-
-func (p *RetentionPolicy) Set(s string) error {
-	switch s {
-	case string(OrphanRetentionPolicy):
-		*p = OrphanRetentionPolicy
-	case string(PruneRetentionPolicy):
-		*p = PruneRetentionPolicy
-	default:
-		return fmt.Errorf("invalid RetentionPolicy: %s", s)
-	}
-	return nil
-}
-
-func (p *RetentionPolicy) Type() string {
-	return "RetentionPolicy"
-}
 
 type OpenStackNodePoolPlatform struct {
 	// Flavor is the OpenStack flavor to use for the node instances.
@@ -162,20 +136,6 @@ type OpenStackPlatformSpec struct {
 	// +kubebuilder:validation:XValidation:rule="isIP(self)",message="floatingIP must be a valid IPv4 or IPv6 address"
 	// +optional
 	IngressFloatingIP string `json:"ingressFloatingIP,omitempty"`
-
-	// imageRetentionPolicy defines the policy for handling resources associated with the image
-	// when the cluster is deleted.
-	// The default (set by the Nodepool controller) matches OpenStack Resource Controller (ORC)
-	// behavior where the OpenStack Glance Image is pruned when the Image object is deleted during the
-	// HostedCluster deletion.
-	// It is defined at the HostedCluster level and will be used for all nodepools images
-	// so there is no conflict between different ORC objects.
-	// On day 2 operations, if this field is changed, the corresponding ORC object will be updated
-	// to reflect the chosen retention policy (prune or orphan) which is translated into ORC format
-	// (either 'delete' or 'detach' in ORC terminology).
-	//
-	// +optional
-	ImageRetentionPolicy RetentionPolicy `json:"imageRetentionPolicy,omitempty"`
 }
 
 // OpenStackIdentityReference is a reference to an infrastructure


### PR DESCRIPTION
**What this PR does / why we need it**:

- Revert of `OpenStackImageRetentionPolicy` for now. We have identified that the current code that was implemented isn't suitable for production.
  We want to re-work it but in the meantime we just revert it.
- Added `ClusterImageName` function to encapsulate image name generation for a HostedCluster.
- Updated `reconcileOpenStackImageCR` and `ReconcileOpenStackImageSpec`
  to use `ClusterImageName` instead of manually constructing image names.
- Use an image name that now contains the Hosted Cluster name in it so
  it's unique and per Hosted Cluster. The OpenStack Glance image won't
  be shared across Hosted Clusters and its lifecycle will be the same as
  the HostedCluster using it (by default).
