### PR TITLE
OCPBUGS-45265: Don't use /version for haproxy health checks

### DIFF
--- a/hypershift-operator/controllers/nodepool/apiserver-haproxy/haproxy.go
+++ b/hypershift-operator/controllers/nodepool/apiserver-haproxy/haproxy.go
@@ -176,7 +176,7 @@ func (r *HAProxy) reconcileHAProxyIgnitionConfig(ctx context.Context, hcluster *
 	serializedConfig, err := apiServerProxyConfig(r.HAProxyImage, controlPlaneOperatorImage, hcluster.Spec.ClusterID,
 		apiServerExternalAddress, apiServerInternalAddress,
 		apiServerExternalPort, apiServerInternalPort,
-		apiserverProxy, noProxy, serviceNetworkCIDR, clusterNetworkCIDR)
+		apiserverProxy, noProxy, serviceNetworkCIDR, clusterNetworkCIDR, hcluster.Spec.Platform.Type)
 	if err != nil {
 		return "", fmt.Errorf("failed to create apiserver haproxy config: %w", err)
 	}
@@ -244,9 +244,15 @@ var (
 
 func apiServerProxyConfig(haProxyImage, cpoImage, clusterID,
 	externalAPIAddress, internalAPIAddress string,
-	externalAPIPort, internalAPIPort int32, proxyAddr, noProxy, serviceNetwork, clusterNetwork string) ([]byte, error) {
+	externalAPIPort, internalAPIPort int32,
+	proxyAddr, noProxy, serviceNetwork, clusterNetwork string, platform hyperv1.PlatformType) ([]byte, error) {
 	config := &ignitionapi.Config{}
 	config.Ignition.Version = ignitionapi.MaxVersion.String()
+	livenessProbeEndpoint := "/version"
+
+	if platform == hyperv1.IBMCloudPlatform {
+		livenessProbeEndpoint = "/livez?exclude=etcd&exclude=log"
+	}
 
 	if sharedingress.UseSharedIngress() {
 		// proxy protocol v2 with TLV support (custom proxy protocol header) requires haproxy v2.9+, see: https://www.haproxy.com/blog/announcing-haproxy-2-9#proxy-protocol-tlv-fields
@@ -285,16 +291,17 @@ func apiServerProxyConfig(haProxyImage, cpoImage, clusterID,
 				name:     "/etc/kubernetes/apiserver-proxy-config/haproxy.cfg",
 				mode:     0644,
 				params: map[string]any{
-					"InternalAPIAddress": internalAPIAddress,
-					"InternalAPIPort":    internalAPIPort,
-					"ExternalAPIAddress": externalAPIAddress,
-					"ExternalAPIPort":    externalAPIPort,
-					"UseProxyProtocol":   sharedingress.UseSharedIngress(),
-					"ClusterID":          clusterID,
+					"InternalAPIAddress":    internalAPIAddress,
+					"InternalAPIPort":       internalAPIPort,
+					"ExternalAPIAddress":    externalAPIAddress,
+					"ExternalAPIPort":       externalAPIPort,
+					"LivenessProbeEndpoint": livenessProbeEndpoint,
+					"UseProxyProtocol":      sharedingress.UseSharedIngress(),
+					"ClusterID":             clusterID,
 				},
 			},
 			{
-				source: generateHAProxyStaticPod("kube-apiserver-proxy", haProxyImage, internalAPIAddress, "/etc/kubernetes/apiserver-proxy-config", internalAPIPort),
+				source: generateHAProxyStaticPod("kube-apiserver-proxy", haProxyImage, internalAPIAddress, "/etc/kubernetes/apiserver-proxy-config", internalAPIPort, livenessProbeEndpoint),
 				name:   "/etc/kubernetes/manifests/kube-apiserver-proxy.yaml",
 				mode:   0644,
 			},
@@ -333,7 +340,7 @@ func apiServerProxyConfig(haProxyImage, cpoImage, clusterID,
 	return json.Marshal(config)
 }
 
-func generateHAProxyStaticPod(name, image, internalAPIAddress, configPath string, internalAPIPort int32) func() ([]byte, error) {
+func generateHAProxyStaticPod(name, image, internalAPIAddress, configPath string, internalAPIPort int32, livenessProbeEndpoint string) func() ([]byte, error) {
 	return func() ([]byte, error) {
 		pod := &corev1.Pod{}
 		pod.APIVersion = corev1.SchemeGroupVersion.String()
@@ -386,7 +393,7 @@ func generateHAProxyStaticPod(name, image, internalAPIAddress, configPath string
 					SuccessThreshold:    1,
 					ProbeHandler: corev1.ProbeHandler{
 						HTTPGet: &corev1.HTTPGetAction{
-							Path:   "/version",
+							Path:   livenessProbeEndpoint,
 							Scheme: corev1.URISchemeHTTPS,
 							Host:   internalAPIAddress,
 							Port:   intstr.FromInt(int(internalAPIPort)),

--- a/hypershift-operator/controllers/nodepool/apiserver-haproxy/haproxy_test.go
+++ b/hypershift-operator/controllers/nodepool/apiserver-haproxy/haproxy_test.go
@@ -35,43 +35,57 @@ func TestAPIServerHAProxyConfig(t *testing.T) {
 		name             string
 		proxy            string
 		noProxy          string
+		platform         hyperv1.PlatformType
 		useSharedIngress bool
 	}{
 		{
-			name:    "when empty proxy it should create an haproxy",
-			proxy:   "",
-			noProxy: "localhost,127.0.0.1",
+			name:     "when empty proxy it should create an haproxy",
+			proxy:    "",
+			platform: "fakePlatform",
+			noProxy:  "localhost,127.0.0.1",
 		},
 		{
-			name:    "when noproxy matches internalAddress it should create an haproxy",
-			proxy:   "proxy",
-			noProxy: "localhost,127.0.0.1," + internalAddress,
+			name:     "when noproxy matches internalAddress it should create an haproxy",
+			proxy:    "proxy",
+			platform: "fakePlatform",
+			noProxy:  "localhost,127.0.0.1," + internalAddress,
 		},
 		{
-			name:    "when noproxy matches serviceNetwork it should create an haproxy",
-			proxy:   "proxy",
-			noProxy: "localhost," + serviceNetwork + ",127.0.0.1,",
+			name:     "when noproxy matches serviceNetwork it should create an haproxy",
+			proxy:    "proxy",
+			platform: "fakePlatform",
+			noProxy:  "localhost," + serviceNetwork + ",127.0.0.1,",
 		},
 		{
-			name:    "when noproxy matches clusterNetwork it should create an haproxy",
-			proxy:   "proxy",
-			noProxy: "localhost," + clusterNetwork + ",127.0.0.1,",
+			name:     "when noproxy matches clusterNetwork it should create an haproxy",
+			proxy:    "proxy",
+			platform: "fakePlatform",
+			noProxy:  "localhost," + clusterNetwork + ",127.0.0.1,",
 		},
 		{
-			name:    "when noproxy matches kubernetes it should create an haproxy",
-			proxy:   "proxy",
-			noProxy: "localhost,kubernetes.svc,127.0.0.1,",
+			name:     "when noproxy matches kubernetes it should create an haproxy",
+			proxy:    "proxy",
+			platform: "fakePlatform",
+			noProxy:  "localhost,kubernetes.svc,127.0.0.1,",
 		},
 		{
-			name:    "when noproxy matches the external kas address it should create an haproxy",
-			proxy:   "proxy",
-			noProxy: "localhost,127.0.0.1," + externalAddress,
+			name:     "when noproxy matches the external kas address it should create an haproxy",
+			proxy:    "proxy",
+			platform: "fakePlatform",
+			noProxy:  "localhost,127.0.0.1," + externalAddress,
 		},
 		{
 			name:             "when use shared router it should use proxy protocol",
 			proxy:            "",
 			noProxy:          "",
+			platform:         "fakePlatform",
 			useSharedIngress: true,
+		},
+		{
+			name:     "when IBM cloud platform it should use livez as liveness probe endpoint",
+			proxy:    "",
+			platform: hyperv1.IBMCloudPlatform,
+			noProxy:  "localhost,127.0.0.1",
 		},
 	}
 
@@ -81,7 +95,7 @@ func TestAPIServerHAProxyConfig(t *testing.T) {
 				t.Setenv("MANAGED_SERVICE", hyperv1.AroHCP)
 			}
 			config, err := apiServerProxyConfig(image, tc.proxy, "fakeClusterID", externalAddress, internalAddress, 443, 8443,
-				tc.proxy, tc.noProxy, serviceNetwork, clusterNetwork)
+				tc.proxy, tc.noProxy, serviceNetwork, clusterNetwork, tc.platform)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -239,6 +253,23 @@ kind: Config`
 			}},
 
 			expectedHAProxyConfigContent: []string{"kubeconfig-host:443"},
+		},
+		{
+			name: "IBMCloud cluster uses livez for liveness probe endpoint",
+			hc: hc(func(hc *hyperv1.HostedCluster) {
+				hc.Spec.Platform.Type = hyperv1.IBMCloudPlatform
+				hc.Spec.Networking.APIServer = &hyperv1.APIServerNetworking{Port: ptr.To[int32](443)}
+				hc.Status.KubeConfig = &corev1.LocalObjectReference{Name: "kk"}
+				hc.Spec.Networking.ServiceNetwork = []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}}
+			}),
+			other: []crclient.Object{&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "kk", Namespace: hc().Namespace},
+				Data: map[string][]byte{
+					"kubeconfig": []byte(kubeconfig(443)),
+				},
+			}},
+
+			expectedHAProxyConfigContent: []string{"/livez?exclude=etcd&amp;exclude=log"},
 		},
 	}
 

--- a/hypershift-operator/controllers/nodepool/apiserver-haproxy/testdata/zz_fixture_TestAPIServerHAProxyConfig_when_IBM_cloud_platform_it_should_use_livez_as_liveness_probe_endpoint.yaml
+++ b/hypershift-operator/controllers/nodepool/apiserver-haproxy/testdata/zz_fixture_TestAPIServerHAProxyConfig_when_IBM_cloud_platform_it_should_use_livez_as_liveness_probe_endpoint.yaml
@@ -1,0 +1,42 @@
+ignition:
+  version: 3.2.0
+storage:
+  files:
+  - contents:
+      source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaApzZXQgLXgKaXAgYWRkciBhZGQgY2x1c3Rlci5pbnRlcm5hbC5leGFtcGxlLmNvbS8zMiBicmQgY2x1c3Rlci5pbnRlcm5hbC5leGFtcGxlLmNvbSBzY29wZSBob3N0IGRldiBsbwppcCByb3V0ZSBhZGQgY2x1c3Rlci5pbnRlcm5hbC5leGFtcGxlLmNvbS8zMiBkZXYgbG8gc2NvcGUgbGluayBzcmMgY2x1c3Rlci5pbnRlcm5hbC5leGFtcGxlLmNvbQo=
+    mode: 493
+    overwrite: true
+    path: /usr/local/bin/setup-apiserver-ip.sh
+  - contents:
+      source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaApzZXQgLXgKaXAgYWRkciBkZWxldGUgY2x1c3Rlci5pbnRlcm5hbC5leGFtcGxlLmNvbS8zMiBkZXYgbG8KaXAgcm91dGUgZGVsIGNsdXN0ZXIuaW50ZXJuYWwuZXhhbXBsZS5jb20vMzIgZGV2IGxvIHNjb3BlIGxpbmsgc3JjIGNsdXN0ZXIuaW50ZXJuYWwuZXhhbXBsZS5jb20K
+    mode: 493
+    overwrite: true
+    path: /usr/local/bin/teardown-apiserver-ip.sh
+  - contents:
+      source: data:text/plain;charset=utf-8;base64,Z2xvYmFsCiAgbWF4Y29ubiA3MDAwCiAgbG9nIHN0ZG91dCBsb2NhbDAKICBsb2cgc3Rkb3V0IGxvY2FsMSBub3RpY2UKCmRlZmF1bHRzCiAgbW9kZSB0Y3AKICB0aW1lb3V0IGNsaWVudCAxMG0KICB0aW1lb3V0IHNlcnZlciAxMG0KICB0aW1lb3V0IGNvbm5lY3QgMTBzCiAgdGltZW91dCBjbGllbnQtZmluIDVzCiAgdGltZW91dCBzZXJ2ZXItZmluIDVzCiAgdGltZW91dCBxdWV1ZSA1cwogIHJldHJpZXMgMwoKZnJvbnRlbmQgbG9jYWxfYXBpc2VydmVyCiAgYmluZCBjbHVzdGVyLmludGVybmFsLmV4YW1wbGUuY29tOjg0NDMKICBsb2cgZ2xvYmFsCiAgbW9kZSB0Y3AKICBvcHRpb24gdGNwbG9nCiAgZGVmYXVsdF9iYWNrZW5kIHJlbW90ZV9hcGlzZXJ2ZXIKCmJhY2tlbmQgcmVtb3RlX2FwaXNlcnZlcgogIG1vZGUgdGNwCiAgbG9nIGdsb2JhbAogIG9wdGlvbiBodHRwY2hrIEdFVCAvbGl2ZXo/ZXhjbHVkZT1ldGNkJmFtcDtleGNsdWRlPWxvZwogIG9wdGlvbiBsb2ctaGVhbHRoLWNoZWNrcwogIGRlZmF1bHQtc2VydmVyIGludGVyIDEwcyBmYWxsIDMgcmlzZSAzCiAgc2VydmVyIGNvbnRyb2xwbGFuZSBjbHVzdGVyLmV4YW1wbGUuY29tOjQ0Mwo=
+    mode: 420
+    overwrite: true
+    path: /etc/kubernetes/apiserver-proxy-config/haproxy.cfg
+  - contents:
+      source: data:text/plain;charset=utf-8;base64,YXBpVmVyc2lvbjogdjEKa2luZDogUG9kCm1ldGFkYXRhOgogIGNyZWF0aW9uVGltZXN0YW1wOiBudWxsCiAgbGFiZWxzOgogICAgazhzLWFwcDoga3ViZS1hcGlzZXJ2ZXItcHJveHkKICBuYW1lOiBrdWJlLWFwaXNlcnZlci1wcm94eQogIG5hbWVzcGFjZToga3ViZS1zeXN0ZW0Kc3BlYzoKICBjb250YWluZXJzOgogIC0gY29tbWFuZDoKICAgIC0gaGFwcm94eQogICAgLSAtZgogICAgLSAvdXNyL2xvY2FsL2V0Yy9oYXByb3h5CiAgICBpbWFnZTogaGEtcHJveHktaW1hZ2U6bGF0ZXN0CiAgICBsaXZlbmVzc1Byb2JlOgogICAgICBmYWlsdXJlVGhyZXNob2xkOiAzCiAgICAgIGh0dHBHZXQ6CiAgICAgICAgaG9zdDogY2x1c3Rlci5pbnRlcm5hbC5leGFtcGxlLmNvbQogICAgICAgIHBhdGg6IC9saXZlej9leGNsdWRlPWV0Y2QmZXhjbHVkZT1sb2cKICAgICAgICBwb3J0OiA4NDQzCiAgICAgICAgc2NoZW1lOiBIVFRQUwogICAgICBpbml0aWFsRGVsYXlTZWNvbmRzOiAxMjAKICAgICAgcGVyaW9kU2Vjb25kczogMTIwCiAgICAgIHN1Y2Nlc3NUaHJlc2hvbGQ6IDEKICAgIG5hbWU6IGhhcHJveHkKICAgIHBvcnRzOgogICAgLSBjb250YWluZXJQb3J0OiA4NDQzCiAgICAgIGhvc3RQb3J0OiA4NDQzCiAgICAgIG5hbWU6IGFwaXNlcnZlcgogICAgICBwcm90b2NvbDogVENQCiAgICByZXNvdXJjZXM6CiAgICAgIHJlcXVlc3RzOgogICAgICAgIGNwdTogMTNtCiAgICAgICAgbWVtb3J5OiAxNk1pCiAgICBzZWN1cml0eUNvbnRleHQ6CiAgICAgIHJ1bkFzVXNlcjogMTAwMQogICAgdm9sdW1lTW91bnRzOgogICAgLSBtb3VudFBhdGg6IC91c3IvbG9jYWwvZXRjL2hhcHJveHkKICAgICAgbmFtZTogY29uZmlnCiAgaG9zdE5ldHdvcms6IHRydWUKICBwcmlvcml0eUNsYXNzTmFtZTogc3lzdGVtLW5vZGUtY3JpdGljYWwKICB2b2x1bWVzOgogIC0gaG9zdFBhdGg6CiAgICAgIHBhdGg6IC9ldGMva3ViZXJuZXRlcy9hcGlzZXJ2ZXItcHJveHktY29uZmlnCiAgICBuYW1lOiBjb25maWcKc3RhdHVzOiB7fQo=
+    mode: 420
+    overwrite: true
+    path: /etc/kubernetes/manifests/kube-apiserver-proxy.yaml
+systemd:
+  units:
+  - contents: |
+      [Unit]
+      Description=Sets up local IP to proxy API server requests
+      Wants=network-online.target
+      After=network-online.target
+
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/local/bin/setup-apiserver-ip.sh
+      ExecStop=/usr/local/bin/teardown-apiserver-ip.sh
+      RemainAfterExit=yes
+
+      [Install]
+      WantedBy=multi-user.target
+    enabled: true
+    name: apiserver-ip.service

--- a/hypershift-operator/controllers/nodepool/apiserver-haproxy/testdata/zz_fixture_TestReconcileHAProxyIgnitionConfig_IBMCloud_cluster_uses_livez_for_liveness_probe_endpoint.yaml
+++ b/hypershift-operator/controllers/nodepool/apiserver-haproxy/testdata/zz_fixture_TestReconcileHAProxyIgnitionConfig_IBMCloud_cluster_uses_livez_for_liveness_probe_endpoint.yaml
@@ -14,7 +14,7 @@ defaults
   retries 3
 
 frontend local_apiserver
-  bind {{ .InternalAPIAddress }}:{{ .InternalAPIPort }}
+  bind 172.20.0.1:443
   log global
   mode tcp
   option tcplog
@@ -23,7 +23,7 @@ frontend local_apiserver
 backend remote_apiserver
   mode tcp
   log global
-  option httpchk GET {{ .LivenessProbeEndpoint }}
+  option httpchk GET /livez?exclude=etcd&amp;exclude=log
   option log-health-checks
   default-server inter 10s fall 3 rise 3
-  server controlplane {{ .ExternalAPIAddress }}:{{ .ExternalAPIPort }}{{ if .UseProxyProtocol }} send-proxy-v2 set-proxy-v2-tlv-fmt(0x20) %[str("{{ .ClusterID }}")]{{ end }}
+  server controlplane kubeconfig-host:443


### PR DESCRIPTION
**What this PR does / why we need it**: /livez is faster and more reliable than /version. We should prefer /livez/ping when possible.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #https://issues.redhat.com/browse/OCPBUGS-45265

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.