### PR TITLE
OCPBUGS-57450: Router publish strategy related changes for IBM Cloud platform

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1551,12 +1551,12 @@ func (r *HostedControlPlaneReconciler) reconcileAPIServerServiceStatus(ctx conte
 		return "", 0, "", errors.New("APIServer service strategy not specified")
 	}
 
-	if sharedingress.UseSharedIngress() || hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
+	if sharedingress.UseSharedIngress() || (hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform && serviceStrategy.Type == hyperv1.Route) {
 		return sharedingress.Hostname(hcp), sharedingress.ExternalDNSLBPort, "", nil
 	}
 
 	var svc *corev1.Service
-	if serviceStrategy.Type == hyperv1.Route && hcp.Spec.Platform.Type != hyperv1.IBMCloudPlatform {
+	if serviceStrategy.Type == hyperv1.Route {
 		if util.IsPublicHCP(hcp) {
 			svc = manifests.RouterPublicService(hcp.Namespace)
 		} else {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -291,7 +291,7 @@ func ReconcileKonnectivityServerService(svc *corev1.Service, ownerRef config.Own
 			portSpec.NodePort = strategy.NodePort.Port
 		}
 	case hyperv1.Route:
-		if ((hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform) && (svc.Spec.Type != corev1.ServiceTypeNodePort)) || (hcp.Spec.Platform.Type != hyperv1.IBMCloudPlatform) {
+		if hcp.Spec.Platform.Type != hyperv1.IBMCloudPlatform || svc.Spec.Type != corev1.ServiceTypeNodePort {
 			svc.Spec.Type = corev1.ServiceTypeClusterIP
 		}
 	default:

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -87,7 +87,9 @@ func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingSt
 			portSpec.NodePort = strategy.NodePort.Port
 		}
 	case hyperv1.Route:
-		svc.Spec.Type = corev1.ServiceTypeClusterIP
+		if ((hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform) && (svc.Spec.Type != corev1.ServiceTypeNodePort)) || (hcp.Spec.Platform.Type != hyperv1.IBMCloudPlatform) {
+			svc.Spec.Type = corev1.ServiceTypeClusterIP
+		}
 	default:
 		return fmt.Errorf("invalid publishing strategy for Kube API server service: %s", strategy.Type)
 	}
@@ -289,7 +291,9 @@ func ReconcileKonnectivityServerService(svc *corev1.Service, ownerRef config.Own
 			portSpec.NodePort = strategy.NodePort.Port
 		}
 	case hyperv1.Route:
-		svc.Spec.Type = corev1.ServiceTypeClusterIP
+		if ((hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform) && (svc.Spec.Type != corev1.ServiceTypeNodePort)) || (hcp.Spec.Platform.Type != hyperv1.IBMCloudPlatform) {
+			svc.Spec.Type = corev1.ServiceTypeClusterIP
+		}
 	default:
 		return fmt.Errorf("invalid publishing strategy for Konnectivity service: %s", strategy.Type)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -87,7 +87,7 @@ func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingSt
 			portSpec.NodePort = strategy.NodePort.Port
 		}
 	case hyperv1.Route:
-		if ((hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform) && (svc.Spec.Type != corev1.ServiceTypeNodePort)) || (hcp.Spec.Platform.Type != hyperv1.IBMCloudPlatform) {
+		if hcp.Spec.Platform.Type != hyperv1.IBMCloudPlatform || svc.Spec.Type != corev1.ServiceTypeNodePort {
 			svc.Spec.Type = corev1.ServiceTypeClusterIP
 		}
 	default:

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service_test.go
@@ -6,10 +6,9 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/config"
 
-	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -19,8 +18,8 @@ func TestReconcileService(t *testing.T) {
 
 	testCases := []struct {
 		name          string
-		platform      v1beta1.PlatformType
-		strategy      v1beta1.ServicePublishingStrategy
+		platform      hyperv1.PlatformType
+		strategy      hyperv1.ServicePublishingStrategy
 		apiServerPort int
 		svc_in        corev1.Service
 		svc_out       corev1.Service
@@ -28,8 +27,8 @@ func TestReconcileService(t *testing.T) {
 	}{
 		{
 			name:          "IBM Cloud, NodePort strategy, NodePort service, expected to fill port number from strategy",
-			platform:      v1beta1.IBMCloudPlatform,
-			strategy:      v1beta1.ServicePublishingStrategy{Type: v1beta1.NodePort, NodePort: &v1beta1.NodePortPublishingStrategy{Port: 31125}},
+			platform:      hyperv1.IBMCloudPlatform,
+			strategy:      hyperv1.ServicePublishingStrategy{Type: hyperv1.NodePort, NodePort: &hyperv1.NodePortPublishingStrategy{Port: 31125}},
 			apiServerPort: 1125,
 			svc_in: corev1.Service{Spec: corev1.ServiceSpec{
 				Type: corev1.ServiceTypeNodePort,
@@ -55,8 +54,8 @@ func TestReconcileService(t *testing.T) {
 		},
 		{
 			name:          "IBM Cloud, Route strategy, NodePort service with existing port number, expected not to change",
-			platform:      v1beta1.IBMCloudPlatform,
-			strategy:      v1beta1.ServicePublishingStrategy{Type: v1beta1.Route},
+			platform:      hyperv1.IBMCloudPlatform,
+			strategy:      hyperv1.ServicePublishingStrategy{Type: hyperv1.Route},
 			apiServerPort: 1125,
 			svc_in: corev1.Service{Spec: corev1.ServiceSpec{
 				Type: corev1.ServiceTypeNodePort,
@@ -83,8 +82,8 @@ func TestReconcileService(t *testing.T) {
 		},
 		{
 			name:          "Non-IBM Cloud, Route strategy, ClusterIP service, expected to fill port value only",
-			platform:      v1beta1.AWSPlatform,
-			strategy:      v1beta1.ServicePublishingStrategy{Type: v1beta1.Route},
+			platform:      hyperv1.AWSPlatform,
+			strategy:      hyperv1.ServicePublishingStrategy{Type: hyperv1.Route},
 			apiServerPort: 1125,
 			svc_in: corev1.Service{Spec: corev1.ServiceSpec{
 				Type: corev1.ServiceTypeClusterIP,
@@ -103,7 +102,7 @@ func TestReconcileService(t *testing.T) {
 		},
 		{
 			name:     "Invalid strategy",
-			strategy: v1beta1.ServicePublishingStrategy{Type: v1beta1.None},
+			strategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.None},
 			err:      fmt.Errorf("invalid publishing strategy for Kube API server service: None"),
 		},
 	}
@@ -130,16 +129,16 @@ func TestKonnectivityServiceReconcile(t *testing.T) {
 
 	testCases := []struct {
 		name     string
-		platform v1beta1.PlatformType
-		strategy v1beta1.ServicePublishingStrategy
+		platform hyperv1.PlatformType
+		strategy hyperv1.ServicePublishingStrategy
 		svc_in   corev1.Service
 		svc_out  corev1.Service
 		err      error
 	}{
 		{
 			name:     "IBM Cloud, NodePort strategy, NodePort service, expected to fill port number from strategy",
-			platform: v1beta1.IBMCloudPlatform,
-			strategy: v1beta1.ServicePublishingStrategy{Type: v1beta1.NodePort, NodePort: &v1beta1.NodePortPublishingStrategy{Port: 1125}},
+			platform: hyperv1.IBMCloudPlatform,
+			strategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.NodePort, NodePort: &hyperv1.NodePortPublishingStrategy{Port: 1125}},
 			svc_in: corev1.Service{Spec: corev1.ServiceSpec{
 				Type: corev1.ServiceTypeNodePort,
 			}},
@@ -158,8 +157,8 @@ func TestKonnectivityServiceReconcile(t *testing.T) {
 		},
 		{
 			name:     "IBM Cloud, Route strategy, NodePort service with existing port number, expected not to change",
-			platform: v1beta1.IBMCloudPlatform,
-			strategy: v1beta1.ServicePublishingStrategy{Type: v1beta1.Route},
+			platform: hyperv1.IBMCloudPlatform,
+			strategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.Route},
 			svc_in: corev1.Service{Spec: corev1.ServiceSpec{
 				Type: corev1.ServiceTypeNodePort,
 				Ports: []corev1.ServicePort{
@@ -186,8 +185,8 @@ func TestKonnectivityServiceReconcile(t *testing.T) {
 		},
 		{
 			name:     "Non-IBM Cloud, Route strategy, ClusterIP service, expected to fill port value only",
-			platform: v1beta1.AWSPlatform,
-			strategy: v1beta1.ServicePublishingStrategy{Type: v1beta1.Route},
+			platform: hyperv1.AWSPlatform,
+			strategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.Route},
 			svc_in: corev1.Service{Spec: corev1.ServiceSpec{
 				Type: corev1.ServiceTypeClusterIP,
 			}},
@@ -205,7 +204,7 @@ func TestKonnectivityServiceReconcile(t *testing.T) {
 		},
 		{
 			name:     "Invalid strategy",
-			strategy: v1beta1.ServicePublishingStrategy{Type: v1beta1.None},
+			strategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.None},
 			err:      fmt.Errorf("invalid publishing strategy for Konnectivity service: None"),
 		},
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service_test.go
@@ -11,8 +11,119 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
+
+func TestReconcileService(t *testing.T) {
+
+	testCases := []struct {
+		name          string
+		platform      v1beta1.PlatformType
+		strategy      v1beta1.ServicePublishingStrategy
+		apiServerPort int
+		svc_in        corev1.Service
+		svc_out       corev1.Service
+		err           error
+	}{
+		{
+			name:          "IBM Cloud, NodePort strategy, NodePort service, expected to fill port number from strategy",
+			platform:      v1beta1.IBMCloudPlatform,
+			strategy:      v1beta1.ServicePublishingStrategy{Type: v1beta1.NodePort, NodePort: &v1beta1.NodePortPublishingStrategy{Port: 31125}},
+			apiServerPort: 1125,
+			svc_in: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol: corev1.ProtocolTCP,
+						Port:     1125,
+					},
+				},
+			}},
+			svc_out: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol:   corev1.ProtocolTCP,
+						Port:       1125,
+						TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: "client"},
+						NodePort:   31125,
+					},
+				},
+			}},
+			err: nil,
+		},
+		{
+			name:          "IBM Cloud, Route strategy, NodePort service with existing port number, expected not to change",
+			platform:      v1beta1.IBMCloudPlatform,
+			strategy:      v1beta1.ServicePublishingStrategy{Type: v1beta1.Route},
+			apiServerPort: 1125,
+			svc_in: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol: corev1.ProtocolTCP,
+						Port:     1125,
+						NodePort: 1125,
+					},
+				},
+			}},
+			svc_out: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol:   corev1.ProtocolTCP,
+						Port:       1125,
+						TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: "client"},
+						NodePort:   1125,
+					},
+				},
+			}},
+			err: nil,
+		},
+		{
+			name:          "Non-IBM Cloud, Route strategy, ClusterIP service, expected to fill port value only",
+			platform:      v1beta1.AWSPlatform,
+			strategy:      v1beta1.ServicePublishingStrategy{Type: v1beta1.Route},
+			apiServerPort: 1125,
+			svc_in: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+			}},
+			svc_out: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol:   corev1.ProtocolTCP,
+						Port:       1125,
+						TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: "client"},
+					},
+				},
+			}},
+			err: nil,
+		},
+		{
+			name:     "Invalid strategy",
+			strategy: v1beta1.ServicePublishingStrategy{Type: v1beta1.None},
+			err:      fmt.Errorf("invalid publishing strategy for Kube API server service: None"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hcp := hyperv1.HostedControlPlane{Spec: hyperv1.HostedControlPlaneSpec{Platform: hyperv1.PlatformSpec{Type: tc.platform}}}
+
+			err := ReconcileService(&tc.svc_in, &tc.strategy, &v1.OwnerReference{}, tc.apiServerPort, []string{}, &hcp)
+
+			g := NewWithT(t)
+			if tc.err == nil {
+				g.Expect(err).To(BeNil())
+				g.Expect(tc.svc_in.Spec.Type).To(Equal(tc.svc_out.Spec.Type))
+				g.Expect(tc.svc_in.Spec.Ports).To(Equal(tc.svc_out.Spec.Ports))
+			} else {
+				g.Expect(tc.err.Error()).To(Equal(err.Error()))
+			}
+		})
+	}
+}
 
 func TestKonnectivityServiceReconcile(t *testing.T) {
 	// Define common inputs

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service_test.go
@@ -1,0 +1,117 @@
+package kas
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestKonnectivityServiceReconcile(t *testing.T) {
+	// Define common inputs
+
+	testCases := []struct {
+		name     string
+		platform v1beta1.PlatformType
+		strategy v1beta1.ServicePublishingStrategy
+		svc_in   corev1.Service
+		svc_out  corev1.Service
+		err      error
+	}{
+		{
+			name:     "IBM Cloud, NodePort strategy, NodePort service, expected to fill port number from strategy",
+			platform: v1beta1.IBMCloudPlatform,
+			strategy: v1beta1.ServicePublishingStrategy{Type: v1beta1.NodePort, NodePort: &v1beta1.NodePortPublishingStrategy{Port: 1125}},
+			svc_in: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+			}},
+			svc_out: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol:   corev1.ProtocolTCP,
+						Port:       8091,
+						TargetPort: intstr.IntOrString{IntVal: 8091},
+						NodePort:   1125,
+					},
+				},
+			}},
+			err: nil,
+		},
+		{
+			name:     "IBM Cloud, Route strategy, NodePort service with existing port number, expected not to change",
+			platform: v1beta1.IBMCloudPlatform,
+			strategy: v1beta1.ServicePublishingStrategy{Type: v1beta1.Route},
+			svc_in: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol:   corev1.ProtocolTCP,
+						Port:       8091,
+						TargetPort: intstr.IntOrString{IntVal: 8091},
+						NodePort:   1125,
+					},
+				},
+			}},
+			svc_out: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol:   corev1.ProtocolTCP,
+						Port:       8091,
+						TargetPort: intstr.IntOrString{IntVal: 8091},
+						NodePort:   1125,
+					},
+				},
+			}},
+			err: nil,
+		},
+		{
+			name:     "Non-IBM Cloud, Route strategy, ClusterIP service, expected to fill port value only",
+			platform: v1beta1.AWSPlatform,
+			strategy: v1beta1.ServicePublishingStrategy{Type: v1beta1.Route},
+			svc_in: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+			}},
+			svc_out: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol:   corev1.ProtocolTCP,
+						Port:       8091,
+						TargetPort: intstr.IntOrString{IntVal: 8091},
+					},
+				},
+			}},
+			err: nil,
+		},
+		{
+			name:     "Invalid strategy",
+			strategy: v1beta1.ServicePublishingStrategy{Type: v1beta1.None},
+			err:      fmt.Errorf("invalid publishing strategy for Konnectivity service: None"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hcp := hyperv1.HostedControlPlane{Spec: hyperv1.HostedControlPlaneSpec{Platform: hyperv1.PlatformSpec{Type: tc.platform}}}
+
+			err := ReconcileKonnectivityServerService(&tc.svc_in, config.OwnerRef{}, &tc.strategy, &hcp)
+
+			g := NewWithT(t)
+			if tc.err == nil {
+				g.Expect(err).To(BeNil())
+				g.Expect(tc.svc_in.Spec.Type).To(Equal(tc.svc_out.Spec.Type))
+				g.Expect(tc.svc_in.Spec.Ports).To(Equal(tc.svc_out.Spec.Ports))
+			} else {
+				g.Expect(tc.err.Error()).To(Equal(err.Error()))
+			}
+		})
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/service.go
@@ -26,7 +26,7 @@ var (
 	}
 )
 
