### PR TITLE
AUTOSCALE-127: fix e2e autonode drift test

### DIFF
--- a/test/e2e/karpenter_test.go
+++ b/test/e2e/karpenter_test.go
@@ -89,6 +89,8 @@ func TestKarpenter(t *testing.T) {
 			workLoads.Object["spec"].(map[string]interface{})["replicas"] = replicas
 
 			// Apply both Karpenter NodePool and workloads.
+			defer guestClient.Delete(ctx, karpenterNodePool)
+			defer guestClient.Delete(ctx, workLoads)
 			g.Expect(guestClient.Create(ctx, karpenterNodePool)).To(Succeed())
 			t.Logf("Created Karpenter NodePool")
 			g.Expect(guestClient.Create(ctx, workLoads)).To(Succeed())
@@ -144,10 +146,10 @@ func TestKarpenter(t *testing.T) {
 						// the actual OS version is at the end of the node's OSImage field
 						fullOSImageString := node.Status.NodeInfo.OSImage
 						parts := strings.Split(fullOSImageString, " ")
-						if len(parts) == 0 {
+						if len(parts) <= 1 {
 							return false, "", fmt.Errorf("unexpected OSImage format: %s", fullOSImageString)
 						}
-						rawVersion := parts[len(parts)-1]
+						rawVersion := parts[len(parts)-2]
 						if rawVersion != expectedRHCOSVersion {
 							return false, fmt.Sprintf("expected %s, got %s", expectedRHCOSVersion, rawVersion), nil
 						}


### PR DESCRIPTION
Fixes the test by grabbing the correct part of the string from node.Status.NodeInfo.OSImage that now points to the rhcos version. See https://github.com/openshift/release/pull/63681#issuecomment-2816838538 as to why we need this.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.