### PR TITLE
OCPBUGS-54916: Set Azure KMS Configuration to v2

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kms/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kms/azure.go
@@ -67,7 +67,7 @@ func NewAzureKMSProvider(kmsSpec *hyperv1.AzureKMSSpec, image string) (*azureKMS
 	}, nil
 }
 
-func (p *azureKMSProvider) GenerateKMSEncryptionConfig(_ string) (*v1.EncryptionConfiguration, error) {
+func (p *azureKMSProvider) GenerateKMSEncryptionConfig(apiVersion string) (*v1.EncryptionConfiguration, error) {
 	var providerConfiguration []v1.ProviderConfiguration
 
 	activeKeyHash, err := util.HashStruct(p.kmsSpec.ActiveKey)
@@ -76,10 +76,11 @@ func (p *azureKMSProvider) GenerateKMSEncryptionConfig(_ string) (*v1.Encryption
 	}
 	providerConfiguration = append(providerConfiguration, v1.ProviderConfiguration{
 		KMS: &v1.KMSConfiguration{
-			Name:      fmt.Sprintf("%s-%s", azureProviderConfigNamePrefix, activeKeyHash),
-			Endpoint:  azureActiveKMSUnixSocket,
-			CacheSize: ptr.To[int32](100),
-			Timeout:   &metav1.Duration{Duration: 35 * time.Second},
+			Name:       fmt.Sprintf("%s-%s", azureProviderConfigNamePrefix, activeKeyHash),
+			APIVersion: apiVersion,
+			Endpoint:   azureActiveKMSUnixSocket,
+			CacheSize:  ptr.To[int32](100),
+			Timeout:    &metav1.Duration{Duration: 35 * time.Second},
 		},
 	})
 	if p.kmsSpec.BackupKey != nil {
@@ -89,10 +90,11 @@ func (p *azureKMSProvider) GenerateKMSEncryptionConfig(_ string) (*v1.Encryption
 		}
 		providerConfiguration = append(providerConfiguration, v1.ProviderConfiguration{
 			KMS: &v1.KMSConfiguration{
-				Name:      fmt.Sprintf("%s-%s", azureProviderConfigNamePrefix, backupKeyHash),
-				Endpoint:  azureBackupKMSUnixSocket,
-				CacheSize: ptr.To[int32](100),
-				Timeout:   &metav1.Duration{Duration: 35 * time.Second},
+				Name:       fmt.Sprintf("%s-%s", azureProviderConfigNamePrefix, backupKeyHash),
+				APIVersion: apiVersion,
+				Endpoint:   azureBackupKMSUnixSocket,
+				CacheSize:  ptr.To[int32](100),
+				Timeout:    &metav1.Duration{Duration: 35 * time.Second},
 			},
 		})
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms/azure.go
@@ -71,7 +71,7 @@ func NewAzureKMSProvider(kmsSpec *hyperv1.AzureKMSSpec, image string) (*azureKMS
 	}, nil
 }
 
-func (p *azureKMSProvider) GenerateKMSEncryptionConfig(_ string) (*v1.EncryptionConfiguration, error) {
+func (p *azureKMSProvider) GenerateKMSEncryptionConfig(apiVersion string) (*v1.EncryptionConfiguration, error) {
 	var providerConfiguration []v1.ProviderConfiguration
 
 	activeKeyHash, err := util.HashStruct(p.kmsSpec.ActiveKey)
@@ -80,10 +80,11 @@ func (p *azureKMSProvider) GenerateKMSEncryptionConfig(_ string) (*v1.Encryption
 	}
 	providerConfiguration = append(providerConfiguration, v1.ProviderConfiguration{
 		KMS: &v1.KMSConfiguration{
-			Name:      fmt.Sprintf("%s-%s", azureProviderConfigNamePrefix, activeKeyHash),
-			Endpoint:  azureActiveKMSUnixSocket,
-			CacheSize: ptr.To[int32](100),
-			Timeout:   &metav1.Duration{Duration: 35 * time.Second},
+			Name:       fmt.Sprintf("%s-%s", azureProviderConfigNamePrefix, activeKeyHash),
+			APIVersion: apiVersion,
+			Endpoint:   azureActiveKMSUnixSocket,
+			CacheSize:  ptr.To[int32](100),
+			Timeout:    &metav1.Duration{Duration: 35 * time.Second},
 		},
 	})
 	if p.kmsSpec.BackupKey != nil {
@@ -93,10 +94,11 @@ func (p *azureKMSProvider) GenerateKMSEncryptionConfig(_ string) (*v1.Encryption
 		}
 		providerConfiguration = append(providerConfiguration, v1.ProviderConfiguration{
 			KMS: &v1.KMSConfiguration{
-				Name:      fmt.Sprintf("%s-%s", azureProviderConfigNamePrefix, backupKeyHash),
-				Endpoint:  azureBackupKMSUnixSocket,
-				CacheSize: ptr.To[int32](100),
-				Timeout:   &metav1.Duration{Duration: 35 * time.Second},
+				Name:       fmt.Sprintf("%s-%s", azureProviderConfigNamePrefix, backupKeyHash),
+				APIVersion: apiVersion,
+				Endpoint:   azureBackupKMSUnixSocket,
+				CacheSize:  ptr.To[int32](100),
+				Timeout:    &metav1.Duration{Duration: 35 * time.Second},
 			},
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit sets the Azure KMS configuration to the apiVersion, which is v2 by default.

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-54916](https://issues.redhat.com/browse/OCPBUGS-54916)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.