### PR TITLE
OCPBUGS-55504: Add postStart hook to kube-apiserver container

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents.yaml
@@ -81,26 +81,6 @@ spec:
             topologyKey: kubernetes.io/hostname
       automountServiceAccountToken: false
       containers:
-      - command:
-        - /usr/bin/control-plane-operator
-        - kas-bootstrap
-        - --resources-path
-        - /work
-        env:
-        - name: KUBECONFIG
-          value: /var/secrets/localhost-kubeconfig/kubeconfig
-        image: controlplane-operator
-        imagePullPolicy: IfNotPresent
-        name: bootstrap
-        resources:
-          requests:
-            cpu: 10m
-            memory: 10Mi
-        volumeMounts:
-        - mountPath: /work
-          name: bootstrap-manifests
-        - mountPath: /var/secrets/localhost-kubeconfig
-          name: localhost-kubeconfig
       - args:
         - kube-apiserver
         - --openshift-config=/etc/kubernetes/config/config.json
@@ -115,6 +95,17 @@ spec:
               fieldPath: status.podIP
         image: hyperkube
         imagePullPolicy: IfNotPresent
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - |
+                until curl -k https://localhost:6443/readyz; do
+                  echo "Waiting for kube-apiserver to be ready..."
+                  sleep 5
+                done
         livenessProbe:
           failureThreshold: 6
           httpGet:
@@ -183,6 +174,26 @@ spec:
         - mountPath: /etc/kubernetes/secrets/svcacct-key
           name: svcacct-key
         workingDir: /var/log/kube-apiserver
+      - command:
+        - /usr/bin/control-plane-operator
+        - kas-bootstrap
+        - --resources-path
+        - /work
+        env:
+        - name: KUBECONFIG
+          value: /var/secrets/localhost-kubeconfig/kubeconfig
+        image: controlplane-operator
+        imagePullPolicy: IfNotPresent
+        name: bootstrap
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /work
+          name: bootstrap-manifests
+        - mountPath: /var/secrets/localhost-kubeconfig
+          name: localhost-kubeconfig
       - args:
         - --logtostderr=true
         - --log-file-max-size=0

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -81,26 +81,6 @@ spec:
             topologyKey: kubernetes.io/hostname
       automountServiceAccountToken: false
       containers:
-      - command:
-        - /usr/bin/control-plane-operator
-        - kas-bootstrap
-        - --resources-path
-        - /work
-        env:
-        - name: KUBECONFIG
-          value: /var/secrets/localhost-kubeconfig/kubeconfig
-        image: controlplane-operator
-        imagePullPolicy: IfNotPresent
-        name: bootstrap
-        resources:
-          requests:
-            cpu: 10m
-            memory: 10Mi
-        volumeMounts:
-        - mountPath: /work
-          name: bootstrap-manifests
-        - mountPath: /var/secrets/localhost-kubeconfig
-          name: localhost-kubeconfig
       - args:
         - kube-apiserver
         - --openshift-config=/etc/kubernetes/config/config.json
@@ -115,6 +95,17 @@ spec:
               fieldPath: status.podIP
         image: hyperkube
         imagePullPolicy: IfNotPresent
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - |
+                until curl -k https://localhost:6443/readyz; do
+                  echo "Waiting for kube-apiserver to be ready..."
+                  sleep 5
+                done
         livenessProbe:
           failureThreshold: 6
           httpGet:
@@ -183,6 +174,26 @@ spec:
         - mountPath: /etc/kubernetes/secrets/svcacct-key
           name: svcacct-key
         workingDir: /var/log/kube-apiserver
+      - command:
+        - /usr/bin/control-plane-operator
+        - kas-bootstrap
+        - --resources-path
+        - /work
+        env:
+        - name: KUBECONFIG
+          value: /var/secrets/localhost-kubeconfig/kubeconfig
+        image: controlplane-operator
+        imagePullPolicy: IfNotPresent
+        name: bootstrap
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /work
+          name: bootstrap-manifests
+        - mountPath: /var/secrets/localhost-kubeconfig
+          name: localhost-kubeconfig
       - args:
         - --logtostderr=true
         - --log-file-max-size=0

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-apiserver/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-apiserver/deployment.yaml
@@ -20,26 +20,6 @@ spec:
         app: kube-apiserver
     spec:
       containers:
-      - command:
-        - /usr/bin/control-plane-operator
-        - kas-bootstrap
-        - --resources-path
-        - /work
-        env:
-        - name: KUBECONFIG
-          value: /var/secrets/localhost-kubeconfig/kubeconfig
-        image: controlplane-operator
-        imagePullPolicy: IfNotPresent
-        name: bootstrap
-        resources:
-          requests:
-            cpu: 10m
-            memory: 10Mi
-        volumeMounts:
-        - mountPath: /work
-          name: bootstrap-manifests
-        - mountPath: /var/secrets/localhost-kubeconfig
-          name: localhost-kubeconfig
       - args:
         - kube-apiserver
         - --openshift-config=/etc/kubernetes/config/config.json
@@ -53,6 +33,17 @@ spec:
               fieldPath: status.podIP
         image: hyperkube
         imagePullPolicy: IfNotPresent
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - |
+                until curl -k https://localhost:6443/readyz; do
+                  echo "Waiting for kube-apiserver to be ready..."
+                  sleep 5
+                done
         livenessProbe:
           failureThreshold: 6
           httpGet:
@@ -63,7 +54,7 @@ spec:
           periodSeconds: 180
           successThreshold: 1
           timeoutSeconds: 160
-        name: kube-apiserver
+        name: kube-apiserver              
         ports:
         - containerPort: 6443
           name: client
@@ -121,6 +112,26 @@ spec:
         - mountPath: /etc/kubernetes/secrets/svcacct-key
           name: svcacct-key
         workingDir: /var/log/kube-apiserver
+      - command:
+        - /usr/bin/control-plane-operator
+        - kas-bootstrap
+        - --resources-path
+        - /work
+        env:
+        - name: KUBECONFIG
+          value: /var/secrets/localhost-kubeconfig/kubeconfig
+        image: controlplane-operator
+        imagePullPolicy: IfNotPresent
+        name: bootstrap
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /work
+          name: bootstrap-manifests
+        - mountPath: /var/secrets/localhost-kubeconfig
+          name: localhost-kubeconfig
       - args:
         - --logtostderr=true
         - --log-file-max-size=0


### PR DESCRIPTION
**What this PR does / why we need it**:
- This blocks the creation of other containers specifically the bootstrap container until kas is ready.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.