### PR TITLE
CNTRLPLANE-112: Fix CNCC RG Permissions & RBAC

### DIFF
--- a/cmd/infra/azure/create.go
+++ b/cmd/infra/azure/create.go
@@ -850,6 +850,7 @@ func assignServicePrincipalRoles(subscriptionID, managedResourceGroupName, nsgRe
 		role = "5b7237c5-45e1-49d6-bc18-a1f62f400748"
 	case cncc:
 		role = "be7a6435-15ae-4171-8f30-4a343eff9e8f"
+		scopes = append(scopes, vnetRG)
 	case ciro:
 		role = "8b32b316-c2f5-4ddf-b05b-83dacd2d08b5"
 	case nodePoolMgmt:

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/rbac.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/rbac.go
@@ -232,3 +232,19 @@ func AzureFileCSIDriverNodeServiceAccountRoleBinding() *rbacv1.ClusterRoleBindin
 		},
 	}
 }
+
+func CloudNetworkConfigControllerServiceAccountRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "system:serviceaccount:openshift-cloud-network-config-controller:cloud-network-config-controller",
+		},
+	}
+}
+
+func CloudNetworkConfigControllerServiceAccountRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "system:serviceaccount:openshift-cloud-network-config-controller:cloud-network-config-controller",
+		},
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
@@ -718,3 +718,41 @@ func ReconcileAzureFileCSIDriverNodeServiceAccountClusterRoleBinding(r *rbacv1.C
 	}
 	return nil
 }
+
+func ReconcileCloudNetworkConfigControllerServiceAccountClusterRole(r *rbacv1.ClusterRole) error {
+	if r.Annotations == nil {
+		r.Annotations = map[string]string{}
+	}
+	r.Annotations["rbac.authorization.kubernetes.io/autoupdate"] = "true"
+	r.Rules = []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"events"},
+			Verbs: []string{
+				"get",
+				"create",
+			},
+		},
+	}
+	return nil
+}
+
+func ReconcileCloudNetworkConfigControllerServiceAccountClusterRoleBinding(r *rbacv1.ClusterRoleBinding) error {
+	if r.Annotations == nil {
+		r.Annotations = map[string]string{}
+	}
+	r.Annotations["rbac.authorization.kubernetes.io/autoupdate"] = "true"
+	r.RoleRef = rbacv1.RoleRef{
+		APIGroup: rbacv1.SchemeGroupVersion.Group,
+		Kind:     "ClusterRole",
+		Name:     "system:serviceaccount:openshift-cloud-network-config-controller:cloud-network-config-controller",
+	}
+	r.Subjects = []rbacv1.Subject{
+		{
+			Kind:      "ServiceAccount",
+			Name:      "cloud-network-config-controller",
+			Namespace: "openshift-cloud-network-config-controller",
+		},
+	}
+	return nil
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1010,6 +1010,9 @@ func (r *reconciler) reconcileRBAC(ctx context.Context) error {
 
 			manifestAndReconcile[*rbacv1.ClusterRole]{manifest: manifests.AzureFileCSIDriverNodeServiceAccountRole, reconcile: rbac.ReconcileAzureFileCSIDriverNodeServiceAccountClusterRole},
 			manifestAndReconcile[*rbacv1.ClusterRoleBinding]{manifest: manifests.AzureFileCSIDriverNodeServiceAccountRoleBinding, reconcile: rbac.ReconcileAzureFileCSIDriverNodeServiceAccountClusterRoleBinding},
+
+			manifestAndReconcile[*rbacv1.ClusterRole]{manifest: manifests.CloudNetworkConfigControllerServiceAccountRole, reconcile: rbac.ReconcileCloudNetworkConfigControllerServiceAccountClusterRole},
+			manifestAndReconcile[*rbacv1.ClusterRoleBinding]{manifest: manifests.CloudNetworkConfigControllerServiceAccountRoleBinding, reconcile: rbac.ReconcileCloudNetworkConfigControllerServiceAccountClusterRoleBinding},
 		)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request:
- adds a role assignment for the CNCC over the VNET resource group for managed Azure, which is needed for CNCC to be able to read and write over items in the VNET resource group
- adds event get & create RBAC for the service account, cloud-network-config-controller, in the openshift-cloud-network-config-controller namespace

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
A part of [CNTRLPLANE-112](https://issues.redhat.com//browse/CNTRLPLANE-112)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.