### PR TITLE
OCPBUGS-44439: Add proxy trustedCA to ignition config

### DIFF
--- a/hypershift-operator/controllers/nodepool/token.go
+++ b/hypershift-operator/controllers/nodepool/token.go
@@ -10,6 +10,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
 	"github.com/openshift/hypershift/support/backwardcompat"
+	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/globalconfig"
 	"github.com/openshift/hypershift/support/upsert"
 	supportutil "github.com/openshift/hypershift/support/util"
@@ -66,6 +67,7 @@ type userData struct {
 	ignitionServerEndpoint string
 	proxy                  *configv1.Proxy
 	ami                    string
+	proxyTrustedCABundle   string
 }
 
 // NewToken is the contract to create a new Token struct.
@@ -145,6 +147,19 @@ func NewToken(ctx context.Context, configGenerator *ConfigGenerator, cpoCapabili
 		caCert:                 caCert,
 		proxy:                  proxy,
 		ami:                    ami,
+	}
+
+	if proxy.Spec.TrustedCA.Name != "" {
+		key := client.ObjectKey{Namespace: configGenerator.hostedCluster.Namespace, Name: proxy.Spec.TrustedCA.Name}
+		cm := &corev1.ConfigMap{}
+		if err := configGenerator.Get(ctx, key, cm); err != nil {
+			return nil, fmt.Errorf("failed to get configMap %s: %w", key.Name, err)
+		}
+		data, hasData := cm.Data[certs.UserCABundleMapKey]
+		if !hasData {
+			return nil, fmt.Errorf("configMap %s must have a %s key", cm.Name, certs.UserCABundleMapKey)
+		}
+		token.userData.proxyTrustedCABundle = data
 	}
 
 	return token, nil
@@ -371,10 +386,14 @@ func (t *Token) reconcileUserDataSecret(userDataSecret *corev1.Secret, token str
 		}
 
 	}
+	var encodedProxyTrustedCACert string
 
 	encodedCACert := base64.StdEncoding.EncodeToString(t.userData.caCert)
 	encodedToken := base64.StdEncoding.EncodeToString([]byte(token))
