### PR TITLE
OCPBUGS-53206: Use a CPO image label to determine whether to run expired cert remediation

### DIFF
--- a/Containerfile.control-plane
+++ b/Containerfile.control-plane
@@ -27,3 +27,5 @@ LABEL io.openshift.hypershift.restricted-psa=true
 LABEL io.openshift.hypershift.control-plane-pki-operator-signs-csrs=true
 LABEL io.openshift.hypershift.hosted-cluster-config-operator-reports-node-count=true
 LABEL io.openshift.hypershift.control-plane-operator-supports-kas-custom-kubeconfig=true
+# TODO: Uncomment when CPO v2 is the default
+# LABEL io.openshift.hypershift.control-plane-operator.v2-isdefault=true

--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -39,3 +39,5 @@ LABEL io.openshift.hypershift.control-plane-operator-applies-management-kas-netw
 LABEL io.openshift.hypershift.restricted-psa=true
 LABEL io.openshift.hypershift.control-plane-pki-operator-signs-csrs=true
 LABEL io.openshift.hypershift.hosted-cluster-config-operator-reports-node-count=true
+# TODO: Uncomment when CPO v2 is the default
+# LABEL io.openshift.hypershift.control-plane-operator.v2-isdefault=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,3 +30,5 @@ LABEL io.openshift.hypershift.control-plane-operator-applies-management-kas-netw
 LABEL io.openshift.hypershift.restricted-psa=true
 LABEL io.openshift.hypershift.control-plane-pki-operator-signs-csrs=true
 LABEL io.openshift.hypershift.hosted-cluster-config-operator-reports-node-count=true
+# TODO: Uncomment when CPO v2 is the default
+# LABEL io.openshift.hypershift.control-plane-operator.v2-isdefault=true

--- a/Dockerfile.control-plane
+++ b/Dockerfile.control-plane
@@ -27,3 +27,5 @@ LABEL io.openshift.hypershift.restricted-psa=true
 LABEL io.openshift.hypershift.control-plane-pki-operator-signs-csrs=true
 LABEL io.openshift.hypershift.hosted-cluster-config-operator-reports-node-count=true
 LABEL io.openshift.hypershift.control-plane-operator-supports-kas-custom-kubeconfig=true
+# TODO: Uncomment when CPO v2 is the default
+# LABEL io.openshift.hypershift.control-plane-operator.v2-isdefault=true

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -38,3 +38,5 @@ LABEL io.openshift.hypershift.restricted-psa=true
 LABEL io.openshift.hypershift.control-plane-pki-operator-signs-csrs=true
 LABEL io.openshift.hypershift.hosted-cluster-config-operator-reports-node-count=true
 LABEL io.openshift.hypershift.control-plane-operator-supports-kas-custom-kubeconfig=true
