### PR TITLE
CNTRLPLANE-233: Add --kas-dns-name CLI flag to consume KubeAPIServerDNSName API

### DIFF
--- a/cmd/cluster/aws/create_test.go
+++ b/cmd/cluster/aws/create_test.go
@@ -203,6 +203,17 @@ func TestCreateCluster(t *testing.T) {
 				"--render-sensitive",
 			},
 		},
+		{
+			name: "minimal with KubeAPIServerDNSName",
+			args: []string{
+				"--sts-creds=" + credentialsFile,
+				"--infra-json=" + infraFile,
+				"--iam-json=" + iamFile,
+				"--role-arn=fakeRoleARN",
+				"--pull-secret=" + pullSecretFile,
+				"--kas-dns-name=test-dns-name.example.com",
+			},
+		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			flags := pflag.NewFlagSet(testCase.name, pflag.ContinueOnError)

--- a/cmd/cluster/aws/testdata/zz_fixture_TestCreateCluster_minimal_with_KubeAPIServerDNSName.yaml
+++ b/cmd/cluster/aws/testdata/zz_fixture_TestCreateCluster_minimal_with_KubeAPIServerDNSName.yaml
@@ -1,0 +1,131 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: clusters
+spec: {}
+status: {}
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  creationTimestamp: null
+  name: example
+  namespace: clusters
+spec:
+  autoscaling: {}
+  configuration:
+    proxy:
+      httpProxy: fakeProxyAddr
+      httpsProxy: fakeProxyAddr
+      trustedCA:
+        name: ""
+  controllerAvailabilityPolicy: SingleReplica
+  dns:
+    baseDomain: fakeBaseDomain
+    baseDomainPrefix: fakeBaseDomainPrefix
+    privateZoneID: fakePrivateZoneID
+    publicZoneID: fakePublicZoneID
+  etcd:
+    managed:
+      storage:
+        persistentVolume:
+          size: 8Gi
+          storageClassName: gp3-csi
+        type: PersistentVolume
+    managementType: Managed
+  fips: false
+  infraID: fakeInfraID
+  issuerURL: fakeIssuerURL
+  kubeAPIServerDNSName: test-dns-name.example.com
+  networking:
+    clusterNetwork:
+    - cidr: 10.132.0.0/14
+    machineNetwork:
+    - cidr: 192.0.2.0/24
+    networkType: OVNKubernetes
+    serviceNetwork:
+    - cidr: 172.31.0.0/16
+  olmCatalogPlacement: management
+  platform:
+    aws:
+      cloudProviderConfig:
+        subnet:
+          id: fakeSubnetID
+        vpc: fakeVPCID
+        zone: fakeName
+      endpointAccess: Public
+      multiArch: false
+      region: us-east-1
+      rolesRef:
+        controlPlaneOperatorARN: fakeControlPlaneOperatorARN
+        imageRegistryARN: fakeImageRegistryARN
+        ingressARN: fakeIngressARN
+        kubeCloudControllerARN: fakeKubeCloudControllerARN
+        networkARN: fakeNetworkARN
+        nodePoolManagementARN: fakeNodePoolManagementARN
+        storageARN: fakeStorageARN
+    type: AWS
+  pullSecret:
+    name: example-pull-secret
+  release:
+    image: ""
+  secretEncryption:
+    kms:
+      aws:
+        activeKey:
+          arn: fakeKMSKeyARN
+        auth:
+          awsKms: fakeKMSProviderRoleARN
+        region: us-east-1
+      provider: AWS
+    type: kms
+  services:
+  - service: APIServer
+    servicePublishingStrategy:
+      type: LoadBalancer
+  - service: Ignition
+    servicePublishingStrategy:
+      type: Route
+  - service: Konnectivity
+    servicePublishingStrategy:
+      type: Route
+  - service: OAuthServer
+    servicePublishingStrategy:
+      type: Route
+  sshKey: {}
+status:
+  controlPlaneEndpoint:
+    host: ""
+    port: 0
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: NodePool
+metadata:
+  creationTimestamp: null
+  name: example-fakeName
+  namespace: clusters
+spec:
+  arch: amd64
+  clusterName: example
+  management:
+    autoRepair: false
+    upgradeType: Replace
+  nodeDrainTimeout: 0s
+  nodeVolumeDetachTimeout: 0s
+  platform:
+    aws:
+      instanceProfile: fakeProfileName
+      instanceType: m5.large
+      rootVolume:
+        size: 120
+        type: gp3
+      subnet:
+        id: fakeSubnetID
+    type: AWS
+  release:
+    image: ""
+  replicas: 0
+status:
+  replicas: 0
+---

--- a/cmd/cluster/azure/create_test.go
+++ b/cmd/cluster/azure/create_test.go
@@ -140,6 +140,17 @@ func TestCreateCluster(t *testing.T) {
 				"--disable-cluster-capabilities=ImageRegistry",
 			},
 		},
