### PR TITLE
OCPBUGS-56777: Disable PSA enforcement in 4.19 hosted cluster

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -116,7 +116,7 @@ func generateConfig(p KubeAPIServerConfigParams) (*kcpv1.KubeAPIServerConfig, er
 									Kind:       "PodSecurityConfiguration",
 								},
 								Defaults: podsecurityadmissionv1beta1.PodSecurityDefaults{
-									Enforce:        "restricted",
+									Enforce:        "privileged",
 									EnforceVersion: "latest",
 									Audit:          "restricted",
 									AuditVersion:   "latest",

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: bootstrap-manifests,logs
-        component.hypershift.openshift.io/config-hash: 19dc307e1d8949e2360eec7552ebd36a741638a5741638a5741638a5741638a58a2366b5c825c12fcf0eb544e7e69167
+        component.hypershift.openshift.io/config-hash: 19dc307e1d8949e2360eec7537c9d3bc52ebd36a741638a5741638a5741638a5741638a58a2366b5c825c12fe7e69167
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: bootstrap-manifests,logs
-        component.hypershift.openshift.io/config-hash: 19dc307e1d8949e2360eec7552ebd36a741638a5741638a5741638a5741638a58a2366b5c825c12fcf0eb544e7e69167
+        component.hypershift.openshift.io/config-hash: 19dc307e1d8949e2360eec7537c9d3bc52ebd36a741638a5741638a5741638a5741638a58a2366b5c825c12fe7e69167
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/config.go
@@ -116,7 +116,7 @@ func generateConfig(p KubeAPIServerConfigParams) (*kcpv1.KubeAPIServerConfig, er
 									Kind:       "PodSecurityConfiguration",
 								},
 								Defaults: podsecurityadmissionv1beta1.PodSecurityDefaults{
-									Enforce:        "restricted",
+									Enforce:        "privileged",
 									EnforceVersion: "latest",
 									Audit:          "restricted",
 									AuditVersion:   "latest",


### PR DESCRIPTION
## What this PR does

Disables Pod Security Admission by setting the enforce policy to `privileged` for HyperShift hosted control planes.

## Why we need it

We are not yet ready to roll out the PSA enforcement on `restricted`.

## Which issue(s) this PR fixes**

- Changes based on [OCPBUGS-45600](https://issues.redhat.com/browse/OCPBUGS-45600)

- [OCP issue](https://issues.redhat.com//browse/OCPBUGS-56773)
- [OCP PR](https://github.com/openshift/api/pull/2346)

 ## Checklist

- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes ~unit tests~ test fixture hash changes.