+# TODO: Uncomment when CPO v2 is the default
+# LABEL io.openshift.hypershift.control-plane-operator.v2-isdefault=true

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -139,6 +139,7 @@ const (
 	controlPlaneOperatorAppliesManagementKASNetworkPolicyLabel = "io.openshift.hypershift.control-plane-operator-applies-management-kas-network-policy-label"
 	controlPlanePKIOperatorSignsCSRsLabel                      = "io.openshift.hypershift.control-plane-pki-operator-signs-csrs"
 	useRestrictedPodSecurityLabel                              = "io.openshift.hypershift.restricted-psa"
+	defaultToControlPlaneV2Label                               = "io.openshift.hypershift.control-plane-operator.v2-isdefault"
 
 	etcdEncKeyPostfix    = "-etcd-encryption-key"
 	managedServiceEnvVar = "MANAGED_SERVICE"
@@ -1229,6 +1230,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 	_, controlPlaneOperatorAppliesManagementKASNetworkPolicyLabel := controlPlaneOperatorImageLabels[controlPlaneOperatorAppliesManagementKASNetworkPolicyLabel]
 	_, controlPlanePKIOperatorSignsCSRs := controlPlaneOperatorImageLabels[controlPlanePKIOperatorSignsCSRsLabel]
 	_, useRestrictedPSA := controlPlaneOperatorImageLabels[useRestrictedPodSecurityLabel]
+	_, defaultToControlPlaneV2 := controlPlaneOperatorImageLabels[defaultToControlPlaneV2Label]
 
 	// Reconcile the hosted cluster namespace
 	_, err = createOrUpdate(ctx, r.Client, controlPlaneNamespace, func() error {
@@ -1609,7 +1611,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		return reconcileHostedControlPlane(hcp, hcluster, isAutoscalingNeeded,
 			annotationsForCertRenewal(log,
 				hcp,
-				shouldCheckForStaleCerts(hcluster, releaseImageVersion),
+				shouldCheckForStaleCerts(hcluster, defaultToControlPlaneV2),
 				r.kasServingCertHashFromSecret(ctx, hcp),
 				r.kasServingCertHashFromEndpoint(kasHostAndPortFromHCP(hcp))))
 	})
@@ -2056,8 +2058,8 @@ func (r *HostedClusterReconciler) kasServingCertHashFromEndpoint(kasHostAndPort 
 // The following pre-conditions must be met:
 // - The HostedCluster must be managing its own PKI (the hyperv1.DisablePKIReconciliationAnnotation is not present)
 // - The HostedCluster has been available once
-// - The cluster version of the HostedCluster is < 4.19.0
-func shouldCheckForStaleCerts(hc *hyperv1.HostedCluster, hcVersion semver.Version) func() bool {
+// - The cluster is using ControlPlaneOperator v2
+func shouldCheckForStaleCerts(hc *hyperv1.HostedCluster, defaultingToControlPlaneV2 bool) func() bool {
 	return func() bool {
 		if hc.Annotations[hcmetrics.HasBeenAvailableAnnotation] != "true" {
 			return false
@@ -2065,9 +2067,10 @@ func shouldCheckForStaleCerts(hc *hyperv1.HostedCluster, hcVersion semver.Versio
 		if hc.Annotations[hyperv1.DisablePKIReconciliationAnnotation] == "true" {
 			return false
 		}
-		hcVersion.Pre = nil
-		hcVersion.Build = nil
-		return !hcVersion.GE(config.Version419)
+		if defaultingToControlPlaneV2 || hc.Annotations[hyperv1.ControlPlaneOperatorV2Annotation] != "" {
+			return false
+		}
+		return true
 	}
 }
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -767,46 +767,47 @@ func TestShouldCheckForStaleCerts(t *testing.T) {
 	tests := []struct {
 		name           string
 		hcAnnotations  map[string]string
-		hcVersion      string
+		cpov2label     bool
 		expectedResult bool
 	}{
 		{
-			name: "version older than 4.19",
+			name: "cpo without cpov2label",
 			hcAnnotations: map[string]string{
 				hcmetrics.HasBeenAvailableAnnotation: "true",
 			},
-			hcVersion:      "4.18.7",
+			cpov2label:     false,
 			expectedResult: true,
 		},
 		{
-			name: "ci version with 4.19",
+			name: "cpo with cpov2label",
 			hcAnnotations: map[string]string{
 				hcmetrics.HasBeenAvailableAnnotation: "true",
 			},
-			hcVersion:      "4.19.0-0.ci-2025-02-03-120046",
+			cpov2label:     true,
 			expectedResult: false,
 		},
 		{
-			name: "4.20",
+			name: "cpo without cpov2label, but has annotation for cpov2",
 			hcAnnotations: map[string]string{
-				hcmetrics.HasBeenAvailableAnnotation: "true",
+				hcmetrics.HasBeenAvailableAnnotation:     "true",
+				hyperv1.ControlPlaneOperatorV2Annotation: "true",
 			},
-			hcVersion:      "4.20.0",
+			cpov2label:     false,
 			expectedResult: false,
 		},
 		{
-			name:           "version older than 4.19, never been available",
+			name:           "has not been available",
 			hcAnnotations:  nil,
-			hcVersion:      "4.17.4",
+			cpov2label:     false,
 			expectedResult: false,
 		},
 		{
-			name: "version older than 4.19, has been available, does not reconcile pki",
+			name: "has been available, does not reconcile pki",
 			hcAnnotations: map[string]string{
 				hcmetrics.HasBeenAvailableAnnotation:       "true",
 				hyperv1.DisablePKIReconciliationAnnotation: "true",
 			},
-			hcVersion:      "4.16.20",
+			cpov2label:     false,
 			expectedResult: false,
 		},
 	}
@@ -815,7 +816,7 @@ func TestShouldCheckForStaleCerts(t *testing.T) {
 			g := NewGomegaWithT(t)
 			hc := &hyperv1.HostedCluster{}
 			hc.Annotations = test.hcAnnotations
-			fn := shouldCheckForStaleCerts(hc, semver.MustParse(test.hcVersion))
+			fn := shouldCheckForStaleCerts(hc, test.cpov2label)
 			result := fn()
 			g.Expect(result).To(Equal(test.expectedResult))
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a commented label to the CPO image that should be uncommented whenever we switch to using CPO v2 as the default. Uses that label (and annotation) to determine whether we should remediate expired certs from the hypershift operator.

We were previously using the HC version, assuming that 4.19 would default to CPOv2, but that won't be the case.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-53206](https://issues.redhat.com/browse/OCPBUGS-53206)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.