### PR TITLE
ARO-15695: test/e2e: run EnsureImageRegistryCapabilityDisabled on 4.18

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -2332,67 +2332,69 @@ func EnsureCustomTolerations(t *testing.T, ctx context.Context, client crclient.
 
 // EnsureImageRegistryCapabilityDisabled validates the expectations for when ImageRegistryCapability is Disabled
 func EnsureImageRegistryCapabilityDisabled(ctx context.Context, t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
-	AtLeast(t, Version419)
-	guestKubeConfigSecretData := WaitForGuestKubeConfig(t, ctx, mgtClient, hostedCluster)
-	guestConfig, err := clientcmd.RESTConfigFromKubeConfig(guestKubeConfigSecretData)
-	g.Expect(err).NotTo(HaveOccurred(), "couldn't load guest kubeconfig")
-	// we know we're the only real clients for these test servers, so turn off client-side throttling
-	guestConfig.QPS = -1
-	guestConfig.Burst = -1
+	t.Run("EnsureImageRegistryCapabilityDisabled", func(t *testing.T) {
+		AtLeast(t, Version418)
+		guestKubeConfigSecretData := WaitForGuestKubeConfig(t, ctx, mgtClient, hostedCluster)
+		guestConfig, err := clientcmd.RESTConfigFromKubeConfig(guestKubeConfigSecretData)
+		g.Expect(err).NotTo(HaveOccurred(), "couldn't load guest kubeconfig")
+		// we know we're the only real clients for these test servers, so turn off client-side throttling
+		guestConfig.QPS = -1
+		guestConfig.Burst = -1
 
-	cfgClient, err := configv1client.NewForConfig(guestConfig)
-	g.Expect(err).NotTo(HaveOccurred(), "couldn't load guest kubeconfig")
+		cfgClient, err := configv1client.NewForConfig(guestConfig)
+		g.Expect(err).NotTo(HaveOccurred(), "couldn't load guest kubeconfig")
 
-	_, err = cfgClient.ConfigV1().ClusterOperators().Get(ctx, "image-registry", metav1.GetOptions{})
-	g.Expect(err).To(HaveOccurred())
-	g.Expect(err.Error()).To(ContainSubstring("clusteroperators.config.openshift.io \"image-registry\" not found"))
+		_, err = cfgClient.ConfigV1().ClusterOperators().Get(ctx, "image-registry", metav1.GetOptions{})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("clusteroperators.config.openshift.io \"image-registry\" not found"))
 
-	guestClient, err := kubernetes.NewForConfig(guestConfig)
-	g.Expect(err).NotTo(HaveOccurred(), "couldn't load guest kubeconfig")
+		guestClient, err := kubernetes.NewForConfig(guestConfig)
+		g.Expect(err).NotTo(HaveOccurred(), "couldn't load guest kubeconfig")
 
-	// ensure existing service accounts don't have pull-secrets.
-	EventuallyObject(t, ctx, "Waiting for service account default/default to be provisioned...",
-		func(ctx context.Context) (*corev1.ServiceAccount, error) {
-			defaultSA, err := guestClient.CoreV1().ServiceAccounts("default").Get(ctx, "default", metav1.GetOptions{})
-			return defaultSA, err
-		},
-		[]Predicate[*corev1.ServiceAccount]{
-			func(serviceAccount *corev1.ServiceAccount) (done bool, reasons string, err error) {
-				return serviceAccount != nil, "expected default/default service account to exist, got nil", nil
+		// ensure existing service accounts don't have pull-secrets.
+		EventuallyObject(t, ctx, "Waiting for service account default/default to be provisioned...",
+			func(ctx context.Context) (*corev1.ServiceAccount, error) {
+				defaultSA, err := guestClient.CoreV1().ServiceAccounts("default").Get(ctx, "default", metav1.GetOptions{})
+				return defaultSA, err
 			},
-		},
-		WithInterval(10*time.Second), WithTimeout(2*time.Minute),
-	)
-
-	defaultSA, err := guestClient.CoreV1().ServiceAccounts("default").Get(ctx, "default", metav1.GetOptions{})
-	g.Expect(err).NotTo(HaveOccurred(), "couldn't get default service account")
-	g.Expect(defaultSA.ImagePullSecrets).To(BeNil())
-
-	// create a namespace and ensure no pull-secrets are provisioned to
-	// the newly auto-created service accounts.
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"}}
-	ns, err = guestClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
-	g.Expect(err).NotTo(HaveOccurred(), "couldn't create test namespace")
-
-	EventuallyObject(t, ctx, fmt.Sprintf("Waiting for service account default/%s to be provisioned...", ns.Name),
-		func(ctx context.Context) (*corev1.ServiceAccount, error) {
-			defaultSA, err := guestClient.CoreV1().ServiceAccounts(ns.Name).Get(ctx, "default", metav1.GetOptions{})
-			return defaultSA, err
-		},
-		[]Predicate[*corev1.ServiceAccount]{
-			func(serviceAccount *corev1.ServiceAccount) (done bool, reasons string, err error) {
-				return serviceAccount != nil, "expected default/default service account to exist, got nil", nil
+			[]Predicate[*corev1.ServiceAccount]{
+				func(serviceAccount *corev1.ServiceAccount) (done bool, reasons string, err error) {
+					return serviceAccount != nil, "expected default/default service account to exist, got nil", nil
+				},
 			},
-		},
-		WithInterval(10*time.Second), WithTimeout(2*time.Minute),
-	)
+			WithInterval(10*time.Second), WithTimeout(2*time.Minute),
+		)
 
-	defaultSA, err = guestClient.CoreV1().ServiceAccounts(ns.Name).Get(ctx, "default", metav1.GetOptions{})
-	g.Expect(err).NotTo(HaveOccurred(), "couldn't get default service account")
-	g.Expect(defaultSA.ImagePullSecrets).To(BeNil())
+		defaultSA, err := guestClient.CoreV1().ServiceAccounts("default").Get(ctx, "default", metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred(), "couldn't get default service account")
+		g.Expect(defaultSA.ImagePullSecrets).To(BeNil())
 
-	// ensure image-registry resources are not present
-	_, err = guestClient.CoreV1().Namespaces().Get(ctx, "openshift-image-registry", metav1.GetOptions{})
-	g.Expect(err).To(HaveOccurred())
-	g.Expect(err.Error()).To(ContainSubstring("namespaces \"openshift-image-registry\" not found"))
+		// create a namespace and ensure no pull-secrets are provisioned to
+		// the newly auto-created service accounts.
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"}}
+		ns, err = guestClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+		g.Expect(err).NotTo(HaveOccurred(), "couldn't create test namespace")
+
+		EventuallyObject(t, ctx, fmt.Sprintf("Waiting for service account default/%s to be provisioned...", ns.Name),
+			func(ctx context.Context) (*corev1.ServiceAccount, error) {
+				defaultSA, err := guestClient.CoreV1().ServiceAccounts(ns.Name).Get(ctx, "default", metav1.GetOptions{})
+				return defaultSA, err
+			},
+			[]Predicate[*corev1.ServiceAccount]{
+				func(serviceAccount *corev1.ServiceAccount) (done bool, reasons string, err error) {
+					return serviceAccount != nil, "expected default/default service account to exist, got nil", nil
+				},
+			},
+			WithInterval(10*time.Second), WithTimeout(2*time.Minute),
+		)
+
+		defaultSA, err = guestClient.CoreV1().ServiceAccounts(ns.Name).Get(ctx, "default", metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred(), "couldn't get default service account")
+		g.Expect(defaultSA.ImagePullSecrets).To(BeNil())
+
+		// ensure image-registry resources are not present
+		_, err = guestClient.CoreV1().Namespaces().Get(ctx, "openshift-image-registry", metav1.GetOptions{})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("namespaces \"openshift-image-registry\" not found"))
+	})
 }


### PR DESCRIPTION
Hold for https://github.com/openshift/hypershift/pull/5964 to merge.

Diff is large because I wrapped `EnsureImageRegistryCapabilityDisabled` in a `t.Run()`

cc @flavianmissi 

Run `/test e2e-aws-4-18` after dep merge and before moving out of draft.