### PR TITLE
OCPBUGS-56430: Add DR operations after HC restoration

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -189,6 +189,12 @@ const (
 	ClusterSizeTransitionPending = "ClusterSizeTransitionPending"
 	// ClusterSizeTransitionRequired exposes the next t-shirt size that the cluster will transition to.
 	ClusterSizeTransitionRequired = "ClusterSizeTransitionRequired"
+
+	// HostedClusterRestoredFromBackup indicates that the HostedCluster was restored from backup.
+	// This condition is set to true when the HostedCluster is restored from backup and the recovery process is complete.
+	// This condition is used to track the status of the recovery process and to determine if the HostedCluster
+	// is ready to be used after restoration.
+	HostedClusterRestoredFromBackup ConditionType = "HostedClusterRestoredFromBackup"
 )
 
 // Reasons.
@@ -241,6 +247,8 @@ const (
 	KubeVirtSuboptimalMTUReason = "KubeVirtSuboptimalMTUDetected"
 
 	KubeVirtNodesLiveMigratableReason = "KubeVirtNodesNotLiveMigratable"
+
+	RecoveryFinishedReason = "RecoveryFinished"
 )
 
 // Messages.

--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -352,6 +352,12 @@ const (
 	// AWSMachinePublicIPs, if set to "true", results in an AWS machine template that creates machines with public IPs
 	// WARNING: This option is for development and testing purposes only
 	AWSMachinePublicIPs = "hypershift.openshift.io/aws-machine-public-ips"
+
+	// HostedClusterRestoredFromBackupAnnotation is set to true when the HostedCluster is restored from a backup using Hypershift
+	// OADP plugin. This annotation is set by the Hypershift OADP plugin during the Backup/Restore process. The annotation will trigger
+	// a process to check if the differents components in the DataPlane are working as expected. Checks:
+	// - Validates the monitoring stack is properly working after restoration, if not HCCO will restart the prometheus-k8s pods.
+	HostedClusterRestoredFromBackupAnnotation = "hypershift.openshift.io/restored-from-backup"
 )
 
 // RetentionPolicy defines the policy for handling resources associated with a cluster when the cluster is deleted.

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/recovery/recovery.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/recovery/recovery.go
@@ -1,0 +1,52 @@
+package recovery
+
+import (
+	"context"
+	"fmt"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func RecoverMonitoringStack(ctx context.Context, hcp *hyperv1.HostedControlPlane, c client.Client) error {
+	log := ctrl.LoggerFrom(ctx)
+	monitoringStackNS := "openshift-monitoring"
+	stsName := "prometheus-k8s"
+
+	// Check deployment of monitoring stack
+	prometheusSts := &appsv1.StatefulSet{}
+	err := c.Get(ctx, types.NamespacedName{Namespace: monitoringStackNS, Name: stsName}, prometheusSts)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get prometheus statefulSet %s in namespace %s: %w", stsName, monitoringStackNS, err)
+		}
+
+		return fmt.Errorf("prometheus statefulSet is still starting, rescheduling reconciliation: %w", err)
+	}
+
+	if prometheusSts.Status.ReadyReplicas < prometheusSts.Status.Replicas {
+		log.Info("Prometheus statefulSet not ready, deleting pods")
+		stsPods := &corev1.PodList{}
+		if err := c.List(ctx, stsPods, client.InNamespace(monitoringStackNS), client.MatchingLabels(prometheusSts.Spec.Selector.MatchLabels)); err != nil {
+			return fmt.Errorf("failed to list prometheus pods in namespace %s with labels %v: %w", monitoringStackNS, prometheusSts.Spec.Selector.MatchLabels, err)
+		}
+
+		// Delete pods associated to the statefulSet
+		for _, pod := range stsPods.Items {
+			if err := c.Delete(ctx, &pod); err != nil {
+				return fmt.Errorf("failed to delete pod %s: %w", pod.Name, err)
+			}
+		}
+
+		return fmt.Errorf("prometheus statefulSet pods were restarted, rescheduling reconciliation")
+	}
+
+	return nil
+}

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -4302,6 +4302,12 @@ The grace period is determined by the hypershift.openshift.io/destroy-grace-peri
 an initial deployment or upgrade.
 When this is false for too long and there&rsquo;s no clear indication in the &ldquo;Reason&rdquo;, please check the remaining more granular conditions.</p>
 </td>
+</tr><tr><td><p>&#34;HostedClusterRestoredFromBackup&#34;</p></td>
+<td><p>HostedClusterRestoredFromBackup indicates that the HostedCluster was restored from backup.
+This condition is set to true when the HostedCluster is restored from backup and the recovery process is complete.
+This condition is used to track the status of the recovery process and to determine if the HostedCluster
+is ready to be used after restoration.</p>
+</td>
 </tr><tr><td><p>&#34;Available&#34;</p></td>
 <td></td>
 </tr><tr><td><p>&#34;Degraded&#34;</p></td>

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -830,6 +830,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 			hyperv1.ValidHostedControlPlaneConfiguration,
 			hyperv1.ValidReleaseInfo,
 			hyperv1.ValidIDPConfiguration,
+			hyperv1.HostedClusterRestoredFromBackup,
 		}
 
 		for _, conditionType := range hcpConditions {
@@ -1346,6 +1347,53 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 			})
 			if statusErr := r.Client.Status().Update(ctx, hcluster); statusErr != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to reconcile platform credentials: %s, failed to update status: %w", err, statusErr)
