### PR TITLE
OCPBUGS-54863: Add annotation to configure KAS goaway-chance

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -344,6 +344,9 @@ const (
 	// DisableIgnitionServerAnnotation controls skipping of the ignition server deployment.
 	DisableIgnitionServerAnnotation = "hypershift.openshift.io/disable-ignition-server"
 
+	// KubeAPIServerGoAwayChance allows the --goaway-chance parameter of the kube-apiserver to be overridden from its default of 0
+	KubeAPIServerGoAwayChance = "hypershift.openshift.io/kube-apiserver-goaway-chance"
+
 	// ControlPlaneOperatorV2Annotation tells the hosted cluster to set 'CPO_V2' env variable on the CPO deployment which enables
 	// the new manifest based CPO implementation.
 	ControlPlaneOperatorV2Annotation = "hypershift.openshift.io/cpo-v2"

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -209,7 +209,7 @@ func generateConfig(p KubeAPIServerConfigParams) (*kcpv1.KubeAPIServerConfig, er
 	featureGates = append(featureGates, "StructuredAuthenticationConfiguration=true")
 	featureGates = append(featureGates, "ValidatingAdmissionPolicy=true")
 	args.Set("feature-gates", featureGates...)
-	args.Set("goaway-chance", "0")
+	args.Set("goaway-chance", p.GoAwayChance)
 	args.Set("http2-max-streams-per-connection", "2000")
 	args.Set("kubelet-certificate-authority", cpath(kasVolumeKubeletClientCA().Name, certs.CASignerCertMapKey))
 	args.Set("kubelet-client-certificate", cpath(kasVolumeKubeletClientCert().Name, corev1.TLSCertKey))

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -79,6 +79,7 @@ type KubeAPIServerParams struct {
 
 	MaxMutatingRequestsInflight string
 	MaxRequestsInflight         string
+	GoAwayChance                string
 }
 
 type KubeAPIServerServiceParams struct {
@@ -93,6 +94,7 @@ const (
 
 	defaultMaxRequestsInflight         = 3000
 	defaultMaxMutatingRequestsInflight = 1000
+	defaultGoAwayChance                = 0
 )
 
 func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider imageprovider.ReleaseImageProvider, externalAPIAddress string, externalAPIPort int32, externalOAuthAddress string, externalOAuthPort int32, setDefaultSecurityContext bool) *KubeAPIServerParams {
@@ -124,6 +126,7 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 		},
 		MaxRequestsInflight:         fmt.Sprint(defaultMaxRequestsInflight),
 		MaxMutatingRequestsInflight: fmt.Sprint(defaultMaxMutatingRequestsInflight),
+		GoAwayChance:                fmt.Sprint(defaultGoAwayChance),
 	}
 
 	if len(hcp.Spec.KubeAPIServerDNSName) > 0 {
@@ -143,6 +146,9 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 	}
 	if mutatingReqInflight := hcp.Annotations[hyperv1.KubeAPIServerMaximumMutatingRequestsInFlight]; mutatingReqInflight != "" {
 		params.MaxMutatingRequestsInflight = mutatingReqInflight
+	}
+	if goAwayChance := hcp.Annotations[hyperv1.KubeAPIServerGoAwayChance]; goAwayChance != "" {
+		params.GoAwayChance = goAwayChance
 	}
 
 	params.AdvertiseAddress = util.GetAdvertiseAddress(hcp, config.DefaultAdvertiseIPv4Address, config.DefaultAdvertiseIPv6Address)
@@ -413,6 +419,7 @@ func (p *KubeAPIServerParams) ConfigParams() KubeAPIServerConfigParams {
 		Authentication:               p.Authentication,
 		MaxRequestsInflight:          p.MaxRequestsInflight,
 		MaxMutatingRequestsInflight:  p.MaxMutatingRequestsInflight,
+		GoAwayChance:                 p.GoAwayChance,
 	}
 }
 
