### PR TITLE
CNTRLPLANE-111: Authenticate to Azure only once in CPO

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -159,6 +160,8 @@ const (
 
 	hcpReadyRequeueInterval    = 1 * time.Minute
 	hcpNotReadyRequeueInterval = 15 * time.Second
+
+	azureCredentials = "AzureCredentials"
 )
 
 var (
@@ -193,6 +196,7 @@ type HostedControlPlaneReconciler struct {
 	reconcileInfrastructureStatus           func(ctx context.Context, hcp *hyperv1.HostedControlPlane) (infra.InfrastructureStatus, error)
 	EnableCVOManagementClusterMetricsAccess bool
 	ImageMetadataProvider                   util.ImageMetadataProvider
+	azureCredentialsLoaded                  sync.Map
 
 	IsCPOV2 bool
 }
@@ -900,7 +904,7 @@ func (r *HostedControlPlaneReconciler) validateConfigAndClusterCapabilities(ctx 
 	}
 
 	if hyperazureutil.IsAroHCP() {
-		if err := verifyResourceGroupLocationsMatch(ctx, hcp); err != nil {
+		if err := r.verifyResourceGroupLocationsMatch(ctx, hcp); err != nil {
 			return err
 		}
 	}
@@ -5604,11 +5608,32 @@ func doesOpenShiftTrustedCABundleConfigMapForCPOExist(ctx context.Context, c cli
 }
 
 // verifyResourceGroupLocationsMatch verifies the locations match for the VNET, network security group, and managed resource groups
-func verifyResourceGroupLocationsMatch(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
-	certPath := config.ManagedAzureCertificatePath + hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ControlPlaneOperator.CredentialsSecretName
-	creds, err := dataplane.NewUserAssignedIdentityCredential(ctx, certPath, dataplane.WithClientOpts(azcore.ClientOptions{Cloud: cloud.AzurePublic}))
-	if err != nil {
-		return fmt.Errorf("failed to create azure creds to verify resource group locations: %v", err)
+func (r *HostedControlPlaneReconciler) verifyResourceGroupLocationsMatch(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
+	var (
+		creds     azcore.TokenCredential
+		found, ok bool
+		err       error
+	)
+
+	key := hcp.Namespace + azureCredentials
+	log := ctrl.LoggerFrom(ctx)
+
+	// We need to only store the Azure credentials once and reuse them after that.
+	storedCreds, found := r.azureCredentialsLoaded.Load(key)
+	if !found {
+		certPath := config.ManagedAzureCertificatePath + hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ControlPlaneOperator.CredentialsSecretName
+		creds, err = dataplane.NewUserAssignedIdentityCredential(ctx, certPath, dataplane.WithClientOpts(azcore.ClientOptions{Cloud: cloud.AzurePublic}), dataplane.WithLogger(&log))
+		if err != nil {
+			return fmt.Errorf("failed to create azure creds to verify resource group locations: %v", err)
+		}
+
+		r.azureCredentialsLoaded.Store(key, creds)
+		log.Info("Storing new UserAssignedManagedIdentity credentials to authenticate to Azure")
+	} else {
+		creds, ok = storedCreds.(azcore.TokenCredential)
+		if !ok {
+			return fmt.Errorf("expected %T to be a TokenCredential", storedCreds)
+		}
 	}
 
 	// Retrieve full vnet information from the VNET ID


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit changes the CPO to look for a stored Azure credential to reuse to authenticate with Azure. If there is no stored Azure credential, authenticate to Azure with UAMI and store the credentials.

Prior to this commit, the CPO was getting new credentials every reconcile; this led to an issue where the CPO would open too many filewatchers as NewUserAssignedIdentityCredential opens a new filewatcher on every call.
```
time=2025-03-06T18:58:45.994Z level=ERROR msg="failed to create file watcher" err="too many open files"
```

**Which issue(s) this PR fixes**:
A part of [CNTRLPLANE-111](https://issues.redhat.com/browse/CNTRLPLANE-111)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.