### PR TITLE
WRKLDS-1676: ocm: Make config compatible with library-go

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-controller-manager/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-controller-manager/zz_fixture_TestControlPlaneComponents.yaml
@@ -81,8 +81,19 @@ spec:
         - start
         - --config
         - /etc/kubernetes/config/config.yaml
+        - --kubeconfig
+        - /etc/kubernetes/secrets/svc-kubeconfig/kubeconfig
+        - --namespace=openshift-controller-manager
         command:
         - openshift-controller-manager
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          value: openshift-controller-manager
         image: openshift-controller-manager
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-controller-manager/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-controller-manager/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -81,8 +81,19 @@ spec:
         - start
         - --config
         - /etc/kubernetes/config/config.yaml
+        - --kubeconfig
+        - /etc/kubernetes/secrets/svc-kubeconfig/kubeconfig
+        - --namespace=openshift-controller-manager
         command:
         - openshift-controller-manager
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          value: openshift-controller-manager
         image: openshift-controller-manager
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-controller-manager/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-controller-manager/deployment.yaml
@@ -22,8 +22,19 @@ spec:
         - start
         - --config
         - /etc/kubernetes/config/config.yaml
+        - --kubeconfig
+        - /etc/kubernetes/secrets/svc-kubeconfig/kubeconfig
+        - --namespace=openshift-controller-manager
         command:
         - openshift-controller-manager
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            value: openshift-controller-manager
         image: openshift-controller-manager
         imagePullPolicy: IfNotPresent
         livenessProbe:


### PR DESCRIPTION
**What this PR does / why we need it**:

As OCM is being migrated to use `library-go`, further config changes are needed as `library-go` only supports  certain ways how to configure things. This change includes in particular:

* Update deployment.yaml to set --kubeconfig and --namespace.
* Define POD_NAME and POD_NAMESPACE env variables.

The current OCM implementation supports the given flags, but ignores them so that the service does not crash.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:

Blocks the following PR: https://github.com/openshift/openshift-controller-manager/pull/378