### PR TITLE
fix(tekton): drop multiarch builds on PR

### DIFF
--- a/.tekton/control-plane-operator-4-17-pull-request.yaml
+++ b/.tekton/control-plane-operator-4-17-pull-request.yaml
@@ -31,7 +31,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to reduce the on-pull-request Konflux load, let's keep the multiarch builds only on the push pipelines.

**Which issue(s) this PR fixes**:
Fixes #CNTRLPLANE-936

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.