### PR TITLE
AUTOSCALE-127: allow karpenter-provider-aws image to be overriden by hcp annotation

### DIFF
--- a/api/karpenter/v1beta1/karpenter_types.go
+++ b/api/karpenter/v1beta1/karpenter_types.go
@@ -9,6 +9,10 @@ const (
 	// KarpenterCoreE2EOverrideAnnotation is an annotation to be applied to a HostedCluster that allows
 	// overriding the default behavior of the Karpenter Operator for upstream Karpenter core E2E testing purposes.
 	KarpenterCoreE2EOverrideAnnotation = "hypershift.openshift.io/karpenter-core-e2e-override"
+
+	// KarpenterProviderAWSImage overrides the Karpenter AWS provider image to use for
+	// a HostedControlPlane with AutoNode enabled.
+	KarpenterProviderAWSImage = "hypershift.openshift.io/karpenter-provider-aws-image"
 )
 
 // Subnet contains resolved Subnet selector values utilized for node launch

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hyperkarpenterv1 "github.com/openshift/hypershift/api/karpenter/v1beta1"
 	"github.com/openshift/hypershift/api/util/configrefs"
 	"github.com/openshift/hypershift/cmd/util"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/machineapprover"
@@ -2110,6 +2111,7 @@ func reconcileHostedControlPlaneAnnotations(hcp *hyperv1.HostedControlPlane, hcl
 		hyperv1.KubeAPIServerMaximumMutatingRequestsInFlight,
 		hyperv1.DisableIgnitionServerAnnotation,
 		hyperv1.AWSMachinePublicIPs,
+		hyperkarpenterv1.KarpenterProviderAWSImage,
 	}
 	for _, key := range mirroredAnnotations {
 		val, hasVal := hcluster.Annotations[key]

--- a/karpenter-operator/controllers/karpenter/machine_approver_test.go
+++ b/karpenter-operator/controllers/karpenter/machine_approver_test.go
@@ -23,6 +23,7 @@ import (
 	certificatesv1 "k8s.io/api/certificates/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -244,6 +245,7 @@ func TestAuthorizeServingCSR(t *testing.T) {
 
 func scheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
 	_ = hyperv1.AddToScheme(scheme)
 
 	// Register the NodeClaim GVK in the scheme

--- a/karpenter-operator/controllers/karpenter/manifests_test.go
+++ b/karpenter-operator/controllers/karpenter/manifests_test.go
@@ -1,0 +1,186 @@
+package karpenter
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hyperkarpenterv1 "github.com/openshift/hypershift/api/karpenter/v1beta1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/go-logr/logr/testr"
+)
+
+func TestReconcileKarpenter(t *testing.T) {
+	g := NewWithT(t)
+	scheme := scheme()
+
+	infraID := "test"
+	hcpNamespace := fmt.Sprintf("%s-hcp", infraID)
+	kubeconfigName := fmt.Sprintf("%s-kubeconfig", infraID)
+
+	fakeImageOverride := "fakeImageOverride"
+	fakeCapiKubeConfigSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kubeconfigName,
+			Namespace: hcpNamespace,
+		},
+		Data: map[string][]byte{
+			kubeconfigName: []byte("fake-kubeconfig"),
+		},
+	}
+
+	testCases := []struct {
+		name                      string
+		hcp                       *hyperv1.HostedControlPlane
+		objects                   []client.Object
+		expectReconcileDeployment bool
+		expectedImage             string
+	}{
+		{
+			name: "Karpenter uses default provider image",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: hcpNamespace,
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					InfraID: infraID,
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							Region: "tatooine",
+						},
+					},
+				},
+				Status: hyperv1.HostedControlPlaneStatus{
+					KubeConfig: &hyperv1.KubeconfigSecretRef{
+						Name: kubeconfigName,
+						Key:  kubeconfigName,
+					},
+				},
+			},
+			objects:                   []client.Object{fakeCapiKubeConfigSecret},
+			expectReconcileDeployment: true,
+			expectedImage:             "public.ecr.aws/karpenter/controller:1.0.7", // TODO: lifecycle image
+		},
+		{
+			name: "Karpenter uses override provider image",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: hcpNamespace,
+					Annotations: map[string]string{
+						hyperkarpenterv1.KarpenterProviderAWSImage: fakeImageOverride,
+					},
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					InfraID: infraID,
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							Region: "tatooine",
+						},
+					},
+				},
+				Status: hyperv1.HostedControlPlaneStatus{
+					KubeConfig: &hyperv1.KubeconfigSecretRef{
+						Name: kubeconfigName,
+						Key:  kubeconfigName,
+					},
+				},
+			},
+			objects:                   []client.Object{fakeCapiKubeConfigSecret},
+			expectReconcileDeployment: true,
+			expectedImage:             fakeImageOverride,
+		},
+		{
+			name: "Karpenter deployment is nil because of incorrect config",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: hcpNamespace,
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					InfraID: infraID,
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							Region: "tatooine",
+						},
+					},
+				},
+				// missing kubeconfig
+			},
+			objects:                   []client.Object{fakeCapiKubeConfigSecret},
+			expectReconcileDeployment: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			objects := append([]client.Object{tc.hcp}, tc.objects...)
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objects...).
+				Build()
+
+			r := &Reconciler{
+				ManagementClient:       fakeClient,
+				CreateOrUpdateProvider: &simpleCreateOrUpdater{},
+			}
+
+			ctx := log.IntoContext(context.Background(), testr.New(t))
+
+			err := r.reconcileKarpenter(ctx, tc.hcp)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			roles := &rbacv1.RoleList{}
+			err = fakeClient.List(ctx, roles, client.InNamespace(tc.hcp.Namespace))
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(roles.Items).To(HaveLen(1))
+
+			serviceAccounts := &corev1.ServiceAccountList{}
+			err = fakeClient.List(ctx, serviceAccounts, client.InNamespace(tc.hcp.Namespace))
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(serviceAccounts.Items).To(HaveLen(1))
+
+			rolebindings := &rbacv1.RoleBindingList{}
+			err = fakeClient.List(ctx, rolebindings, client.InNamespace(tc.hcp.Namespace))
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(rolebindings.Items).To(HaveLen(1))
+
+			expectedDeploymentsLen := 0
+			if tc.expectReconcileDeployment {
+				expectedDeploymentsLen = 1
+			}
+			deployments := &appsv1.DeploymentList{}
+			err = fakeClient.List(ctx, deployments, client.InNamespace(tc.hcp.Namespace))
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(deployments.Items).To(HaveLen(expectedDeploymentsLen))
+
+			// Verify image
+			if tc.expectedImage != "" && len(deployments.Items) > 0 {
+				g.Expect(deployments.Items[0].Spec.Template.Spec.Containers[0].Image).To(Equal(tc.expectedImage))
+			}
+		})
+	}
+}
+
+type simpleCreateOrUpdater struct{}
+
+func (*simpleCreateOrUpdater) CreateOrUpdate(ctx context.Context, c client.Client, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
+	return controllerutil.CreateOrUpdate(ctx, c, obj, f)
+}

--- a/vendor/github.com/openshift/hypershift/api/karpenter/v1beta1/karpenter_types.go
+++ b/vendor/github.com/openshift/hypershift/api/karpenter/v1beta1/karpenter_types.go
@@ -9,6 +9,10 @@ const (
 	// KarpenterCoreE2EOverrideAnnotation is an annotation to be applied to a HostedCluster that allows
 	// overriding the default behavior of the Karpenter Operator for upstream Karpenter core E2E testing purposes.
 	KarpenterCoreE2EOverrideAnnotation = "hypershift.openshift.io/karpenter-core-e2e-override"
+
+	// KarpenterProviderAWSImage overrides the Karpenter AWS provider image to use for
+	// a HostedControlPlane with AutoNode enabled.
+	KarpenterProviderAWSImage = "hypershift.openshift.io/karpenter-provider-aws-image"
 )
 
 // Subnet contains resolved Subnet selector values utilized for node launch


### PR DESCRIPTION
Allows the karpenter-provider-aws image to be overriden by an HCP annotation.

~We need this in order to test/e2e our OpenShift karpenter-provider-aws image since it's not in the release payload yet.~ This is a helpful quality of life change to allow devs to test different aws-karpenter-provider versions with HyperShift autonode.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.