### PR TITLE
OCPBUGS-54819: Update OpenShift apiserver liveness and readiness probe endpoints to …

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
@@ -86,10 +86,10 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, observedConfig
 					HTTPGet: &corev1.HTTPGetAction{
 						Scheme: corev1.URISchemeHTTPS,
 						Port:   intstr.FromInt(int(OpenShiftAPIServerPort)),
-						Path:   "healthz",
+						Path:   "livez?exclude=etcd",
 					},
 				},
-				InitialDelaySeconds: 30,
+				InitialDelaySeconds: 0,
 				TimeoutSeconds:      10,
 				PeriodSeconds:       10,
 				FailureThreshold:    3,
@@ -102,13 +102,30 @@ func NewOpenShiftAPIServerParams(hcp *hyperv1.HostedControlPlane, observedConfig
 					HTTPGet: &corev1.HTTPGetAction{
 						Scheme: corev1.URISchemeHTTPS,
 						Port:   intstr.FromInt(int(OpenShiftAPIServerPort)),
-						Path:   "healthz",
+						Path:   "readyz?exclude=etcd&exclude=etcd-readiness",
 					},
 				},
-				TimeoutSeconds:   1,
-				PeriodSeconds:    10,
-				SuccessThreshold: 1,
-				FailureThreshold: 10,
+				InitialDelaySeconds: 0,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       10,
+				SuccessThreshold:    1,
+				FailureThreshold:    10,
+			},
+		},
+		StartupProbes: config.StartupProbes{
+			oasContainerMain().Name: {
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Scheme: corev1.URISchemeHTTPS,
+						Port:   intstr.FromInt(int(OpenShiftAPIServerPort)),
+						Path:   "livez",
+					},
+				},
+				InitialDelaySeconds: 0,
+				PeriodSeconds:       5,
+				TimeoutSeconds:      10,
+				SuccessThreshold:    1,
+				FailureThreshold:    30,
 			},
 		},
 		Resources: map[string]corev1.ResourceRequirements{

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents.yaml
@@ -101,10 +101,9 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: healthz
+            path: livez?exclude=etcd
             port: 8443
             scheme: HTTPS
-          initialDelaySeconds: 30
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 10
@@ -116,7 +115,7 @@ spec:
         readinessProbe:
           failureThreshold: 10
           httpGet:
-            path: healthz
+            path: readyz?exclude=etcd&exclude=etcd-readiness
             port: 8443
             scheme: HTTPS
           periodSeconds: 10
@@ -126,6 +125,15 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        startupProbe:
+          failureThreshold: 30
+          httpGet:
+            path: livez
+            port: 8443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 10
         volumeMounts:
         - mountPath: /etc/kubernetes/certs/aggregator-client-ca
           name: aggregator-ca

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -101,10 +101,9 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: healthz
+            path: livez?exclude=etcd
             port: 8443
             scheme: HTTPS
-          initialDelaySeconds: 30
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 10
@@ -116,7 +115,7 @@ spec:
         readinessProbe:
           failureThreshold: 10
           httpGet:
-            path: healthz
+            path: readyz?exclude=etcd&exclude=etcd-readiness
             port: 8443
             scheme: HTTPS
           periodSeconds: 10
@@ -126,6 +125,15 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        startupProbe:
+          failureThreshold: 30
+          httpGet:
+            path: livez
+            port: 8443
+            scheme: HTTPS
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 10
         volumeMounts:
         - mountPath: /etc/kubernetes/certs/aggregator-client-ca
           name: aggregator-ca

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-apiserver/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-apiserver/deployment.yaml
@@ -41,10 +41,10 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: healthz
+            path: livez?exclude=etcd
             port: 8443
             scheme: HTTPS
-          initialDelaySeconds: 30
+          initialDelaySeconds: 0
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 10
@@ -56,12 +56,23 @@ spec:
         readinessProbe:
           failureThreshold: 10
           httpGet:
-            path: healthz
+            path: readyz?exclude=etcd&exclude=etcd-readiness
             port: 8443
             scheme: HTTPS
+          initialDelaySeconds: 0
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
+        startupProbe:
+          httpGet:
+            path: livez
+            port: 8443
+            scheme: HTTPS
+          initialDelaySeconds: 0
+          periodSeconds: 5
+          timeoutSeconds: 10
+          successThreshold: 1
+          failureThreshold: 30
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
…livez and readyz

Similar to what was implemented for OpenShift IPI, the liveness and readiness probes associated with the OpenShift apiserver are updated to use the /livez (for liveness probe) and /readyz (for readiness probe) endpoints instead of the /healthz endpoint.

References: 
- https://github.com/openshift/cluster-openshift-apiserver-operator/pull/612
- https://github.com/openshift/cluster-openshift-apiserver-operator/pull/588
 

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

https://issues.redhat.com/browse/OCPBUGS-54819

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.