### PR TITLE
[proposal] Test Bucketing Support for HyperShift E2E Tests

### DIFF
--- a/docs/proposals/e2e-test-bucketing.md
+++ b/docs/proposals/e2e-test-bucketing.md
@@ -1,0 +1,342 @@
+# E2E Test Bucketing Proposal
+
+## Prelude
+
+There are several potential approaches to improve HyperShift's CI stability and efficiency:
+
+1. **Cluster Pools**
+   - Pre-provision management clusters
+   - Reduce setup/teardown overhead
+   - Complex implementation and maintenance
+
+2. **Infrastructure Optimization**
+   - Tune instance types and configurations
+   - Optimize resource requests/limits
+   - Requires extensive testing and validation
+
+3. **Test Suite Refactoring**
+   - Reorganize test dependencies
+   - Remove redundant validations
+   - Long-term, high-effort initiative
+
+This proposal focuses on a low-hanging fruit: test bucketing. By implementing a simple but effective test distribution strategy, we can achieve immediate improvements in resource utilization and retest efficiency, while leaving room for more comprehensive optimizations in the future.
+
+## Current State
+
+```mermaid
+graph TB
+    A[CI Operator Job: e2e-aws] --> B[Pre: Setup Management Cluster<br/>~45min]
+    B --> C[Test: Run ALL e2e tests<br/>18 top level tests<br/>468 total tests<br/>~45-60min]
+    C --> D[Post: Teardown<br/>~15min]
+    
+    style C fill:#f96,stroke:#333,stroke-width:4px
+```
+
+### Problems
+
+1. **Single Test Execution Context**
+   - 18 top-level test suites (~468 total test cases)
+   - Each test suite creates 1 hosted cluster
+   - Some test suites take 45+ minutes
+   - When a single test fails, entire suite must be rerun
+   - Boskos lease blocked for entire duration (~1h 45min)
+
+2. **Resource Inefficiency**
+   ```mermaid
+   graph LR
+       A[Boskos Lease] --> B[Single e2e Job<br/>~1h 45min duration]
+       B --> C1[Test Suite 1<br/>45min]
+       B --> C2[Test Suite 2<br/>20min]
+       B --> C3[Test Suite 3<br/>15min]
+       B --> C4[More Suites...]
+       
+       style C1 fill:#f96,stroke:#333,stroke-width:4px
+   ```
+   - Single lease holds resources for longest test duration
+   - Even quick tests (~15-20min) block lease for full duration
+   - Resources underutilized after quick tests complete
+
+## Proposed Solution
+
+```mermaid
+graph TB
+    subgraph Setup
+    A[Pre: Setup Management Cluster<br/>~45min]
+    end
+    
+    subgraph "Parallel Test Buckets"
+    B1[e2e-aws-b1<br/>~6 test suites<br/>Mix of durations<br/>Release lease when done] 
+    B2[e2e-aws-b2<br/>~6 test suites<br/>Mix of durations<br/>Release lease when done]
+    B3[e2e-aws-b3<br/>~6 test suites<br/>Mix of durations<br/>Release lease when done]
+    end
+    
+    subgraph Cleanup
+    C[Post: Teardown<br/>~15min]
+    end
+    
+    A --> B1
+    A --> B2
+    A --> B3
+    B1 --> C
+    B2 --> C
+    B3 --> C
+```
+
+### Key Changes
+
+1. **Test Bucketing**
+   - 18 test suites split into 3 buckets (~6 suites each)
+   - Each bucket completes independently
+   - Resources released as soon as bucket completes
+   - Long-running tests don't block shorter ones
+
+2. **Resource Optimization**
+   ```mermaid
+   graph TB
+       subgraph "Current Approach"
+       A1[PR1 Job Lease<br/>1h 45min] --> B1[All Tests]
+       A2[PR2 Job Waiting] --> B2[Blocked]
+       end
+       
+       subgraph "Bucketed Approach"
+       C1[PR1 Bucket1<br/>45min] --> D1[Long Tests]
+       C2[PR1 Bucket2<br/>20min] --> D2[Medium Tests]
+       C3[PR1 Bucket3<br/>15min] --> D3[Short Tests]
+       D3 --> E1[PR2 Can Start Here]
+       end
+   ```
+   - Shorter test buckets release resources earlier
+   - Other PRs can utilize freed resources sooner
+   - More efficient resource utilization
+
+## Advantages
+
+1. **Improved Resource Utilization**
+   - Resources released incrementally as buckets complete
+   - Faster resource availability for other PRs
+   - More efficient Boskos lease usage
+
+2. **Faster Retests**
+   - Only failed bucket needs to be rerun
+   - Most buckets complete in 15-30 minutes
+   - Significant time savings on retests
+   - Lower resource waste on retests
+
+3. **Better PR Testing Flow**
+   ```mermaid
+   graph LR
+       subgraph "Current Retest"
+       A1[Test Failure] --> B1[Rerun ALL Tests<br/>1h 45min]
+       end
+       
+       subgraph "Bucketed Retest"
+       A2[Test Failure] --> B2[Rerun Single Bucket<br/>15-30min]
+       end
+   ```
+
+## Example Test Distribution
+
+```mermaid
+pie
+    title "E2E Test Duration Distribution"
+    "Quick Tests (15-20min)" : 40
+    "Medium Tests (20-30min)" : 35
+    "Long Tests (30-45min)" : 25
+```
+
+1. **Quick Test Suites (~15-20min)**
+   - Configuration validation
+   - API testing
+   - Basic functionality
+
+2. **Medium Test Suites (~20-30min)**
+   - Cluster creation
+   - Node operations
+   - Platform features
+
+3. **Long Test Suites (~30-45min)**
+   - Upgrade testing
+   - Scale testing
+   - Complex operations
+
+## Implementation Overview
+
+1. **Test Discovery and Bucketing**
+   ```mermaid
+   graph LR
+       A[List _test.go files] --> B[Sort files]
+       B --> C[Calculate bucket size]
+       C --> D[Assign files to buckets]
+       D --> E[Run bucket tests]
+   ```
+
+2. **CI Integration**
+   ```mermaid
+   graph TB
+       A[Input YAML] --> B[Parse test blocks]
+       B --> C[Generate N copies]
+       C --> D[Add bucket env vars]
+       D --> E[Output modified YAML]
+   ```
+
+### POC Components
+
+1. **Test Bucketing Logic**
+   - Located in `test/e2e_exp/`
+   - Uses build tags for selective compilation
+   - Deterministic file distribution
+
+2. **CI Job Generation**
+   - New jobtemplate tool
+   - Transforms single job into N bucketed jobs
+   - Preserves shared pre/post steps
+
+## Next Steps
+
+### Phase 1: PoC Validation (1 day)
+```mermaid
+graph TB
+    A[Create Dummy CI Job] --> B[Use Rehearsal]
+    B --> C[Verify Job Success]
+```
+- Add test job with bucketing enabled
+- Use rehearsal to validate changes
+- Verify tooling and bucket distribution
+
+### Phase 2: Integration (1 day)
+```mermaid
+graph LR
+    A[Move Bucket Implementation] --> B[e2e_test Package]
+    B --> C[Test aws_e2e_main Only]
+    C --> D[Monitor Results]
+```
+- Move bucketing code from e2e_exp to core e2e_test
+- Apply bucketing to aws_e2e_main job first
+- Keep other jobs unchanged as control group
+
+### Phase 3: Rollout (1-2 weeks)
+```mermaid
+graph TB
+    subgraph "Gradual Migration"
+    A[Monitor aws_e2e_main] --> B{Success?}
+    B -->|Yes| C[Move Next Job]
+    B -->|No| D[Rollback]
+    C --> E[Wait 1-2 days]
+    E --> F[Evaluate]
+    F --> B
+    end
+```
+- Monitor initial bucketed job performance
+- If successful, gradually migrate other jobs
+- Allow some time for observation between migrations
+
+### Implementation Timeline
+| Phase | Duration | Activities |
+|-------|----------|------------|
+| PoC Validation | 1 day | Dummy job creation and testing |
+| Integration | 1 day | Move to core e2e_test package |
+| Initial Rollout | 1-2 days | aws_e2e_main migration |
+
+
+## Future Improvements
+
+### Static Bucket Assignment
+
+The current implementation uses a simple dynamic bucketing strategy that distributes test files equally across buckets. While this provides a basic level of parallelization, we can improve resource utilization through static bucket assignment based on test duration heuristics.
+
+```mermaid
+graph TB
+    subgraph "Current Dynamic Assignment"
+        D1[6 Test Files<br/>Unknown Duration] --> DB1[Bucket 1]
+        D2[6 Test Files<br/>Unknown Duration] --> DB2[Bucket 2]
+        D3[6 Test Files<br/>Unknown Duration] --> DB3[Bucket 3]
+    end
+
+    subgraph "Future Static Assignment"
+        S1[Long Tests<br/>~45min total] --> SB1[Bucket 1]
+        S2[Medium Tests<br/>~30min total] --> SB2[Bucket 2]
+        S3[Short Tests<br/>~15min total] --> SB3[Bucket 3]
+    end
+```
+
+#### Duration-Based Assignment Strategy
+
+1. **Test Duration Collection**
+   ```mermaid
+   graph LR
+       A[CI Jobs] --> B[Test Duration<br/>Metrics Collection]
+       B --> C[Duration Database]
+       C --> D[Static Bucket<br/>Configuration]
+   ```
+   - Record test durations across multiple runs
+   - Calculate average and variance
+   - Identify patterns in resource usage
+
+2. **Test Categories by Duration**
+   - **Long-Running Tests (~45 min)**
+     - Control plane upgrades
+     - Full cluster creation/destroy cycles
+     - Complex multi-component tests
+   - **Medium Tests (~20-30 min)**
+     - NodePool operations
+     - Platform-specific features
+     - Multi-step validations
+   - **Quick Tests (~5-15 min)**
+     - API validation
+     - Configuration checks
+     - Simple component tests
+
+3. **Static Assignment Benefits**
+   ```mermaid
+   graph TB
+       subgraph "Resource Usage Over Time"
+           B1[Bucket 1] --> L1[45min]
+           B2[Bucket 2] --> L2[30min]
+           B3[Bucket 3] --> L3[15min]
+           
+           L3 --> F1[Resources Free]
+           L2 --> F2[Resources Free]
+           L1 --> F3[Resources Free]
+       end
+   ```
+   - More predictable bucket durations
+   - Better resource planning
+   - Earlier resource release for shorter tests
+   - Improved CI queue throughput
+
+4. **Implementation Plan**
+   - Phase 1: Collect test duration metrics
+   - Phase 2: Analyze resource usage patterns
+   - Phase 3: Define static bucket assignments
+   - Phase 4: Add configuration for manual overrides
+
+#### Configuration Example
+```yaml
+buckets:
+  bucket1:
+    name: long-running
+    tests:
+      - TestUpgradeControlPlane  # ~40min
+      - TestNodePool             # ~52min
+    expected_duration: "50m"
+  
+  bucket2:
+    name: medium
+    tests:
+      - TestCreateCluster        # ~36min
+      - TestAutoscaling         # ~30min
+    expected_duration: "35m"
+  
+  bucket3:
+    name: quick
+    tests:
+      - TestValidation          # ~15min
+      - TestConfiguration       # ~10min
+    expected_duration: "15m"
+```
+
+This static assignment approach will be implemented after:
+1. Collecting sufficient duration data from current dynamic implementation
+2. Analyzing resource usage patterns across test runs
+3. Identifying stable test duration patterns
+4. Developing bucket assignment algorithms

