### PR TITLE
NO-JIRA: Revert "OCPBUGS-50915: Disable capi machineset preflights"

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3439,7 +3439,6 @@ func reconcileCAPIManagerDeployment(deployment *appsv1.Deployment, hc *hyperv1.H
 							fmt.Sprintf("--leader-elect-lease-duration=%s", config.RecommendedLeaseDuration),
 							fmt.Sprintf("--leader-elect-retry-period=%s", config.RecommendedRetryPeriod),
 							fmt.Sprintf("--leader-elect-renew-deadline=%s", config.RecommendedRenewDeadline),
-							"--feature-gates=MachineSetPreflightChecks=false",
 						},
 						LivenessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{

--- a/hypershift-operator/controllers/nodepool/capi.go
+++ b/hypershift-operator/controllers/nodepool/capi.go
@@ -374,8 +374,6 @@ func (c *CAPI) reconcileMachineDeployment(ctx context.Context, log logr.Logger,
 		machineDeployment.Annotations = map[string]string{}
 	}
 	machineDeployment.Annotations[nodePoolAnnotation] = client.ObjectKeyFromObject(nodePool).String()
-	machineDeployment.Annotations[capiv1.MachineSetSkipPreflightChecksAnnotation] = string(capiv1.MachineSetPreflightCheckAll)
-
 	// Delete any paused annotation
 	delete(machineDeployment.Annotations, capiv1.PausedAnnotation)
 	if machineDeployment.GetLabels() == nil {
@@ -933,8 +931,6 @@ func (c *CAPI) reconcileMachineSet(ctx context.Context,
 		return err
 	}
 	machineSet.Annotations[nodePoolAnnotationMaxUnavailable] = strconv.Itoa(maxUnavailable)
-
-	machineSet.Annotations[capiv1.MachineSetSkipPreflightChecksAnnotation] = string(capiv1.MachineSetPreflightCheckAll)
 
 	// Set selector and template
 	machineSet.Spec.ClusterName = capiClusterName

--- a/hypershift-operator/controllers/nodepool/capi_test.go
+++ b/hypershift-operator/controllers/nodepool/capi_test.go
@@ -1456,8 +1456,6 @@ func TestCAPIReconcile(t *testing.T) {
 				g.Expect(md.Spec.Template.Spec.InfrastructureRef.Name).To(Equal(awsMachineTemplateName))
 				// Check MachineDeployment annotations
 				g.Expect(md.Annotations).To(HaveKeyWithValue(nodePoolAnnotation, "test-namespace/test-nodepool"))
-				// Check skip preflight annotation.
-				g.Expect(md.Annotations).To(HaveKeyWithValue(capiv1.MachineSetSkipPreflightChecksAnnotation, string(capiv1.MachineSetPreflightCheckAll)))
 
 				// Check MachineDeployment spec.
 				g.Expect(md.Spec.Strategy.Type).To(Equal(capiv1.MachineDeploymentStrategyType("RollingUpdate")))


### PR DESCRIPTION
Reverts openshift/hypershift#5653

This broke 4.14 payload jobs with `cluster-api` pod not able to start
```
invalid argument "MachineSetPreflightChecks=false" for "--feature-gates" flag: unrecognized feature gate: MachineSetPreflightChecks
```

https://testgrid.k8s.io/redhat-hypershift#4.14-aws-ovn

TRT SOP is to revert.

@stbenjam @neisw 