### PR TITLE
OCPBUGS-54533: Update DNS names for ovn-kubernetes cp metrics

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/pki/ovn_control_plane_metrics.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/ovn_control_plane_metrics.go
@@ -8,12 +8,16 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// This is the expected DNS name for the server name in the ServiceMonitor the cluster network operator lays down.
+// https://github.com/openshift/cluster-network-operator/blob/a1283bfaf7bf0a90c82cf72d8da97035a7b7020e/bindata/network/ovn-kubernetes/managed/monitor-control-plane.yaml#L35
+const ovnkubeControlPlaneServingCertName = "ovn-kubernetes-control-plane"
+
 func ReconcileOVNControlPlaneMetricsServingCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
 	dnsNames := []string{
-		fmt.Sprintf("ovnkube-control-plane.%s.svc", secret.Namespace),
-		fmt.Sprintf("ovnkube-control-plane.%s.svc.cluster.local", secret.Namespace),
-		"ovnkube-control-plane",
+		fmt.Sprintf("%s.%s.svc", ovnkubeControlPlaneServingCertName, secret.Namespace),
+		fmt.Sprintf("%s.%s.svc.cluster.local", ovnkubeControlPlaneServingCertName, secret.Namespace),
+		ovnkubeControlPlaneServingCertName,
 		"localhost",
 	}
-	return reconcileSignedCertWithAddressesAndSecretType(secret, ca, ownerRef, "ovnkube-control-plane", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil, corev1.SecretTypeTLS)
+	return reconcileSignedCertWithAddressesAndSecretType(secret, ca, ownerRef, ovnkubeControlPlaneServingCertName, []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil, corev1.SecretTypeTLS)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit updates the DNS names for ovn-kubernetes-control-plane from ovnkube-control-plane to ovn-kubernetes-control-plane. This is what is expected by the cluster network operator.

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-54533](https://issues.redhat.com/browse/OCPBUGS-54533)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.