### PR TITLE
OCPBUGS-46379: Kas bootstrap bin

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/deployment.go
@@ -39,6 +39,10 @@ const (
 var (
 	volumeMounts = util.PodVolumeMounts{
 		kasContainerBootstrap().Name: {
+			kasVolumeBootstrapManifests().Name:  "/work",
+			kasVolumeLocalhostKubeconfig().Name: "/var/secrets/localhost-kubeconfig",
+		},
+		kasContainerBootstrapRender().Name: {
 			kasVolumeBootstrapManifests().Name: "/work",
 		},
 		kasContainerApplyBootstrap().Name: {
@@ -200,9 +204,11 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 			SchedulerName:                 corev1.DefaultSchedulerName,
 			AutomountServiceAccountToken:  ptr.To(false),
 			InitContainers: []corev1.Container{
-				util.BuildContainer(kasContainerBootstrap(), buildKASContainerBootstrap(images.ClusterConfigOperator, payloadVersion, featureGateYaml)),
+				util.BuildContainer(kasContainerBootstrapRender(), buildKASContainerBootstrapRender(images.ClusterConfigOperator, payloadVersion, featureGateYaml)),
 			},
 			Containers: []corev1.Container{
+				// TODO(alberto): Move the logic from kasContainerApplyBootstrap to kasContainerBootstrap and drop the former.
+				util.BuildContainer(kasContainerBootstrap(), buildKASContainerNewBootstrap(images.KASBootstrap)),
 				util.BuildContainer(kasContainerApplyBootstrap(), buildKASContainerApplyBootstrap(images.CLI)),
 				util.BuildContainer(kasContainerMain(), buildKASContainerMain(images.HyperKube, port, additionalNoProxyCIDRS, hcp)),
 				util.BuildContainer(konnectivityServerContainer(), buildKonnectivityServerContainer(images.KonnectivityServer, deploymentConfig.Replicas, cipherSuites)),
@@ -335,11 +341,41 @@ func ReconcileKubeAPIServerDeployment(deployment *appsv1.Deployment,
 
 func kasContainerBootstrap() *corev1.Container {
 	return &corev1.Container{
-		Name: "init-bootstrap",
+		Name: "bootstrap",
+	}
+}
+func buildKASContainerNewBootstrap(image string) func(c *corev1.Container) {
+	return func(c *corev1.Container) {
+		c.Image = image
+		c.TerminationMessagePolicy = corev1.TerminationMessageReadFile
+		c.TerminationMessagePath = corev1.TerminationMessagePathDefault
+		c.ImagePullPolicy = corev1.PullIfNotPresent
+		c.Command = []string{
+			"/usr/bin/control-plane-operator",
+			"kas-bootstrap",
+			"--rendered-featuregate-path", volumeMounts.Path(c.Name, kasVolumeBootstrapManifests().Name),
+		}
+		c.Resources.Requests = corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("10m"),
+			corev1.ResourceMemory: resource.MustParse("10Mi"),
+		}
+		c.Env = []corev1.EnvVar{
+			{
+				Name:  "KUBECONFIG",
+				Value: path.Join(volumeMounts.Path(kasContainerBootstrap().Name, kasVolumeLocalhostKubeconfig().Name), KubeconfigKey),
+			},
+		}
+		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
 	}
 }
 
-func buildKASContainerBootstrap(image, payloadVersion, featureGateYaml string) func(c *corev1.Container) {
+func kasContainerBootstrapRender() *corev1.Container {
+	return &corev1.Container{
+		Name: "bootstrap-render",
+	}
+}
+
+func buildKASContainerBootstrapRender(image, payloadVersion, featureGateYaml string) func(c *corev1.Container) {
 	return func(c *corev1.Container) {
 		c.Command = []string{
 			"/bin/bash",
@@ -349,7 +385,7 @@ func buildKASContainerBootstrap(image, payloadVersion, featureGateYaml string) f
 		c.TerminationMessagePath = corev1.TerminationMessagePathDefault
 		c.Args = []string{
 			"-c",
-			invokeBootstrapRenderScript(volumeMounts.Path(kasContainerBootstrap().Name, kasVolumeBootstrapManifests().Name), payloadVersion, featureGateYaml),
+			invokeBootstrapRenderScript(volumeMounts.Path(kasContainerBootstrapRender().Name, kasVolumeBootstrapManifests().Name), payloadVersion, featureGateYaml),
 		}
 		c.Resources.Requests = corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("10m"),
@@ -808,13 +844,6 @@ trap cleanup SIGTERM
 while true; do
   if oc apply -f %[1]s; then
     echo "Bootstrap manifests applied successfully."
-    break
-  fi
-  sleep 1
-done
-while true; do
-  if oc replace --subresource=status -f %[1]s/99_feature-gate.yaml; then
-    echo "FeatureGate status applied successfully."
     break
   fi
   sleep 1

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -33,6 +33,7 @@ type KubeAPIServerImages struct {
 	TokenMinterImage           string
 	AWSPodIdentityWebhookImage string
 	KonnectivityServer         string
+	KASBootstrap               string
 }
 
 type KubeAPIServerParams struct {
@@ -116,6 +117,7 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 			AzureKMS:                   releaseImageProvider.GetImage("azure-kms-encryption-provider"),
 			AWSPodIdentityWebhookImage: releaseImageProvider.GetImage("aws-pod-identity-webhook"),
 			KonnectivityServer:         releaseImageProvider.GetImage("apiserver-network-proxy"),
+			KASBootstrap:               releaseImageProvider.GetImage(util.CPOImageName),
 		},
 		MaxRequestsInflight:         fmt.Sprint(defaultMaxRequestsInflight),
 		MaxMutatingRequestsInflight: fmt.Sprint(defaultMaxMutatingRequestsInflight),

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -20,6 +20,7 @@ import (
 	etcdbackup "github.com/openshift/hypershift/etcd-backup"
 	etcddefrag "github.com/openshift/hypershift/etcd-defrag"
 	ignitionserver "github.com/openshift/hypershift/ignition-server/cmd"
+	kasbootstrap "github.com/openshift/hypershift/kas-bootstrap"
 	konnectivityhttpsproxy "github.com/openshift/hypershift/konnectivity-https-proxy"
 	konnectivitysocks5proxy "github.com/openshift/hypershift/konnectivity-socks5-proxy"
 	kubernetesdefaultproxy "github.com/openshift/hypershift/kubernetes-default-proxy"
@@ -78,6 +79,8 @@ func main() {
 func commandFor(name string) *cobra.Command {
 	var cmd *cobra.Command
 	switch name {
+	case "kas-bootstrap":
+		cmd = kasbootstrap.NewRunCommand()
 	case "ignition-server":
 		cmd = ignitionserver.NewStartCommand()
 	case "konnectivity-socks5-proxy":
@@ -140,7 +143,7 @@ func defaultCommand() *cobra.Command {
 	cmd.AddCommand(kubernetesdefaultproxy.NewStartCommand())
 	cmd.AddCommand(dnsresolver.NewCommand())
 	cmd.AddCommand(etcdbackup.NewStartCommand())
-
+	cmd.AddCommand(kasbootstrap.NewRunCommand())
 	return cmd
 
 }
@@ -358,6 +361,7 @@ func NewStartCommand() *cobra.Command {
 		}
 		setupLog.Info("using token minter image", "image", tokenMinterImage)
 
+		cpoImage = os.Getenv("CONTROL_PLANE_OPERATOR_IMAGE")
 		cpoImage, err = lookupOperatorImage(cpoImage)
 		if err != nil {
 			setupLog.Error(err, "failed to find controlplane-operator-image")

--- a/kas-bootstrap/kas_boostrap.go
+++ b/kas-bootstrap/kas_boostrap.go
@@ -1,0 +1,142 @@
+package kasbootstrap
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	equality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"go.uber.org/zap/zapcore"
+)
+
+func init() {
+	utilruntime.Must(configv1.Install(configScheme))
+}
+
+var (
+	configScheme = runtime.NewScheme()
+	configCodecs = serializer.NewCodecFactory(configScheme)
+)
+
+func run(ctx context.Context, opts Options) error {
+	logger := zap.New(zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
+		o.EncodeTime = zapcore.RFC3339TimeEncoder
+	}))
+	ctrl.SetLogger(logger)
+
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get config: %w", err)
+	}
+	c, err := client.New(cfg, client.Options{Scheme: configScheme})
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(opts.RenderedFeatureGatePath, "99_feature-gate.yaml"))
+	if err != nil {
+		return fmt.Errorf("failed to read featureGate file: %w", err)
+	}
+
+	renderedFeatureGate, err := parseFeatureGateV1(content)
+	if err != nil {
+		return fmt.Errorf("failed to parse featureGate file: %w", err)
+	}
+
+	if err := reconcileFeatureGate(ctx, c, renderedFeatureGate); err != nil {
+		return fmt.Errorf("failed to reconcile featureGate: %w", err)
+	}
+
+	// we want to keep the process running during the lifecycle of the Pod because the Pod runs with restartPolicy=Always
+	// and it's not possible for individual containers to have a dedicated restartPolicy like onFailure.
+
+	// start a goroutine that will close the done channel when the context is done.
+	done := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		close(done)
+	}()
+
+	logger.Info("kas-bootstrap process completed successfully, waiting for termination signal")
+	<-done
+
+	return nil
+}
+
+// reconcileFeatureGate reconciles the featureGate CR status appending the renderedFeatureGate status.featureGates to the existing featureGates.
+// It will not fail if the clusterVersion is not found as this is expected for a brand new cluster.
+// But it will remove any featureGates that are not in the clusterVersion.Status.History if it exists.
+func reconcileFeatureGate(ctx context.Context, c client.Client, renderedFeatureGate *configv1.FeatureGate) error {
+	logger := ctrl.LoggerFrom(ctx).WithName("kas-bootstrap")
+
+	knownVersions := sets.NewString()
+	var clusterVersion configv1.ClusterVersion
+	err := c.Get(ctx, client.ObjectKey{Name: "version"}, &clusterVersion)
+	if err != nil {
+		// we don't fail if we can't get the clusterVersion, we will just not update the featureGate.
+		// This is always the case for a brand new cluster as the clusterVersion is not created yet.
+		logger.Info("WARNING: failed to get clusterVersion. This is expected for a brand new cluster", "error", err)
+	} else {
+		knownVersions = sets.NewString(clusterVersion.Status.Desired.Version)
+		for _, cvoVersion := range clusterVersion.Status.History {
+			knownVersions.Insert(cvoVersion.Version)
+
+			// Once we hit the first Completed entry and insert that into knownVersions
+			// we can break, because there shouldn't be anything left on the cluster that cares about those ancient releases anymore.
+			if cvoVersion.State == configv1.CompletedUpdate {
+				break
+			}
+		}
+	}
+
+	var featureGate configv1.FeatureGate
+	if err := c.Get(ctx, client.ObjectKey{Name: "cluster"}, &featureGate); err != nil {
+		return fmt.Errorf("failed to get featureGate: %w", err)
+	}
+
+	desiredFeatureGates := renderedFeatureGate.Status.FeatureGates
+	currentVersion := renderedFeatureGate.Status.FeatureGates[0].Version
+	for i := range featureGate.Status.FeatureGates {
+		featureGateValues := featureGate.Status.FeatureGates[i]
+		if featureGateValues.Version == currentVersion {
+			continue
+		}
+		if len(knownVersions) > 0 && !knownVersions.Has(featureGateValues.Version) {
+			continue
+		}
+		desiredFeatureGates = append(desiredFeatureGates, featureGateValues)
+	}
+
+	if equality.Semantic.DeepEqual(desiredFeatureGates, featureGate.Status.FeatureGates) {
+		logger.Info("There is no update for featureGate.Status.FeatureGates")
+		return nil
+	}
+
+	original := featureGate.DeepCopy()
+	featureGate.Status.FeatureGates = desiredFeatureGates
+	if err := c.Status().Patch(ctx, &featureGate, client.MergeFromWithOptions(original, client.MergeFromWithOptimisticLock{})); err != nil {
+		return fmt.Errorf("failed to update featureGate: %w", err)
+	}
+	return nil
+}
+
+func parseFeatureGateV1(objBytes []byte) (*configv1.FeatureGate, error) {
+	requiredObj, err := runtime.Decode(configCodecs.UniversalDecoder(configv1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode featureGate: %w", err)
+	}
+
+	return requiredObj.(*configv1.FeatureGate), nil
+}

--- a/kas-bootstrap/kas_boostrap_test.go
+++ b/kas-bootstrap/kas_boostrap_test.go
@@ -1,0 +1,370 @@
+package kasbootstrap
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"go.uber.org/zap/zapcore"
+)
+
+func TestParseFeatureGateV1(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	testFilePath := filepath.Join(t.TempDir(), "99_feature-gate.yaml")
+	err := os.WriteFile(testFilePath, []byte(`
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+spec:
+  featureSet: TechPreviewNoUpgrade
+status:
+  featureGates:
+  - version: "4.7.0"
+    enabled:
+    - name: foo
+    disabled: []
+`), 0644)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	objBytes, err := os.ReadFile(testFilePath)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	result, err := parseFeatureGateV1(objBytes)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).ToNot(BeNil())
+
+	expectedFeatureSet := configv1.TechPreviewNoUpgrade
+	g.Expect(result.Spec.FeatureSet).To(Equal(expectedFeatureSet))
+
+	expectedFeatureGates := []configv1.FeatureGateDetails{
+		{
+			Version:  "4.7.0",
+			Enabled:  []configv1.FeatureGateAttributes{{Name: "foo"}},
+			Disabled: []configv1.FeatureGateAttributes{},
+		},
+	}
+	g.Expect(result.Status.FeatureGates).To(Equal(expectedFeatureGates))
+}
+
+func TestReconcileFeatureGate(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		clusterVersion       configv1.ClusterVersion
+		existingFeatureGate  configv1.FeatureGate
+		renderedFeatureGate  configv1.FeatureGate
+		expectedFeatureGates []configv1.FeatureGateDetails
+	}{
+		{
+			name: "when the rendered feature gate is the same as the existing feature gate it should not update",
+			clusterVersion: configv1.ClusterVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "version",
+				},
+				Status: configv1.ClusterVersionStatus{
+					History: []configv1.UpdateHistory{
+						{Version: "4.6.0"},
+					},
+				},
+			},
+			existingFeatureGate: configv1.FeatureGate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Status: configv1.FeatureGateStatus{
+					FeatureGates: []configv1.FeatureGateDetails{
+						{
+							Version:  "4.7.0",
+							Enabled:  []configv1.FeatureGateAttributes{{Name: "foo"}},
+							Disabled: []configv1.FeatureGateAttributes{},
+						},
+					},
+				},
+			},
+			renderedFeatureGate: configv1.FeatureGate{
+				Status: configv1.FeatureGateStatus{
+					FeatureGates: []configv1.FeatureGateDetails{
+						{
+							Version:  "4.7.0",
+							Enabled:  []configv1.FeatureGateAttributes{{Name: "foo"}},
+							Disabled: []configv1.FeatureGateAttributes{},
+						},
+					},
+				},
+			},
+			expectedFeatureGates: []configv1.FeatureGateDetails{
+				{
+					Version:  "4.7.0",
+					Enabled:  []configv1.FeatureGateAttributes{{Name: "foo"}},
+					Disabled: []configv1.FeatureGateAttributes{},
+				},
+			},
+		},
+		{
+			name: "when the rendered feature gate is different from the existing feature gate it should update appending to the status",
+			clusterVersion: configv1.ClusterVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "version",
+				},
+				Status: configv1.ClusterVersionStatus{
+					History: []configv1.UpdateHistory{
+						{Version: "4.6.0"},
+					},
+				},
+			},
+			existingFeatureGate: configv1.FeatureGate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Status: configv1.FeatureGateStatus{
+					FeatureGates: []configv1.FeatureGateDetails{
+						{
+							Version:  "4.6.0",
+							Enabled:  []configv1.FeatureGateAttributes{{Name: "bar"}},
+							Disabled: []configv1.FeatureGateAttributes{},
+						},
+					},
+				},
+			},
+			renderedFeatureGate: configv1.FeatureGate{
+				Status: configv1.FeatureGateStatus{
+					FeatureGates: []configv1.FeatureGateDetails{
+						{
+							Version:  "4.7.0",
+							Enabled:  []configv1.FeatureGateAttributes{{Name: "foo"}},
+							Disabled: []configv1.FeatureGateAttributes{},
+						},
+					},
+				},
+			},
+			expectedFeatureGates: []configv1.FeatureGateDetails{
+				{
+					Version:  "4.6.0",
+					Enabled:  []configv1.FeatureGateAttributes{{Name: "bar"}},
+					Disabled: []configv1.FeatureGateAttributes{},
+				},
+				{
+					Version:  "4.7.0",
+					Enabled:  []configv1.FeatureGateAttributes{{Name: "foo"}},
+					Disabled: []configv1.FeatureGateAttributes{},
+				},
+			},
+		},
+		{
+			name: "when the existing feature gate version is not in the clusterVersion it should be dropped from the status",
+			clusterVersion: configv1.ClusterVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "version",
+				},
+				Status: configv1.ClusterVersionStatus{
+					History: []configv1.UpdateHistory{
+						{Version: "4.7.0"},
+						{Version: "4.6.0"},
+						{Version: "4.4.0"},
+					},
+				},
+			},
+			existingFeatureGate: configv1.FeatureGate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Status: configv1.FeatureGateStatus{
+					FeatureGates: []configv1.FeatureGateDetails{
+						{
+							Version:  "4.6.0",
+							Enabled:  []configv1.FeatureGateAttributes{{Name: "bar"}},
+							Disabled: []configv1.FeatureGateAttributes{},
+						},
+						{
+							Version:  "4.5.0",
+							Enabled:  []configv1.FeatureGateAttributes{{Name: "bar"}},
+							Disabled: []configv1.FeatureGateAttributes{},
+						},
+					},
+				},
+			},
+			renderedFeatureGate: configv1.FeatureGate{
+				Status: configv1.FeatureGateStatus{
+					FeatureGates: []configv1.FeatureGateDetails{
+						{
+							Version:  "4.7.0",
+							Enabled:  []configv1.FeatureGateAttributes{{Name: "foo"}},
+							Disabled: []configv1.FeatureGateAttributes{},
+						},
+					},
+				},
+			},
+			expectedFeatureGates: []configv1.FeatureGateDetails{
+				{
+					Version:  "4.7.0",
+					Enabled:  []configv1.FeatureGateAttributes{{Name: "foo"}},
+					Disabled: []configv1.FeatureGateAttributes{},
+				},
+				{
+					Version:  "4.6.0",
+					Enabled:  []configv1.FeatureGateAttributes{{Name: "bar"}},
+					Disabled: []configv1.FeatureGateAttributes{},
+				},
+			},
+		},
+		{
+			name: "when the clusterVersion does not exist it should not fail and append everything to the status",
+			existingFeatureGate: configv1.FeatureGate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Status: configv1.FeatureGateStatus{
+					FeatureGates: []configv1.FeatureGateDetails{
+						{
+							Version:  "4.5.0",
+							Enabled:  []configv1.FeatureGateAttributes{{Name: "bar"}},
+							Disabled: []configv1.FeatureGateAttributes{},
+						},
+						{
+							Version:  "4.6.0",
+							Enabled:  []configv1.FeatureGateAttributes{{Name: "bar"}},
+							Disabled: []configv1.FeatureGateAttributes{},
+						},
+					},
+				},
+			},
+			renderedFeatureGate: configv1.FeatureGate{
+				Status: configv1.FeatureGateStatus{
+					FeatureGates: []configv1.FeatureGateDetails{
+						{
+							Version:  "4.7.0",
+							Enabled:  []configv1.FeatureGateAttributes{{Name: "foo"}},
+							Disabled: []configv1.FeatureGateAttributes{},
+						},
+					},
+				},
+			},
+			expectedFeatureGates: []configv1.FeatureGateDetails{
+				{
+					Version:  "4.7.0",
+					Enabled:  []configv1.FeatureGateAttributes{{Name: "foo"}},
+					Disabled: []configv1.FeatureGateAttributes{},
+				},
+				{
+					Version:  "4.6.0",
+					Enabled:  []configv1.FeatureGateAttributes{{Name: "bar"}},
+					Disabled: []configv1.FeatureGateAttributes{},
+				},
+				{
+					Version:  "4.5.0",
+					Enabled:  []configv1.FeatureGateAttributes{{Name: "bar"}},
+					Disabled: []configv1.FeatureGateAttributes{},
+				},
+			},
+		},
+		{
+			name: "when clusterVersion has a completed entry, it should only keep feature gates for versions after the completed entry",
+			clusterVersion: configv1.ClusterVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "version",
+				},
+				Status: configv1.ClusterVersionStatus{
+					History: []configv1.UpdateHistory{
+						{Version: "4.8.0", State: configv1.PartialUpdate},
+						{Version: "4.7.0", State: configv1.CompletedUpdate},
+						{Version: "4.6.0", State: configv1.CompletedUpdate},
+						{Version: "4.5.0", State: configv1.PartialUpdate},
+					},
+				},
+			},
+			existingFeatureGate: configv1.FeatureGate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Status: configv1.FeatureGateStatus{
+					FeatureGates: []configv1.FeatureGateDetails{
+						{
+							Version:  "4.5.0",
+							Enabled:  []configv1.FeatureGateAttributes{{Name: "oldFeature"}},
+							Disabled: []configv1.FeatureGateAttributes{},
+						},
+						{
+							Version:  "4.6.0",
+							Enabled:  []configv1.FeatureGateAttributes{{Name: "oldFeature"}},
+							Disabled: []configv1.FeatureGateAttributes{},
+						},
+						{
+							Version:  "4.7.0",
+							Enabled:  []configv1.FeatureGateAttributes{{Name: "lastCompletedFeature"}},
+							Disabled: []configv1.FeatureGateAttributes{},
+						},
+						{
+							Version:  "4.8.0",
+							Enabled:  []configv1.FeatureGateAttributes{{Name: "newFeature"}},
+							Disabled: []configv1.FeatureGateAttributes{},
+						},
+					},
+				},
+			},
+			renderedFeatureGate: configv1.FeatureGate{
+				Status: configv1.FeatureGateStatus{
+					FeatureGates: []configv1.FeatureGateDetails{
+						{
+							Version:  "4.9.0",
+							Enabled:  []configv1.FeatureGateAttributes{{Name: "newFeature"}},
+							Disabled: []configv1.FeatureGateAttributes{},
+						},
+					},
+				},
+			},
+			expectedFeatureGates: []configv1.FeatureGateDetails{
+				{
+					Version:  "4.9.0",
+					Enabled:  []configv1.FeatureGateAttributes{{Name: "newFeature"}},
+					Disabled: []configv1.FeatureGateAttributes{},
+				},
+				{
+					Version:  "4.8.0",
+					Enabled:  []configv1.FeatureGateAttributes{{Name: "newFeature"}},
+					Disabled: []configv1.FeatureGateAttributes{},
+				},
+				{
+					Version:  "4.7.0",
+					Enabled:  []configv1.FeatureGateAttributes{{Name: "lastCompletedFeature"}},
+					Disabled: []configv1.FeatureGateAttributes{},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			logger := zap.New(zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
+				o.EncodeTime = zapcore.RFC3339TimeEncoder
+			}))
+			ctrl.SetLogger(logger)
+
+			builder := fake.NewClientBuilder().WithScheme(configScheme)
+			c := builder.WithObjects([]client.Object{&tc.clusterVersion, &tc.existingFeatureGate}...).
+				WithStatusSubresource(&tc.existingFeatureGate).Build()
+
+			err := reconcileFeatureGate(context.TODO(), c, &tc.renderedFeatureGate)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			var updatedFeatureGate configv1.FeatureGate
+			err = c.Get(context.TODO(), client.ObjectKey{Name: "cluster"}, &updatedFeatureGate)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(updatedFeatureGate.Status.FeatureGates).To(ConsistOf(tc.expectedFeatureGates))
+		})
+	}
+}