+			}
+		}
+	}
+
+	// Set the HostedCluster restored from backup condition
+	{
+		if _, exists := hcluster.Annotations[hyperv1.HostedClusterRestoredFromBackupAnnotation]; exists {
+			freshCondition := &metav1.Condition{
+				Type:               string(hyperv1.HostedClusterRestoredFromBackup),
+				Reason:             hyperv1.RecoveryFinishedReason,
+				Status:             metav1.ConditionUnknown,
+				ObservedGeneration: hcluster.Generation,
+			}
+
+			if hcp != nil {
+				hostedClusterRestoredFromBackupCondition := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.HostedClusterRestoredFromBackup))
+				if hostedClusterRestoredFromBackupCondition != nil {
+					freshCondition = hostedClusterRestoredFromBackupCondition
+				}
+			}
+
+			oldCondition := meta.FindStatusCondition(hcluster.Status.Conditions, string(hyperv1.HostedClusterRestoredFromBackup))
+
+			// Preserve previous status if we can no longer determine the status
+			if oldCondition != nil && freshCondition.Status == metav1.ConditionUnknown {
+				freshCondition.Status = oldCondition.Status
+			}
+
+			// If the condition is not set, or the status is different, set the condition
+			if oldCondition == nil || oldCondition.Status != freshCondition.Status {
+				freshCondition.ObservedGeneration = hcluster.Generation
+			}
+
+			// If the condition is true, delete the hc annotation. It will be eventually bubbled down to the hcp.
+			if freshCondition.Status == metav1.ConditionTrue {
+				hclusterAnnotations := hcluster.GetAnnotations()
+				delete(hclusterAnnotations, hyperv1.HostedClusterRestoredFromBackupAnnotation)
+				hcluster.SetAnnotations(hclusterAnnotations)
+				if err := r.Update(ctx, hcluster); err != nil {
+					return ctrl.Result{}, fmt.Errorf("failed to remove annotations %v: %w", string(hyperv1.HostedClusterRestoredFromBackup), err)
+				}
+			}
+
+			// Persist status updates
+			meta.SetStatusCondition(&hcluster.Status.Conditions, *freshCondition)
+			if err := r.Client.Status().Update(ctx, hcluster); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to update status %v: %w", string(hyperv1.HostedClusterRestoredFromBackup), err)
 			}
 		}
 	}
@@ -2169,6 +2217,7 @@ func reconcileHostedControlPlaneAnnotations(hcp *hyperv1.HostedControlPlane, hcl
 		hyperv1.AWSMachinePublicIPs,
 		hyperkarpenterv1.KarpenterProviderAWSImage,
 		hyperv1.KubeAPIServerGoAwayChance,
+		hyperv1.HostedClusterRestoredFromBackupAnnotation,
 	}
 	for _, key := range mirroredAnnotations {
 		val, hasVal := hcluster.Annotations[key]

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -189,6 +189,12 @@ const (
 	ClusterSizeTransitionPending = "ClusterSizeTransitionPending"
 	// ClusterSizeTransitionRequired exposes the next t-shirt size that the cluster will transition to.
 	ClusterSizeTransitionRequired = "ClusterSizeTransitionRequired"
+
+	// HostedClusterRestoredFromBackup indicates that the HostedCluster was restored from backup.
+	// This condition is set to true when the HostedCluster is restored from backup and the recovery process is complete.
+	// This condition is used to track the status of the recovery process and to determine if the HostedCluster
+	// is ready to be used after restoration.
+	HostedClusterRestoredFromBackup ConditionType = "HostedClusterRestoredFromBackup"
 )
 
 // Reasons.
@@ -241,6 +247,8 @@ const (
 	KubeVirtSuboptimalMTUReason = "KubeVirtSuboptimalMTUDetected"
 
 	KubeVirtNodesLiveMigratableReason = "KubeVirtNodesNotLiveMigratable"
+
+	RecoveryFinishedReason = "RecoveryFinished"
 )
 
 // Messages.

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -352,6 +352,12 @@ const (
 	// AWSMachinePublicIPs, if set to "true", results in an AWS machine template that creates machines with public IPs
 	// WARNING: This option is for development and testing purposes only
 	AWSMachinePublicIPs = "hypershift.openshift.io/aws-machine-public-ips"
+
+	// HostedClusterRestoredFromBackupAnnotation is set to true when the HostedCluster is restored from a backup using Hypershift
+	// OADP plugin. This annotation is set by the Hypershift OADP plugin during the Backup/Restore process. The annotation will trigger
+	// a process to check if the differents components in the DataPlane are working as expected. Checks:
+	// - Validates the monitoring stack is properly working after restoration, if not HCCO will restart the prometheus-k8s pods.
+	HostedClusterRestoredFromBackupAnnotation = "hypershift.openshift.io/restored-from-backup"
 )
 
 // RetentionPolicy defines the policy for handling resources associated with a cluster when the cluster is deleted.


### PR DESCRIPTION
## What this PR does / why we need it
This PR includes a new annotation and a new condition for the hosted clusters that has been restored using the HCP OADP plugin.

- Annotation: `hypershift.openshift.io/restored-from-backup`
- Condition: `HostedClusterRestoredFromBackup`

The annotation will be included by the plugin on restored clusters. The HC Controller bubbles down the annotation to the HCP and the HCCO triggers a procedure that makes sure the recovery is done properly through some concrete checks in the DataPlane side.

Once the HCCO detects `HostedClusterRestoredFromBackupAnnotation` annotation it begins the recovery actions and sets the new condition called HostedClusterRestoredFromBackup. 

It will stays on False until all the procedures and checks ends properly. After that the HCCO sets the new condition signaling the HostedCluster controller to remove the annotation of `HostedClusterRestoredFromBackupAnnotation` from the HC

## Which issue(s) this PR fixes:
- Fixes [OCPBUGS-56430](https://issues.redhat.com/browse/OCPBUGS-56430)

## Related PRs
- https://github.com/openshift/hypershift-oadp-plugin/pull/60
- https://github.com/openshift/hypershift-oadp-plugin/pull/62