### PR TITLE
CNV-61396: Sync RBAC for expansion support in kubevirt CSI driver

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -1125,6 +1125,15 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 				Verbs: []string{rbacv1.VerbAll},
 			},
 			{
+				APIGroups: []string{""},
+				Resources: []string{
+					"persistentvolumes",
+				},
+				Verbs: []string{
+					"get",
+				},
+			},
+			{
 				APIGroups: []string{"apps"},
 				Resources: []string{"deployments", "replicasets", "statefulsets"},
 				Verbs:     []string{rbacv1.VerbAll},

--- a/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/controller.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/controller.yaml
@@ -129,6 +129,26 @@ spec:
             requests:
               memory: 20Mi
               cpu: 10m
+        - name: csi-resizer
+          args:
+          - "--v=5"
+          - "--csi-address=/csi/csi.sock"
+          - "--kubeconfig=/var/run/secrets/tenantcluster/kubeconfig"
+          - "--timeout=3m"
+          - "--handle-volume-inuse-error=false"
+          image: quay.io/openshift/origin-csi-external-resizer:latest
+          imagePullPolicy: IfNotPresent
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /csi
+            name: socket-dir
+          - name: tenantcluster
+            mountPath: "/var/run/secrets/tenantcluster"
+          resources:
+            requests:
+              memory: 20Mi
+              cpu: 10m
       volumes:
         - name: socket-dir
           emptyDir: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/infra_role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/files/infra_role.yaml
@@ -18,4 +18,4 @@ rules:
   verbs: ["get", "create", "delete"]
 - apiGroups: [""]
   resources: ["persistentvolumeclaims"]
-  verbs: ["get"]
+  verbs: ["get", "patch"]

--- a/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/kubevirt.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/kubevirt.go
@@ -129,6 +129,7 @@ func reconcileCustomTenantStorageClass(sc *storagev1.StorageClass, infraSCName s
 		"bus":                   "scsi",
 		"infraStorageClassName": infraSCName,
 	}
+	sc.AllowVolumeExpansion = ptr.To(true)
 
 	return nil
 }
@@ -141,6 +142,7 @@ func reconcileDefaultTenantStorageClass(sc *storagev1.StorageClass) error {
 	sc.Parameters = map[string]string{
 		"bus": "scsi",
 	}
+	sc.AllowVolumeExpansion = ptr.To(true)
 
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-csi-controller/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kubevirt_csi_controller_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-csi-controller/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kubevirt_csi_controller_deployment.yaml
@@ -184,6 +184,26 @@ spec:
           name: socket-dir
         - mountPath: /var/run/secrets/tenantcluster
           name: service-account-kubeconfig
+      - args:
+        - --v=5
+        - --csi-address=/csi/csi.sock
+        - --kubeconfig=/var/run/secrets/tenantcluster/kubeconfig
+        - --timeout=3m
+        - --handle-volume-inuse-error=false
+        image: csi-external-resizer
+        imagePullPolicy: IfNotPresent
+        name: csi-resizer
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+        - mountPath: /var/run/secrets/tenantcluster
+          name: service-account-kubeconfig
       priorityClassName: hypershift-control-plane
       serviceAccount: kubevirt-csi
       tolerations:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-csi-controller/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kubevirt_csi_role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-csi-controller/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kubevirt_csi_role.yaml
@@ -52,3 +52,4 @@ rules:
   - persistentvolumeclaims
   verbs:
   - get
+  - patch

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-csi-controller/zz_fixture_TestControlPlaneComponents_kubevirt_csi_controller_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-csi-controller/zz_fixture_TestControlPlaneComponents_kubevirt_csi_controller_deployment.yaml
@@ -184,6 +184,26 @@ spec:
           name: socket-dir
         - mountPath: /var/run/secrets/tenantcluster
           name: service-account-kubeconfig
+      - args:
+        - --v=5
+        - --csi-address=/csi/csi.sock
+        - --kubeconfig=/var/run/secrets/tenantcluster/kubeconfig
+        - --timeout=3m
+        - --handle-volume-inuse-error=false
+        image: csi-external-resizer
+        imagePullPolicy: IfNotPresent
+        name: csi-resizer
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /csi
+          name: socket-dir
+        - mountPath: /var/run/secrets/tenantcluster
+          name: service-account-kubeconfig
       priorityClassName: hypershift-control-plane
       serviceAccount: kubevirt-csi
       tolerations:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-csi-controller/zz_fixture_TestControlPlaneComponents_kubevirt_csi_role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-csi-controller/zz_fixture_TestControlPlaneComponents_kubevirt_csi_role.yaml
@@ -52,3 +52,4 @@ rules:
   - persistentvolumeclaims
   verbs:
   - get
+  - patch

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kubevirt-csi-controller/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kubevirt-csi-controller/deployment.yaml
@@ -122,6 +122,24 @@ spec:
             requests:
               memory: 50Mi
               cpu: 10m
+        - name: csi-resizer
+          args:
+          - "--v=5"
+          - "--csi-address=/csi/csi.sock"
+          - "--kubeconfig=/var/run/secrets/tenantcluster/kubeconfig"
+          - "--timeout=3m"
+          - "--handle-volume-inuse-error=false"
+          image: csi-external-resizer
+          imagePullPolicy: IfNotPresent
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /csi
+            name: socket-dir
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
       volumes:
         - name: socket-dir
           emptyDir: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kubevirt-csi-controller/infra_role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kubevirt-csi-controller/infra_role.yaml
@@ -18,4 +18,4 @@ rules:
   verbs: ["get", "create", "delete"]
 - apiGroups: [""]
   resources: ["persistentvolumeclaims"]
-  verbs: ["get"]
+  verbs: ["get", "patch"]

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1967,6 +1967,11 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
+	err = r.reconcileKubevirtCSIClusterRBAC(ctx, createOrUpdate, hcluster)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to reconcile kubevirt CSI cluster wide RBAC: %w", err)
+	}
+
 	// Reconcile the network policies
 	if err = r.reconcileNetworkPolicies(ctx, log, createOrUpdate, hcluster, hcp, releaseImageVersion, controlPlaneOperatorAppliesManagementKASNetworkPolicyLabel); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile network policies: %w", err)
