### PR TITLE
AUTOSCALE-44: add autonode karpenter drift hcp upgrade e2e test

### DIFF
--- a/support/api/scheme.go
+++ b/support/api/scheme.go
@@ -23,7 +23,9 @@ import (
 	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1beta1"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	apiserverconfigv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 	kasv1beta1 "k8s.io/apiserver/pkg/apis/apiserver/v1beta1"
@@ -40,6 +42,8 @@ import (
 	capiopenstackv1beta1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ipamv1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1beta1"
+	karpenterapis "sigs.k8s.io/karpenter/pkg/apis"
+	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	secretsstorev1 "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
 
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
@@ -114,4 +118,12 @@ func init() {
 	_ = secretsstorev1.AddToScheme(Scheme)
 	_ = kcpv1.AddToScheme(Scheme)
 	_ = orcv1alpha1.AddToScheme(Scheme)
+	karpenterGroupVersion := schema.GroupVersion{Group: karpenterapis.Group, Version: "v1"}
+	metav1.AddToGroupVersion(Scheme, karpenterGroupVersion)
+	Scheme.AddKnownTypes(karpenterGroupVersion,
+		&karpenterv1.NodeClaim{},
+		&karpenterv1.NodeClaimList{},
+		&karpenterv1.NodePool{},
+		&karpenterv1.NodePoolList{},
+	)
 }

--- a/test/e2e/assets/karpenter-workloads.yaml
+++ b/test/e2e/assets/karpenter-workloads.yaml
@@ -29,7 +29,7 @@ spec:
         name: web-app
         resources:
           requests:
-            cpu: "1"
+            cpu: "250m"
             memory: 256M
         securityContext:
           allowPrivilegeEscalation: false

--- a/test/e2e/karpenter_test.go
+++ b/test/e2e/karpenter_test.go
@@ -7,14 +7,21 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	awskarpenterv1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
 	. "github.com/onsi/gomega"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/releaseinfo"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/yaml"
 )
 
@@ -33,6 +40,8 @@ func TestKarpenter(t *testing.T) {
 
 	clusterOpts := globalOpts.DefaultClusterOptions(t)
 	clusterOpts.AWSPlatform.AutoNode = true
+	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.HighlyAvailable)
+	clusterOpts.ReleaseImage = globalOpts.PreviousReleaseImage
 
 	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 		guestClient := e2eutil.WaitForGuestClient(t, ctx, mgtClient, hostedCluster)
@@ -51,51 +60,156 @@ func TestKarpenter(t *testing.T) {
 		err = yaml.Unmarshal(yamlFile, workLoads)
 		g.Expect(err).NotTo(HaveOccurred())
 
-		// Apply both Karpenter NodePool and workloads.
-		defer guestClient.Delete(ctx, karpenterNodePool)
-		defer guestClient.Delete(ctx, workLoads)
-		g.Expect(guestClient.Create(ctx, karpenterNodePool)).To(Succeed())
-		t.Logf("Created Karpenter NodePool")
-		g.Expect(guestClient.Create(ctx, workLoads)).To(Succeed())
-		t.Logf("Created workloads")
-
-		// Wait for Karpenter Nodes.
 		nodeLabels := map[string]string{
 			"node.kubernetes.io/instance-type": "t3.large",
 			"karpenter.sh/nodepool":            karpenterNodePool.GetName(),
 		}
 
-		t.Logf("Waiting for Karpenter Nodes to come up")
-		_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, guestClient, hostedCluster.Spec.Platform.Type, 3, nodeLabels)
+		t.Run("Control plane upgrade and Karpenter Drift", func(t *testing.T) {
+			g := NewWithT(t)
 
-		// Delete both Karpenter NodePool and workloads.
-		g.Expect(guestClient.Delete(ctx, karpenterNodePool)).To(Succeed())
-		t.Logf("Deleted Karpenter NodePool")
-		g.Expect(guestClient.Delete(ctx, workLoads)).To(Succeed())
-		t.Logf("Delete workloads")
+			t.Logf("Starting Karpenter control plane upgrade. FromImage: %s, toImage: %s", globalOpts.PreviousReleaseImage, globalOpts.LatestReleaseImage)
 
-		// Wait for Karpenter Nodes to go away.
-		_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, guestClient, hostedCluster.Spec.Platform.Type, 0, nodeLabels)
-		t.Logf("Waiting for Karpenter Nodes to disappear")
+			// Lookup os and kubelet versions of the latestReleaseImage
+			releaseProvider := &releaseinfo.RegistryClientProvider{}
+			pullSecret, err := os.ReadFile(clusterOpts.PullSecretFile)
+			g.Expect(err).NotTo(HaveOccurred())
 
-		karpenterNodePool.SetResourceVersion("")
-		workLoads.SetResourceVersion("")
+			latestReleaseImage, err := releaseProvider.Lookup(ctx, globalOpts.LatestReleaseImage, pullSecret)
+			g.Expect(err).NotTo(HaveOccurred())
+			releaseImageComponentVersions, err := latestReleaseImage.ComponentVersions()
+			g.Expect(err).NotTo(HaveOccurred())
 
-		// Leave dangling resources, and hope the teardown is not blocked, else the test will fail.
-		g.Expect(guestClient.Create(ctx, karpenterNodePool)).To(Succeed())
-		t.Logf("Created Karpenter NodePool")
-		g.Expect(guestClient.Create(ctx, workLoads)).To(Succeed())
-		t.Logf("Created workloads")
+			expectedRHCOSVersion := releaseImageComponentVersions["machine-os"]
+			g.Expect(expectedRHCOSVersion).NotTo(BeEmpty())
+			expectedKubeletVersion := releaseImageComponentVersions["kubernetes"]
+			g.Expect(expectedKubeletVersion).NotTo(BeEmpty())
 
-		t.Logf("Waiting for Karpenter Nodes to come up")
-		_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, guestClient, hostedCluster.Spec.Platform.Type, 3, nodeLabels)
+			replicas := 1
+			workLoads.Object["spec"].(map[string]interface{})["replicas"] = replicas
 
-		ec2NodeClassList := &awskarpenterv1.EC2NodeClassList{}
-		g.Expect(guestClient.List(ctx, ec2NodeClassList)).To(Succeed())
-		g.Expect(ec2NodeClassList.Items).ToNot(BeEmpty())
+			// Apply both Karpenter NodePool and workloads.
+			g.Expect(guestClient.Create(ctx, karpenterNodePool)).To(Succeed())
+			t.Logf("Created Karpenter NodePool")
+			g.Expect(guestClient.Create(ctx, workLoads)).To(Succeed())
+			t.Logf("Created workloads")
 
-		ec2NodeClass := ec2NodeClassList.Items[0]
-		g.Expect(guestClient.Delete(ctx, &ec2NodeClass)).To(MatchError(ContainSubstring("EC2NodeClass resource can't be created/updated/deleted directly, please use OpenshiftEC2NodeClass resource instead")))
+			// Wait for Nodes, NodeClaims and Pods to be ready.
+			nodes := e2eutil.WaitForReadyNodesByLabels(t, ctx, guestClient, hostedCluster.Spec.Platform.Type, int32(replicas), nodeLabels)
+			nodeClaims := waitForReadyNodeClaims(t, ctx, guestClient, len(nodes))
+			waitForReadyKarpenterPods(t, ctx, guestClient, nodes, replicas)
+
+			// Update hosted control plane to induce Drift
+			t.Logf("Updating cluster image. Image: %s", globalOpts.LatestReleaseImage)
+			err = e2eutil.UpdateObject(t, ctx, mgtClient, hostedCluster, func(obj *hyperv1.HostedCluster) {
+				obj.Spec.Release.Image = globalOpts.LatestReleaseImage
+				if obj.Annotations == nil {
+					obj.Annotations = make(map[string]string)
+				}
+				obj.Annotations[hyperv1.ForceUpgradeToAnnotation] = globalOpts.LatestReleaseImage
+				if globalOpts.DisablePKIReconciliation {
+					obj.Annotations[hyperv1.DisablePKIReconciliationAnnotation] = "true"
+				}
+			})
+			g.Expect(err).NotTo(HaveOccurred(), "failed update hostedcluster image")
+
+			// Check that the NodeClaim(s) actually Drift
+			driftChan := make(chan struct{})
+			go func() {
+				defer close(driftChan)
+				for _, nodeClaim := range nodeClaims.Items {
+					waitForNodeClaimDrifted(t, ctx, guestClient, &nodeClaim)
+				}
+			}()
+
+			// Wait for the new rollout to be complete
+			e2eutil.WaitForImageRollout(t, ctx, mgtClient, hostedCluster)
+			err = mgtClient.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
+			g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
+
+			// Ensure Karpenter Drift behaviour
+			t.Logf("Waiting for Karpenter Nodes to drift and come up")
+			<-driftChan
+
+			nodes = e2eutil.WaitForNReadyNodesWithOptions(t, ctx, guestClient, int32(replicas), hyperv1.AWSPlatform, "",
+				e2eutil.WithClientOptions(
+					crclient.MatchingLabelsSelector{Selector: labels.SelectorFromSet(labels.Set(nodeLabels))},
+				),
+				e2eutil.WithPredicates(
+					e2eutil.ConditionPredicate[*corev1.Node](e2eutil.Condition{
+						Type:   string(corev1.NodeReady),
+						Status: metav1.ConditionTrue,
+					}),
+					e2eutil.Predicate[*corev1.Node](func(node *corev1.Node) (done bool, reasons string, err error) {
+						// the actual OS version is at the end of the node's OSImage field
+						fullOSImageString := node.Status.NodeInfo.OSImage
+						parts := strings.Split(fullOSImageString, " ")
+						if len(parts) == 0 {
+							return false, "", fmt.Errorf("unexpected OSImage format: %s", fullOSImageString)
+						}
+						rawVersion := parts[len(parts)-1]
+						if rawVersion != expectedRHCOSVersion {
+							return false, fmt.Sprintf("expected %s, got %s", expectedRHCOSVersion, rawVersion), nil
+						}
+
+						// the node's KubeletVersion field is prefixed, but the releaseImageComponent version is not
+						rawKubeletVersion := strings.TrimPrefix(node.Status.NodeInfo.KubeletVersion, "v")
+						if rawKubeletVersion != expectedKubeletVersion {
+							return false, fmt.Sprintf("expected %s, got %s", expectedKubeletVersion, rawKubeletVersion), nil
+						}
+						correctMachineOSVersionMessage := fmt.Sprintf("correct machineOS: wanted %s, got %s", expectedRHCOSVersion, rawVersion)
+						correctK8sVersionMessage := fmt.Sprintf("correct kube: wanted %s, got %s", expectedKubeletVersion, rawKubeletVersion)
+						return true, fmt.Sprintf("%s, %s", correctMachineOSVersionMessage, correctK8sVersionMessage), nil
+					}),
+				),
+			)
+
+			t.Logf("Waiting for Karpenter pods to schedule on the new node")
+			waitForReadyKarpenterPods(t, ctx, guestClient, nodes, replicas)
+
+			// Test we can delete both Karpenter NodePool and workloads.
+			g.Expect(guestClient.Delete(ctx, karpenterNodePool)).To(Succeed())
+			t.Logf("Deleted Karpenter NodePool")
+			g.Expect(guestClient.Delete(ctx, workLoads)).To(Succeed())
+			t.Logf("Delete workloads")
+
+			// Wait for Karpenter Nodes to go away.
+			t.Logf("Waiting for Karpenter Nodes to disappear")
+			_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, guestClient, hostedCluster.Spec.Platform.Type, 0, nodeLabels)
+		})
+
+		t.Run("Test basic provisioning and deprovising", func(t *testing.T) {
+			// Test that we can provision as many nodes as needed (in this case, we need 3 nodes for 3 replicas)
+			replicas := 3
+			workLoads.Object["spec"].(map[string]interface{})["replicas"] = replicas
+			workLoads.Object["spec"].(map[string]interface{})["containers"] = []interface{}{
+				map[string]interface{}{
+					"resources": map[string]interface{}{
+						"requests": map[string]interface{}{
+							"cpu":    "1", // set to 1 CPU since t3.large has 2 vCPUs and cannot fit more than 1 replica
+							"memory": "256M",
+						},
+					},
+				},
+			}
+			workLoads.SetResourceVersion("")
+			karpenterNodePool.SetResourceVersion("")
+
+			// Leave dangling resources, and hope the teardown is not blocked, else the test will fail.
+			g.Expect(guestClient.Create(ctx, karpenterNodePool)).To(Succeed())
+			t.Logf("Created Karpenter NodePool")
+			g.Expect(guestClient.Create(ctx, workLoads)).To(Succeed())
+			t.Logf("Created workloads")
+
+			_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, guestClient, hostedCluster.Spec.Platform.Type, int32(replicas), nodeLabels)
+
+			ec2NodeClassList := &awskarpenterv1.EC2NodeClassList{}
+			g.Expect(guestClient.List(ctx, ec2NodeClassList)).To(Succeed())
+			g.Expect(ec2NodeClassList.Items).ToNot(BeEmpty())
+
+			ec2NodeClass := ec2NodeClassList.Items[0]
+			g.Expect(guestClient.Delete(ctx, &ec2NodeClass)).To(MatchError(ContainSubstring("EC2NodeClass resource can't be created/updated/deleted directly, please use OpenshiftEC2NodeClass resource instead")))
+		})
 
 		// TODO(alberto): increase coverage:
 		// - Karpenter operator plumbing, e.g:
@@ -103,6 +217,139 @@ func TestKarpenter(t *testing.T) {
 		// -- validate the default class is created and has expected values
 		// -- validate admin can't modify fields owned by the service, e.g. ami.
 		// - Karpenter functionality:
-		// -- Drift and Upgrades
 	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, "karpenter", globalOpts.ServiceAccountSigningKey)
+}
+
+func waitForReadyKarpenterPods(t *testing.T, ctx context.Context, client crclient.Client, nodes []corev1.Node, n int) []corev1.Pod {
+	pods := &corev1.PodList{}
+	waitTimeout := 10 * time.Minute
+	e2eutil.EventuallyObjects(t, ctx, fmt.Sprintf("Pods to be scheduled on provisioned Karpenter nodes"),
+		func(ctx context.Context) ([]*corev1.Pod, error) {
+			err := client.List(ctx, pods, crclient.InNamespace("default"))
+			items := make([]*corev1.Pod, len(pods.Items))
+			for i := range pods.Items {
+				items[i] = &pods.Items[i]
+			}
+			return items, err
+		},
+		[]e2eutil.Predicate[[]*corev1.Pod]{
+			func(pods []*corev1.Pod) (done bool, reasons string, err error) {
+				want, got := int(n), len(pods)
+				return want == got, fmt.Sprintf("expected %d nodes, got %d", want, got), nil
+			},
+		},
+		[]e2eutil.Predicate[*corev1.Pod]{
+			e2eutil.ConditionPredicate[*corev1.Pod](e2eutil.Condition{
+				Type:   string(corev1.PodScheduled),
+				Status: metav1.ConditionTrue,
+			}),
+			e2eutil.Predicate[*corev1.Pod](func(pod *corev1.Pod) (done bool, reasons string, err error) {
+				nodeName := pod.Spec.NodeName
+				for _, node := range getNodeNames(nodes) {
+					if nodeName == node {
+						return true, fmt.Sprintf("correctly scheduled on one of the specified nodes %s", nodeName), nil
+					}
+				}
+				return false, fmt.Sprintf("expected at least one of the nodes %v, got %s", getNodeNames(nodes), nodeName), nil
+			}),
+		},
+		e2eutil.WithTimeout(waitTimeout),
+	)
+	return pods.Items
+}
+
+func waitForReadyNodeClaims(t *testing.T, ctx context.Context, client crclient.Client, n int) *karpenterv1.NodeClaimList {
+	nodeClaims := &karpenterv1.NodeClaimList{}
+	waitTimeout := 5 * time.Minute
+	e2eutil.EventuallyObjects(t, ctx, fmt.Sprintf("NodeClaims to be ready"),
+		func(ctx context.Context) ([]*karpenterv1.NodeClaim, error) {
+			err := client.List(ctx, nodeClaims)
+			if err != nil {
+				return nil, err
+			}
+			items := make([]*karpenterv1.NodeClaim, 0)
+			for i := range nodeClaims.Items {
+				items = append(items, &nodeClaims.Items[i])
+			}
+			return items, nil
+		},
+		[]e2eutil.Predicate[[]*karpenterv1.NodeClaim]{
+			func(claims []*karpenterv1.NodeClaim) (done bool, reasons string, err error) {
+				want, got := n, len(claims)
+				return want == got, fmt.Sprintf("expected %d NodeClaims, got %d", want, got), nil
+			},
+		},
+		[]e2eutil.Predicate[*karpenterv1.NodeClaim]{
+			func(claim *karpenterv1.NodeClaim) (done bool, reasons string, err error) {
+				hasLaunched := false
+				hasRegistered := false
+				hasInitialized := false
+
+				for _, condition := range claim.Status.Conditions {
+					if condition.Type == karpenterv1.ConditionTypeLaunched && condition.Status == metav1.ConditionTrue {
+						hasLaunched = true
+					}
+					if condition.Type == karpenterv1.ConditionTypeRegistered && condition.Status == metav1.ConditionTrue {
+						hasRegistered = true
+					}
+					if condition.Type == karpenterv1.ConditionTypeInitialized && condition.Status == metav1.ConditionTrue {
+						hasInitialized = true
+					}
+				}
+
+				if !hasLaunched || !hasRegistered || !hasInitialized {
+					return false, fmt.Sprintf("NodeClaim %s not ready: Launched=%v, Registered=%v, Initialized=%v",
+						claim.Name, hasLaunched, hasRegistered, hasInitialized), nil
+				}
+				return true, "", nil
+			},
+		},
+		e2eutil.WithTimeout(waitTimeout),
+	)
+
+	return nodeClaims
+}
+
+func waitForNodeClaimDrifted(t *testing.T, ctx context.Context, client crclient.Client, nc *karpenterv1.NodeClaim) {
+	waitTimeout := 5 * time.Minute
+	e2eutil.EventuallyObject(t, ctx, fmt.Sprintf("NodeClaim %s to be drifted", nc.Name),
+		func(ctx context.Context) (*karpenterv1.NodeClaim, error) {
+			nodeClaim := &karpenterv1.NodeClaim{}
+			err := client.Get(ctx, crclient.ObjectKeyFromObject(nc), nodeClaim)
+			// make sure that the condition actually exists first
+			if err == nil {
+				haystack, err := e2eutil.Conditions(nodeClaim)
+				if err != nil {
+					return nil, err
+				}
+				for _, condition := range haystack {
+					if karpenterv1.ConditionTypeDrifted == condition.Type {
+						if condition.Status == metav1.ConditionTrue {
+							return nodeClaim, nil
+						}
+						return nil, fmt.Errorf("condition %s is not True in NodeClaim %s", karpenterv1.ConditionTypeDrifted, nc.Name)
+					}
+				}
+				return nil, fmt.Errorf("condition %s not found in NodeClaim %s", karpenterv1.ConditionTypeDrifted, nc.Name)
+			} else {
+				return nil, err
+			}
+		},
+		[]e2eutil.Predicate[*karpenterv1.NodeClaim]{
+			e2eutil.ConditionPredicate[*karpenterv1.NodeClaim](e2eutil.Condition{
+				Type:   karpenterv1.ConditionTypeDrifted,
+				Status: metav1.ConditionTrue,
+			}),
+		},
+		e2eutil.WithTimeout(waitTimeout),
+	)
+}
+
+// getNodeNames returns the names of the nodes in the list
+func getNodeNames(nodes []corev1.Node) []string {
+	nodeNames := make([]string, len(nodes))
+	for i, node := range nodes {
+		nodeNames[i] = node.Name
+	}
+	return nodeNames
 }

