### PR TITLE
WIP: AUTOSCALE-266: Refactor karpenter-operator and karpenter into v2 components

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -45,6 +45,7 @@ import (
 	ignitionserverv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver"
 	ignitionproxyv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy"
 	ingressoperatorv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/ingressoperator"
+	karpenterv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/karpenter"
 	kasv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/kas"
 	kcmv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/kcm"
 	konnectivityv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/konnectivity_agent"
@@ -233,6 +234,7 @@ func (r *HostedControlPlaneReconciler) registerComponents() {
 		konnectivityv2.NewComponent(),
 		ignitionserverv2.NewComponent(r.ReleaseProvider, r.DefaultIngressDomain),
 		ignitionproxyv2.NewComponent(r.DefaultIngressDomain),
+		karpenterv2.NewComponent(),
 	)
 	r.components = append(r.components,
 		olmv2.NewComponents(r.ManagementClusterCapabilities.Has(capabilities.CapabilityImageStream))...,

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/karpenter-operator/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/karpenter-operator/deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: karpenter-operator
+  namespace: HCP_NAMESPACE
+  labels:
+    app: karpenter-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: karpenter-operator
+  template:
+    metadata:
+      labels:
+        app: karpenter-operator
+    spec:
+      serviceAccountName: karpenter-operator
+      terminationGracePeriodSeconds: 10
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          effect: "NoSchedule"
+      volumes:
+        - name: target-kubeconfig
+          secret:
+            secretName: hcco-kubeconfig
+            defaultMode: 0640
+            items:
+              - key: kubeconfig
+                path: target-kubeconfig
+      containers:
+        - name: karpenter-operator
+          image: karpenter-operator # replaced by adaptDeployment
+          command:
+            - "/usr/bin/karpenter-operator"
+          args:
+            - "--target-kubeconfig=/mnt/kubeconfig/target-kubeconfig"
+            - "--namespace=$(MY_NAMESPACE)"
+          env:
+            - name: MY_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources:
+            requests:
+              memory: "60Mi"
+              cpu: "10m"
+          volumeMounts:
+            - name: target-kubeconfig
+              mountPath: "/mnt/kubeconfig"

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/karpenter-operator/karpenter-credentials.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/karpenter-operator/karpenter-credentials.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  credentials: ""
+kind: Secret
+metadata:
+  name: karpenter-credentials
+type: Opaque

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/karpenter-operator/role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/karpenter-operator/role.yaml
@@ -1,0 +1,63 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: karpenter-operator
+  namespace: HCP_NAMESPACE
+rules:
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - "leases"
+    verbs:
+      - "get"
+      - "watch"
+      - "create"
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - "leases"
+    verbs:
+      - "patch"
+      - "update"
+    resourceNames:
+      - "karpenter-leader-election"
+  - apiGroups:
+      - "apps"
+    resources:
+      - "deployments"
+    verbs:
+      - "create"
+      - "update"
+      - "patch"
+      - "delete"
+      - "get"
+      - "list"
+      - "watch"
+  - apiGroups:
+      - ""
+    resources:
+      - "secrets"
+      - "serviceaccounts"
+    verbs:
+      - "*"
+  - apiGroups:
+      - "hypershift.openshift.io"
+    resources:
+      - "hostedcontrolplanes"
+      - "hostedcontrolplanes/finalizers"
+    verbs:
+      - "*"
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      - "roles"
+      - "rolebindings"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "create"
+      - "update"
+      - "patch"
+      - "delete"
+      - "deletecollection"

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/karpenter-operator/rolebinding.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/karpenter-operator/rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: karpenter-operator
+  namespace: HCP_NAMESPACE
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: karpenter-operator
+subjects:
+- kind: ServiceAccount
+  name: karpenter-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/karpenter-operator/serviceaccount.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/karpenter-operator/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: karpenter-operator
+  namespace: HCP_NAMESPACE

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/karpenter/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/karpenter/deployment.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: karpenter
+  namespace: HCP_NAMESPACE
+  labels:
+    app: karpenter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: karpenter
+  template:
+    metadata:
+      labels:
+        app: karpenter
+    spec:
+      serviceAccountName: karpenter
+      terminationGracePeriodSeconds: 10
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          effect: "NoSchedule"
+      volumes:
+        - name: target-kubeconfig
+          secret:
+            # secretName: to be replaced by adaptDeployment
+            defaultMode: 0640
+            items:
+              - key: value
+                path: target-kubeconfig
+        - name: serviceaccount-token
+          emptyDir: {}
+        - name: provider-creds
+          secret:
+            secretName: "karpenter-credentials"
+      containers:
+        - name: karpenter
+          image: karpenter # replaced by payload
+          args:
+            - "--log-level=debug"
+          env:
+            - name: KUBECONFIG
+              value: "/mnt/kubeconfig/target-kubeconfig"
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: DISABLE_WEBHOOK
+              value: "true"
+            - name: DISABLE_LEADER_ELECTION
+              value: "true"
+            - name: FEATURE_GATES
+              value: "Drift=true"
+            - name: AWS_SHARED_CREDENTIALS_FILE
+              value: "/etc/provider/credentials"
+            - name: AWS_SDK_LOAD_CONFIG
+              value: "true"
+            - name: HEALTH_PROBE_PORT
+              value: "8081"
+            - name: CLUSTER_ENDPOINT
+              value: "https://fake.com"
+          ports:
+            - name: metrics
+              containerPort: 8080
+            - name: http
+              containerPort: 8081
+              protocol: TCP
+          resources:
+            requests:
+              memory: "60Mi"
+              cpu: "10m"
+          volumeMounts:
+            - name: target-kubeconfig
+              mountPath: "/mnt/kubeconfig"
+            - name: provider-creds
+              mountPath: "/etc/provider"
+            - name: serviceaccount-token
+              mountPath: "/var/run/secrets/openshift/serviceaccount"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 60
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+            timeoutSeconds: 5

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/karpenter/role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/karpenter/role.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: karpenter
+  namespace: HCP_NAMESPACE
+rules:
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - "leases"
+    verbs:
+      - "get"
+      - "watch"
+      - "create"
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - "leases"
+    verbs:
+      - "patch"
+      - "update"
+    resourceNames:
+      - "karpenter-leader-election"

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/karpenter/rolebinding.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/karpenter/rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: karpenter
+  namespace: HCP_NAMESPACE
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: karpenter
+subjects:
+- kind: ServiceAccount
+  name: karpenter

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/karpenter/serviceacccount.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/karpenter/serviceacccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: karpenter
+  namespace: HCP_NAMESPACE

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/karpenter/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/karpenter/component.go
@@ -1,0 +1,65 @@
+package karpenter
+
+import (
+	"fmt"
+
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	karpenteroperatorv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/util"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	ComponentName = "karpenter"
+)
+
+var _ component.ComponentOptions = &karpenterOptions{}
+
+type karpenterOptions struct{}
+
+// IsRequestServing implements controlplanecomponent.ComponentOptions.
+func (c *karpenterOptions) IsRequestServing() bool {
+	return false
+}
+
+// MultiZoneSpread implements controlplanecomponent.ComponentOptions.
+func (c *karpenterOptions) MultiZoneSpread() bool {
+	return false
+}
+
+// NeedsManagementKASAccess implements controlplanecomponent.ComponentOptions.
+func (c *karpenterOptions) NeedsManagementKASAccess() bool {
+	return true
+}
+
+func NewComponent() component.ControlPlaneComponent {
+	return component.NewDeploymentComponent(ComponentName, &karpenterOptions{}).
+		WithAdaptFunction(adaptDeployment).
+		WithManifestAdapter(
+			"role.yaml",
+			component.WithAdaptFunction(adaptRole),
+		).
+		WithPredicate(predicate).
+		WithDependencies(karpenteroperatorv2.ComponentName).
+		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{}).
+		Build()
+}
+
+func predicate(cpContext component.WorkloadContext) (bool, error) {
+	hcp := cpContext.HCP
+
+	// The deployment depends on the kubeconfig being reported.
+	if hcp.Status.KubeConfig == nil {
+		return false, nil
+	}
+	// Resolve the kubeconfig secret for CAPI which the autoscaler is deployed alongside of.
+	capiKubeConfigSecret := manifests.KASServiceCAPIKubeconfigSecret(hcp.Namespace, hcp.Spec.InfraID)
+	err := cpContext.Client.Get(cpContext, client.ObjectKeyFromObject(capiKubeConfigSecret), capiKubeConfigSecret)
+	if err != nil {
+		return false, fmt.Errorf("failed to get hosted controlplane kubeconfig secret %q: %w", capiKubeConfigSecret.Name, err)
+	}
+
+	return true, nil
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/karpenter/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/karpenter/deployment.go
@@ -1,0 +1,82 @@
+package karpenter
+
+import (
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/util"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
+
+	component "github.com/openshift/hypershift/support/controlplane-component"
+
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+const (
+	kubeconfigVolumeName = "target-kubeconfig"
+)
+
+func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
+
+	hcp := cpContext.HCP
+
+	util.UpdateVolume(kubeconfigVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
+		v.Secret.SecretName = manifests.KASServiceCAPIKubeconfigSecret(hcp.Namespace, hcp.Spec.InfraID).Name
+	})
+
+	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+		c.Env = append(c.Env,
+			corev1.EnvVar{
+				Name:  "AWS_REGION",
+				Value: hcp.Spec.Platform.AWS.Region,
+			},
+			corev1.EnvVar{
+				Name:  "CLUSTER_NAME",
+				Value: hcp.Spec.InfraID,
+			},
+		)
+	})
+
+	image := cpContext.ReleaseImageProvider.GetImage("token-minter")
+	deployment.Spec.Template.Spec.InitContainers = append(deployment.Spec.Template.Spec.InitContainers,
+		corev1.Container{
+			Name:    "token-minter",
+			Image:   image,
+			Command: []string{"/usr/bin/control-plane-operator", "token-minter"},
+			Args: []string{
+				"--service-account-namespace=kube-system",
+				"--service-account-name=karpenter",
+				"--token-file=/var/run/secrets/openshift/serviceaccount/token",
+				"--kubeconfig=/mnt/kubeconfig/target-kubeconfig",
+			},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("30Mi"),
+				},
+			},
+			RestartPolicy: ptr.To(corev1.ContainerRestartPolicyAlways),
+			StartupProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					Exec: &corev1.ExecAction{
+						Command: []string{"cat", "/var/run/secrets/openshift/serviceaccount/token"}, // waits until the token file is created.
+					},
+				},
+				FailureThreshold: 10,
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "target-kubeconfig",
+					MountPath: "/mnt/kubeconfig",
+				},
+				{
+					Name:      "serviceaccount-token",
+					MountPath: "/var/run/secrets/openshift/serviceaccount",
+				},
+			},
+		},
+	)
+
+	return nil
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/karpenter/role.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/karpenter/role.go
@@ -1,0 +1,15 @@
+package karpenter
+
+import (
+	"github.com/openshift/hypershift/support/config"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func adaptRole(cpContext component.WorkloadContext, role *rbacv1.Role) error {
+	ownerRef := config.OwnerRefFrom(cpContext.HCP)
+	ownerRef.ApplyTo(role)
+
+	return nil
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/component.go
@@ -1,0 +1,66 @@
+package karpenteroperator
+
+import (
+	"fmt"
+
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	ComponentName = "karpenter-operator"
+)
+
+var _ component.ComponentOptions = &KarpenterOperatorOptions{}
+
+type KarpenterOperatorOptions struct {
+	HyperShiftOperatorImage   string
+	ControlPlaneOperatorImage string
+	KarpenterProviderAWSImage string
+	ControlPlaneContext       component.ControlPlaneContext
+}
+
+// IsRequestServing implements controlplanecomponent.ComponentOptions.
+func (c *KarpenterOperatorOptions) IsRequestServing() bool {
+	return false
+}
+
+// MultiZoneSpread implements controlplanecomponent.ComponentOptions.
+func (c *KarpenterOperatorOptions) MultiZoneSpread() bool {
+	return false
+}
+
+// NeedsManagementKASAccess implements controlplanecomponent.ComponentOptions.
+func (c *KarpenterOperatorOptions) NeedsManagementKASAccess() bool {
+	return true
+}
+
+func NewComponent(options *KarpenterOperatorOptions) component.ControlPlaneComponent {
+	return component.NewDeploymentComponent(ComponentName, options).
+		WithAdaptFunction(options.adaptDeployment).
+		WithManifestAdapter("karpenter-credentials.yaml",
+			component.WithAdaptFunction(adaptCredentialsSecret),
+			component.ReconcileExisting(),
+		).
+		WithPredicate(predicate).
+		Build()
+}
+
+func predicate(cpContext component.WorkloadContext) (bool, error) {
+	hcp := cpContext.HCP
+
+	// The deployment depends on the kubeconfig being reported.
+	if hcp.Status.KubeConfig == nil {
+		return false, nil
+	}
+	// Resolve the kubeconfig secret for HCCO which is used for karpenter for convenience.
+	kubeConfigSecret := manifests.HCCOKubeconfigSecret(hcp.Namespace)
+	err := cpContext.Client.Get(cpContext, client.ObjectKeyFromObject(kubeConfigSecret), kubeConfigSecret)
+	if err != nil {
+		return false, fmt.Errorf("failed to get hosted controlplane kubeconfig secret %q: %w", kubeConfigSecret.Name, err)
+	}
+
+	return true, nil
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/component.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/util"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -18,8 +19,6 @@ var _ component.ComponentOptions = &KarpenterOperatorOptions{}
 type KarpenterOperatorOptions struct {
 	HyperShiftOperatorImage   string
 	ControlPlaneOperatorImage string
-	KarpenterProviderAWSImage string
-	ControlPlaneContext       component.ControlPlaneContext
 }
 
 // IsRequestServing implements controlplanecomponent.ComponentOptions.
@@ -45,6 +44,7 @@ func NewComponent(options *KarpenterOperatorOptions) component.ControlPlaneCompo
 			component.ReconcileExisting(),
 		).
 		WithPredicate(predicate).
+		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{}).
 		Build()
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment.go
@@ -1,0 +1,108 @@
+package karpenteroperator
+
+import (
+	"fmt"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/util"
+
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	component "github.com/openshift/hypershift/support/controlplane-component"
+
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func (karp *KarpenterOperatorOptions) adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
+	hcp := cpContext.HCP
+
+	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+		c.Image = karp.HyperShiftOperatorImage
+	})
+
+	switch hcp.Spec.Platform.Type {
+	case hyperv1.AWSPlatform:
+		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes,
+			corev1.Volume{
+				Name: "serviceaccount-token",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{
+						Medium: corev1.StorageMediumMemory,
+					},
+				},
+			},
+			corev1.Volume{
+				Name: "provider-creds",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: "karpenter-credentials",
+					},
+				},
+			},
+		)
+		util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+			c.Env = append(c.Env,
+				corev1.EnvVar{
+					Name:  "AWS_SHARED_CREDENTIALS_FILE",
+					Value: "/etc/provider/credentials",
+				},
+				corev1.EnvVar{
+					Name:  "AWS_REGION",
+					Value: hcp.Spec.Platform.AWS.Region,
+				},
+				corev1.EnvVar{
+					Name:  "AWS_SDK_LOAD_CONFIG",
+					Value: "true",
+				},
+			)
+			c.VolumeMounts = append(c.VolumeMounts,
+				corev1.VolumeMount{
+					Name:      "serviceaccount-token",
+					MountPath: "/var/run/secrets/openshift/serviceaccount",
+				},
+				corev1.VolumeMount{
+					Name:      "provider-creds",
+					MountPath: "/etc/provider",
+				},
+			)
+			c.Args = append(c.Args,
+				"--control-plane-operator-image="+karp.ControlPlaneOperatorImage,
+				"--karpenter-provider-aws-image="+karp.KarpenterProviderAWSImage,
+			)
+		})
+	}
+
+	deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers,
+		corev1.Container{
+			Name:            "token-minter",
+			Image:           karp.ControlPlaneOperatorImage,
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Command:         []string{"/usr/bin/control-plane-operator", "token-minter"},
+			Args: []string{
+				"--service-account-namespace=kube-system",
+				"--service-account-name=karpenter",
+				"--token-file=/var/run/secrets/openshift/serviceaccount/token",
+				fmt.Sprintf("--kubeconfig-secret-namespace=%s", deployment.Namespace),
+				"--kubeconfig-secret-name=service-network-admin-kubeconfig",
+			},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10m"),
+					corev1.ResourceMemory: resource.MustParse("30Mi"),
+				},
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "serviceaccount-token",
+					MountPath: "/var/run/secrets/openshift/serviceaccount",
+				},
+			},
+		},
+	)
+
+	util.AvailabilityProber(kas.InClusterKASReadyURL(hcp.Spec.Platform.Type), karp.ControlPlaneOperatorImage, &deployment.Spec.Template.Spec)
+
+	return nil
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment.go
@@ -6,7 +6,6 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/util"
 
