### PR TITLE
OCPBUGS-55266: [release-4.15] Add konnectivity-proxy sidecar to openshift-oauth-apiserver

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -2,7 +2,6 @@ package oapi
 
 import (
 	"fmt"
-	"net/url"
 	"path"
 	"strings"
 
@@ -138,9 +137,9 @@ func ReconcileDeployment(deployment *appsv1.Deployment,
 		}
 	}
 	deployment.Spec.Template.ObjectMeta.Labels = openShiftAPIServerLabels()
-	etcdUrlData, err := url.Parse(etcdURL)
+	etcdHost, err := util.HostFromURL(etcdURL)
 	if err != nil {
-		return fmt.Errorf("failed to parse etcd url: %w", err)
+		return err
 	}
 	if deployment.Spec.Template.Annotations == nil {
 		deployment.Spec.Template.Annotations = map[string]string{}
@@ -151,7 +150,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment,
 	deployment.Spec.Template.Spec.AutomountServiceAccountToken = ptr.To(false)
 	deployment.Spec.Template.Spec.InitContainers = []corev1.Container{util.BuildContainer(oasTrustAnchorGenerator(), buildOASTrustAnchorGenerator(image))}
 	deployment.Spec.Template.Spec.Containers = []corev1.Container{
-		util.BuildContainer(oasContainerMain(), buildOASContainerMain(image, strings.Split(etcdUrlData.Host, ":")[0], defaultOAPIPort, internalOAuthDisable)),
+		util.BuildContainer(oasContainerMain(), buildOASContainerMain(image, etcdHost, defaultOAPIPort, internalOAuthDisable)),
 		util.BuildContainer(oasKonnectivityProxyContainer(), buildOASKonnectivityProxyContainer(konnectivityHTTPSProxyImage, proxyConfig, noProxy)),
 	}
 	deployment.Spec.Template.Spec.Volumes = []corev1.Volume{

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/oauth_deployment.go
@@ -3,6 +3,7 @@ package oapi
 import (
 	"fmt"
 	"path"
+	"strings"
 
 	configv1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -14,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
@@ -40,6 +42,11 @@ var (
 			oauthVolumeEtcdClientCert().Name:  "/etc/kubernetes/certs/etcd-client",
 			common.VolumeTotalClientCA().Name: "/etc/kubernetes/certs/client-ca",
 		},
+		oauthKonnectivityProxyContainer().Name: {
+			oauthVolumeKubeconfig().Name:            "/etc/kubernetes/secrets/kubeconfig",
+			oauthVolumeKonnectivityProxyCert().Name: "/etc/konnectivity/proxy-client",
+			oauthVolumeKonnectivityProxyCA().Name:   "/etc/konnectivity/proxy-ca",
+		},
 	}
 	oauthAuditWebhookConfigFileVolumeMount = util.PodVolumeMounts{
 		oauthContainerMain().Name: {
@@ -55,9 +62,17 @@ func openShiftOAuthAPIServerLabels() map[string]string {
 	}
 }
 
-func ReconcileOAuthAPIServerDeployment(deployment *appsv1.Deployment, ownerRef config.OwnerRef, auditConfig *corev1.ConfigMap, p *OAuthDeploymentParams, platformType hyperv1.PlatformType) error {
+func ReconcileOAuthAPIServerDeployment(deployment *appsv1.Deployment,
+	ownerRef config.OwnerRef,
+	auditConfig *corev1.ConfigMap,
+	p *OAuthDeploymentParams,
+	platformType hyperv1.PlatformType) error {
 	ownerRef.ApplyTo(deployment)
 
+	etcdHost, err := util.HostFromURL(p.EtcdURL)
+	if err != nil {
+		return err
+	}
 	// preserve existing resource requirements for main oauth apiserver container
 	mainContainer := util.FindContainer(oauthContainerMain().Name, deployment.Spec.Template.Spec.Containers)
 	if mainContainer != nil {
@@ -95,7 +110,8 @@ func ReconcileOAuthAPIServerDeployment(deployment *appsv1.Deployment, ownerRef c
 		AutomountServiceAccountToken:  pointer.Bool(false),
 		TerminationGracePeriodSeconds: pointer.Int64(120),
 		Containers: []corev1.Container{
-			util.BuildContainer(oauthContainerMain(), buildOAuthContainerMain(p)),
+			util.BuildContainer(oauthContainerMain(), buildOAuthContainerMain(p, etcdHost)),
+			util.BuildContainer(oauthKonnectivityProxyContainer(), buildOAuthKonnectivityProxyContainer(p.KonnectivityProxyImage)),
 		},
 		Volumes: []corev1.Volume{
 			util.BuildVolume(oauthVolumeWorkLogs(), buildOAuthVolumeWorkLogs),
@@ -106,6 +122,8 @@ func ReconcileOAuthAPIServerDeployment(deployment *appsv1.Deployment, ownerRef c
 			util.BuildVolume(oauthVolumeServingCert(), buildOAuthVolumeServingCert),
 			util.BuildVolume(oauthVolumeEtcdClientCert(), buildOAuthVolumeEtcdClientCert),
 			util.BuildVolume(common.VolumeTotalClientCA(), common.BuildVolumeTotalClientCA),
+			util.BuildVolume(oauthVolumeKonnectivityProxyCert(), buildOAuthVolumeKonnectivityProxyCert),
+			util.BuildVolume(oauthVolumeKonnectivityProxyCA(), buildOAuthVolumeKonnectivityProxyCA),
 		},
 	}
 
@@ -147,7 +165,13 @@ func oauthContainerMain() *corev1.Container {
 	}
 }
 
-func buildOAuthContainerMain(p *OAuthDeploymentParams) func(c *corev1.Container) {
+func oauthKonnectivityProxyContainer() *corev1.Container {
+	return &corev1.Container{
+		Name: "konnectivity-proxy",
+	}
+}
+
+func buildOAuthContainerMain(p *OAuthDeploymentParams, etcdHost string) func(c *corev1.Container) {
 	return func(c *corev1.Container) {
 		cpath := func(volume, file string) string {
 			return path.Join(oauthVolumeMounts.Path(c.Name, volume), file)
@@ -199,6 +223,41 @@ func buildOAuthContainerMain(p *OAuthDeploymentParams) func(c *corev1.Container)
 				corev1.ResourceCPU:    resource.MustParse("10m"),
 			},
 		}
+		c.Env = append(c.Env, []corev1.EnvVar{
+			{
+				Name:  "HTTP_PROXY",
+				Value: "socks5://127.0.0.1:8090",
+			},
+			{
+				Name:  "HTTPS_PROXY",
+				Value: "socks5://127.0.0.1:8090",
+			},
+			{
+				Name: "NO_PROXY",
+				Value: strings.Join([]string{
+					manifests.KubeAPIServerService("").Name,
+					etcdHost,
+					config.AuditWebhookService,
+				}, ","),
+			},
+		}...)
+	}
+}
+
+func buildOAuthKonnectivityProxyContainer(image string) func(c *corev1.Container) {
+	return func(c *corev1.Container) {
+		c.Image = image
+		c.Command = []string{"/usr/bin/control-plane-operator", "konnectivity-socks5-proxy"}
+		c.Args = []string{"run", "--resolve-from-guest-cluster-dns=true"}
+		c.Env = []corev1.EnvVar{{
+			Name:  "KUBECONFIG",
+			Value: fmt.Sprintf("%s/kubeconfig", volumeMounts.Path(c.Name, oauthVolumeKubeconfig().Name)),
+		}}
+		c.Resources.Requests = corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("10m"),
+			corev1.ResourceMemory: resource.MustParse("10Mi"),
+		}
+		c.VolumeMounts = oauthVolumeMounts.ContainerMounts(c.Name)
 	}
 }
 
@@ -295,6 +354,29 @@ func applyOauthAuditWebhookConfigFileVolume(podSpec *corev1.PodSpec, auditWebhoo
 func oauthAuditWebhookConfigFile() string {
 	cfgDir := oauthAuditWebhookConfigFileVolumeMount.Path(oauthContainerMain().Name, oauthAuditWebhookConfigFileVolume().Name)
 	return path.Join(cfgDir, hyperv1.AuditWebhookKubeconfigKey)
+}
+
+func oauthVolumeKonnectivityProxyCert() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "oauth-konnectivity-proxy-cert",
+	}
+}
+
+func oauthVolumeKonnectivityProxyCA() *corev1.Volume {
+	return &corev1.Volume{
+		Name: "oauth-konnectivity-proxy-ca",
+	}
+}
+
+func buildOAuthVolumeKonnectivityProxyCert(v *corev1.Volume) {
+	v.Secret = &corev1.SecretVolumeSource{}
+	v.Secret.SecretName = manifests.KonnectivityClientSecret("").Name
+	v.Secret.DefaultMode = ptr.To[int32](0640)
+}
+
+func buildOAuthVolumeKonnectivityProxyCA(v *corev1.Volume) {
+	v.ConfigMap = &corev1.ConfigMapVolumeSource{}
+	v.ConfigMap.Name = manifests.KonnectivityCAConfigMap("").Name
 }
 
 func buildOAuthVolumeEtcdClientCert(v *corev1.Volume) {

--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/params.go
@@ -44,6 +44,7 @@ type OAuthDeploymentParams struct {
 	ServiceAccountIssuerURL      string
 	DeploymentConfig             config.DeploymentConfig
 	AvailabilityProberImage      string
+	KonnectivityProxyImage       string
 	Availability                 hyperv1.AvailabilityPolicy
 	OwnerRef                     config.OwnerRef
 	AuditWebhookRef              *corev1.LocalObjectReference
@@ -220,6 +221,7 @@ func (p *OpenShiftAPIServerParams) AuditPolicyConfig() configv1.Audit {
 func (p *OpenShiftAPIServerParams) OAuthAPIServerDeploymentParams(hcp *hyperv1.HostedControlPlane) *OAuthDeploymentParams {
 	params := &OAuthDeploymentParams{
 		Image:                   p.OAuthAPIServerImage,
+		KonnectivityProxyImage:  p.ProxyImage,
 		EtcdURL:                 p.EtcdURL,
 		ServiceAccountIssuerURL: p.ServiceAccountIssuerURL,
 		DeploymentConfig:        p.OpenShiftOAuthAPIServerDeploymentConfig,

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -12,7 +12,9 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -424,4 +426,30 @@ func SanitizeIgnitionPayload(payload []byte) error {
 	}
 
 	return nil
+}
+
+var (
+	hasPortRegex = regexp.MustCompile(`:\d{1,5}$`)
+)
+
+func HostFromURL(addr string) (string, error) {
+	parsedURL, err := url.Parse(addr)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse URL(%s): %w", addr, err)
+	}
+	hostPort := parsedURL.Host
+	if hostPort == "" {
+		return "", fmt.Errorf("missing host/port name in URL(%s)", addr)
+	}
+	if !hasPortRegex.MatchString(hostPort) {
+		return hostPort, nil
+	}
+	hostName, _, err := net.SplitHostPort(hostPort)
+	if err != nil {
+		return "", fmt.Errorf("failed to split host/port from (%s): %w", hostPort, err)
+	}
+	if hostName == "" {
+		return "", fmt.Errorf("missing host name in URL(%s)", addr)
+	}
+	return hostName, nil
 }

--- a/support/util/util_test.go
+++ b/support/util/util_test.go
@@ -482,3 +482,33 @@ func TestIsIPv4Address(t *testing.T) {
 		})
 	}
 }
+func TestHostFromURL(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		{"http://example.com", "example.com", false},
+		{"https://example.com:443", "example.com", false},
+		{"http://localhost:8080", "localhost", false},
+		{"https://127.0.0.1:9000", "127.0.0.1", false},
+		{"ftp://example.org:21", "example.org", false},
+		{"http://[::1]:8080", "::1", false},                // IPv6 localhost
+		{"http://[2001:db8::1]:443", "2001:db8::1", false}, // IPv6 example
+		{"??", "", true},           // Invalid URL
+		{"http://:8080", "", true}, // Missing hostname
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			g := NewWithT(t)
+			result, err := HostFromURL(tt.input)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}


### PR DESCRIPTION
Backport PR https://github.com/openshift/hypershift/pull/6026 to release-4.15 manually.
Finished pre-merge testing for the PR, detail see https://issues.redhat.com/browse/OCPBUGS-55266?focusedId=27046163&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-27046163, looks good.