### PR TITLE
OCPBUGS-54763: openstack/cli: only set port security when specified

### DIFF
--- a/cmd/nodepool/openstack/create.go
+++ b/cmd/nodepool/openstack/create.go
@@ -153,13 +153,8 @@ func convertAdditionalPorts(additionalPorts []string) ([]hyperv1.PortSpec, error
 			return res, fmt.Errorf("--openstack-node-additional-port requires network-id to be set")
 		}
 		var portSecurityPolicy hyperv1.PortSecurityPolicy
-		switch additionalPortOpts.DisablePortSecurity {
-		case true:
+		if additionalPortOpts.DisablePortSecurity {
 			portSecurityPolicy = hyperv1.PortSecurityDisabled
-		case false:
-			portSecurityPolicy = hyperv1.PortSecurityEnabled
-		default:
-			portSecurityPolicy = hyperv1.PortSecurityDefault
 		}
 		res = append(res, hyperv1.PortSpec{
 			Network: &hyperv1.NetworkParam{


### PR DESCRIPTION
**What this PR does / why we need it**:

A follow-up from 59ca93668729a35abd6faecee145055720f06ecb
The CLI was mapping CLI options to a struct and the bool was False by
default so disable port security was false which was enabling port
security in the spec, which we try to avoid in this bug fix.