### PR TITLE
OCPBUGS-55913: Fix Job status returning empty reason and message

### DIFF
--- a/support/controlplane-component/job.go
+++ b/support/controlplane-component/job.go
@@ -48,32 +48,42 @@ func (c *jobProvider) Replicas(object *batchv1.Job) *int32 {
 
 // IsAvailable implements WorkloadProvider.
 func (c *jobProvider) IsAvailable(job *batchv1.Job) (status metav1.ConditionStatus, reason string, message string) {
-	complete := util.FindJobCondition(job, batchv1.JobComplete)
-	if complete != nil {
-		return metav1.ConditionStatus(complete.Status), complete.Reason, complete.Message
-	}
-	failed := util.FindJobCondition(job, batchv1.JobFailed)
-	if failed != nil {
-		return metav1.ConditionFalse, failed.Reason, failed.Message
-	}
 	if job.Status.Active > 0 {
 		return metav1.ConditionTrue, "JobActive", "Job is still running"
 	}
-	return metav1.ConditionFalse, "Unknown", "Job status unknown"
+	return JobCompletionStatus(job)
 }
 
 // IsReady implements WorkloadProvider.
 func (c *jobProvider) IsReady(job *batchv1.Job) (status metav1.ConditionStatus, reason string, message string) {
-	complete := util.FindJobCondition(job, batchv1.JobComplete)
-	if complete != nil {
-		return metav1.ConditionStatus(complete.Status), complete.Reason, complete.Message
-	}
-	failed := util.FindJobCondition(job, batchv1.JobFailed)
-	if failed != nil {
-		return metav1.ConditionFalse, failed.Reason, failed.Message
-	}
 	if job.Status.Active > 0 {
 		return metav1.ConditionFalse, "JobActive", "Job is still running"
 	}
+	return JobCompletionStatus(job)
+}
+
+// JobCompletionStatus checks the status of a job and returns the appropriate condition status, reason, and message.
+// It checks if the job is complete or failed and returns the corresponding status.
+// If the job is neither complete nor failed, it returns unknown status.
+func JobCompletionStatus(job *batchv1.Job) (status metav1.ConditionStatus, reason string, message string) {
+	complete := util.FindJobCondition(job, batchv1.JobComplete)
+	if complete != nil && complete.Status == corev1.ConditionTrue {
+		return metav1.ConditionTrue, "JobComplete", "Job completed successfully"
+	}
+
+	failed := util.FindJobCondition(job, batchv1.JobFailed)
+	if failed != nil && failed.Status == corev1.ConditionTrue {
+		// If the job failed, we return false and the reason and message from the condition to provide more context.
+		// we set default values for the reason and message if not set to avoid errors as reason and message are required fields
+		// in the ControlPlaneComponent status conditions.
+		if failed.Reason == "" {
+			failed.Reason = "JobFailed"
+		}
+		if failed.Message == "" {
+			failed.Message = "Job failed"
+		}
+		return metav1.ConditionFalse, failed.Reason, failed.Message
+	}
+
 	return metav1.ConditionFalse, "Unknown", "Job status unknown"
 }

--- a/support/controlplane-component/job_test.go
+++ b/support/controlplane-component/job_test.go
@@ -1,0 +1,205 @@
+package controlplanecomponent
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestJobProvider_IsAvailable(t *testing.T) {
+	g := NewWithT(t)
+	provider := &jobProvider{}
+
+	testCases := []struct {
+		name        string
+		job         *batchv1.Job
+		wantStatus  metav1.ConditionStatus
+		wantReason  string
+		wantMessage string
+	}{
+		{
+			name: "Should return true when job is active",
+			job: &batchv1.Job{
+				Status: batchv1.JobStatus{
+					Active: 1,
+				},
+			},
+			wantStatus:  metav1.ConditionTrue,
+			wantReason:  "JobActive",
+			wantMessage: "Job is still running",
+		},
+		{
+			name: "Should return true when job is completed",
+			job: &batchv1.Job{
+				Status: batchv1.JobStatus{
+					Conditions: []batchv1.JobCondition{
+						{
+							Type:   batchv1.JobComplete,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			wantStatus:  metav1.ConditionTrue,
+			wantReason:  "JobComplete",
+			wantMessage: "Job completed successfully",
+		},
+		{
+			name: "Should return false when job has failed",
+			job: &batchv1.Job{
+				Status: batchv1.JobStatus{
+					Conditions: []batchv1.JobCondition{
+						{
+							Type:    batchv1.JobFailed,
+							Status:  corev1.ConditionTrue,
+							Reason:  "BackoffLimitExceeded",
+							Message: "Job has reached the specified backoff limit",
+						},
+					},
+				},
+			},
+			wantStatus:  metav1.ConditionFalse,
+			wantReason:  "BackoffLimitExceeded",
+			wantMessage: "Job has reached the specified backoff limit",
+		},
+		{
+			name: "Should return false with Unknown reason when job status is empty",
+			job: &batchv1.Job{
+				Status: batchv1.JobStatus{},
+			},
+			wantStatus:  metav1.ConditionFalse,
+			wantReason:  "Unknown",
+			wantMessage: "Job status unknown",
+		},
+		{
+			name: "Should return false with Unknown reason when job conditions are false",
+			job: &batchv1.Job{
+				Status: batchv1.JobStatus{
+					Conditions: []batchv1.JobCondition{
+						{
+							Type:   batchv1.JobComplete,
+							Status: corev1.ConditionFalse,
+						},
+						{
+							Type:   batchv1.JobFailed,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			},
+			wantStatus:  metav1.ConditionFalse,
+			wantReason:  "Unknown",
+			wantMessage: "Job status unknown",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, reason, message := provider.IsAvailable(tc.job)
+			g.Expect(status).To(Equal(tc.wantStatus))
+			g.Expect(reason).To(Equal(tc.wantReason))
+			g.Expect(message).To(Equal(tc.wantMessage))
+		})
+	}
+}
+
+func TestJobProvider_IsReady(t *testing.T) {
+	g := NewWithT(t)
+	provider := &jobProvider{}
+
+	testCases := []struct {
+		name        string
+		job         *batchv1.Job
+		wantStatus  metav1.ConditionStatus
+		wantReason  string
+		wantMessage string
+	}{
+		{
+			name: "Should return false when job is active",
+			job: &batchv1.Job{
+				Status: batchv1.JobStatus{
+					Active: 1,
+				},
+			},
+			wantStatus:  metav1.ConditionFalse,
+			wantReason:  "JobActive",
+			wantMessage: "Job is still running",
+		},
+		{
+			name: "Should return true when job is completed",
+			job: &batchv1.Job{
+				Status: batchv1.JobStatus{
+					Conditions: []batchv1.JobCondition{
+						{
+							Type:   batchv1.JobComplete,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			wantStatus:  metav1.ConditionTrue,
+			wantReason:  "JobComplete",
+			wantMessage: "Job completed successfully",
+		},
+		{
+			name: "Should return false when job has failed",
+			job: &batchv1.Job{
+				Status: batchv1.JobStatus{
+					Conditions: []batchv1.JobCondition{
+						{
+							Type:    batchv1.JobFailed,
+							Status:  corev1.ConditionTrue,
+							Reason:  "BackoffLimitExceeded",
+							Message: "Job has reached the specified backoff limit",
+						},
+					},
+				},
+			},
+			wantStatus:  metav1.ConditionFalse,
+			wantReason:  "BackoffLimitExceeded",
+			wantMessage: "Job has reached the specified backoff limit",
+		},
+		{
+			name: "Should return false with Unknown reason when job status is empty",
+			job: &batchv1.Job{
+				Status: batchv1.JobStatus{},
+			},
+			wantStatus:  metav1.ConditionFalse,
+			wantReason:  "Unknown",
+			wantMessage: "Job status unknown",
+		},
+		{
+			name: "Should return false with Unknown reason when job conditions are false",
+			job: &batchv1.Job{
+				Status: batchv1.JobStatus{
+					Conditions: []batchv1.JobCondition{
+						{
+							Type:   batchv1.JobComplete,
+							Status: corev1.ConditionFalse,
+						},
+						{
+							Type:   batchv1.JobFailed,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			},
+			wantStatus:  metav1.ConditionFalse,
+			wantReason:  "Unknown",
+			wantMessage: "Job status unknown",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			status, reason, message := provider.IsReady(tc.job)
+			g.Expect(status).To(Equal(tc.wantStatus))
+			g.Expect(reason).To(Equal(tc.wantReason))
+			g.Expect(message).To(Equal(tc.wantMessage))
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes the issue of the controller failing to update ControlPlaneComponent status condition on older versions of openshift/k8s management clusters where the job controller doesn't set the reason and message fields in the Job conditions.


**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.