### PR TITLE
NO-JIRA: Add e2e flags to test Azure KMS

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -120,6 +120,8 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.ConfigurableClusterOptions.AzureIssuerURL, "e2e.oidc-issuer-url", "", "The OIDC provider issuer URL")
 	flag.StringVar(&globalOpts.ConfigurableClusterOptions.AzureServiceAccountTokenIssuerKeyPath, "e2e.sa-token-issuer-private-key-path", "", "The file to the private key for the service account token issuer")
 	flag.StringVar(&globalOpts.ConfigurableClusterOptions.AzureDataPlaneIdentities, "e2e.azure-data-plane-identities-file", "", "Path to a file containing the client IDs of the managed identities associated with the data plane")
+	flag.StringVar(&globalOpts.ConfigurableClusterOptions.AzureEncryptionKeyID, "e2e.azure-encryption-key-id", "", "etcd encryption key identifier in the form of https://<vaultName>.vault.azure.net/keys/<keyName>/<keyVersion>")
+	flag.StringVar(&globalOpts.ConfigurableClusterOptions.AzureKMSUserAssignedCredsSecretName, "e2e.azure-kms-credentials-secret-name", "", "The name of a secret, in Azure KeyVault, containing the JSON UserAssignedIdentityCredentials used in KMS to authenticate to Azure.")
 
 	// Kubevirt specific flags
 	flag.StringVar(&globalOpts.ConfigurableClusterOptions.KubeVirtContainerDiskImage, "e2e.kubevirt-container-disk-image", "", "DEPRECATED (ignored will be removed soon)")

--- a/test/e2e/util/options.go
+++ b/test/e2e/util/options.go
@@ -104,6 +104,8 @@ type ConfigurableClusterOptions struct {
 	AzureIssuerURL                        string
 	AzureServiceAccountTokenIssuerKeyPath string
 	AzureDataPlaneIdentities              string
+	AzureEncryptionKeyID                  string
+	AzureKMSUserAssignedCredsSecretName   string
 	OpenStackCredentialsFile              string
 	OpenStackCACertFile                   string
 	AzureLocation                         string


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit adds two e2e flags that will be needed to test the Azure KMS configuration in e2e-aks.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.