### PR TITLE
NO-JIRA: Ensure that artifact directory exists for dump

### DIFF
--- a/cmd/cluster/core/dump.go
+++ b/cmd/cluster/core/dump.go
@@ -538,7 +538,11 @@ func (i *OCAdmInspect) Run(ctx context.Context, cmdArgs ...string) {
 	allArgs = append(allArgs, cmdArgs...)
 	cmd := exec.CommandContext(ctx, i.oc, allArgs...)
 	// oc adm inspect command always returns an error so ignore
-	_, _ = cmd.CombinedOutput()
+	result, err := cmd.CombinedOutput()
+	if err != nil {
+		i.log.Info(fmt.Sprintf("oc adm inspect error: %v", err))
+	}
+	i.log.Info(fmt.Sprintf("oc adm inspect output: %s", string(result)))
 }
 
 type OCAdmNodeLogs struct {

--- a/cmd/cluster/core/dump.go
+++ b/cmd/cluster/core/dump.go
@@ -521,6 +521,10 @@ func (i *OCAdmInspect) WithNamespace(namespace string) *OCAdmInspect {
 }
 
 func (i *OCAdmInspect) Run(ctx context.Context, cmdArgs ...string) {
+	if err := os.MkdirAll(i.artifactDir, 0755); err != nil {
+		i.log.Info(fmt.Sprintf("failed to ensure artifact directory exists: %v", err))
+		return
+	}
 	allArgs := []string{"adm", "inspect", "--dest-dir", i.artifactDir}
 	if len(i.namespace) > 0 {
 		allArgs = append(allArgs, "-n", i.namespace)
@@ -546,6 +550,12 @@ type OCAdmNodeLogs struct {
 }
 
 func (i *OCAdmNodeLogs) Run(ctx context.Context, cmdArgs ...string) {
+	// Ensure that artifact directory exists
+	if err := os.MkdirAll(i.artifactDir, 0755); err != nil {
+		i.log.Info(fmt.Sprintf("failed to ensure artifact directory exists: %v", err))
+		return
+	}
+
 	allArgs := []string{"adm", "node-logs"}
 	if len(i.kubeconfig) > 0 {
 		allArgs = append(allArgs, "--kubeconfig", i.kubeconfig)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes error in creating guest cluster artifact dump by ensuring that destination artifact directory exists before attempting to dump artifacts to it.

**Checklist**
- [x] Subject and description added to both, commit and PR.
