### PR TITLE
[release-4.16] OCPBUGS-49914: Reconcile proxy CA bundle into hosted cluster

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/pki.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/pki.go
@@ -23,6 +23,15 @@ func UserCABundle() *corev1.ConfigMap {
 	}
 }
 
+func OpenShiftUserCABundle() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "openshift-user-ca",
+			Namespace: "openshift-controller-manager",
+		},
+	}
+}
+
 func ImageRegistryAdditionalTrustedCAConfigMap(name string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -500,6 +500,11 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 		errs = append(errs, fmt.Errorf("failed to reconcile user cert CA bundle: %w", err))
 	}
 
+	log.Info("reconciling proxy CA bundle")
+	if err := r.reconcileProxyCABundle(ctx, hcp); err != nil {
+		errs = append(errs, fmt.Errorf("failed to reconcile proxy CA bundle: %w", err))
+	}
+
 	if util.HCPOAuthEnabled(hcp) {
 		log.Info("reconciling oauth serving cert ca bundle")
 		if err := r.reconcileOAuthServingCertCABundle(ctx, hcp); err != nil {
@@ -1333,6 +1338,29 @@ func (r *reconciler) reconcileUserCertCABundle(ctx context.Context, hcp *hyperv1
 			return nil
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile the %s ConfigMap: %w", client.ObjectKeyFromObject(userCAConfigMap), err)
+		}
+	}
+	return nil
+}
+
+func (r *reconciler) reconcileProxyCABundle(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
+	proxyCADestination := manifests.OpenShiftUserCABundle()
+	if hcp.Spec.Configuration != nil && hcp.Spec.Configuration.Proxy != nil && hcp.Spec.Configuration.Proxy.TrustedCA.Name != "" {
+		cpProxyCA := &corev1.ConfigMap{}
+		cpProxyCA.Namespace = hcp.Namespace
+		cpProxyCA.Name = hcp.Spec.Configuration.Proxy.TrustedCA.Name
+		if err := r.cpClient.Get(ctx, client.ObjectKeyFromObject(cpProxyCA), cpProxyCA); err != nil {
+			return fmt.Errorf("cannot get proxy CA bundle ConfigMap: %w", err)
+		}
+		if _, err := r.CreateOrUpdate(ctx, r.client, proxyCADestination, func() error {
+			proxyCADestination.Data = cpProxyCA.Data
+			return nil
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile the proxy CA bundle ConfigMap: %w", err)
+		}
+	} else {
+		if _, err := util.DeleteIfNeeded(ctx, r.client, proxyCADestination); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -60,6 +60,7 @@ var initialObjects = []client.Object{
 	},
 	manifests.NodeTuningClusterOperator(),
 	manifests.NamespaceKubeSystem(),
+	manifests.OpenShiftUserCABundle(),
 	&configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version"}},
 	fakeOperatorHub(),
 }


### PR DESCRIPTION
Manual cherry-pick to resolve conflicts in #5573

**What this PR does / why we need it**:
The openshift controller manager operator syncs the CA bundle that was configured in the global proxy config into a configmap in the openshift-controller-manager namespace. This configmap is then used by the build controller to generate the CA that is mounted into builds for registry access. Because we don't run the controller manager operator in hypershift, this needs to be done by the HCCO. This code adds the reconciliation to the HCCO so that it puts the configmap in the right location.

Ref: https://github.com/openshift/cluster-openshift-controller-manager-operator/blob/08c64512c055ae246b3a14f6d1088d39988c44fe/pkg/operator/usercaobservation/user_ca_observation_controller.go#L80-L90

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-49914