### PR TITLE
OCPBUGS-56205: Switch back to rh catalog

### DIFF
--- a/Containerfile.cli
+++ b/Containerfile.cli
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23.6 AS builder
+FROM registry.redhat.io/rhel9/go-toolset:1.23.6-1745588370 AS builder
 
 WORKDIR /hypershift
 

--- a/Containerfile.control-plane
+++ b/Containerfile.control-plane
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23.6 AS builder
+FROM registry.redhat.io/rhel9/go-toolset:1.23.6-1745588370 AS builder
 
 WORKDIR /hypershift
 

--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23.6 AS builder
+FROM registry.redhat.io/rhel9/go-toolset:1.23.6-1745588370 AS builder
 
 WORKDIR /hypershift
 


### PR DESCRIPTION
**What this PR does / why we need it**:

For a time, there was no red hat catalog image that had go 1.23.6. Now that it is available, we need to use it.

**Which issue(s) this PR fixes**:
Fixes #OCPBUGS-56205

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.