### PR TITLE
CNTRLPLANE-436: Doc for CIM in bare and non bare metal envs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -270,6 +270,7 @@ nav:
     - reference/infrastructure/index.md
     - "AWS": reference/infrastructure/aws.md
     - "Agent": reference/infrastructure/agent.md
+    - "Central Infrastructure Management": reference/infrastructure/central-infrastructure-management.md
   - 'Architecture':
     - reference/architecture/index.md
     - 'Multicluster Engine and Agent': reference/architecture/mce-and-agent.md


### PR DESCRIPTION
## What this PR does / why we need it
Documentation about Central Management Infrastructure for HCP in bare metal and non bare metal environments.

##Which issue(s) this PR fixes:
- Fixes [CNTRLPLANE-436](https://issues.redhat.com/browse/CNTRLPLANE-436)