### PR TITLE
CNTRLPLANE-111: Support KMSv2 encryption encryption for ARO HCP, with MIv3

### DIFF
--- a/contrib/managed-azure/setup_etcd_kv.sh
+++ b/contrib/managed-azure/setup_etcd_kv.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -x
+
+# Prerequisites: define these constants
+LOCATION="eastus"
+KV_RG_NAME="example-kms"
+KV_NAME="example-key-vault"
+KEY_NAME="example-key"
+SUBSCRIPTION_ID="<your-subscription-id-here>"
+
+# This is the object ID of the KMS Managed Identity. This object ID can be found under the enterprise application for
+# your KMS Managed Identity.
+USER_OBJECT_ID="<fill-me-out>"
+
+# This is the object ID of the KMS Managed Identity. This object ID can be found under the enterprise application for
+# your KMS Managed Identity.
+OBJECT_ID="<fill-me-out>"
+
+# Create a resource group to hold the Key Vault
+az group create --name $KV_RG_NAME --location $LOCATION
+
+# Create the Key Vault
+az keyvault create --name $KV_NAME --resource-group $KV_RG_NAME --location $LOCATION --enable-rbac-authorization
+
+## Associate your SP/Account with the Key Vault; this is so you can use your SP/Account can use the CLI to create the key in the key vault
+az role assignment create \
+    --assignee ${USER_OBJECT_ID} \
+    --scope /subscriptions/${SUBSCRIPTION_ID}/resourceGroups/$KV_RG_NAME/providers/Microsoft.KeyVault/vaults/${KV_NAME} \
+    --role "Key Vault Administrator"
+
+#Create a key in the Key Vault
+export KEY_ID=$(az keyvault key create --vault-name $KV_NAME --name $KEY_NAME --protection software --kty RSA --query key.kid -o tsv)
+
+# Assign the Key Vault Crypto User role to the KMS Managed Identity
+az role assignment create --assignee $OBJECT_ID --role "Key Vault Crypto User" --scope "$(az keyvault show --name $KV_NAME --query "resourceGroup" -o tsv | xargs -I{} az group show --name {} --query "id" -o tsv)"
+
+set +x
+
+set +x

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -6,7 +6,6 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/aws"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/pki"
@@ -298,12 +297,8 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 		},
 	}
 
-	switch hcp.Spec.Platform.Type {
-	case hyperv1.AWSPlatform:
+	if hcp.Spec.Platform.Type == hyperv1.AWSPlatform {
 		params.CloudProvider = aws.Provider
-	case hyperv1.AzurePlatform:
-		params.CloudProvider = azure.Provider
-		params.CloudProviderConfig = &corev1.LocalObjectReference{Name: manifests.AzureProviderConfigWithCredentials("").Name}
 	}
 
 	if hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/secretencryption.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/secretencryption.go
@@ -3,7 +3,7 @@ package kas
 import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
-	hcpconfig "github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/config"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -14,7 +14,7 @@ const (
 )
 
 func ReconcileKMSEncryptionConfig(config *corev1.Secret,
-	ownerRef hcpconfig.OwnerRef,
+	ownerRef config.OwnerRef,
 	encryptionSpec *hyperv1.KMSSpec,
 ) error {
 	ownerRef.ApplyTo(config)
@@ -32,7 +32,7 @@ func ReconcileKMSEncryptionConfig(config *corev1.Secret,
 }
 
 func ReconcileAESCBCEncryptionConfig(config *corev1.Secret,
-	ownerRef hcpconfig.OwnerRef,
+	ownerRef config.OwnerRef,
 	activeKey []byte,
 	backupKey []byte,
 ) error {

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/azure.go
@@ -25,6 +25,15 @@ func AzureProviderConfigWithCredentials(ns string) *corev1.Secret {
 	}
 }
 
+func AzureKMSWithCredentials(ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "azure-kms-config",
+			Namespace: ns,
+		},
+	}
+}
+
 func AzureDiskConfigWithCredentials(ns string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms/azure.go
@@ -83,7 +83,6 @@ func (p *azureKMSProvider) GenerateKMSEncryptionConfig(apiVersion string) (*v1.E
 			Name:       fmt.Sprintf("%s-%s", azureProviderConfigNamePrefix, activeKeyHash),
 			APIVersion: apiVersion,
 			Endpoint:   azureActiveKMSUnixSocket,
-			CacheSize:  ptr.To[int32](100),
 			Timeout:    &metav1.Duration{Duration: 35 * time.Second},
 		},
 	})
