### PR TITLE
OCPBUGS-52984: annotate AWSEndpointServices with HostedClusterAnnotation

### DIFF
--- a/hypershift-operator/controllers/platform/aws/controller.go
+++ b/hypershift-operator/controllers/platform/aws/controller.go
@@ -264,7 +264,7 @@ func (r *AWSEndpointServiceReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	// Reconcile the AWSEndpointService Spec
 	if _, err := r.CreateOrUpdate(ctx, r.Client, awsEndpointService, func() error {
-		return reconcileAWSEndpointServiceSpec(ctx, r, awsEndpointService, hc)
+		return reconcileAWSEndpointService(ctx, r, awsEndpointService, hc)
 	}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile AWSEndpointService spec: %w", err)
 	}
@@ -309,7 +309,11 @@ func (r *AWSEndpointServiceReconciler) Reconcile(ctx context.Context, req ctrl.R
 	return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
 }
 
-func reconcileAWSEndpointServiceSpec(ctx context.Context, c client.Client, awsEndpointService *hyperv1.AWSEndpointService, hc *hyperv1.HostedCluster) error {
+func reconcileAWSEndpointService(ctx context.Context, c client.Client, awsEndpointService *hyperv1.AWSEndpointService, hc *hyperv1.HostedCluster) error {
+	if awsEndpointService.Annotations == nil {
+		awsEndpointService.Annotations = make(map[string]string)
+	}
+	awsEndpointService.Annotations[supportutil.HostedClusterAnnotation] = fmt.Sprintf("%s/%s", hc.Namespace, hc.Name)
 	return reconcileAWSEndpointServiceSubnetIDs(ctx, c, awsEndpointService, hc)
 }
 


### PR DESCRIPTION
Follow on to https://github.com/openshift/hypershift/pull/5674

Previous PR added `AWSEndpointService` objects to the `HostedCluster` controller Watch, however, `enqueueHostedClustersFunc()` is unable to map to a `HostedCluster` to reconcile because the `AWSEndpointService` type does not have an explicit mapping method or the `HostedClusterAnnotation`.

This PR adds the `HostedClusterAnnotation` to the `AWSEndpointService` so that `handleDefault` can map it to a `HostedCluster`

https://github.com/openshift/hypershift/blob/dd7cb9264226444e5026d67575562b11a932aa38/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go#L4194-L4205