### PR TITLE
OCPBUGS-55399: cluster-node-tuning-operator Pod of the hosted cluster is not listening on 60000 port which makes the target to be down

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/nto/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/nto/servicemonitor.go
@@ -5,8 +5,6 @@ import (
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/util"
 
-	"k8s.io/utils/ptr"
-
 	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
@@ -19,7 +17,8 @@ func adaptServiceMonitor(cpContext component.WorkloadContext, sm *prometheusoper
 		MatchNames: []string{sm.Namespace},
 	}
 
-	sm.Spec.Endpoints[0].TLSConfig.ServerName = ptr.To(metricsServiceName + "." + sm.Namespace + ".svc")
+	sm.Spec.Endpoints[0].Scheme = "http"
+	sm.Spec.Endpoints[0].TLSConfig = nil
 	sm.Spec.Endpoints[0].MetricRelabelConfigs = metrics.NTORelabelConfigs(cpContext.MetricsSet)
 	util.ApplyClusterIDLabel(&sm.Spec.Endpoints[0], cpContext.HCP.Spec.ClusterID)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the NTO to run NTO related metrics on port 60000 by changing the port protocol from HTTPS to HTTP, which allows the metrics to run without the need for additional permissions to RBAC resources in the kube-system namespace to the HyperShift operator.
**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-55399](https://issues.redhat.com/browse/OCPBUGS-55399)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.