### PR TITLE
OCPBUGS-57125: Support deserializing monitoring manifests when RHOBS enabled

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/assets.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/assets.go
@@ -4,20 +4,15 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
-	"os"
 	"path"
-	"strings"
 
 	hyperapi "github.com/openshift/hypershift/support/api"
-	"github.com/openshift/hypershift/support/rhobsmonitoring"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
 //go:embed */*.yaml
@@ -83,15 +78,7 @@ func LoadManifestInto(componentName string, fileName string, into client.Object)
 		return nil, nil, err
 	}
 
-	content := string(bytes)
-	if os.Getenv(rhobsmonitoring.EnvironmentVariable) == "1" && strings.Contains(content, prometheusoperatorv1.SchemeGroupVersion.Group) {
-		// Replace the API group for monitoring manifests if RHOBS is enabled.
-		// We need to do this before decoding the manifest
-		// because monitoring.coreos.com group is not registered in the scheme when RHOBS is enabled.
-		bytes = []byte(strings.ReplaceAll(content, prometheusoperatorv1.SchemeGroupVersion.Group, rhobsmonitoring.SchemeGroupVersion.Group))
-	}
-
-	obj, gvk, err := hyperapi.YamlSerializer.Decode(bytes, nil, into)
+	obj, gvk, err := hyperapi.AllMonitoringYamlSerializer.Decode(bytes, nil, into)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load %s manifest: %v", filePath, err)
 	}

