### PR TITLE
CNTRLPLANE-201: feat(shared-ingress): Add el10 Containerfile

### DIFF
--- a/shared-ingress/Containerfile
+++ b/shared-ingress/Containerfile
@@ -1,0 +1,16 @@
+FROM registry.redhat.io/ubi10-beta/ubi:10.0-beta-1741674993
+
+RUN dnf install -y haproxy-3.0.5-4.el10 \
+  && dnf clean all
+
+ENTRYPOINT [ "/usr/sbin/haproxy" ]
+CMD ["-W", "-db", "-f", "/config/haproxy.cfg"]
+
+LABEL name="multicluster-engine/hypershift-shared-ingress"
+LABEL description="HyperShift's HAProxy 3 based Shared Ingress container"
+LABEL summary="HyperShift Shared Ingress"
+LABEL url="https://quay.io/repository/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress"
+LABEL version="3.0.5-4"
+LABEL com.redhat.component="multicluster-engine-hypershift-shared-ingress"
+LABEL io.openshift.tags="data,images"
+LABEL io.k8s.display-name="multicluster-engine-hypershift-shared-ingress"

--- a/shared-ingress/README.md
+++ b/shared-ingress/README.md
@@ -1,0 +1,11 @@
+# HAProxy v3 image for shared ingress in ARO/HCP
+
+This subdirectory contains the necessary files to perform a hermetic build of an
+HAProxy v3 image that we can use as a shared ingress router pod. Following best
+practices, we pin both the base image and the rpm versions of the dependencies
+we install. If you need to change them, do so and then regenerate the lock file
+doing:
+
+```shell
+rpm-lockfile-prototype --outfile=shared-ingress/rpms.lock.yaml shared-ingress/rpms.in.yaml
+```

--- a/shared-ingress/rpms.in.yaml
+++ b/shared-ingress/rpms.in.yaml
@@ -1,0 +1,11 @@
+contentOrigin:
+  repos:
+    - repoid: ubi-10-appstream-rpms
+      baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/${basearch}/appstream/os/
+packages:
+  - haproxy
+context:
+  containerfile: Containerfile
+arches:
+  - aarch64
+  - x86_64

--- a/shared-ingress/rpms.lock.yaml
+++ b/shared-ingress/rpms.lock.yaml
@@ -1,0 +1,26 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: aarch64
+  packages:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/appstream/os/Packages/h/haproxy-3.0.5-4.el10.aarch64.rpm
+    repoid: ubi-10-appstream-rpms
+    size: 2699949
+    checksum: sha256:e19b22e2a2b576ccda7a517e648593555150f5d0c09a3e1e3e41521ecbeb3f1f
+    name: haproxy
+    evr: 3.0.5-4.el10
+    sourcerpm: haproxy-3.0.5-4.el10.src.rpm
+  source: []
+  module_metadata: []
+- arch: x86_64
+  packages:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/appstream/os/Packages/h/haproxy-3.0.5-4.el10.x86_64.rpm
+    repoid: ubi-10-appstream-rpms
+    size: 2704478
+    checksum: sha256:4edc13a962fe3833b0ac2f6e240ff7e6a4453124391bbb9c4e2fe7fa20f6df60
+    name: haproxy
+    evr: 3.0.5-4.el10
+    sourcerpm: haproxy-3.0.5-4.el10.src.rpm
+  source: []
+  module_metadata: []


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit introduces:

* shared-ingress: Directory for the new HAProxy v3 container for shared ingress.
* shared-ingress/Containerfile: Containerfile to have Konflux build the new el10 HAProxy v3 image.
* shared-ingress/rpm.in.yaml: rpm-lockfile-prototype input file. This is used by rpm-lockfile-prototype to generate a lockfile for hermetic builds of the container image.
* shared-ingress/rpm.lock.yaml: The generated lockfile.

In order to generate the lockfile, I:

* Used a distrobox of fedora 41
* DNF installed python3-pip
* from the root of the repository I ran: rpm-lockfile-prototype --outfile=shared-ingress/rpms.lock.yaml shared-ingress/rpms.in.yaml

Should you want to change the HAProxy version, this should be done again.

Once this is merged, the next steps are:

- Build the Konflux pipeline
- Modify the image in use and the location of the ConfigMap in https://github.com/openshift/hypershift/blob/1923f5b84fa803f26e2ddd61ffbc83d9c3cbd8eb/hypershift-operator/controllers/sharedingress/router.go#L212-L215

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new container image with HAProxy 3 for use as a shared ingress router, supporting both aarch64 and x86_64 architectures.
- **Documentation**
  - Added a README with usage details and instructions for maintaining package version consistency.
- **Chores**
  - Added configuration and lock files to ensure reproducible builds and pinned package versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->