### PR TITLE
NO-JIRA: bump HO supported version to 4.20

### DIFF
--- a/support/supportedversion/version.go
+++ b/support/supportedversion/version.go
@@ -19,7 +19,7 @@ import (
 // HyperShift operator.
 // NOTE: The .0 (z release) should be ignored. It's only here to support
 // semver parsing.
-var LatestSupportedVersion = semver.MustParse("4.19.0")
+var LatestSupportedVersion = semver.MustParse("4.20.0")
 var MinSupportedVersion = semver.MustParse("4.14.0")
 
 func GetMinSupportedVersion(hc *hyperv1.HostedCluster) semver.Version {

--- a/support/supportedversion/version_test.go
+++ b/support/supportedversion/version_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestSupportedVersions(t *testing.T) {
 	g := NewGomegaWithT(t)
-	g.Expect(Supported()).To(Equal([]string{"4.19", "4.18", "4.17", "4.16", "4.15", "4.14"}))
+	g.Expect(Supported()).To(Equal([]string{"4.20", "4.19", "4.18", "4.17", "4.16", "4.15", "4.14"}))
 }
 
 func TestIsValidReleaseVersion(t *testing.T) {

--- a/test/e2e/util/version.go
+++ b/test/e2e/util/version.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	// y-stream versions supported by e2e in main
+	Version420 = semver.MustParse("4.20.0")
 	Version419 = semver.MustParse("4.19.0")
 	Version418 = semver.MustParse("4.18.0")
 	Version417 = semver.MustParse("4.17.0")
@@ -28,6 +29,7 @@ func init() {
 	// Ensure that the version constants are valid semver versions
 	// This is a compile-time check to ensure that the versions are valid
 	// semver versions.
+	_ = Version420
 	_ = Version419
 	_ = Version418
 	_ = Version417


### PR DESCRIPTION
For supporting 4.20 after branch cut.  Wait for branch cut before merging.

/hold