+		{
+			name: "with KubeAPIServerDNSName",
+			args: []string{
+				"--azure-creds=" + credentialsFile,
+				"--infra-json=" + infraFile,
+				"--rhcos-image=whatever",
+				"--render-sensitive",
+				"--managed-identities-file", filepath.Join(tempDir, "managedIdentities.json"),
+				"--kas-dns-name=test-dns-name.example.com",
+			},
+		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(api.Scheme).Build()

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_KubeAPIServerDNSName.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_KubeAPIServerDNSName.yaml
@@ -1,0 +1,166 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: clusters
+spec: {}
+status: {}
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: null
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-pull-secret
+  namespace: clusters
+---
+apiVersion: v1
+data:
+  AZURE_SUBSCRIPTION_ID: ZmFrZVN1YnNjcmlwdGlvbklE
+  AZURE_TENANT_ID: ZmFrZVRlbmFudElE
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: example-cloud-credentials
+  namespace: clusters
+---
+apiVersion: v1
+data:
+  key: qO1Sny2IAcCrq0VGlEp7O6WsknhpszO7eSLmXjsPDxs=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "true"
+  name: example-etcd-encryption-key
+  namespace: clusters
+type: Opaque
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  creationTimestamp: null
+  name: example
+  namespace: clusters
+spec:
+  autoscaling: {}
+  configuration: {}
+  controllerAvailabilityPolicy: SingleReplica
+  dns:
+    baseDomain: fakeBaseDomain
+    privateZoneID: fakePrivateZoneID
+    publicZoneID: fakePublicZoneID
+  etcd:
+    managed:
+      storage:
+        persistentVolume:
+          size: 8Gi
+        type: PersistentVolume
+    managementType: Managed
+  fips: false
+  infraID: fakeInfraID
+  kubeAPIServerDNSName: test-dns-name.example.com
+  networking:
+    clusterNetwork:
+    - cidr: 10.132.0.0/14
+    networkType: OVNKubernetes
+    serviceNetwork:
+    - cidr: 172.31.0.0/16
+  olmCatalogPlacement: management
+  platform:
+    azure:
+      location: fakeLocation
+      managedIdentities:
+        controlPlane:
+          cloudProvider:
+            objectEncoding: utf-8
+          controlPlaneOperator:
+            objectEncoding: utf-8
+          disk:
+            objectEncoding: utf-8
+          file:
+            objectEncoding: utf-8
+          imageRegistry:
+            objectEncoding: utf-8
+          ingress:
+            objectEncoding: utf-8
+          managedIdentitiesKeyVault:
+            name: ""
+            tenantID: ""
+          network:
+            objectEncoding: utf-8
+          nodePoolManagement:
+            objectEncoding: utf-8
+        dataPlane:
+          diskMSIClientID: ""
+          fileMSIClientID: ""
+          imageRegistryMSIClientID: ""
+      resourceGroup: fakeResourceGroupName
+      securityGroupID: fakeSecurityGroupID
+      subnetID: fakeSubnetID
+      subscriptionID: fakeSubscriptionID
+      tenantID: fakeTenantID
+      vnetID: fakeVNetID
+    type: Azure
+  pullSecret:
+    name: example-pull-secret
+  release:
+    image: ""
+  secretEncryption:
+    aescbc:
+      activeKey:
+        name: example-etcd-encryption-key
+    type: aescbc
+  services:
+  - service: APIServer
+    servicePublishingStrategy:
+      type: LoadBalancer
+  - service: Ignition
+    servicePublishingStrategy:
+      type: Route
+  - service: Konnectivity
+    servicePublishingStrategy:
+      type: Route
+  - service: OAuthServer
+    servicePublishingStrategy:
+      type: Route
+  sshKey: {}
+status:
+  controlPlaneEndpoint:
+    host: ""
+    port: 0
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: NodePool
+metadata:
+  creationTimestamp: null
+  name: example
+  namespace: clusters
+spec:
+  arch: amd64
+  clusterName: example
+  management:
+    autoRepair: false
+    upgradeType: Replace
+  nodeDrainTimeout: 0s
+  nodeVolumeDetachTimeout: 0s
+  platform:
+    azure:
+      image:
+        imageID: fakeBootImageID
+        type: ImageID
+      osDisk:
+        diskStorageAccountType: Premium_LRS
+        sizeGiB: 120
+      subnetID: fakeSubnetID
+      vmSize: Standard_D4s_v3
+    type: Azure
+  release:
+    image: ""
+  replicas: 0
+status:
+  replicas: 0
+---

--- a/cmd/cluster/core/create_test.go
+++ b/cmd/cluster/core/create_test.go
@@ -164,6 +164,7 @@ func TestPrototypeResources(t *testing.T) {
 				validatedCreateOptions: &validatedCreateOptions{
 					RawCreateOptions: &RawCreateOptions{
 						DisableClusterCapabilities: []string{string(hyperv1.ImageRegistryCapability)},
+						KubeAPIServerDNSName:       "test-dns-name.example.com",
 					},
 				},
 			},
@@ -173,6 +174,7 @@ func TestPrototypeResources(t *testing.T) {
 	g.Expect(err).To(BeNil())
 	g.Expect(resources.Cluster.Spec.Capabilities.Disabled).
 		To(Equal([]hyperv1.OptionalCapability{hyperv1.ImageRegistryCapability}))
+	g.Expect(resources.Cluster.Spec.KubeAPIServerDNSName).To(Equal("test-dns-name.example.com"))
 }
 
 func TestValidate(t *testing.T) {
@@ -200,6 +202,26 @@ func TestValidate(t *testing.T) {
 				Namespace:                  "test-hc",
 				Arch:                       "amd64",
 				DisableClusterCapabilities: []string{"ImageRegistry"},
+			},
+			expectedErr: "",
+		},
+		{
+			name: "fails with an invalid DNS name as KubeAPIServerDNSName",
+			rawOpts: &RawCreateOptions{
+				Name:                 "test-hc",
+				Namespace:            "test-hc",
+				Arch:                 "amd64",
+				KubeAPIServerDNSName: "INVALID-DNS-NAME.example.com",
+			},
+			expectedErr: "KubeAPIServerDNSName failed DNS validation: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters",
+		},
+		{
+			name: "passes with KubeAPIServerDNSName",
+			rawOpts: &RawCreateOptions{
+				Name:                 "test-hc",
+				Namespace:            "test-hc",
+				Arch:                 "amd64",
+				KubeAPIServerDNSName: "test-dns-name.example.com",
 			},
 			expectedErr: "",
 		},


### PR DESCRIPTION
This PR includes the new flag --kas-dns-name, which enables the customer to create a HostedCluster directly to consume KubeAPIServerDNSName API

**Which issue(s) this PR fixes** :
Fixes #[CNTRLPLANE-233](https://issues.redhat.com/browse/CNTRLPLANE-233)