### PR TITLE
CNTRLPLANE-788: Configure ClusterServiceLoadBalancerHealthProbeMode a…

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/providerconfig.go
@@ -18,7 +18,8 @@ const configTemplate = `[Global]
 Zone = %s
 VPC = %s
 KubernetesClusterID = %s
-SubnetID = %s`
+SubnetID = %s
+ClusterServiceLoadBalancerHealthProbeMode = Shared`
 
 func (p *AWSParams) ReconcileCloudConfig(cm *corev1.ConfigMap) error {
 	util.EnsureOwnerRef(cm, p.OwnerRef)


### PR DESCRIPTION
…s Shared

**What this PR does / why we need it**:
This commit ensures that LoadBalancer services running in AWS produce AWS LoadBalancer with health check target "HTTP:10256/healthz". This health check target will point to kube-proxy health endpoints running on nodes.
This change is equivalent to setting the mode via
cluster-cloud-controller-manager-operator in non-hypershift installations (like it was done in
https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/383)

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes [CNTRLPLANE-788](https://issues.redhat.com/browse/CNTRLPLANE-788)

**Checklist**
- [X ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.