-	ignConfig := ignConfig(encodedCACert, encodedToken, t.userData.ignitionServerEndpoint, t.Hash(), t.userData.proxy, t.nodePool)
+	if t.userData.proxyTrustedCABundle != "" {
+		encodedProxyTrustedCACert = base64.StdEncoding.EncodeToString([]byte(t.userData.proxyTrustedCABundle))
+	}
+	ignConfig := ignConfig(encodedCACert, encodedToken, encodedProxyTrustedCACert, t.userData.ignitionServerEndpoint, t.Hash(), t.userData.proxy, t.nodePool)
 	userDataValue, err := json.Marshal(ignConfig)
 	if err != nil {
 		return fmt.Errorf("failed to marshal ignition config: %w", err)
@@ -386,7 +405,7 @@ func (t *Token) reconcileUserDataSecret(userDataSecret *corev1.Secret, token str
 	return nil
 }
 
-func ignConfig(encodedCACert, encodedToken, endpoint, targetConfigVersionHash string, proxy *configv1.Proxy, nodePool *hyperv1.NodePool) ignitionapi.Config {
+func ignConfig(encodedCACert, encodedToken, encodedProxyTrustedCACert, endpoint, targetConfigVersionHash string, proxy *configv1.Proxy, nodePool *hyperv1.NodePool) ignitionapi.Config {
 	cfg := ignitionapi.Config{
 		Ignition: ignitionapi.Ignition{
 			Version: "3.2.0",
@@ -432,6 +451,11 @@ func ignConfig(encodedCACert, encodedToken, endpoint, targetConfigVersionHash st
 		for _, item := range strings.Split(proxy.Status.NoProxy, ",") {
 			cfg.Ignition.Proxy.NoProxy = append(cfg.Ignition.Proxy.NoProxy, ignitionapi.NoProxyItem(item))
 		}
+	}
+	if encodedProxyTrustedCACert != "" {
+		cfg.Ignition.Security.TLS.CertificateAuthorities = append(cfg.Ignition.Security.TLS.CertificateAuthorities, ignitionapi.Resource{
+			Source: ptr.To(fmt.Sprintf("data:text/plain;base64,%s", encodedProxyTrustedCACert)),
+		})
 	}
 	return cfg
 }

--- a/hypershift-operator/controllers/nodepool/token_test.go
+++ b/hypershift-operator/controllers/nodepool/token_test.go
@@ -57,6 +57,16 @@ func TestNewToken(t *testing.T) {
 		},
 	}
 
+	proxyTrustedCABundle := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "proxy-trusted-ca",
+			Namespace: hcNamespace,
+		},
+		Data: map[string]string{
+			"ca-bundle.crt": "proxy-trusted-ca-bundle",
+		},
+	}
+
 	ignitionServerCACert := ignitionserver.IgnitionCACertSecret(controlplaneNamespace)
 	ignitionServerCACert.Data = map[string][]byte{
 		corev1.TLSCertKey: []byte("test-ignition-ca-cert"),
@@ -106,6 +116,88 @@ func TestNewToken(t *testing.T) {
 			},
 			cpoCapabilities: &CPOCapabilities{},
 			expectedError:   "",
+		},
+		{
+			name: "when proxy trusted CA bundle is configured it should create token successfully",
+			configGenerator: &ConfigGenerator{
+				hostedCluster: &hyperv1.HostedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      hcName,
+						Namespace: hcNamespace,
+					},
+					Spec: hyperv1.HostedClusterSpec{
+						PullSecret: corev1.LocalObjectReference{
+							Name: pullSecret.GetName(),
+						},
+						AdditionalTrustBundle: &corev1.LocalObjectReference{
+							Name: additionalTrustBundle.GetName(),
+						},
+						Configuration: &hyperv1.ClusterConfiguration{
+							Proxy: &configv1.ProxySpec{
+								HTTPProxy:  "http://proxy.example.com",
+								HTTPSProxy: "https://proxy.example.com",
+								NoProxy:    "example.com,10.0.0.0/8,192.168.0.0/16",
+								TrustedCA: configv1.ConfigMapNameReference{
+									Name: proxyTrustedCABundle.GetName(),
+								},
+							},
+						},
+					},
+					Status: hyperv1.HostedClusterStatus{
+						IgnitionEndpoint: "https://example.com",
+					},
+				},
+				nodePool:              &hyperv1.NodePool{},
+				controlplaneNamespace: controlplaneNamespace,
+			},
+			fakeObjects: []crclient.Object{
+				pullSecret,
+				additionalTrustBundle,
+				ignitionServerCACert,
+				proxyTrustedCABundle,
+			},
+			cpoCapabilities: &CPOCapabilities{},
+			expectedError:   "",
+		},
+		{
+			name: "when proxy trusted CA bundle is configured but missing it should fail",
+			configGenerator: &ConfigGenerator{
+				hostedCluster: &hyperv1.HostedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      hcName,
+						Namespace: hcNamespace,
+					},
+					Spec: hyperv1.HostedClusterSpec{
+						PullSecret: corev1.LocalObjectReference{
+							Name: pullSecret.GetName(),
+						},
+						AdditionalTrustBundle: &corev1.LocalObjectReference{
+							Name: additionalTrustBundle.GetName(),
+						},
+						Configuration: &hyperv1.ClusterConfiguration{
+							Proxy: &configv1.ProxySpec{
+								HTTPProxy:  "http://proxy.example.com",
+								HTTPSProxy: "https://proxy.example.com",
+								TrustedCA: configv1.ConfigMapNameReference{
+									Name: "missing-trusted-ca",
+								},
+							},
+						},
+					},
+					Status: hyperv1.HostedClusterStatus{
+						IgnitionEndpoint: "https://example.com",
+					},
+				},
+				nodePool:              &hyperv1.NodePool{},
+				controlplaneNamespace: controlplaneNamespace,
+			},
+			fakeObjects: []crclient.Object{
+				pullSecret,
+				additionalTrustBundle,
+				ignitionServerCACert,
+			},
+			cpoCapabilities: &CPOCapabilities{},
+			expectedError:   "failed to get configMap missing-trusted-ca",
 		},
 		{
 			name: "When missing ignition endpoint it should fail",
@@ -547,6 +639,16 @@ func TestTokenReconcile(t *testing.T) {
 		},
 	}
 
