### PR TITLE
ACM-21713: adding .git in .dockerignore to fix version info

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 bin/
 hack/tools/bin/
 contrib/
-.git/
 .github/
 .tekton/
 .ci-operator.yaml

--- a/Containerfile.cli
+++ b/Containerfile.cli
@@ -1,8 +1,8 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23.6 AS builder
+FROM registry.redhat.io/rhel9/go-toolset:1.23.6-1745588370 AS builder
 
 WORKDIR /hypershift
 
-COPY . .
+COPY --chown=default . .
 
 RUN make product-cli-release
 

--- a/Containerfile.control-plane
+++ b/Containerfile.control-plane
@@ -1,8 +1,8 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23.6 AS builder
+FROM registry.redhat.io/rhel9/go-toolset:1.23.6-1745588370 AS builder
 
 WORKDIR /hypershift
 
-COPY . .
+COPY --chown=default . .
 
 RUN make control-plane-operator \
   && make control-plane-pki-operator

--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -1,8 +1,8 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23.6 AS builder
+FROM registry.redhat.io/rhel9/go-toolset:1.23.6-1745588370 AS builder
 
 WORKDIR /hypershift
 
-COPY . .
+COPY --chown=default . .
 
 RUN make hypershift \
   && make hypershift-operator \

--- a/hack/tools/git-hooks/cpo-containerfiles-in-sync.sh
+++ b/hack/tools/git-hooks/cpo-containerfiles-in-sync.sh
@@ -3,7 +3,7 @@ echo >&2 "Processing " "$@"
 
 eval_cmd=("diff")
 for f in "$@"; do
-  eval_cmd+=("<(sed -e '/^FROM /d' \"$f\")")
+  eval_cmd+=("<(sed -e '/^FROM /d' -e '/COPY .* \. \./d' -e '/COPY \. \./d' \"$f\")")
 done
 
 eval "${eval_cmd[*]}"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds .git back to the .dockerignore file so that vsc build information gets added to the binaries. Without this change, you get version information for the server and the client.

The `hack/tools/git-hooks/cpo-containerfiles-in-sync.sh` was modified to skip comparing the first COPY line due to golang builder image differences in the two dockerfiles it compares.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #https://issues.redhat.com/browse/ACM-21713

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.