### PR TITLE
OCPBUGS-54431: Don't set IgnitionServerTokenExpirationTimestampAnnotation if already set

### DIFF
--- a/hypershift-operator/controllers/nodepool/token.go
+++ b/hypershift-operator/controllers/nodepool/token.go
@@ -206,6 +206,12 @@ func setExpirationTimestampOnToken(ctx context.Context, c client.Client, tokenSe
 		now = time.Now
 	}
 
+	// there's no need to set the expiration timestamp annotation again if already set
+	_, hasExpirationTimestamp := tokenSecret.Annotations[hyperv1.IgnitionServerTokenExpirationTimestampAnnotation]
+	if hasExpirationTimestamp {
+		return nil
+	}
+
 	// this should be a reasonable value to allow all in flight provisions to complete.
 	timeUntilExpiry := 2 * time.Hour
 	if tokenSecret.Annotations == nil {

--- a/hypershift-operator/controllers/nodepool/token_test.go
+++ b/hypershift-operator/controllers/nodepool/token_test.go
@@ -417,7 +417,7 @@ func TestTokenCleanupOutdated(t *testing.T) {
 					controlplaneNamespace: controlplaneNamespace,
 				},
 			},
-			fakeObjects:   []crclient.Object{
+			fakeObjects: []crclient.Object{
 				tokenSecretWithTimestamp,
 			},
 			expectedError: "",
@@ -468,8 +468,8 @@ func TestSetExpirationTimestampOnToken(t *testing.T) {
 	fakeCurrentTokenVal := "tokenval1"
 
 	testCases := []struct {
-		name        string
-		inputSecret *corev1.Secret
+		name              string
+		inputSecret       *corev1.Secret
 		expectedTimestamp string
 	}{
 		{

--- a/hypershift-operator/controllers/nodepool/token_test.go
+++ b/hypershift-operator/controllers/nodepool/token_test.go
@@ -332,6 +332,16 @@ func TestTokenCleanupOutdated(t *testing.T) {
 		},
 	}
 
+	tokenSecretWithTimestamp := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: controlplaneNamespace,
+			Name:      fmt.Sprintf("%s-%s-%s", TokenSecretPrefix, nodePoolName, outdatedHash),
+			Annotations: map[string]string{
+				hyperv1.IgnitionServerTokenExpirationTimestampAnnotation: time.Now().Add(2 * time.Hour).Format(time.RFC3339),
+			},
+		},
+	}
+
 	testCases := []struct {
 		name          string
 		token         *Token
@@ -387,6 +397,31 @@ func TestTokenCleanupOutdated(t *testing.T) {
 			fakeObjects:   []crclient.Object{},
 			expectedError: "",
 		},
+		{
+			name: "When token secret exists, but already has an expiration timestamp annotation, it should succeed",
+			token: &Token{
+				ConfigGenerator: &ConfigGenerator{
+					nodePool: &hyperv1.NodePool{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: nodePoolName,
+							Annotations: map[string]string{
+								nodePoolAnnotationCurrentConfigVersion: outdatedHash,
+							},
+						},
+						Spec: hyperv1.NodePoolSpec{
+							Platform: hyperv1.NodePoolPlatform{
+								Type: hyperv1.AzurePlatform,
+							},
+						},
+					},
+					controlplaneNamespace: controlplaneNamespace,
+				},
+			},
+			fakeObjects:   []crclient.Object{
+				tokenSecretWithTimestamp,
+			},
+			expectedError: "",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -435,6 +470,7 @@ func TestSetExpirationTimestampOnToken(t *testing.T) {
 	testCases := []struct {
 		name        string
 		inputSecret *corev1.Secret
+		expectedTimestamp string
 	}{
 		{
 			name: "when set expiration timestamp on token is called on a secret then the expiration timestamp is set",
@@ -447,6 +483,23 @@ func TestSetExpirationTimestampOnToken(t *testing.T) {
 					TokenSecretTokenKey: []byte(fakeCurrentTokenVal),
 				},
 			},
+			expectedTimestamp: theTime.Add(2 * time.Hour).Format(time.RFC3339),
+		},
+		{
+			name: "when set expiration timestamp on token is called on a secret that already has an expiration timestamp, timestamp is not reset",
+			inputSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fakeName,
+					Namespace: fakeNamespace,
+					Annotations: map[string]string{
+						hyperv1.IgnitionServerTokenExpirationTimestampAnnotation: theTime.Add(1 * time.Hour).Format(time.RFC3339),
+					},
+				},
+				Data: map[string][]byte{
+					TokenSecretTokenKey: []byte(fakeCurrentTokenVal),
+				},
+			},
+			expectedTimestamp: theTime.Add(1 * time.Hour).Format(time.RFC3339),
 		},
 	}
 	for _, tc := range testCases {
@@ -464,7 +517,7 @@ func TestSetExpirationTimestampOnToken(t *testing.T) {
 			err = c.Get(context.Background(), crclient.ObjectKeyFromObject(actualSecretData), actualSecretData)
 			g.Expect(err).To(Not(HaveOccurred()))
 			g.Expect(actualSecretData.Annotations).To(testutil.MatchExpected(map[string]string{
-				hyperv1.IgnitionServerTokenExpirationTimestampAnnotation: theTime.Add(2 * time.Hour).Format(time.RFC3339),
+				hyperv1.IgnitionServerTokenExpirationTimestampAnnotation: tc.expectedTimestamp,
 			}))
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

If the reconcile loop runs more often than every 2 hours, the `IgnitionServerTokenExpirationTimestampAnnotation` annotation gets reset on the ignition token secrets, potentially preventing them from being cleaned up and causing a backup of secrets.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-54431

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.