### PR TITLE
OCPBUGS-49812: Sanitize PowerVS image name to comply with updated naming standards

### DIFF
--- a/hypershift-operator/controllers/nodepool/powervs.go
+++ b/hypershift-operator/controllers/nodepool/powervs.go
@@ -3,6 +3,7 @@ package nodepool
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/releaseinfo"
@@ -119,6 +120,9 @@ func getPowerVSImage(region string, releaseImage *releaseinfo.ReleaseImage) (*re
 	if !hasRegionData {
 		return nil, "", fmt.Errorf("couldn't find PowerVS image for region %q", COSRegion)
 	}
+	// PowerVS now enforces stricter validation rules on image names, disallowing dots.
+	// To ensure compatibility, transform the release name by replacing dots with hyphens.
+	regionData.Release = strings.ReplaceAll(regionData.Release, ".", "-")
 	return &regionData, COSRegion, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Recent changes in IBM PowerVS have introduced stricter validation on image names, disallowing the use of dots (.)
Attempting to import an image with a name like` 418.94.202501221327-0` results in the following error:
`Bad Request: 418.94.202501221327-0 is not a valid image name. the image name does not meet the resource naming standards.`
Due to this PowerVS Hypershift deployments are failing.

This PR resolves the above mentioned issue by replacing all dots with hyphens (-) in PowerVS image name.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/browse/OCPBUGS-49812

**Checklist**
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.