### PR TITLE
MGMT-20682: Enable disabling of openshift-samples capability

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -369,10 +369,12 @@ const (
 	PruneRetentionPolicy RetentionPolicy = "Prune"
 )
 
-// +kubebuilder:validation:Enum=ImageRegistry
+// +kubebuilder:validation:Enum=ImageRegistry;openshift-samples
 type OptionalCapability string
 
 const ImageRegistryCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityImageRegistry)
+
+const OpenShiftSamplesCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityOpenShiftSamples)
 
 // capabilities allows disabling optional components at install time.
 // Once set, it cannot be changed.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -169,6 +169,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -216,6 +216,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -169,6 +169,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -169,6 +169,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -169,6 +169,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -169,6 +169,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -169,6 +169,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -169,6 +169,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -169,6 +169,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -169,6 +169,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -137,6 +137,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -184,6 +184,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -137,6 +137,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -137,6 +137,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -137,6 +137,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -137,6 +137,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -137,6 +137,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -137,6 +137,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -137,6 +137,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -137,6 +137,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/cmd/cluster/core/create_test.go
+++ b/cmd/cluster/core/create_test.go
@@ -204,7 +204,7 @@ func TestValidate(t *testing.T) {
 				Arch:                       "amd64",
 				DisableClusterCapabilities: []string{"UnsupportedCapability"},
 			},
-			expectedErr: "unknown capability, accepted values are:",
+			expectedErr: "unknown capability: UnsupportedCapability, accepted values are:",
 		},
 		{
 			name: "passes with ImageRegistry capability",
@@ -214,6 +214,17 @@ func TestValidate(t *testing.T) {
 				PullSecretFile:             pullSecretFile,
 				Arch:                       "amd64",
 				DisableClusterCapabilities: []string{"ImageRegistry"},
+			},
+			expectedErr: "",
+		},
+		{
+			name: "passes with openshift-samples capability",
+			rawOpts: &RawCreateOptions{
+				Name:                       "test-hc",
+				Namespace:                  "test-hc",
+				PullSecretFile:             pullSecretFile,
+				Arch:                       "amd64",
+				DisableClusterCapabilities: []string{"openshift-samples"},
 			},
 			expectedErr: "",
 		},

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
@@ -219,6 +219,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
@@ -172,6 +172,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
@@ -219,6 +219,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
@@ -187,6 +187,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
@@ -140,6 +140,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
@@ -187,6 +187,7 @@ spec:
                     items:
                       enum:
                       - ImageRegistry
+                      - openshift-samples
                       type: string
                     maxItems: 25
                     type: array

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment.go
@@ -69,7 +69,7 @@ func (cvo *clusterVersionOperator) adaptDeployment(cpContext component.WorkloadC
 			ClusterID: configv1.ClusterID(cpContext.HCP.Spec.ClusterID),
 		},
 	}
