### PR TITLE
[release-4.18] OCPBUGS-54737: Bump socks5 proxy, konnectivity proxy, http proxy, token minter memory requests

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -388,7 +388,7 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, platformType hyp
 
 	kProxyResources := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("10Mi"),
+			corev1.ResourceMemory: resource.MustParse("30Mi"),
 			corev1.ResourceCPU:    resource.MustParse("10m"),
 		},
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_No_private_apiserver_connectivity__proxy_apiserver_address_is_set.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_No_private_apiserver_connectivity__proxy_apiserver_address_is_set.yaml
@@ -114,7 +114,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 30Mi
         volumeMounts:
         - mountPath: /etc/kubernetes
           name: hosted-etc-kube
@@ -141,7 +141,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 30Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/client-token
@@ -204,7 +204,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 30Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/client-token

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Preserve_existing_resources.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Preserve_existing_resources.yaml
@@ -117,7 +117,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 30Mi
         volumeMounts:
         - mountPath: /etc/kubernetes
           name: hosted-etc-kube
@@ -144,7 +144,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 30Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/client-token
@@ -207,7 +207,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 30Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/client-token

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Private_apiserver_connectivity__proxy_apiserver_address_is_unset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Private_apiserver_connectivity__proxy_apiserver_address_is_unset.yaml
@@ -112,7 +112,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 30Mi
         volumeMounts:
         - mountPath: /etc/kubernetes
           name: hosted-etc-kube
@@ -139,7 +139,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 30Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/client-token
@@ -202,7 +202,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 30Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/client-token

--- a/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingressoperator/ingressoperator.go
@@ -198,7 +198,7 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, platformType hyp
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("10Mi"),
+					corev1.ResourceMemory: resource.MustParse("30Mi"),
 				},
 			},
 			Image: params.TokenMinterImage,
@@ -271,7 +271,7 @@ func ingressOperatorKonnectivityProxyContainer(proxyImage string, proxyConfig *c
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
-				corev1.ResourceMemory: resource.MustParse("10Mi"),
+				corev1.ResourceMemory: resource.MustParse("30Mi"),
 			},
 		},
 		VolumeMounts: []corev1.VolumeMount{

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kms/aws.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kms/aws.go
@@ -271,7 +271,7 @@ func buildKASContainerAWSKMSTokenMinter(image string) func(*corev1.Container) {
 		}
 		c.Resources.Requests = corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("10m"),
-			corev1.ResourceMemory: resource.MustParse("10Mi"),
+			corev1.ResourceMemory: resource.MustParse("30Mi"),
 		}
 		c.VolumeMounts = awsKMSVolumeMounts.ContainerMounts(c.Name)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -362,7 +362,7 @@ func buildOASKonnectivityProxyContainer(konnectivityHTTPSProxyImage string, prox
 		}
 		c.Resources.Requests = corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("10m"),
-			corev1.ResourceMemory: resource.MustParse("10Mi"),
+			corev1.ResourceMemory: resource.MustParse("30Mi"),
 		}
 		c.Env = []corev1.EnvVar{{
 			Name:  "KUBECONFIG",

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
@@ -255,7 +255,7 @@ func buildOAuthKonnectivityProxyContainer(image string) func(c *corev1.Container
 		}}
 		c.Resources.Requests = corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("10m"),
-			corev1.ResourceMemory: resource.MustParse("10Mi"),
+			corev1.ResourceMemory: resource.MustParse("30Mi"),
 		}
 		c.VolumeMounts = oauthVolumeMounts.ContainerMounts(c.Name)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
@@ -123,13 +123,13 @@ func NewOAuthServerParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider 
 		oauthContainerHTTPProxy().Name: {
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
-				corev1.ResourceMemory: resource.MustParse("10Mi"),
+				corev1.ResourceMemory: resource.MustParse("30Mi"),
 			},
 		},
 		oauthContainerSocks5Proxy().Name: {
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
-				corev1.ResourceMemory: resource.MustParse("10Mi"),
+				corev1.ResourceMemory: resource.MustParse("30Mi"),
 			},
 		},
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/operator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/operator.go
@@ -78,7 +78,7 @@ func ReconcileCatalogOperatorDeployment(deployment *appsv1.Deployment, ownerRef 
 			deployment.Spec.Template.Spec.Containers[i].ImagePullPolicy = corev1.PullIfNotPresent
 			deployment.Spec.Template.Spec.Containers[i].Resources.Requests = corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
-				corev1.ResourceMemory: resource.MustParse("15Mi"),
+				corev1.ResourceMemory: resource.MustParse("30Mi"),
 			}
 		}
 	}
