### PR TITLE
NO-JIRA: version check csi-snapshot-webhook for EnsureSATokenNotMountedUnlessNecessary

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -2341,6 +2341,12 @@ func EnsureSATokenNotMountedUnlessNecessary(t *testing.T, ctx context.Context, c
 			"shared-resource-csi-driver-operator",
 		)
 
+		if IsLessThan(Version418) {
+			expectedComponentsWithTokenMount = append(expectedComponentsWithTokenMount,
+				"csi-snapshot-webhook",
+			)
+		}
+
 		if hostedCluster.Spec.Platform.Type == hyperv1.AzurePlatform {
 			expectedComponentsWithTokenMount = append(expectedComponentsWithTokenMount,
 				"azure-cloud-controller-manager",


### PR DESCRIPTION
https://github.com/openshift/hypershift/pull/6004 removed `csi-snapshot-webhook` from the excluded prefixes, however, the webhook is only removed back to 4.18.  4.16 and 4.17 still have it and it still needs to be excluded.

This is causing payload test failures.