+	proxyTrustedCABundle := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "proxy-trusted-ca",
+			Namespace: hcNamespace,
+		},
+		Data: map[string]string{
+			"ca-bundle.crt": "proxy-trusted-ca-bundle",
+		},
+	}
+
 	ignitionServerCACert := ignitionserver.IgnitionCACertSecret(controlplaneNamespace)
 	ignitionServerCACert.Data = map[string][]byte{
 		corev1.TLSCertKey: []byte("test-ignition-ca-cert"),
@@ -623,6 +725,72 @@ func TestTokenReconcile(t *testing.T) {
 				pullSecret,
 				additionalTrustBundle,
 				ignitionServerCACert,
+			},
+			cpoCapabilities: &CPOCapabilities{
+				DecompressAndDecodeConfig: true,
+			},
+		},
+		{
+			name: "when proxy trusted CA bundle is configured it should include it in ignition config",
+			configGenerator: &ConfigGenerator{
+				hostedCluster: &hyperv1.HostedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      hcName,
+						Namespace: hcNamespace,
+					},
+					Spec: hyperv1.HostedClusterSpec{
+						PullSecret: corev1.LocalObjectReference{
+							Name: pullSecret.GetName(),
+						},
+						AdditionalTrustBundle: &corev1.LocalObjectReference{
+							Name: additionalTrustBundle.GetName(),
+						},
+						Configuration: &hyperv1.ClusterConfiguration{
+							Proxy: &configv1.ProxySpec{
+								HTTPProxy:  "http://proxy.example.com",
+								HTTPSProxy: "https://proxy.example.com",
+								TrustedCA: configv1.ConfigMapNameReference{
+									Name: proxyTrustedCABundle.GetName(),
+								},
+							},
+						},
+					},
+					Status: hyperv1.HostedClusterStatus{
+						IgnitionEndpoint: "https://example.com",
+					},
+				},
+				nodePool: &hyperv1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "name",
+						Namespace: "namespace",
+					},
+					Spec: hyperv1.NodePoolSpec{
+						Management: hyperv1.NodePoolManagement{
+							UpgradeType: hyperv1.UpgradeTypeReplace,
+						},
+						Release: hyperv1.Release{
+							Image: "image:4.17",
+						},
+					},
+				},
+				controlplaneNamespace: controlplaneNamespace,
+				rolloutConfig: &rolloutConfig{
+					releaseImage: &releaseinfo.ReleaseImage{
+						ImageStream: &imageapi.ImageStream{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "4.17",
+							},
+						},
+					},
+					globalConfig: "test-global-config",
+					mcoRawConfig: "raw-config",
+				},
+			},
+			fakeObjects: []crclient.Object{
+				pullSecret,
+				additionalTrustBundle,
+				ignitionServerCACert,
+				proxyTrustedCABundle,
 			},
 			cpoCapabilities: &CPOCapabilities{
 				DecompressAndDecodeConfig: true,
@@ -741,12 +909,29 @@ func TestTokenReconcile(t *testing.T) {
 					},
 				},
 			}
+			if tc.configGenerator.hostedCluster.Spec.Configuration.Proxy != nil &&
+				tc.configGenerator.hostedCluster.Spec.Configuration.Proxy.TrustedCA.Name != "" {
+				encodedCACert := base64.StdEncoding.EncodeToString([]byte("proxy-trusted-ca-bundle"))
+				expectedIgnition.Ignition.Security.TLS.CertificateAuthorities = append(expectedIgnition.Ignition.Security.TLS.CertificateAuthorities, ignitionapi.Resource{
+					Source: ptr.To(fmt.Sprintf("data:text/plain;base64,%s", encodedCACert)),
+				})
+			}
 
 			// Validate the userdata[value] returns the expected ignition config
 			var gotIgnition ignitionapi.Config
 			err = json.Unmarshal(gotUserDataSecret.Data["value"], &gotIgnition)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(gotIgnition).To(Equal(expectedIgnition))
+
+			// Add verification for proxy trusted CA bundle
+			if tc.configGenerator.hostedCluster.Spec.Configuration.Proxy != nil &&
+				tc.configGenerator.hostedCluster.Spec.Configuration.Proxy.TrustedCA.Name != "" {
+				// Verify proxy trusted CA bundle is included in ignition config
+				g.Expect(gotIgnition.Ignition.Security.TLS.CertificateAuthorities).To(HaveLen(2))
+				g.Expect(gotIgnition.Ignition.Security.TLS.CertificateAuthorities[1].Source).
+					To(Equal(ptr.To(fmt.Sprintf("data:text/plain;base64,%s",
+						base64.StdEncoding.EncodeToString([]byte("proxy-trusted-ca-bundle"))))))
+			}
 		})
 
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ensures that if the proxy set for a HostedCluster has a TrustedCA set, then the that CA will be included in the nodes ignition config. 


**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.