### PR TITLE
NO-JIRA: Sync labels between CPO and RHTAP CPO dockerfile

### DIFF
--- a/Containerfile.control-plane
+++ b/Containerfile.control-plane
@@ -26,3 +26,4 @@ LABEL io.openshift.hypershift.control-plane-operator-applies-management-kas-netw
 LABEL io.openshift.hypershift.restricted-psa=true
 LABEL io.openshift.hypershift.control-plane-pki-operator-signs-csrs=true
 LABEL io.openshift.hypershift.hosted-cluster-config-operator-reports-node-count=true
+LABEL io.openshift.hypershift.control-plane-operator-supports-kas-custom-kubeconfig=true

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -5718,7 +5718,7 @@ func setKASCustomKubeconfigStatus(ctx context.Context, hcp *hyperv1.HostedContro
 			Key:  DefaultAdminKubeconfigKey,
 		}
 	} else {
-		// Cleanning up custom kubeconfig status
+		// Cleaning up custom kubeconfig status
 		hcp.Status.CustomKubeconfig = nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit adds the label, LABEL io.openshift.hypershift .control-plane-operator-supports-kas-custom-kubeconfig=true, to the RHTAP CPO dockerfile as the CPO dockerfile was updated to include the label.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.