### PR TITLE
OCPBUGS-54483: Add support for registry root entry only in the IDMS/ICSP

### DIFF
--- a/support/util/imagemetadata.go
+++ b/support/util/imagemetadata.go
@@ -374,7 +374,52 @@ func ImageLabels(metadata *dockerv1client.DockerImageConfig) map[string]string {
 	}
 }
 
-func GetRegistryOverrides(ctx context.Context, ref reference.DockerImageReference, source string, mirror string) (*reference.DockerImageReference, bool, error) {
+// Attempts only a root registry override match.
+func tryOnlyRootRegistryOverride(ref, sourceRef, mirrorRef reference.DockerImageReference) (*reference.DockerImageReference, bool, error) {
+	if sourceRef.Namespace == "" && sourceRef.Registry == "" && sourceRef.Name != "" {
+		if ref.Registry == sourceRef.Name {
+			composedImage := buildComposedRef(mirrorRef.String(), ref.Namespace, ref.NameString())
+			composedRef, err := reference.Parse(composedImage)
+			if err != nil {
+				return nil, false, fmt.Errorf("failed to parse composed image reference (root registry match): %w", err)
+			}
+			return &composedRef, true, nil
+		}
+	}
+	return nil, false, nil
+}
+
+// Attempts only a namespace override match.
+func tryOnlyNamespaceOverride(ref, sourceRef, mirrorRef reference.DockerImageReference) (*reference.DockerImageReference, bool, error) {
+	if sourceRef.Namespace == "" {
+		if sourceRef.Name == ref.Namespace {
+			composedImage := buildComposedRef(mirrorRef.Registry, ref.Namespace, ref.NameString())
+			composedRef, err := reference.Parse(composedImage)
+			if err != nil {
+				return nil, false, fmt.Errorf("failed to parse composed image reference (namespace match): %w", err)
+			}
+			return &composedRef, true, nil
+		}
+	}
+	return nil, false, nil
+}
+
+// Attempts only an exact repository override match.
+func tryExactCoincidenceOverride(ref, sourceRef, mirrorRef reference.DockerImageReference) (*reference.DockerImageReference, bool, error) {
+	if ref.Namespace == sourceRef.Namespace && ref.Name == sourceRef.Name {
+		mirrorRef.ID = ref.ID
+		mirrorRef.Tag = ref.Tag
+		composedImage := buildComposedRef(mirrorRef.Registry, mirrorRef.Namespace, mirrorRef.NameString())
+		composedRef, err := reference.Parse(composedImage)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to parse composed image reference (exact match): %w", err)
+		}
+		return &composedRef, true, nil
+	}
+	return nil, false, nil
+}
+
+func GetRegistryOverrides(ctx context.Context, ref reference.DockerImageReference, source, mirror string) (*reference.DockerImageReference, bool, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	sourceRef, err := reference.Parse(source)
@@ -384,35 +429,34 @@ func GetRegistryOverrides(ctx context.Context, ref reference.DockerImageReferenc
 
 	mirrorRef, err := reference.Parse(mirror)
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to parse mirror image reference %q: %w", source, err)
+		return nil, false, fmt.Errorf("failed to parse mirror image reference %q: %w", mirror, err)
 	}
 
-	// docker lib, by default will empty the Namespace once we pass an override with just a Namespace
-	// and it will assume that is the Name instead
-	if sourceRef.Namespace == "" {
-		if sourceRef.Name == ref.Namespace {
-			composedImage := buildComposedRef(mirrorRef.Registry, ref.Namespace, ref.NameString())
-			composedRef, err := reference.Parse(composedImage)
-			if err != nil {
-				return nil, false, fmt.Errorf("failed to parse composed image reference (partial match) %q: %w", source, err)
-			}
-			log.Info("registry override coincidence found (namespace)", "original", buildComposedRef(ref.Registry, ref.Namespace, ref.NameString()), "mirror", mirror, "composed", composedRef)
-			return &composedRef, true, nil
+	// Try only root registry override
+	if composedRef, found, err := tryOnlyRootRegistryOverride(ref, sourceRef, mirrorRef); found || err != nil {
+		if found {
+			log.Info("registry override found (root registry match)", "original", buildComposedRef(sourceRef.Name, ref.Namespace, ref.NameString()), "mirror", mirror, "composed", composedRef)
 		}
+		return composedRef, found, err
 	}
 
-	if ref.Namespace == sourceRef.Namespace && ref.Name == sourceRef.Name {
-		mirrorRef.ID = ref.ID
-		mirrorRef.Tag = ref.Tag
-		composedImage := buildComposedRef(mirrorRef.Registry, mirrorRef.Namespace, mirrorRef.NameString())
-		composedRef, err := reference.Parse(composedImage)
-		if err != nil {
-			return nil, false, fmt.Errorf("failed to parse composed image reference (exact match) %q: %w", source, err)
+	// Try only namespace override
+	if composedRef, found, err := tryOnlyNamespaceOverride(ref, sourceRef, mirrorRef); found || err != nil {
+		if found {
+			log.Info("registry override found (namespace match)", "original", buildComposedRef(ref.Registry, ref.Namespace, ref.NameString()), "mirror", mirror, "composed", composedRef)
 		}
-		log.Info("registry override coincidence found (exact match)", "original", buildComposedRef(ref.Registry, ref.Namespace, ref.NameString()), "mirror", mirror, "composed", composedRef)
-		return &composedRef, true, nil
+		return composedRef, found, err
 	}
 
+	// Try only exact repository override
+	if composedRef, found, err := tryExactCoincidenceOverride(ref, sourceRef, mirrorRef); found || err != nil {
+		if found {
+			log.Info("registry override found (exact match)", "original", buildComposedRef(ref.Registry, ref.Namespace, ref.NameString()), "mirror", mirror, "composed", composedRef)
+		}
+		return composedRef, found, err
+	}
+
+	// No match found
 	return &ref, false, nil
 }
 
@@ -446,7 +490,7 @@ func seekOverride(ctx context.Context, openshiftImageRegistryOverrides map[strin
 	log := ctrl.LoggerFrom(ctx)
 	for source, mirrors := range openshiftImageRegistryOverrides {
 		for _, mirror := range mirrors {
-			ref, overrideFound, err := GetRegistryOverrides(context.Background(), parsedImageReference, source, mirror)
+			ref, overrideFound, err := GetRegistryOverrides(ctx, parsedImageReference, source, mirror)
 			if err != nil {
 				log.Info(fmt.Sprintf("failed to find registry override for image reference %q with source, %s, mirror %s: %s", parsedImageReference, source, mirror, err.Error()))
 				continue

--- a/support/util/imagemetadata_test.go
+++ b/support/util/imagemetadata_test.go
@@ -229,6 +229,7 @@ func TestGetDigest(t *testing.T) {
 		})
 	}
 }
+
 func TestSeekOverride(t *testing.T) {
 	testsCases := []struct {
 		name           string
@@ -348,6 +349,38 @@ func TestSeekOverride(t *testing.T) {
 				ID:        "sha256:ba93b7791accfb38e76634edbc815d596ebf39c3d4683a001f8286b3e122ae69",
 			},
 		},
+		{
+			name:      "if only the root registry is provided",
+			overrides: fakeOverrides(),
+			imageRef: reference.DockerImageReference{
+				Registry:  "registry.build02.ci.openshift.org",
+				Name:      "release",
+				Namespace: "ocp",
+				ID:        "sha256:f225d0f0fd7d4509ed00e82f11c871731ee04aecff7d924f820ac6dba7c7b346",
+			},
+			expectedImgRef: &reference.DockerImageReference{
+				Registry:  "virthost.ostest.test.metalkube.org:5000",
+				Name:      "release",
+				Namespace: "ocp",
+				ID:        "sha256:f225d0f0fd7d4509ed00e82f11c871731ee04aecff7d924f820ac6dba7c7b346",
+			},
+		},
+		{
+			name:      "if only the root registry is provided and multiple mirrors are provided",
+			overrides: fakeOverrides(),
+			imageRef: reference.DockerImageReference{
+				Registry:  "registry.build03.ci.openshift.org",
+				Name:      "release",
+				Namespace: "ocp",
+				ID:        "sha256:f225d0f0fd7d4509ed00e82f11c871731ee04aecff7d924f820ac6dba7c7b346",
+			},
+			expectedImgRef: &reference.DockerImageReference{
+				Registry:  "myregistry1.io",
+				Name:      "release",
+				Namespace: "ocp",
+				ID:        "sha256:f225d0f0fd7d4509ed00e82f11c871731ee04aecff7d924f820ac6dba7c7b346",
+			},
+		},
 	}
 
 	for _, tc := range testsCases {
@@ -375,5 +408,275 @@ func fakeOverrides() map[string][]string {
 		"registry.ci.openshift.org/ocp/4.18-2025-01-04-031500": {
 			"virthost.ostest.test.metalkube.org:5000/localimages/local-release-image",
 		},
+		"registry.build02.ci.openshift.org": {
+			"virthost.ostest.test.metalkube.org:5000",
+		},
+		"registry.build03.ci.openshift.org": {
+			"myregistry1.io",
+			"myregistry2.io",
+		},
+	}
+}
+
+func TestTryOnlyNamespaceOverride(t *testing.T) {
+	testsCases := []struct {
+		name           string
+		ref            reference.DockerImageReference
+		sourceRef      reference.DockerImageReference
+		mirrorRef      reference.DockerImageReference
+		expectedImgRef *reference.DockerImageReference
+		overrideFound  bool
+		expectAnErr    bool
+	}{
+		{
+			name: "if namespace override is found",
+			ref: reference.DockerImageReference{
+				Registry:  "quay.io",
+				Name:      "ocp-release",
+				Namespace: "openshift-release-dev",
+				Tag:       "4.15.0-rc.0-multi",
+			},
+			sourceRef: reference.DockerImageReference{
+				Name: "openshift-release-dev",
+			},
+			mirrorRef: reference.DockerImageReference{
+				Registry: "myregistry.io",
+			},
+			expectedImgRef: &reference.DockerImageReference{
+				Registry:  "myregistry.io",
+				Name:      "ocp-release",
+				Namespace: "openshift-release-dev",
+				Tag:       "4.15.0-rc.0-multi",
+			},
+			overrideFound: true,
+			expectAnErr:   false,
+		},
+		{
+			name: "if namespace override is not found - namespace not empty",
+			ref: reference.DockerImageReference{
+				Registry:  "quay.io",
+				Name:      "ocp-release",
+				Namespace: "openshift-release-dev",
+				Tag:       "4.15.0-rc.0-multi",
+			},
+			sourceRef: reference.DockerImageReference{
+				Namespace: "test",
+				Name:      "openshift-release-dev",
+			},
+			mirrorRef: reference.DockerImageReference{
+				Registry: "myregistry.io",
+			},
+			expectedImgRef: nil,
+			overrideFound:  false,
+			expectAnErr:    false,
+		},
+		{
+			name: "if namespace override is not found - name mismatch",
+			ref: reference.DockerImageReference{
+				Registry:  "quay.io",
+				Name:      "ocp-release",
+				Namespace: "openshift-release-dev",
+				Tag:       "4.15.0-rc.0-multi",
+			},
+			sourceRef: reference.DockerImageReference{
+				Name: "different-namespace",
+			},
+			mirrorRef: reference.DockerImageReference{
+				Registry: "myregistry.io",
+			},
+			expectedImgRef: nil,
+			overrideFound:  false,
+			expectAnErr:    false,
+		},
+	}
+
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			imgRef, overrideFound, err := tryOnlyNamespaceOverride(tc.ref, tc.sourceRef, tc.mirrorRef)
+			g.Expect(imgRef).To(Equal(tc.expectedImgRef))
+			g.Expect(overrideFound).To(Equal(tc.overrideFound))
+			g.Expect(err != nil).To(Equal(tc.expectAnErr))
+		})
+	}
+}
+
+func TestTryExactCoincidenceOverride(t *testing.T) {
+	testsCases := []struct {
+		name           string
+		ref            reference.DockerImageReference
+		sourceRef      reference.DockerImageReference
+		mirrorRef      reference.DockerImageReference
+		expectedImgRef *reference.DockerImageReference
+		overrideFound  bool
+		expectAnErr    bool
+	}{
+		{
+			name: "if exact coincidence override is found",
+			ref: reference.DockerImageReference{
+				Registry:  "quay.io",
+				Name:      "ocp-release",
+				Namespace: "openshift-release-dev",
+				Tag:       "4.15.0-rc.0-multi",
+			},
+			sourceRef: reference.DockerImageReference{
+				Registry:  "quay.io",
+				Name:      "ocp-release",
+				Namespace: "openshift-release-dev",
+			},
+			mirrorRef: reference.DockerImageReference{
+				Registry:  "myregistry.io",
+				Namespace: "openshift-release-dev",
+				Name:      "ocp-release",
+			},
+			expectedImgRef: &reference.DockerImageReference{
+				Registry:  "myregistry.io",
+				Name:      "ocp-release",
+				Namespace: "openshift-release-dev",
+				Tag:       "4.15.0-rc.0-multi",
+			},
+			overrideFound: true,
+			expectAnErr:   false,
+		},
+		{
+			name: "if exact coincidence override is not found",
+			ref: reference.DockerImageReference{
+				Registry:  "quay.io",
+				Name:      "ocp-release",
+				Namespace: "openshift-release-dev",
+				Tag:       "4.15.0-rc.0-multi",
+			},
+			sourceRef: reference.DockerImageReference{
+				Registry:  "quay.io",
+				Name:      "different-name",
+				Namespace: "openshift-release-dev",
+			},
+			mirrorRef: reference.DockerImageReference{
+				Registry: "myregistry.io",
+			},
+			expectedImgRef: nil,
+			overrideFound:  false,
+			expectAnErr:    false,
+		},
+	}
+
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			imgRef, overrideFound, err := tryExactCoincidenceOverride(tc.ref, tc.sourceRef, tc.mirrorRef)
+			if tc.overrideFound {
+				g.Expect(imgRef).To(Equal(tc.expectedImgRef))
+			} else {
+				g.Expect(imgRef).To(BeNil())
+			}
+			g.Expect(overrideFound).To(Equal(tc.overrideFound))
+			g.Expect(err != nil).To(Equal(tc.expectAnErr))
+		})
+	}
+}
+
+func TestTryOnlyRootRegistryOverride(t *testing.T) {
+	testsCases := []struct {
+		name           string
+		ref            reference.DockerImageReference
+		sourceRef      reference.DockerImageReference
+		mirrorRef      reference.DockerImageReference
+		expectedImgRef *reference.DockerImageReference
+		overrideFound  bool
+		expectAnErr    bool
+	}{
+		{
+			name: "if root registry override is found",
+			ref: reference.DockerImageReference{
+				Registry:  "registry.build02.ci.openshift.org",
+				Name:      "release",
+				Namespace: "ocp",
+				Tag:       "4.15.0-rc.0-multi",
+			},
+			sourceRef: reference.DockerImageReference{
+				Name: "registry.build02.ci.openshift.org",
+			},
+			mirrorRef: reference.DockerImageReference{
+				Name: "virthost.ostest.test.metalkube.org:5000",
+			},
+			expectedImgRef: &reference.DockerImageReference{
+				Registry:  "virthost.ostest.test.metalkube.org:5000",
+				Name:      "release",
+				Namespace: "ocp",
+				Tag:       "4.15.0-rc.0-multi",
+			},
+			overrideFound: true,
+			expectAnErr:   false,
+		},
+		{
+			name: "if root registry override is not found - namespace not empty",
+			ref: reference.DockerImageReference{
+				Registry:  "registry.build02.ci.openshift.org",
+				Name:      "release",
+				Namespace: "ocp",
+				Tag:       "4.15.0-rc.0-multi",
+			},
+			sourceRef: reference.DockerImageReference{
+				Namespace: "test",
+				Name:      "registry.build02.ci.openshift.org",
+			},
+			mirrorRef: reference.DockerImageReference{
+				Registry: "virthost.ostest.test.metalkube.org:5000",
+			},
+			expectedImgRef: nil,
+			overrideFound:  false,
+			expectAnErr:    false,
+		},
+		{
+			name: "if root registry override is not found - registry not empty",
+			ref: reference.DockerImageReference{
+				Registry:  "registry.build02.ci.openshift.org",
+				Name:      "release",
+				Namespace: "ocp",
+				Tag:       "4.15.0-rc.0-multi",
+			},
+			sourceRef: reference.DockerImageReference{
+				Registry: "test",
+				Name:     "registry.build02.ci.openshift.org",
+			},
+			mirrorRef: reference.DockerImageReference{
+				Registry: "virthost.ostest.test.metalkube.org:5000",
+			},
+			expectedImgRef: nil,
+			overrideFound:  false,
+			expectAnErr:    false,
+		},
+		{
+			name: "if root registry override is not found - name mismatch",
+			ref: reference.DockerImageReference{
+				Registry:  "registry.build02.ci.openshift.org",
+				Name:      "release",
+				Namespace: "ocp",
+				Tag:       "4.15.0-rc.0-multi",
+			},
+			sourceRef: reference.DockerImageReference{
+				Name: "different-registry",
+			},
+			mirrorRef: reference.DockerImageReference{
+				Registry: "virthost.ostest.test.metalkube.org:5000",
+			},
+			expectedImgRef: nil,
+			overrideFound:  false,
+			expectAnErr:    false,
+		},
+	}
+
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			imgRef, overrideFound, err := tryOnlyRootRegistryOverride(tc.ref, tc.sourceRef, tc.mirrorRef)
+			if tc.overrideFound {
+				g.Expect(imgRef).To(Equal(tc.expectedImgRef))
+			} else {
+				g.Expect(imgRef).To(BeNil())
+			}
+			g.Expect(overrideFound).To(Equal(tc.overrideFound))
+			g.Expect(err != nil).To(Equal(tc.expectAnErr))
+		})
 	}
 }


### PR DESCRIPTION
## What this PR does / why we need it
The reference.Parse function tries to retrieve the whole entry string, but if the entry reference does not contain Namespace and Name but registry, it will return the Registry field as the Name which is not a good behavior. We added the proper changes to have this in consideration and return the right override. Also we covered it with the unit test to avoid regressions.

## Which issue(s) this PR fixes
- Fixes [OCPBUGS-54483](https://issues.redhat.com/browse/OCPBUGS-54483)
