### PR TITLE
NO-JIRA: Bump CAPZ to v1.19.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,9 +93,9 @@ require (
 	k8s.io/utils v0.0.0-20241210054802-24370beab758
 	kubevirt.io/api v1.4.0
 	kubevirt.io/containerized-data-importer-api v1.61.1
-	sigs.k8s.io/cluster-api v1.9.5
+	sigs.k8s.io/cluster-api v1.9.6
 	sigs.k8s.io/cluster-api-provider-aws/v2 v2.7.1
-	sigs.k8s.io/cluster-api-provider-azure v1.19.1
+	sigs.k8s.io/cluster-api-provider-azure v1.19.2
 	sigs.k8s.io/cluster-api-provider-ibmcloud v0.7.0
 	sigs.k8s.io/cluster-api-provider-kubevirt v0.1.9
 	sigs.k8s.io/cluster-api-provider-openstack v0.12.1

--- a/go.sum
+++ b/go.sum
@@ -951,12 +951,12 @@ kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90/go.mod h1:018lASpFYBsYN6XwmA2TIrPCx6e0gviTd/ZNtSitKgc=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 h1:CPT0ExVicCzcpeN4baWEV2ko2Z/AsiZgEdwgcfwLgMo=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
-sigs.k8s.io/cluster-api v1.9.5 h1:68164Q201Y5ANVkhyrOZenoMbfL2SEBjVYZs/ihhSro=
-sigs.k8s.io/cluster-api v1.9.5/go.mod h1:DyqyZ4jRvKGKewDRn1Q4OCHaVjsdTogymbO6mrgHEDI=
+sigs.k8s.io/cluster-api v1.9.6 h1:2jZ434qC0bzrPQzmRDm4/b0PZWVMnOocoCjsAonQN5Q=
+sigs.k8s.io/cluster-api v1.9.6/go.mod h1:DyqyZ4jRvKGKewDRn1Q4OCHaVjsdTogymbO6mrgHEDI=
 sigs.k8s.io/cluster-api-provider-aws/v2 v2.7.1 h1:NmsH/IZsMIiQV/kfJY7+mNriqvk5ImCGZrnmbxUMEM0=
 sigs.k8s.io/cluster-api-provider-aws/v2 v2.7.1/go.mod h1:fQ/aPIQs1YKb1hDJtibBY7kspUqvXb9JSWIYkzWlX34=
-sigs.k8s.io/cluster-api-provider-azure v1.19.1 h1:KLMrzQocUzjk49CrTp9KuwmiSfSqAEznKFuZUi+G/qE=
-sigs.k8s.io/cluster-api-provider-azure v1.19.1/go.mod h1:d3Inm47F1tUBdDHzjTpFu2AZIjPtA6pcMxmfnldubw8=
+sigs.k8s.io/cluster-api-provider-azure v1.19.2 h1:Su0xk55+/nfVskowhd9XISMCz2mgtj/0ganRGt5B5fk=
+sigs.k8s.io/cluster-api-provider-azure v1.19.2/go.mod h1:vgIOjI5i9W+yxCUNJx0Bu/jvBzFVNkfV/xUt4uX/oL0=
 sigs.k8s.io/cluster-api-provider-ibmcloud v0.7.0 h1:3IDw0U2ZFX/RQmJ2mFu3ibQ5mBUUcG1ShcHm7eLHGJ4=
 sigs.k8s.io/cluster-api-provider-ibmcloud v0.7.0/go.mod h1:/tqPsGYcODyLUP+DcqMZDeF2l2jiE9qET32s8/eeJTA=
 sigs.k8s.io/cluster-api-provider-kubevirt v0.1.9 h1:hQO7Y5GP7FMnH6Aono9WVE90I3vRLBxw/48iKHerjtg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2246,7 +2246,7 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client/metrics
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/common/metrics
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client
-# sigs.k8s.io/cluster-api v1.9.5
+# sigs.k8s.io/cluster-api v1.9.6
 ## explicit; go 1.22.0
 sigs.k8s.io/cluster-api/api/v1beta1
 sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3
@@ -2274,7 +2274,7 @@ sigs.k8s.io/cluster-api-provider-aws/v2/feature
 sigs.k8s.io/cluster-api-provider-aws/v2/iam/api/v1beta1
 sigs.k8s.io/cluster-api-provider-aws/v2/pkg/eks
 sigs.k8s.io/cluster-api-provider-aws/v2/pkg/hash
-# sigs.k8s.io/cluster-api-provider-azure v1.19.1
+# sigs.k8s.io/cluster-api-provider-azure v1.19.2
 ## explicit; go 1.22.7
 sigs.k8s.io/cluster-api-provider-azure/api/v1beta1
 sigs.k8s.io/cluster-api-provider-azure/feature


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit bumps CAPZ to v1.19.2 to include the patch for the memory leak related to NewBatchSpanProcessor. Incidentally, this also bumps CAPI to v1.9.6.

More details on the leak: https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/5410 

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
N/A

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.