### PR TITLE
OCPBUGS-53462: Check for availability of individual catalog images

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -89,6 +89,7 @@ import (
 	supportawsutil "github.com/openshift/hypershift/support/awsutil"
 	hyperazureutil "github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/capabilities"
+	"github.com/openshift/hypershift/support/catalogs"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/conditions"
 	"github.com/openshift/hypershift/support/config"
@@ -3993,7 +3994,7 @@ func (r *HostedControlPlaneReconciler) reconcileOperatorLifecycleManager(ctx con
 				return fmt.Errorf("failed to get pull secret for namespace %s: %w", hcp.Namespace, err)
 			}
 
-			catalogImages, err = olm.GetCatalogImages(ctx, *hcp, pullSecret.Data[corev1.DockerConfigJsonKey], r.ImageMetadataProvider, isImageRegistryOverrides)
+			catalogImages, err = catalogs.GetCatalogImages(ctx, *hcp, pullSecret.Data[corev1.DockerConfigJsonKey], r.ImageMetadataProvider, isImageRegistryOverrides)
 			if err != nil {
 				return fmt.Errorf("failed to get catalog images: %w", err)
 			}

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/catalogs.go
@@ -1,7 +1,6 @@
 package olm
 
 import (
-	"context"
 	"fmt"
 	"math/big"
 	"strings"
@@ -21,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
-	"github.com/blang/semver"
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
@@ -120,67 +118,6 @@ func findTagReference(tags []imagev1.TagReference, name string) *imagev1.TagRefe
 		}
 	}
 	return nil
-}
-
-func GetCatalogImages(ctx context.Context, hcp hyperv1.HostedControlPlane, pullSecret []byte, imageMetadataProvider util.ImageMetadataProvider, registryOverrides map[string][]string) (map[string]string, error) {
-	imageRef := hcp.Spec.ReleaseImage
-	imageConfig, _, _, err := imageMetadataProvider.GetMetadata(ctx, imageRef, pullSecret)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get image metadata: %w", err)
-	}
-
-	version, err := semver.Parse(imageConfig.Config.Labels["io.openshift.release"])
-	if err != nil {
-		return nil, fmt.Errorf("invalid OpenShift release version format: %s", imageConfig.Config.Labels["io.openshift.release"])
-	}
-
-	registries := []string{
-		"registry.redhat.io/redhat",
-	}
-	if len(registryOverrides) > 0 {
-		for registrySource, registryDest := range registryOverrides {
-			if registries[0] == registrySource {
-				registries = registryDest
-				break
-			}
-		}
-	}
-
-	//check catalogs of last 4 supported version in case new version is not available
-	supportedVersions := 4
-	imageRegistry := ""
-	for i := 0; i < supportedVersions; i++ {
-		for _, registry := range registries {
-			testImage := fmt.Sprintf("%s/certified-operator-index:v%d.%d", registry, version.Major, version.Minor)
-
-			_, dockerImage, err := imageMetadataProvider.GetDigest(ctx, testImage, pullSecret)
-			if err == nil {
-				imageRegistry = fmt.Sprintf("%s/%s", dockerImage.Registry, dockerImage.Namespace)
-				break
-			}
-
-			// Manifest unknown error is expected if the image is not available.
-			if !strings.Contains(err.Error(), "manifest unknown") {
-				return nil, err // Return if it's an unexpected error
-			}
-		}
-		if imageRegistry != "" {
-			break
-		}
-		if i == supportedVersions-1 {
-			return nil, fmt.Errorf("failed to get image digest for 4 previous versions of certified-operator-index: %w", err)
-		}
-		version.Minor--
-	}
-
-	operators := map[string]string{
-		"certified-operators": fmt.Sprintf("%s/certified-operator-index:v%d.%d", imageRegistry, version.Major, version.Minor),
-		"community-operators": fmt.Sprintf("%s/community-operator-index:v%d.%d", imageRegistry, version.Major, version.Minor),
-		"redhat-marketplace":  fmt.Sprintf("%s/redhat-marketplace-index:v%d.%d", imageRegistry, version.Major, version.Minor),
-		"redhat-operators":    fmt.Sprintf("%s/redhat-operator-index:v%d.%d", imageRegistry, version.Major, version.Minor),
-	}
-
-	return operators, nil
 }
 
 func ReconcileCatalogsImageStream(imageStream *imagev1.ImageStream, ownerRef config.OwnerRef, catalogImages map[string]string) error {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/olm/catalogs/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/olm/catalogs/deployment.go
@@ -7,6 +7,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
+	"github.com/openshift/hypershift/support/catalogs"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
 	"github.com/openshift/hypershift/support/util"
@@ -16,8 +17,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/blang/semver"
 )
 
 func (c *catalogOptions) adaptCatalogDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
