### PR TITLE
CNTRLPLANE-645: Rename NodeCount flag to Replicas

### DIFF
--- a/cmd/nodepool/core/create.go
+++ b/cmd/nodepool/core/create.go
@@ -27,7 +27,7 @@ type CreateNodePoolOptions struct {
 	Name            string
 	Namespace       string
 	ClusterName     string
-	NodeCount       int32
+	Replicas        int32
 	ReleaseImage    string
 	Render          bool
 	NodeUpgradeType hyperv1.UpgradeType
@@ -135,7 +135,7 @@ func (o *CreateNodePoolOptions) CreateNodePool(ctx context.Context, platformOpts
 				AutoRepair:  o.AutoRepair,
 			},
 			ClusterName: o.ClusterName,
-			Replicas:    &o.NodeCount,
+			Replicas:    &o.Replicas,
 			Release: hyperv1.Release{
 				Image: releaseImage,
 			},

--- a/cmd/nodepool/create.go
+++ b/cmd/nodepool/create.go
@@ -30,7 +30,7 @@ func NewCreateCommand() *cobra.Command {
 		Name:            "example",
 		Namespace:       "clusters",
 		ClusterName:     "example",
-		NodeCount:       2,
+		Replicas:        2,
 		ReleaseImage:    "",
 		NodeUpgradeType: hyperv1.UpgradeTypeReplace,
 		Arch:            "amd64",
@@ -38,7 +38,7 @@ func NewCreateCommand() *cobra.Command {
 
 	cmd.PersistentFlags().StringVar(&opts.Name, "name", opts.Name, "The name of the NodePool")
 	cmd.PersistentFlags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "The namespace in which to create the NodePool")
-	cmd.PersistentFlags().Int32Var(&opts.NodeCount, "node-count", opts.NodeCount, "The number of nodes to create in the NodePool")
+	cmd.PersistentFlags().Int32Var(&opts.Replicas, "replicas", opts.Replicas, "The number of nodes to create in the NodePool")
 	cmd.PersistentFlags().StringVar(&opts.ClusterName, "cluster-name", opts.ClusterName, "The name of the HostedCluster nodes in this pool will join")
 	cmd.PersistentFlags().StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The release image for nodes. If empty, defaults to the same release image as the HostedCluster.")
 	cmd.PersistentFlags().Var(&opts.NodeUpgradeType, "node-upgrade-type", "The NodePool upgrade strategy for how nodes should behave when upgraded. Supported options: Replace, InPlace")
@@ -46,6 +46,9 @@ func NewCreateCommand() *cobra.Command {
 
 	cmd.PersistentFlags().BoolVar(&opts.Render, "render", false, "Render output as YAML to stdout instead of applying")
 	cmd.PersistentFlags().BoolVar(&opts.AutoRepair, "auto-repair", opts.AutoRepair, "Enables machine auto-repair with machine health checks.")
+
+	cmd.PersistentFlags().Int32Var(&opts.Replicas, "node-count", opts.Replicas, "The number of nodes to create in the NodePool (DEPRECATED, use '--replicas' instead)")
+	_ = cmd.PersistentFlags().MarkDeprecated("node-count", "please use '--replicas' instead")
 
 	cmd.AddCommand(kubevirt.NewCreateCommand(opts))
 	cmd.AddCommand(aws.NewCreateCommand(opts))

--- a/contrib/managed-azure/setup_aks_cluster.sh
+++ b/contrib/managed-azure/setup_aks_cluster.sh
@@ -34,7 +34,7 @@ az group create \
 az aks create \
 --resource-group ${AKS_RG} \
 --name ${AKS_CLUSTER_NAME} \
---node-count 2 \
+--replicas 2 \
 --generate-ssh-keys \
 --load-balancer-sku standard \
 --os-sku AzureLinux \

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -177,7 +177,7 @@ hypershift create nodepool aws \
   --cluster-name $CLUSTER_NAME \
   --namespace clusters \
   --name $NODEPOOL_NAME \
-  --node-count $NODEPOOL_REPLICAS \
+  --replicas $NODEPOOL_REPLICAS \
   --instance-type $INSTANCE_TYPE
 ```
 

--- a/docs/content/how-to/automated-machine-management/node-tuning.md
+++ b/docs/content/how-to/automated-machine-management/node-tuning.md
@@ -155,7 +155,7 @@ As an example, the following steps can be followed to create a NodePool with hug
     hypershift create nodepool aws \
       --cluster-name $CLUSTER_NAME \
       --name $NODEPOOL_NAME \
-      --node-count $NODEPOOL_REPLICAS \
+      --replicas $NODEPOOL_REPLICAS \
       --instance-type $INSTANCE_TYPE \
       --render > hugepages-nodepool.yaml
     ```

--- a/docs/content/how-to/aws/create-aws-hosted-cluster-arm-workers.md
+++ b/docs/content/how-to/aws/create-aws-hosted-cluster-arm-workers.md
@@ -100,6 +100,6 @@ ARCH="arm64"
 hypershift create nodepool aws \
 --cluster-name $CLUSTER_NAME \
 --name $NODE_POOLNAME \
---node-count=3 \
+--replicas=3 \
 --arch $ARCH \
 ```

--- a/docs/content/how-to/azure/create-azure-cluster-with-options.md
+++ b/docs/content/how-to/azure/create-azure-cluster-with-options.md
@@ -139,7 +139,7 @@ You can also set the `enable-ephemeral-disk` flag when creating a NodePool.
 hypershift create nodepool azure \
 --name <name_of_nodepool> \
 --cluster-name <cluster_name> \
---node-count <number_of_replicas> \
+--replicas <number_of_replicas> \
 --release-image <release_image> \
 --enable-ephemeral-disk true \
 --instance-type Standard_DS4_v2 \

--- a/docs/content/how-to/azure/create-azure-cluster_on_aks.md
+++ b/docs/content/how-to/azure/create-azure-cluster_on_aks.md
@@ -339,7 +339,7 @@ az group create --name $AKS_CLUSTER_RG_NAME --location eastus
 az aks create \
     --resource-group $AKS_CLUSTER_RG_NAME \
     --name $AKS_CLUSTER_NAME \
-    --node-count 3 \
+    --replicas 3 \
     --generate-ssh-keys \
     --load-balancer-sku standard \
     --os-sku AzureLinux \

--- a/docs/content/how-to/kubevirt/create-kubevirt-cluster.md
+++ b/docs/content/how-to/kubevirt/create-kubevirt-cluster.md
@@ -257,7 +257,7 @@ export DISK="16"
 hcp create nodepool kubevirt \
   --cluster-name $CLUSTER_NAME \
   --name $NODEPOOL_NAME \
-  --node-count $WORKER_COUNT \
+  --replicas $WORKER_COUNT \
   --memory $MEM \
   --cores $CPU \
   --root-volume-size $DISK

--- a/docs/content/how-to/openstack/additional-ports.md
+++ b/docs/content/how-to/openstack/additional-ports.md
@@ -38,7 +38,7 @@ export FLAVOR="m1.xlarge"
 hcp create nodepool openstack \
   --cluster-name $CLUSTER_NAME \
   --name $NODEPOOL_NAME \
-  --node-count $WORKER_COUNT \
+  --replicas $WORKER_COUNT \
   --openstack-node-flavor $FLAVOR \
   --openstack-node-additional-port "network-id=<SRIOV_NET_ID>,vnic-type=direct,disable-port-security=true" \
   --openstack-node-additional-port "network-id=<LB_NET_ID>,address-pairs:192.168.0.1-192.168.0.2"

--- a/docs/content/how-to/openstack/az.md
+++ b/docs/content/how-to/openstack/az.md
@@ -12,7 +12,7 @@ export AZ="az1"
 hcp create nodepool openstack \
   --cluster-name $CLUSTER_NAME \
   --name $NODEPOOL_NAME \
-  --node-count $WORKER_COUNT \
+  --replicas $WORKER_COUNT \
   --openstack-node-flavor $FLAVOR \
   --openstack-node-availability-zone $AZ \
 ```

--- a/docs/content/how-to/openstack/performance-tuning.md
+++ b/docs/content/how-to/openstack/performance-tuning.md
@@ -86,7 +86,7 @@ export FLAVOR="m1.xlarge.nfv"
 hcp create nodepool openstack \
   --cluster-name $CLUSTER_NAME \
   --name $NODEPOOL_NAME \
-  --node-count 0 \
+  --replicas 0 \
   --openstack-node-flavor $FLAVOR
 ```
 

--- a/product-cli/cmd/nodepool/create.go
+++ b/product-cli/cmd/nodepool/create.go
@@ -21,14 +21,14 @@ func NewCreateCommand() *cobra.Command {
 		Arch:            "amd64",
 		ClusterName:     "example",
 		Namespace:       "clusters",
-		NodeCount:       2,
+		Replicas:        2,
 		NodeUpgradeType: "",
 		ReleaseImage:    "",
 	}
 
 	cmd.PersistentFlags().StringVar(&opts.Name, "name", opts.Name, "The name of the NodePool.")
 	cmd.PersistentFlags().StringVar(&opts.Namespace, "namespace", opts.Namespace, "The namespace in which to create the NodePool.")
-	cmd.PersistentFlags().Int32Var(&opts.NodeCount, "node-count", opts.NodeCount, "The number of nodes to create in the NodePool.")
+	cmd.PersistentFlags().Int32Var(&opts.Replicas, "replicas", opts.Replicas, "The number of nodes to create in the NodePool")
 	cmd.PersistentFlags().StringVar(&opts.ClusterName, "cluster-name", opts.ClusterName, "The name of the HostedCluster nodes in this pool will join.")
 	cmd.PersistentFlags().StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The release image for nodes; if this is empty, defaults to the same release image as the HostedCluster.")
 	cmd.PersistentFlags().Var(&opts.NodeUpgradeType, "node-upgrade-type", "The NodePool upgrade strategy for how nodes should behave when upgraded. Supported options: Replace, InPlace")
@@ -37,6 +37,9 @@ func NewCreateCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.Arch, "arch", opts.Arch, "The processor architecture for the NodePool (e.g. arm64, amd64)")
 
 	_ = cmd.MarkPersistentFlagRequired("name")
+
+	cmd.PersistentFlags().Int32Var(&opts.Replicas, "node-count", opts.Replicas, "The number of nodes to create in the NodePool (DEPRECATED, use '--replicas' instead)")
+	_ = cmd.PersistentFlags().MarkDeprecated("node-count", "please use '--replicas' instead")
 
 	cmd.AddCommand(agent.NewCreateCommand(opts))
 	cmd.AddCommand(aws.NewCreateCommand(opts))


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the `--node-count` flag to be renamed to `--replicas` so that it is consistent with what the term is called in the API.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[CNTRLPLANE-645](https://issues.redhat.com/browse/CNTRLPLANE-645)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.