--- a/support/api/scheme.go
+++ b/support/api/scheme.go
@@ -55,7 +55,8 @@ import (
 )
 
 var (
-	Scheme = runtime.NewScheme()
+	Scheme              = runtime.NewScheme()
+	AllMonitoringScheme = runtime.NewScheme()
 	// TODO: Even though an object typer is specified here, serialized objects
 	// are not always getting their TypeMeta set unless explicitly initialized
 	// on the variable declarations.
@@ -74,58 +75,77 @@ var (
 		json.DefaultMetaFactory, Scheme, Scheme,
 		json.SerializerOptions{Yaml: true, Pretty: true, Strict: false},
 	)
+	// AllMonitoringYamlSerializer allows decoding monitoring resources
+	// from either the default coreos group version or the rhobs group version
+	AllMonitoringYamlSerializer = json.NewSerializerWithOptions(
+		json.DefaultMetaFactory, AllMonitoringScheme, AllMonitoringScheme,
+		json.SerializerOptions{Yaml: true, Pretty: true, Strict: true},
+	)
 )
 
 func init() {
-	_ = capiaws.AddToScheme(Scheme)
-	_ = capiibm.AddToScheme(Scheme)
-	_ = clientgoscheme.AddToScheme(Scheme)
-	_ = auditv1.AddToScheme(Scheme)
-	_ = apiregistrationv1.AddToScheme(Scheme)
-	_ = hyperv1beta1.AddToScheme(Scheme)
-	_ = schedulingv1alpha1.AddToScheme(Scheme)
-	_ = certificatesv1alpha1.AddToScheme(Scheme)
-	_ = capiv1.AddToScheme(Scheme)
-	_ = ipamv1.AddToScheme(Scheme)
-	_ = configv1.AddToScheme(Scheme)
-	_ = securityv1.AddToScheme(Scheme)
-	_ = operatorv1.AddToScheme(Scheme)
-	_ = oauthv1.AddToScheme(Scheme)
-	_ = osinv1.AddToScheme(Scheme)
-	_ = routev1.AddToScheme(Scheme)
-	_ = imagev1.AddToScheme(Scheme)
-	_ = clientgoscheme.AddToScheme(Scheme)
-	_ = apiextensionsv1.AddToScheme(Scheme)
-	_ = kasv1beta1.AddToScheme(Scheme)
-	_ = openshiftcpv1.AddToScheme(Scheme)
-	_ = v1alpha1.AddToScheme(Scheme)
-	_ = apiserverconfigv1.AddToScheme(Scheme)
-	if os.Getenv(rhobsmonitoring.EnvironmentVariable) == "1" {
-		_ = rhobsmonitoring.AddToScheme(Scheme)
-	} else {
-		_ = prometheusoperatorv1.AddToScheme(Scheme)
+	schemes := []struct {
+		scheme               *runtime.Scheme
+		includeAllMonitoring bool
+	}{
+		{scheme: Scheme, includeAllMonitoring: false},
+		{scheme: AllMonitoringScheme, includeAllMonitoring: true},
 	}
-	_ = snapshotv1.AddToScheme(Scheme)
-	_ = mcfgv1.AddToScheme(Scheme)
-	_ = cdiv1beta1.AddToScheme(Scheme)
-	_ = kubevirtv1.AddToScheme(Scheme)
-	_ = capikubevirt.AddToScheme(Scheme)
-	_ = capiazure.AddToScheme(Scheme)
-	_ = agentv1.AddToScheme(Scheme)
-	_ = capipowervs.AddToScheme(Scheme)
-	_ = machinev1beta1.AddToScheme(Scheme)
-	_ = capiopenstackv1alpha1.AddToScheme(Scheme)
-	_ = capiopenstackv1beta1.AddToScheme(Scheme)
-	_ = secretsstorev1.AddToScheme(Scheme)
-	_ = kcpv1.AddToScheme(Scheme)
-	_ = orcv1alpha1.AddToScheme(Scheme)
-	_ = batchv1.AddToScheme(Scheme)
-	karpenterGroupVersion := schema.GroupVersion{Group: karpenterapis.Group, Version: "v1"}
-	metav1.AddToGroupVersion(Scheme, karpenterGroupVersion)
-	Scheme.AddKnownTypes(karpenterGroupVersion,
-		&karpenterv1.NodeClaim{},
-		&karpenterv1.NodeClaimList{},
-		&karpenterv1.NodePool{},
-		&karpenterv1.NodePoolList{},
-	)
+	for _, sd := range schemes {
+		scheme := sd.scheme
+		_ = capiaws.AddToScheme(scheme)
+		_ = capiibm.AddToScheme(scheme)
+		_ = clientgoscheme.AddToScheme(scheme)
+		_ = auditv1.AddToScheme(scheme)
+		_ = apiregistrationv1.AddToScheme(scheme)
+		_ = hyperv1beta1.AddToScheme(scheme)
+		_ = schedulingv1alpha1.AddToScheme(scheme)
+		_ = certificatesv1alpha1.AddToScheme(scheme)
+		_ = capiv1.AddToScheme(scheme)
+		_ = ipamv1.AddToScheme(scheme)
+		_ = configv1.AddToScheme(scheme)
+		_ = securityv1.AddToScheme(scheme)
+		_ = operatorv1.AddToScheme(scheme)
+		_ = oauthv1.AddToScheme(scheme)
+		_ = osinv1.AddToScheme(scheme)
+		_ = routev1.AddToScheme(scheme)
+		_ = imagev1.AddToScheme(scheme)
+		_ = clientgoscheme.AddToScheme(scheme)
+		_ = apiextensionsv1.AddToScheme(scheme)
+		_ = kasv1beta1.AddToScheme(scheme)
+		_ = openshiftcpv1.AddToScheme(scheme)
+		_ = v1alpha1.AddToScheme(scheme)
+		_ = apiserverconfigv1.AddToScheme(scheme)
+		if os.Getenv(rhobsmonitoring.EnvironmentVariable) == "1" {
+			_ = rhobsmonitoring.AddToScheme(scheme)
+			if sd.includeAllMonitoring {
+				_ = prometheusoperatorv1.AddToScheme(scheme)
+			}
+		} else {
+			_ = prometheusoperatorv1.AddToScheme(scheme)
+		}
+		_ = snapshotv1.AddToScheme(scheme)
+		_ = mcfgv1.AddToScheme(scheme)
+		_ = cdiv1beta1.AddToScheme(scheme)
+		_ = kubevirtv1.AddToScheme(scheme)
+		_ = capikubevirt.AddToScheme(scheme)
+		_ = capiazure.AddToScheme(scheme)
+		_ = agentv1.AddToScheme(scheme)
+		_ = capipowervs.AddToScheme(scheme)
+		_ = machinev1beta1.AddToScheme(scheme)
+		_ = capiopenstackv1alpha1.AddToScheme(scheme)
+		_ = capiopenstackv1beta1.AddToScheme(scheme)
+		_ = secretsstorev1.AddToScheme(scheme)
+		_ = kcpv1.AddToScheme(scheme)
+		_ = orcv1alpha1.AddToScheme(scheme)
+		_ = batchv1.AddToScheme(scheme)
+		karpenterGroupVersion := schema.GroupVersion{Group: karpenterapis.Group, Version: "v1"}
+		metav1.AddToGroupVersion(scheme, karpenterGroupVersion)
+		scheme.AddKnownTypes(karpenterGroupVersion,
+			&karpenterv1.NodeClaim{},
+			&karpenterv1.NodeClaimList{},
+			&karpenterv1.NodePool{},
+			&karpenterv1.NodePoolList{},
+		)
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduces a new Scheme and YAML serializer that includes both RHOBS and CoreOS monitoring types when RHOBS is enabled. The new YAML serializer is only used to deserialize manifests for resources we apply.

Follow up to #6228

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-57125](https://issues.redhat.com/browse/OCPBUGS-57125)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.