-	if !capabilities.IsImageRegistryCapabilityEnabled(cpContext.HCP.Spec.Capabilities) {
+	if capabilities.HasDisabledCapabilities(cpContext.HCP.Spec.Capabilities) {
 		cv.Spec.Capabilities = &configv1.ClusterVersionCapabilitiesSpec{
 			BaselineCapabilitySet:         configv1.ClusterVersionCapabilitySetNone,
 			AdditionalEnabledCapabilities: capabilities.CalculateEnabledCapabilities(cpContext.HCP.Spec.Capabilities),

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1240,7 +1240,7 @@ func (r *reconciler) reconcileClusterVersion(ctx context.Context, hcp *hyperv1.H
 	if _, err := r.CreateOrUpdate(ctx, r.client, clusterVersion, func() error {
 		clusterVersion.Spec.ClusterID = configv1.ClusterID(hcp.Spec.ClusterID)
 		clusterVersion.Spec.Capabilities = nil
-		if !capabilities.IsImageRegistryCapabilityEnabled(hcp.Spec.Capabilities) {
+		if capabilities.HasDisabledCapabilities(hcp.Spec.Capabilities) {
 			clusterVersion.Spec.Capabilities = &configv1.ClusterVersionCapabilitiesSpec{
 				BaselineCapabilitySet:         configv1.ClusterVersionCapabilitySetNone,
 				AdditionalEnabledCapabilities: capabilities.CalculateEnabledCapabilities(hcp.Spec.Capabilities),

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -961,7 +961,7 @@ func TestReconcileClusterVersionWithDisabledCapabilities(t *testing.T) {
 			ClusterID: "test-cluster-id",
 			Capabilities: &hyperv1.Capabilities{
 				Disabled: []hyperv1.OptionalCapability{
-					hyperv1.ImageRegistryCapability,
+					hyperv1.ImageRegistryCapability, hyperv1.OpenShiftSamplesCapability,
 				},
 			},
 		},
@@ -1027,7 +1027,7 @@ func TestReconcileClusterVersionWithDisabledCapabilities(t *testing.T) {
 			configv1.ClusterVersionCapabilityStorage,
 			configv1.ClusterVersionCapabilityBaremetal,
 			configv1.ClusterVersionCapabilityMarketplace,
-			configv1.ClusterVersionCapabilityOpenShiftSamples,
+			//configv1.ClusterVersionCapabilityOpenShiftSamples,
 		},
 	}
 	g.Expect(clusterVersion.Spec.Capabilities).To(Equal(expectedCapabilities))

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -9733,6 +9733,8 @@ ClusterVersionOperatorSpec
 </thead>
 <tbody><tr><td><p>&#34;ImageRegistry&#34;</p></td>
 <td></td>
+</tr><tr><td><p>&#34;openshift-samples&#34;</p></td>
+<td></td>
 </tr></tbody>
 </table>
 ###PayloadArchType { #hypershift.openshift.io/v1beta1.PayloadArchType }

--- a/support/capabilities/hosted_control_plane_capabilities.go
+++ b/support/capabilities/hosted_control_plane_capabilities.go
@@ -11,6 +11,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
+// HasDisabledCapabilities returns true if any capabilities are disabled; otherwise, it returns false.
+func HasDisabledCapabilities(capabilities *hyperv1.Capabilities) bool {
+	if capabilities == nil {
+		return false
+	}
+	return len(capabilities.Disabled) > 0
+}
+
 // IsImageRegistryCapabilityEnabled returns true if the Image Registry
 // capability is enabled, or false if disabled.
 //

--- a/support/capabilities/hosted_control_plane_capabilities_test.go
+++ b/support/capabilities/hosted_control_plane_capabilities_test.go
@@ -111,3 +111,37 @@ func TestCalculateEnabledCapabilities(t *testing.T) {
 		})
 	}
 }
+
+func TestHasDisabledCapabilities(t *testing.T) {
+	tests := []struct {
+		name                 string
+		disabledCapabilities []hyperv1.OptionalCapability
+		expectResult         bool
+	}{
+		{
+			name:                 "returns false when none capabilities are disabled",
+			disabledCapabilities: nil,
+			expectResult:         false,
+		},
+		{
+			name:                 "returns true if any capabilities are disabled",
+			disabledCapabilities: []hyperv1.OptionalCapability{hyperv1.OpenShiftSamplesCapability},
+			expectResult:         true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			caps := &hyperv1.Capabilities{
+				Disabled: test.disabledCapabilities,
+			}
+			hasDisabledCapabilities := HasDisabledCapabilities(caps)
+			if test.expectResult && !hasDisabledCapabilities {
+				t.Fatal("expected HasDisabledCapabilities, to be true, but it wasn't")
+			}
+			if !test.expectResult && hasDisabledCapabilities {
+				t.Fatal("expected HasDisabledCapabilities, to be false, but it wasn't")
+			}
+		})
+	}
+}

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -64,6 +64,17 @@ func TestOnCreateAPIUX(t *testing.T) {
 						expectedErrorSubstring: "",
 					},
 					{
+						name: "when capabilities.disabled is set to openshift-samples it should pass",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.Capabilities = &hyperv1.Capabilities{
+								Disabled: []hyperv1.OptionalCapability{
+									hyperv1.OpenShiftSamplesCapability,
+								},
+							}
+						},
+						expectedErrorSubstring: "",
+					},
+					{
 						name: "when capabilities.disabled is set to an unsupported capability it should fail",
 						mutateInput: func(hc *hyperv1.HostedCluster) {
 							hc.Spec.Capabilities = &hyperv1.Capabilities{
@@ -1288,6 +1299,7 @@ func TestCreateClusterCustomConfig(t *testing.T) {
 			hc.Spec.Capabilities = &hyperv1.Capabilities{
 				Disabled: []hyperv1.OptionalCapability{
 					hyperv1.ImageRegistryCapability,
+					hyperv1.OpenShiftSamplesCapability,
 				},
 			}
 		}
@@ -1311,8 +1323,13 @@ func TestCreateClusterCustomConfig(t *testing.T) {
 		// test oauth with identity provider
 		e2eutil.EnsureOAuthWithIdentityProvider(t, ctx, mgtClient, hostedCluster)
 
+		clients := e2eutil.InitGuestClients(ctx, t, g, mgtClient, hostedCluster)
+
 		// ensure image registry component is disabled
-		e2eutil.EnsureImageRegistryCapabilityDisabled(ctx, t, g, mgtClient, hostedCluster)
+		e2eutil.EnsureImageRegistryCapabilityDisabled(ctx, t, g, clients)
+
+		// ensure openshift-samples component is disabled
+		e2eutil.EnsureOpenshiftSamplesCapabilityDisabled(ctx, t, g, clients)
 
 		// ensure KAS DNS name is configured with a KAS Serving cert
 		e2eutil.EnsureKubeAPIDNSNameCustomCert(t, ctx, mgtClient, hostedCluster)

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -369,10 +369,12 @@ const (
 	PruneRetentionPolicy RetentionPolicy = "Prune"
 )
 
-// +kubebuilder:validation:Enum=ImageRegistry
+// +kubebuilder:validation:Enum=ImageRegistry;openshift-samples
 type OptionalCapability string
 
 const ImageRegistryCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityImageRegistry)
+
+const OpenShiftSamplesCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityOpenShiftSamples)
 
 // capabilities allows disabling optional components at install time.
 // Once set, it cannot be changed.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is the first step in expanding support for disabling openshift capabilities in hypershift. Currently, only the ImageRegistry capability can be disabled. This change adds support for disabling the openshift-samples capability, who managed by the Cluster Version Operator. Additional capabilities will be supported in future updates.

**Checklist**
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [X] This change includes unit tests.