### PR TITLE
CNTRLPLANE-831: feat(konflux): add arm64 builds to cpo pipeline

### DIFF
--- a/.tekton/control-plane-operator-4-19-push.yaml
+++ b/.tekton/control-plane-operator-4-19-push.yaml
@@ -27,6 +27,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: /Containerfile.control-plane
   pipelineSpec:


### PR DESCRIPTION
**What this PR does / why we need it**:

CPO might run on both arm64 and amd64. We need to build both in case we need to override in either.

**Which issue(s) this PR fixes**:
Fixes #[CNTRLPLANE-831](https://issues.redhat.com//browse/CNTRLPLANE-831)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.