### PR TITLE
OCPBUGS-13292: Add functionality to limit CAPI CRD installation on HO installation

### DIFF
--- a/cmd/install/assets/assets.go
+++ b/cmd/install/assets/assets.go
@@ -23,7 +23,7 @@ import (
 //go:embed cluster-api-provider-agent/*
 //go:embed cluster-api-provider-azure/*
 //go:embed cluster-api-provider-openstack/*
-var crds embed.FS
+var CRDS embed.FS
 
 //go:embed recordingrules/*
 var recordingRules embed.FS
@@ -82,14 +82,14 @@ func getContents(fs embed.FS, file string) []byte {
 // CustomResourceDefinitions returns all existing CRDs as controller-runtime objects
 func CustomResourceDefinitions(include func(path string, crd *apiextensionsv1.CustomResourceDefinition) bool, transform func(*apiextensionsv1.CustomResourceDefinition)) []crclient.Object {
 	var allCrds []crclient.Object
-	err := fs.WalkDir(crds, ".", func(path string, d fs.DirEntry, err error) error {
+	err := fs.WalkDir(CRDS, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			panic(err)
 		}
 		if filepath.Ext(path) != ".yaml" {
 			return nil
 		}
-		crd := getCustomResourceDefinition(crds, path)
+		crd := getCustomResourceDefinition(CRDS, path)
 		if include(path, crd) {
 
 			if transform != nil {

--- a/docs/content/how-to/install/index.md
+++ b/docs/content/how-to/install/index.md
@@ -1,0 +1,22 @@
+# HyperShift Operator Installation
+
+This document describes different installation flags or methods for HyperShift Operator (HO).
+
+## Limiting the CAPI CRDs installed
+The HO uses the Cluster API (CAPI) to manage the nodes in the NodePool. By default, the HO installation will install all 
+CAPI related CRDs. If you want to limit the CRDs installed, you can set the `--limit-crd-install` flag to a 
+comma-separated list of CRDs to install. The valid values for this flag are: AWS, Azure, IBMCloud, KubeVirt, Agent, 
+OpenStack.
+
+For example, to only install the AWS and Azure related CAPI CRDs, you would use 
+the following flag in your HO install command:
+
+```bash
+--limit-crd-install=AWS,Azure
+```
+
+!!! important
+
+    Limiting the CAPI CRDs installed means the HO will only be able to manage HostedClusters of the same platform.
+    For example, in the above example, if you limit the CRDs to AWS and Azure, the HO will only be able to manage 
+    AWS and Azure HostedClusters.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -68,6 +68,8 @@ nav:
   - 'Common':
     - how-to/common/exposing-services-from-hcp.md
     - how-to/common/multi-arch-on-hcp.md
+  - 'HyperShift Operator Install':
+    - how-to/install/index.md
   - 'Disaster Recovery':
     - how-to/disaster-recovery/index.md
     - how-to/disaster-recovery/backup-and-restore-oadp.md


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new flag to the HO installation, limit-crd-install. This flag allows a user to limit what CAPI CRDs are installed per platform basis.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.