### PR TITLE
OCPBUGS-53265: Use the image reference for the cache in the image metadata provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	github.com/go-jose/go-jose/v3 v3.0.4
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0
-	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8
 	github.com/google/cel-go v0.22.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/gofuzz v1.2.0
@@ -159,6 +158,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
+	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.6.9-0.20230804172637-c7be7c783f49 // indirect

--- a/support/util/imagemetadata.go
+++ b/support/util/imagemetadata.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/releaseinfo"
@@ -13,6 +14,7 @@ import (
 	"github.com/openshift/hypershift/support/thirdparty/oc/pkg/cli/image/manifest"
 	"github.com/openshift/hypershift/support/thirdparty/oc/pkg/cli/image/manifest/dockercredentials"
 
+	"k8s.io/apimachinery/pkg/util/cache"
 	"k8s.io/client-go/rest"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -20,14 +22,15 @@ import (
 	"github.com/blang/semver"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/registry/client/transport"
-	"github.com/golang/groupcache/lru"
 	"github.com/opencontainers/go-digest"
 )
 
+const cacheTTL = time.Hour * 12
+
 var (
-	imageMetadataCache = lru.New(1000)
-	manifestsCache     = lru.New(1000)
-	digestCache        = lru.New(1000)
+	imageMetadataCache = cache.NewLRUExpireCache(1000)
+	manifestsCache     = cache.NewLRUExpireCache(1000)
+	digestCache        = cache.NewLRUExpireCache(1000)
 )
 
 type ImageMetadataProvider interface {
@@ -42,52 +45,26 @@ type RegistryClientImageMetadataProvider struct {
 	OpenShiftImageRegistryOverrides map[string][]string
 }
 
-// ImageMetadata returns metadata for a given image using the given pull secret
-// to authenticate. This lookup uses a cache based on the image digest. If the
-// reference of the image contains a digest (which is the mainline case for images in a release payload),
-// the digest is parsed from the image reference and then used to lookup image metadata in the
-// cache. When the image reference does not contain a digest, a lookup is made to the registry to
-// fetch the digest of the image that the tag refers to. This is because the actual image that the
-// tag is referring to could have changed. Once a digest is obtained, the cache is checked so that
-// no further fetching occurs. Only if both cache lookups fail, the image metadata is fetched and
-// stored in the cache.
+// ImageMetadata returns metadata for a given image using the given pull secret to authenticate.
+// The ICSPs/IDMSs are checked first for overrides and then the cache is checked using the image
+// pull spec. If not found in the cache, the manifest is looked up and added to the cache.
 func (r *RegistryClientImageMetadataProvider) ImageMetadata(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, error) {
 
-	var (
-		repo           distribution.Repository
-		ref            *reference.DockerImageReference
-		parsedImageRef reference.DockerImageReference
-		err            error
-	)
-
-	parsedImageRef, err = reference.Parse(imageRef)
+	parsedImageRef, err := reference.Parse(imageRef)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse image reference %q: %w", imageRef, err)
 	}
 
-	// There are no ICSPs/IDMSs to process.
-	// That means the image reference should be pulled from the external registry
-	if len(r.OpenShiftImageRegistryOverrides) == 0 {
-		// If the image reference contains a digest, immediately look it up in the cache
-		if parsedImageRef.ID != "" {
-			if imageConfigObject, exists := imageMetadataCache.Get(parsedImageRef.ID); exists {
-				return imageConfigObject.(*dockerv1client.DockerImageConfig), nil
-			}
-		}
-		ref = &parsedImageRef
-	}
-
 	// Get the image repo info based the source/mirrors in the ICSPs/IDMSs
-	ref = seekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret)
+	ref := seekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret)
+	refPullSpec := ref.String()
 
-	// If the image reference contains a digest, immediately look it up in the cache
-	if ref.ID != "" {
-		if imageConfigObject, exists := imageMetadataCache.Get(ref.ID); exists {
-			return imageConfigObject.(*dockerv1client.DockerImageConfig), nil
-		}
+	// Check the cache for the image
+	if imageConfigObject, exists := imageMetadataCache.Get(refPullSpec); exists {
+		return imageConfigObject.(*dockerv1client.DockerImageConfig), nil
 	}
 
-	repo, err = getRepository(ctx, *ref, pullSecret)
+	repo, err := getRepository(ctx, *ref, pullSecret)
 	if err != nil || repo == nil {
 		return nil, fmt.Errorf("failed to create repository client for %s: %w", ref.DockerClientDefaults().RegistryURL(), err)
 	}
@@ -98,18 +75,13 @@ func (r *RegistryClientImageMetadataProvider) ImageMetadata(ctx context.Context,
 		return nil, fmt.Errorf("failed to obtain root manifest for %s: %w", imageRef, err)
 	}
 
-	// If the image ref did not contain a digest, attempt looking it up by digest after we've fetched the digest
-	if ref.ID == "" {
-		if imageConfigObject, exists := imageMetadataCache.Get(string(location.Manifest)); exists {
-			return imageConfigObject.(*dockerv1client.DockerImageConfig), nil
-		}
-	}
-
 	config, _, err := manifest.ManifestToImageConfig(ctx, firstManifest, repo.Blobs(ctx), location)
 	if err != nil {
 		return nil, fmt.Errorf("failed to obtain image configuration for %s: %w", imageRef, err)
 	}
-	imageMetadataCache.Add(string(location.Manifest), config)
+
+	// Cache the image config using the image reference pull spec
+	imageMetadataCache.Add(refPullSpec, config, cacheTTL)
 
 	return config, nil
 }