-func ReconcileService(svc *corev1.Service, ownerRef config.OwnerRef, strategy *hyperv1.ServicePublishingStrategy) error {
+func ReconcileService(svc *corev1.Service, ownerRef config.OwnerRef, strategy *hyperv1.ServicePublishingStrategy, platformType hyperv1.PlatformType) error {
 	ownerRef.ApplyTo(svc)
 	if svc.Spec.Selector == nil {
 		svc.Spec.Selector = oauthServerLabels
@@ -52,7 +52,9 @@ func ReconcileService(svc *corev1.Service, ownerRef config.OwnerRef, strategy *h
 			portSpec.NodePort = strategy.NodePort.Port
 		}
 	case hyperv1.Route:
-		svc.Spec.Type = corev1.ServiceTypeClusterIP
+		if ((platformType == hyperv1.IBMCloudPlatform) && (svc.Spec.Type != corev1.ServiceTypeNodePort)) || (platformType != hyperv1.IBMCloudPlatform) {
+			svc.Spec.Type = corev1.ServiceTypeClusterIP
+		}
 	default:
 		return fmt.Errorf("invalid publishing strategy for OAuth service: %s", strategy.Type)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/service_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/service_test.go
@@ -1,0 +1,114 @@
+package oauth
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/config"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestOauthServiceReconcile(t *testing.T) {
+	// Define common inputs
+
+	testCases := []struct {
+		name     string
+		platform v1beta1.PlatformType
+		strategy v1beta1.ServicePublishingStrategy
+		svc_in   corev1.Service
+		svc_out  corev1.Service
+		err      error
+	}{
+		{
+			name:     "IBM Cloud, NodePort strategy, NodePort service, expected to fill port number from strategy",
+			platform: v1beta1.IBMCloudPlatform,
+			strategy: v1beta1.ServicePublishingStrategy{Type: v1beta1.NodePort, NodePort: &v1beta1.NodePortPublishingStrategy{Port: 1125}},
+			svc_in: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+			}},
+			svc_out: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol:   corev1.ProtocolTCP,
+						Port:       6443,
+						TargetPort: intstr.IntOrString{IntVal: 6443},
+						NodePort:   1125,
+					},
+				},
+			}},
+			err: nil,
+		},
+		{
+			name:     "IBM Cloud, Route strategy, NodePort service with existing port number, expected not to change",
+			platform: v1beta1.IBMCloudPlatform,
+			strategy: v1beta1.ServicePublishingStrategy{Type: v1beta1.Route},
+			svc_in: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol:   corev1.ProtocolTCP,
+						Port:       6443,
+						TargetPort: intstr.IntOrString{IntVal: 6443},
+						NodePort:   1125,
+					},
+				},
+			}},
+			svc_out: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol:   corev1.ProtocolTCP,
+						Port:       6443,
+						TargetPort: intstr.IntOrString{IntVal: 6443},
+						NodePort:   1125,
+					},
+				},
+			}},
+			err: nil,
+		},
+		{
+			name:     "Non-IBM Cloud, Route strategy, ClusterIP service, expected to fill port value only",
+			platform: v1beta1.AWSPlatform,
+			strategy: v1beta1.ServicePublishingStrategy{Type: v1beta1.Route},
+			svc_in: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+			}},
+			svc_out: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol:   corev1.ProtocolTCP,
+						Port:       6443,
+						TargetPort: intstr.IntOrString{IntVal: 6443},
+					},
+				},
+			}},
+			err: nil,
+		},
+		{
+			name:     "Invalid strategy",
+			strategy: v1beta1.ServicePublishingStrategy{Type: v1beta1.LoadBalancer},
+			err:      fmt.Errorf("invalid publishing strategy for OAuth service: LoadBalancer"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ReconcileService(&tc.svc_in, config.OwnerRef{}, &tc.strategy, tc.platform)
+
+			g := NewWithT(t)
+			if tc.err == nil {
+				g.Expect(err).To(BeNil())
+				g.Expect(tc.svc_in.Spec.Type).To(Equal(tc.svc_out.Spec.Type))
+				g.Expect(tc.svc_in.Spec.Ports).To(Equal(tc.svc_out.Spec.Ports))
+			} else {
+				g.Expect(tc.err.Error()).To(Equal(err.Error()))
+			}
+		})
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/service.go
@@ -27,7 +27,10 @@ func adaptService(cpContext component.WorkloadContext, svc *corev1.Service) erro
 			svc.Spec.Ports[0].NodePort = strategy.NodePort.Port
 		}
 	case hyperv1.Route:
