### PR TITLE
NO-JIRA: cpov1: set TerminationMessagePolicy on oas-trust-anchor-generator

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oapi/deployment.go
@@ -343,6 +343,7 @@ chmod 0444 /run/ca-trust-generated/tls-ca-bundle.pem
 func buildOASTrustAnchorGenerator(oasImage string) func(*corev1.Container) {
 	return func(c *corev1.Container) {
 		c.Image = oasImage
+		c.TerminationMessagePolicy = corev1.TerminationMessageFallbackToLogsOnError
 		c.Command = []string{
 			"/bin/bash",
 			"-c",


### PR DESCRIPTION
Missed this one on https://github.com/openshift/hypershift/pull/6245

So we can close the gate on this one https://github.com/openshift/hypershift/pull/6291