### PR TITLE
CNTRLPLANE-201: feat(shared-ingress): Bump ubi10 out of beta

### DIFF
--- a/shared-ingress/Containerfile
+++ b/shared-ingress/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi10-beta/ubi:10.0-beta-1741674993
+FROM registry.access.redhat.com/ubi10/ubi:10.0-1747220028
 
 RUN dnf install -y haproxy-3.0.5-4.el10 \
   && dnf clean all


### PR DESCRIPTION
**What this PR does / why we need it**:

Now that UBI 10 is no longer in beta state, we should move to the GA version.

**Which issue(s) this PR fixes**:
Fixes #[CNTRLPLANE-201](https://issues.redhat.com//browse/CNTRLPLANE-201)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.