### PR TITLE
CNTRLPLANE-112: Enable MIv3 for Ingress

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3935,7 +3935,7 @@ func (r *HostedControlPlaneReconciler) reconcileIngressOperator(ctx context.Cont
 	if hyperazureutil.IsAroHCP() {
 		ingressSecretProviderClass := manifests.ManagedAzureSecretProviderClass(config.ManagedAzureIngressSecretStoreProviderClassName, hcp.Namespace)
 		if _, err := createOrUpdate(ctx, r, ingressSecretProviderClass, func() error {
-			secretproviderclass.ReconcileManagedAzureSecretProviderClass(ingressSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Ingress)
+			secretproviderclass.ReconcileManagedAzureSecretProviderClass(ingressSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Ingress, true)
 			return nil
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile ingress operator secret provider class: %w", err)

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3940,8 +3940,6 @@ func (r *HostedControlPlaneReconciler) reconcileIngressOperator(ctx context.Cont
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile ingress operator secret provider class: %w", err)
 		}
-
-		p.AzureTenantID = hcp.Spec.Platform.Azure.TenantID
 	}
 
 	if _, exists := hcp.Annotations[hyperv1.DisablePKIReconciliationAnnotation]; !exists {
@@ -4290,8 +4288,6 @@ func (r *HostedControlPlaneReconciler) reconcileImageRegistryOperator(ctx contex
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile image registry operator secret provider class: %w", err)
 		}
-
-		params.AzureTenantID = hcp.Spec.Platform.Azure.TenantID
 	}
 
 	deployment := manifests.ImageRegistryOperatorDeployment(hcp.Namespace)

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ingressoperator/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ingressoperator/azure.go
@@ -9,6 +9,6 @@ import (
 
 func adaptAzureSecretProvider(cpContext component.WorkloadContext, secretProvider *secretsstorev1.SecretProviderClass) error {
 	managedIdentity := cpContext.HCP.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Ingress
-	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, managedIdentity)
+	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, managedIdentity, true)
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/registryoperator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/registryoperator/deployment.go
@@ -24,15 +24,13 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 			{Name: "IMAGE_PRUNER", Value: cpContext.UserReleaseImageProvider.GetImage("cli")},
 		})
 
-		// For managed Azure deployments, we pass environment variables so we authenticate with Azure API through certificate
-		// authentication. We also mount the SecretProviderClass for the Secrets Store CSI driver to use; it will grab the
-		// certificate related to the ARO_HCP_MI_CLIENT_ID and mount it as a volume in the ingress pod in the path,
-		// ARO_HCP_CLIENT_CERTIFICATE_PATH.
+		// For managed Azure deployments, we pass an environment variable, MANAGED_AZURE_HCP_CREDENTIALS_FILE_PATH, so
+		// we authenticate with Azure API through UserAssignedCredential authentication. We also mount the
+		// SecretProviderClass for the Secrets Store CSI driver to use; it will grab the JSON object stored in the
+		// MANAGED_AZURE_HCP_CREDENTIALS_FILE_PATH and mount it as a volume in the image registry pod in the path.
 		if azureutil.IsAroHCP() {
-			managedIdentiity := cpContext.HCP.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ImageRegistry
-
 			c.Env = append(c.Env,
-				azureutil.CreateEnvVarsForAzureManagedIdentity(managedIdentiity.ClientID, cpContext.HCP.Spec.Platform.Azure.TenantID, managedIdentiity.CertificateName, managedIdentiity.CredentialsSecretName)...)
+				azureutil.CreateEnvVarsForAzureManagedIdentity(cpContext.HCP.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ImageRegistry.CredentialsSecretName)...)
 
 			c.VolumeMounts = append(c.VolumeMounts,
 				azureutil.CreateVolumeMountForAzureSecretStoreProviderClass(config.ManagedAzureImageRegistrySecretStoreVolumeName),

--- a/support/azureutil/azureutil.go
+++ b/support/azureutil/azureutil.go
@@ -190,20 +190,8 @@ func GetKeyVaultAuthorizedUser() string {
 	return os.Getenv(config.AROHCPKeyVaultManagedIdentityClientID)
 }
 
-func CreateEnvVarsForAzureManagedIdentity(azureClientID, azureTenantID, azureCertificateName, azureCredentialsName string) []corev1.EnvVar {
+func CreateEnvVarsForAzureManagedIdentity(azureCredentialsName string) []corev1.EnvVar {
 	return []corev1.EnvVar{
-		{
-			Name:  config.ManagedAzureClientIdEnvVarKey,
-			Value: azureClientID,
-		},
-		{
-			Name:  config.ManagedAzureTenantIdEnvVarKey,
-			Value: azureTenantID,
-		},
-		{
-			Name:  config.ManagedAzureCertificatePathEnvVarKey,
-			Value: config.ManagedAzureCertificatePath + azureCertificateName,
-		},
 		{
 			Name:  config.ManagedAzureCredentialsFilePath,
 			Value: config.ManagedAzureCertificatePath + azureCredentialsName,

--- a/support/azureutil/azureutil_test.go
+++ b/support/azureutil/azureutil_test.go
@@ -180,9 +180,6 @@ func TestIsAroHCP(t *testing.T) {
 
 func TestCreateEnvVarsForAzureManagedIdentity(t *testing.T) {
 	type args struct {
-		azureClientID            string
-		azureTenantID            string
-		azureCertificateName     string
 		azureCredentialsFilepath string
 	}
 	tests := []struct {
@@ -193,24 +190,9 @@ func TestCreateEnvVarsForAzureManagedIdentity(t *testing.T) {
 		{
 			name: "returns a slice of environment variables with the azure creds",
 			args: args{
-				azureClientID:            "my-client-id",
-				azureTenantID:            "my-tenant-id",
-				azureCertificateName:     "my-certificate-name",
 				azureCredentialsFilepath: "my-credentials-file",
 			},
 			want: []corev1.EnvVar{
-				{
-					Name:  config.ManagedAzureClientIdEnvVarKey,
-					Value: "my-client-id",
-				},
-				{
-					Name:  config.ManagedAzureTenantIdEnvVarKey,
-					Value: "my-tenant-id",
-				},
-				{
-					Name:  config.ManagedAzureCertificatePathEnvVarKey,
-					Value: config.ManagedAzureCertificatePath + "my-certificate-name",
-				},
 				{
 					Name:  config.ManagedAzureCredentialsFilePath,
 					Value: config.ManagedAzureCertificatePath + "my-credentials-file",
@@ -220,7 +202,7 @@ func TestCreateEnvVarsForAzureManagedIdentity(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := CreateEnvVarsForAzureManagedIdentity(tt.args.azureClientID, tt.args.azureTenantID, tt.args.azureCertificateName, tt.args.azureCredentialsFilepath); !reflect.DeepEqual(got, tt.want) {
+			if got := CreateEnvVarsForAzureManagedIdentity(tt.args.azureCredentialsFilepath); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("CreateEnvVarsForAzureManagedIdentity() = %v, want %v", got, tt.want)
 			}
 		})

--- a/support/config/constants.go
+++ b/support/config/constants.go
@@ -61,7 +61,8 @@ const (
 	// management cluster's resource group in Azure.
 	AROHCPKeyVaultManagedIdentityClientID = "ARO_HCP_KEY_VAULT_USER_CLIENT_ID"
 
-	ManagedAzureCredentialsFilePath          = "MANAGED_AZURE_HCP_CREDENTIALS_FILE_PATH"
+	ManagedAzureCredentialsFilePath = "MANAGED_AZURE_HCP_CREDENTIALS_FILE_PATH"
+	// TODO - MIv3 - this release version check can be removed once 4.18 and 4.19 both support MIv3
 	ManagedAzureClientIdEnvVarKey            = "ARO_HCP_MI_CLIENT_ID"
 	ManagedAzureTenantIdEnvVarKey            = "ARO_HCP_TENANT_ID"
 	ManagedAzureCertificatePathEnvVarKey     = "ARO_HCP_CLIENT_CERTIFICATE_PATH"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR:
- enables managed identity version 3 for ingress on managed azure, ARO HCP
- removes unneeded managed Azure environment variables now that all HO, HCP, and OpenShift operators support managed identity version 3

**Which issue(s) this PR fixes**:
Fixes [CNTRLPLANE-112](https://issues.redhat.com/browse/CNTRLPLANE-112)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.