### PR TITLE
CNTRLPLANE-217: Add E2E to KubeAPIServerDNSName API to cover KAS custom certificate

### DIFF
--- a/support/certs/tls.go
+++ b/support/certs/tls.go
@@ -140,6 +140,8 @@ func SelfSignedCertificate(cfg *CertCfg, key *rsa.PrivateKey) (*x509.Certificate
 		NotBefore:             now,
 		SerialNumber:          serial,
 		Subject:               cfg.Subject,
+		DNSNames:              cfg.DNSNames,
+		ExtKeyUsage:           cfg.ExtKeyUsages,
 	}
 	// verifies that the CN and/or OU for the cert is set
 	if len(cfg.Subject.CommonName) == 0 || len(cfg.Subject.OrganizationalUnit) == 0 {

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -1374,7 +1374,9 @@ func TestCreateClusterCustomConfig(t *testing.T) {
 
 		// ensure image registry component is disabled
 		e2eutil.EnsureImageRegistryCapabilityDisabled(ctx, t, g, mgtClient, hostedCluster)
-		e2eutil.EnsureKubeAPIDNSName(t, ctx, mgtClient, hostedCluster)
+
+		// ensure KAS DNS name is configured with a KAS Serving cert
+		e2eutil.EnsureKubeAPIDNSNameCustomCert(t, ctx, mgtClient, hostedCluster)
 	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, "custom-config", globalOpts.ServiceAccountSigningKey)
 }
 

--- a/test/e2e/util/util_test.go
+++ b/test/e2e/util/util_test.go
@@ -1,0 +1,89 @@
+package util
+
+import (
+	"crypto/x509"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/support/certs"
+)
+
+// TestGenerateCustomCertificate verifies that our certificate generation works correctly
+func TestGenerateCustomCertificate(t *testing.T) {
+	testsCases := []struct {
+		name       string
+		dnsNames   []string
+		duration   time.Duration
+		wantErr    bool
+		expectedCN string
+	}{
+		{
+			name:       "When generating a certificate with DNS names it should succeed",
+			dnsNames:   []string{"example.com", "test.example.com"},
+			duration:   24 * time.Hour,
+			wantErr:    false,
+			expectedCN: "example.com",
+		},
+		{
+			name:     "When generating a certificate with no DNS names it should fail",
+			dnsNames: []string{},
+			duration: 24 * time.Hour,
+			wantErr:  true,
+		},
+		{
+			name:       "When generating a certificate with zero duration it should succeed",
+			dnsNames:   []string{"example.com"},
+			duration:   0,
+			wantErr:    false,
+			expectedCN: "example.com",
+		},
+	}
+
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			certPEM, keyPEM, err := GenerateCustomCertificate(tc.dnsNames, tc.duration)
+
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(certPEM).NotTo(BeNil())
+			g.Expect(keyPEM).NotTo(BeNil())
+
+			// Parse the certificate to verify its contents
+			cert, err := certs.PemToCertificate(certPEM)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			// Verify CommonName
+			g.Expect(cert.Subject.CommonName).To(Equal(tc.expectedCN))
+
+			// Verify DNS names
+			if len(tc.dnsNames) == 0 {
+				g.Expect(cert.DNSNames).To(BeEmpty())
+			} else {
+				g.Expect(cert.DNSNames).To(Equal(tc.dnsNames))
+			}
+
+			// Verify validity period
+			if tc.duration > 0 {
+				g.Expect(cert.NotAfter.Sub(cert.NotBefore)).To(Equal(tc.duration))
+			}
+
+			// Verify key usage
+			g.Expect(cert.KeyUsage & x509.KeyUsageKeyEncipherment).NotTo(BeZero())
+			g.Expect(cert.KeyUsage & x509.KeyUsageDigitalSignature).NotTo(BeZero())
+
+			// Verify extended key usage
+			g.Expect(cert.ExtKeyUsage).To(ContainElement(x509.ExtKeyUsageServerAuth))
+
+			// Verify the private key can be parsed
+			_, err = certs.PemToPrivateKey(keyPEM)
+			g.Expect(err).NotTo(HaveOccurred())
+		})
+	}
+}


### PR DESCRIPTION
## Why do we want this PR
This PR addresses the customer use case of using a KAS custom serving certificate in combination with the `KubeAPIServerDNSName` API. This setup enables the user to access the new API custom DNS name using the custom certificate they provided.

## Which issue(s) this PR fixes
Fixes #[CNTRLPLANE-217](https://issues.redhat.com/browse/CNTRLPLANE-217)

## Flake detection
|Index|Status|Job|Info|
|---|---|---|---|
| 1 | 🟢 | [Link](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/5968/pull-ci-openshift-hypershift-main-e2e-aws/1910379370497708032) | N/A|
| 2 | 🔴 | [Link](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/5968/pull-ci-openshift-hypershift-main-e2e-aws/1910424321671565312) |TestUpgradeControlPlane/Teardown |
| 3 | 🔴 | [Link](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/5968/pull-ci-openshift-hypershift-main-e2e-aws/1910479316563529728) | TestCreateClusterPrivateWithRouteKAS/Teardown |
| 4 | 🟢 | [Link](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/5968/pull-ci-openshift-hypershift-main-e2e-aws/1910568290439139328) | N/A|
| 5 | 🟢 | [Link](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/5968/pull-ci-openshift-hypershift-main-e2e-aws/1910603479877947392)| N\A|