### PR TITLE
OCPBUGS-52190: Add konnectivity-proxy sidecar to openshift-oauth-apiserver

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment_test.go
@@ -239,7 +239,9 @@ func TestReconcileOpenshiftOAuthAPIServerDeployment(t *testing.T) {
 			name:             "Empty deployment config and oauth params",
 			deploymentConfig: config.DeploymentConfig{},
 			auditConfig:      manifests.OpenShiftOAuthAPIServerAuditConfig(targetNamespace),
-			params:           OAuthDeploymentParams{},
+			params: OAuthDeploymentParams{
+				EtcdURL: "https://etcd-client:2379",
+			},
 		},
 	}
 	for _, tc := range testCases {

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
@@ -3,6 +3,7 @@ package oapi
 import (
 	"fmt"
 	"path"
+	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
@@ -40,6 +41,11 @@ var (
 			oauthVolumeEtcdClientCert().Name:  "/etc/kubernetes/certs/etcd-client",
 			common.VolumeTotalClientCA().Name: "/etc/kubernetes/certs/client-ca",
 		},
+		oauthKonnectivityProxyContainer().Name: {
+			oauthVolumeKubeconfig().Name:            "/etc/kubernetes/secrets/kubeconfig",
+			oauthVolumeKonnectivityProxyCert().Name: "/etc/konnectivity/proxy-client",
+			oauthVolumeKonnectivityProxyCA().Name:   "/etc/konnectivity/proxy-ca",
+		},
 	}
 	oauthAuditWebhookConfigFileVolumeMount = util.PodVolumeMounts{
 		oauthContainerMain().Name: {
@@ -55,8 +61,17 @@ func openShiftOAuthAPIServerLabels() map[string]string {
 	}
 }
 
-func ReconcileOAuthAPIServerDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, auditConfig *corev1.ConfigMap, p *OAuthDeploymentParams, platformType hyperv1.PlatformType) error {
+func ReconcileOAuthAPIServerDeployment(deployment *appsv1.Deployment,
+	ownerRef config.OwnerRef,
+	auditConfig *corev1.ConfigMap,
+	p *OAuthDeploymentParams,
+	platformType hyperv1.PlatformType) error {
 	ownerRef.ApplyTo(deployment)
+
+	etcdHost, err := util.HostFromURL(p.EtcdURL)
+	if err != nil {
+		return err
+	}
 
 	// preserve existing resource requirements for main oauth apiserver container
 	mainContainer := util.FindContainer(oauthContainerMain().Name, deployment.Spec.Template.Spec.Containers)
@@ -95,7 +110,8 @@ func ReconcileOAuthAPIServerDeployment(deployment *appsv1.Deployment, ownerRef c
 		AutomountServiceAccountToken:  ptr.To(false),
 		TerminationGracePeriodSeconds: ptr.To[int64](120),
 		Containers: []corev1.Container{
-			util.BuildContainer(oauthContainerMain(), buildOAuthContainerMain(p)),
+			util.BuildContainer(oauthContainerMain(), buildOAuthContainerMain(p, etcdHost)),
+			util.BuildContainer(oauthKonnectivityProxyContainer(), buildOAuthKonnectivityProxyContainer(p.KonnectivityProxyImage)),
 		},
 		Volumes: []corev1.Volume{
 			util.BuildVolume(oauthVolumeWorkLogs(), buildOAuthVolumeWorkLogs),
@@ -106,6 +122,8 @@ func ReconcileOAuthAPIServerDeployment(deployment *appsv1.Deployment, ownerRef c
 			util.BuildVolume(oauthVolumeServingCert(), buildOAuthVolumeServingCert),
 			util.BuildVolume(oauthVolumeEtcdClientCert(), buildOAuthVolumeEtcdClientCert),
 			util.BuildVolume(common.VolumeTotalClientCA(), common.BuildVolumeTotalClientCA),
+			util.BuildVolume(oauthVolumeKonnectivityProxyCert(), buildOAuthVolumeKonnectivityProxyCert),
+			util.BuildVolume(oauthVolumeKonnectivityProxyCA(), buildOAuthVolumeKonnectivityProxyCA),
 		},
 	}
 
@@ -147,7 +165,13 @@ func oauthContainerMain() *corev1.Container {
 	}
 }
 
-func buildOAuthContainerMain(p *OAuthDeploymentParams) func(c *corev1.Container) {
+func oauthKonnectivityProxyContainer() *corev1.Container {
+	return &corev1.Container{
+		Name: "konnectivity-proxy",
+	}
+}
+
+func buildOAuthContainerMain(p *OAuthDeploymentParams, etcdHost string) func(c *corev1.Container) {
 	return func(c *corev1.Container) {
 		cpath := func(volume, file string) string {
 			return path.Join(oauthVolumeMounts.Path(c.Name, volume), file)
@@ -199,6 +223,41 @@ func buildOAuthContainerMain(p *OAuthDeploymentParams) func(c *corev1.Container)
 				corev1.ResourceCPU:    resource.MustParse("10m"),
 			},
 		}
+		c.Env = append(c.Env, []corev1.EnvVar{
+			{
+				Name:  "HTTP_PROXY",
+				Value: "socks5://127.0.0.1:8090",
+			},
+			{
+				Name:  "HTTPS_PROXY",
+				Value: "socks5://127.0.0.1:8090",
+			},
+			{
+				Name: "NO_PROXY",
+				Value: strings.Join([]string{
+					manifests.KubeAPIServerService("").Name,
+					etcdHost,
+					config.AuditWebhookService,
+				}, ","),
+			},
+		}...)
+	}
+}
+
+func buildOAuthKonnectivityProxyContainer(image string) func(c *corev1.Container) {
+	return func(c *corev1.Container) {
+		c.Image = image
+		c.Command = []string{"/usr/bin/control-plane-operator", "konnectivity-socks5-proxy"}
+		c.Args = []string{"run", "--resolve-from-guest-cluster-dns=true"}
+		c.Env = []corev1.EnvVar{{
+			Name:  "KUBECONFIG",
+			Value: fmt.Sprintf("%s/kubeconfig", volumeMounts.Path(c.Name, oauthVolumeKubeconfig().Name)),
+		}}
+		c.Resources.Requests = corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("10m"),
+			corev1.ResourceMemory: resource.MustParse("10Mi"),
+		}
+		c.VolumeMounts = oauthVolumeMounts.ContainerMounts(c.Name)
 	}
 }
 
@@ -295,6 +354,29 @@ func applyOauthAuditWebhookConfigFileVolume(podSpec *corev1.PodSpec, auditWebhoo
 func oauthAuditWebhookConfigFile() string {
 	cfgDir := oauthAuditWebhookConfigFileVolumeMount.Path(oauthContainerMain().Name, oauthAuditWebhookConfigFileVolume().Name)
 	return path.Join(cfgDir, hyperv1.AuditWebhookKubeconfigKey)
+}
+
+func oauthVolumeKonnectivityProxyCert() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "oauth-konnectivity-proxy-cert",
+	}
+}
+
+func oauthVolumeKonnectivityProxyCA() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "oauth-konnectivity-proxy-ca",
+	}
+}
+
+func buildOAuthVolumeKonnectivityProxyCert(v *corev1.Volume) {
+	v.Secret = &corev1.SecretVolumeSource{}
+	v.Secret.SecretName = manifests.KonnectivityClientSecret("").Name
+	v.Secret.DefaultMode = ptr.To[int32](0640)
+}
+
+func buildOAuthVolumeKonnectivityProxyCA(v *corev1.Volume) {
+	v.ConfigMap = &corev1.ConfigMapVolumeSource{}
+	v.ConfigMap.Name = manifests.KonnectivityCAConfigMap("").Name
 }
 
 func buildOAuthVolumeEtcdClientCert(v *corev1.Volume) {

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
@@ -45,6 +45,7 @@ type OAuthDeploymentParams struct {
 	ServiceAccountIssuerURL      string
 	DeploymentConfig             config.DeploymentConfig
 	AvailabilityProberImage      string
+	KonnectivityProxyImage       string
 	Availability                 hyperv1.AvailabilityPolicy
 	OwnerRef                     config.OwnerRef
 	AuditWebhookRef              *corev1.LocalObjectReference
@@ -221,6 +222,7 @@ func (p *OpenShiftAPIServerParams) AuditPolicyConfig() configv1.Audit {
 func (p *OpenShiftAPIServerParams) OAuthAPIServerDeploymentParams(hcp *hyperv1.HostedControlPlane) *OAuthDeploymentParams {
 	params := &OAuthDeploymentParams{
 		Image:                   p.OAuthAPIServerImage,
+		KonnectivityProxyImage:  p.ProxyImage,
 		EtcdURL:                 p.EtcdURL,
 		ServiceAccountIssuerURL: p.ServiceAccountIssuerURL,
 		DeploymentConfig:        p.OpenShiftOAuthAPIServerDeploymentConfig,

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents.yaml
@@ -109,6 +109,13 @@ spec:
         - --tls-min-version=VersionTLS12
         command:
         - /usr/bin/oauth-apiserver
+        env:
+        - name: HTTP_PROXY
+          value: socks5://127.0.0.1:8090
+        - name: HTTPS_PROXY
+          value: socks5://127.0.0.1:8090
+        - name: NO_PROXY
+          value: kube-apiserver,etcd-client,audit-webhook
         image: oauth-apiserver
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -181,6 +188,28 @@ spec:
         volumeMounts:
         - mountPath: /var/log/openshift-oauth-apiserver
           name: work-logs
+      - args:
+        - run
+        - --resolve-from-guest-cluster-dns=true
+        command:
+        - /usr/bin/control-plane-operator
+        - konnectivity-socks5-proxy
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/secrets/kubeconfig/kubeconfig
+        image: controlplane-operator
+        name: konnectivity-proxy-socks5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/secrets/kubeconfig
+          name: kubeconfig
+        - mountPath: /etc/konnectivity/proxy-client
+          name: konnectivity-proxy-cert
+        - mountPath: /etc/konnectivity/proxy-ca
+          name: konnectivity-proxy-ca
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -233,4 +262,11 @@ spec:
           defaultMode: 420
           name: client-ca
         name: client-ca
+      - name: konnectivity-proxy-cert
+        secret:
+          defaultMode: 416
+          secretName: konnectivity-client
+      - configMap:
+          name: konnectivity-ca-bundle
+        name: konnectivity-proxy-ca
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -109,6 +109,13 @@ spec:
         - --tls-min-version=VersionTLS12
         command:
         - /usr/bin/oauth-apiserver
+        env:
+        - name: HTTP_PROXY
+          value: socks5://127.0.0.1:8090
+        - name: HTTPS_PROXY
+          value: socks5://127.0.0.1:8090
+        - name: NO_PROXY
+          value: kube-apiserver,etcd-client,audit-webhook
         image: oauth-apiserver
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -181,6 +188,28 @@ spec:
         volumeMounts:
         - mountPath: /var/log/openshift-oauth-apiserver
           name: work-logs
+      - args:
+        - run
+        - --resolve-from-guest-cluster-dns=true
+        command:
+        - /usr/bin/control-plane-operator
+        - konnectivity-socks5-proxy
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/secrets/kubeconfig/kubeconfig
+        image: controlplane-operator
+        name: konnectivity-proxy-socks5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/secrets/kubeconfig
+          name: kubeconfig
+        - mountPath: /etc/konnectivity/proxy-client
+          name: konnectivity-proxy-cert
+        - mountPath: /etc/konnectivity/proxy-ca
+          name: konnectivity-proxy-ca
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -233,4 +262,11 @@ spec:
           defaultMode: 420
           name: client-ca
         name: client-ca
+      - name: konnectivity-proxy-cert
+        secret:
+          defaultMode: 416
+          secretName: konnectivity-client
+      - configMap:
+          name: konnectivity-ca-bundle
+        name: konnectivity-proxy-ca
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-oauth-apiserver/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-oauth-apiserver/deployment.yaml
@@ -47,6 +47,13 @@ spec:
         - --client-ca-file=/etc/kubernetes/certs/client-ca/ca.crt
         command:
         - /usr/bin/oauth-apiserver
+        env:
+        - name: HTTP_PROXY
+          value: socks5://127.0.0.1:8090
+        - name: HTTPS_PROXY
+          value: socks5://127.0.0.1:8090
+        - name: NO_PROXY
+          value: kube-apiserver,etcd-client,audit-webhook
         image: oauth-apiserver
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oapi/deployment.go
@@ -2,7 +2,6 @@ package oapi
 
 import (
 	"fmt"
-	"net/url"
 	"path"
 	"strings"
 
@@ -44,11 +43,10 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 
 	etcdHostname := "etcd-client"
 	if cpContext.HCP.Spec.Etcd.ManagementType == hyperv1.Unmanaged {
-		etcdUrl, err := url.Parse(cpContext.HCP.Spec.Etcd.Unmanaged.Endpoint)
+		etcdHostname, err = util.HostFromURL(cpContext.HCP.Spec.Etcd.Unmanaged.Endpoint)
 		if err != nil {
-			return fmt.Errorf("failed to parse etcd url: %w", err)
+			return err
 		}
-		etcdHostname = strings.Split(etcdUrl.Host, ":")[0]
 	}
 	noProxy := []string{
 		manifests.KubeAPIServerService("").Name,

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/component.go
@@ -5,6 +5,8 @@ import (
 	oapiv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/oapi"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/util"
+
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -45,6 +47,12 @@ func NewComponent() component.ControlPlaneComponent {
 		).
 		WithDependencies(oapiv2.ComponentName).
 		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{}).
+		InjectKonnectivityContainer(component.KonnectivityContainerOptions{
+			Mode: component.Socks5,
+			Socks5Options: component.Socks5Options{
+				ResolveFromGuestClusterDNS: ptr.To(true),
+			},
+		}).
 		Build()
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/deployment.go
@@ -3,8 +3,10 @@ package oapi
 import (
 	"fmt"
 	"path"
+	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/util"
@@ -20,6 +22,21 @@ const (
 )
 
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
+
+	var err error
+	etcdHostname := "etcd-client"
+	if cpContext.HCP.Spec.Etcd.ManagementType == hyperv1.Unmanaged {
+		etcdHostname, err = util.HostFromURL(cpContext.HCP.Spec.Etcd.Unmanaged.Endpoint)
+		if err != nil {
+			return err
+		}
+	}
+	noProxy := []string{
+		manifests.KubeAPIServerService("").Name,
+		etcdHostname,
+		config.AuditWebhookService,
+	}
+
 	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		etcdURL := config.DefaultEtcdURL
 		if cpContext.HCP.Spec.Etcd.ManagementType == hyperv1.Unmanaged {
@@ -42,6 +59,11 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 			tokenInactivityTimeout := configuration.OAuth.TokenConfig.AccessTokenInactivityTimeout.Duration.String()
 			c.Args = append(c.Args, fmt.Sprintf("--accesstoken-inactivity-timeout=%s", tokenInactivityTimeout))
 		}
+
+		util.UpsertEnvVar(c, corev1.EnvVar{
+			Name:  "NO_PROXY",
+			Value: strings.Join(noProxy, ","),
+		})
 	})
 
 	if cpContext.HCP.Spec.Configuration.GetAuditPolicyConfig().Profile == configv1.NoneAuditProfileType {

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"regexp"
 	"sort"
@@ -654,4 +655,30 @@ func GetControlPlaneOperatorImageLabels(ctx context.Context, hc *hyperv1.HostedC
 	}
 
 	return ImageLabels(controlPlaneOperatorImageMetadata), nil
+}
+
+var (
+	hasPortRegex = regexp.MustCompile(`:\d{1,5}$`)
+)
+
+func HostFromURL(addr string) (string, error) {
+	parsedURL, err := url.Parse(addr)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse URL(%s): %w", addr, err)
+	}
+	hostPort := parsedURL.Host
+	if hostPort == "" {
+		return "", fmt.Errorf("missing host/port name in URL(%s)", addr)
+	}
+	if !hasPortRegex.MatchString(hostPort) {
+		return hostPort, nil
+	}
+	hostName, _, err := net.SplitHostPort(hostPort)
+	if err != nil {
+		return "", fmt.Errorf("failed to split host/port from (%s): %w", hostPort, err)
+	}
+	if hostName == "" {
+		return "", fmt.Errorf("missing host name in URL(%s)", addr)
+	}
+	return hostName, nil
 }

--- a/support/util/util_test.go
+++ b/support/util/util_test.go
@@ -862,3 +862,34 @@ func TestRemoveEmptyJSONField(t *testing.T) {
 		})
 	}
 }
+
+func TestHostFromURL(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		{"http://example.com", "example.com", false},
+		{"https://example.com:443", "example.com", false},
+		{"http://localhost:8080", "localhost", false},
+		{"https://127.0.0.1:9000", "127.0.0.1", false},
+		{"ftp://example.org:21", "example.org", false},
+		{"http://[::1]:8080", "::1", false},                // IPv6 localhost
+		{"http://[2001:db8::1]:443", "2001:db8::1", false}, // IPv6 example
+		{"??", "", true},           // Invalid URL
+		{"http://:8080", "", true}, // Missing hostname
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			g := NewWithT(t)
+			result, err := HostFromURL(tt.input)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
ValidatingWebhooks installed in the data plane were not able to validate resources managed by the OpenShift oauth apiserver because the OpenShift oauth apiserver did not have a konnectivity-proxy. This commit adds the konnectivity-proxy sidecar to the openshift oauth apiserver deployment and uses the socks5 proxy given that the openshift-oauth-apiserver only needs to communicate with services inside the data plane.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-52190](https://issues.redhat.com/browse/OCPBUGS-52190)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.