### PR TITLE
CNTRLPLANE-709: Add ability to limit platform specific resources managed by HostedCluster

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -399,6 +399,7 @@ type HyperShiftOperatorDeployment struct {
 	AROHCPKeyVaultUsersClientID             string
 	TechPreviewNoUpgrade                    bool
 	RegistryOverrides                       string
+	PlatformsInstalled                      string
 }
 
 func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
@@ -537,6 +538,13 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  controlplaneoperatoroverrides.CPOOverridesEnvVar,
 			Value: "1",
+		})
+	}
+
+	if len(o.PlatformsInstalled) > 0 {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "PLATFORMS_INSTALLED",
+			Value: o.PlatformsInstalled,
 		})
 	}
 

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -802,6 +802,7 @@ func setupOperatorResources(opts Options, userCABundleCM *corev1.ConfigMap, trus
 		AROHCPKeyVaultUsersClientID:             opts.AroHCPKeyVaultUsersClientID,
 		TechPreviewNoUpgrade:                    opts.TechPreviewNoUpgrade,
 		RegistryOverrides:                       opts.RegistryOverrides,
+		PlatformsInstalled:                      strings.Join(opts.PlatformsToInstall, ","),
 	}.Build()
 	operatorService := assets.HyperShiftOperatorService{
 		Namespace: operatorNamespace,

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -72,7 +72,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
-	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1beta1"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -101,9 +100,6 @@ import (
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 
-	capiaws "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2" // Need this dep atm to satisfy IBM provider dep.
-	capiibmv1 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
-	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -253,10 +249,7 @@ func (r *HostedClusterReconciler) SetupWithManager(mgr ctrl.Manager, createOrUpd
 // managedResources are all the resources that are managed as childresources for a HostedCluster
 func (r *HostedClusterReconciler) managedResources() []client.Object {
 	managedResources := []client.Object{
-		&capiaws.AWSCluster{},
 		&hyperv1.HostedControlPlane{},
-		&hyperv1.AWSEndpointService{},
-		&capiv1.Cluster{},
 		&appsv1.Deployment{},
 		&prometheusoperatorv1.PodMonitor{},
 		&networkingv1.NetworkPolicy{},
@@ -270,25 +263,46 @@ func (r *HostedClusterReconciler) managedResources() []client.Object {
 		&corev1.ServiceAccount{},
 		&corev1.Service{},
 		&corev1.Endpoints{},
-		&agentv1.AgentCluster{},
-		&capiibmv1.IBMVPCCluster{},
-		&capikubevirt.KubevirtCluster{},
 		&hyperv1.NodePool{},
 	}
 
+	// Watch based on platforms installed
+	if platformsInstalled := os.Getenv("PLATFORMS_INSTALLED"); len(platformsInstalled) > 0 {
+		managedResources = append(managedResources, hyperutil.GetHostedClusterManagedResources(platformsInstalled)...)
+	} else {
+		managedResources = append(managedResources, hyperutil.BaseResources...)
+		managedResources = append(managedResources, hyperutil.AWSResources...)
+		managedResources = append(managedResources, hyperutil.AzureResources...)
+		managedResources = append(managedResources, hyperutil.IBMCloudResources...)
+		managedResources = append(managedResources, hyperutil.KubevirtResources...)
+		managedResources = append(managedResources, hyperutil.AgentResources...)
+		managedResources = append(managedResources, hyperutil.OpenStackResources...)
+	}
+
+	// Only watch managed Azure resources if the HO is explicitly configured to do so. Otherwise, the HO will fail to
+	// reconcile HostedClusters since some CRs are only installed in the managed Azure use case.
+	if azureutil.IsAroHCP() {
+		managedResources = append(managedResources, hyperutil.ManagedAzure...)
+	}
+
+	// Watch if etcd recovery is enabled
 	if r.EnableEtcdRecovery {
 		managedResources = append(managedResources, []client.Object{
 			&appsv1.StatefulSet{},
 			&batchv1.Job{},
 		}...)
 	}
+
 	// Watch based on Routes capability
 	if r.ManagementClusterCapabilities.Has(capabilities.CapabilityRoute) {
 		managedResources = append(managedResources, &routev1.Route{})
 	}
+
+	// Watch based on Ingress capability
 	if r.ManagementClusterCapabilities.Has(capabilities.CapabilityIngress) {
 		managedResources = append(managedResources, &configv1.Ingress{})
 	}
+
 	return managedResources
 }
 
@@ -2005,7 +2019,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile nodepool management secret provider class: %w", err)
 		}
 
-		if hcluster.Spec.SecretEncryption.KMS != nil {
+		if hcluster.Spec.SecretEncryption != nil && hcluster.Spec.SecretEncryption.KMS != nil {
 			// Reconcile KMS SecretProviderClass CR
 			kmsSecretProviderClass := cpomanifests.ManagedAzureSecretProviderClass(config.ManagedAzureKMSSecretProviderClassName, hcp.Namespace)
 			if _, err := createOrUpdate(ctx, r, kmsSecretProviderClass, func() error {
@@ -3130,7 +3144,7 @@ func reconcileControlPlaneOperatorDeployment(
 		)
 
 		// Mount the KMS credentials so the HCP reconciliation can validate the Azure KMS configuration.
-		if hcp.Spec.SecretEncryption.KMS != nil {
+		if hcp.Spec.SecretEncryption != nil && hcp.Spec.SecretEncryption.KMS != nil {
 			deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts,
 				azureutil.CreateVolumeMountForKMSAzureSecretStoreProviderClass(config.ManagedAzureKMSSecretStoreVolumeName),
 			)
@@ -5603,10 +5617,12 @@ func (r *HostedClusterReconciler) reconcileKubevirtPlatformDefaultSettings(ctx c
 		if err := r.Get(ctx, mgmtInfraKey, mgmtInfra); err != nil {
 			return fmt.Errorf("failed to get infrastructure.config.openshift.io status: %w", err)
 		}
-		mgmtPlatformType := mgmtInfra.Status.PlatformStatus.Type
-		hc.Annotations[hyperv1.ManagementPlatformAnnotation] = string(mgmtPlatformType)
-		if err := r.Client.Update(ctx, hc); err != nil {
-			return fmt.Errorf("failed to update hostedcluster %s annotation: %w", hc.Name, err)
+		if mgmtInfra.Status.PlatformStatus != nil {
+			mgmtPlatformType := mgmtInfra.Status.PlatformStatus.Type
+			hc.Annotations[hyperv1.ManagementPlatformAnnotation] = string(mgmtPlatformType)
+			if err := r.Client.Update(ctx, hc); err != nil {
+				return fmt.Errorf("failed to update hostedcluster %s annotation: %w", hc.Name, err)
+			}
 		}
 	}
 

--- a/support/releaseinfo/fake/fake.go
+++ b/support/releaseinfo/fake/fake.go
@@ -31,7 +31,7 @@ type FakeReleaseProvider struct {
 func (f *FakeReleaseProvider) Lookup(_ context.Context, image string, _ []byte) (*releaseinfo.ReleaseImage, error) {
 	releaseImage := &releaseinfo.ReleaseImage{
 		ImageStream: &imagev1.ImageStream{
-			ObjectMeta: metav1.ObjectMeta{Name: "4.15.0"},
+			ObjectMeta: metav1.ObjectMeta{Name: "4.18.0"},
 			Spec: imagev1.ImageStreamSpec{
 				Tags: []imagev1.TagReference{
 					{
@@ -48,6 +48,14 @@ func (f *FakeReleaseProvider) Lookup(_ context.Context, image string, _ []byte) 
 					},
 					{
 						Name: "cluster-capi-controllers",
+						From: &corev1.ObjectReference{Name: ""},
+					},
+					{
+						Name: "azure-cluster-api-controllers",
+						From: &corev1.ObjectReference{Name: ""},
+					},
+					{
+						Name: "openstack-cluster-api-controllers",
 						From: &corev1.ObjectReference{Name: ""},
 					},
 					{

--- a/support/releaseinfo/testutils/testutils.go
+++ b/support/releaseinfo/testutils/testutils.go
@@ -40,6 +40,14 @@ func InitReleaseImageOrDie(version string) *releaseinfo.ReleaseImage {
 						From: &corev1.ObjectReference{Name: ""},
 					},
 					{
+						Name: "azure-cluster-api-controllers",
+						From: &corev1.ObjectReference{Name: ""},
+					},
+					{
+						Name: "openstack-cluster-api-controllers",
+						From: &corev1.ObjectReference{Name: ""},
+					},
+					{
 						Name: util.AvailabilityProberImageName,
 						From: &corev1.ObjectReference{Name: ""},
 					},

--- a/support/util/resources.go
+++ b/support/util/resources.go
@@ -53,6 +53,22 @@ var (
 	OpenStackResources = []client.Object{
 		&capiopenstackv1beta1.OpenStackCluster{},
 	}
+
+	AWSNodePoolResources = []client.Object{
+		&capiaws.AWSMachineTemplate{},
+	}
+
+	AzureNodePoolResources = []client.Object{
+		&capiazure.AzureMachineTemplate{},
+	}
+
+	AgentNodePoolResources = []client.Object{
+		&agentv1.AgentMachineTemplate{},
+	}
+
+	OpenStackNodePoolResources = []client.Object{
+		&capiopenstackv1beta1.OpenStackMachineTemplate{},
+	}
 )
 
 func GetHostedClusterManagedResources(platformsInstalled string) []client.Object {
@@ -91,6 +107,27 @@ func GetHostedClusterManagedResources(platformsInstalled string) []client.Object
 			managedResources = append(managedResources, AgentResources...)
 		case strings.EqualFold(platform, string(hyperv1.OpenStackPlatform)):
 			managedResources = append(managedResources, OpenStackResources...)
+		}
+	}
+
+	return managedResources
+}
+
+func GetNodePoolManagedResources(platformsInstalled string) []client.Object {
+	var managedResources []client.Object
+
+	platformsInstalledList := strings.Split(platformsInstalled, ",")
+	for _, platform := range platformsInstalledList {
+		platform = strings.ToLower(strings.TrimSpace(platform))
+		switch {
+		case strings.EqualFold(platform, string(hyperv1.AWSPlatform)):
+			managedResources = append(managedResources, AWSNodePoolResources...)
+		case strings.EqualFold(platform, string(hyperv1.AzurePlatform)):
+			managedResources = append(managedResources, AzureNodePoolResources...)
+		case strings.EqualFold(platform, string(hyperv1.AgentPlatform)):
+			managedResources = append(managedResources, AgentNodePoolResources...)
+		case strings.EqualFold(platform, string(hyperv1.OpenStackPlatform)):
+			managedResources = append(managedResources, OpenStackNodePoolResources...)
 		}
 	}
 

--- a/support/util/resources.go
+++ b/support/util/resources.go
@@ -1,0 +1,98 @@
+package util
+
+import (
+	"strings"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1beta1"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	capiaws "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	capiazure "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	capiibmv1 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
+	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
+	capiopenstackv1beta1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	secretsstorev1 "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
+)
+
+var (
+	BaseResources = []client.Object{
+		&capiv1.Cluster{},
+	}
+
+	AWSResources = []client.Object{
+		&capiaws.AWSCluster{},
+		&hyperv1.AWSEndpointService{},
+	}
+
+	AzureResources = []client.Object{
+		&capiazure.AzureCluster{},
+		&capiazure.AzureClusterIdentity{},
+	}
+
+	ManagedAzure = []client.Object{
+		&secretsstorev1.SecretProviderClass{},
+	}
+
+	IBMCloudResources = []client.Object{
+		&capiibmv1.IBMVPCCluster{},
+	}
+
+	KubevirtResources = []client.Object{
+		&capikubevirt.KubevirtCluster{},
+	}
+
+	AgentResources = []client.Object{
+		&agentv1.AgentCluster{},
+	}
+
+	OpenStackResources = []client.Object{
+		&capiopenstackv1beta1.OpenStackCluster{},
+	}
+)
+
+func GetHostedClusterManagedResources(platformsInstalled string) []client.Object {
+	var managedResources []client.Object
+
+	platformsInstalledList := sets.New[string]()
+	for _, p := range strings.Split(platformsInstalled, ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			platformsInstalledList.Insert(p)
+		}
+	}
+
+	if platformsInstalledList.Len() == 0 {
+		return managedResources
+	}
+
+	if platformsInstalledList.Len() == 1 && strings.EqualFold(platformsInstalledList.UnsortedList()[0], string(hyperv1.NonePlatform)) {
+		return managedResources
+	}
+
+	// All platforms have the same base resources
+	managedResources = append(managedResources, BaseResources...)
+
+	for _, platform := range platformsInstalledList.UnsortedList() {
+		switch {
+		case strings.EqualFold(platform, string(hyperv1.AWSPlatform)):
+			managedResources = append(managedResources, AWSResources...)
+		case strings.EqualFold(platform, string(hyperv1.AzurePlatform)):
+			managedResources = append(managedResources, AzureResources...)
+		case strings.EqualFold(platform, string(hyperv1.IBMCloudPlatform)):
+			managedResources = append(managedResources, IBMCloudResources...)
+		case strings.EqualFold(platform, string(hyperv1.KubevirtPlatform)):
+			managedResources = append(managedResources, KubevirtResources...)
+		case strings.EqualFold(platform, string(hyperv1.AgentPlatform)):
+			managedResources = append(managedResources, AgentResources...)
+		case strings.EqualFold(platform, string(hyperv1.OpenStackPlatform)):
+			managedResources = append(managedResources, OpenStackResources...)
+		}
+	}
+
+	return managedResources
+}

--- a/support/util/resources_test.go
+++ b/support/util/resources_test.go
@@ -1,0 +1,54 @@
+package util
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetHostedClusterManagedResources(t *testing.T) {
+	testCases := []struct {
+		name               string
+		platformsInstalled string
+		expectedObjectsSet sets.Set[client.Object]
+	}{
+		{
+			name:               "when no platforms are installed, expect no resources",
+			platformsInstalled: "",
+			expectedObjectsSet: sets.Set[client.Object]{},
+		},
+		{
+			name:               "when only the None platform is installed, expect no resources",
+			platformsInstalled: "None",
+			expectedObjectsSet: sets.Set[client.Object]{},
+		},
+		{
+			name:               "when only the AWS platform is installed, expect only AWS resources",
+			platformsInstalled: "AWS",
+			expectedObjectsSet: sets.New[client.Object](append(BaseResources, AWSResources...)...),
+		},
+		{
+			name:               "when the Azure and AWS platforms are installed, expect only Azure and AWS resources",
+			platformsInstalled: "azure,AWS", // testing case insensitivity here
+			expectedObjectsSet: sets.New[client.Object](
+				append(append(BaseResources, AWSResources...), AzureResources...)...,
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			actualObjects := GetHostedClusterManagedResources(tc.platformsInstalled)
+			actualObjectSet := sets.New[client.Object](actualObjects...)
+
+			if diff := cmp.Diff(actualObjectSet, tc.expectedObjectsSet); diff != "" {
+				t.Errorf("the set of managed resources did not match expected set of managed resources: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows the HostedCluster to only watch platform specific resources based on what platforms installed in the HO. If the HO does not limit the platform CRDs installed, the HostedCluster watches all platform CRDs as it did before this PR.

**Which issue(s) this PR fixes**:
[CNTRLPLANE-709](https://issues.redhat.com/browse/CNTRLPLANE-709)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.