--- a/hack/tools/jobtemplate/main.go
+++ b/hack/tools/jobtemplate/main.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Test struct {
+	As           string                 `yaml:"as"`
+	Steps        map[string]interface{} `yaml:"steps,omitempty"`
+	Commands     string                 `yaml:"commands,omitempty"`
+	Container    map[string]interface{} `yaml:"container,omitempty"`
+	Capabilities []string               `yaml:"capabilities,omitempty"`
+	Optional     bool                   `yaml:"optional,omitempty"`
+	Raw          map[string]interface{} `yaml:",inline"`
+}
+
+type Config struct {
+	Tests []Test               `yaml:"tests"`
+	Raw   map[string]interface{} `yaml:",inline"`
+}
+
+var (
+	configFile  string
+	outputFile string
+	testBlocks string
+	buckets    int
+)
+
+func init() {
+	flag.StringVar(&configFile, "config", "", "Path to the job config yaml file")
+	flag.StringVar(&outputFile, "output", "", "Path to write the output yaml file (use '-' for stdout)")
+	flag.StringVar(&testBlocks, "test-blocks", "", "Comma-separated list of test block names (as: values)")
+	flag.IntVar(&buckets, "total-buckets", 0, "Total number of buckets to generate")
+}
+
+// detectIndentation determines the indentation used in the YAML file
+func detectIndentation(content []byte) int {
+	lines := strings.Split(string(content), "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "  ") {
+			// Find first line with indentation under a sequence item
+			if strings.HasPrefix(strings.TrimSpace(line), "as:") ||
+				strings.HasPrefix(strings.TrimSpace(line), "commands:") ||
+				strings.HasPrefix(strings.TrimSpace(line), "container:") {
+				return len(line) - len(strings.TrimLeft(line, " "))
+			}
+		}
+	}
+	return 2 // Default to 2 spaces if no indentation detected
+}
+
+// generateBucketedJobs applies bucketing to specific test blocks in a config
+func generateBucketedJobs(content []byte, testBlockNames []string, totalBuckets int) ([]byte, error) {
+	// First decode into a Node to preserve style
+	var node yaml.Node
+	dec := yaml.NewDecoder(bytes.NewReader(content))
+	dec.KnownFields(false)
+	if err := dec.Decode(&node); err != nil {
+		return nil, fmt.Errorf("failed to parse yaml: %v", err)
+	}
+
+	indentSpaces := detectIndentation(content)
+
+	// Find the tests sequence node
+	var testsNode *yaml.Node
+	if node.Kind == yaml.DocumentNode {
+		node = *node.Content[0]
+	}
+
+	// Set the style for the root node and tests node to preserve indentation
+	node.Style = yaml.Style(0)
+	for i, n := range node.Content {
+		if i%2 == 0 && n.Value == "tests" {
+			testsNode = node.Content[i+1]
+			testsNode.Style = yaml.Style(0)
+			break
+		}
+	}
+	if testsNode == nil {
+		return nil, fmt.Errorf("no tests section found in yaml")
+	}
+
+	// Convert test blocks slice to a set for easy lookup
+	testBlockSet := make(map[string]bool)
+	for _, block := range testBlockNames {
+		testBlockSet[strings.TrimSpace(block)] = true
+	}
+
+	// Create a new slice to hold all tests
+	var modifiedTests []*yaml.Node
+
+	// Process all tests
+	for _, testNode := range testsNode.Content {
+		// Find the "as" field to get the test name
+		var testName string
+		for i := 0; i < len(testNode.Content); i += 2 {
+			if testNode.Content[i].Value == "as" {
+				testName = testNode.Content[i+1].Value
+				break
+			}
+		}
+
+		if testBlockSet[testName] {
+			// This test needs bucketing - create multiple copies
+			for i := 1; i <= totalBuckets; i++ {
+				// Deep copy the test by marshaling and unmarshaling
+				testBytes, err := yaml.Marshal(testNode)
+				if err != nil {
+					return nil, fmt.Errorf("failed to marshal test: %v", err)
+				}
+
+				var bucketTest yaml.Node
+				if err := yaml.Unmarshal(testBytes, &bucketTest); err != nil {
+					return nil, fmt.Errorf("failed to unmarshal test: %v", err)
+				}
+
+				// The unmarshaled node will be a document node, get its content
+				bucketTestNode := bucketTest.Content[0]
+
+				// Update the test name with bucket suffix
+				for j := 0; j < len(bucketTestNode.Content); j += 2 {
+					if bucketTestNode.Content[j].Value == "as" {
+						bucketTestNode.Content[j+1].Value = fmt.Sprintf("%s-b%d", testName, i)
+						break
+					}
+				}
+
+				// Set or update the env section
+				var stepsNode *yaml.Node
+				var envNode *yaml.Node
+				for j := 0; j < len(bucketTestNode.Content); j += 2 {
+					if bucketTestNode.Content[j].Value == "steps" {
+						stepsNode = bucketTestNode.Content[j+1]
+						// Find or create env section in steps
+						for k := 0; k < len(stepsNode.Content); k += 2 {
+							if stepsNode.Content[k].Value == "env" {
+								envNode = stepsNode.Content[k+1]
+								break
+							}
+						}
+						break
+					}
+				}
+
+				if stepsNode == nil {
+					// Create steps section if it doesn't exist
+					stepsNode = &yaml.Node{
+						Kind:  yaml.MappingNode,
+						Style: yaml.Style(indentSpaces),
+					}
+					bucketTestNode.Content = append(bucketTestNode.Content,
+						&yaml.Node{Kind: yaml.ScalarNode, Value: "steps", Style: yaml.Style(indentSpaces)},
+						stepsNode,
+					)
+				}
+
+				if envNode == nil {
+					// Create env section if it doesn't exist
+					envNode = &yaml.Node{
+						Kind:  yaml.MappingNode,
+						Style: yaml.Style(indentSpaces),
+					}
+					stepsNode.Content = append(stepsNode.Content,
+						&yaml.Node{Kind: yaml.ScalarNode, Value: "env", Style: yaml.Style(indentSpaces)},
+						envNode,
+					)
+				}
+
+				// Add or update BUCKET_NUM and BUCKET_TOTAL
+				bucketNumFound := false
+				bucketTotalFound := false
+				for j := 0; j < len(envNode.Content); j += 2 {
+					if envNode.Content[j].Value == "BUCKET_NUM" {
+						envNode.Content[j+1].Value = fmt.Sprintf("%d", i)
+						bucketNumFound = true
+					} else if envNode.Content[j].Value == "BUCKET_TOTAL" {
+						envNode.Content[j+1].Value = fmt.Sprintf("%d", totalBuckets)
+						bucketTotalFound = true
+					}
+				}
+
+				if !bucketNumFound {
+					envNode.Content = append(envNode.Content,
+						&yaml.Node{Kind: yaml.ScalarNode, Value: "BUCKET_NUM", Style: yaml.Style(indentSpaces)},
+						&yaml.Node{Kind: yaml.ScalarNode, Value: fmt.Sprintf("%d", i), Style: yaml.Style(indentSpaces)},
+					)
+				}
+				if !bucketTotalFound {
+					envNode.Content = append(envNode.Content,
+						&yaml.Node{Kind: yaml.ScalarNode, Value: "BUCKET_TOTAL", Style: yaml.Style(indentSpaces)},
+						&yaml.Node{Kind: yaml.ScalarNode, Value: fmt.Sprintf("%d", totalBuckets), Style: yaml.Style(indentSpaces)},
+					)
+				}
+
+				modifiedTests = append(modifiedTests, bucketTestNode)
+			}
+		} else {
+			// This test doesn't need bucketing - keep it exactly as is
+			modifiedTests = append(modifiedTests, testNode)
+		}
+	}
+
+	// Replace tests content with modified version
+	testsNode.Content = modifiedTests
+
+	// Create a new encoder that preserves the input indentation
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(indentSpaces)
+	if err := enc.Encode(&node); err != nil {
+		return nil, fmt.Errorf("failed to encode yaml: %v", err)
+	}
+	
+	return buf.Bytes(), nil
+}
+
+func main() {
+	flag.Parse()
+
+	if configFile == "" || testBlocks == "" || buckets <= 0 {
+		fmt.Fprintf(os.Stderr, "Required flags: -config, -test-blocks, and -total-buckets\n")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	// If no output file specified, default to input file
+	if outputFile == "" {
+		outputFile = configFile
+	}
+
+	content, err := os.ReadFile(configFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to read config file: %v\n", err)
+		os.Exit(1)
+	}
+
+	blockNames := strings.Split(testBlocks, ",")
+	output, err := generateBucketedJobs(content, blockNames, buckets)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to generate bucketed jobs: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Write to stdout if outputFile is "-"
+	if outputFile == "-" {
+		_, err = os.Stdout.Write(output)
+	} else {
+		err = os.WriteFile(outputFile, output, 0644)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to write output: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/hack/tools/jobtemplate/main_test.go
+++ b/hack/tools/jobtemplate/main_test.go
@@ -1,0 +1,249 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestJobTemplate(t *testing.T) {
+	// Create temp copy of input file
+	inputData, err := os.ReadFile("testdata/input.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read test input file: %v", err)
+	}
+
+	fmt.Printf("\n=== TestJobTemplate ===\n")
+	fmt.Printf("Input YAML:\n%s\n", string(inputData))
+	fmt.Printf("Generation args:\n- test blocks: [e2e-aws, e2e-aws-upgrade]\n- total buckets: 2\n")
+
+	testBlocks := []string{"e2e-aws", "e2e-aws-upgrade"}
+	output, err := generateBucketedJobs(inputData, testBlocks, 2)
+	if err != nil {
+		t.Fatalf("Failed to generate bucketed jobs: %v", err)
+	}
+
+	fmt.Printf("Output YAML:\n%s\n", string(output))
+
+	var actualConfig Config
+	if err := yaml.Unmarshal(output, &actualConfig); err != nil {
+		t.Fatalf("Failed to parse output yaml: %v", err)
+	}
+
+	// Validate the output
+	expectedTestNames := map[string]bool{
+		"verify":             true,
+		"e2e-aws-b1":         true,
+		"e2e-aws-b2":         true,
+		"e2e-aws-upgrade-b1": true,
+		"e2e-aws-upgrade-b2": true,
+	}
+
+	for _, test := range actualConfig.Tests {
+		if !expectedTestNames[test.As] {
+			t.Errorf("Unexpected test block found: %s", test.As)
+		}
+		delete(expectedTestNames, test.As)
+
+		if strings.HasPrefix(test.As, "e2e-aws") {
+			// Validate env variables for bucketed tests
+			env, ok := test.Steps["env"].(map[string]interface{})
+			if !ok {
+				t.Errorf("Test %s: env section not found or wrong type", test.As)
+				continue
+			}
+
+			bucketNum, numOk := env["BUCKET_NUM"].(int)
+			bucketTotal, totalOk := env["BUCKET_TOTAL"].(int)
+
+			if !numOk || !totalOk {
+				t.Errorf("Test %s: BUCKET_NUM or BUCKET_TOTAL not found or wrong type", test.As)
+			}
+
+			if bucketTotal != 2 {
+				t.Errorf("Test %s: expected BUCKET_TOTAL=2, got %d", test.As, bucketTotal)
+			}
+
+			suffix := test.As[strings.LastIndex(test.As, "-b")+2:]
+			expectedNum := int(suffix[0] - '0')
+			if bucketNum != expectedNum {
+				t.Errorf("Test %s: expected BUCKET_NUM=%d, got %d", test.As, expectedNum, bucketNum)
+			}
+		}
+	}
+
+	// Check that all expected test names were found
+	for name := range expectedTestNames {
+		t.Errorf("Expected test block not found: %s", name)
+	}
+}
+
+// Helper function to run a test with different parameters and validate output
+func runToolTest(t *testing.T, testBlocks []string, totalBuckets int, validateFunc func(config Config) error) {
+	t.Helper()
+
+	// Read input file
+	inputData, err := os.ReadFile("testdata/input.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read test input file: %v", err)
+	}
+
+	fmt.Printf("\nInput YAML:\n%s\n", string(inputData))
+	fmt.Printf("Generation args:\n- test blocks: %v\n- total buckets: %d\n", testBlocks, totalBuckets)
+
+	// Generate bucketed jobs
+	output, err := generateBucketedJobs(inputData, testBlocks, totalBuckets)
+	if err != nil {
+		t.Fatalf("Failed to generate bucketed jobs: %v", err)
+	}
+
+	fmt.Printf("Output YAML:\n%s\n", string(output))
+
+	var result Config
+	if err := yaml.Unmarshal(output, &result); err != nil {
+		t.Fatalf("Failed to parse output yaml: %v", err)
+	}
+
+	if err := validateFunc(result); err != nil {
+		t.Error(err)
+	}
+}
+
+// Test cases
+func TestJobTemplateVariations(t *testing.T) {
+	tests := []struct {
+		name         string
+		testBlocks   []string
+		totalBuckets int
+		validate     func(config Config) error
+	}{
+		{
+			name:         "Single test block",
+			testBlocks:   []string{"e2e-aws"},
+			totalBuckets: 3,
+			validate: func(config Config) error {
+				// Create a map of expected test names - ONLY verify and e2e-aws variants
+				expectedNames := map[string]bool{
+					"verify":      true,
+					"e2e-aws-b1": true,
+					"e2e-aws-b2": true,
+					"e2e-aws-b3": true,
+					"e2e-aws-upgrade": true,
+				}
+
+				// Check each test in the config
+				for _, test := range config.Tests {
+					if !expectedNames[test.As] {
+						return fmt.Errorf("unexpected test found: %s", test.As)
+					}
+					delete(expectedNames, test.As)
+
+					// Validate bucket env vars for e2e-aws tests
+					if strings.HasPrefix(test.As, "e2e-aws-b") {
+						env, ok := test.Steps["env"].(map[string]interface{})
+						if !ok {
+							return fmt.Errorf("test %s: env section not found or wrong type", test.As)
+						}
+
+						bucketNum, numOk := env["BUCKET_NUM"].(int)
+						bucketTotal, totalOk := env["BUCKET_TOTAL"].(int)
+
+						if !numOk || !totalOk {
+							return fmt.Errorf("test %s: BUCKET_NUM or BUCKET_TOTAL not found or wrong type", test.As)
+						}
+
+						if bucketTotal != 3 {
+							return fmt.Errorf("test %s: expected BUCKET_TOTAL=3, got %d", test.As, bucketTotal)
+						}
+
+						suffix := test.As[strings.LastIndex(test.As, "-b")+2:]
+						expectedNum := int(suffix[0] - '0')
+						if bucketNum != expectedNum {
+							return fmt.Errorf("test %s: expected BUCKET_NUM=%d, got %d", test.As, expectedNum, bucketNum)
+						}
+					}
+				}
+
+				// Any remaining expected names weren't found
+				if len(expectedNames) > 0 {
+					var missing []string
+					for name := range expectedNames {
+						missing = append(missing, name)
+					}
+					return fmt.Errorf("expected tests not found: %v", missing)
+				}
+
+				return nil
+			},
+		},
+		{
+			name:         "No matching blocks",
+			testBlocks:   []string{"non-existent-test"},
+			totalBuckets: 2,
+			validate: func(config Config) error {
+				if len(config.Tests) != 3 { // original tests unchanged
+					return fmt.Errorf("expected 3 tests, got %d", len(config.Tests))
+				}
+				return nil
+			},
+		},
+		{
+			name:         "Multiple test blocks",
+			testBlocks:   []string{"e2e-aws", "e2e-aws-upgrade"},
+			totalBuckets: 2,
+			validate: func(config Config) error {
+				expectedNames := []string{
+					"verify",
+					"e2e-aws-b1", "e2e-aws-b2",
+					"e2e-aws-upgrade-b1", "e2e-aws-upgrade-b2",
+				}
+				return validateTestNames(config, expectedNames)
+			},
+		},
+		{
+			name:         "Empty test blocks",
+			testBlocks:   []string{},
+			totalBuckets: 2,
+			validate: func(config Config) error {
+				if len(config.Tests) != 3 { // original tests unchanged
+					return fmt.Errorf("expected tests to be unchanged when no test blocks specified")
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fmt.Printf("\n=== TestJobTemplateVariations/%s ===\n", tc.name)
+			runToolTest(t, tc.testBlocks, tc.totalBuckets, tc.validate)
+		})
+	}
+}
+
+func validateTestNames(config Config, expectedNames []string) error {
+	actualNames := make(map[string]bool)
+	for _, test := range config.Tests {
+		actualNames[test.As] = true
+	}
+
+	for _, name := range expectedNames {
+		if !actualNames[name] {
+			return fmt.Errorf("expected test %q not found", name)
+		}
+		delete(actualNames, name)
+	}
+
+	if len(actualNames) > 0 {
+		var unexpected []string
+		for name := range actualNames {
+			unexpected = append(unexpected, name)
+		}
+		return fmt.Errorf("unexpected tests found: %v", unexpected)
+	}
+
+	return nil
+}

--- a/hack/tools/jobtemplate/testdata/expected.yaml
+++ b/hack/tools/jobtemplate/testdata/expected.yaml
@@ -1,0 +1,66 @@
+tests:
+- as: verify
+  commands: make verify
+  container:
+    from: src
+  skip_if_only_changed: (^(\.tekton|\.github|docs|examples|enhancements|contrib)/)|(^[A-Z]+\.md$)|((^|/)OWNERS$)|(/overrides\.yaml$)|(/\.testcoverage\.yml$)
+- as: e2e-aws-b1
+  capabilities:
+  - build-tmpfs
+  skip_if_only_changed: (^(\.tekton|\.github|docs|examples|enhancements|contrib)/)|(^[A-Z]+\.md$)|((^|/)OWNERS$)|(/overrides\.yaml$)|(/\.testcoverage\.yml$)
+  steps:
+    cluster_profile: hypershift
+    dependencies:
+      OCP_IMAGE_N1: release:n1minor
+      OCP_IMAGE_N2: release:n2minor
+    env:
+      ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
+      REQUEST_SERVING_COMPONENT_TEST: "true"
+      BUCKET_NUM: 1
+      BUCKET_TOTAL: 2
+    workflow: hypershift-aws-e2e-external
+- as: e2e-aws-b2
+  capabilities:
+  - build-tmpfs
+  skip_if_only_changed: (^(\.tekton|\.github|docs|examples|enhancements|contrib)/)|(^[A-Z]+\.md$)|((^|/)OWNERS$)|(/overrides\.yaml$)|(/\.testcoverage\.yml$)
+  steps:
+    cluster_profile: hypershift
+    dependencies:
+      OCP_IMAGE_N1: release:n1minor
+      OCP_IMAGE_N2: release:n2minor
+    env:
+      ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
+      REQUEST_SERVING_COMPONENT_TEST: "true"
+      BUCKET_NUM: 2
+      BUCKET_TOTAL: 2
+    workflow: hypershift-aws-e2e-external
+- as: e2e-aws-upgrade-b1
+  capabilities:
+  - build-tmpfs
+  skip_if_only_changed: (^(\.tekton|\.github|docs|examples|enhancements|contrib)/)|(^[A-Z]+\.md$)|((^|/)OWNERS$)|(/overrides\.yaml$)|(/\.testcoverage\.yml$)
+  steps:
+    cluster_profile: hypershift
+    dependencies:
+      OCP_IMAGE_N1: release:n1minor
+      OCP_IMAGE_N2: release:n2minor
+    env:
+      ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
+      REQUEST_SERVING_COMPONENT_TEST: "true"
+      BUCKET_NUM: 1
+      BUCKET_TOTAL: 2
+    workflow: hypershift-aws-e2e-external
+- as: e2e-aws-upgrade-b2
+  capabilities:
+  - build-tmpfs
+  skip_if_only_changed: (^(\.tekton|\.github|docs|examples|enhancements|contrib)/)|(^[A-Z]+\.md$)|((^|/)OWNERS$)|(/overrides\.yaml$)|(/\.testcoverage\.yml$)
+  steps:
+    cluster_profile: hypershift
+    dependencies:
+      OCP_IMAGE_N1: release:n1minor
+      OCP_IMAGE_N2: release:n2minor
+    env:
+      ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
+      REQUEST_SERVING_COMPONENT_TEST: "true"
+      BUCKET_NUM: 2
+      BUCKET_TOTAL: 2
+    workflow: hypershift-aws-e2e-external

--- a/hack/tools/jobtemplate/testdata/input.yaml
+++ b/hack/tools/jobtemplate/testdata/input.yaml
@@ -1,0 +1,32 @@
+tests:
+- as: verify
+  commands: make verify
+  container:
+    from: src
+  skip_if_only_changed: (^(\.tekton|\.github|docs|examples|enhancements|contrib)/)|(^[A-Z]+\.md$)|((^|/)OWNERS$)|(/overrides\.yaml$)|(/\.testcoverage\.yml$)
+- as: e2e-aws
+  capabilities:
+  - build-tmpfs
+  skip_if_only_changed: (^(\.tekton|\.github|docs|examples|enhancements|contrib)/)|(^[A-Z]+\.md$)|((^|/)OWNERS$)|(/overrides\.yaml$)|(/\.testcoverage\.yml$)
+  steps:
+    cluster_profile: hypershift
+    dependencies:
+      OCP_IMAGE_N1: release:n1minor
+      OCP_IMAGE_N2: release:n2minor
+    env:
+      ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
+      REQUEST_SERVING_COMPONENT_TEST: "true"
+    workflow: hypershift-aws-e2e-external
+- as: e2e-aws-upgrade
+  capabilities:
+  - build-tmpfs
+  skip_if_only_changed: (^(\.tekton|\.github|docs|examples|enhancements|contrib)/)|(^[A-Z]+\.md$)|((^|/)OWNERS$)|(/overrides\.yaml$)|(/\.testcoverage\.yml$)
+  steps:
+    cluster_profile: hypershift
+    dependencies:
+      OCP_IMAGE_N1: release:n1minor
+      OCP_IMAGE_N2: release:n2minor
+    env:
+      ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
+      REQUEST_SERVING_COMPONENT_TEST: "true"
+    workflow: hypershift-aws-e2e-external

--- a/hack/tools/jobtemplate/testdata/input_with_anchors.yaml
+++ b/hack/tools/jobtemplate/testdata/input_with_anchors.yaml
@@ -1,0 +1,24 @@
+references: &common_refs
+  skip_if_only_changed: &skip_regex (^(\.tekton|\.github|docs|examples|enhancements|contrib)/)|(^[A-Z]+\.md$)|((^|/)OWNERS$)|(/overrides\.yaml$)|(/\.testcoverage\.yml$)
+  test_env: &test_env
+    ENABLE_HYPERSHIFT_CERT_ROTATION_SCALE: "true"
+    REQUEST_SERVING_COMPONENT_TEST: "true"
+
+tests:
+- as: verify
+  commands: make verify
+  container:
+    from: src
+  skip_if_only_changed: *skip_regex
+- as: e2e-aws
+  capabilities:
+  - build-tmpfs
+  skip_if_only_changed: *skip_regex
+  steps:
+    cluster_profile: hypershift
+    dependencies:
+      OCP_IMAGE_N1: release:n1minor
+      OCP_IMAGE_N2: release:n2minor
+    env:
+      <<: *test_env
+    workflow: hypershift-aws-e2e-external

--- a/test/e2e_exp/create_cluster_test.go
+++ b/test/e2e_exp/create_cluster_test.go
@@ -1,0 +1,35 @@
+//go:build e2e_batch
+// +build e2e_batch
+
+package e2e_exp
+
+import (
+    "testing"
+    "math/rand"
+    "time"
+)
+
+func TestCreateCluster(t *testing.T) {
+    t.Parallel()
+    t.Log("Running TestCreateCluster")
+
+    tests := []struct {
+        name string
+        duration time.Duration
+    }{
+        {"ValidateControlPlane", time.Duration(rand.Intn(3000)) * time.Millisecond},
+        {"ValidateNodes", time.Duration(rand.Intn(2000)) * time.Millisecond},
+        {"ValidateOperators", time.Duration(rand.Intn(4000)) * time.Millisecond},
+    }
+
+    for _, tt := range tests {
+        tt := tt
+        t.Run(tt.name, func(t *testing.T) {
+            t.Parallel()
+            time.Sleep(tt.duration)
+            if rand.Float64() < FailureProb() {
+                t.Fatalf("Random failure in cluster creation test: %s", tt.name)
+            }
+        })
+    }
+}

--- a/test/e2e_exp/e2e_test.go
+++ b/test/e2e_exp/e2e_test.go
@@ -1,0 +1,140 @@
+//go:build e2e_batch
+// +build e2e_batch
+
+package e2e_exp
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+var (
+	batchTotal  = flag.Int("e2e.batch-total", 0, "Total number of batches to split tests into (optional)")
+	batchNumber = flag.Int("e2e.batch-number", 0, "Which batch number to run (1-based index, optional)")
+	failureProb = flag.Float64("e2e.failure-probability", 0.0, "Probability of test failure (0.0 to 1.0, default 0 means all tests pass)")
+)
+
+// FailureProb returns the configured failure probability
+func FailureProb() float64 {
+	return *failureProb
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	os.Exit(main(m))
+}
+
+func main(m *testing.M) int {
+	// Handle batch processing if enabled
+	if *batchTotal > 0 {
+		var (
+			files   []string
+			err     error
+			pattern string
+		)
+
+		// Get current working directory
+		wd, err := os.Getwd()
+		if err != nil {
+			klog.Error("failed to get working directory:", err)
+			return -1
+		}
+
+		// Look for test files in e2e_exp directory
+		pattern = filepath.Join(wd, "*_test.go")
+		files, err = filepath.Glob(pattern)
+		if err != nil {
+			klog.Error("failed to list test files:", err)
+			return -1
+		}
+
+		// Filter out e2e_test.go since it contains test setup
+		var testFiles []string
+		for _, f := range files {
+			if filepath.Base(f) != "e2e_test.go" {
+				testFiles = append(testFiles, f)
+			}
+		}
+
+		if len(testFiles) == 0 {
+			klog.Error("no test files found")
+			return -1
+		}
+
+		if *batchNumber < 1 || *batchNumber > *batchTotal {
+			klog.Error("batch number must be between 1 and total batches",
+				"batchNumber", *batchNumber,
+				"totalBatches", *batchTotal)
+			return -1
+		}
+
+		// Sort files for consistent batching
+		sort.Strings(testFiles)
+
+		// Calculate which files belong to this batch
+		filesPerBatch := (len(testFiles) + *batchTotal - 1) / *batchTotal // Round up division
+		startIdx := (*batchNumber - 1) * filesPerBatch
+		endIdx := startIdx + filesPerBatch
+		if endIdx > len(testFiles) {
+			endIdx = len(testFiles)
+		}
+
+		if startIdx >= len(testFiles) {
+			klog.Error("batch number exceeds available test files",
+				"batchNumber", *batchNumber,
+				"totalBatches", *batchTotal)
+			return -1
+		}
+
+		// Build test patterns for this batch
+		var testPatterns []string
+		for _, file := range testFiles[startIdx:endIdx] {
+			base := filepath.Base(file)
+			base = strings.TrimSuffix(base, "_test.go")
+			testPatterns = append(testPatterns, fmt.Sprintf("Test%s", strings.Title(base)))
+		}
+
+		pattern = strings.Join(testPatterns, "|")
+		flag.Set("test.run", pattern)
+
+		klog.Info("Running test batch",
+			"batchNumber", *batchNumber,
+			"totalBatches", *batchTotal,
+			"pattern", pattern,
+			"files", testFiles[startIdx:endIdx])
+	}
+
+	// Handle cancellation
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		select {
+		case <-sigs:
+			klog.Info("tests received shutdown signal and will be cancelled")
+			cancel()
+		case <-ctx.Done():
+			return
+		}
+	}()
+
+	return m.Run()
+}

--- a/test/e2e_exp/monitoring_test.go
+++ b/test/e2e_exp/monitoring_test.go
@@ -1,0 +1,35 @@
+//go:build e2e_batch
+// +build e2e_batch
+
+package e2e_exp
+
+import (
+    "testing"
+    "math/rand"
+    "time"
+)
+
+func TestMonitoring(t *testing.T) {
+    t.Parallel()
+    t.Log("Running TestMonitoring")
+
+    tests := []struct {
+        name string
+        duration time.Duration
+    }{
+        {"PrometheusDeployment", time.Duration(rand.Intn(2500)) * time.Millisecond},
+        {"AlertmanagerConfig", time.Duration(rand.Intn(2000)) * time.Millisecond},
+        {"MetricsAvailability", time.Duration(rand.Intn(3000)) * time.Millisecond},
+    }
+
+    for _, tt := range tests {
+        tt := tt
+        t.Run(tt.name, func(t *testing.T) {
+            t.Parallel()
+            time.Sleep(tt.duration)
+            if rand.Float64() < FailureProb() {
+                t.Fatalf("Random failure in monitoring test: %s", tt.name)
+            }
+        })
+    }
+}

--- a/test/e2e_exp/networking_test.go
+++ b/test/e2e_exp/networking_test.go
@@ -1,0 +1,35 @@
+//go:build e2e_batch
+// +build e2e_batch
+
+package e2e_exp
+
+import (
+    "testing"
+    "math/rand"
+    "time"
+)
+
+func TestNetworking(t *testing.T) {
+    t.Parallel()
+    t.Log("Running TestNetworking")
+
+    tests := []struct {
+        name string
+        duration time.Duration
+    }{
+        {"DNSResolution", time.Duration(rand.Intn(2000)) * time.Millisecond},
+        {"LoadBalancers", time.Duration(rand.Intn(3000)) * time.Millisecond},
+        {"ServiceConnectivity", time.Duration(rand.Intn(1500)) * time.Millisecond},
+    }
+
+    for _, tt := range tests {
+        tt := tt
+        t.Run(tt.name, func(t *testing.T) {
+            t.Parallel()
+            time.Sleep(tt.duration)
+            if rand.Float64() < FailureProb() {
+                t.Fatalf("Random failure in networking test: %s", tt.name)
+            }
+        })
+    }
+}

--- a/test/e2e_exp/nodepool_test.go
+++ b/test/e2e_exp/nodepool_test.go
@@ -1,0 +1,35 @@
+//go:build e2e_batch
+// +build e2e_batch
+
+package e2e_exp
+
+import (
+    "testing"
+    "math/rand"
+    "time"
+)
+
+func TestNodepool(t *testing.T) {
+    t.Parallel()
+    t.Log("Running TestNodepool")
+
+    tests := []struct {
+        name string
+        duration time.Duration
+    }{
+        {"NodepoolCreation", time.Duration(rand.Intn(3000)) * time.Millisecond},
+        {"NodepoolScaling", time.Duration(rand.Intn(4000)) * time.Millisecond},
+        {"NodepoolUpdates", time.Duration(rand.Intn(2500)) * time.Millisecond},
+    }
+
+    for _, tt := range tests {
+        tt := tt
+        t.Run(tt.name, func(t *testing.T) {
+            t.Parallel()
+            time.Sleep(tt.duration)
+            if rand.Float64() < FailureProb() {
+                t.Fatalf("Random failure in nodepool test: %s", tt.name)
+            }
+        })
+    }
+}

--- a/test/e2e_exp/platform_aws_test.go
+++ b/test/e2e_exp/platform_aws_test.go
@@ -1,0 +1,35 @@
+//go:build e2e_batch
+// +build e2e_batch
+
+package e2e_exp
+
+import (
+    "testing"
+    "math/rand"
+    "time"
+)
+
+func TestPlatformAWS(t *testing.T) {
+    t.Parallel()
+    t.Log("Running TestPlatformAWS")
+
+    tests := []struct {
+        name string
+        duration time.Duration
+    }{
+        {"LoadBalancerIntegration", time.Duration(rand.Intn(3000)) * time.Millisecond},
+        {"IAMConfiguration", time.Duration(rand.Intn(2000)) * time.Millisecond},
+        {"StorageIntegration", time.Duration(rand.Intn(2500)) * time.Millisecond},
+    }
+
+    for _, tt := range tests {
+        tt := tt
+        t.Run(tt.name, func(t *testing.T) {
+            t.Parallel()
+            time.Sleep(tt.duration)
+            if rand.Float64() < FailureProb() {
+                t.Fatalf("Random failure in AWS platform test: %s", tt.name)
+            }
+        })
+    }
+}

--- a/test/e2e_exp/run_batched_tests.sh
+++ b/test/e2e_exp/run_batched_tests.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Default values
+BATCH_COUNT=3
+REPEAT_COUNT=1
+VERBOSE=false
+FAILURE_PROB=0.0
+
+# Parse command line arguments
+while getopts "b:r:f:vh" opt; do
+  case $opt in
+    b)
+      BATCH_COUNT=$OPTARG
+      ;;
+    r)
+      REPEAT_COUNT=$OPTARG
+      ;;
+    f)
+      FAILURE_PROB=$OPTARG
+      ;;
+    v)
+      VERBOSE=true
+      ;;
+    h)
+      echo "Usage: $0 [-b batch_count] [-r repeat_count] [-f failure_probability] [-v] [-h]"
+      echo "  -b: Number of batches to split tests into (default: 3)"
+      echo "  -r: Number of times to repeat the test run (default: 1)"
+      echo "  -f: Probability of test failure between 0.0 and 1.0 (default: 0.0)"
+      echo "  -v: Verbose mode"
+      echo "  -h: Show this help message"
+      exit 0
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Function to run a single batch
+run_batch() {
+    local batch_num=$1
+    local total_batches=$2
+    local test_args="-e2e.batch-total=$total_batches -e2e.batch-number=$batch_num -e2e.failure-probability=$FAILURE_PROB"
+
+    if [ "$VERBOSE" = true ]; then
+        test_args="$test_args -test.v"
+    fi
+
+    echo "Running batch $batch_num of $total_batches (failure probability: $FAILURE_PROB)"
+    cd "$(dirname "$0")" && go test -tags e2e_batch -timeout 30m . -args $test_args
+}
+
+# Main execution
+for ((r=1; r<=REPEAT_COUNT; r++)); do
+    if [ "$REPEAT_COUNT" -gt 1 ]; then
+        echo "=== Starting test run $r of $REPEAT_COUNT ==="
+    fi
+
+    # Run all batches in parallel
+    pids=()
+    for ((b=1; b<=BATCH_COUNT; b++)); do
+        run_batch $b $BATCH_COUNT &
+        pids+=($!)
+    done
+
+    # Wait for all batches to complete
+    for pid in "${pids[@]}"; do
+        wait $pid || exit 1
+    done
+done

