### PR TITLE
MULTIARCH-5544: Added support to create s390x NodePool with kubevirt platform

### DIFF
--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -206,10 +206,9 @@ type NodePoolSpec struct {
 	// arch is the preferred processor architecture for the NodePool. Different platforms might have different supported architectures.
 	// TODO: This is set as optional to prevent validation from failing due to a limitation on client side validation with open API machinery:
 	//	https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215
-	// TODO Add s390x to enum validation once the architecture is supported
 	//
 	// +kubebuilder:default:=amd64
-	// +kubebuilder:validation:Enum=arm64;amd64;ppc64le
+	// +kubebuilder:validation:Enum=arm64;amd64;ppc64le;s390x
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Arch is immutable"
 	// +optional
 	Arch string `json:"arch,omitempty"`

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
@@ -89,6 +89,7 @@ spec:
                 - arm64
                 - amd64
                 - ppc64le
+                - s390x
                 type: string
                 x-kubernetes-validations:
                 - message: Arch is immutable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
@@ -89,6 +89,7 @@ spec:
                 - arm64
                 - amd64
                 - ppc64le
+                - s390x
                 type: string
                 x-kubernetes-validations:
                 - message: Arch is immutable

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -671,12 +671,12 @@ func (opts *RawCreateOptions) Validate(ctx context.Context) (*ValidatedCreateOpt
 		}
 	}
 
-	// Validate arch is only hyperv1.ArchitectureAMD64 or hyperv1.ArchitectureARM64 or hyperv1.ArchitecturePPC64LE
 	arch := strings.ToLower(opts.Arch)
 	switch arch {
 	case hyperv1.ArchitectureAMD64:
 	case hyperv1.ArchitectureARM64:
 	case hyperv1.ArchitecturePPC64LE:
+	case hyperv1.ArchitectureS390X:
 	default:
 		return nil, fmt.Errorf("specified arch %q is not supported", opts.Arch)
 	}

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -92,6 +92,7 @@ spec:
                 - arm64
                 - amd64
                 - ppc64le
+                - s390x
                 type: string
                 x-kubernetes-validations:
                 - message: Arch is immutable

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -92,6 +92,7 @@ spec:
                 - arm64
                 - amd64
                 - ppc64le
+                - s390x
                 type: string
                 x-kubernetes-validations:
                 - message: Arch is immutable

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -92,6 +92,7 @@ spec:
                 - arm64
                 - amd64
                 - ppc64le
+                - s390x
                 type: string
                 x-kubernetes-validations:
                 - message: Arch is immutable

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1019,8 +1019,7 @@ string
 <em>(Optional)</em>
 <p>arch is the preferred processor architecture for the NodePool. Different platforms might have different supported architectures.
 TODO: This is set as optional to prevent validation from failing due to a limitation on client side validation with open API machinery:
-<a href="https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215">https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215</a>
-TODO Add s390x to enum validation once the architecture is supported</p>
+<a href="https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215">https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215</a></p>
 </td>
 </tr>
 </table>
@@ -9239,8 +9238,7 @@ string
 <em>(Optional)</em>
 <p>arch is the preferred processor architecture for the NodePool. Different platforms might have different supported architectures.
 TODO: This is set as optional to prevent validation from failing due to a limitation on client side validation with open API machinery:
-<a href="https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215">https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215</a>
-TODO Add s390x to enum validation once the architecture is supported</p>
+<a href="https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215">https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215</a></p>
 </td>
 </tr>
 </tbody>

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -442,7 +442,7 @@ func isArchAndPlatformSupported(nodePool *hyperv1.NodePool) bool {
 			supported = true
 		}
 	case hyperv1.KubevirtPlatform:
-		if nodePool.Spec.Arch == hyperv1.ArchitectureAMD64 {
+		if nodePool.Spec.Arch == hyperv1.ArchitectureAMD64 || nodePool.Spec.Arch == hyperv1.ArchitectureS390X {
 			supported = true
 		}
 	case hyperv1.OpenStackPlatform:

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -1336,6 +1336,18 @@ func TestIsArchAndPlatformSupported(t *testing.T) {
 			expect: true,
 		},
 		{
+			name: "supported arch and platform used - s390x",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.KubevirtPlatform,
+					},
+					Arch: hyperv1.ArchitectureS390X,
+				},
+			},
+			expect: true,
+		},
+		{
 			name: "supported platform with multiple arch baremetal - arm64",
 			nodePool: &hyperv1.NodePool{
 				Spec: hyperv1.NodePoolSpec{

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -206,10 +206,9 @@ type NodePoolSpec struct {
 	// arch is the preferred processor architecture for the NodePool. Different platforms might have different supported architectures.
 	// TODO: This is set as optional to prevent validation from failing due to a limitation on client side validation with open API machinery:
 	//	https://github.com/kubernetes/kubernetes/issues/108768#issuecomment-1253912215
-	// TODO Add s390x to enum validation once the architecture is supported
 	//
 	// +kubebuilder:default:=amd64
-	// +kubebuilder:validation:Enum=arm64;amd64;ppc64le
+	// +kubebuilder:validation:Enum=arm64;amd64;ppc64le;s390x
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Arch is immutable"
 	// +optional
 	Arch string `json:"arch,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:

**Added support to create s390x Nodepool with  kubevirt platform.**
- Currently there is no support to create s390x nodepool with platform kubevirt
- To install hcp with kubevirt platform, on an s390x management cluster we need to have this support.


**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] Subject and description added to both, commit and PR.
- [x] This change includes unit tests.