--- a/test/e2e/util/eventually.go
+++ b/test/e2e/util/eventually.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -481,6 +482,17 @@ func Conditions(item client.Object) ([]Condition, error) {
 			conditions[i] = Condition{
 				Type:    string(obj.Status.Conditions[i].Type),
 				Status:  metav1.ConditionStatus(obj.Status.Conditions[i].Status),
+				Reason:  obj.Status.Conditions[i].Reason,
+				Message: obj.Status.Conditions[i].Message,
+			}
+		}
+		return conditions, nil
+	case *karpenterv1.NodeClaim:
+		conditions := make([]Condition, len(obj.Status.Conditions))
+		for i := range obj.Status.Conditions {
+			conditions[i] = Condition{
+				Type:    obj.Status.Conditions[i].Type,
+				Status:  obj.Status.Conditions[i].Status,
 				Reason:  obj.Status.Conditions[i].Reason,
 				Message: obj.Status.Conditions[i].Message,
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new test to the karpenter e2e suite which upgrades the hcp and validates that karpenter nodes are drift and upgraded to the control-plane's new release image version. Also validates that any pods that were already scheduled to the old karpenter node, will be rescheduled to the new karpenter node.

Also this PR lowers the CPU of the tested workload to avoid them being unschedulable because of the small CPU allocation of `t3.large` instances.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes: https://issues.redhat.com/browse/AUTOSCALE-44

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.