### PR TITLE
OCPBUGS-56914: fix: Do not admit OAuth route by private router unless it has external DNS

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1124,11 +1124,7 @@ func useHCPRouter(hostedControlPlane *hyperv1.HostedControlPlane) bool {
 	if sharedingress.UseSharedIngress() {
 		return false
 	}
-	return labelHCPRoutes(hostedControlPlane)
-}
-
-func labelHCPRoutes(hcp *hyperv1.HostedControlPlane) bool {
-	return util.IsPrivateHCP(hcp) || util.IsPublicKASWithDNS(hcp)
+	return util.IsPrivateHCP(hostedControlPlane) || util.IsPublicWithDNS(hostedControlPlane)
 }
 
 func IsStorageAndCSIManaged(hostedControlPlane *hyperv1.HostedControlPlane) bool {
@@ -1282,7 +1278,7 @@ func (r *HostedControlPlaneReconciler) reconcileKonnectivityServerService(ctx co
 			if serviceStrategy.Route != nil {
 				hostname = serviceStrategy.Route.Hostname
 			}
-			return kas.ReconcileKonnectivityExternalRoute(konnectivityRoute, p.OwnerRef, hostname, r.DefaultIngressDomain, labelHCPRoutes(hcp))
+			return kas.ReconcileKonnectivityExternalRoute(konnectivityRoute, p.OwnerRef, hostname, r.DefaultIngressDomain, util.UseDedicatedDNSForKonnectivity(hcp))
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile Konnectivity server external route: %w", err)
 		}
@@ -1320,7 +1316,7 @@ func (r *HostedControlPlaneReconciler) reconcileOAuthServerService(ctx context.C
 			if serviceStrategy.Route != nil {
 				hostname = serviceStrategy.Route.Hostname
 			}
-			return oauth.ReconcileExternalPublicRoute(oauthExternalPublicRoute, p.OwnerRef, hostname, r.DefaultIngressDomain, labelHCPRoutes(hcp))
+			return oauth.ReconcileExternalPublicRoute(oauthExternalPublicRoute, p.OwnerRef, hostname, r.DefaultIngressDomain, util.UseDedicatedDNSForOAuth(hcp))
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile OAuth external public route: %w", err)
 		}
@@ -1334,7 +1330,7 @@ func (r *HostedControlPlaneReconciler) reconcileOAuthServerService(ctx context.C
 		// Reconcile the external private route if a hostname is specified
 		if serviceStrategy.Route != nil && serviceStrategy.Route.Hostname != "" {
 			if _, err := createOrUpdate(ctx, r.Client, oauthExternalPrivateRoute, func() error {
-				return oauth.ReconcileExternalPrivateRoute(oauthExternalPrivateRoute, p.OwnerRef, serviceStrategy.Route.Hostname, r.DefaultIngressDomain, labelHCPRoutes(hcp))
+				return oauth.ReconcileExternalPrivateRoute(oauthExternalPrivateRoute, p.OwnerRef, serviceStrategy.Route.Hostname, r.DefaultIngressDomain, util.UseDedicatedDNSForOAuth(hcp))
 			}); err != nil {
 				return fmt.Errorf("failed to reconcile OAuth external private route: %w", err)
 			}
@@ -1395,7 +1391,6 @@ func (r *HostedControlPlaneReconciler) reconcileHCPRouterServices(ctx context.Co
 	if sharedingress.UseSharedIngress() || hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
 		return nil
 	}
-	exposeKASThroughRouter := util.IsRouteKAS(hcp)
 	// Create the Service type LB internal for private endpoints.
 	pubSvc := manifests.RouterPublicService(hcp.Namespace)
 	if util.IsPrivateHCP(hcp) {
@@ -1420,8 +1415,8 @@ func (r *HostedControlPlaneReconciler) reconcileHCPRouterServices(ctx context.Co
 		}
 	}
 
-	// When Public access endpoint we need to create a Service type LB external for the KAS.
-	if util.IsPublicHCP(hcp) && exposeKASThroughRouter {
+	// When Public access endpoint we need to create a Service type LB external.
+	if util.IsPublicWithDNS(hcp) {
 		if _, err := createOrUpdate(ctx, r.Client, pubSvc, func() error {
 			return ingress.ReconcileRouterService(pubSvc, false, util.IsPrivateHCP(hcp), hcp)
 		}); err != nil {
@@ -1532,7 +1527,7 @@ func (r *HostedControlPlaneReconciler) reconcileInternalRouterServiceStatus(ctx 
 }
 
 func (r *HostedControlPlaneReconciler) reconcileExternalRouterServiceStatus(ctx context.Context, hcp *hyperv1.HostedControlPlane) (host string, needed bool, message string, err error) {
-	if !util.IsPublicHCP(hcp) || !util.IsRouteKAS(hcp) || sharedingress.UseSharedIngress() || hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
+	if !util.IsPublicWithDNS(hcp) || sharedingress.UseSharedIngress() || hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
 		return
 	}
 	return r.reconcileRouterServiceStatus(ctx, manifests.RouterPublicService(hcp.Namespace), events.NewMessageCollector(ctx, r.Client))

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -163,6 +163,240 @@ func TestReconcileKubeadminPassword(t *testing.T) {
 	}
 }
 
+func TestReconcileOAuthService(t *testing.T) {
+	targetNamespace := "test"
+	apiPort := int32(config.KASSVCPort)
+	hostname := "test.example.com"
+	allowCIDR := []hyperv1.CIDRBlock{"1.2.3.4/24"}
+	ipFamilyPolicy := corev1.IPFamilyPolicyPreferDualStack
+
+	ownerRef := metav1.OwnerReference{
+		APIVersion:         "hypershift.openshift.io/v1beta1",
+		Kind:               "HostedControlPlane",
+		Name:               "test",
+		Controller:         ptr.To(true),
+		BlockOwnerDeletion: ptr.To(true),
+	}
+	oauthPublicService := func(m ...func(*corev1.Service)) corev1.Service {
+		svc := corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:       targetNamespace,
+				Name:            manifests.OauthServerService(targetNamespace).Name,
+				OwnerReferences: []metav1.OwnerReference{ownerRef},
+			},
+			Spec: corev1.ServiceSpec{
+				Type:           corev1.ServiceTypeClusterIP,
+				IPFamilyPolicy: &ipFamilyPolicy,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol:   corev1.ProtocolTCP,
+						Port:       apiPort,
+						TargetPort: intstr.FromInt32(apiPort),
+					},
+				},
+				Selector: map[string]string{
+					"app": "oauth-openshift",
+					"hypershift.openshift.io/control-plane-component": "oauth-openshift",
+				},
+			},
+		}
+		for _, m := range m {
+			m(&svc)
+		}
+		return svc
+	}
+	oauthExternalPublicRoute := func(m ...func(*routev1.Route)) routev1.Route {
+		route := routev1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: targetNamespace,
+				Name:      "oauth",
+				Labels: map[string]string{
+					"hypershift.openshift.io/hosted-control-plane": targetNamespace,
+				},
+				OwnerReferences: []metav1.OwnerReference{ownerRef},
+			},
+			Spec: routev1.RouteSpec{
+				Host: hostname,
+				To: routev1.RouteTargetReference{
+					Kind: "Service",
+					Name: manifests.OauthServerService("").Name,
+				},
+				TLS: &routev1.TLSConfig{
+					Termination:                   routev1.TLSTerminationPassthrough,
+					InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
+				},
+			},
+		}
+		for _, m := range m {
+			m(&route)
+		}
+		return route
+	}
+	oauthInternalRoute := routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: targetNamespace,
+			Name:      "oauth-internal",
+			Labels: map[string]string{
+				"hypershift.openshift.io/hosted-control-plane": targetNamespace,
+				"hypershift.openshift.io/internal-route":       "true",
+			},
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+		},
+		Spec: routev1.RouteSpec{
+			Host: "oauth.apps.test.hypershift.local",
+			To: routev1.RouteTargetReference{
+				Kind: "Service",
+				Name: manifests.OauthServerService("").Name,
+			},
+			TLS: &routev1.TLSConfig{
+				Termination:                   routev1.TLSTerminationPassthrough,
+				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
+			},
+		},
+	}
+	testsCases := []struct {
+		name                    string
+		endpointAccess          hyperv1.AWSEndpointAccessType
+		oauthPublishingStrategy hyperv1.ServicePublishingStrategy
+
+		expectedServices []corev1.Service
+		expectedRoutes   []routev1.Route
+	}{
+		{
+			name:           "Route strategy, Public",
+			endpointAccess: hyperv1.Public,
+			oauthPublishingStrategy: hyperv1.ServicePublishingStrategy{
+				Type: hyperv1.Route,
+				Route: &hyperv1.RoutePublishingStrategy{
+					Hostname: hostname,
+				},
+			},
+			expectedServices: []corev1.Service{
+				oauthPublicService(func(s *corev1.Service) {
+					s.Spec.Type = corev1.ServiceTypeClusterIP
+				}),
+			},
+			expectedRoutes: []routev1.Route{
+				oauthExternalPublicRoute(),
+			},
+		},
+		{
+			name:           "Route strategy, PublicPrivate",
+			endpointAccess: hyperv1.PublicAndPrivate,
+			oauthPublishingStrategy: hyperv1.ServicePublishingStrategy{
+				Type: hyperv1.Route,
+				Route: &hyperv1.RoutePublishingStrategy{
+					Hostname: hostname,
+				},
+			},
+
+			expectedServices: []corev1.Service{
+				oauthPublicService(func(s *corev1.Service) {
+					s.Spec.Type = corev1.ServiceTypeClusterIP
+				}),
+			},
+			expectedRoutes: []routev1.Route{
+				oauthExternalPublicRoute(),
+				oauthInternalRoute,
+			},
+		},
+		{
+			name:           "Route strategy, PublicPrivate, no hostname",
+			endpointAccess: hyperv1.PublicAndPrivate,
+			oauthPublishingStrategy: hyperv1.ServicePublishingStrategy{
+				Type: hyperv1.Route,
+			},
+
+			expectedServices: []corev1.Service{
+				oauthPublicService(func(s *corev1.Service) {
+					s.Spec.Type = corev1.ServiceTypeClusterIP
+				}),
+			},
+			expectedRoutes: []routev1.Route{
+				oauthExternalPublicRoute(func(s *routev1.Route) {
+					s.Spec.Host = ""
+					// The route should not be admitted by the private router.
+					delete(s.Labels, "hypershift.openshift.io/hosted-control-plane")
+				}),
+				oauthInternalRoute,
+			},
+		},
+		{
+			name:           "Route strategy, Private",
+			endpointAccess: hyperv1.Private,
+			oauthPublishingStrategy: hyperv1.ServicePublishingStrategy{
+				Type:  hyperv1.Route,
+				Route: &hyperv1.RoutePublishingStrategy{},
+			},
+			expectedServices: []corev1.Service{
+				oauthPublicService(func(s *corev1.Service) {
+					s.Spec.Type = corev1.ServiceTypeClusterIP
+				}),
+			},
+			expectedRoutes: []routev1.Route{
+				oauthInternalRoute,
+			},
+		},
+	}
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: targetNamespace,
+					Name:      "test",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Networking: hyperv1.ClusterNetworking{
+						APIServer: &hyperv1.APIServerNetworking{
+							Port:              &apiPort,
+							AllowedCIDRBlocks: allowCIDR,
+						},
+					},
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: tc.endpointAccess,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{{
+						Service:                   hyperv1.OAuthServer,
+						ServicePublishingStrategy: tc.oauthPublishingStrategy,
+					}},
+				},
+			}
+
+			ctx := ctrl.LoggerInto(context.Background(), zapr.NewLogger(zaptest.NewLogger(t)))
+
+			fakeClient := fake.NewClientBuilder().WithScheme(api.Scheme).Build()
+			r := &HostedControlPlaneReconciler{
+				Client: fakeClient,
+				Log:    ctrl.LoggerFrom(ctx),
+			}
+
+			if err := r.reconcileOAuthServerService(ctx, hcp, controllerutil.CreateOrUpdate); err != nil {
+				t.Fatalf("reconcileOAuthServerService failed: %v", err)
+			}
+
+			var actualServices corev1.ServiceList
+			if err := fakeClient.List(ctx, &actualServices); err != nil {
+				t.Fatalf("failed to list services: %v", err)
+			}
+
+			if diff := testutil.MarshalYamlAndDiff(&actualServices, &corev1.ServiceList{Items: tc.expectedServices}, t); diff != "" {
+				t.Errorf("actual services differ from expected: %s", diff)
+			}
+
+			var actualRoutes routev1.RouteList
+			if err := fakeClient.List(ctx, &actualRoutes); err != nil {
+				t.Fatalf("failed to list routes: %v", err)
+			}
+			if diff := testutil.MarshalYamlAndDiff(&actualRoutes, &routev1.RouteList{Items: tc.expectedRoutes}, t); diff != "" {
+				t.Errorf("actual routes differ from expected: %s", diff)
+			}
+		})
+	}
+}
+
 func TestReconcileAPIServerService(t *testing.T) {
 	targetNamespace := "test"
 	apiPort := int32(config.KASSVCPort)

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/route.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/route.go
@@ -40,9 +40,5 @@ func (ign *ignitionServer) adaptRoute(cpContext component.WorkloadContext, route
 	if strategy.Route != nil {
 		hostname = strategy.Route.Hostname
 	}
-	return util.ReconcileExternalRoute(route, hostname, ign.defaultIngressDomain, serviceName, labelHCPRoutes(hcp))
-}
-
-func labelHCPRoutes(hcp *hyperv1.HostedControlPlane) bool {
-	return util.IsPrivateHCP(hcp) || util.IsPublicKASWithDNS(hcp)
+	return util.ReconcileExternalRoute(route, hostname, ign.defaultIngressDomain, serviceName, util.UseDedicatedDNSForIgnition(hcp))
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
@@ -56,5 +56,5 @@ func useHCPRouter(cpContext component.WorkloadContext) (bool, error) {
 	if sharedingress.UseSharedIngress() {
 		return false, nil
 	}
-	return util.IsPrivateHCP(cpContext.HCP) || util.IsPublicKASWithDNS(cpContext.HCP), nil
+	return util.IsPrivateHCP(cpContext.HCP) || util.IsPublicWithDNS(cpContext.HCP), nil
 }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3667,6 +3667,10 @@ func (r *HostedClusterReconciler) validateAWSConfig(hc *hyperv1.HostedCluster) e
 		if !hyperutil.UseDedicatedDNSForKASByHC(hc) && kasPublishingStrategy.Type != hyperv1.LoadBalancer {
 			errs = append(errs, fmt.Errorf("service type %v with publishing strategy %v is not supported, use Route or LoadBalancer", hyperv1.APIServer, kasPublishingStrategy.Type))
 		}
+		// When using dedicated DNS, the KAS should be exposed as Route.
+		if hyperutil.IsPublicWithDNSByHC(hc) && hyperutil.IsLBKASByHC(hc) {
+			errs = append(errs, fmt.Errorf("service type %v with publishing strategy %v is not supported when any service specifies external DNS, use Route", hyperv1.APIServer, kasPublishingStrategy.Type))
+		}
 	}
 
 	return utilerrors.NewAggregate(errs)

--- a/support/util/visibility.go
+++ b/support/util/visibility.go
@@ -37,6 +37,16 @@ func IsPublicHC(hc *hyperv1.HostedCluster) bool {
 	return access == hyperv1.PublicAndPrivate || access == hyperv1.Public
 }
 
-func IsPublicKASWithDNS(hostedControlPlane *hyperv1.HostedControlPlane) bool {
-	return IsPublicHCP(hostedControlPlane) && UseDedicatedDNSforKAS(hostedControlPlane)
+func IsPublicWithDNS(hcp *hyperv1.HostedControlPlane) bool {
+	return IsPublicHCP(hcp) && (UseDedicatedDNS(hcp, hyperv1.APIServer) ||
+		UseDedicatedDNS(hcp, hyperv1.OAuthServer) ||
+		UseDedicatedDNS(hcp, hyperv1.Konnectivity) ||
+		UseDedicatedDNS(hcp, hyperv1.Ignition))
+}
+
+func IsPublicWithDNSByHC(hc *hyperv1.HostedCluster) bool {
+	return IsPublicHC(hc) && (UseDedicatedDNSByHC(hc, hyperv1.APIServer) ||
+		UseDedicatedDNSByHC(hc, hyperv1.OAuthServer) ||
+		UseDedicatedDNSByHC(hc, hyperv1.Konnectivity) ||
+		UseDedicatedDNSByHC(hc, hyperv1.Ignition))
 }


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

* Label the OAuth Route for admission by the private router only if the OAuth endpoint has hostname (external DNS). This fixes the case when KAS is exposed as LoadBalancer and OAuth via Route without specifying external DNS.
* In order to fix the previous point, label routes for admission by the private router independently from each other (previously, all routes were labeled based on KAS Route)
* Expose private HCP router service if the endpoint access is Private or any endpoint exposes Route with external DNS. (previously it took into account just KAS Route). This fixes the missing routerCanonicalHostname on OAuth Route when KAS has LoadBalancer strategy and OAuth has Route *with* external DNS.
* Add unit test for renconciling OAuth Service and Routes

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-56914](https://issues.redhat.com/browse/OCPBUGS-56914)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.