### PR TITLE
WRKLDS-1676: ocm config: Update leaderElection.name

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-controller-manager/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-controller-manager/zz_fixture_TestControlPlaneComponents.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        component.hypershift.openshift.io/config-hash: c0288285
+        component.hypershift.openshift.io/config-hash: 3c0a48c9
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-controller-manager/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-controller-manager/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        component.hypershift.openshift.io/config-hash: c0288285
+        component.hypershift.openshift.io/config-hash: 3c0a48c9
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-controller-manager/config.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-controller-manager/config.yaml
@@ -34,6 +34,7 @@ data:
       kubeConfig: /etc/kubernetes/secrets/svc-kubeconfig/kubeconfig
     leaderElection:
       leaseDuration: 0s
+      name: openshift-master-controllers
       renewDeadline: 0s
       retryPeriod: 0s
     network:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ocm/testdata/zz_fixture_TestReconcileOpenShiftControllerManagerConfig_WithAllCapabilitiesEnabled.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ocm/testdata/zz_fixture_TestReconcileOpenShiftControllerManagerConfig_WithAllCapabilitiesEnabled.yaml
@@ -40,6 +40,7 @@ data:
       kubeConfig: /etc/kubernetes/secrets/svc-kubeconfig/kubeconfig
     leaderElection:
       leaseDuration: 0s
+      name: openshift-master-controllers
       renewDeadline: 0s
       retryPeriod: 0s
     network:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ocm/testdata/zz_fixture_TestReconcileOpenShiftControllerManagerConfig_WithImageRegistryCapabilityDisabled.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ocm/testdata/zz_fixture_TestReconcileOpenShiftControllerManagerConfig_WithImageRegistryCapabilityDisabled.yaml
@@ -42,6 +42,7 @@ data:
       kubeConfig: /etc/kubernetes/secrets/svc-kubeconfig/kubeconfig
     leaderElection:
       leaseDuration: 0s
+      name: openshift-master-controllers
       renewDeadline: 0s
       retryPeriod: 0s
     network:


### PR DESCRIPTION
**What this PR does / why we need it**:

OCM is being refactored to use library-go, which also means that the custom leader election lock name is not hard-coded in the executable any more and must be set in the config. And that is what this patch does.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:

Related to:

* https://issues.redhat.com/browse/WRKLDS-1676
* https://github.com/openshift/openshift-controller-manager/pull/378 

**Checklist**
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [X] This change includes unit tests.