@@ -2538,6 +2543,64 @@ func (r *HostedClusterReconciler) reconcileControlPlanePKIOperatorRBAC(ctx conte
 	})
 	if err != nil {
 		return fmt.Errorf("failed to reconcile controlplane PKI operator CSR signer cluster role binding: %w", err)
+	}
+
+	return nil
+}
+
+func (r *HostedClusterReconciler) reconcileKubevirtCSIClusterRBAC(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster) error {
+	// We don't create this ServiceAccount, it's part of the kubevirt CSI manifests, but we can reference it due to eventual consistency
+	serviceAccount := cpomanifests.KubevirtCSIDriverInfraSA(manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name))
+
+	kubevirtCSIClusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kubevirt-csi-cluster",
+			Labels: map[string]string{
+				controlplanepkioperatormanifests.OwningHostedClusterNamespaceLabel: hcluster.Namespace,
+				controlplanepkioperatormanifests.OwningHostedClusterNameLabel:      hcluster.Name,
+			},
+		},
+	}
+	_, err := createOrUpdate(ctx, r.Client, kubevirtCSIClusterRole, func() error {
+		kubevirtCSIClusterRole.Rules = []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"persistentvolumes"},
+				Verbs:     []string{"get"},
+			},
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to reconcile kubevirt CSI cluster role: %w", err)
+	}
+
+	kubevirtCSIClusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: kubevirtCSIClusterRole.Name,
+			Labels: map[string]string{
+				controlplanepkioperatormanifests.OwningHostedClusterNamespaceLabel: hcluster.Namespace,
+				controlplanepkioperatormanifests.OwningHostedClusterNameLabel:      hcluster.Name,
+			},
+		},
+	}
+	_, err = createOrUpdate(ctx, r.Client, kubevirtCSIClusterRoleBinding, func() error {
+		kubevirtCSIClusterRoleBinding.RoleRef = rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     kubevirtCSIClusterRole.Name,
+		}
+		kubevirtCSIClusterRoleBinding.Subjects = []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      serviceAccount.Name,
+				Namespace: serviceAccount.Namespace,
+			},
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to reconcile kubevirt CSI cluster role binding: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
This is basically about adapting RBAC for this CSI driver upstream PR:
https://github.com/kubevirt/csi-driver/pull/138
So that we can safely consume this change in the openshift fork.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.