### PR TITLE
CNTRLPLANE-905: feat(shared-ingress): add arm64 builds

### DIFF
--- a/.tekton/hypershift-shared-ingress-main-pull-request.yaml
+++ b/.tekton/hypershift-shared-ingress-main-pull-request.yaml
@@ -30,6 +30,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: /shared-ingress/Containerfile
   pipelineSpec:

--- a/.tekton/hypershift-shared-ingress-main-push.yaml
+++ b/.tekton/hypershift-shared-ingress-main-push.yaml
@@ -27,6 +27,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: /shared-ingress/Containerfile
   pipelineSpec:


### PR DESCRIPTION
**What this PR does / why we need it**:

Modifies the shared ingress Konflux pipelines so that they also build arm64.

**Which issue(s) this PR fixes** :
Fixes: #[CNTRLPLANE-905](https://issues.redhat.com//browse/CNTRLPLANE-905)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for building container images for both x86_64 and ARM64 platforms, enabling multi-architecture builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->