### PR TITLE
NO-JIRA: set default expriationDate tag in AWS if not set

### DIFF
--- a/test/e2e/util/options.go
+++ b/test/e2e/util/options.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	hypershiftaws "github.com/openshift/hypershift/cmd/cluster/aws"
@@ -252,6 +253,20 @@ func (o *Options) DefaultAWSOptions() hypershiftaws.RawCreateOptions {
 	}
 	if IsLessThan(semver.MustParse("4.16.0")) {
 		opts.PublicOnly = false
+	}
+
+	// Set an expiration date tag if it's not already set
+	expirationDateTagSet := false
+	for _, tag := range o.AdditionalTags {
+		key := strings.Split(tag, "=")[0]
+		if key == "expirationDate" {
+			expirationDateTagSet = true
+			break
+		}
+	}
+	if !expirationDateTagSet {
+		// Set the expiration date tag to be 4 hours from now
+		o.AdditionalTags = append(o.AdditionalTags, fmt.Sprintf("expirationDate=%s", time.Now().Add(4*time.Hour).UTC().Format(time.RFC3339)))
 	}
 
 	opts.AdditionalTags = append(opts.AdditionalTags, o.AdditionalTags...)


### PR DESCRIPTION
Had a recent issue where new dev ran e2e locally against AWS infra without including an expirationDate tag causing orphaned resources