### PR TITLE
NO-JIRA: Fix TestHostedClusterWatchesEverythingItCreates not working locally

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -202,6 +202,8 @@ type HostedClusterReconciler struct {
 	EnableEtcdRecovery bool
 
 	FeatureSet configv1.FeatureSet
+
+	OpenShiftTrustedCAFilePath string
 }
 
 // +kubebuilder:rbac:groups=hypershift.openshift.io,resources=hostedclusters,verbs=get;list;watch;create;update;patch;delete
@@ -2692,9 +2694,9 @@ func (r *HostedClusterReconciler) reconcileOpenShiftTrustedCAs(ctx context.Conte
 	trustedCABundle := new(bytes.Buffer)
 	var trustCABundleFile []byte
 
-	_, err := os.Stat("/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem")
+	_, err := os.Stat(r.OpenShiftTrustedCAFilePath)
 	if err == nil {
-		trustCABundleFile, err = os.ReadFile("/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem")
+		trustCABundleFile, err = os.ReadFile(r.OpenShiftTrustedCAFilePath)
 		if err != nil {
 			return false, fmt.Errorf("unable to read trust bundle file: %w", err)
 		}

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -354,6 +354,7 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 		EnableCVOManagementClusterMetricsAccess: enableCVOManagementClusterMetricsAccess,
 		EnableEtcdRecovery:                      enableEtcdRecovery,
 		FeatureSet:                              featuregate.FeatureSet(),
+		OpenShiftTrustedCAFilePath:              "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
 	}
 	if opts.OIDCStorageProviderS3BucketName != "" {
 		awsSession := awsutil.NewSession("hypershift-operator-oidc-bucket", opts.OIDCStorageProviderS3Credentials, "", "", opts.OIDCStorageProviderS3Region)


### PR DESCRIPTION
**What this PR does / why we need it**:
The test was failing locally because it was not creating any configMaps. This PR adds a temp file to allow the test to always created openshift-config-managed-trusted-ca-bundle configmap and pass locally.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.