### PR TITLE
OCPBUGS-54439: Change KASGoMemLimit to a string pointer type

### DIFF
--- a/api/scheduling/v1alpha1/clustersizingconfiguration_types.go
+++ b/api/scheduling/v1alpha1/clustersizingconfiguration_types.go
@@ -109,9 +109,13 @@ type NodeCountCriteria struct {
 type Effects struct {
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Pattern=`^\d+(B|KiB|MiB|GiB|TiB)?$`
+	// +kubebuilder:validation:MaxLength=20
 
 	// KASGoMemLimit is the value to set for the $GOMEMLIMIT of the Kube APIServer container
-	KASGoMemLimit *resource.Quantity `json:"kasGoMemLimit,omitempty"`
+	// Expected format is a number followed by a unit (B, KiB, MiB, GiB, TiB). See the Go runtime library for more
+	// information on the format - https://pkg.go.dev/runtime#hdr-Environment_Variables.
+	KASGoMemLimit *string `json:"kasGoMemLimit,omitempty"`
 
 	// +kubebuilder:validation:Optional
 

--- a/api/scheduling/v1alpha1/zz_generated.deepcopy.go
+++ b/api/scheduling/v1alpha1/zz_generated.deepcopy.go
@@ -156,8 +156,8 @@ func (in *Effects) DeepCopyInto(out *Effects) {
 	*out = *in
 	if in.KASGoMemLimit != nil {
 		in, out := &in.KASGoMemLimit, &out.KASGoMemLimit
-		x := (*in).DeepCopy()
-		*out = &x
+		*out = new(string)
+		**out = **in
 	}
 	if in.ControlPlanePriorityClassName != nil {
 		in, out := &in.ControlPlanePriorityClassName, &out.ControlPlanePriorityClassName

--- a/client/applyconfiguration/scheduling/v1alpha1/effects.go
+++ b/client/applyconfiguration/scheduling/v1alpha1/effects.go
@@ -18,14 +18,13 @@ limitations under the License.
 package v1alpha1
 
 import (
-	resource "k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // EffectsApplyConfiguration represents an declarative configuration of the Effects type for use
 // with apply.
 type EffectsApplyConfiguration struct {
-	KASGoMemLimit                   *resource.Quantity                  `json:"kasGoMemLimit,omitempty"`
+	KASGoMemLimit                   *string                             `json:"kasGoMemLimit,omitempty"`
 	ControlPlanePriorityClassName   *string                             `json:"controlPlanePriorityClassName,omitempty"`
 	EtcdPriorityClassName           *string                             `json:"etcdPriorityClassName,omitempty"`
 	APICriticalPriorityClassName    *string                             `json:"APICriticalPriorityClassName,omitempty"`
@@ -44,7 +43,7 @@ func Effects() *EffectsApplyConfiguration {
 // WithKASGoMemLimit sets the KASGoMemLimit field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the KASGoMemLimit field is set to the value of the last call.
-func (b *EffectsApplyConfiguration) WithKASGoMemLimit(value resource.Quantity) *EffectsApplyConfiguration {
+func (b *EffectsApplyConfiguration) WithKASGoMemLimit(value string) *EffectsApplyConfiguration {
 	b.KASGoMemLimit = &value
 	return b
 }

--- a/cmd/install/assets/hypershift-operator/scheduling.hypershift.openshift.io_clustersizingconfigurations.yaml
+++ b/cmd/install/assets/hypershift-operator/scheduling.hypershift.openshift.io_clustersizingconfigurations.yaml
@@ -132,13 +132,13 @@ spec:
                             to use for etcd pods
                           type: string
                         kasGoMemLimit:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          description: KASGoMemLimit is the value to set for the $GOMEMLIMIT
-                            of the Kube APIServer container
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
+                          description: |-
+                            KASGoMemLimit is the value to set for the $GOMEMLIMIT of the Kube APIServer container
+                            Expected format is a number followed by a unit (B, KiB, MiB, GiB, TiB). See the Go runtime library for more
+                            information on the format - https://pkg.go.dev/runtime#hdr-Environment_Variables.
+                          maxLength: 20
+                          pattern: ^\d+(B|KiB|MiB|GiB|TiB)?$
+                          type: string
                         machineHealthCheckTimeout:
                           description: |-
                             MachineHealthCheckTimeout specifies an optional timeout for machinehealthchecks created

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -5718,7 +5718,7 @@ func setKASCustomKubeconfigStatus(ctx context.Context, hcp *hyperv1.HostedContro
 			Key:  DefaultAdminKubeconfigKey,
 		}
 	} else {
-		// Cleanning up custom kubeconfig status
+		// Cleaning up custom kubeconfig status
 		hcp.Status.CustomKubeconfig = nil
 	}
 

--- a/hypershift-operator/controllers/scheduler/azure/controllers_test.go
+++ b/hypershift-operator/controllers/scheduler/azure/controllers_test.go
@@ -11,7 +11,6 @@ import (
 	schedulingv1alpha1 "github.com/openshift/hypershift/api/scheduling/v1alpha1"
 	hyperapi "github.com/openshift/hypershift/support/api"
 
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -21,14 +20,6 @@ import (
 )
 
 func TestReconcile(t *testing.T) {
-	mustQty := func(qty string) *resource.Quantity {
-		result, err := resource.ParseQuantity(qty)
-		if err != nil {
-			panic(err)
-		}
-		return &result
-	}
-
 	sizingConfig := &schedulingv1alpha1.ClusterSizingConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "cluster",
@@ -42,7 +33,7 @@ func TestReconcile(t *testing.T) {
 						To:   ptr.To(uint32(1)),
 					},
 					Effects: &schedulingv1alpha1.Effects{
-						KASGoMemLimit: mustQty("1Gi"),
+						KASGoMemLimit: ptr.To("1GiB"),
 					},
 				},
 				{
@@ -52,7 +43,7 @@ func TestReconcile(t *testing.T) {
 						To:   ptr.To(uint32(2)),
 					},
 					Effects: &schedulingv1alpha1.Effects{
-						KASGoMemLimit: mustQty("2Gi"),
+						KASGoMemLimit: ptr.To("2GiB"),
 					},
 				},
 				{
@@ -62,7 +53,7 @@ func TestReconcile(t *testing.T) {
 						To:   nil,
 					},
 					Effects: &schedulingv1alpha1.Effects{
-						KASGoMemLimit: mustQty("3Gi"),
+						KASGoMemLimit: ptr.To("3GiB"),
 					},
 				},
 			},
@@ -163,7 +154,7 @@ func TestReconcile(t *testing.T) {
 			expectError:   false,
 			expectRequeue: false,
 			expectAnnotations: map[string]string{
-				hyperv1.KubeAPIServerGOMemoryLimitAnnotation: "1Gi",
+				hyperv1.KubeAPIServerGOMemoryLimitAnnotation: "1GiB",
 			},
 		},
 	}

--- a/hypershift-operator/controllers/scheduler/util/scheduler.go
+++ b/hypershift-operator/controllers/scheduler/util/scheduler.go
@@ -10,6 +10,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -37,7 +38,7 @@ func setHostedClusterSchedulingAnnotations(hc *hyperv1.HostedCluster, size strin
 
 	goMemLimit := ""
 	if sizeConfig.Effects != nil && sizeConfig.Effects.KASGoMemLimit != nil {
-		goMemLimit = sizeConfig.Effects.KASGoMemLimit.String()
+		goMemLimit = ptr.Deref(sizeConfig.Effects.KASGoMemLimit, "")
 	}
 
 	// For AWS try and get the goMem limit from the nodes

--- a/hypershift-operator/controllers/scheduler/util/scheduler_test.go
+++ b/hypershift-operator/controllers/scheduler/util/scheduler_test.go
@@ -48,7 +48,7 @@ func TestSetHostedClusterSchedulingAnnotations(t *testing.T) {
 						{
 							Name: "medium",
 							Effects: &schedulingv1alpha1.Effects{
-								KASGoMemLimit: resource.NewQuantity(1024, resource.BinarySI),
+								KASGoMemLimit: ptr.To("1KiB"),
 							},
 						},
 					},
@@ -59,7 +59,7 @@ func TestSetHostedClusterSchedulingAnnotations(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						hyperv1.HostedClusterScheduledAnnotation:     "true",
-						hyperv1.KubeAPIServerGOMemoryLimitAnnotation: "1Ki",
+						hyperv1.KubeAPIServerGOMemoryLimitAnnotation: "1KiB",
 					},
 				},
 			},
@@ -79,7 +79,7 @@ func TestSetHostedClusterSchedulingAnnotations(t *testing.T) {
 						{
 							Name: "large",
 							Effects: &schedulingv1alpha1.Effects{
-								KASGoMemLimit: resource.NewQuantity(2048, resource.BinarySI),
+								KASGoMemLimit: ptr.To("2048MiB"),
 							},
 						},
 					},

--- a/vendor/github.com/openshift/hypershift/api/scheduling/v1alpha1/clustersizingconfiguration_types.go
+++ b/vendor/github.com/openshift/hypershift/api/scheduling/v1alpha1/clustersizingconfiguration_types.go
@@ -109,9 +109,13 @@ type NodeCountCriteria struct {
 type Effects struct {
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Pattern=`^\d+(B|KiB|MiB|GiB|TiB)?$`
+	// +kubebuilder:validation:MaxLength=20
 
 	// KASGoMemLimit is the value to set for the $GOMEMLIMIT of the Kube APIServer container
-	KASGoMemLimit *resource.Quantity `json:"kasGoMemLimit,omitempty"`
+	// Expected format is a number followed by a unit (B, KiB, MiB, GiB, TiB). See the Go runtime library for more
+	// information on the format - https://pkg.go.dev/runtime#hdr-Environment_Variables.
+	KASGoMemLimit *string `json:"kasGoMemLimit,omitempty"`
 
 	// +kubebuilder:validation:Optional
 

--- a/vendor/github.com/openshift/hypershift/api/scheduling/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/openshift/hypershift/api/scheduling/v1alpha1/zz_generated.deepcopy.go
@@ -156,8 +156,8 @@ func (in *Effects) DeepCopyInto(out *Effects) {
 	*out = *in
 	if in.KASGoMemLimit != nil {
 		in, out := &in.KASGoMemLimit, &out.KASGoMemLimit
-		x := (*in).DeepCopy()
-		*out = &x
+		*out = new(string)
+		**out = **in
 	}
 	if in.ControlPlanePriorityClassName != nil {
 		in, out := &in.ControlPlanePriorityClassName, &out.ControlPlanePriorityClassName


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the KASGoMemLimit to a string pointer type instead of a k8s api/resource Quantity pointer type and updates related unit tests.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.