@@ -146,7 +146,7 @@ func ReconcileOLMOperatorDeployment(deployment *appsv1.Deployment, ownerRef conf
 			deployment.Spec.Template.Spec.Containers[i].ImagePullPolicy = corev1.PullIfNotPresent
 			deployment.Spec.Template.Spec.Containers[i].Resources.Requests = corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
-				corev1.ResourceMemory: resource.MustParse("15Mi"),
+				corev1.ResourceMemory: resource.MustParse("30Mi"),
 			}
 		}
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/packageserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/packageserver.go
@@ -50,7 +50,7 @@ func ReconcilePackageServerDeployment(deployment *appsv1.Deployment, ownerRef co
 			deployment.Spec.Template.Spec.Containers[i].ImagePullPolicy = corev1.PullIfNotPresent
 			deployment.Spec.Template.Spec.Containers[i].Resources.Requests = corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
-				corev1.ResourceMemory: resource.MustParse("15Mi"),
+				corev1.ResourceMemory: resource.MustParse("30Mi"),
 			}
 		}
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/testdata/zz_fixture_TestReconcileCatalogOperatorDeployment_Preserve_existing_resources.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/testdata/zz_fixture_TestReconcileCatalogOperatorDeployment_Preserve_existing_resources.yaml
@@ -100,7 +100,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 15Mi
+            memory: 30Mi
         volumeMounts:
         - mountPath: /etc/konnectivity/proxy-client
           name: oas-konnectivity-proxy-cert

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/testdata/zz_fixture_TestReconcileOLMOperatorDeployment_Preserve_existing_resources.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/testdata/zz_fixture_TestReconcileOLMOperatorDeployment_Preserve_existing_resources.yaml
@@ -97,7 +97,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 15Mi
+            memory: 30Mi
         volumeMounts:
         - mountPath: /etc/konnectivity/proxy-client
           name: oas-konnectivity-proxy-cert

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
@@ -135,13 +135,13 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 				containerClientTokenMinter().Name: {
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("10m"),
-						corev1.ResourceMemory: resource.MustParse("10Mi"),
+						corev1.ResourceMemory: resource.MustParse("30Mi"),
 					},
 				},
 				containerWebIdentityTokenMinter().Name: {
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("10m"),
-						corev1.ResourceMemory: resource.MustParse("10Mi"),
+						corev1.ResourceMemory: resource.MustParse("30Mi"),
 					},
 				},
 			},

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
@@ -137,7 +137,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 30Mi
         volumeMounts:
         - mountPath: /var/client-token
           name: client-token
@@ -160,7 +160,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 30Mi
         volumeMounts:
         - mountPath: /etc/kubernetes
           name: kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/zz_fixture_TestControlPlaneComponents.yaml
@@ -173,7 +173,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 30Mi
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
           name: kubeconfig
@@ -196,7 +196,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 30Mi
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
           name: kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents.yaml
@@ -177,7 +177,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 30Mi
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
           name: kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents.yaml
@@ -188,7 +188,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 10Mi
+            memory: 30Mi
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
           name: kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms/aws.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms/aws.go
@@ -260,7 +260,7 @@ func buildKASContainerAWSKMSTokenMinter(image string) func(*corev1.Container) {
 		}
 		c.Resources.Requests = corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("10m"),
-			corev1.ResourceMemory: resource.MustParse("10Mi"),
+			corev1.ResourceMemory: resource.MustParse("30Mi"),
 		}
 		c.VolumeMounts = awsKMSVolumeMounts.ContainerMounts(c.Name)
 	}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2808,7 +2808,7 @@ func reconcileControlPlaneOperatorDeployment(
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("10m"),
-					corev1.ResourceMemory: resource.MustParse("10Mi"),
+					corev1.ResourceMemory: resource.MustParse("30Mi"),
 				},
 			},
 			VolumeMounts: []corev1.VolumeMount{

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -231,7 +231,7 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hy
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("10m"),
-								corev1.ResourceMemory: resource.MustParse("10Mi"),
+								corev1.ResourceMemory: resource.MustParse("30Mi"),
 							},
 						},
 					},

--- a/support/controlplane-component/konnectivity-container.go
+++ b/support/controlplane-component/konnectivity-container.go
@@ -189,7 +189,7 @@ func (opts *KonnectivityContainerOptions) buildContainer(hcp *hyperv1.HostedCont
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
-				corev1.ResourceMemory: resource.MustParse("10Mi"),
+				corev1.ResourceMemory: resource.MustParse("30Mi"),
 			},
 		},
 		Env: []corev1.EnvVar{{

--- a/support/util/cloudprovidercreds.go
+++ b/support/util/cloudprovidercreds.go
@@ -116,7 +116,7 @@ func buildCloudProviderTokenMinterContainer(image string, args []string) func(c 
 		c.Args = args
 		c.Resources.Requests = corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("10m"),
-			corev1.ResourceMemory: resource.MustParse("10Mi"),
+			corev1.ResourceMemory: resource.MustParse("30Mi"),
 		}
 		c.VolumeMounts = cloudProviderTokenVolumeMount(c.Name).ContainerMounts(c.Name)
 	}

--- a/support/util/manifests.go
+++ b/support/util/manifests.go
@@ -8,6 +8,6 @@ import (
 func DefaultTokenMinterResources() corev1.ResourceRequirements {
 	return corev1.ResourceRequirements{Requests: corev1.ResourceList{
 		corev1.ResourceCPU:    resource.MustParse("10m"),
-		corev1.ResourceMemory: resource.MustParse("10Mi"),
+		corev1.ResourceMemory: resource.MustParse("30Mi"),
 	}}
 }


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/hypershift/pull/5897. 

**What this PR does / why we need it**:

The steady-state memory utilization of socks5 proxy, konnectivity proxy, http proxy, and token minter containers is approximately ~30Mi. This PR bumps `apiserver-token-minter`, `init-client-token-minter`, `client-token-minter`, `cloud-token-minter`, `token-minter`, `konnectivity-proxy`, `konnectivity-proxy-socks5`, `konnectivity-proxy-https`, `socks5-proxy`, `http-proxy` container requests to 30Mi to reflect this usage.  The total persistent (non-init container) memory increase per HCP is ~200Mi.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

https://issues.redhat.com/browse/OCPBUGS-54737

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.