### PR TITLE
CNTRLPLANE-777: Update manifest.go to use latest oc committed code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	k8s.io/cli-runtime v0.32.2
 	k8s.io/client-go v0.32.2
 	k8s.io/component-base v0.32.2
+	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/kube-aggregator v0.32.2
 	k8s.io/kube-scheduler v0.32.2
@@ -243,7 +244,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
-	k8s.io/klog v1.0.0 // indirect
 	k8s.io/kms v0.32.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
 	k8s.io/kubelet v0.31.1 // indirect

--- a/support/releaseinfo/registryclient/client.go
+++ b/support/releaseinfo/registryclient/client.go
@@ -250,7 +250,8 @@ func GetMetadata(ctx context.Context, imageRef string, pullSecret []byte) (*dock
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to get repo setup: %w", err)
 	}
-	firstManifest, location, err := manifest.FirstManifest(ctx, *ref, repo)
+	filterOptions := manifest.FilterOptions{}
+	firstManifest, location, err := manifest.FirstManifest(ctx, *ref, repo, filterOptions.Include)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to obtain root manifest for %s: %w", imageRef, err)
 	}

--- a/support/thirdparty/oc/pkg/cli/image/manifest/README.md
+++ b/support/thirdparty/oc/pkg/cli/image/manifest/README.md
@@ -1,0 +1,30 @@
+# Third Party Code from OpenShift CLI (oc)
+
+This directory contains third party code copied from the [OpenShift CLI (oc)](https://github.com/openshift/oc) repository.
+
+## Files and Their Sources
+
+### manifest.go
+Contains copied function calls from:
+- **Source**: https://github.com/openshift/oc/blob/ea5c72052233361761ba371b7c39518d443422be/pkg/cli/image/manifest/manifest.go
+- **Functions copied**: `FirstManifest`, `ManifestToImageConfig`, `ProcessManifestList`, and related types (`FilterFunc`, `ManifestLocation`)
+- **Purpose**: Provides image manifest processing functionality for container image operations
+
+### dockercredentials/credentials.go  
+Contains copied credential handling code from the oc repository:
+- **Purpose**: Provides Docker credential store functionality for registry authentication
+- **Functions**: `NewFromFile`, `NewFromBytes`, `BasicFromKeyring`, and related types
+
+## Rationale
+
+At the time of copying, it was easier to copy and paste the function call contents rather than calling the exported 
+functions from oc directly. Calling the functions directly would have invoked many go.mod changes including several 
+conflicting dependencies between HyperShift, oc, and the library-go repositories.
+
+## Maintenance
+
+This code is a point-in-time copy and may become outdated as the upstream oc repository evolves. When updating or maintaining this code:
+
+1. Consider whether direct imports from oc are feasible with current dependency management
+2. If copying updates, ensure compatibility with HyperShift's usage patterns
+ 

--- a/support/util/imagemetadata.go
+++ b/support/util/imagemetadata.go
@@ -93,7 +93,9 @@ func (r *RegistryClientImageMetadataProvider) ImageMetadata(ctx context.Context,
 	}
 
 	ref.ID = parsedImageRef.ID
-	firstManifest, location, err := manifest.FirstManifest(ctx, *ref, repo)
+
+	filterOptions := manifest.FilterOptions{}
+	firstManifest, location, err := manifest.FirstManifest(ctx, *ref, repo, filterOptions.Include)
 	if err != nil {
 		return nil, fmt.Errorf("failed to obtain root manifest for %s: %w", imageRef, err)
 	}
@@ -312,7 +314,8 @@ func getMetadata(ctx context.Context, imageRef string, pullSecret []byte) (*dock
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to get repo setup: %w", err)
 	}
-	firstManifest, location, err := manifest.FirstManifest(ctx, *ref, repo)
+	filterOptions := manifest.FilterOptions{}
+	firstManifest, location, err := manifest.FirstManifest(ctx, *ref, repo, filterOptions.Include)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to obtain root manifest for %s: %w", imageRef, err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR tries to help resolve the intermittent issue seen [here](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.20-periodics-e2e-aks/1937299784293421056) by updating the copied `oc` third party code. The code was copied instead of called directly in order to avoid the go.mod changes that were required when calling the oc functions directly.

**Which issue(s) this PR fixes**:
Part of [CNTRLPLANE-777](https://issues.redhat.com/browse/CNTRLPLANE-777)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.