### PR TITLE
ARO-15626: Disallow users from setting .spec.managementState to Removed in the image registry operator config on Azure

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/admissionpolicies.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/admissionpolicies.go
@@ -1,0 +1,114 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
+	"github.com/openshift/hypershift/support/upsert"
+
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+
+	k8sadmissionv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type AdmissionPolicy struct {
+	Name             string
+	MatchConstraints *k8sadmissionv1.MatchResources
+	Validations      []k8sadmissionv1.Validation
+}
+
+const (
+	AdmissionPolicyNameManagementState = "deny-removed-managementstate"
+)
+
+var (
+	defaultMatchResourcesScope           = k8sadmissionv1.ScopeType("*")
+	defaultMatchPolicyType               = k8sadmissionv1.Equivalent
+	denyRemovedManagementStateValidation = k8sadmissionv1.Validation{
+		Message: "Setting managementState to 'Removed' is not allowed in Image Registry config.",
+		Reason:  ptr.To(metav1.StatusReasonInvalid),
+	}
+)
+
+func ReconcileRegistryConfigValidatingAdmissionPolicies(ctx context.Context, hcp *hyperv1.HostedControlPlane, client client.Client, createOrUpdate upsert.CreateOrUpdateFN) error {
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("reconciling image registry config validating admission policies")
+
+	if err := reconcileRegistryConfigManagementStateValidatingAdmissionPolicy(ctx, hcp, client, createOrUpdate); err != nil {
+		return fmt.Errorf("failed to reconcile ManagementState Validating Admission Policy: %v", err)
+	}
+
+	return nil
+}
+
+func reconcileRegistryConfigManagementStateValidatingAdmissionPolicy(ctx context.Context, hcp *hyperv1.HostedControlPlane, client client.Client, createOrUpdate upsert.CreateOrUpdateFN) error {
+	registryConfigManagementStateAdmissionPolicy := AdmissionPolicy{Name: AdmissionPolicyNameManagementState}
+	registryConfigManagementStateAPIVersion := []string{imageregistryv1.GroupVersion.Version}
+	registryConfigManagementStateAPIGroup := []string{imageregistryv1.GroupVersion.Group}
+	registryConfigManagementStateResources := []string{
+		"configs",
+	}
+
+	denyRemovedManagementStateValidation.Expression = "object.spec.managementState != 'Removed'"
+	registryConfigManagementStateAdmissionPolicy.Validations = []k8sadmissionv1.Validation{denyRemovedManagementStateValidation}
+	registryConfigManagementStateAdmissionPolicy.MatchConstraints = constructPolicyMatchConstraints(registryConfigManagementStateResources, registryConfigManagementStateAPIVersion, registryConfigManagementStateAPIGroup, []k8sadmissionv1.OperationType{"CREATE", "UPDATE"})
+	if err := registryConfigManagementStateAdmissionPolicy.reconcileAdmissionPolicy(ctx, client, createOrUpdate); err != nil {
+		return fmt.Errorf("error reconciling management State Validating Admission Policy: %v", err)
+	}
+
+	return nil
+}
+
+func (ap *AdmissionPolicy) reconcileAdmissionPolicy(ctx context.Context, client client.Client, createOrUpdate upsert.CreateOrUpdateFN) error {
+	vap := manifests.ValidatingAdmissionPolicy(ap.Name)
+	if _, err := createOrUpdate(ctx, client, vap, func() error {
+		if vap.Spec.MatchConstraints != nil {
+			vap.Spec.MatchConstraints.ResourceRules = ap.MatchConstraints.ResourceRules
+			vap.Spec.MatchConstraints.MatchPolicy = ap.MatchConstraints.MatchPolicy
+		} else {
+			vap.Spec.MatchConstraints = ap.MatchConstraints
+		}
+		vap.Spec.Validations = ap.Validations
+
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to create/update Validating Admission Policy with name %s: %v", ap.Name, err)
+	}
+
+	policyBinding := manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", ap.Name))
+	if _, err := createOrUpdate(ctx, client, policyBinding, func() error {
+		policyBinding.Spec.PolicyName = ap.Name
+		policyBinding.Spec.ValidationActions = []k8sadmissionv1.ValidationAction{k8sadmissionv1.Deny}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to create/update Validating Admission Policy Binding with name %s: %v", ap.Name, err)
+	}
+
+	return nil
+}
+
+func constructPolicyMatchConstraints(resources, apiVersion, apiGroup []string, operations []k8sadmissionv1.OperationType) *k8sadmissionv1.MatchResources {
+	return &k8sadmissionv1.MatchResources{
+		ResourceRules: []k8sadmissionv1.NamedRuleWithOperations{
+			{
+				RuleWithOperations: k8sadmissionv1.RuleWithOperations{
+					Operations: operations,
+					Rule: k8sadmissionv1.Rule{
+						APIGroups:   apiGroup,
+						APIVersions: apiVersion,
+						Resources:   resources,
+						Scope:       &defaultMatchResourcesScope,
+					},
+				},
+			},
+		},
+		MatchPolicy: &defaultMatchPolicyType,
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/admissionpolicies_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/admissionpolicies_test.go
@@ -1,0 +1,52 @@
+package registry
+
+import (
+	"context"
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
+	"github.com/openshift/hypershift/support/upsert"
+
+	admissionv1beta1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	k8sfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReconcileRegistryConfigValidatingAdmissionPolicies(t *testing.T) {
+	ctx := context.Background()
+
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "bar",
+		},
+	}
+
+	fakeClient := k8sfake.NewClientBuilder().
+		WithScheme(api.Scheme).
+		Build()
+
+	createOrUpdate := upsert.New(true).CreateOrUpdate
+
+	err := ReconcileRegistryConfigValidatingAdmissionPolicies(ctx, hcp, fakeClient, createOrUpdate)
+	require.NoError(t, err, "expected no error during reconciliation")
+
+	// validate ValidatingAdmissionPolicy creation
+	vap := &admissionv1beta1.ValidatingAdmissionPolicy{}
+	vapName := AdmissionPolicyNameManagementState
+	err = fakeClient.Get(ctx, client.ObjectKey{Name: vapName}, vap)
+	require.NoError(t, err, "expected ValidatingAdmissionPolicy to be created")
+	require.Len(t, vap.Spec.Validations, 1)
+	require.Contains(t, vap.Spec.Validations[0].Expression, "managementState != 'Removed'")
+
+	// validate ValidatingAdmissionPolicyBinding
+	vapb := &admissionv1beta1.ValidatingAdmissionPolicyBinding{}
+	err = fakeClient.Get(ctx, client.ObjectKey{Name: vapName + "-binding"}, vapb)
+	require.NoError(t, err, "expected ValidatingAdmissionPolicyBinding to be created")
+	require.Equal(t, vapb.Spec.PolicyName, vapName)
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -379,6 +379,12 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 		if imageRegistryPlatformWithPVC(hcp.Spec.Platform.Type) && (!registryConfigExists || registryConfig == nil) {
 			log.Info("skipping registry config to let CIRO bootstrap")
 		} else {
+			log.Info("reconciling image registry validating admission policy")
+			if r.platformType == hyperv1.AzurePlatform {
+				if err := registry.ReconcileRegistryConfigValidatingAdmissionPolicies(ctx, hcp, r.client, r.CreateOrUpdate); err != nil {
+					errs = append(errs, fmt.Errorf("failed to reconcile image registry validating admission policy: %w", err))
+				}
+			}
 			log.Info("reconciling registry config")
 			if _, err := r.CreateOrUpdate(ctx, r.client, registryConfig, func() error {
 				err = registry.ReconcileRegistryConfig(registryConfig, r.platformType, hcp.Spec.InfrastructureAvailabilityPolicy)

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -389,8 +389,9 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 			}); err != nil {
 				errs = append(errs, fmt.Errorf("failed to reconcile imageregistry config: %w", err))
 			}
-			// TODO(fmissi): remove this when Hypershift Capabilities becomes GA
-			if registryConfig.Spec.ManagementState == operatorv1.Removed && r.platformType != hyperv1.IBMCloudPlatform {
+
+			// TODO: remove this when ROSA HCP stops setting the managementState to Removed to disable the Image Registry
+			if registryConfig.Spec.ManagementState == operatorv1.Removed && r.platformType != hyperv1.IBMCloudPlatform && r.platformType != hyperv1.AzurePlatform {
 				log.Info("imageregistry operator managementstate is removed, disabling openshift-controller-manager controllers and cleaning up resources")
 				ocmConfigMap := cpomanifests.OpenShiftControllerManagerConfig(r.hcpNamespace)
 				if _, err := r.CreateOrUpdate(ctx, r.cpClient, ocmConfigMap, func() error {


### PR DESCRIPTION
**What this PR does / why we need it**:
With the capabilities API introduced to disable image registry, this PR prevents user from setting ".spec.managementState: Removed" in the image registry operator config for hosted clusters on Azure(thus preventing the bad side effect of the pod restarts). This is ensured using two steps:

- Prevent disabling OCM controllers on Azure when image registry operator managementState is set to Removed
- Introduce `ValidatingAdmissionPolicy` to prevent the users from setting management State to Removed in image registry operator config on ARO HCP.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an admission policy that prevents setting the Image Registry management state to "Removed" for Azure clusters in hosted control plane environments.

- **Bug Fixes**
  - Updated logic to ensure disabling and cleanup of OpenShift controller manager components do not occur for Azure clusters when the registry management state is "Removed".

- **Tests**
  - Added tests to verify the new admission policy and platform-specific reconciliation behavior for Azure and AWS clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->