### PR TITLE
OCPBUGS-54763: openstack: set port security only if explicitly specified

### DIFF
--- a/hypershift-operator/controllers/nodepool/openstack/openstack.go
+++ b/hypershift-operator/controllers/nodepool/openstack/openstack.go
@@ -65,15 +65,16 @@ func MachineTemplateSpec(hcluster *hyperv1.HostedCluster, nodePool *hyperv1.Node
 			if port.VNICType != "" {
 				additionalPorts[i].ResolvedPortSpecFields.VNICType = &port.VNICType
 			}
+			// OCPBUGS-54763 was reported because we were initially setting port security every time
+			// but in most cases the network is now owned by the project so the default policy
+			// wouldn't allow the port to be created with a port security option, whether it's enabled
+			// or disabled. So we need to set the port security policy only if it's explicitly set in the
+			// additional port spec.
 			switch port.PortSecurityPolicy {
 			case hyperv1.PortSecurityEnabled:
 				additionalPorts[i].ResolvedPortSpecFields.DisablePortSecurity = ptr.To(false)
 			case hyperv1.PortSecurityDisabled:
 				additionalPorts[i].ResolvedPortSpecFields.DisablePortSecurity = ptr.To(true)
-			case hyperv1.PortSecurityDefault:
-				additionalPorts[i].ResolvedPortSpecFields.DisablePortSecurity = ptr.To(false)
-			default:
-				additionalPorts[i].ResolvedPortSpecFields.DisablePortSecurity = ptr.To(false)
 			}
 		}
 		openStackMachineTemplate.Template.Spec.Ports = append(openStackMachineTemplate.Template.Spec.Ports, additionalPorts...)

--- a/hypershift-operator/controllers/nodepool/openstack/openstack_test.go
+++ b/hypershift-operator/controllers/nodepool/openstack/openstack_test.go
@@ -60,6 +60,53 @@ func TestOpenStackMachineTemplate(t *testing.T) {
 			},
 		},
 		{
+			name: "basic additional port",
+			nodePool: hyperv1.NodePoolSpec{
+				ClusterName: "",
+				Replicas:    nil,
+				Config:      nil,
+				Management:  hyperv1.NodePoolManagement{},
+				AutoScaling: nil,
+				Platform: hyperv1.NodePoolPlatform{
+					Type: hyperv1.OpenStackPlatform,
+					OpenStack: &hyperv1.OpenStackNodePoolPlatform{
+						Flavor:    flavor,
+						ImageName: imageName,
+						AdditionalPorts: []hyperv1.PortSpec{
+							{
+								Network: &hyperv1.NetworkParam{
+									ID: ptr.To("123"),
+								},
+							},
+						},
+					},
+				},
+				Release: hyperv1.Release{},
+			},
+
+			expected: &capiopenstackv1beta1.OpenStackMachineTemplateSpec{
+				Template: capiopenstackv1beta1.OpenStackMachineTemplateResource{
+					Spec: capiopenstackv1beta1.OpenStackMachineSpec{
+						Flavor: ptr.To(flavor),
+						Image: capiopenstackv1beta1.ImageParam{
+							Filter: &capiopenstackv1beta1.ImageFilter{
+								Name: ptr.To(imageName),
+							},
+						},
+						Ports: []capiopenstackv1beta1.PortOpts{
+							{},
+							{
+								Description: ptr.To("Additional port for Hypershift node pool tests"),
+								Network: &capiopenstackv1beta1.NetworkParam{
+									ID: ptr.To("123"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "additional port for SR-IOV",
 			nodePool: hyperv1.NodePoolSpec{
 				ClusterName: "",


### PR DESCRIPTION
**What this PR does / why we need it**:

Avoids setting DisablePortSecurity by default to prevent failures when networks
are project-owned and the default Neutron policy won't allow explicit port security
options.
