### PR TITLE
OCPBUGS-53403: Remove synced annotations from HCP when they are removed from HC

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -499,92 +499,31 @@ func TestReconcileHostedControlPlaneConfiguration(t *testing.T) {
 	}
 }
 
-func TestReconcileHostedControlPlaneAutoscalingNeeded(t *testing.T) {
-	tests := []struct {
-		name                     string
-		autoscalingNeeded        bool
-		existingHCPAnnotations   map[string]string
-		expectedHCPAnnotations   map[string]string
-		unexpectedHCPAnnotations []string
-	}{
-		{
-			name:                   "Autoscaling not needed, no annotation set",
-			autoscalingNeeded:      false,
-			existingHCPAnnotations: nil,
-			expectedHCPAnnotations: map[string]string{
-				hyperv1.DisableClusterAutoscalerAnnotation: "true",
-			},
-		},
-		{
-			name:                     "Autoscaling needed, no annotation set",
-			autoscalingNeeded:        true,
-			existingHCPAnnotations:   nil,
-			unexpectedHCPAnnotations: []string{hyperv1.DisableClusterAutoscalerAnnotation},
-		},
-		{
-			name:              "Autoscaling not needed, annotation set",
-			autoscalingNeeded: false,
-			existingHCPAnnotations: map[string]string{
-				hyperv1.DisableClusterAutoscalerAnnotation: "true",
-			},
-			expectedHCPAnnotations: map[string]string{
-				hyperv1.DisableClusterAutoscalerAnnotation: "true",
-			},
-		},
-		{
-			name:              "Autoscaling needed, annotation set",
-			autoscalingNeeded: true,
-			existingHCPAnnotations: map[string]string{
-				hyperv1.DisableClusterAutoscalerAnnotation: "true",
-			},
-			unexpectedHCPAnnotations: []string{hyperv1.DisableClusterAutoscalerAnnotation},
-		},
+func TestReconcileHostedControlPlaneAnnotations(t *testing.T) {
+	type testCase struct {
+		name                   string
+		hcpAnnotations         map[string]string
+		hcAnnotations          map[string]string
+		isAutoscalingNeeded    bool
+		certRenewalAnnotations map[string]string
+		expectedAnnotations    map[string]string
 	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
-			hc := &hyperv1.HostedCluster{}
-			hcp := &hyperv1.HostedControlPlane{}
-			hcp.Annotations = test.existingHCPAnnotations
-			err := reconcileHostedControlPlane(hcp, hc, test.autoscalingNeeded, func() (map[string]string, error) { return nil, nil })
-			g.Expect(err).ToNot(HaveOccurred())
-			for k, v := range test.expectedHCPAnnotations {
-				g.Expect(hcp.Annotations).To(HaveKeyWithValue(k, v))
-			}
-			for _, k := range test.unexpectedHCPAnnotations {
-				g.Expect(hcp.Annotations).ToNot(HaveKey(k))
-			}
-		})
-	}
-}
 
