### PR TITLE
CNTRLPLANE-112: Enable MIv3 for azure file csi driver

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -5098,7 +5098,7 @@ func (r *HostedControlPlaneReconciler) reconcileClusterStorageOperator(ctx conte
 
 		azureFileSecretProviderClass := manifests.ManagedAzureSecretProviderClass(config.ManagedAzureFileCSISecretStoreProviderClassName, hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r, azureFileSecretProviderClass, func() error {
-			secretproviderclass.ReconcileManagedAzureSecretProviderClass(azureFileSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.File)
+			secretproviderclass.ReconcileManagedAzureSecretProviderClass(azureFileSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.File, true)
 			return nil
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile Azure File Secret Provider Class: %w", err)

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -1699,7 +1699,7 @@ func TestControlPlaneComponents(t *testing.T) {
 			cpContext.Client = fakeClient
 
 			// Reconcile multiple times to make sure multiple runs don't produce different results,
-			// and to check if resrouces are making a no-op update calls.
+			// and to check if resources are making a no-op update calls.
 			for range 2 {
 				if err := component.Reconcile(cpContext); err != nil {
 					t.Fatalf("failed to reconcile component %s: %v", component.Name(), err)

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/azure.go
@@ -47,8 +47,7 @@ func ReconcileAzureDiskCSISecret(secret *corev1.Secret, hcp *hyperv1.HostedContr
 // ReconcileAzureFileCSISecret reconciles the configuration for the secret as expected by azure-file-csi-controller
 func ReconcileAzureFileCSISecret(secret *corev1.Secret, hcp *hyperv1.HostedControlPlane, tenantID string) error {
 	config := initializeAzureCSIControllerConfig(hcp, tenantID)
-	config.AADClientID = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.File.ClientID
-	config.AADClientCertPath = path.Join(hypershiftconfig.ManagedAzureCertificatePath, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.File.CertificateName)
+	config.AADMSIDataPlaneIdentityPath = path.Join(hypershiftconfig.ManagedAzureCertificatePath, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.File.CredentialsSecretName)
 
 	var getVnetNameAndResourceGroupErr error
 	// aro hcp csi nfs protocol provision volumes needs the vnetName/vnetResourceGroup config

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/storage/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/storage/azure.go
@@ -63,6 +63,6 @@ func adaptAzureCSIFileSecret(cpContext component.WorkloadContext, secret *corev1
 
 func adaptAzureCSIFileSecretProvider(cpContext component.WorkloadContext, secretProvider *secretsstorev1.SecretProviderClass) error {
 	managedIdentity := cpContext.HCP.Spec.Platform.Azure.ManagedIdentities.ControlPlane.File
-	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, managedIdentity)
+	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, managedIdentity, true)
 	return nil
 }

--- a/kas-bootstrap/main.go
+++ b/kas-bootstrap/main.go
@@ -1,6 +1,6 @@
 package kasbootstrap
 
-// kas-bootstrap is a tool to run the pre-required actions for bootstraping the kas during cluster creation (or upgrade).
+// kas-bootstrap is a tool to run the pre-required actions for bootstrapping the kas during cluster creation (or upgrade).
 // It will apply some CRDs rendered by the cluster-config-operator and update the featureGate CR status by appending the git FeatureGate status.
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request enables managed identity version 3 for azure file csi driver for managed Azure HCP.

**Which issue(s) this PR fixes**:
A part of [CNTRLPLANE-112](https://issues.redhat.com/browse/CNTRLPLANE-112)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.