@@ -192,62 +164,40 @@ func (r *RegistryClientImageMetadataProvider) GetDigest(ctx context.Context, ima
 		composedParsedRef.ID = string(srcDigest)
 	}
 
-	digestCache.Add(composedRef, srcDigest)
-	digestCache.Add(imageRef, srcDigest)
+	digestCache.Add(composedRef, srcDigest, cacheTTL)
+	digestCache.Add(imageRef, srcDigest, cacheTTL)
 
 	return srcDigest, composedParsedRef, nil
 }
 
-// GetManifest returns the manifest for a given image using the given pull secret
-// to authenticate. This lookup uses a cache based on the image digest. If The
-// reference of the image contains a digest (which is the mainline case for images in a release payload),
-// the digest is parsed from the image reference and then used to lookup the manifest in the
-// cache and return it with the ImageOverrides already included.
+// GetManifest returns the manifest for a given image using the given pull secret to authenticate.
+// The ICSPs/IDMSs are checked first for overrides and then the cache is checked using the image
+// pull spec. If not found in the cache, the manifest is looked up and added to the cache.
 func (r *RegistryClientImageMetadataProvider) GetManifest(ctx context.Context, imageRef string, pullSecret []byte) (distribution.Manifest, error) {
 
-	var (
-		ref            *reference.DockerImageReference
-		parsedImageRef reference.DockerImageReference
-		err            error
-		srcDigest      digest.Digest
-	)
-
-	parsedImageRef, err = reference.Parse(imageRef)
+	parsedImageRef, err := reference.Parse(imageRef)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse image reference %q: %w", imageRef, err)
 	}
 
-	// There are no ICSPs/IDMSs to process.
-	// That means the image reference should be pulled from the external registry
-	if len(r.OpenShiftImageRegistryOverrides) == 0 {
-		// If the image reference contains a digest, immediately look it up in the cache
-		if parsedImageRef.ID != "" {
-			if manifest, exists := manifestsCache.Get(parsedImageRef.ID); exists {
-				return manifest.(distribution.Manifest), nil
-			}
-		}
-		ref = &parsedImageRef
-	}
-
 	// Get the image repo info based the source/mirrors in the ICSPs/IDMSs
-	ref = seekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret)
+	ref := seekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret)
 