-func TestReconcileHostedControlPlaneRestartAnnotation(t *testing.T) {
-	tests := []struct {
-		name                     string
-		hcAnnotations            map[string]string
-		existingHCPAnnotations   map[string]string
-		expectedHCPAnnotations   map[string]string
-		unexpectedHCPAnnotations []string
-	}{
-		{
-			name:                   "No annotation set",
-			hcAnnotations:          nil,
-			existingHCPAnnotations: nil,
-			expectedHCPAnnotations: nil,
-			unexpectedHCPAnnotations: []string{
-				hyperv1.RestartDateAnnotation,
-				previouslySyncedRestartDateAnnotation,
-			},
-		},
+	hcNamespace := "clusters"
+	hcName := "example"
+	hcKey := hcNamespace + "/" + hcName
+
+	tests := []testCase{
 		{
 			name: "Newly set restart annotation",
 			hcAnnotations: map[string]string{
 				hyperv1.RestartDateAnnotation: "01012024",
 			},
-			existingHCPAnnotations: nil,
-			expectedHCPAnnotations: map[string]string{
-				hyperv1.RestartDateAnnotation:         "01012024",
-				previouslySyncedRestartDateAnnotation: "01012024",
+			expectedAnnotations: map[string]string{
+				hyperv1.RestartDateAnnotation:              "01012024",
+				previouslySyncedRestartDateAnnotation:      "01012024",
+				hyperutil.HostedClusterAnnotation:          hcKey,
+				hyperv1.DisableClusterAutoscalerAnnotation: "true",
 			},
 		},
 		{
@@ -592,13 +531,15 @@ func TestReconcileHostedControlPlaneRestartAnnotation(t *testing.T) {
 			hcAnnotations: map[string]string{
 				hyperv1.RestartDateAnnotation: "05012024",
 			},
-			existingHCPAnnotations: map[string]string{
+			hcpAnnotations: map[string]string{
 				hyperv1.RestartDateAnnotation:         "01012024",
 				previouslySyncedRestartDateAnnotation: "01012024",
 			},
-			expectedHCPAnnotations: map[string]string{
-				hyperv1.RestartDateAnnotation:         "05012024",
-				previouslySyncedRestartDateAnnotation: "05012024",
+			expectedAnnotations: map[string]string{
+				hyperv1.RestartDateAnnotation:              "05012024",
+				previouslySyncedRestartDateAnnotation:      "05012024",
+				hyperutil.HostedClusterAnnotation:          hcKey,
+				hyperv1.DisableClusterAutoscalerAnnotation: "true",
 			},
 		},
 		{
@@ -606,13 +547,15 @@ func TestReconcileHostedControlPlaneRestartAnnotation(t *testing.T) {
 			hcAnnotations: map[string]string{
 				hyperv1.RestartDateAnnotation: "01012024",
 			},
-			existingHCPAnnotations: map[string]string{
+			hcpAnnotations: map[string]string{
 				hyperv1.RestartDateAnnotation:         "some other value",
 				previouslySyncedRestartDateAnnotation: "01012024",
 			},
-			expectedHCPAnnotations: map[string]string{
-				hyperv1.RestartDateAnnotation:         "some other value",
-				previouslySyncedRestartDateAnnotation: "01012024",
+			expectedAnnotations: map[string]string{
+				hyperv1.RestartDateAnnotation:              "some other value",
+				previouslySyncedRestartDateAnnotation:      "01012024",
+				hyperutil.HostedClusterAnnotation:          hcKey,
+				hyperv1.DisableClusterAutoscalerAnnotation: "true",
 			},
 		},
 		{
@@ -620,32 +563,116 @@ func TestReconcileHostedControlPlaneRestartAnnotation(t *testing.T) {
 			hcAnnotations: map[string]string{
 				hyperv1.RestartDateAnnotation: "05012024",
 			},
-			existingHCPAnnotations: map[string]string{
+			hcpAnnotations: map[string]string{
 				hyperv1.RestartDateAnnotation:         "some other value",
 				previouslySyncedRestartDateAnnotation: "01012024",
 			},
-			expectedHCPAnnotations: map[string]string{
-				hyperv1.RestartDateAnnotation:         "05012024",
-				previouslySyncedRestartDateAnnotation: "05012024",
+			expectedAnnotations: map[string]string{
+				hyperv1.RestartDateAnnotation:              "05012024",
+				previouslySyncedRestartDateAnnotation:      "05012024",
+				hyperutil.HostedClusterAnnotation:          hcKey,
+				hyperv1.DisableClusterAutoscalerAnnotation: "true",
+			},
+		},
+		{
+			name: "Initial reconcile",
+			hcAnnotations: map[string]string{
+				hyperutil.DebugDeploymentsAnnotation:                         "control-plane-operator",
+				hyperv1.EtcdPriorityClass:                                    "high-priority",
+				hyperv1.RequestServingNodeAdditionalSelectorAnnotation:       "node-size=m5xl",
+				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test1": "test1",
+				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test2": "test2",
+				"foo": "bar", // should not be copied
+			},
+			expectedAnnotations: map[string]string{
+				hyperutil.DebugDeploymentsAnnotation:                         "control-plane-operator",
+				hyperv1.EtcdPriorityClass:                                    "high-priority",
+				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test1": "test1",
+				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test2": "test2",
+				hyperv1.RequestServingNodeAdditionalSelectorAnnotation:       "node-size=m5xl",
+				hyperutil.HostedClusterAnnotation:                            hcKey,
+				hyperv1.DisableClusterAutoscalerAnnotation:                   "true",
+			},
+		},
+		{
+			name: "Initial reconcile - autoscaling needed",
+			hcAnnotations: map[string]string{
+				hyperutil.DebugDeploymentsAnnotation:                         "control-plane-operator",
+				hyperv1.EtcdPriorityClass:                                    "high-priority",
+				hyperv1.RequestServingNodeAdditionalSelectorAnnotation:       "node-size=m5xl",
+				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test1": "test1",
+				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test2": "test2",
+				"foo": "bar",
+			},
+			expectedAnnotations: map[string]string{
+				hyperutil.DebugDeploymentsAnnotation:                         "control-plane-operator",
+				hyperv1.EtcdPriorityClass:                                    "high-priority",
+				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test1": "test1",
+				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test2": "test2",
+				hyperv1.RequestServingNodeAdditionalSelectorAnnotation:       "node-size=m5xl",
+				hyperutil.HostedClusterAnnotation:                            hcKey,
+			},
+			isAutoscalingNeeded: true,
+		},
+		{
+			name: "Existing disable autoscaling annotation, autoscaling no longer needed",
+			hcAnnotations: map[string]string{
+				hyperutil.DebugDeploymentsAnnotation: "control-plane-operator",
+			},
+			hcpAnnotations: map[string]string{
+				hyperv1.DisableClusterAutoscalerAnnotation: "true",
+			},
+			expectedAnnotations: map[string]string{
+				hyperutil.DebugDeploymentsAnnotation: "control-plane-operator",
+				hyperutil.HostedClusterAnnotation:    hcKey,
+			},
+			isAutoscalingNeeded: true,
+		},
+		{
+			name: "Remove known annotations that are no longer set",
+			hcAnnotations: map[string]string{
+				hyperv1.EtcdPriorityClass:                                      "high-priority",
+				hyperv1.RequestServingNodeAdditionalSelectorAnnotation:         "node-size=m5xl",
+				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test1":   "test1",
+				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test2":   "test2",
+				hyperv1.ResourceRequestOverrideAnnotationPrefix + "-override1": "override1",
+				hyperv1.ResourceRequestOverrideAnnotationPrefix + "-override2": "override2",
+				"foo": "bar",
+			},
+			hcpAnnotations: map[string]string{
+				hyperutil.DebugDeploymentsAnnotation:                           "control-plane-operator",
+				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test1":   "test1",
+				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test3":   "test3",
+				hyperv1.ResourceRequestOverrideAnnotationPrefix + "-override4": "override4",
+				hyperv1.ResourceRequestOverrideAnnotationPrefix + "-override2": "override2",
+				"unrelated": "test", // should remain
+			},
+			expectedAnnotations: map[string]string{
+				hyperv1.EtcdPriorityClass:                                      "high-priority",
+				hyperv1.RequestServingNodeAdditionalSelectorAnnotation:         "node-size=m5xl",
+				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test1":   "test1",
+				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test2":   "test2",
+				hyperv1.ResourceRequestOverrideAnnotationPrefix + "-override1": "override1",
+				hyperv1.ResourceRequestOverrideAnnotationPrefix + "-override2": "override2",
+				hyperutil.HostedClusterAnnotation:                              hcKey,
+				hyperv1.DisableClusterAutoscalerAnnotation:                     "true",
+				"unrelated": "test",
 			},
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 			hc := &hyperv1.HostedCluster{}
+			hc.Name = hcName
+			hc.Namespace = hcNamespace
 			hcp := &hyperv1.HostedControlPlane{}
-			hc.Annotations = test.hcAnnotations
-			hcp.Annotations = test.existingHCPAnnotations
-			err := reconcileHostedControlPlane(hcp, hc, true, func() (map[string]string, error) { return nil, nil })
+			hcp.Annotations = tc.hcpAnnotations
+			hc.Annotations = tc.hcAnnotations
+			err := reconcileHostedControlPlaneAnnotations(hcp, hc, tc.isAutoscalingNeeded, func() (map[string]string, error) { return tc.certRenewalAnnotations, nil })
 			g.Expect(err).ToNot(HaveOccurred())
-			for k, v := range test.expectedHCPAnnotations {
-				g.Expect(hcp.Annotations).To(HaveKeyWithValue(k, v))
-			}
-			for _, k := range test.unexpectedHCPAnnotations {
-				g.Expect(hcp.Annotations).ToNot(HaveKey(k))
-			}
+			g.Expect(hcp.Annotations).To(Equal(tc.expectedAnnotations))
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit ensures that annotations that are synced by the HostedCluster are removed from the HostedControlPlane when they are removed from the HostedCluster. Annotations that the HostedCluster reconciler does not know about are not removed.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-53403](https://issues.redhat.com/browse/OCPBUGS-53403)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.