-		svc.Spec.Type = corev1.ServiceTypeClusterIP
+		if (cpContext.HCP.Spec.Platform.Type != hyperv1.IBMCloudPlatform) ||
+			(cpContext.HCP.Spec.Platform.Type == hyperv1.IBMCloudPlatform && svc.Spec.Type != corev1.ServiceTypeNodePort) {
+			svc.Spec.Type = corev1.ServiceTypeClusterIP
+		}
 	default:
 		return fmt.Errorf("invalid publishing strategy for Ignition service: %s", strategy.Type)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/service.go
@@ -8,11 +8,27 @@ import (
 	"github.com/openshift/hypershift/support/util"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func adaptService(cpContext component.WorkloadContext, svc *corev1.Service) error {
 	if cpContext.HCP.Spec.Platform.Type != hyperv1.IBMCloudPlatform {
 		return nil
+	}
+
+	existingServiceUsesNodePort := false
+	existingService := &corev1.Service{}
+	if err := cpContext.Client.Get(cpContext.Context, client.ObjectKeyFromObject(svc), existingService); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get existing ignition service: %w", err)
+		}
+	} else {
+		if len(existingService.Spec.Ports) != 1 {
+			return fmt.Errorf("existing ignition service must have exactly one port exposed, this has: %d", len(existingService.Spec.Ports))
+		}
+		existingServiceUsesNodePort = existingService.Spec.Type == corev1.ServiceTypeNodePort
 	}
 
 	strategy := util.ServicePublishingStrategyByTypeForHCP(cpContext.HCP, hyperv1.Ignition)
