### PR TITLE
MGMT-20771: Enable disabling of Console capability

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -379,13 +379,14 @@ const (
 	PruneRetentionPolicy RetentionPolicy = "Prune"
 )
 
-// +kubebuilder:validation:Enum=ImageRegistry;openshift-samples;Insights;baremetal
+// +kubebuilder:validation:Enum=ImageRegistry;openshift-samples;Insights;baremetal;Console
 type OptionalCapability string
 
 const ImageRegistryCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityImageRegistry)
 const OpenShiftSamplesCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityOpenShiftSamples)
 const InsightsCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityInsights)
 const BaremetalCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityBaremetal)
+const ConsoleCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityConsole)
 
 // capabilities allows enabling or disabling optional components at install time.
 // When this is not supplied, the cluster will use the DefaultCapabilitySet defined for the respective
@@ -407,7 +408,7 @@ type Capabilities struct {
 	// disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
 	// Once set, this field cannot be changed.
 	//
-	// Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+	// Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
 	//
 	// +listType=atomic
 	// +immutable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -161,13 +161,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -186,6 +187,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -208,13 +208,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -233,6 +234,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -161,13 +161,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -186,6 +187,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -161,13 +161,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -186,6 +187,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -161,13 +161,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -186,6 +187,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -161,13 +161,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -186,6 +187,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -161,13 +161,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -186,6 +187,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -161,13 +161,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -186,6 +187,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -161,13 +161,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -186,6 +187,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -161,13 +161,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -186,6 +187,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -129,13 +129,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -154,6 +155,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -176,13 +176,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -201,6 +202,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -129,13 +129,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -154,6 +155,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -129,13 +129,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -154,6 +155,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -129,13 +129,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -154,6 +155,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -129,13 +129,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -154,6 +155,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -129,13 +129,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -154,6 +155,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -129,13 +129,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -154,6 +155,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -129,13 +129,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -154,6 +155,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -129,13 +129,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -154,6 +155,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -108,7 +108,7 @@ func bindCoreOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
 	flags.StringVar(&opts.PausedUntil, "pausedUntil", opts.PausedUntil, "If a date is provided in RFC3339 format, HostedCluster creation is paused until that date. If the boolean true is provided, HostedCluster creation is paused until the field is removed.")
 	flags.StringVar(&opts.ReleaseStream, "release-stream", opts.ReleaseStream, "The OCP release stream for the cluster (e.g. 4-stable-multi), this flag is ignored if release-image is set")
 	flags.StringVar(&opts.FeatureSet, "feature-set", opts.FeatureSet, "The predefined feature set to use for the cluster (TechPreviewNoUpgrade or DevPreviewNoUpgrade)")
-	flags.StringSliceVar(&opts.DisableClusterCapabilities, "disable-cluster-capabilities", nil, "Optional cluster capabilities to disable. The only currently supported values are ImageRegistry,openshift-samples,Insights,baremetal.")
+	flags.StringSliceVar(&opts.DisableClusterCapabilities, "disable-cluster-capabilities", nil, "Optional cluster capabilities to disable. The only currently supported values are ImageRegistry,openshift-samples,Insights,baremetal,Console.")
 	flags.StringSliceVar(&opts.EnableClusterCapabilities, "enable-cluster-capabilities", nil, "Optional cluster capabilities to enable. The only currently supported values are ImageRegistry,openshift-samples,Insights,baremetal.")
 	flags.StringVar(&opts.KubeAPIServerDNSName, "kas-dns-name", opts.KubeAPIServerDNSName, "The custom DNS name for the kube-apiserver service. Make sure the DNS name is valid and addressable.")
 }
