### PR TITLE
OCPBUGS-56036: add multi-arch build for MCE 2.9

### DIFF
--- a/.tekton/hypershift-cli-mce-29-push.yaml
+++ b/.tekton/hypershift-cli-mce-29-push.yaml
@@ -27,6 +27,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
   - name: dockerfile
     value: Containerfile.cli
   - name: path-context

--- a/.tekton/hypershift-release-mce-29-push.yaml
+++ b/.tekton/hypershift-release-mce-29-push.yaml
@@ -27,6 +27,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
   - name: dockerfile
     value: Containerfile.operator
   - name: path-context

--- a/Containerfile.cli
+++ b/Containerfile.cli
@@ -27,10 +27,11 @@ COPY --from=builder /hypershift/bin/    /opt/app-root/src/
 CMD ["nginx", "-g", "daemon off;"]
 
 LABEL name="multicluster-engine/hypershift-cli-rhel9"
-LABEL description="HyperShift Operator is an operator to manage the lifecycle of Hosted Clusters"
+LABEL description="HyperShift HCP CLI is to manage the lifecycle of Hosted Clusters in command lines."
 LABEL summary="HyperShift HCP CLI"
 LABEL url="https://catalog.redhat.com/software/containers/multicluster-engine/hypershift-cli-rhel9/"
 LABEL version=4.19
 LABEL com.redhat.component="multicluster-engine-hypershift-cli-container"
 LABEL io.openshift.tags="data,images"
 LABEL io.k8s.display-name="multicluster-engine-hypershift-cli"
+LABEL io.k8s.description="HyperShift HCP CLI is to manage the lifecycle of Hosted Clusters in command lines."


### PR DESCRIPTION
**What this PR does / why we need it**:

For MCE 2.9 multi-arch build.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-56036

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.