### PR TITLE
OCPBUGS-56457: Do not validate OCP API Server SANS if PKI reconciliation is disabled

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/validations/ocpapiserver.go
+++ b/hypershift-operator/controllers/hostedcluster/validations/ocpapiserver.go
@@ -33,6 +33,11 @@ func ValidateOCPAPIServerSANs(ctx context.Context, hc *hyperv1.HostedCluster, cl
 		kasIPs            = make([]string, 0)
 	)
 
+	// Only validate if PKI is being reconciled by Hypershift
+	if _, exists := hc.Annotations[hyperv1.DisablePKIReconciliationAnnotation]; exists {
+		return errs
+	}
+
 	// At this point, maybe the HCP is not there yet
 	if hc.Spec.Configuration != nil && hc.Spec.Configuration.APIServer != nil && hc.Spec.Configuration.APIServer.ServingCerts.NamedCertificates != nil {
 		for _, cert := range hc.Spec.Configuration.APIServer.ServingCerts.NamedCertificates {


### PR DESCRIPTION
**What this PR does / why we need it**:
Checks the DisablePKIReconciliationAnnotation annotation and only does OCP API Server SANs validation if not set.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-56457

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where SAN validation for serving certificates was incorrectly performed when PKI reconciliation was disabled via annotation.

- **Tests**
  - Added a test case to ensure that SAN validation is skipped when PKI reconciliation is disabled, even if the certificate data is invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->