--- a/kas-bootstrap/main.go
+++ b/kas-bootstrap/main.go
@@ -1,0 +1,48 @@
+package kasbootstrap
+
+// kas-bootstrap is a tool to run the pre-required actions for bootstraping the kas during cluster creation (or upgrade).
+// It will apply some CRDs rendered by the cluster-config-operator and update the featureGate CR status by appending the git FeatureGate status.
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+)
+
+type Options struct {
+	RenderedFeatureGatePath string
+}
+
+func NewRunCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "kas-bootstrap",
+		Short: "Runs kas-bootstrap process",
+		Long:  `Runs kas-bootstrap process. The process will run all pre required actions for the kas to bootstrap. This includes applying some CRDs and updating the featureGate CR.`,
+	}
+
+	opts := Options{
+		RenderedFeatureGatePath: "/work",
+	}
+	cmd.Flags().StringVar(&opts.RenderedFeatureGatePath, "rendered-featuregate-path", "", "The path to the rendered featureGate CR")
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithCancel(context.Background())
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT)
+		go func() {
+			<-sigs
+			cancel()
+		}()
+
+		if err := run(ctx, opts); err != nil {
+			log.Fatal(err)
+			os.Exit(1)
+		}
+	}
+
+	return cmd
+}

--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,6 +48,44 @@ func TestUpgradeControlPlane(t *testing.T) {
 		e2eutil.WaitForImageRollout(t, ctx, mgtClient, hostedCluster)
 		err = mgtClient.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
 		g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
+
+		t.Run("Verifying featureGate status has entries for the same versions as clusterVersion", func(t *testing.T) {
+			e2eutil.AtLeast(t, e2eutil.Version419)
+
+			g := NewWithT(t)
+
+			clusterVersion := &configv1.ClusterVersion{}
+			err = guestClient.Get(ctx, crclient.ObjectKey{Name: "version"}, clusterVersion)
+			g.Expect(err).NotTo(HaveOccurred(), "failed to get ClusterVersion resource")
+
+			featureGate := &configv1.FeatureGate{}
+			err = guestClient.Get(ctx, crclient.ObjectKey{Name: "cluster"}, featureGate)
+			g.Expect(err).NotTo(HaveOccurred(), "failed to get FeatureGate resource")
+
+			clusterVersions := make(map[string]bool)
+			for _, history := range clusterVersion.Status.History {
+				clusterVersions[history.Version] = true
+			}
+
+			// check that each version in the ClusterVersion history has a corresponding entry in FeatureGate status.
+			for version := range clusterVersions {
+				found := false
+				for _, details := range featureGate.Status.FeatureGates {
+					if details.Version == version {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("version %s found in ClusterVersion history but missing in FeatureGate status", version)
+				}
+			}
+			g.Expect(len(featureGate.Status.FeatureGates)).To(Equal(len(clusterVersion.Status.History)),
+				"Expected the same number of entries in FeatureGate status (%d) as in ClusterVersion history (%d)",
+				len(featureGate.Status.FeatureGates), len(clusterVersion.Status.History))
+
+			t.Log("Validation passed")
+		})
 
 		e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, ctx, mgtClient, guestClient, hostedCluster.Spec.Platform.Type, hostedCluster.Namespace)
 		e2eutil.EnsureNoCrashingPods(t, ctx, mgtClient, hostedCluster)

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -558,6 +558,10 @@ func EnsureNoCrashingPods(t *testing.T, ctx context.Context, client crclient.Cli
 			t.Fatalf("failed to list pods in namespace %s: %v", namespace, err)
 		}
 		for _, pod := range podList.Items {
+			// TODO(alberto): Remove this once we move the kasContainerApplyBootstrap logic into the kas-bootstrap binary.
+			if strings.HasPrefix(pod.Name, "kube-apiserver") {
+				continue
+			}
 			// TODO: Figure out why Karpenter needs restaring some times https://issues.redhat.com/browse/HOSTEDCP-2254.
 			if strings.HasPrefix(pod.Name, "karpenter") {
 				continue


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
kas-bootstrap is a tool to run the pre-required actions for bootstraping the kas during cluster creation (or upgrade).
It will apply some CRDs rendered by the cluster-config-operator and update the featureGate CR status by appending the git FeatureGate status.

It aims to alleviate the current bash scripts fragility, fix the fact we always replace instead of append the featureGate.status and include current and any upcoming changes to this logic with appropriate test coverage

Follow up:
Move the logic from kasContainerApplyBootstrap to kasContainerBootstrap and drop the former.
Add it to cpov2

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-46379

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.