### PR TITLE
CORENET-6094: CNO: add FRR-k8s image

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_network_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_network_operator_deployment.yaml
@@ -151,6 +151,8 @@ spec:
           value: networking-console-plugin
         - name: CLI_IMAGE
           value: cli
+        - name: FRR_K8S_IMAGE
+          value: metallb-frr
         - name: PROXY_INTERNAL_APISERVER_ADDRESS
           value: "true"
         image: cluster-network-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/zz_fixture_TestControlPlaneComponents_cluster_network_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/zz_fixture_TestControlPlaneComponents_cluster_network_operator_deployment.yaml
@@ -151,6 +151,8 @@ spec:
           value: networking-console-plugin
         - name: CLI_IMAGE
           value: cli
+        - name: FRR_K8S_IMAGE
+          value: metallb-frr
         - name: PROXY_INTERNAL_APISERVER_ADDRESS
           value: "true"
         image: cluster-network-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cno/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cno/deployment.go
@@ -111,6 +111,7 @@ func buildCNOEnvVars(cpContext component.WorkloadContext) ([]corev1.EnvVar, erro
 		{Name: "NETWORK_CHECK_TARGET_IMAGE", Value: userReleaseImageProvider.GetImage("cluster-network-operator")},
 		{Name: "NETWORKING_CONSOLE_PLUGIN_IMAGE", Value: userReleaseImageProvider.GetImage("networking-console-plugin")},
 		{Name: "CLI_IMAGE", Value: userReleaseImageProvider.GetImage("cli")},
+		{Name: "FRR_K8S_IMAGE", Value: userReleaseImageProvider.GetImage("metallb-frr")},
 	}
 
 	if !util.IsPrivateHCP(hcp) {


### PR DESCRIPTION
The BGP feature added a new image to the payload, `metallb-frr`, since 4.19. This image is not used by default and has to be enabled through CNO config. For 4.19, tech-preview feature set needs to be enabled as of today but there are plans to promote it to the default feature set in a 4.19.z release.