### PR TITLE
OCPBUGS-53082: Skip AWS cleanup check for 4.14 and earlier

### DIFF
--- a/kas-bootstrap/kas_boostrap.go
+++ b/kas-bootstrap/kas_boostrap.go
@@ -57,7 +57,7 @@ func run(ctx context.Context, opts Options) error {
 	// This binary is meant to run next to the KAS container within the same pod.
 	// We briefly poll here to retry on race and transient network issues.
 	// 50s is a high margin chosen here as in CI aws kms is observed to take up to 30s to start.
-	// This to avoid unncessary restarts of this container.
+	// This to avoid unnecessary restarts of this container.
 	if err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 50*time.Second, true,
 		func(ctx context.Context) (done bool, err error) {
 			if err := applyBootstrapResources(ctx, c, opts.ResourcesPath); err != nil {

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"slices"
 	"strings"
 	"testing"
 
@@ -1487,6 +1488,13 @@ func testCreateClusterPrivate(t *testing.T, enableExternalDNS bool) {
 	defer cancel()
 
 	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	if e2eutil.IsLessThan(e2eutil.Version415) {
+		cleanupAnnotationIndex := slices.Index(clusterOpts.Annotations, fmt.Sprintf("%s=true", hyperv1.CleanupCloudResourcesAnnotation))
+		if cleanupAnnotationIndex != -1 {
+			clusterOpts.Annotations = slices.Delete(clusterOpts.Annotations, cleanupAnnotationIndex, cleanupAnnotationIndex+1)
+		}
+	}
+
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.SingleReplica)
 	clusterOpts.AWSPlatform.EndpointAccess = string(hyperv1.Private)
 	expectGuestKubeconfHostChange := false

--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -276,6 +276,12 @@ func destroyCluster(ctx context.Context, t *testing.T, hc *hyperv1.HostedCluster
 
 // validateAWSGuestResourcesDeletedFunc waits for 15min or until the guest cluster resources are gone.
 func validateAWSGuestResourcesDeletedFunc(ctx context.Context, t *testing.T, infraID, awsCreds, awsRegion string) func() {
+	if IsLessThan(Version415) {
+		return func() {
+			t.Log("SKIPPED: skipping AWS cleanup validation for OCP <= 4.14")
+		}
+	}
+
 	return func() {
 		awsSession := awsutil.NewSession("cleanup-validation", awsCreds, "", "", awsRegion)
 		awsConfig := awsutil.NewConfig()


### PR DESCRIPTION
**What this PR does / why we need it**:
Skips AWS resource deletion validation for releases 4.14 and earlier and explicitly skips cloud resource cleanup for TestCreatePrivate.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-53082](https://issues.redhat.com/browse/OCPBUGS-53082)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.