### PR TITLE
CNTRLPLANE-936: fix(tekton): drop multiarch builds on PR

### DIFF
--- a/.tekton/control-plane-operator-main-pull-request.yaml
+++ b/.tekton/control-plane-operator-main-pull-request.yaml
@@ -35,7 +35,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
   - name: dockerfile
     value: /Containerfile.control-plane
   pipelineSpec:

--- a/.tekton/hypershift-operator-main-pull-request.yaml
+++ b/.tekton/hypershift-operator-main-pull-request.yaml
@@ -32,8 +32,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
   - name: dockerfile
     value: Containerfile.operator
   - name: path-context

--- a/.tekton/hypershift-shared-ingress-main-pull-request.yaml
+++ b/.tekton/hypershift-shared-ingress-main-pull-request.yaml
@@ -30,7 +30,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
   - name: dockerfile
     value: /shared-ingress/Containerfile
   pipelineSpec:


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to reduce the on-pull-request Konflux load, let's keep the multiarch builds only on the push pipelines.

**Which issue(s) this PR fixes**:
Fixes #[CNTRLPLANE-936](https://issues.redhat.com//browse/CNTRLPLANE-936)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.