### PR TITLE
NO-JIRA: Follow up PR from #6192

### DIFF
--- a/support/catalogs/images.go
+++ b/support/catalogs/images.go
@@ -13,7 +13,11 @@ import (
 	"github.com/blang/semver"
 )
 
-const cacheExpiration = 5 * time.Minute
+const (
+	cacheExpiration          = 5 * time.Minute
+	defaultRegistryURL       = "registry.redhat.io"
+	defaultRegistryNamespace = "redhat"
+)
 
 type imagesCache struct {
 	timeStamp time.Time
@@ -124,8 +128,6 @@ func computeCatalogImages(releaseVersion func() (*semver.Version, error), imageE
 		return nil, err
 	}
 
-	defaultRegistryURL := "registry.redhat.io"
-	defaultRegistryNamespace := "redhat"
 	defaultRegistry := fmt.Sprintf("%s/%s", defaultRegistryURL, defaultRegistryNamespace)
 
 	if len(registryOverrides) > 0 {


### PR DESCRIPTION
## What this PR does / why we need it
- Small fixes requested from https://github.com/openshift/hypershift/pull/6192. Includes:
  - Set some constants
  - Use a logger instead of `fmt.Println`