### PR TITLE
NO-JIRA: Add misspell to golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,6 +38,7 @@ linters:
     - gosimple
     - govet
     - ineffassign
+    - misspell
     - staticcheck
     - unused
 linters-settings:
@@ -53,3 +54,11 @@ linters-settings:
       - prefix(sigs.k8s.io)
       - default
     custom-order: true
+  misspell:
+    # The use of US spelling over other English spellings, like UK, is inline with the OpenShift conventions:
+    # https://github.com/openshift/enhancements/blob/master/CONVENTIONS.md#terminology-grammar-and-spelling
+    locale: US
+    # Typos to ignore.
+    # Should be in lower case.
+    ignore-words:
+      - nto

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,13 +33,13 @@ issues:
       text: "const `tuningConfigKey` is unused"
 linters:
   enable:
-    - gci
-    - unused
-    - ineffassign
-    - gosimple
     - errcheck
+    - gci
+    - gosimple
     - govet
+    - ineffassign
     - staticcheck
+    - unused
 linters-settings:
   gci:
     sections:

--- a/cmd/infra/powervs/create.go
+++ b/cmd/infra/powervs/create.go
@@ -587,7 +587,7 @@ func checkForExistingDNSRecord(ctx context.Context, options *CreateInfraOptions,
 }
 
 // setupBaseDomain get domain id and crn of given base domain