@@ -441,6 +448,7 @@ type KubeAPIServerConfigParams struct {
 	Authentication               *configv1.AuthenticationSpec
 	MaxRequestsInflight          string
 	MaxMutatingRequestsInflight  string
+	GoAwayChance                 string
 }
 
 func (p *KubeAPIServerParams) TLSSecurityProfile() *configv1.TLSSecurityProfile {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/config.go
@@ -205,7 +205,7 @@ func generateConfig(p KubeAPIServerConfigParams) (*kcpv1.KubeAPIServerConfig, er
 	featureGates = append(featureGates, "StructuredAuthenticationConfiguration=true")
 	featureGates = append(featureGates, "ValidatingAdmissionPolicy=true")
 	args.Set("feature-gates", featureGates...)
-	args.Set("goaway-chance", "0")
+	args.Set("goaway-chance", p.GoAwayChance)
 	args.Set("http2-max-streams-per-connection", "2000")
 	args.Set("kubelet-certificate-authority", cpath(kubeletClientCAVolumeName, certs.CASignerCertMapKey))
 	args.Set("kubelet-client-certificate", cpath(kubeletClientCertVolumeName, corev1.TLSCertKey))

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/params.go
@@ -24,6 +24,7 @@ const (
 
 	defaultMaxRequestsInflight         = 3000
 	defaultMaxMutatingRequestsInflight = 1000
+	defaultGoAwayChance                = 0
 )
 
 type KubeAPIServerConfigParams struct {
@@ -51,6 +52,7 @@ type KubeAPIServerConfigParams struct {
 	Authentication               *configv1.AuthenticationSpec
 	MaxRequestsInflight          string
 	MaxMutatingRequestsInflight  string
+	GoAwayChance                 string
 }
 
 func NewConfigParams(hcp *hyperv1.HostedControlPlane) KubeAPIServerConfigParams {
@@ -116,6 +118,11 @@ func NewConfigParams(hcp *hyperv1.HostedControlPlane) KubeAPIServerConfigParams 
 	kasConfig.MaxMutatingRequestsInflight = fmt.Sprint(defaultMaxMutatingRequestsInflight)
 	if mutatingReqInflight := hcp.Annotations[hyperv1.KubeAPIServerMaximumMutatingRequestsInFlight]; mutatingReqInflight != "" {
 		kasConfig.MaxMutatingRequestsInflight = mutatingReqInflight
+	}
+
+	kasConfig.GoAwayChance = fmt.Sprint(defaultGoAwayChance)
+	if goAwayChance := hcp.Annotations[hyperv1.KubeAPIServerGoAwayChance]; goAwayChance != "" {
+		kasConfig.GoAwayChance = hcp.Annotations[hyperv1.KubeAPIServerGoAwayChance]
 	}
 
 	if capabilities.IsImageRegistryCapabilityEnabled(hcp.Spec.Capabilities) {

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2115,6 +2115,7 @@ func reconcileHostedControlPlaneAnnotations(hcp *hyperv1.HostedControlPlane, hcl
 		hyperv1.DisableIgnitionServerAnnotation,
 		hyperv1.AWSMachinePublicIPs,
 		hyperkarpenterv1.KarpenterProviderAWSImage,
+		hyperv1.KubeAPIServerGoAwayChance,
 	}
 	for _, key := range mirroredAnnotations {
 		val, hasVal := hcluster.Annotations[key]

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -596,13 +596,15 @@ func TestReconcileHostedControlPlaneAnnotations(t *testing.T) {
 				hyperv1.RequestServingNodeAdditionalSelectorAnnotation:       "node-size=m5xl",
 				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test1": "test1",
 				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test2": "test2",
-				"foo": "bar", // should not be copied
+				hyperv1.KubeAPIServerGoAwayChance:                            "0.001",
+				"foo":                                                        "bar", // should not be copied
 			},
 			expectedAnnotations: map[string]string{
 				hyperutil.DebugDeploymentsAnnotation:                         "control-plane-operator",
 				hyperv1.EtcdPriorityClass:                                    "high-priority",
 				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test1": "test1",
 				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test2": "test2",
+				hyperv1.KubeAPIServerGoAwayChance:                            "0.001",
 				hyperv1.RequestServingNodeAdditionalSelectorAnnotation:       "node-size=m5xl",
 				hyperutil.HostedClusterAnnotation:                            hcKey,
 				hyperv1.DisableClusterAutoscalerAnnotation:                   "true",

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -344,6 +344,9 @@ const (
 	// DisableIgnitionServerAnnotation controls skipping of the ignition server deployment.
 	DisableIgnitionServerAnnotation = "hypershift.openshift.io/disable-ignition-server"
 
+	// KubeAPIServerGoAwayChance allows the --goaway-chance parameter of the kube-apiserver to be overridden from its default of 0
+	KubeAPIServerGoAwayChance = "hypershift.openshift.io/kube-apiserver-goaway-chance"
+
 	// ControlPlaneOperatorV2Annotation tells the hosted cluster to set 'CPO_V2' env variable on the CPO deployment which enables
 	// the new manifest based CPO implementation.
 	ControlPlaneOperatorV2Annotation = "hypershift.openshift.io/cpo-v2"


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support to override the --goaway-chance parameter for the kube-apiserver. The default will remain the previously hardcoded value of 0.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #https://issues.redhat.com/browse/OCPBUGS-54863

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.