@@ -712,6 +712,7 @@ func (opts *RawCreateOptions) Validate(ctx context.Context) (*ValidatedCreateOpt
 		string(hyperv1.OpenShiftSamplesCapability),
 		string(hyperv1.InsightsCapability),
 		string(hyperv1.BaremetalCapability),
+		string(hyperv1.ConsoleCapability),
 	)
 	if len(opts.DisableClusterCapabilities) > 0 {
 		for _, capability := range opts.DisableClusterCapabilities {

--- a/cmd/cluster/core/create_test.go
+++ b/cmd/cluster/core/create_test.go
@@ -255,6 +255,17 @@ func TestValidate(t *testing.T) {
 			expectedErr: "",
 		},
 		{
+			name: "passes with Console capability",
+			rawOpts: &RawCreateOptions{
+				Name:                       "test-hc",
+				Namespace:                  "test-hc",
+				PullSecretFile:             pullSecretFile,
+				Arch:                       "amd64",
+				DisableClusterCapabilities: []string{"Console"},
+			},
+			expectedErr: "",
+		},
+		{
 			name: "fails with an invalid DNS name as KubeAPIServerDNSName",
 			rawOpts: &RawCreateOptions{
 				Name:                 "test-hc",

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
@@ -211,13 +211,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -236,6 +237,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
@@ -164,13 +164,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -189,6 +190,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
@@ -211,13 +211,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -236,6 +237,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
@@ -179,13 +179,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -204,6 +205,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
@@ -132,13 +132,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -157,6 +158,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
@@ -179,13 +179,14 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array
@@ -204,6 +205,7 @@ spec:
                       - openshift-samples
                       - Insights
                       - baremetal
+                      - Console
                       type: string
                     maxItems: 25
                     type: array

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -985,7 +985,7 @@ func TestReconcileClusterVersionWithDisabledCapabilities(t *testing.T) {
 			ClusterID: "test-cluster-id",
 			Capabilities: &hyperv1.Capabilities{
 				Disabled: []hyperv1.OptionalCapability{
-					hyperv1.ImageRegistryCapability, hyperv1.OpenShiftSamplesCapability, hyperv1.InsightsCapability,
+					hyperv1.ImageRegistryCapability, hyperv1.OpenShiftSamplesCapability, hyperv1.InsightsCapability, hyperv1.ConsoleCapability,
 				},
 			},
 		},
@@ -1039,7 +1039,7 @@ func TestReconcileClusterVersionWithDisabledCapabilities(t *testing.T) {
 			configv1.ClusterVersionCapabilityCSISnapshot,
 			configv1.ClusterVersionCapabilityCloudControllerManager,
 			configv1.ClusterVersionCapabilityCloudCredential,
-			configv1.ClusterVersionCapabilityConsole,
+			//configv1.ClusterVersionCapabilityConsole,
 			configv1.ClusterVersionCapabilityDeploymentConfig,
 			// configv1.ClusterVersionCapabilityImageRegistry,
 			configv1.ClusterVersionCapabilityIngress,

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -3538,7 +3538,7 @@ Once set, this field cannot be changed.</p>
 <em>(Optional)</em>
 <p>disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
 Once set, this field cannot be changed.</p>
-<p>Note: Disabling &lsquo;openshift-samples&rsquo;,&lsquo;Insights&rsquo; are only supported in OpenShift versions 4.20 and above.</p>
+<p>Note: Disabling &lsquo;openshift-samples&rsquo;,&lsquo;Insights&rsquo;, &lsquo;Console&rsquo; are only supported in OpenShift versions 4.20 and above.</p>
 </td>
 </tr>
 </tbody>
@@ -9753,6 +9753,8 @@ ClusterVersionOperatorSpec
 </tr>
 </thead>
 <tbody><tr><td><p>&#34;baremetal&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;Console&#34;</p></td>
 <td></td>
 </tr><tr><td><p>&#34;ImageRegistry&#34;</p></td>
 <td></td>

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -2670,3 +2670,19 @@ func EnsureInsightsCapabilityDisabled(ctx context.Context, t *testing.T, g Gomeg
 		g.Expect(err.Error()).To(ContainSubstring("namespaces \"openshift-insights\" not found"))
 	})
 }
+
+// EnsureConsoleCapabilityDisabled validates the expectations for when ConsoleCapability is Disabled
+func EnsureConsoleCapabilityDisabled(ctx context.Context, t *testing.T, g Gomega, clients *GuestClients) {
+	t.Run("EnsureConsoleCapabilityDisabled", func(t *testing.T) {
+		AtLeast(t, Version420)
+
+		_, err := clients.CfgClient.ConfigV1().ClusterOperators().Get(ctx, "console", metav1.GetOptions{})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("clusteroperators.config.openshift.io \"console\" not found"))
+
+		// ensure console resources are not present
+		_, err = clients.KubeClient.CoreV1().Namespaces().Get(ctx, "openshift-console", metav1.GetOptions{})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("namespaces \"openshift-console\" not found"))
+	})
+}

--- a/test/e2e/util/version.go
+++ b/test/e2e/util/version.go
@@ -78,3 +78,7 @@ func CPOAtLeast(t *testing.T, version semver.Version, hc *hyperv1.HostedCluster)
 func IsLessThan(version semver.Version) bool {
 	return releaseVersion.LT(version)
 }
+
+func IsGreaterThanOrEqualTo(version semver.Version) bool {
+	return releaseVersion.GE(version)
+}

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -379,13 +379,14 @@ const (
 	PruneRetentionPolicy RetentionPolicy = "Prune"
 )
 
-// +kubebuilder:validation:Enum=ImageRegistry;openshift-samples;Insights;baremetal
+// +kubebuilder:validation:Enum=ImageRegistry;openshift-samples;Insights;baremetal;Console
 type OptionalCapability string
 
 const ImageRegistryCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityImageRegistry)
 const OpenShiftSamplesCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityOpenShiftSamples)
 const InsightsCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityInsights)
 const BaremetalCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityBaremetal)
+const ConsoleCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityConsole)
 
 // capabilities allows enabling or disabling optional components at install time.
 // When this is not supplied, the cluster will use the DefaultCapabilitySet defined for the respective
@@ -407,7 +408,7 @@ type Capabilities struct {
 	// disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
 	// Once set, this field cannot be changed.
 	//
-	// Note: Disabling 'openshift-samples','Insights' are only supported in OpenShift versions 4.20 and above.
+	// Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
 	//
 	// +listType=atomic
 	// +immutable


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is part of expanding support for disabling openshift capabilities in hypershift. This change adds support for disabling the Console capability, who managed by the Cluster Version Operator. Additional capabilities will be supported in future updates.

NOTE: OCPBUGS-57055 is a UX issue. Since the problem is limited to non-functional CRDs appearing, there’s no straightforward fix, and this behavior is already a known limitation in standalone OpenShift, it was decided not to block the “disable console” functionality in HyperShift because of it.

**Checklist**
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.