-// TODO(dharaneeshvrd): Currently, resource group provided will be considered only for VPC and PowerVS. Need to look at utilising a common resource group in future for CIS service too and use it while filtering the list
+// TODO(dharaneeshvrd): Currently, resource group provided will be considered only for VPC and PowerVS. Need to look at utilizing a common resource group in future for CIS service too and use it while filtering the list
 func (infra *Infra) setupBaseDomain(ctx context.Context, logger logr.Logger, options *CreateInfraOptions) error {
 	var err error
 	infra.CISCRN, infra.CISDomainID, err = getCISDomainDetails(ctx, options.BaseDomain)

--- a/cmd/install/assets/assets.go
+++ b/cmd/install/assets/assets.go
@@ -30,7 +30,7 @@ var recordingRules embed.FS
 
 const capiLabel = "cluster.x-k8s.io/v1beta1"
 
-// capiResources specifies which CRDs should get labelled with capiLabel
+// capiResources specifies which CRDs should get labeled with capiLabel
 // to satisfy CAPI contracts. There might be a way to achieve this during CRD
 // generation, but for now we're just post-processing at runtime here.
 var capiResources = map[string]string{

--- a/cmd/install/assets/hypershift_operator_test.go
+++ b/cmd/install/assets/hypershift_operator_test.go
@@ -21,7 +21,7 @@ func TestHyperShiftOperatorDeployment_Build(t *testing.T) {
 		expectedVolumes      []corev1.Volume
 		expectedArgs         []string
 	}{
-		"empty oidc paramaters result in no volume mounts": {
+		"empty oidc parameters result in no volume mounts": {
 			inputBuildParameters: HyperShiftOperatorDeployment{
 				Namespace: &corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2353,7 +2353,7 @@ func (r *HostedControlPlaneReconciler) reconcileMachineConfigServerConfig(ctx co
 
 	p, err := mcs.NewMCSParams(hcp, rootCA, pullSecret, trustedCABundle, kubeletClientCA)
 	if err != nil {
-		return fmt.Errorf("failed to initialise machine config server parameters config: %w", err)
+		return fmt.Errorf("failed to initialize machine config server parameters config: %w", err)
 	}
 
 	cm := manifests.MachineConfigServerConfig(hcp.Namespace)

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/auth.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/auth.go
@@ -295,7 +295,7 @@ func validateExtraMappingExpression(expression string) error {
 func HCPAuthConfigToAPIServerAuthConfig(authConfig *AuthenticationConfiguration) (*apiserver.AuthenticationConfiguration, error) {
 	outBytes, err := json.Marshal(authConfig)
 	if err != nil {
-		return nil, fmt.Errorf("marshalling HCP auth config to JSON: %v", err)
+		return nil, fmt.Errorf("marshaling HCP auth config to JSON: %v", err)
 	}
 
 	apiserverAuthConfig := &apiserver.AuthenticationConfiguration{}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/auth.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/auth.go
@@ -340,7 +340,7 @@ func validateAuthConfig(authConfig *AuthenticationConfiguration, disallowIssuers
 func HCPAuthConfigToAPIServerAuthConfig(authConfig *AuthenticationConfiguration) (*apiserver.AuthenticationConfiguration, error) {
 	outBytes, err := json.Marshal(authConfig)
 	if err != nil {
-		return nil, fmt.Errorf("marshalling HCP auth config to JSON: %v", err)
+		return nil, fmt.Errorf("marshaling HCP auth config to JSON: %v", err)
 	}
 
 	apiserverAuthConfig := &apiserver.AuthenticationConfiguration{}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/drainer/drainer.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/drainer/drainer.go
@@ -105,7 +105,7 @@ func (r *Reconciler) handleNodeDrainRequest(ctx context.Context, node *corev1.No
 
 	if isNodeUnreachable(node) {
 		// When the node is unreachable and some pods are not evicted for as long as this timeout, we ignore them.
-		// This is copied from cluster-api to match the drain behaviour there for machines
+		// This is copied from cluster-api to match the drain behavior there for machines
 		drainer.SkipWaitForDeleteTimeoutSeconds = 60 * 5 // 5 minutes
 	}
 

--- a/control-plane-pki-operator/certificatesigningcontroller/certificateloadingcontroller_test.go
+++ b/control-plane-pki-operator/certificatesigningcontroller/certificateloadingcontroller_test.go
@@ -90,7 +90,7 @@ func TestCertificateLoadingController_CurrentCA(t *testing.T) {
 	}
 	rawCert, rawKey, err := cas[0].Config.GetPEMBytes()
 	if err != nil {
-		t.Fatalf("unexpected error marshalling pem: %v", err)
+		t.Fatalf("unexpected error marshaling pem: %v", err)
 	}
 	if diff := cmp.Diff(rawCert, crt); diff != "" {
 		t.Fatalf("got incorrect cert: %v", diff)
@@ -108,7 +108,7 @@ func TestCertificateLoadingController_CurrentCA(t *testing.T) {
 	}
 	rawCert, rawKey, err = ca.Config.GetPEMBytes()
 	if err != nil {
-		t.Fatalf("unexpected error marshalling pem: %v", err)
+		t.Fatalf("unexpected error marshaling pem: %v", err)
 	}
 	if diff := cmp.Diff(rawCert, crt); diff != "" {
 		t.Fatalf("got incorrect cert: %v", diff)

--- a/hypershift-operator/controllers/manifests/controlplanepkioperator/manifests.go
+++ b/hypershift-operator/controllers/manifests/controlplanepkioperator/manifests.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// we require labelling these cluster-scoped resources so that the controller cleaning them up
+// we require labeling these cluster-scoped resources so that the controller cleaning them up
 // can find them efficiently, as we can't use namespace-based scoping for these objects
 const (
 	OwningHostedClusterNamespaceLabel = "hypershift.openshift.io/owner.namespace"

--- a/hypershift-operator/controllers/nodepool/aws_test.go
+++ b/hypershift-operator/controllers/nodepool/aws_test.go
@@ -284,7 +284,6 @@ func TestValidateAWSPlatformConfig(t *testing.T) {
 		oldCondition         *hyperv1.NodePoolCondition
 		expectedError        string
 	}{
-
 		{
 			name:                 "If hostedCluster < 4.19 it should fail",
 			hostedClusterVersion: "4.18.0",

--- a/hypershift-operator/controllers/nodepool/capi.go
+++ b/hypershift-operator/controllers/nodepool/capi.go
@@ -565,7 +565,7 @@ func (c *CAPI) reconcileMachineDeployment(ctx context.Context, log logr.Logger,
 	// Bubble up AvailableReplicas and Ready condition from MachineDeployment.
 	nodePool.Status.Replicas = machineDeployment.Status.AvailableReplicas
 	for _, c := range machineDeployment.Status.Conditions {
-		// This condition should aggregate and summarise readiness from underlying MachineSets and Machines
+		// This condition should aggregate and summarize readiness from underlying MachineSets and Machines
 		// https://github.com/kubernetes-sigs/cluster-api/issues/3486.
 		if c.Type == capiv1.ReadyCondition {
 			// this is so api server does not complain
@@ -972,7 +972,7 @@ func (c *CAPI) reconcileMachineSet(ctx context.Context,
 	// Propagate labels.
 	for k, v := range nodePool.Spec.NodeLabels {
 		// Propagated managed labels down to Machines with a known hardcoded prefix
-		// so the CPO HCCO Node controller can recognise them and apply them to Nodes.
+		// so the CPO HCCO Node controller can recognize them and apply them to Nodes.
 		labelKey := fmt.Sprintf("%s.%s", labelManagedPrefix, k)
 		machineSet.Spec.Template.Labels[labelKey] = v
 	}
@@ -1061,7 +1061,7 @@ func (c *CAPI) reconcileMachineSet(ctx context.Context,
 	// Bubble up AvailableReplicas and Ready condition from MachineSet.
 	nodePool.Status.Replicas = machineSet.Status.AvailableReplicas
 	for _, c := range machineSet.Status.Conditions {
-		// This condition should aggregate and summarise readiness from underlying MachineSets and Machines
+		// This condition should aggregate and summarize readiness from underlying MachineSets and Machines
 		// https://github.com/kubernetes-sigs/cluster-api/issues/3486.
 		if c.Type == capiv1.ReadyCondition {
 			// this is so api server does not complain

--- a/hypershift-operator/controllers/nodepool/conditions.go
+++ b/hypershift-operator/controllers/nodepool/conditions.go
@@ -31,7 +31,7 @@ const (
 
 // These are copies pf metav1.Condition to accept hyperv1.NodePoolCondition
 // We use different conditions struct to relax metav1 input validation.
-// We want to relax validation to ease bubbling up from CAPI which uses their own type not honouring metav1 validations, particularly "Reason" accepts pretty much free string.
+// We want to relax validation to ease bubbling up from CAPI which uses their own type not honoring metav1 validations, particularly "Reason" accepts pretty much free string.
 // TODO (alberto): work upstream towards consolidation and programmatic Reasons.
 
 // SetStatusCondition sets the corresponding condition in conditions to newCondition.
@@ -141,7 +141,7 @@ func generateReconciliationActiveCondition(pausedUntilField *string, objectGener
 }
 
 // setPlatformConditions is a hook for platforms to implement custom logic/conditions freely
-// TODO: refactor signature to be inline with the rest of condition setters, and move common conditions like NodePoolValidPlatformImageType to a seperate function.
+// TODO: refactor signature to be inline with the rest of condition setters, and move common conditions like NodePoolValidPlatformImageType to a separate function.
 func (r *NodePoolReconciler) setPlatformConditions(ctx context.Context, hcluster *hyperv1.HostedCluster, nodePool *hyperv1.NodePool, controlPlaneNamespace string, releaseImage *releaseinfo.ReleaseImage) error {
 	switch nodePool.Spec.Platform.Type {
 	case hyperv1.KubevirtPlatform:

--- a/hypershift-operator/controllers/nodepool/config.go
+++ b/hypershift-operator/controllers/nodepool/config.go
@@ -34,7 +34,7 @@ import (
 
 // ConfigGenerator knows how to:
 // - Generate a unique hash id for any NodePool API input that requires a NodePool rollout.
-// - Generate a compressed and encoded artefact of the mco RawConfig that can be stored in a Secret
+// - Generate a compressed and encoded artifact of the mco RawConfig that can be stored in a Secret
 // and consumed by mco/local-ignition-provider to generate the final ignition config served to Nodes.
 type ConfigGenerator struct {
 	client.Client
@@ -108,7 +108,7 @@ func (cg *ConfigGenerator) Compressed() (*bytes.Buffer, error) {
 	return supportutil.Compress([]byte(cg.mcoRawConfig))
 }
 
-// CompressedAndEncoded returns a gzipped and base-64 encodesd artefact of the raw config.
+// CompressedAndEncoded returns a gzipped and base-64 encodesd artifact of the raw config.
 func (cg *ConfigGenerator) CompressedAndEncoded() (*bytes.Buffer, error) {
 	return supportutil.CompressAndEncode([]byte(cg.mcoRawConfig))
 }
@@ -132,7 +132,7 @@ func (cg *ConfigGenerator) Version() string {
 	return cg.releaseImage.Version()
 }
 
-// generateMCORawConfig generates a mco consumable artefact of the mco Config.
+// generateMCORawConfig generates a mco consumable artifact of the mco Config.
 func (cg *ConfigGenerator) generateMCORawConfig(ctx context.Context) (configsRaw string, err error) {
 	var configs []corev1.ConfigMap
 

--- a/hypershift-operator/controllers/nodepool/config_test.go
+++ b/hypershift-operator/controllers/nodepool/config_test.go
@@ -1754,15 +1754,15 @@ func TestGlobalConfigString(t *testing.T) {
 		globalConfig   *hyperv1.ClusterConfiguration
 		expectedOutput string
 	}{
-		// Expected behaviour for backward compatibility for empty values is:
+		// Expected behavior for backward compatibility for empty values is:
 		// return serialized string with empty values for AdditionalTrustedCA and RegistrySources and drop everything else even if it doesn't have a omitempty tag in the API.
 		{
-			name:           "When Empty GlobalConfig it should return serialized string honouring backward compatibility expectation (see code comment)",
+			name:           "When Empty GlobalConfig it should return serialized string honoring backward compatibility expectation (see code comment)",
 			globalConfig:   &hyperv1.ClusterConfiguration{},
 			expectedOutput: expectedGlobalConfigStringWhenEmpty,
 		},
 		{
-			name: "When GlobalConfig is set with empty structs it should return serialized string honouring backward compatibility expectation (see code comment)",
+			name: "When GlobalConfig is set with empty structs it should return serialized string honoring backward compatibility expectation (see code comment)",
 			globalConfig: &hyperv1.ClusterConfiguration{
 				APIServer:      &configv1.APIServerSpec{},
 				Authentication: &configv1.AuthenticationSpec{},
@@ -1773,7 +1773,7 @@ func TestGlobalConfigString(t *testing.T) {
 			expectedOutput: expectedGlobalConfigStringWhenEmpty,
 		},
 		{
-			name: "When GlobalConfig is set with some values GlobalConfig it should keep them and it should honour backward compatibility expectation (see code comment)",
+			name: "When GlobalConfig is set with some values GlobalConfig it should keep them and it should honor backward compatibility expectation (see code comment)",
 			globalConfig: &hyperv1.ClusterConfiguration{
 				APIServer:      &configv1.APIServerSpec{},
 				Authentication: &configv1.AuthenticationSpec{},

--- a/support/capabilities/management_cluster_capabilities.go
+++ b/support/capabilities/management_cluster_capabilities.go
@@ -81,7 +81,7 @@ type ManagementClusterCapabilities struct {
 func (m *ManagementClusterCapabilities) Has(capabilities ...CapabilityType) bool {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
-	// clearly define the behaviour if no capabilities are passed in
+	// clearly define the behavior if no capabilities are passed in
 	if len(capabilities) == 0 {
 		return false
 	}

--- a/support/certs/tls.go
+++ b/support/certs/tls.go
@@ -325,7 +325,7 @@ func ValidateKeyPair(pemKey, pemCertificate []byte, cfg *CertCfg, minimumRemaini
 		errs = append(errs, fmt.Errorf("actual key usage %d differs from expected %d", cert.KeyUsage, cfg.KeyUsages))
 	}
 
-	// subjectDiff ignores the "Names" field, as it contains the parsed attributes but is ignored during marshalling.
+	// subjectDiff ignores the "Names" field, as it contains the parsed attributes but is ignored during marshaling.
 	subjectDiff := cmp.Diff(cert.Subject, cfg.Subject, cmpopts.SortSlices(stringLessFN), cmpopts.IgnoreFields(pkix.Name{}, "Names"))
 	if subjectDiff != "" {
 		errs = append(errs, fmt.Errorf("actual subject differs from expected: %s", subjectDiff))

--- a/support/controlplane-component/controlplane-component_test.go
+++ b/support/controlplane-component/controlplane-component_test.go
@@ -145,7 +145,7 @@ func TestReconcile(t *testing.T) {
 				g.Expect(container.ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
 			}
 
-			// honour replicas in the yaml.
+			// honor replicas in the yaml.
 			g.Expect(*got.Spec.Replicas).To(Equal(int32(1)))
 
 			// enforce volume permissions.

--- a/support/util/imagemetadata_test.go
+++ b/support/util/imagemetadata_test.go
@@ -224,7 +224,7 @@ func TestGetDigest(t *testing.T) {
 			expectedDigest: "sha256:e96047c50caf0aaffeaf7ed0fe50bd3f574ad347cd0f588a56b876f79cc29d3e",
 		},
 		{
-			name:           "Image not present in overriden registry, falling back to original imageRef",
+			name:           "Image not present in overridden registry, falling back to original imageRef",
 			imageRef:       "quay.io/prometheus/busybox:latest",
 			pullSecret:     pullSecret,
 			expectedErr:    false,

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -243,13 +243,13 @@ func HashSimple(o interface{}) string {
 }
 
 // HashStruct takes a struct and returns a 32-bit FNV-1a hashed version of the struct as a string
-// The struct is first marshalled to JSON before hashing
+// The struct is first marshaled to JSON before hashing
 func HashStruct(data interface{}) (string, error) {
 	return HashStructWithJSONMapper(data, nil)
 }
 
 // HashStructWithJSONMapper takes a struct and returns a 32-bit FNV-1a hashed version of the struct as a string after
-// The struct is first marshalled to JSON before hashing. You can provide a JSONMapper that transforms the marshalled
+// The struct is first marshaled to JSON before hashing. You can provide a JSONMapper that transforms the marshaled
 // JSON before computing the hash or nil if no transformation is needed.
 func HashStructWithJSONMapper(data interface{}, mapper JSONMapper) (string, error) {
 	jsonData, err := json.Marshal(data)

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1081,7 +1081,7 @@ func checkPodsHaveLabel(ctx context.Context, c crclient.Client, allowedComponent
 		return fmt.Errorf("failed to list pods: %w", err)
 	}
 
-	// Get the component name for each labelled pod and ensure it exists in the components slice
+	// Get the component name for each labeled pod and ensure it exists in the components slice
 	for _, pod := range podList.Items {
 		if pod.Labels[suppconfig.NeedManagementKASAccessLabel] == "" {
 			continue

--- a/test/integration/framework/hosted-cluster.go
+++ b/test/integration/framework/hosted-cluster.go
@@ -30,7 +30,7 @@ func InterruptableContext(parent context.Context) context.Context {
 	signal.Notify(sigs, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigs
-		fmt.Println("Received an interrupt, cancelling test context...")
+		fmt.Println("Received an interrupt, canceling test context...")
 		cancel()
 	}()
 	return ctx


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds misspell linter to the list of enabled golanci-lint linters and fixes all the spelling mistakes.

**Which issue(s) this PR fixes**
N/A

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.