@@ -27,9 +43,13 @@ func adaptService(cpContext component.WorkloadContext, svc *corev1.Service) erro
 			svc.Spec.Ports[0].NodePort = strategy.NodePort.Port
 		}
 	case hyperv1.Route:
-		if (cpContext.HCP.Spec.Platform.Type != hyperv1.IBMCloudPlatform) ||
-			(cpContext.HCP.Spec.Platform.Type == hyperv1.IBMCloudPlatform && svc.Spec.Type != corev1.ServiceTypeNodePort) {
-			svc.Spec.Type = corev1.ServiceTypeClusterIP
+		if existingServiceUsesNodePort {
+			svc.Spec.Type = corev1.ServiceTypeNodePort
+			if strategy.NodePort != nil {
+				svc.Spec.Ports[0].NodePort = strategy.NodePort.Port
+			} else {
+				svc.Spec.Ports[0].NodePort = existingService.Spec.Ports[0].NodePort
+			}
 		}
 	default:
 		return fmt.Errorf("invalid publishing strategy for Ignition service: %s", strategy.Type)

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/service_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/service_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/openshift/hypershift/api/hypershift/v1beta1"
-
 	component "github.com/openshift/hypershift/support/controlplane-component"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/service_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/service_test.go
@@ -1,0 +1,163 @@
+package ignitionserver
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	component "github.com/openshift/hypershift/support/controlplane-component"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestIgnitionServiceReconcile(t *testing.T) {
+	// Define common inputs
+
+	testCases := []struct {
+		name     string
+		platform v1beta1.PlatformType
+		services []v1beta1.ServicePublishingStrategyMapping
+		svc_in   corev1.Service
+		svc_out  corev1.Service
+		err      error
+	}{
+		{
+			name:     "IBM Cloud, NodePort strategy, NodePort service, expected to fill port number from strategy",
+			platform: v1beta1.IBMCloudPlatform,
+			services: []v1beta1.ServicePublishingStrategyMapping{
+				{
+					Service: v1beta1.Ignition,
+					ServicePublishingStrategy: v1beta1.ServicePublishingStrategy{
+						Type:     v1beta1.NodePort,
+						NodePort: &v1beta1.NodePortPublishingStrategy{Port: 1125},
+					},
+				},
+			},
+			svc_in: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol:   corev1.ProtocolTCP,
+						Port:       6443,
+						TargetPort: intstr.IntOrString{IntVal: 6443},
+					},
+				},
+			}},
+			svc_out: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol:   corev1.ProtocolTCP,
+						Port:       6443,
+						TargetPort: intstr.IntOrString{IntVal: 6443},
+						NodePort:   1125,
+					},
+				},
+			}},
+			err: nil,
+		},
+		{
+			name:     "IBM Cloud, Route strategy, NodePort service with existing port number, expected not to change",
+			platform: v1beta1.IBMCloudPlatform,
+			services: []v1beta1.ServicePublishingStrategyMapping{
+				{
+					Service:                   v1beta1.Ignition,
+					ServicePublishingStrategy: v1beta1.ServicePublishingStrategy{Type: v1beta1.Route},
+				}},
+			svc_in: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol:   corev1.ProtocolTCP,
+						Port:       6443,
+						TargetPort: intstr.IntOrString{IntVal: 6443},
+						NodePort:   1125,
+					},
+				},
+			}},
+			svc_out: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol:   corev1.ProtocolTCP,
+						Port:       6443,
+						TargetPort: intstr.IntOrString{IntVal: 6443},
+						NodePort:   1125,
+					},
+				},
+			}},
+			err: nil,
+		},
+		{
+			name:     "Non-IBM Cloud, Route strategy, ClusterIP service, expected to not change",
+			platform: v1beta1.AWSPlatform,
+			services: []v1beta1.ServicePublishingStrategyMapping{
+				{
+					Service:                   v1beta1.Ignition,
+					ServicePublishingStrategy: v1beta1.ServicePublishingStrategy{Type: v1beta1.Route},
+				}},
+			svc_in: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol:   corev1.ProtocolTCP,
+						Port:       6443,
+						TargetPort: intstr.IntOrString{IntVal: 6443},
+					},
+				},
+			}},
+			svc_out: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol:   corev1.ProtocolTCP,
+						Port:       6443,
+						TargetPort: intstr.IntOrString{IntVal: 6443},
+					},
+				},
+			}},
+			err: nil,
+		},
+		{
+			name:     "IBM Cloud, Invalid strategy",
+			platform: v1beta1.IBMCloudPlatform,
+			services: []v1beta1.ServicePublishingStrategyMapping{
+				{
+					Service:                   v1beta1.Ignition,
+					ServicePublishingStrategy: v1beta1.ServicePublishingStrategy{Type: v1beta1.LoadBalancer},
+				}},
+			err: fmt.Errorf("invalid publishing strategy for Ignition service: LoadBalancer"),
+		},
+		{
+			name:     "IBM Cloud, strategy missing",
+			platform: v1beta1.IBMCloudPlatform,
+			services: []v1beta1.ServicePublishingStrategyMapping{},
+			err:      fmt.Errorf("ignition service strategy not specified"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := component.WorkloadContext{
+				HCP: &v1beta1.HostedControlPlane{
+					Spec: v1beta1.HostedControlPlaneSpec{
+						Platform: v1beta1.PlatformSpec{Type: tc.platform},
+						Services: tc.services,
+					},
+				},
+			}
+			err := adaptService(ctx, &tc.svc_in)
+
+			g := NewWithT(t)
+			if tc.err == nil {
+				g.Expect(err).To(BeNil())
+				g.Expect(tc.svc_in.Spec.Type).To(Equal(tc.svc_out.Spec.Type))
+				g.Expect(tc.svc_in.Spec.Ports).To(Equal(tc.svc_out.Spec.Ports))
+			} else {
+				g.Expect(tc.err.Error()).To(Equal(err.Error()))
+			}
+		})
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/service_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/service_test.go
@@ -6,53 +6,53 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestIgnitionServiceReconcile(t *testing.T) {
-	// Define common inputs
-
 	testCases := []struct {
-		name     string
-		platform v1beta1.PlatformType
-		services []v1beta1.ServicePublishingStrategyMapping
-		svc_in   corev1.Service
-		svc_out  corev1.Service
-		err      error
+		name         string
+		platform     hyperv1.PlatformType
+		services     []hyperv1.ServicePublishingStrategyMapping
+		svc_existing *corev1.Service
+		svc_out      corev1.Service
+		err          error
 	}{
 		{
 			name:     "IBM Cloud, NodePort strategy, NodePort service, expected to fill port number from strategy",
-			platform: v1beta1.IBMCloudPlatform,
-			services: []v1beta1.ServicePublishingStrategyMapping{
+			platform: hyperv1.IBMCloudPlatform,
+			services: []hyperv1.ServicePublishingStrategyMapping{
 				{
-					Service: v1beta1.Ignition,
-					ServicePublishingStrategy: v1beta1.ServicePublishingStrategy{
-						Type:     v1beta1.NodePort,
-						NodePort: &v1beta1.NodePortPublishingStrategy{Port: 1125},
+					Service: hyperv1.Ignition,
+					ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+						Type:     hyperv1.NodePort,
+						NodePort: &hyperv1.NodePortPublishingStrategy{Port: 1125},
 					},
 				},
 			},
-			svc_in: corev1.Service{Spec: corev1.ServiceSpec{
-				Type: corev1.ServiceTypeNodePort,
-				Ports: []corev1.ServicePort{
-					{
-						Protocol:   corev1.ProtocolTCP,
-						Port:       6443,
-						TargetPort: intstr.IntOrString{IntVal: 6443},
+			svc_existing: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeNodePort,
+					Ports: []corev1.ServicePort{
+						{},
 					},
 				},
-			}},
+			},
 			svc_out: corev1.Service{Spec: corev1.ServiceSpec{
 				Type: corev1.ServiceTypeNodePort,
 				Ports: []corev1.ServicePort{
 					{
+						Name:       "https",
 						Protocol:   corev1.ProtocolTCP,
-						Port:       6443,
-						TargetPort: intstr.IntOrString{IntVal: 6443},
+						Port:       443,
+						TargetPort: intstr.IntOrString{IntVal: 9090},
 						NodePort:   1125,
 					},
 				},
@@ -61,30 +61,30 @@ func TestIgnitionServiceReconcile(t *testing.T) {
 		},
 		{
 			name:     "IBM Cloud, Route strategy, NodePort service with existing port number, expected not to change",
-			platform: v1beta1.IBMCloudPlatform,
-			services: []v1beta1.ServicePublishingStrategyMapping{
+			platform: hyperv1.IBMCloudPlatform,
+			services: []hyperv1.ServicePublishingStrategyMapping{
 				{
-					Service:                   v1beta1.Ignition,
-					ServicePublishingStrategy: v1beta1.ServicePublishingStrategy{Type: v1beta1.Route},
+					Service:                   hyperv1.Ignition,
+					ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.Route},
 				}},
-			svc_in: corev1.Service{Spec: corev1.ServiceSpec{
-				Type: corev1.ServiceTypeNodePort,
-				Ports: []corev1.ServicePort{
-					{
-						Protocol:   corev1.ProtocolTCP,
-						Port:       6443,
-						TargetPort: intstr.IntOrString{IntVal: 6443},
-						NodePort:   1125,
+			svc_existing: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeNodePort,
+					Ports: []corev1.ServicePort{
+						{
+							NodePort: 1125,
+						},
 					},
 				},
-			}},
+			},
 			svc_out: corev1.Service{Spec: corev1.ServiceSpec{
 				Type: corev1.ServiceTypeNodePort,
 				Ports: []corev1.ServicePort{
 					{
+						Name:       "https",
 						Protocol:   corev1.ProtocolTCP,
-						Port:       6443,
-						TargetPort: intstr.IntOrString{IntVal: 6443},
+						Port:       443,
+						TargetPort: intstr.IntOrString{IntVal: 9090},
 						NodePort:   1125,
 					},
 				},
@@ -93,29 +93,20 @@ func TestIgnitionServiceReconcile(t *testing.T) {
 		},
 		{
 			name:     "Non-IBM Cloud, Route strategy, ClusterIP service, expected to not change",
-			platform: v1beta1.AWSPlatform,
-			services: []v1beta1.ServicePublishingStrategyMapping{
+			platform: hyperv1.AWSPlatform,
+			services: []hyperv1.ServicePublishingStrategyMapping{
 				{
-					Service:                   v1beta1.Ignition,
-					ServicePublishingStrategy: v1beta1.ServicePublishingStrategy{Type: v1beta1.Route},
+					Service:                   hyperv1.Ignition,
+					ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.Route},
 				}},
-			svc_in: corev1.Service{Spec: corev1.ServiceSpec{
-				Type: corev1.ServiceTypeClusterIP,
-				Ports: []corev1.ServicePort{
-					{
-						Protocol:   corev1.ProtocolTCP,
-						Port:       6443,
-						TargetPort: intstr.IntOrString{IntVal: 6443},
-					},
-				},
-			}},
 			svc_out: corev1.Service{Spec: corev1.ServiceSpec{
 				Type: corev1.ServiceTypeClusterIP,
 				Ports: []corev1.ServicePort{
 					{
+						Name:       "https",
 						Protocol:   corev1.ProtocolTCP,
-						Port:       6443,
-						TargetPort: intstr.IntOrString{IntVal: 6443},
+						Port:       443,
+						TargetPort: intstr.IntOrString{IntVal: 9090},
 					},
 				},
 			}},
@@ -123,38 +114,60 @@ func TestIgnitionServiceReconcile(t *testing.T) {
 		},
 		{
 			name:     "IBM Cloud, Invalid strategy",
-			platform: v1beta1.IBMCloudPlatform,
-			services: []v1beta1.ServicePublishingStrategyMapping{
+			platform: hyperv1.IBMCloudPlatform,
+			services: []hyperv1.ServicePublishingStrategyMapping{
 				{
-					Service:                   v1beta1.Ignition,
-					ServicePublishingStrategy: v1beta1.ServicePublishingStrategy{Type: v1beta1.LoadBalancer},
+					Service:                   hyperv1.Ignition,
+					ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.LoadBalancer},
 				}},
 			err: fmt.Errorf("invalid publishing strategy for Ignition service: LoadBalancer"),
 		},
 		{
 			name:     "IBM Cloud, strategy missing",
-			platform: v1beta1.IBMCloudPlatform,
-			services: []v1beta1.ServicePublishingStrategyMapping{},
+			platform: hyperv1.IBMCloudPlatform,
+			services: []hyperv1.ServicePublishingStrategyMapping{},
 			err:      fmt.Errorf("ignition service strategy not specified"),
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+
+			clientBuilder := fake.NewClientBuilder().WithScheme(api.Scheme)
+			if tc.svc_existing != nil {
+				clientBuilder = clientBuilder.WithObjects(tc.svc_existing)
+			}
+			client := clientBuilder.Build()
+
 			ctx := component.WorkloadContext{
-				HCP: &v1beta1.HostedControlPlane{
-					Spec: v1beta1.HostedControlPlaneSpec{
-						Platform: v1beta1.PlatformSpec{Type: tc.platform},
+				HCP: &hyperv1.HostedControlPlane{
+					Spec: hyperv1.HostedControlPlaneSpec{
+						Platform: hyperv1.PlatformSpec{Type: tc.platform},
 						Services: tc.services,
 					},
 				},
+				Client: client,
 			}
-			err := adaptService(ctx, &tc.svc_in)
+			svc_out := corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeClusterIP,
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "https",
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.IntOrString{IntVal: 9090},
+						},
+					},
+					Selector: map[string]string{"app": "ignition-server"},
+				}}
+
+			err := adaptService(ctx, &svc_out)
 
 			g := NewWithT(t)
 			if tc.err == nil {
 				g.Expect(err).To(BeNil())
-				g.Expect(tc.svc_in.Spec.Type).To(Equal(tc.svc_out.Spec.Type))
-				g.Expect(tc.svc_in.Spec.Ports).To(Equal(tc.svc_out.Spec.Ports))
+				g.Expect(svc_out.Spec.Type).To(Equal(tc.svc_out.Spec.Type))
+				g.Expect(svc_out.Spec.Ports).To(Equal(tc.svc_out.Spec.Ports))
 			} else {
 				g.Expect(tc.err.Error()).To(Equal(err.Error()))
 			}


### PR DESCRIPTION
When HCP contains router publish strategy for the
master services, IBM Cloud platform implementation will take care of the proper exposure of the
services, without using the actual cluster Router
(similar implementation to Azure). That is, CPO should not create any LoadBalancer or actual router deployment as part of reconciling the HCP.
The current change also makes the migration from NodePort services backward compatible, for existing clusters. That is, the NodePort services will remain as is
(they are not converted to regular ClusterIP services, resulting in permanently losing the reserved nodeports) allowing existing external clients (e.g. kubelet,
master proxy) to work as before, until they are also upgraded.

The expected behavior is to:
* Do not manage any ingress component (LB Svc, Router)
* Keep NodePort master services (if they are already existing)
* (Re)configure node agents (e.g. connectivity) to use 443 as server port

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.