-	// If the image reference contains a digest, immediately look it up in the cache
-	if ref.ID != "" {
-		if manifest, exists := manifestsCache.Get(ref.ID); exists {
-			return manifest.(distribution.Manifest), nil
-		}
+	// Check the cache for the image
+	if manifest, exists := manifestsCache.Get(ref.String()); exists {
+		return manifest.(distribution.Manifest), nil
 	}
 
-	composedRef := ref.String()
-
-	digestsManifest, srcDigest, err := getManifest(ctx, composedRef, pullSecret)
+	// Look up the manifest
+	manifest, _, err := getManifest(ctx, ref.String(), pullSecret)
 	if err != nil {
 		return nil, err
 	}
-	manifestsCache.Add(srcDigest, digestsManifest)
 
-	return digestsManifest, nil
+	// Cache the manifest using the image reference pull spec
+	manifestsCache.Add(ref.String(), manifest, cacheTTL)
+
+	return manifest, nil
 }
 
 func (r *RegistryClientImageMetadataProvider) GetMetadata(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, []distribution.Descriptor, distribution.BlobStore, error) {

--- a/support/util/imagemetadata_test.go
+++ b/support/util/imagemetadata_test.go
@@ -112,40 +112,46 @@ func TestGetManifest(t *testing.T) {
 	pullSecret := []byte("{}")
 
 	testsCases := []struct {
-		name           string
-		imageRef       string
-		pullSecret     []byte
-		expectedErr    bool
-		validateCache  bool
-		expectedDigest digest.Digest
+		name             string
+		imageRef         string
+		pullSecret       []byte
+		expectedErr      bool
+		expectedCacheHit bool
 	}{
 		{
-			name:        "if failed to parse image reference",
-			imageRef:    "invalid-image-ref",
-			pullSecret:  pullSecret,
-			expectedErr: true,
+			name:             "if failed to parse image reference",
+			imageRef:         "invalid-image-ref",
+			pullSecret:       pullSecret,
+			expectedErr:      true,
+			expectedCacheHit: false,
 		},
 		{
-			name:        "Pull x86 manifest",
-			imageRef:    "quay.io/openshift-release-dev/ocp-release:4.16.12-x86_64",
-			pullSecret:  pullSecret,
-			expectedErr: false,
+			name:             "Pull x86 manifest",
+			imageRef:         "quay.io/openshift-release-dev/ocp-release:4.16.12-x86_64",
+			pullSecret:       pullSecret,
+			expectedErr:      false,
+			expectedCacheHit: true,
 		},
 		{
-			name:           "Pull x86 manifest from cache",
-			imageRef:       "quay.io/openshift-release-dev/ocp-release:4.16.12-x86_64",
-			pullSecret:     pullSecret,
-			expectedErr:    false,
-			validateCache:  true,
-			expectedDigest: "sha256:2a50e5d5267916078145731db740bbc85ee764e1a194715fd986ab5bf9a3414e",
+			name:             "Pull x86 manifest from cache",
+			imageRef:         "quay.io/openshift-release-dev/ocp-release:4.16.12-x86_64",
+			pullSecret:       pullSecret,
+			expectedErr:      false,
+			expectedCacheHit: true,
 		},
 		{
-			name:           "Pull Multiarch manifest",
-			imageRef:       "quay.io/openshift-release-dev/ocp-release:4.16.12-multi",
-			pullSecret:     pullSecret,
-			expectedErr:    false,
-			validateCache:  true,
-			expectedDigest: "sha256:727276732f03d8d5a2374efa3d01fb0ed9f65b32488b862e9a9d2ff4cde89ff6",
+			name:             "Pull Multiarch manifest",
+			imageRef:         "quay.io/openshift-release-dev/ocp-release:4.16.12-multi",
+			pullSecret:       pullSecret,
+			expectedErr:      false,
+			expectedCacheHit: true,
+		},
+		{
+			name:             "Pull Multiarch manifest with Shah",
+			imageRef:         "quay.io/openshift-release-dev/ocp-release@sha256:be8bcea2ab176321a4e1e54caab4709f9024bc437e52ca5bc088e729367cd0cf",
+			pullSecret:       pullSecret,
+			expectedErr:      false,
+			expectedCacheHit: true,
 		},
 	}
 
@@ -165,10 +171,10 @@ func TestGetManifest(t *testing.T) {
 				g.Expect(manifest).NotTo(BeNil())
 			}
 
-			if tc.validateCache {
-				_, exists := manifestsCache.Get(tc.expectedDigest)
-				g.Expect(exists).To(BeTrue())
-			}
+			parsedImageRef, err := reference.Parse(tc.imageRef)
+			g.Expect(err).NotTo(HaveOccurred())
+			_, exists := manifestsCache.Get(parsedImageRef.String())
+			g.Expect(exists).To(Equal(tc.expectedCacheHit))
 		})
 	}
 }

--- a/support/util/util_test.go
+++ b/support/util/util_test.go
@@ -565,6 +565,14 @@ func TestGetImageArchitecture(t *testing.T) {
 		expectErr             bool
 	}{
 		{
+			name:                  "Bad pull secret, cache empty; err",
+			image:                 "quay.io/openshift-release-dev/ocp-release:4.16.11-ppc64le",
+			pullSecretBytes:       []byte(""),
+			imageMetadataProvider: &RegistryClientImageMetadataProvider{},
+			expectedArch:          "",
+			expectErr:             true,
+		},
+		{
 			name:                  "Get amd64 from amd64 image; no err",
 			image:                 "quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64",
 			pullSecretBytes:       pullSecretBytes,
@@ -579,14 +587,6 @@ func TestGetImageArchitecture(t *testing.T) {
 			imageMetadataProvider: &RegistryClientImageMetadataProvider{},
 			expectedArch:          hyperv1.PPC64LE,
 			expectErr:             false,
-		},
-		{
-			name:                  "Bad pull secret; err",
-			image:                 "quay.io/openshift-release-dev/ocp-release:4.16.11-ppc64le",
-			pullSecretBytes:       []byte(""),
-			imageMetadataProvider: &RegistryClientImageMetadataProvider{},
-			expectedArch:          "",
-			expectErr:             true,
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows release images to utilize tags (instead of a shah) and still utilize the image and image metadata caches.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-53265

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.