@@ -108,65 +107,7 @@ func getCatalogImagesOverrides(cpContext component.WorkloadContext, capabilityIm
 
 func getCatalogImages(cpContext component.WorkloadContext, pullSecret []byte) (map[string]string, error) {
 	registryOverrides := util.ConvertImageRegistryOverrideStringToMap(cpContext.HCP.Annotations[hyperv1.OLMCatalogsISRegistryOverridesAnnotation])
-
-	imageRef := cpContext.HCP.Spec.ReleaseImage
-	imageConfig, _, _, err := cpContext.ImageMetadataProvider.GetMetadata(cpContext, imageRef, pullSecret)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get image metadata: %w", err)
-	}
-
-	version, err := semver.Parse(imageConfig.Config.Labels["io.openshift.release"])
-	if err != nil {
-		return nil, fmt.Errorf("invalid OpenShift release version format: %s", imageConfig.Config.Labels["io.openshift.release"])
-	}
-
-	registries := []string{
-		"registry.redhat.io/redhat",
-	}
-	if len(registryOverrides) > 0 {
-		for registrySource, registryDest := range registryOverrides {
-			if registries[0] == registrySource {
-				registries = registryDest
-				break
-			}
-		}
-	}
-
-	//check catalogs of last 4 supported version in case new version is not available
-	supportedVersions := 4
-	imageRegistry := ""
-	for i := 0; i < supportedVersions; i++ {
-		for _, registry := range registries {
-			testImage := fmt.Sprintf("%s/certified-operator-index:v%d.%d", registry, version.Major, version.Minor)
-
-			_, dockerImage, err := cpContext.ImageMetadataProvider.GetDigest(cpContext, testImage, pullSecret)
-			if err == nil {
-				imageRegistry = fmt.Sprintf("%s/%s", dockerImage.Registry, dockerImage.Namespace)
-				break
-			}
-
-			// Manifest unknown error is expected if the image is not available.
-			if !strings.Contains(err.Error(), "manifest unknown") {
-				return nil, err // Return if it's an unexpected error
-			}
-		}
-		if imageRegistry != "" {
-			break
-		}
-		if i == supportedVersions-1 {
-			return nil, fmt.Errorf("failed to get image digest for 4 previous versions of certified-operator-index: %w", err)
-		}
-		version.Minor--
-	}
-
-	operators := map[string]string{
-		"certified-operators": fmt.Sprintf("%s/certified-operator-index:v%d.%d", imageRegistry, version.Major, version.Minor),
-		"community-operators": fmt.Sprintf("%s/community-operator-index:v%d.%d", imageRegistry, version.Major, version.Minor),
-		"redhat-marketplace":  fmt.Sprintf("%s/redhat-marketplace-index:v%d.%d", imageRegistry, version.Major, version.Minor),
-		"redhat-operators":    fmt.Sprintf("%s/redhat-operator-index:v%d.%d", imageRegistry, version.Major, version.Minor),
-	}
-
-	return operators, nil
+	return catalogs.GetCatalogImages(cpContext, *cpContext.HCP, pullSecret, cpContext.ImageMetadataProvider, registryOverrides)
 }
 
 func checkCatalogImageOverides(images map[string]string) (bool, error) {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm/params.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm/params.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/olm"
+	"github.com/openshift/hypershift/support/catalogs"
 	"github.com/openshift/hypershift/support/util"
 
 	corev1 "k8s.io/api/core/v1"
@@ -21,7 +21,7 @@ type OperatorLifecycleManagerParams struct {
 
 func NewOperatorLifecycleManagerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, pullSecret *corev1.Secret, imageMetadataProvider util.ImageMetadataProvider) (*OperatorLifecycleManagerParams, error) {
 	isImageRegistryOverrides := util.ConvertImageRegistryOverrideStringToMap(hcp.Annotations[hyperv1.OLMCatalogsISRegistryOverridesAnnotation])
-	catalogImages, err := olm.GetCatalogImages(ctx, *hcp, pullSecret.Data[corev1.DockerConfigJsonKey], imageMetadataProvider, isImageRegistryOverrides)
+	catalogImages, err := catalogs.GetCatalogImages(ctx, *hcp, pullSecret.Data[corev1.DockerConfigJsonKey], imageMetadataProvider, isImageRegistryOverrides)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get catalog images: %w", err)
 	}

--- a/support/catalogs/images.go
+++ b/support/catalogs/images.go
@@ -1,0 +1,177 @@
+package catalogs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/util"
+
+	"github.com/blang/semver"
+)
+
+const cacheExpiration = 5 * time.Minute
+
+type imagesCache struct {
+	timeStamp time.Time
+	hash      string
+	images    map[string]string
+	m         sync.Mutex
+}
+
+func (c *imagesCache) getImages(inputsHash string) map[string]string {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	if inputsHash != c.hash {
+		return nil
+	}
+
+	if time.Since(c.timeStamp) > cacheExpiration {
+		return nil
+	}
+
+	return c.images
+}
+
+func (c *imagesCache) setImages(images map[string]string, inputsHash string) {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	c.timeStamp = time.Now()
+	c.hash = inputsHash
+	c.images = images
+}
+
+var catalogImagesCache = &imagesCache{}
+
+// GetCatalogImages uses a simple cache to prevent frequent registry lookups for catalog images
+func GetCatalogImages(ctx context.Context, hcp hyperv1.HostedControlPlane, pullSecret []byte, imageMetadataProvider util.ImageMetadataProvider, registryOverrides map[string][]string) (map[string]string, error) {
+	return getCatalogImagesWithCache(
+		imageLookupCacheKeyFn(&hcp, pullSecret, registryOverrides),
+		releaseVersionFn(ctx, &hcp, pullSecret, imageMetadataProvider),
+		imageExistsFn(ctx, pullSecret, imageMetadataProvider),
+		registryOverrides)
+}
+
+func getCatalogImagesWithCache(cacheKey func() any, releaseVersion func() (*semver.Version, error), imageExists func(string) (bool, error), registryOverrides map[string][]string) (map[string]string, error) {
+	hash := util.HashSimple(cacheKey())
+	if images := catalogImagesCache.getImages(hash); images != nil {
+		return images, nil
+	}
+	images, err := computeCatalogImages(releaseVersion, imageExists, registryOverrides)
+	if err != nil {
+		return nil, err
+	}
+	catalogImagesCache.setImages(images, hash)
+	return images, nil
+}
+
+func imageLookupCacheKeyFn(hcp *hyperv1.HostedControlPlane, pullSecret []byte, registryOverrides map[string][]string) func() any {
+	return func() any {
+		cacheKey := struct {
+			releaseImage string
+			overrides    map[string][]string
+			pullSecret   []byte
+		}{
+			releaseImage: hcp.Spec.ReleaseImage,
+			overrides:    registryOverrides,
+			pullSecret:   pullSecret,
+		}
+		return cacheKey
+	}
+}
+
+func releaseVersionFn(ctx context.Context, hcp *hyperv1.HostedControlPlane, pullSecret []byte, imageMetadataProvider util.ImageMetadataProvider) func() (*semver.Version, error) {
+	return func() (*semver.Version, error) {
+		imageRef := hcp.Spec.ReleaseImage
+		imageConfig, _, _, err := imageMetadataProvider.GetMetadata(ctx, imageRef, pullSecret)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get image metadata: %w", err)
+		}
+
+		version, err := semver.Parse(imageConfig.Config.Labels["io.openshift.release"])
+		if err != nil {
+			return nil, fmt.Errorf("invalid OpenShift release version format: %s", imageConfig.Config.Labels["io.openshift.release"])
+		}
+		return &version, nil
+	}
+}
+
+func imageExistsFn(ctx context.Context, pullSecret []byte, imageMetadataProvider util.ImageMetadataProvider) func(image string) (bool, error) {
+	return func(image string) (bool, error) {
+		_, _, err := imageMetadataProvider.GetDigest(ctx, image, pullSecret)
+		if err == nil {
+			return true, nil
+		}
+		if strings.Contains(err.Error(), "manifest unknown") {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get image digest: %w", err)
+	}
+}
+
+func computeCatalogImages(releaseVersion func() (*semver.Version, error), imageExists func(string) (bool, error), registryOverrides map[string][]string) (map[string]string, error) {
+	version, err := releaseVersion()
+	if err != nil {
+		return nil, err
+	}
+
+	defaultRegistry := "registry.redhat.io/redhat"
+	registries := []string{
+		defaultRegistry,
+	}
+	if len(registryOverrides) > 0 {
+		for registrySource, registryDest := range registryOverrides {
+			if registrySource == defaultRegistry {
+				registries = registryDest
+				break
+			}
+		}
+	}
+
+	//check catalogs of last 4 supported version in case new version is not available
+	supportedVersions := 4
+
+	catalogImageNames := map[string]string{
+		"certified-operators": "certified-operator-index",
+		"community-operators": "community-operator-index",
+		"redhat-marketplace":  "redhat-marketplace-index",
+		"redhat-operators":    "redhat-operator-index",
+	}
+
+	catalogs := map[string]string{
+		"certified-operators": "",
+		"community-operators": "",
+		"redhat-marketplace":  "",
+		"redhat-operators":    "",
+	}
+
+	for catalog := range catalogs {
+		catalogVersion := *version
+		for i := range supportedVersions {
+			for _, registry := range registries {
+				testImage := fmt.Sprintf("%s/%s:v%d.%d", registry, catalogImageNames[catalog], catalogVersion.Major, catalogVersion.Minor)
+				exists, err := imageExists(testImage)
+				if err != nil {
+					return nil, err
+				}
+				if exists {
+					catalogs[catalog] = testImage
+					break
+				}
+			}
+			if catalogs[catalog] != "" {
+				break
+			}
+			if i == supportedVersions-1 {
+				return nil, fmt.Errorf("failed to fetch image digest for 4 previous versions of %s", catalog)
+			}
+			catalogVersion.Minor--
+		}
+	}
+	return catalogs, nil
+}

--- a/support/catalogs/images_test.go
+++ b/support/catalogs/images_test.go
@@ -1,0 +1,285 @@
+package catalogs
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/util"
+
+	"github.com/blang/semver"
+)
+
+func TestComputeCatalogImages(t *testing.T) {
+	tests := []struct {
+		name              string
+		releaseVersion    semver.Version
+		existingImages    []string
+		registryOverrides map[string][]string
+		expected          map[string]string
+	}{
+		{
+			name:           "All current release images are available",
+			releaseVersion: semver.MustParse("4.19.2"),
+			existingImages: []string{
+				"registry.redhat.io/redhat/certified-operator-index:v4.19",
+				"registry.redhat.io/redhat/community-operator-index:v4.19",
+				"registry.redhat.io/redhat/redhat-marketplace-index:v4.19",
+				"registry.redhat.io/redhat/redhat-operator-index:v4.19",
+			},
+			expected: map[string]string{
+				"certified-operators": "registry.redhat.io/redhat/certified-operator-index:v4.19",
+				"community-operators": "registry.redhat.io/redhat/community-operator-index:v4.19",
+				"redhat-marketplace":  "registry.redhat.io/redhat/redhat-marketplace-index:v4.19",
+				"redhat-operators":    "registry.redhat.io/redhat/redhat-operator-index:v4.19",
+			},
+		},
+		{
+			name:           "Some catalogs only have previous release images",
+			releaseVersion: semver.MustParse("4.19.2"),
+			existingImages: []string{
+				"registry.redhat.io/redhat/certified-operator-index:v4.19",
+				"registry.redhat.io/redhat/community-operator-index:v4.17",
+				"registry.redhat.io/redhat/redhat-marketplace-index:v4.19",
+				"registry.redhat.io/redhat/redhat-operator-index:v4.18",
+			},
+			expected: map[string]string{
+				"certified-operators": "registry.redhat.io/redhat/certified-operator-index:v4.19",
+				"community-operators": "registry.redhat.io/redhat/community-operator-index:v4.17",
+				"redhat-marketplace":  "registry.redhat.io/redhat/redhat-marketplace-index:v4.19",
+				"redhat-operators":    "registry.redhat.io/redhat/redhat-operator-index:v4.18",
+			},
+		},
+		{
+			name:           "image overrides are used if present",
+			releaseVersion: semver.MustParse("4.19.0"),
+			existingImages: []string{
+				"example.org/test/certified-operator-index:v4.19",
+				"example.org/test/community-operator-index:v4.19",
+				"example.org/test/community-operator-index:v4.18",
+				"another.example.org/redhat/redhat-marketplace-index:v4.19",
+				"another.example.org/redhat/redhat-operator-index:v4.19",
+			},
+			registryOverrides: map[string][]string{
+				"registry.redhat.io/redhat": {
+					"example.org/test",
+					"another.example.org/redhat",
+				},
+			},
+			expected: map[string]string{
+				"certified-operators": "example.org/test/certified-operator-index:v4.19",
+				"community-operators": "example.org/test/community-operator-index:v4.19",
+				"redhat-marketplace":  "another.example.org/redhat/redhat-marketplace-index:v4.19",
+				"redhat-operators":    "another.example.org/redhat/redhat-operator-index:v4.19",
+			},
+		},
+		{
+			name:           "previous versions are used for overrides",
+			releaseVersion: semver.MustParse("4.19.0"),
+			existingImages: []string{
+				"example.org/test/certified-operator-index:v4.19",
+				"example.org/test/community-operator-index:v4.18",
+				"another.example.org/redhat/redhat-marketplace-index:v4.19",
+				"another.example.org/redhat/redhat-operator-index:v4.17",
+			},
+			registryOverrides: map[string][]string{
+				"registry.redhat.io/redhat": {
+					"example.org/test",
+					"another.example.org/redhat",
+				},
+			},
+			expected: map[string]string{
+				"certified-operators": "example.org/test/certified-operator-index:v4.19",
+				"community-operators": "example.org/test/community-operator-index:v4.18",
+				"redhat-marketplace":  "another.example.org/redhat/redhat-marketplace-index:v4.19",
+				"redhat-operators":    "another.example.org/redhat/redhat-operator-index:v4.17",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result, err := computeCatalogImages(func() (*semver.Version, error) {
+				return &tc.releaseVersion, nil
+			}, func(image string) (bool, error) {
+				return slices.Contains(tc.existingImages, image), nil
+			}, tc.registryOverrides)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(result).To(Equal(tc.expected))
+		})
+	}
+}
+
+func TestImagesCacheGetImages(t *testing.T) {
+	tests := []struct {
+		name      string
+		cache     *imagesCache
+		inputHash string
+		expected  map[string]string
+	}{
+		{
+			name:      "cache empty",
+			cache:     &imagesCache{},
+			inputHash: "1234",
+			expected:  nil,
+		},
+		{
+			name: "valid entry",
+			cache: &imagesCache{
+				timeStamp: time.Now(),
+				hash:      "4567",
+				images: map[string]string{
+					"foo":  "bar",
+					"foo1": "bar1",
+				},
+			},
+			inputHash: "4567",
+			expected: map[string]string{
+				"foo":  "bar",
+				"foo1": "bar1",
+			},
+		},
+		{
+			name: "hash doesn't match",
+			cache: &imagesCache{
+				timeStamp: time.Now(),
+				hash:      "4567",
+				images: map[string]string{
+					"foo":  "bar",
+					"foo1": "bar1",
+				},
+			},
+			inputHash: "1234",
+			expected:  nil,
+		},
+		{
+			name: "cache expired",
+			cache: &imagesCache{
+				timeStamp: time.Now().Add(-30 * time.Minute),
+				hash:      "4567",
+				images: map[string]string{
+					"foo":  "bar",
+					"foo1": "bar1",
+				},
+			},
+			inputHash: "4567",
+			expected:  nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			result := tc.cache.getImages(tc.inputHash)
+			g.Expect(result).To(Equal(tc.expected))
+		})
+	}
+}
+
+func TestImagesCacheSetImages(t *testing.T) {
+	g := NewGomegaWithT(t)
+	images := map[string]string{
+		"foo":  "bar",
+		"foo1": "bar1",
+	}
+	c := &imagesCache{}
+	c.setImages(images, "12345")
+	result := c.getImages("12345")
+	g.Expect(result).To(Equal(images))
+	result = c.getImages("45678")
+	g.Expect(result).To(BeNil())
+}
+
+func TestGetCatalogImagesWithCache(t *testing.T) {
+	cacheKeyFn := func() any { return "12345" }
+	alternateCacheKeyFn := func() any { return "7890" }
+	releaseVersioFn := func() (*semver.Version, error) {
+		version := semver.MustParse("4.19.0")
+		return &version, nil
+	}
+	imageExistsFn := func(img string) (bool, error) {
+		return true, nil
+	}
+
+	only417ImgsExist := func(img string) (bool, error) {
+		imgs := []string{
+			"registry.redhat.io/redhat/certified-operator-index:v4.17",
+			"registry.redhat.io/redhat/community-operator-index:v4.17",
+			"registry.redhat.io/redhat/redhat-marketplace-index:v4.17",
+			"registry.redhat.io/redhat/redhat-operator-index:v4.17",
+		}
+		return slices.Contains(imgs, img), nil
+	}
+
+	g := NewGomegaWithT(t)
+
+	// First call should not use the cache
+	result, err := getCatalogImagesWithCache(cacheKeyFn, releaseVersioFn, imageExistsFn, nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(
+		map[string]string{
+			"certified-operators": "registry.redhat.io/redhat/certified-operator-index:v4.19",
+			"community-operators": "registry.redhat.io/redhat/community-operator-index:v4.19",
+			"redhat-marketplace":  "registry.redhat.io/redhat/redhat-marketplace-index:v4.19",
+			"redhat-operators":    "registry.redhat.io/redhat/redhat-operator-index:v4.19",
+		},
+	))
+
+	// Next call should use the cache, even if we pass an alternate imageExistsFn
+	result, err = getCatalogImagesWithCache(cacheKeyFn, releaseVersioFn, only417ImgsExist, nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(
+		map[string]string{
+			"certified-operators": "registry.redhat.io/redhat/certified-operator-index:v4.19",
+			"community-operators": "registry.redhat.io/redhat/community-operator-index:v4.19",
+			"redhat-marketplace":  "registry.redhat.io/redhat/redhat-marketplace-index:v4.19",
+			"redhat-operators":    "registry.redhat.io/redhat/redhat-operator-index:v4.19",
+		},
+	))
+
+	// If we change the cache key (such as different release), then the image lookup function should
+	// be called again
+	result, err = getCatalogImagesWithCache(alternateCacheKeyFn, releaseVersioFn, only417ImgsExist, nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(
+		map[string]string{
+			"certified-operators": "registry.redhat.io/redhat/certified-operator-index:v4.17",
+			"community-operators": "registry.redhat.io/redhat/community-operator-index:v4.17",
+			"redhat-marketplace":  "registry.redhat.io/redhat/redhat-marketplace-index:v4.17",
+			"redhat-operators":    "registry.redhat.io/redhat/redhat-operator-index:v4.17",
+		},
+	))
+}
+
+func TestImageLookupCacheKeyFn(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	hc := &hyperv1.HostedControlPlane{}
+	hc.Spec.ReleaseImage = "registry.redhat.io/release:example"
+	pullSecret := []byte("12345")
+	registryOverrides := map[string][]string{
+		"test": {"one", "two"},
+	}
+
+	// Test that hashes for the same input are the same
+	fn1 := imageLookupCacheKeyFn(hc, pullSecret, registryOverrides)
+	fn2 := imageLookupCacheKeyFn(hc, pullSecret, registryOverrides)
+	hash1 := util.HashSimple(fn1())
+	hash2 := util.HashSimple(fn2())
+	g.Expect(hash1).To(Equal(hash2))
+
+	// Test that if we change part of the key, the hashes will defer
+	hc.Spec.ReleaseImage = hc.Spec.ReleaseImage + "v2"
+	fn3 := imageLookupCacheKeyFn(hc, pullSecret, registryOverrides)
+	hash3 := util.HashSimple(fn3())
+	g.Expect(hash3).ToNot(Equal(hash1))
+
+	registryOverrides = map[string][]string{
+		"test": {"one", "two", "three"},
+	}
+	fn4 := imageLookupCacheKeyFn(hc, pullSecret, registryOverrides)
+	hash4 := util.HashSimple(fn4())
+	g.Expect(hash4).ToNot(Equal(hash3))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit refactors the code that fetches the images to use for OLM catalogs into a common support package. It checks individual catalog images instead of assuming that all of them have the same tag available. It also introduces a cache for images so that every reconcile loop does not result in registry lookups.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-53462](https://issues.redhat.com/browse/OCPBUGS-53462)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.