### PR TITLE
CNTRLPLANE-995: Support in-place update of AWS tags

### DIFF
--- a/hypershift-operator/controllers/nodepool/agent.go
+++ b/hypershift-operator/controllers/nodepool/agent.go
@@ -1,19 +1,30 @@
 package nodepool
 
 import (
-	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"fmt"
 
 	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1beta1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func agentMachineTemplateSpec(nodePool *hyperv1.NodePool) *agentv1.AgentMachineTemplateSpec {
-	spec := agentv1.AgentMachineSpec{}
-	if nodePool.Spec.Platform.Agent != nil {
-		spec.AgentLabelSelector = nodePool.Spec.Platform.Agent.AgentLabelSelector
+func (c *CAPI) agentMachineTemplate(templateNameGenerator func(spec any) (string, error)) (*agentv1.AgentMachineTemplate, error) {
+	spec := agentv1.AgentMachineTemplateSpec{}
+	if c.nodePool.Spec.Platform.Agent != nil {
+		spec.Template.Spec.AgentLabelSelector = c.nodePool.Spec.Platform.Agent.AgentLabelSelector
 	}
-	return &agentv1.AgentMachineTemplateSpec{
-		Template: agentv1.AgentMachineTemplateResource{
-			Spec: spec,
+
+	templateName, err := templateNameGenerator(spec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate template name: %w", err)
+	}
+
+	template := &agentv1.AgentMachineTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: templateName,
 		},
+		Spec: spec,
 	}
+
+	return template, nil
 }

--- a/hypershift-operator/controllers/nodepool/aws_test.go
+++ b/hypershift-operator/controllers/nodepool/aws_test.go
@@ -2,21 +2,26 @@ package nodepool
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/releaseinfo"
+	supportutil "github.com/openshift/hypershift/support/util"
 
 	configv1 "github.com/openshift/api/config/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/utils/ptr"
 
 	capiaws "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/google/go-cmp/cmp"
@@ -31,7 +36,7 @@ var volume = hyperv1.Volume{
 	IOPS: 5000,
 }
 
-func TestAWSMachineTemplate(t *testing.T) {
+func TestAWSMachineTemplateSpec(t *testing.T) {
 	infraName := "test"
 	defaultSG := []hyperv1.AWSResourceReference{
 		{
@@ -249,6 +254,224 @@ func defaultAWSMachineTemplate(modify ...func(*capiaws.AWSMachineTemplate)) *cap
 	}
 
 	return template
+}
+
+func TestAWSMachineTemplate(t *testing.T) {
+	// A simple name generator for predictable test outcomes.
+	mockTemplateNameGenerator := func(spec any) (string, error) {
+		specJSON, err := json.Marshal(spec)
+		if err != nil {
+			return "", err
+		}
+		return getName("test-prefix", supportutil.HashSimple(specJSON),
+			validation.DNS1123SubdomainMaxLength), nil
+	}
+
+	namespace := "test-ns"
+
+	testCases := []struct {
+		name             string
+		nodePool         *hyperv1.NodePool
+		existingTemplate *capiaws.AWSMachineTemplate
+		expectedName     string
+		expectedTags     capiaws.Tags
+	}{
+		{
+			name: "Migration: should avoid rollout on existing nodepools by reusing existing template name when nothing changes",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{Name: "stable-nodepool"},
+				Spec: hyperv1.NodePoolSpec{
+					Management: hyperv1.NodePoolManagement{UpgradeType: hyperv1.UpgradeTypeReplace},
+					Platform: hyperv1.NodePoolPlatform{AWS: &hyperv1.AWSNodePoolPlatform{
+						AMI:          amiName,
+						InstanceType: "t3.large",
+						ResourceTags: []hyperv1.AWSResourceTag{{Key: "version", Value: "stable"}},
+					}},
+				},
+			},
+			existingTemplate: defaultAWSMachineTemplate(func(template *capiaws.AWSMachineTemplate) {
+				template.Name = "stable-name"
+				template.Spec.Template.Spec.InstanceType = "t3.large"
+				template.Spec.Template.Spec.AdditionalTags = capiaws.Tags{"version": "stable"}
+			}),
+			expectedName: "stable-name",
+			expectedTags: capiaws.Tags{"version": "stable"},
+		},
+		{
+			name: "should reuse existing template name when only tags change",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-nodepool"},
+				Spec: hyperv1.NodePoolSpec{
+					Management: hyperv1.NodePoolManagement{UpgradeType: hyperv1.UpgradeTypeReplace},
+					Platform: hyperv1.NodePoolPlatform{AWS: &hyperv1.AWSNodePoolPlatform{
+						AMI:          amiName,
+						InstanceType: "t3.large",
+						ResourceTags: []hyperv1.AWSResourceTag{{Key: "version", Value: "new"}}, // New tags
+					}},
+				},
+			},
+			existingTemplate: defaultAWSMachineTemplate(func(template *capiaws.AWSMachineTemplate) {
+				template.Name = "old-name-from-spec-with-old-tags"
+				template.Spec.Template.Spec.InstanceType = "t3.large"
+				template.Spec.Template.Spec.AdditionalTags = capiaws.Tags{"version": "old"} // Old tags
+			}),
+			expectedName: "old-name-from-spec-with-old-tags", // Crucial: Expect the old name to be reused.
+			expectedTags: capiaws.Tags{"version": "new"},
+		},
+		{
+			name: "should create a new template name when instanceType changes",
+			nodePool: &hyperv1.NodePool{ // Desired state has a new instance type.
+				ObjectMeta: metav1.ObjectMeta{Name: "test-nodepool-structural"},
+				Spec: hyperv1.NodePoolSpec{
+					Management: hyperv1.NodePoolManagement{UpgradeType: hyperv1.UpgradeTypeReplace},
+					Platform: hyperv1.NodePoolPlatform{AWS: &hyperv1.AWSNodePoolPlatform{
+						AMI:          amiName,
+						InstanceType: "m5.xlarge", // Structural change
+						ResourceTags: []hyperv1.AWSResourceTag{{Key: "version", Value: "new"}},
+					}},
+				},
+			},
+			existingTemplate: defaultAWSMachineTemplate(func(template *capiaws.AWSMachineTemplate) {
+				template.Name = "name-with-t3-large"
+				template.Spec.Template.Spec.InstanceType = "t3.large"
+			}),
+			expectedName: func() string {
+				// The new name is based on a spec with the new instance type and no tags.
+				template := defaultAWSMachineTemplate(func(template *capiaws.AWSMachineTemplate) {
+					template.Spec.Template.Spec.InstanceType = "m5.xlarge"
+					template.Spec.Template.Spec.AdditionalTags = nil
+				})
+				name, _ := mockTemplateNameGenerator(template.Spec)
+				return name
+			}(),
+			expectedTags: capiaws.Tags{"version": "new"},
+		},
+		{
+			name: "should create new template when none exists",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-nodepool"},
+				Spec: hyperv1.NodePoolSpec{
+					Management: hyperv1.NodePoolManagement{UpgradeType: hyperv1.UpgradeTypeReplace},
+					Platform: hyperv1.NodePoolPlatform{AWS: &hyperv1.AWSNodePoolPlatform{
+						AMI:          amiName,
+						InstanceType: "t3.medium",
+						ResourceTags: []hyperv1.AWSResourceTag{{Key: "app", Value: "new"}},
+					}},
+				},
+			},
+			existingTemplate: nil, // No existing resources
+			expectedName: func() string {
+				template := defaultAWSMachineTemplate(func(template *capiaws.AWSMachineTemplate) {
+					template.Spec.Template.Spec.InstanceType = "t3.medium"
+					template.Spec.Template.Spec.AdditionalTags = nil
+				})
+				name, _ := mockTemplateNameGenerator(template.Spec)
+
+				return name
+			}(),
+			expectedTags: capiaws.Tags{"app": "new"},
+		},
+
+		{
+			name: "should find template via MachineSet when UpgradeType is InPlace",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{Name: "inplace-nodepool"},
+				Spec: hyperv1.NodePoolSpec{
+					Management: hyperv1.NodePoolManagement{UpgradeType: hyperv1.UpgradeTypeInPlace}, // Different UpgradeType
+					Platform: hyperv1.NodePoolPlatform{AWS: &hyperv1.AWSNodePoolPlatform{
+						AMI:          amiName,
+						InstanceType: "t3.large",
+						ResourceTags: []hyperv1.AWSResourceTag{{Key: "version", Value: "new"}},
+					}},
+				},
+			},
+
+			existingTemplate: defaultAWSMachineTemplate(func(template *capiaws.AWSMachineTemplate) {
+				template.Name = "inplace-template-name"
+				template.Spec.Template.Spec.InstanceType = "t3.large"
+				template.Spec.Template.Spec.AdditionalTags = capiaws.Tags{"version": "old"}
+			}),
+			expectedName: "inplace-template-name", // Expect reuse
+			expectedTags: capiaws.Tags{"version": "new"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup the fake client for this specific test case
+			var existingObjs []client.Object
+			if tc.existingTemplate != nil {
+				tc.existingTemplate.Namespace = namespace
+				existingObjs = append(existingObjs, tc.existingTemplate)
+
+				// Automatically create the corresponding MachineDeployment or MachineSet.
+				if tc.nodePool.Spec.Management.UpgradeType == hyperv1.UpgradeTypeReplace {
+					md := &capiv1.MachineDeployment{
+						ObjectMeta: metav1.ObjectMeta{Name: tc.nodePool.GetName(), Namespace: namespace},
+						Spec: capiv1.MachineDeploymentSpec{Template: capiv1.MachineTemplateSpec{Spec: capiv1.MachineSpec{
+							InfrastructureRef: corev1.ObjectReference{Name: tc.existingTemplate.Name},
+						}}},
+					}
+					existingObjs = append(existingObjs, md)
+				} else { // Handle InPlace (MachineSet)
+					ms := &capiv1.MachineSet{
+						ObjectMeta: metav1.ObjectMeta{Name: tc.nodePool.GetName(), Namespace: namespace},
+						Spec: capiv1.MachineSetSpec{Template: capiv1.MachineTemplateSpec{Spec: capiv1.MachineSpec{
+							InfrastructureRef: corev1.ObjectReference{Name: tc.existingTemplate.Name},
+						}}},
+					}
+					existingObjs = append(existingObjs, ms)
+				}
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(existingObjs...).Build()
+
+			hc := &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						AWS: &hyperv1.AWSPlatformSpec{},
+					},
+				},
+				Status: hyperv1.HostedClusterStatus{Platform: &hyperv1.PlatformStatus{AWS: &hyperv1.AWSPlatformStatus{DefaultWorkerSecurityGroupID: "default"}}},
+			}
+
+			c := &CAPI{
+				Token: &Token{
+					ConfigGenerator: &ConfigGenerator{
+						Client:                fakeClient,
+						nodePool:              tc.nodePool,
+						controlplaneNamespace: namespace,
+						hostedCluster:         hc,
+						rolloutConfig: &rolloutConfig{
+							releaseImage: &releaseinfo.ReleaseImage{},
+						},
+					},
+					cpoCapabilities: &CPOCapabilities{
+						CreateDefaultAWSSecurityGroup: true,
+					},
+				},
+				capiClusterName: infraName,
+			}
+
+			// Execute the function under test
+			result, err := c.awsMachineTemplate(context.Background(), mockTemplateNameGenerator)
+
+			// Assertions
+			if err != nil {
+				t.Fatalf("Function returned an unexpected error: %v", err)
+			}
+			if result.Name != tc.expectedName {
+				t.Errorf("Wrong template name: \n- got:  %s\n- want: %s", result.Name, tc.expectedName)
+			}
+
+			// always add the cluster tag
+			tc.expectedTags[awsClusterCloudProviderTagKey(infraName)] = infraLifecycleOwned
+
+			if diff := cmp.Diff(tc.expectedTags, result.Spec.Template.Spec.AdditionalTags); diff != "" {
+				t.Errorf("Final spec has incorrect tags (-want +got):\n%s", diff)
+			}
+		})
+	}
 }
 
 func fakePullSecret(hc *hyperv1.HostedCluster) *corev1.Secret {

--- a/hypershift-operator/controllers/nodepool/azure.go
+++ b/hypershift-operator/controllers/nodepool/azure.go
@@ -14,6 +14,10 @@ import (
 	capiazure "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 )
 
+// dummySSHKey is a base64 encoded dummy SSH public key.
+// The CAPI AzureMachineTemplate requires an SSH key to be set, so we provide a dummy one here.
+const dummySSHKey = "c3NoLXJzYSBBQUFBQjNOemFDMXljMkVBQUFBREFRQUJBQUFCQVFDTGFjOTR4dUE4QjkyMEtjejhKNjhUdmZCRjQyR2UwUllXSUx3Lzd6dDhUQlU5ell5Q0Q2K0ZlekFwWndLRjB1V3luMGVBQmlBWVdIV0tKbENxS0VIT2hOQmV2Mkx3S0dnZHFqM0dvcHV2N3RpZFVqSVpqYi9DVWtjQVRZUWhMWkxVTCs3eWkzRThKNHdhYkxEMWVNS1p1U3ZmMUsxT0RwVUFXYTkwbWVmR0FBOVdIVEhMcnF1UUpWdC9JT0JLN1ROZFNwMDVuM0Ywa29xZlE2empwRlFYMk8zaWJUc29yR3ZEekdhYS9yUENxQWhTSjRJaEhnMDNVb3FBbVlraW51NTFvVEcxRlRXaTh2b00vRVJ4TlduamNUSElET1JmYmo2bFVyZ3Zkci9MZGtqc2dFcENiNEMxUS9IbW5MRHVpTEdPM2tNZ2cyOHFzZ0ZmTHloUjl3ay8K"
+
 func azureMachineTemplateSpec(nodePool *hyperv1.NodePool) (*capiazure.AzureMachineTemplateSpec, error) {
 	subnetName, err := azureutil.GetSubnetNameFromSubnetID(nodePool.Spec.Platform.Azure.SubnetID)
 	if err != nil {
@@ -88,6 +92,8 @@ func azureMachineTemplateSpec(nodePool *hyperv1.NodePool) (*capiazure.AzureMachi
 			}
 		}
 	}
+
+	azureMachineTemplate.Template.Spec.SSHPublicKey = dummySSHKey
 
 	return azureMachineTemplate, nil
 }

--- a/hypershift-operator/controllers/nodepool/azure_test.go
+++ b/hypershift-operator/controllers/nodepool/azure_test.go
@@ -14,14 +14,6 @@ import (
 )
 
 func TestAzureMachineTemplateSpec(t *testing.T) {
-	testAzureMachineTemplateSpec := capiazure.AzureMachineTemplateSpec{
-		Template: capiazure.AzureMachineTemplateResource{
-			Spec: capiazure.AzureMachineSpec{
-				SSHPublicKey: "asdf",
-			},
-		},
-	}
-
 	testCases := []struct {
 		name                             string
 		nodePool                         *hyperv1.NodePool
@@ -78,7 +70,7 @@ func TestAzureMachineTemplateSpec(t *testing.T) {
 							CachingType:      "",
 						},
 						DataDisks:              nil,
-						SSHPublicKey:           "asdf",
+						SSHPublicKey:           dummySSHKey,
 						AdditionalTags:         nil,
 						AdditionalCapabilities: nil,
 						AllocatePublicIP:       false,
@@ -152,7 +144,7 @@ func TestAzureMachineTemplateSpec(t *testing.T) {
 							CachingType:      "",
 						},
 						DataDisks:              nil,
-						SSHPublicKey:           "asdf",
+						SSHPublicKey:           dummySSHKey,
 						AdditionalTags:         nil,
 						AdditionalCapabilities: nil,
 						AllocatePublicIP:       false,
@@ -236,7 +228,7 @@ func TestAzureMachineTemplateSpec(t *testing.T) {
 							CachingType:      "",
 						},
 						DataDisks:              nil,
-						SSHPublicKey:           "asdf",
+						SSHPublicKey:           dummySSHKey,
 						AdditionalTags:         nil,
 						AdditionalCapabilities: nil,
 						AllocatePublicIP:       false,
@@ -326,7 +318,7 @@ func TestAzureMachineTemplateSpec(t *testing.T) {
 							CachingType:      "ReadOnly",
 						},
 						DataDisks:              nil,
-						SSHPublicKey:           "asdf",
+						SSHPublicKey:           dummySSHKey,
 						AdditionalTags:         nil,
 						AdditionalCapabilities: nil,
 						AllocatePublicIP:       false,
@@ -422,7 +414,7 @@ func TestAzureMachineTemplateSpec(t *testing.T) {
 							CachingType:      "ReadOnly",
 						},
 						DataDisks:              nil,
-						SSHPublicKey:           "asdf",
+						SSHPublicKey:           dummySSHKey,
 						AdditionalTags:         nil,
 						AdditionalCapabilities: nil,
 						AllocatePublicIP:       false,
@@ -516,10 +508,6 @@ func TestAzureMachineTemplateSpec(t *testing.T) {
 			g := NewGomegaWithT(t)
 
 			azureSpec, err := azureMachineTemplateSpec(tc.nodePool)
-			if azureSpec != nil && azureSpec.Template.Spec.SSHPublicKey == "" {
-				azureSpec.Template.Spec.SSHPublicKey = testAzureMachineTemplateSpec.Template.Spec.SSHPublicKey
-			}
-
 			if tc.expectedErr {
 				g.Expect(err.Error()).To(Equal(tc.expectedErrMsg))
 			} else {

--- a/hypershift-operator/controllers/nodepool/capi.go
+++ b/hypershift-operator/controllers/nodepool/capi.go
@@ -70,6 +70,12 @@ func (c *CAPI) Reconcile(ctx context.Context) error {
 		return err
 	}
 
+	if c.nodePool.Spec.Platform.Type == hyperv1.AWSPlatform {
+		if err := c.reconcileAWSMachines(ctx); err != nil {
+			return err
+		}
+	}
+
 	//  Reconcile (Platform)MachineTemplate.
 	template, err := c.machineTemplateBuilders()
 	if err != nil {

--- a/hypershift-operator/controllers/nodepool/capi.go
+++ b/hypershift-operator/controllers/nodepool/capi.go
@@ -9,10 +9,8 @@ import (
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
-	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
-	"github.com/openshift/hypershift/hypershift-operator/controllers/nodepool/kubevirt"
-	"github.com/openshift/hypershift/hypershift-operator/controllers/nodepool/openstack"
 	"github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/upsert"
 	supportutil "github.com/openshift/hypershift/support/util"
 
 	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1beta1"
@@ -28,7 +26,6 @@ import (
 
 	capiaws "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	capiazure "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
-	capipowervs "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
 	capikubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 	capiopenstackv1beta1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -46,6 +43,7 @@ import (
 type CAPI struct {
 	*Token
 	capiClusterName string
+	upsert.ApplyProvider
 }
 
 func newCAPI(token *Token, capiClusterName string) (*CAPI, error) {
@@ -60,6 +58,7 @@ func newCAPI(token *Token, capiClusterName string) (*CAPI, error) {
 	return &CAPI{
 		Token:           token,
 		capiClusterName: capiClusterName,
+		ApplyProvider:   upsert.NewApplyProvider(false),
 	}, nil
 }
 
@@ -72,13 +71,12 @@ func (c *CAPI) Reconcile(ctx context.Context) error {
 	}
 
 	//  Reconcile (Platform)MachineTemplate.
-	template, mutateTemplate, _, err := c.machineTemplateBuilders()
+	template, err := c.machineTemplateBuilders()
 	if err != nil {
 		return err
 	}
-	if result, err := c.CreateOrUpdate(ctx, c.Client, template, func() error {
-		return mutateTemplate(template)
-	}); err != nil {
+
+	if result, err := c.ApplyManifest(ctx, c.Client, template); err != nil {
 		return err
 	} else {
 		log.Info("Reconciled Machine template", "result", result)
@@ -727,161 +725,52 @@ func setMachineDeploymentReplicas(nodePool *hyperv1.NodePool, machineDeployment 
 // machineTemplateBuilders returns a client.Object with a particular (platform)MachineTemplate type.
 // a func to mutate the (platform)MachineTemplate.spec, a json string representation for (platform)MachineTemplate.spec
 // and an error.
-func (c *CAPI) machineTemplateBuilders() (client.Object, func(object client.Object) error, string, error) {
-	var mutateTemplate func(object client.Object) error
+func (c *CAPI) machineTemplateBuilders() (client.Object, error) {
+	templateNameGenerator := func(spec any) (string, error) {
+		specJSON, err := json.Marshal(spec)
+		if err != nil {
+			return "", err
+		}
+		// using HashStruct(specJSON) ensures a rolling upgrade is triggered
+		// by creating a new template with a different name if any field changes.
+		return getName(c.nodePool.GetName(), supportutil.HashSimple(specJSON),
+			validation.DNS1123SubdomainMaxLength), nil
+	}
+
 	var template client.Object
-	var machineTemplateSpec interface{}
+	var err error
 
-	nodePool := c.nodePool
-	capiClusterName := c.capiClusterName
-	hcluster := c.hostedCluster
-	createDefaultAWSSecurityGroup := c.cpoCapabilities.CreateDefaultAWSSecurityGroup
-	releaseImage := c.releaseImage
-
-	switch nodePool.Spec.Platform.Type {
+	switch c.nodePool.Spec.Platform.Type {
 	// Define the desired template type and mutateTemplate function.
 	case hyperv1.AWSPlatform:
-		template = &capiaws.AWSMachineTemplate{}
-		var err error
-		machineTemplateSpec, err = awsMachineTemplateSpec(capiClusterName, hcluster, nodePool, createDefaultAWSSecurityGroup, releaseImage)
-		if err != nil {
-			return nil, nil, "", err
-		}
-		mutateTemplate = func(object client.Object) error {
-			o, _ := object.(*capiaws.AWSMachineTemplate)
-			o.Spec = *machineTemplateSpec.(*capiaws.AWSMachineTemplateSpec)
-			if o.Annotations == nil {
-				o.Annotations = make(map[string]string)
-			}
-			o.Annotations[nodePoolAnnotation] = client.ObjectKeyFromObject(nodePool).String()
-			return nil
-		}
+		template, err = c.awsMachineTemplate(templateNameGenerator)
 	case hyperv1.AgentPlatform:
-		template = &agentv1.AgentMachineTemplate{}
-		machineTemplateSpec = agentMachineTemplateSpec(nodePool)
-		mutateTemplate = func(object client.Object) error {
-			o, _ := object.(*agentv1.AgentMachineTemplate)
-			o.Spec = *machineTemplateSpec.(*agentv1.AgentMachineTemplateSpec)
-			if o.Annotations == nil {
-				o.Annotations = make(map[string]string)
-			}
-			o.Annotations[nodePoolAnnotation] = client.ObjectKeyFromObject(nodePool).String()
-			return nil
-		}
+		template, err = c.agentMachineTemplate(templateNameGenerator)
 	case hyperv1.KubevirtPlatform:
-		template = &capikubevirt.KubevirtMachineTemplate{}
-		var err error
-		machineTemplateSpec, err = kubevirt.MachineTemplateSpec(nodePool, hcluster, c.releaseImage, nil)
-		if err != nil {
-			SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
-				Type:               hyperv1.NodePoolValidMachineTemplateConditionType,
-				Status:             corev1.ConditionFalse,
-				Reason:             hyperv1.InvalidKubevirtMachineTemplate,
-				Message:            err.Error(),
-				ObservedGeneration: nodePool.Generation,
-			})
-
-			return nil, nil, "", err
-		} else {
-			removeStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolValidMachineTemplateConditionType)
-		}
-
-		mutateTemplate = func(object client.Object) error {
-			o, _ := object.(*capikubevirt.KubevirtMachineTemplate)
-			o.Spec = *machineTemplateSpec.(*capikubevirt.KubevirtMachineTemplateSpec)
-			if o.Annotations == nil {
-				o.Annotations = make(map[string]string)
-			}
-			o.Annotations[nodePoolAnnotation] = client.ObjectKeyFromObject(nodePool).String()
-			return nil
-		}
+		template, err = c.kubevirtMachineTemplate(templateNameGenerator)
 	case hyperv1.AzurePlatform:
-		var err error
-		template = &capiazure.AzureMachineTemplate{}
-		machineTemplateSpec, err = azureMachineTemplateSpec(nodePool)
-		if err != nil {
-			return nil, nil, "", err
-		}
-		mutateTemplate = func(object client.Object) error {
-			o, _ := object.(*capiazure.AzureMachineTemplate)
-
-			// The azure api requires passing a public key. This key is randomly generated, the private portion is thrown away and the public key
-			// gets written to the template.
-			sshKey := o.Spec.Template.Spec.SSHPublicKey
-			if sshKey == "" {
-				sshKey, err = generateSSHPubkey()
-				if err != nil {
-					return fmt.Errorf("failed to generate a SSH key: %w", err)
-				}
-			}
-
-			o.Spec = *machineTemplateSpec.(*capiazure.AzureMachineTemplateSpec)
-			o.Spec.Template.Spec.SSHPublicKey = sshKey
-
-			if o.Annotations == nil {
-				o.Annotations = make(map[string]string)
-			}
-			o.Annotations[nodePoolAnnotation] = client.ObjectKeyFromObject(nodePool).String()
-			return nil
-		}
-
+		template, err = c.azureMachineTemplate(templateNameGenerator)
 	case hyperv1.PowerVSPlatform:
-		template = &capipowervs.IBMPowerVSMachineTemplate{}
-		var err error
-		machineTemplateSpec, err = ibmPowerVSMachineTemplateSpec(hcluster, nodePool, c.releaseImage)
-		if err != nil {
-			return nil, nil, "", err
-		}
-		mutateTemplate = func(object client.Object) error {
-			o, _ := object.(*capipowervs.IBMPowerVSMachineTemplate)
-			o.Spec = *machineTemplateSpec.(*capipowervs.IBMPowerVSMachineTemplateSpec)
-			if o.Annotations == nil {
-				o.Annotations = make(map[string]string)
-			}
-			o.Annotations[nodePoolAnnotation] = client.ObjectKeyFromObject(nodePool).String()
-			return nil
-		}
+		template, err = c.ibmPowerVSMachineTemplate(templateNameGenerator)
 	case hyperv1.OpenStackPlatform:
-		template = &capiopenstackv1beta1.OpenStackMachineTemplate{}
-		var err error
-		machineTemplateSpec, err = openstack.MachineTemplateSpec(hcluster, nodePool, c.releaseImage)
-		if err != nil {
-			SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
-				Type:               hyperv1.NodePoolValidMachineTemplateConditionType,
-				Status:             corev1.ConditionFalse,
-				Reason:             hyperv1.InvalidOpenStackMachineTemplate,
-				Message:            err.Error(),
-				ObservedGeneration: nodePool.Generation,
-			})
-
-			return nil, nil, "", err
-		} else {
-			removeStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolValidMachineTemplateConditionType)
-		}
-
-		mutateTemplate = func(object client.Object) error {
-			o, _ := object.(*capiopenstackv1beta1.OpenStackMachineTemplate)
-			o.Spec = *machineTemplateSpec.(*capiopenstackv1beta1.OpenStackMachineTemplateSpec)
-			if o.Annotations == nil {
-				o.Annotations = make(map[string]string)
-			}
-			o.Annotations[nodePoolAnnotation] = client.ObjectKeyFromObject(nodePool).String()
-			return nil
-		}
+		template, err = c.openstackMachineTemplate(templateNameGenerator)
 	default:
 		// TODO(alberto): Consider signal in a condition.
-		return nil, nil, "", fmt.Errorf("unsupported platform type: %s", nodePool.Spec.Platform.Type)
+		err = fmt.Errorf("unsupported platform type: %s", c.nodePool.Spec.Platform.Type)
 	}
-	template.SetNamespace(manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name))
-
-	machineTemplateSpecJSON, err := json.Marshal(machineTemplateSpec)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, fmt.Errorf("failed to create machine template: %w", err)
 	}
 
-	template.SetName(generateMachineTemplateName(nodePool, machineTemplateSpecJSON))
+	annotations := template.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[nodePoolAnnotation] = client.ObjectKeyFromObject(c.nodePool).String()
 
-	return template, mutateTemplate, string(machineTemplateSpecJSON), nil
+	template.SetAnnotations(annotations)
+	template.SetNamespace(c.controlplaneNamespace)
+	return template, nil
 }
 
 func generateMachineTemplateName(nodePool *hyperv1.NodePool, machineTemplateSpecJSON []byte) string {

--- a/hypershift-operator/controllers/nodepool/capi_test.go
+++ b/hypershift-operator/controllers/nodepool/capi_test.go
@@ -504,6 +504,7 @@ func RunTestMachineTemplateBuilders(t *testing.T, preCreateMachineTemplate bool)
 			ConfigGenerator: &ConfigGenerator{
 				hostedCluster: hcluster,
 				nodePool:      nodePool,
+				Client:        c,
 				rolloutConfig: &rolloutConfig{
 					releaseImage: &releaseinfo.ReleaseImage{},
 				},
@@ -514,7 +515,7 @@ func RunTestMachineTemplateBuilders(t *testing.T, preCreateMachineTemplate bool)
 		},
 		capiClusterName: "test",
 	}
-	template, err := capi.machineTemplateBuilders()
+	template, err := capi.machineTemplateBuilders(context.Background())
 	g.Expect(err).ToNot(HaveOccurred())
 
 	machineTemplateSpec := template.(*capiaws.AWSMachineTemplate).Spec
@@ -1033,7 +1034,7 @@ func TestCAPIReconcile(t *testing.T) {
 	maxSurge := intstr.FromInt(1)
 	// This is the generated name by machineTemplateBuilders.
 	// So reconciliation doesn't create a new AWSMachineTemplate but reconcile this one.
-	awsMachineTemplateName := "test-nodepool-77a60936"
+	awsMachineTemplateName := "test-nodepool-28d5cf5a"
 	capiClusterName := "infra-id"
 
 	tests := []struct {
@@ -1397,6 +1398,7 @@ func TestCAPIReconcile(t *testing.T) {
 					CreateOrUpdateProvider: upsert.New(false),
 				},
 				capiClusterName: capiClusterName,
+				ApplyProvider:   upsert.NewApplyProvider(false),
 			}
 
 			// Make sure the templates are populates in the control plane namespace

--- a/hypershift-operator/controllers/nodepool/openstack.go
+++ b/hypershift-operator/controllers/nodepool/openstack.go
@@ -12,11 +12,43 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	capiopenstackv1beta1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	orc "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
 )
 
+func (c *CAPI) openstackMachineTemplate(templateNameGenerator func(spec any) (string, error)) (*capiopenstackv1beta1.OpenStackMachineTemplate, error) {
+	nodePool := c.nodePool
+	spec, err := openstack.MachineTemplateSpec(c.hostedCluster, nodePool, c.releaseImage)
+	if err != nil {
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+			Type:               hyperv1.NodePoolValidMachineTemplateConditionType,
+			Status:             corev1.ConditionFalse,
+			Reason:             hyperv1.InvalidOpenStackMachineTemplate,
+			Message:            err.Error(),
+			ObservedGeneration: nodePool.Generation,
+		})
+
+		return nil, err
+	} else {
+		removeStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolValidMachineTemplateConditionType)
+	}
+
+	templateName, err := templateNameGenerator(spec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate template name: %w", err)
+	}
+
+	template := &capiopenstackv1beta1.OpenStackMachineTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: templateName,
+		},
+		Spec: *spec,
+	}
+
+	return template, nil
+}
 func (r *NodePoolReconciler) setOpenStackConditions(ctx context.Context, nodePool *hyperv1.NodePool, hcluster *hyperv1.HostedCluster, controlPlaneNamespace string, releaseImage *releaseinfo.ReleaseImage) error {
 	if nodePool.Spec.Platform.OpenStack.ImageName == "" {
 		_, err := openstack.OpenStackReleaseImage(releaseImage)

--- a/hypershift-operator/controllers/nodepool/powervs.go
+++ b/hypershift-operator/controllers/nodepool/powervs.go
@@ -86,6 +86,27 @@ func ibmPowerVSMachineTemplateSpec(hcluster *hyperv1.HostedCluster, nodePool *hy
 	}, nil
 }
 
+func (c *CAPI) ibmPowerVSMachineTemplate(templateNameGenerator func(spec any) (string, error)) (*capipowervs.IBMPowerVSMachineTemplate, error) {
+	spec, err := ibmPowerVSMachineTemplateSpec(c.hostedCluster, c.nodePool, c.releaseImage)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate PowerVSMachineTemplateSpec: %w", err)
+	}
+
+	templateName, err := templateNameGenerator(spec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate template name: %w", err)
+	}
+
+	template := &capipowervs.IBMPowerVSMachineTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: templateName,
+		},
+		Spec: *spec,
+	}
+
+	return template, nil
+}
+
 func getPowerVSImage(region string, releaseImage *releaseinfo.ReleaseImage) (*releaseinfo.CoreOSPowerVSImage, string, error) {
 	arch, foundArch := releaseImage.StreamMetadata.Architectures["ppc64le"]
 	if !foundArch {

--- a/test/e2e/nodepool_autorepair_test.go
+++ b/test/e2e/nodepool_autorepair_test.go
@@ -99,7 +99,7 @@ func (ar *NodePoolAutoRepairTest) Run(t *testing.T, nodePool hyperv1.NodePool, n
 }
 
 func ec2Client(awsCredsFile, region string) *ec2.EC2 {
-	awsSession := awsutil.NewSession("e2e-autorepair", awsCredsFile, "", "", region)
+	awsSession := awsutil.NewSession("hypershift-e2e", awsCredsFile, "", "", region)
 	awsConfig := awsutil.NewConfig()
 	return ec2.New(awsSession, awsConfig)
 }

--- a/test/e2e/nodepool_day2_tags_test.go
+++ b/test/e2e/nodepool_day2_tags_test.go
@@ -1,0 +1,119 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	. "github.com/onsi/gomega"
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capiaws "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type NodePoolDay2TagsTest struct {
+	DummyInfraSetup
+
+	ctx           context.Context
+	mgmtClient    crclient.Client
+	hostedCluster *hyperv1.HostedCluster
+	clusterOpts   e2eutil.PlatformAgnosticOptions
+}
+
+func NewNodePoolDay2TagsTest(ctx context.Context, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster, clusterOpts e2eutil.PlatformAgnosticOptions) *NodePoolDay2TagsTest {
+	return &NodePoolDay2TagsTest{
+		ctx:           ctx,
+		hostedCluster: hostedCluster,
+		mgmtClient:    mgmtClient,
+		clusterOpts:   clusterOpts,
+	}
+}
+
+func (ar *NodePoolDay2TagsTest) Setup(t *testing.T) {
+	if globalOpts.Platform != hyperv1.AWSPlatform {
+		t.Skip("test only supported on platform AWS")
+	}
+}
+
+func (ar *NodePoolDay2TagsTest) BuildNodePoolManifest(defaultNodepool hyperv1.NodePool) (*hyperv1.NodePool, error) {
+	nodePool := &hyperv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ar.hostedCluster.Name + "-" + "test-day2-tags",
+			Namespace: ar.hostedCluster.Namespace,
+		},
+	}
+	defaultNodepool.Spec.DeepCopyInto(&nodePool.Spec)
+
+	nodePool.Spec.Replicas = &oneReplicas
+
+	return nodePool, nil
+}
+
+func (ar *NodePoolDay2TagsTest) Run(t *testing.T, nodePool hyperv1.NodePool, nodes []corev1.Node) {
+	g := NewWithT(t)
+
+	day2TagKey := "test-day2-tag"
+	day2TagValue := "test-day2-value"
+
+	err := e2eutil.UpdateObject(t, ar.ctx, ar.mgmtClient, &nodePool, func(nodePool *hyperv1.NodePool) {
+		nodePool.Spec.Platform.AWS.ResourceTags = append(nodePool.Spec.Platform.AWS.ResourceTags, hyperv1.AWSResourceTag{
+			Key:   day2TagKey,
+			Value: day2TagValue,
+		})
+	})
+	g.Expect(err).NotTo(HaveOccurred(), "failed to update nodePool tags")
+
+	ec2client := ec2Client(ar.clusterOpts.AWSPlatform.Credentials.AWSCredentialsFile, ar.clusterOpts.AWSPlatform.Region)
+	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(ar.hostedCluster.Namespace, ar.hostedCluster.Name)
+
+	g.Eventually(func(g Gomega) {
+		awsMachines := &capiaws.AWSMachineList{}
+		err = ar.mgmtClient.List(ar.ctx, awsMachines, crclient.InNamespace(controlPlaneNamespace), crclient.MatchingLabels{
+			capiv1.MachineDeploymentNameLabel: nodePool.Name,
+		})
+		g.Expect(err).NotTo(HaveOccurred(), "failed to list AWSMachines for node pool")
+
+		for _, awsMachine := range awsMachines.Items {
+			g.Expect(awsMachine.Spec.AdditionalTags).To(HaveKeyWithValue(day2TagKey, day2TagValue))
+
+			instanceID := awsMachines.Items[0].Spec.InstanceID
+			// Fetch the EC2 instance to verify the tag
+			instance, err := ec2client.DescribeInstancesWithContext(ar.ctx, &ec2.DescribeInstancesInput{
+				InstanceIds: []*string{instanceID},
+			})
+			g.Expect(err).NotTo(HaveOccurred(), "failed to describe EC2 instance")
+
+			g.Expect(instance.Reservations).NotTo(BeEmpty(), "expected at least one reservation")
+			g.Expect(instance.Reservations[0].Instances).NotTo(BeEmpty(), "expected at least one instance")
+			g.Expect(instance.Reservations[0].Instances[0].Tags).To(ContainElement(&ec2.Tag{
+				Key:   aws.String(day2TagKey),
+				Value: aws.String(day2TagValue),
+			}))
+		}
+	}).WithContext(ar.ctx).WithTimeout(time.Minute * 2).WithPolling(time.Second).Should(Succeed())
+
+	// Ensure the machine deployment generation is not updated after the tag change.
+	// This is to ensure that the tag change does not trigger a rolling update.
+	// If the generation is updated, it indicates that the tag change triggered a rolling update
+	// which is not an expected behavior.
+	// The generation should only be updated when the node pool spec changes in a way that requires a rolling update
+	// such as changing the instance type.
+	md := &capiv1.MachineDeployment{}
+	err = ar.mgmtClient.Get(ar.ctx, crclient.ObjectKey{
+		Name:      nodePool.Name,
+		Namespace: controlPlaneNamespace,
+	}, md)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to get machine deployment for node pool")
+
+	g.Expect(md.Generation).To(BeEquivalentTo(1), "machine deployment generation should not change after day 2 tag update")
+}

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -90,6 +90,10 @@ func TestNodePool(t *testing.T) {
 						test: NewRollingUpgradeTest(ctx, mgtClient, hostedCluster),
 					},
 					{
+						name: "TestNodePoolDay2Tags",
+						test: NewNodePoolDay2TagsTest(ctx, mgtClient, hostedCluster, clusterOpts),
+					},
+					{
 						name: "KubeVirtQoSClassGuaranteedTest",
 						test: NewKubeVirtQoSClassGuaranteedTest(ctx, mgtClient, hostedCluster),
 					},


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently changing the `resourceTags` field on the HostedCluster or `Tags` field on the NodePool will cause a rolling upgrade of all the nodes. This PR allows tags changes to be updated in-place.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.