### PR TITLE
OCPBUGS-54178: Add missing servicemonitors and prometheusrules permissions for non-OVN

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -275,6 +275,14 @@ func ReconcileRole(role *rbacv1.Role, ownerRef config.OwnerRef, networkType hype
 				},
 				Verbs: []string{"*"},
 			},
+			{
+				APIGroups: []string{"monitoring.coreos.com", "monitoring.rhobs"},
+				Resources: []string{
+					"servicemonitors",
+					"prometheusrules",
+				},
+				Verbs: []string{"*"},
+			},
 		}
 		return nil
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator_test.go
@@ -281,6 +281,14 @@ func expectedRules(networkType hyperv1.NetworkType) []rbacv1.PolicyRule {
 			},
 			Verbs: []string{"*"},
 		},
+		{
+			APIGroups: []string{"monitoring.coreos.com", "monitoring.rhobs"},
+			Resources: []string{
+				"servicemonitors",
+				"prometheusrules",
+			},
+			Verbs: []string{"*"},
+		},
 	}
 
 	if networkType != hyperv1.OVNKubernetes {


### PR DESCRIPTION
**What this PR does / why we need it**:

Resolves permission errors in the CNO for patching servicemonitors and prometheusrules for non-OVN clusters.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

https://issues.redhat.com/browse/OCPBUGS-54178

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.