### PR TITLE
Revert "Revert "CNTRLPLANE-112: Enable MIv3 for CNO/CNCC on managed Azure""

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -117,8 +117,6 @@ type Params struct {
 	DeploymentConfig         config.DeploymentConfig
 	IsPrivate                bool
 	DefaultIngressDomain     string
-	AzureClientID            string
-	AzureTenantID            string
 	AzureCertificateName     string
 	AzureCredentialsFilepath string
 }
@@ -170,8 +168,6 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 	}
 
 	if azureutil.IsAroHCP() {
-		p.AzureClientID = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Network.ClientID
-		p.AzureCertificateName = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Network.CertificateName
 		p.AzureCredentialsFilepath = hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Network.CredentialsSecretName
 	}
 
@@ -630,22 +626,11 @@ if [[ -n $sc ]]; then kubectl --kubeconfig $kc delete --ignore-not-found validat
 		{Name: "ca-bundle", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: manifests.RootCASecret("").Name, DefaultMode: ptr.To[int32](0640)}}},
 	}
 
-	// For ARO HCP deployments, we pass the env variable for the SecretProviderClass for the Secrets Store CSI driver
-	// to use on the CNCC deployment.
+	// For managed Azure deployments, we pass the env variables for:
+	// - the SecretProviderClass for the Secrets Store CSI driver to use on the CNCC deployment
+	// - the filepath of the credentials
 	if azureutil.IsAroHCP() {
 		dep.Spec.Template.Spec.Containers[0].Env = append(dep.Spec.Template.Spec.Containers[0].Env,
-			corev1.EnvVar{
-				Name:  config.ManagedAzureClientIdEnvVarKey,
-				Value: params.AzureClientID,
-			},
-			corev1.EnvVar{
-				Name:  config.ManagedAzureTenantIdEnvVarKey,
-				Value: params.AzureTenantID,
-			},
-			corev1.EnvVar{
-				Name:  config.ManagedAzureCertificateNameEnvVarKey,
-				Value: params.AzureCertificateName,
-			},
 			corev1.EnvVar{
 				Name:  config.ManagedAzureSecretProviderClassEnvVarKey,
 				Value: config.ManagedAzureNetworkSecretStoreProviderClassName,

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3780,13 +3780,11 @@ func (r *HostedControlPlaneReconciler) reconcileClusterNetworkOperator(ctx conte
 	if hyperazureutil.IsAroHCP() {
 		cnccSecretProviderClass := manifests.ManagedAzureSecretProviderClass(config.ManagedAzureNetworkSecretStoreProviderClassName, hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r, cnccSecretProviderClass, func() error {
-			secretproviderclass.ReconcileManagedAzureSecretProviderClass(cnccSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Network)
+			secretproviderclass.ReconcileManagedAzureSecretProviderClass(cnccSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Network, true)
 			return nil
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile ingressoperator secret provider class: %w", err)
 		}
-
-		p.AzureTenantID = hcp.Spec.Platform.Azure.TenantID
 	}
 
 	sa := manifests.ClusterNetworkOperatorServiceAccount(hcp.Namespace)

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cno/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cno/azure.go
@@ -9,6 +9,6 @@ import (
 
 func adaptAzureSecretProvider(cpContext component.WorkloadContext, secretProvider *secretsstorev1.SecretProviderClass) error {
 	managedIdentity := cpContext.HCP.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Network
-	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, managedIdentity)
+	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, managedIdentity, true)
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cno/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cno/deployment.go
@@ -141,22 +141,11 @@ func buildCNOEnvVars(cpContext component.WorkloadContext) ([]corev1.EnvVar, erro
 		})
 	}
 
-	// For ARO HCP deployments, we pass the env variable for the SecretProviderClass for the Secrets Store CSI driver
-	// to use on the CNCC deployment.
+	// For managed Azure deployments, we pass the env variables for:
+	// - the SecretProviderClass for the Secrets Store CSI driver to use on the CNCC deployment
+	// - the filepath of the credentials
 	if azureutil.IsAroHCP() {
 		cnoEnv = append(cnoEnv,
-			corev1.EnvVar{
-				Name:  config.ManagedAzureClientIdEnvVarKey,
-				Value: hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Network.ClientID,
-			},
-			corev1.EnvVar{
-				Name:  config.ManagedAzureTenantIdEnvVarKey,
-				Value: hcp.Spec.Platform.Azure.TenantID,
-			},
-			corev1.EnvVar{
-				Name:  config.ManagedAzureCertificateNameEnvVarKey,
-				Value: hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Network.CertificateName,
-			},
 			corev1.EnvVar{
 				Name:  config.ManagedAzureSecretProviderClassEnvVarKey,
 				Value: config.ManagedAzureNetworkSecretStoreProviderClassName,

--- a/support/config/constants.go
+++ b/support/config/constants.go
@@ -65,7 +65,6 @@ const (
 	ManagedAzureClientIdEnvVarKey            = "ARO_HCP_MI_CLIENT_ID"
 	ManagedAzureTenantIdEnvVarKey            = "ARO_HCP_TENANT_ID"
 	ManagedAzureCertificatePathEnvVarKey     = "ARO_HCP_CLIENT_CERTIFICATE_PATH"
-	ManagedAzureCertificateNameEnvVarKey     = "ARO_HCP_CLIENT_CERTIFICATE_NAME"
 	ManagedAzureSecretProviderClassEnvVarKey = "ARO_HCP_SECRET_PROVIDER_CLASS"
 	ManagedAzureCertificateMountPath         = "/mnt/certs"
 	ManagedAzureCertificatePath              = "/mnt/certs/"


### PR DESCRIPTION
Reverts openshift/hypershift#5860

This PR:
- was originally introduced in https://github.com/openshift/hypershift/pull/5837
- It was previously reverted [here](https://github.com/openshift/hypershift/pull/5860) by @kyrtapz as the change affected CNCC on azure standalone. Example [here](https://sippy.dptools.openshift.org/sippy-ng/component_readiness/test_details?Aggregation=none&Architecture=amd64&Architecture=amd64&FeatureSet=techpreview&FeatureSet=techpreview&Installer=ipi&Installer=ipi&LayeredProduct=none&Network=ovn&Network=ovn&Platform=azure&Platform=azure&Procedure=none&Suite=serial&Suite=serial&Topology=ha&Topology=ha&Upgrade=none&Upgrade=none&baseEndTime=2025-03-17%2023%3A59%3A59&baseRelease=4.18&baseStartTime=2025-02-15%2000%3A00%3A00&capability=EgressIP&columnGroupBy=Architecture%2CNetwork%2CPlatform%2CTopology&component=Networking%20%2F%20ovn-kubernetes&confidence=95&dbGroupBy=Platform%2CArchitecture%2CNetwork%2CTopology%2CFeatureSet%2CUpgrade%2CSuite%2CInstaller&environment=amd64%20techpreview%20ipi%20ovn%20azure%20serial%20ha%20none&flakeAsFailure=false&ignoreDisruption=true&ignoreMissing=false&includeMultiReleaseAnalysis=true&includeVariant=Architecture%3Aamd64&includeVariant=CGroupMode%3Av2&includeVariant=ContainerRuntime%3Acrun&includeVariant=ContainerRuntime%3Arunc&includeVariant=FeatureSet%3Adefault&includeVariant=FeatureSet%3Atechpreview&includeVariant=Installer%3Aipi&includeVariant=Installer%3Aupi&includeVariant=JobTier%3Ablocking&includeVariant=JobTier%3Ainforming&includeVariant=JobTier%3Astandard&includeVariant=LayeredProduct%3Anone&includeVariant=Network%3Aovn&includeVariant=Owner%3Aeng&includeVariant=Owner%3Aservice-delivery&includeVariant=Platform%3Aaws&includeVariant=Platform%3Aazure&includeVariant=Platform%3Agcp&includeVariant=Platform%3Ametal&includeVariant=Platform%3Arosa&includeVariant=Platform%3Avsphere&includeVariant=Topology%3Aha&includeVariant=Topology%3Amicroshift&minFail=3&passRateAllTests=0&passRateNewTests=95&pity=5&sampleEndTime=2025-03-17%2023%3A59%3A59&sampleRelease=4.19&sampleStartTime=2025-03-10%2000%3A00%3A00&testBasisRelease=4.18&testId=openshift-tests%3A3322cf74a1f537e188239ef3f31f2a74&testName=%5Bsig-network%5D%5BFeature%3AEgressIP%5D%5Bapigroup%3Aoperator.openshift.io%5D%20%5Bexternal-targets%5D%5Bapigroup%3Auser.openshift.io%5D%5Bapigroup%3Asecurity.openshift.io%5D%20only%20pods%20matched%20by%20the%20pod%20selector%20should%20have%20the%20EgressIPs%20%5BSkipped%3ANetwork%2FOpenShiftSDN%5D%20%5BSerial%5D%20%5BSuite%3Aopenshift%2Fconformance%2Fserial%5D).
- This PR can now be reintroduced because changes were made to the CNCC to update the Azure SDK to the latest libraries in https://github.com/openshift/cloud-network-config-controller/pull/166

Internal Slack Conversation: https://redhat-internal.slack.com/archives/C07RFUYNXDF/p1742312125268599?thread_ts=1741623807.150429&cid=C07RFUYNXDF