### PR TITLE
[release-4.18] OCPBUGS-53404: Set shutdown watch termination grace period on kube-apiserver

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -225,6 +225,7 @@ func generateConfig(p KubeAPIServerConfigParams) *kcpv1.KubeAPIServerConfig {
 	args.Set("service-account-signing-key-file", cpath(kasVolumeServiceAccountKey().Name, pki.ServiceSignerPrivateKey))
 	args.Set("service-node-port-range", p.NodePortRange)
 	args.Set("shutdown-delay-duration", "70s")
+	args.Set("shutdown-watch-termination-grace-period", "25s")
 	args.Set("shutdown-send-retry-after", "true")
 	args.Set("storage-backend", "etcd3")
 	args.Set("storage-media-type", "application/vnd.kubernetes.protobuf")

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: bootstrap-manifests,logs
-        component.hypershift.openshift.io/config-hash: 19dc307e1d8949e23415eb66926e10aa
+        component.hypershift.openshift.io/config-hash: 19dc307e1d8949e23415eb665be103a4
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/config.go
@@ -227,6 +227,7 @@ func generateConfig(p KubeAPIServerConfigParams) *kcpv1.KubeAPIServerConfig {
 	args.Set("service-account-signing-key-file", cpath(serviceAccountKeyVolumeName, pki.ServiceSignerPrivateKey))
 	args.Set("service-node-port-range", p.NodePortRange)
 	args.Set("shutdown-delay-duration", "70s")
+	args.Set("shutdown-watch-termination-grace-period", "25s")
 	args.Set("shutdown-send-retry-after", "true")
 	args.Set("storage-backend", "etcd3")
 	args.Set("storage-media-type", "application/vnd.kubernetes.protobuf")


### PR DESCRIPTION
Cherry pick of #5760 on release-4.18.

#5760: Set shutdown watch termination grace period on kas

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```