### PR TITLE
CNTRLPLANE-261: Enable pprof in hosted control plane etcd

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/reconcile.go
@@ -408,6 +408,10 @@ fi
 				Name:  "QUOTA_BACKEND_BYTES",
 				Value: strconv.FormatInt(EtcdSTSQuotaBackendSize, 10),
 			},
+			{
+				Name:  "ETCD_ENABLE_PPROF",
+				Value: "true",
+			},
 		}
 		c.Ports = []corev1.ContainerPort{
 			{

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents.yaml
@@ -129,6 +129,8 @@ spec:
           value: /etc/etcd/tls/server/server.key
         - name: ETCD_TRUSTED_CA_FILE
           value: /etc/etcd/tls/etcd-ca/ca.crt
+        - name: ETCD_ENABLE_PPROF
+          value: "true"
         - name: ETCD_INITIAL_CLUSTER
           value: etcd-0=https://etcd-0.etcd-discovery.hcp-namespace.svc:2380
         image: etcd

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -129,6 +129,8 @@ spec:
           value: /etc/etcd/tls/server/server.key
         - name: ETCD_TRUSTED_CA_FILE
           value: /etc/etcd/tls/etcd-ca/ca.crt
+        - name: ETCD_ENABLE_PPROF
+          value: "true"
         - name: ETCD_INITIAL_CLUSTER
           value: etcd-0=https://etcd-0.etcd-discovery.hcp-namespace.svc:2380
         image: etcd

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/etcd/statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/etcd/statefulset.yaml
@@ -69,6 +69,8 @@ spec:
           value: /etc/etcd/tls/server/server.key
         - name: ETCD_TRUSTED_CA_FILE
           value: /etc/etcd/tls/etcd-ca/ca.crt
+        - name:  ETCD_ENABLE_PPROF
+          value: "true"
         image: etcd
         imagePullPolicy: IfNotPresent
         livenessProbe:


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables pprof in hosted etcd, similar to self-managed or not-hypershift openshift deployments (re-opened from previous [PR](https://github.com/openshift/hypershift/pull/2245) that staled out)

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[CNTRLPLANE-261](https://issues.redhat.com/browse/CNTRLPLANE-261)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.