### PR TITLE
OCPBUGS-56930: test/e2e: fix version gate checks on minor upgrade

### DIFF
--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -30,9 +30,15 @@ func TestUpgradeControlPlane(t *testing.T) {
 		// Sanity check the cluster by waiting for the nodes to report ready
 		guestClient := e2eutil.WaitForGuestClient(t, ctx, mgtClient, hostedCluster)
 
+		// Set the semantic version to the latest release image for version gating tests
+		err := e2eutil.SetReleaseImageVersion(testContext, globalOpts.LatestReleaseImage, globalOpts.ConfigurableClusterOptions.PullSecretFile)
+		if err != nil {
+			g.Expect(err).NotTo(HaveOccurred(), "failed to set latest release image version")
+		}
+
 		// Update the cluster image
 		t.Logf("Updating cluster image. Image: %s", globalOpts.LatestReleaseImage)
-		err := e2eutil.UpdateObject(t, ctx, mgtClient, hostedCluster, func(obj *hyperv1.HostedCluster) {
+		err = e2eutil.UpdateObject(t, ctx, mgtClient, hostedCluster, func(obj *hyperv1.HostedCluster) {
 			obj.Spec.Release.Image = globalOpts.LatestReleaseImage
 			if obj.Annotations == nil {
 				obj.Annotations = make(map[string]string)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -213,8 +213,13 @@ func main(m *testing.M) int {
 		defer cleanupSharedOIDCProvider()
 	}
 
-	// set the semantic version of the latest release image for version gating tests
-	err := util.SetReleaseImageVersion(testContext, globalOpts.LatestReleaseImage, globalOpts.ConfigurableClusterOptions.PullSecretFile)
+	// Set the semantic version of the previous release image for version gating tests.
+	// If the previous release image is not set, use the latest release image.
+	releaseImage := globalOpts.PreviousReleaseImage
+	if releaseImage == "" {
+		releaseImage = globalOpts.LatestReleaseImage
+	}
+	err := util.SetReleaseImageVersion(testContext, releaseImage, globalOpts.ConfigurableClusterOptions.PullSecretFile)
 	if err != nil {
 		log.Error(err, "failed to set release image version")
 		return -1


### PR DESCRIPTION
For the `e2e-aws-upgrade` job, there is minor (y-stream) skew between `initial` and `latest` releases.

The current version checking code just uses the `latest` image for the version checks but, on `TestUpgradeControlPlane`, `inital` can be minor skew, which can result in checks not being gated properly pre-upgrade.

This PR sets the version to be that of `initial` then switches it to `latest` in `TestUpgradeControlPlane` after the initial rollout checks, but before the HCP upgrade begins.