--- a/test/e2e_exp/upgrade_test.go
+++ b/test/e2e_exp/upgrade_test.go
@@ -1,0 +1,35 @@
+//go:build e2e_batch
+// +build e2e_batch
+
+package e2e_exp
+
+import (
+    "testing"
+    "math/rand"
+    "time"
+)
+
+func TestUpgrade(t *testing.T) {
+    t.Parallel()
+    t.Log("Running TestUpgrade")
+
+    tests := []struct {
+        name string
+        duration time.Duration
+    }{
+        {"ControlPlaneUpgrade", time.Duration(rand.Intn(5000)) * time.Millisecond},
+        {"WorkerUpgrade", time.Duration(rand.Intn(4000)) * time.Millisecond},
+        {"ValidatePostUpgrade", time.Duration(rand.Intn(2000)) * time.Millisecond},
+    }
+
+    for _, tt := range tests {
+        tt := tt
+        t.Run(tt.name, func(t *testing.T) {
+            t.Parallel()
+            time.Sleep(tt.duration)
+            if rand.Float64() < FailureProb() {
+                t.Fatalf("Random failure in upgrade test: %s", tt.name)
+            }
+        })
+    }
+}


### PR DESCRIPTION
# Test Bucketing Support for HyperShift E2E Tests

This PR introduces test bucketing support to improve CI efficiency and resource utilization in HyperShift's E2E test suite. Full proposal can be found here: [E2E Test Bucketing Proposal](https://github.com/devguyio/hypershift/blob/ef153fd313ce9d377d8fc427c32e617680d319d9/docs/proposals/e2e-test-bucketing.md)

## Key Changes

### 1. E2E Test Bucketing (`test/e2e_exp/`)
- Added build tag `e2e_batch` and bucketing support
- Tests can be split into N equal buckets using:
  - `batch-total`: Total number of buckets
  - `batch-number`: Current bucket (1-N)
- Deterministic file-based distribution across buckets
- No changes to existing test code required

### 2. CI Job Generation (`hack/tools/jobtemplate/`)
- New tool to transform single test job into N bucketed jobs
- Preserves all job configuration (env vars, dependencies, etc.)
- Adds bucket-specific environment variables:
  ```yaml
  env:
    BUCKET_NUM: N      # Current bucket number
    BUCKET_TOTAL: M    # Total number of buckets
  ```
- Maintains exact YAML structure and style of input

## Usage

Generate bucketed jobs:
```sh
make generate-bucketed-jobs TOTAL_BUCKETS=3 CONFIG_FILE=config.yaml TEST_BLOCKS=e2e-aws
```

Run a specific test bucket:
```sh
go test -tags=e2e_batch -e2e.batch-total=3 -e2e.batch-number=1 ./test/e2e_exp/...
```

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.