@@ -97,7 +96,6 @@ func (p *azureKMSProvider) GenerateKMSEncryptionConfig(apiVersion string) (*v1.E
 				Name:       fmt.Sprintf("%s-%s", azureProviderConfigNamePrefix, backupKeyHash),
 				APIVersion: apiVersion,
 				Endpoint:   azureBackupKMSUnixSocket,
-				CacheSize:  ptr.To[int32](100),
 				Timeout:    &metav1.Duration{Duration: 35 * time.Second},
 			},
 		})
@@ -221,7 +219,7 @@ func kasVolumeAzureKMSCredentials() *corev1.Volume {
 
 func buildVolumeAzureKMSCredentials(v *corev1.Volume) {
 	v.Secret = &corev1.SecretVolumeSource{
-		SecretName: manifests.AzureProviderConfigWithCredentials("").Name,
+		SecretName: manifests.AzureKMSWithCredentials("").Name,
 		Items: []corev1.KeyToPath{
 			{
 				Key:  azure.CloudConfigKey,

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/params.go
@@ -5,7 +5,6 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/aws"
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/capabilities"
 	"github.com/openshift/hypershift/support/config"
@@ -18,9 +17,7 @@ import (
 )
 
 const (
-	KonnectivityHealthPort      = 2041
 	KonnectivityServerLocalPort = 8090
-	KonnectivityServerPort      = 8091
 
 	defaultMaxRequestsInflight         = 3000
 	defaultMaxMutatingRequestsInflight = 1000
@@ -77,12 +74,8 @@ func NewConfigParams(hcp *hyperv1.HostedControlPlane, featureGates []string) Kub
 		DisableProfiling:             util.StringListContains(hcp.Annotations[hyperv1.DisableProfilingAnnotation], manifests.KASDeployment("").Name),
 	}
 
-	switch hcp.Spec.Platform.Type {
-	case hyperv1.AWSPlatform:
+	if hcp.Spec.Platform.Type == hyperv1.AWSPlatform {
 		kasConfig.CloudProvider = aws.Provider
-	case hyperv1.AzurePlatform:
-		kasConfig.CloudProvider = azure.Provider
-		// kasConfig.CloudProviderConfigRef = &corev1.LocalObjectReference{Name: manifests.AzureProviderConfigWithCredentials("").Name}
 	}
 
 	switch hcp.Spec.Etcd.ManagementType {

--- a/docs/content/how-to/azure/create-azure-cluster-with-options.md
+++ b/docs/content/how-to/azure/create-azure-cluster-with-options.md
@@ -1,5 +1,5 @@
 # Create an Azure cluster with Additional Options
-This document describes how to set up an Azure cluster with Hypershift with additional flag options.
+This document describes how to set up an Azure cluster with Hypershift with additional options.
 
 Creating an Azure cluster with Hypershift without any additional flag options can be found [here](create-azure-cluster_on_aks.md).
 
@@ -22,86 +22,6 @@ There are a few prerequisites for encrypting the OS disks on the Azure VMs:
     You will need to use the `resource-group-name` flag when using the `DiskEncryptionSetID` flag.
 
 After performing these steps, you just need to provide the DiskEncryptionSet ID when creating a hosted cluster.
-
-## Creating Service Principals for Managed Identities
-Pre-requisites:
-1. Key Vault Administrator role on the Key Vault
-
-
-### Define variables for service principal names
-```
-AZURE_DISK_SP_NAME=<azure-disk-sp-name>
-AZURE_FILE_SP_NAME=<azure-file-sp-name>
-NODEPOOL_MGMT=<nodepool-mgmt-sp-name>
-CLOUD_PROVIDER_SP_NAME=<cloud-provider-sp-name>
-CNCC_NAME=<cncc-sp-name>
-CONTROL_PLANE_SP_NAME=<cpo-sp-name>
-IMAGE_REGISTRY_SP_NAME=<ciro-sp-name>
-INGRESS_SP_NAME=<ingress-sp-name>
-KEY_VAULT_NAME=<name-of-precreated-key-vault>
-KEY_VAULT_TENANT_ID=<tenant-id-of-precreated-key-vault>
-```
-
-### Create service principals and capture app IDs
-```
-DISK_SP_APP_ID=$(az ad sp create-for-rbac --name "${AZURE_DISK_SP_NAME}" --create-cert --cert "${AZURE_DISK_SP_NAME}" --keyvault ${KV_NAME} --output json --only-show-errors | jq '.appId' | sed 's/"//g')
-FILE_SP_APP_ID=$(az ad sp create-for-rbac --name "${AZURE_FILE_SP_NAME}" --create-cert --cert "${AZURE_FILE_SP_NAME}" --keyvault ${KV_NAME} --output json --only-show-errors | jq '.appId' | sed 's/"//g')
-NODEPOOL_MGMT_APP_ID=$(az ad sp create-for-rbac --name "${NODEPOOL_MGMT}" --create-cert --cert "${NODEPOOL_MGMT}" --keyvault ${KV_NAME} --output json --only-show-errors | jq '.appId' | sed 's/"//g')
-CLOUD_PROVIDER_APP_ID=$(az ad sp create-for-rbac --name "${CLOUD_PROVIDER_SP_NAME}" --create-cert --cert "${CLOUD_PROVIDER_SP_NAME}" --keyvault ${KV_NAME} --output json --only-show-errors | jq '.appId' | sed 's/"//g')
-CNCC_APP_ID=$(az ad sp create-for-rbac --name "${CNCC_NAME}" --create-cert --cert "${CNCC_NAME}" --keyvault ${KV_NAME} --output json --only-show-errors | jq '.appId' | sed 's/"//g')
-CONTROL_PLANE_APP_ID=$(az ad sp create-for-rbac --name "${CONTROL_PLANE_SP_NAME}" --create-cert --cert "${CONTROL_PLANE_SP_NAME}" --keyvault ${KV_NAME} --output json --only-show-errors | jq '.appId' | sed 's/"//g')
-IMAGE_REGISTRY_APP_ID=$(az ad sp create-for-rbac --name "${IMAGE_REGISTRY_SP_NAME}" --create-cert --cert "${IMAGE_REGISTRY_SP_NAME}" --keyvault ${KV_NAME} --output json --only-show-errors | jq '.appId' | sed 's/"//g')
-INGRESS_APP_ID=$(az ad sp create-for-rbac --name "${INGRESS_SP_NAME}" --create-cert --cert "${INGRESS_SP_NAME}" --keyvault ${KV_NAME} --output json --only-show-errors | jq '.appId' | sed 's/"//g')
-```
-
-### Save service principal IDs and certificate names to a JSON file
-```
-SP_FILE="service-principals.json"
-
-# Save service principal IDs and certificate names to a JSON file
-OUTPUT_FILE="service-principals.json"
-
-cat <<EOF > SP_FILE
-{
-    "cloudProvider": {
-        "certificateName": "${CLOUD_PROVIDER_SP_NAME}",
-        "clientID": "${CLOUD_PROVIDER_APP_ID}"
-    },
-    "controlPlaneOperator": {
-        "certificateName": "${CONTROL_PLANE_SP_NAME}",
-        "clientID": "${CONTROL_PLANE_APP_ID}"
-    },
-    "disk": {
-        "certificateName": "${AZURE_DISK_SP_NAME}",
-        "clientID": "${DISK_SP_APP_ID}"
-    },
-    "file": {
-        "certificateName": "${AZURE_FILE_SP_NAME}",
-        "clientID": "${FILE_SP_APP_ID}"
-    },
-    "imageRegistry": {
-        "certificateName": "${IMAGE_REGISTRY_SP_NAME}",
-        "clientID": "${IMAGE_REGISTRY_APP_ID}"
-    },
-    "ingress": {
-        "certificateName": "${INGRESS_SP_NAME}",
-        "clientID": "${INGRESS_APP_ID}"
-    },
-    "network": {
-        "certificateName": "${CNCC_NAME}",
-        "clientID": "${CNCC_APP_ID}"
-    },
-    "nodePoolManagement": {
-        "certificateName": "${NODEPOOL_MGMT}",
-        "clientID": "${NODEPOOL_MGMT_APP_ID}"
-    },
-    "managedIdentitiesKeyVault": {
-        "name": "${KV_NAME}",
-        "tenantID": "{KV_TENANT_ID}"
-    }
-}
-EOF
-```
 
 ### CLI Example
 ```

--- a/docs/content/how-to/azure/scheduler.md
+++ b/docs/content/how-to/azure/scheduler.md
@@ -1,4 +1,4 @@
-# Azure Scheduler
+# Using Azure Scheduler
 
 The Azure Scheduler works with the default `ClusterSizingConfiguration` resource and the `HostedClusterSizing` controller.
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -100,8 +100,8 @@ nav:
         - how-to/aws/troubleshooting/debug-nodes.md
         - how-to/aws/troubleshooting/troubleshooting-disaster-recovery.md
   - 'Azure':
-    - how-to/azure/create-azure-cluster-with-options.md
     - how-to/azure/create-azure-cluster_on_aks.md
+    - how-to/azure/create-azure-cluster-with-options.md
     - how-to/azure/scheduler.md
     - 'Troubleshooting':
         - how-to/azure/troubleshooting/index.md

--- a/support/azureutil/azureutil.go
+++ b/support/azureutil/azureutil.go
@@ -207,6 +207,14 @@ func CreateVolumeMountForAzureSecretStoreProviderClass(secretStoreVolumeName str
 	}
 }
 
+func CreateVolumeMountForKMSAzureSecretStoreProviderClass(secretStoreVolumeName string) corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      secretStoreVolumeName,
+		MountPath: config.ManagedAzureCredentialsMountPathForKMS,
+		ReadOnly:  true,
+	}
+}
+
 func CreateVolumeForAzureSecretStoreProviderClass(secretStoreVolumeName, secretProviderClassName string) corev1.Volume {
 	return corev1.Volume{
 		Name: secretStoreVolumeName,

--- a/support/config/constants.go
+++ b/support/config/constants.go
@@ -68,7 +68,9 @@ const (
 	ManagedAzureCertificatePathEnvVarKey     = "ARO_HCP_CLIENT_CERTIFICATE_PATH"
 	ManagedAzureSecretProviderClassEnvVarKey = "ARO_HCP_SECRET_PROVIDER_CLASS"
 	ManagedAzureCertificateMountPath         = "/mnt/certs"
+	ManagedAzureCredentialsMountPathForKMS   = "/mnt/kms"
 	ManagedAzureCertificatePath              = "/mnt/certs/"
+	ManagedAzureCredentialsPathForKMS        = "/mnt/kms/"
 	ManagedAzureSecretsStoreCSIDriver        = "secrets-store.csi.k8s.io"
 	ManagedAzureSecretProviderClass          = "secretProviderClass"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR:
- updates Azure KMS implementation by updating the encryption configuration to only support v2 parameters
- have Azure KMS use it's own Azure authentication configuration; previously, it was reusing CP/CCM configuration
- reorders some of the Azure how-to pages in our docs
- adds a how-to section on setting up and verifying etcd encryption

**Which issue(s) this PR fixes**:
Fixes [CNTRLPLANE-111](https://issues.redhat.com//browse/CNTRLPLANE-111)

**Notes to Reviewers**:
- The first commit contains the actual code changes. The other commits are docs related.
- CacheSize: ptr.To\[int32\]\(100\), was removed because it is not valid for v2

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.