-	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -69,7 +68,6 @@ func (karp *KarpenterOperatorOptions) adaptDeployment(cpContext component.Worklo
 			)
 			c.Args = append(c.Args,
 				"--control-plane-operator-image="+karp.ControlPlaneOperatorImage,
-				"--karpenter-provider-aws-image="+karp.KarpenterProviderAWSImage,
 			)
 		})
 	}
@@ -101,8 +99,6 @@ func (karp *KarpenterOperatorOptions) adaptDeployment(cpContext component.Worklo
 			},
 		},
 	)
-
-	util.AvailabilityProber(kas.InClusterKASReadyURL(hcp.Spec.Platform.Type), karp.ControlPlaneOperatorImage, &deployment.Spec.Template.Spec)
 
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/secret.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/secret.go
@@ -1,0 +1,25 @@
+package karpenteroperator
+
+import (
+	"fmt"
+
+	component "github.com/openshift/hypershift/support/controlplane-component"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func adaptCredentialsSecret(cpContext component.WorkloadContext, secret *corev1.Secret) error {
+	hcp := cpContext.HCP
+
+	awsCredentialsTemplate := `[default]
+	role_arn = %s
+	web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
+	sts_regional_endpoints = regional
+`
+	arn := hcp.Spec.AutoNode.Provisioner.Karpenter.AWS.RoleARN
+
+	credentials := fmt.Sprintf(awsCredentialsTemplate, arn)
+	secret.Data = map[string][]byte{"credentials": []byte(credentials)}
+	secret.Type = corev1.SecretTypeOpaque
+	return nil
+}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1881,6 +1881,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 
 	imageProvider := imageprovider.New(releaseImage)
 	imageProvider.ComponentImages()["token-minter"] = utilitiesImage
+	imageProvider.ComponentImages()[hyperutil.AvailabilityProberImageName] = utilitiesImage
 	cpContext := controlplanecomponent.ControlPlaneContext{
 		Context:                   ctx,
 		Client:                    r.Client,

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1989,7 +1989,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	if err := r.reconcileKarpenterOperator(ctx, createOrUpdate, hcluster, hcp, r.HypershiftOperatorImage, controlPlaneOperatorImage); err != nil {
+	if err := r.reconcileKarpenterOperator(cpContext, createOrUpdate, hcluster, hcp, r.HypershiftOperatorImage, controlPlaneOperatorImage); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile karpenter operator: %w", err)
 	}
 

--- a/hypershift-operator/controllers/hostedcluster/karpenter.go
+++ b/hypershift-operator/controllers/hostedcluster/karpenter.go
@@ -17,10 +17,12 @@ import (
 	"fmt"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	karpenteroperatorv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/nodepool"
 	haproxy "github.com/openshift/hypershift/hypershift-operator/controllers/nodepool/apiserver-haproxy"
 	"github.com/openshift/hypershift/karpenter-operator/controllers/karpenter/assets"
-	karpenteroperatormanifest "github.com/openshift/hypershift/karpenter-operator/manifests"
+	controlplanecomponent "github.com/openshift/hypershift/support/controlplane-component"
+
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/upsert"
 	hyperutil "github.com/openshift/hypershift/support/util"
@@ -30,7 +32,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func (r *HostedClusterReconciler) reconcileKarpenterOperator(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane, hypershiftOperatorImage, controlPlaneOperatorImage string) error {
+func (r *HostedClusterReconciler) reconcileKarpenterOperator(cpContext controlplanecomponent.ControlPlaneContext, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane, hypershiftOperatorImage, controlPlaneOperatorImage string) error {
 	if hcluster.Spec.AutoNode == nil || hcluster.Spec.AutoNode.Provisioner.Name != hyperv1.ProvisionerKarpeneter ||
 		hcluster.Spec.AutoNode.Provisioner.Karpenter.Platform != hyperv1.AWSPlatform || hcluster.Status.KubeConfig == nil {
 		return nil
@@ -56,7 +58,7 @@ spec:
         value: "true"
         effect: "NoExecute"`
 
-	_, err := createOrUpdate(ctx, r.Client, configMap, func() error {
+	_, err := createOrUpdate(cpContext, r.Client, configMap, func() error {
 		configMap.Data = map[string]string{
 			"config": kubeletConfig,
 		}
@@ -84,22 +86,22 @@ spec:
 		},
 	}
 
-	releaseProvider, imageMetadataProvider, err := r.ReconcileMetadataProvidersImpl(ctx, r.RegistryOverrides)
+	releaseProvider, imageMetadataProvider, err := r.ReconcileMetadataProvidersImpl(cpContext, r.RegistryOverrides)
 	if err != nil {
 		return err
 	}
 
-	pullSecretBytes, err := hyperutil.GetPullSecretBytes(ctx, r.Client, hcluster)
+	pullSecretBytes, err := hyperutil.GetPullSecretBytes(cpContext, r.Client, hcluster)
 	if err != nil {
 		return err
 	}
 
-	releaseImage, err := releaseProvider.Lookup(ctx, nodePool.Spec.Release.Image, pullSecretBytes)
+	releaseImage, err := releaseProvider.Lookup(cpContext, nodePool.Spec.Release.Image, pullSecretBytes)
 	if err != nil {
 		return err
 	}
 
-	if err := r.reconcileKarpenterUserDataSecret(ctx, hcluster, releaseImage, nodePool, releaseProvider, imageMetadataProvider); err != nil {
+	if err := r.reconcileKarpenterUserDataSecret(cpContext, hcluster, releaseImage, nodePool, releaseProvider, imageMetadataProvider); err != nil {
 		return err
 	}
 
@@ -113,13 +115,20 @@ spec:
 		karpenterProviderAWSImage = assets.DefaultKarpenterProviderAWSImage
 	}
 
-	if err := karpenteroperatormanifest.ReconcileKarpenterOperator(ctx, createOrUpdate, r.Client, hypershiftOperatorImage, controlPlaneOperatorImage, karpenterProviderAWSImage, hcp); err != nil {
-		return err
+	karpenteroperator := karpenteroperatorv2.NewComponent(&karpenteroperatorv2.KarpenterOperatorOptions{
+		HyperShiftOperatorImage:   hypershiftOperatorImage,
+		ControlPlaneOperatorImage: controlPlaneOperatorImage,
+		KarpenterProviderAWSImage: karpenterProviderAWSImage,
+	})
+
+	if err := karpenteroperator.Reconcile(cpContext); err != nil {
+		return fmt.Errorf("failed to reconcile controlplane operator component: %w", err)
 	}
+
 	return nil
 }
 
-func (r *HostedClusterReconciler) reconcileKarpenterUserDataSecret(ctx context.Context, hcluster *hyperv1.HostedCluster, releaseImage *releaseinfo.ReleaseImage, nodePool *hyperv1.NodePool, releaseProvider releaseinfo.Provider, imageMetadataProvider hyperutil.ImageMetadataProvider) error {
+func (r *HostedClusterReconciler) reconcileKarpenterUserDataSecret(cpContext context.Context, hcluster *hyperv1.HostedCluster, releaseImage *releaseinfo.ReleaseImage, nodePool *hyperv1.NodePool, releaseProvider releaseinfo.Provider, imageMetadataProvider hyperutil.ImageMetadataProvider) error {
 	haProxyImage, ok := releaseImage.ComponentImages()[haproxy.HAProxyRouterImageName]
 	if !ok {
 		return fmt.Errorf("release image doesn't have %s image", haproxy.HAProxyRouterImageName)
@@ -132,24 +141,24 @@ func (r *HostedClusterReconciler) reconcileKarpenterUserDataSecret(ctx context.C
 		ReleaseProvider:         releaseProvider,
 		ImageMetadataProvider:   imageMetadataProvider,
 	}
-	haproxyRawConfig, err := haproxy.GenerateHAProxyRawConfig(ctx, hcluster)
+	haproxyRawConfig, err := haproxy.GenerateHAProxyRawConfig(cpContext, hcluster)
 	if err != nil {
 		return err
 	}
 
-	configGenerator, err := nodepool.NewConfigGenerator(ctx, r.Client, hcluster, nodePool, releaseImage, haproxyRawConfig)
+	configGenerator, err := nodepool.NewConfigGenerator(cpContext, r.Client, hcluster, nodePool, releaseImage, haproxyRawConfig)
 	if err != nil {
 		return fmt.Errorf("failed to generate config: %w", err)
 	}
 
-	token, err := nodepool.NewToken(ctx, configGenerator, &nodepool.CPOCapabilities{
+	token, err := nodepool.NewToken(cpContext, configGenerator, &nodepool.CPOCapabilities{
 		DecompressAndDecodeConfig: true,
 	})
 	if err != nil {
 		return err
 	}
 
-	if err := token.Reconcile(ctx); err != nil {
+	if err := token.Reconcile(cpContext); err != nil {
 		return err
 	}
 

--- a/hypershift-operator/controllers/hostedcluster/karpenter.go
+++ b/hypershift-operator/controllers/hostedcluster/karpenter.go
@@ -20,7 +20,6 @@ import (
 	karpenteroperatorv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/nodepool"
 	haproxy "github.com/openshift/hypershift/hypershift-operator/controllers/nodepool/apiserver-haproxy"
-	"github.com/openshift/hypershift/karpenter-operator/controllers/karpenter/assets"
 	controlplanecomponent "github.com/openshift/hypershift/support/controlplane-component"
 
 	"github.com/openshift/hypershift/support/releaseinfo"
@@ -109,16 +108,9 @@ spec:
 
 	// Run karpenter Operator to manage CRs management and guest side.
 
-	// TODO(jkyros): Grab the karpenter image in the proper place at the beginning with args, not here?
-	karpenterProviderAWSImage, hasImage := releaseImage.ComponentImages()["aws-karpenter-provider-aws"]
-	if !hasImage {
-		karpenterProviderAWSImage = assets.DefaultKarpenterProviderAWSImage
-	}
-
 	karpenteroperator := karpenteroperatorv2.NewComponent(&karpenteroperatorv2.KarpenterOperatorOptions{
 		HyperShiftOperatorImage:   hypershiftOperatorImage,
 		ControlPlaneOperatorImage: controlPlaneOperatorImage,
-		KarpenterProviderAWSImage: karpenterProviderAWSImage,
 	})
 
 	if err := karpenteroperator.Reconcile(cpContext); err != nil {

--- a/karpenter-operator/controllers/karpenter/karpenter_controller.go
+++ b/karpenter-operator/controllers/karpenter/karpenter_controller.go
@@ -47,7 +47,6 @@ type Reconciler struct {
 	GuestClient               client.Client
 	Namespace                 string
 	ControlPlaneOperatorImage string
-	KarpenterProviderAWSImage string
 	upsert.CreateOrUpdateProvider
 }
 
@@ -192,10 +191,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if err := r.reconcileOpenshiftEC2NodeClassDefault(ctx, hcp); err != nil {
 			return ctrl.Result{}, err
 		}
-	}
-
-	if err := r.reconcileKarpenter(ctx, hcp); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to reconcile karpenter deployment: %w", err)
 	}
 
 	if err := r.reconcileCRDs(ctx, false); err != nil {

--- a/karpenter-operator/controllers/karpenter/manifests.go
+++ b/karpenter-operator/controllers/karpenter/manifests.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
-	hyperkarpenterv1 "github.com/openshift/hypershift/api/karpenter/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/controlplaneoperator"
 	"github.com/openshift/hypershift/support/config"
@@ -73,7 +72,7 @@ func ReconcileKarpenterDeployment(deployment *appsv1.Deployment,
 	hcp *hyperv1.HostedControlPlane,
 	sa *corev1.ServiceAccount,
 	kubeConfigSecret *corev1.Secret,
-	availabilityProberImage, tokenMinterImage, karpenterProviderAWSImage string,
+	availabilityProberImage, tokenMinterImage string,
 	setDefaultSecurityContext bool,
 	ownerRef config.OwnerRef) error {
 
@@ -182,7 +181,7 @@ func ReconcileKarpenterDeployment(deployment *appsv1.Deployment,
 						Name:      karpenterName,
 						Resources: karpenterResources,
 						// TODO(alberto): lifecycle this image.
-						Image:           karpenterProviderAWSImage,
+						// Image:           karpenterProviderAWSImage,
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						VolumeMounts: []corev1.VolumeMount{
 							{
@@ -378,12 +377,6 @@ func (r *Reconciler) reconcileKarpenter(ctx context.Context, hcp *hyperv1.Hosted
 	setDefaultSecurityContext := false
 	availabilityProberImage := r.ControlPlaneOperatorImage
 	tokenMinterImage := r.ControlPlaneOperatorImage
-	karpenterProviderAWSImage, exists := hcp.Annotations[hyperkarpenterv1.KarpenterProviderAWSImage]
-	if !exists {
-		// TODO(jkyros): precedence ends up being annotation > payload > default with this here. I'd like to
-		// centralize the decision at a higher level so we can test it together
-		karpenterProviderAWSImage = r.KarpenterProviderAWSImage
-	}
 
 	role := KarpenterRole(hcp.Namespace)
 	_, err := createOrUpdate(ctx, c, role, func() error {
@@ -427,7 +420,7 @@ func (r *Reconciler) reconcileKarpenter(ctx context.Context, hcp *hyperv1.Hosted
 
 		deployment := KarpenterDeployment(hcp.Namespace)
 		_, err = createOrUpdate(ctx, c, deployment, func() error {
-			return ReconcileKarpenterDeployment(deployment, hcp, serviceAccount, capiKubeConfigSecret, availabilityProberImage, tokenMinterImage, karpenterProviderAWSImage, setDefaultSecurityContext, ownerRef)
+			return ReconcileKarpenterDeployment(deployment, hcp, serviceAccount, capiKubeConfigSecret, availabilityProberImage, tokenMinterImage, setDefaultSecurityContext, ownerRef)
 		})
 		if err != nil {
 			return fmt.Errorf("failed to reconcile karpenter deployment: %w", err)

--- a/karpenter-operator/main.go
+++ b/karpenter-operator/main.go
@@ -34,7 +34,6 @@ var (
 	targetKubeconfig          string
 	namespace                 string
 	controlPlaneOperatorImage string
-	karpenterProviderAWSImage string
 )
 
 func main() {
@@ -59,7 +58,6 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&targetKubeconfig, "target-kubeconfig", "", "Path to guest side kubeconfig file. Where the karpenter CRs (nodeClaim, nodePool, nodeClass) live")
 	rootCmd.PersistentFlags().StringVar(&namespace, "namespace", "", "The namespace to infer input for reconciliation, e.g the userData secret")
 	rootCmd.PersistentFlags().StringVar(&controlPlaneOperatorImage, "control-plane-operator-image", "", "The image to run the tokenMinter and the availability prober")
-	rootCmd.PersistentFlags().StringVar(&karpenterProviderAWSImage, "karpenter-provider-aws-image", "", "The image to run the actual platform-specific karpenter provider")
 
 	_ = rootCmd.MarkPersistentFlagRequired("target-kubeconfig")
 	_ = rootCmd.MarkPersistentFlagRequired("namespace")
@@ -124,7 +122,6 @@ func run(ctx context.Context) error {
 	r := karpenter.Reconciler{
 		Namespace:                 namespace,
 		ControlPlaneOperatorImage: controlPlaneOperatorImage,
-		KarpenterProviderAWSImage: karpenterProviderAWSImage,
 	}
 	if err := r.SetupWithManager(ctx, mgr, managementCluster); err != nil {
 		return fmt.Errorf("failed to setup controller with manager: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR refactors the karpenter-operator and karpenter into CPOv2 components.

As part of this PR, one of the commits allows the hcp_controller to now manage and reconcile the karpenter deployment instead of the karpenter-operator. This is needed because in order to use CPOv2, we need to pass in a cpoContext, and it is non-trivial to create a new cpoContext specially for the karpenter-operator container.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.