### PR TITLE
MGMT-20826: Enable disabling of Ingress capability

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -379,7 +379,7 @@ const (
 	PruneRetentionPolicy RetentionPolicy = "Prune"
 )
 
-// +kubebuilder:validation:Enum=ImageRegistry;openshift-samples;Insights;baremetal;Console;NodeTuning
+// +kubebuilder:validation:Enum=ImageRegistry;openshift-samples;Insights;baremetal;Console;NodeTuning;Ingress
 type OptionalCapability string
 
 const ImageRegistryCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityImageRegistry)
@@ -388,6 +388,7 @@ const InsightsCapability OptionalCapability = OptionalCapability(configv1.Cluste
 const BaremetalCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityBaremetal)
 const ConsoleCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityConsole)
 const NodeTuningCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityNodeTuning)
+const IngressCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityIngress)
 
 // capabilities allows enabling or disabling optional components at install time.
 // When this is not supplied, the cluster will use the DefaultCapabilitySet defined for the respective
@@ -406,16 +407,19 @@ type Capabilities struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Enabled is immutable. Changes might result in unpredictable and disruptive behavior."
 	Enabled []OptionalCapability `json:"enabled,omitempty"`
 
+	// TODO: Remove the validation that requires the Ingress capability to be disabled only when Console is also disabled, once OCPBUGS-58422 is resolved by the console team
+
 	// disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
 	// Once set, this field cannot be changed.
 	//
-	// Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+	// Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
 	//
 	// +listType=atomic
 	// +immutable
 	// +optional
 	// +kubebuilder:validation:MaxItems=25
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Disabled is immutable. Changes might result in unpredictable and disruptive behavior."
+	// +kubebuilder:validation:XValidation:rule="!self.exists(cap, cap == 'Ingress') || self.exists(cap, cap == 'Console')",message="Ingress capability can only be disabled if Console capability is also disabled"
 	Disabled []OptionalCapability `json:"disabled,omitempty"`
 }
 

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -161,7 +161,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -170,6 +170,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -178,6 +179,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -190,6 +195,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -208,7 +208,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -217,6 +217,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -225,6 +226,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -237,6 +242,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -161,7 +161,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -170,6 +170,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -178,6 +179,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -190,6 +195,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -161,7 +161,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -170,6 +170,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -178,6 +179,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -190,6 +195,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -161,7 +161,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -170,6 +170,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -178,6 +179,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -190,6 +195,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -161,7 +161,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -170,6 +170,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -178,6 +179,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -190,6 +195,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -161,7 +161,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -170,6 +170,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -178,6 +179,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -190,6 +195,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -161,7 +161,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -170,6 +170,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -178,6 +179,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -190,6 +195,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -161,7 +161,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -170,6 +170,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -178,6 +179,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -190,6 +195,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -161,7 +161,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -170,6 +170,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -178,6 +179,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -190,6 +195,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -129,7 +129,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -138,6 +138,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -146,6 +147,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -158,6 +163,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -176,7 +176,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -185,6 +185,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -193,6 +194,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -205,6 +210,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -129,7 +129,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -138,6 +138,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -146,6 +147,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -158,6 +163,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -129,7 +129,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -138,6 +138,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -146,6 +147,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -158,6 +163,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -129,7 +129,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -138,6 +138,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -146,6 +147,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -158,6 +163,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -129,7 +129,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -138,6 +138,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -146,6 +147,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -158,6 +163,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -129,7 +129,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -138,6 +138,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -146,6 +147,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -158,6 +163,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -129,7 +129,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -138,6 +138,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -146,6 +147,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -158,6 +163,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -129,7 +129,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -138,6 +138,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -146,6 +147,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -158,6 +163,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -129,7 +129,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -138,6 +138,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -146,6 +147,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -158,6 +163,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -108,8 +108,8 @@ func bindCoreOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
 	flags.StringVar(&opts.PausedUntil, "pausedUntil", opts.PausedUntil, "If a date is provided in RFC3339 format, HostedCluster creation is paused until that date. If the boolean true is provided, HostedCluster creation is paused until the field is removed.")
 	flags.StringVar(&opts.ReleaseStream, "release-stream", opts.ReleaseStream, "The OCP release stream for the cluster (e.g. 4-stable-multi), this flag is ignored if release-image is set")
 	flags.StringVar(&opts.FeatureSet, "feature-set", opts.FeatureSet, "The predefined feature set to use for the cluster (TechPreviewNoUpgrade or DevPreviewNoUpgrade)")
-	flags.StringSliceVar(&opts.DisableClusterCapabilities, "disable-cluster-capabilities", nil, "Optional cluster capabilities to disable. The only currently supported values are ImageRegistry,openshift-samples,Insights,baremetal,Console,NodeTuning.")
-	flags.StringSliceVar(&opts.EnableClusterCapabilities, "enable-cluster-capabilities", nil, "Optional cluster capabilities to enable. The only currently supported values are ImageRegistry,openshift-samples,Insights,baremetal,Console,NodeTuning.")
+	flags.StringSliceVar(&opts.DisableClusterCapabilities, "disable-cluster-capabilities", nil, "Optional cluster capabilities to disable. The only currently supported values are ImageRegistry,openshift-samples,Insights,baremetal,Console,NodeTuning,Ingress.")
+	flags.StringSliceVar(&opts.EnableClusterCapabilities, "enable-cluster-capabilities", nil, "Optional cluster capabilities to enable. The only currently supported values are ImageRegistry,openshift-samples,Insights,baremetal,Console,NodeTuning,Ingress.")
 	flags.StringVar(&opts.KubeAPIServerDNSName, "kas-dns-name", opts.KubeAPIServerDNSName, "The custom DNS name for the kube-apiserver service. Make sure the DNS name is valid and addressable.")
 }
 
@@ -714,6 +714,7 @@ func (opts *RawCreateOptions) Validate(ctx context.Context) (*ValidatedCreateOpt
 		string(hyperv1.BaremetalCapability),
 		string(hyperv1.ConsoleCapability),
 		string(hyperv1.NodeTuningCapability),
+		string(hyperv1.IngressCapability),
 	)
 	if len(opts.DisableClusterCapabilities) > 0 {
 		for _, capability := range opts.DisableClusterCapabilities {

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
@@ -211,7 +211,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -220,6 +220,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -228,6 +229,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -240,6 +245,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
@@ -164,7 +164,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -173,6 +173,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -181,6 +182,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -193,6 +198,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
@@ -211,7 +211,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -220,6 +220,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -228,6 +229,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -240,6 +245,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
@@ -179,7 +179,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -188,6 +188,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -196,6 +197,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -208,6 +213,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
@@ -132,7 +132,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -141,6 +141,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -149,6 +150,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -161,6 +166,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
@@ -179,7 +179,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -188,6 +188,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array
@@ -196,6 +197,10 @@ spec:
                     - message: Disabled is immutable. Changes might result in unpredictable
                         and disruptive behavior.
                       rule: self == oldSelf
+                    - message: Ingress capability can only be disabled if Console
+                        capability is also disabled
+                      rule: '!self.exists(cap, cap == ''Ingress'') || self.exists(cap,
+                        cap == ''Console'')'
                   enabled:
                     description: |-
                       enabled when specified, explicitly enables the specified capabilitíes on the hosted cluster.
@@ -208,6 +213,7 @@ spec:
                       - baremetal
                       - Console
                       - NodeTuning
+                      - Ingress
                       type: string
                     maxItems: 25
                     type: array

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -1362,7 +1362,6 @@ func TestControlPlaneComponents(t *testing.T) {
 		ReleaseProvider:               mockedProviderWithOpenshiftImageRegistryOverrides,
 		ManagementClusterCapabilities: &fakecapabilities.FakeSupportAllCapabilities{},
 	}
-	reconciler.registerComponents()
 
 	hcp := &hyperv1.HostedControlPlane{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1414,6 +1413,8 @@ func TestControlPlaneComponents(t *testing.T) {
 			ReleaseImage: "quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64",
 		},
 	}
+
+	reconciler.registerComponents(hcp)
 
 	cpContext := controlplanecomponent.ControlPlaneContext{
 		Context:                  context.Background(),

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/configoperator/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/configoperator/component.go
@@ -1,6 +1,8 @@
 package configoperator
 
 import (
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/capabilities"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/util"
 
@@ -33,11 +35,13 @@ func (h *hcco) NeedsManagementKASAccess() bool {
 	return true
 }
 
-func NewComponent(registryOverrides map[string]string, openShiftImageRegistryOverrides map[string][]string) component.ControlPlaneComponent {
+func NewComponent(registryOverrides map[string]string, openShiftImageRegistryOverrides map[string][]string, caps *hyperv1.Capabilities) component.ControlPlaneComponent {
 	hcco := &hcco{
 		registryOverrides:               registryOverrides,
 		openShiftImageRegistryOverrides: openShiftImageRegistryOverrides,
 	}
+
+	availabilityProberOpts := hccpAvailabilityProberOpts(caps)
 
 	return component.NewDeploymentComponent(ComponentName, hcco).
 		WithAdaptFunction(hcco.adaptDeployment).
@@ -49,26 +53,33 @@ func NewComponent(registryOverrides map[string]string, openShiftImageRegistryOve
 			"role.yaml",
 			component.WithAdaptFunction(adaptRole),
 		).
-		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{
-			KubeconfigVolumeName: "kubeconfig",
-			RequiredAPIs: []schema.GroupVersionKind{
-				{Group: "imageregistry.operator.openshift.io", Version: "v1", Kind: "Config"},
-				{Group: "config.openshift.io", Version: "v1", Kind: "Infrastructure"},
-				{Group: "config.openshift.io", Version: "v1", Kind: "DNS"},
-				{Group: "config.openshift.io", Version: "v1", Kind: "Ingress"},
-				{Group: "config.openshift.io", Version: "v1", Kind: "Network"},
-				{Group: "config.openshift.io", Version: "v1", Kind: "Proxy"},
-				{Group: "config.openshift.io", Version: "v1", Kind: "Build"},
-				{Group: "config.openshift.io", Version: "v1", Kind: "Image"},
-				{Group: "config.openshift.io", Version: "v1", Kind: "Project"},
-				{Group: "config.openshift.io", Version: "v1", Kind: "ClusterVersion"},
-				{Group: "config.openshift.io", Version: "v1", Kind: "FeatureGate"},
-				{Group: "config.openshift.io", Version: "v1", Kind: "ClusterOperator"},
-				{Group: "config.openshift.io", Version: "v1", Kind: "OperatorHub"},
-				{Group: "operator.openshift.io", Version: "v1", Kind: "Network"},
-				{Group: "operator.openshift.io", Version: "v1", Kind: "CloudCredential"},
-				{Group: "operator.openshift.io", Version: "v1", Kind: "IngressController"},
-			},
-		}).
+		InjectAvailabilityProberContainer(availabilityProberOpts).
 		Build()
+}
+
+func hccpAvailabilityProberOpts(caps *hyperv1.Capabilities) util.AvailabilityProberOpts {
+	availabilityProberOpts := util.AvailabilityProberOpts{
+		KubeconfigVolumeName: "kubeconfig",
+		RequiredAPIs: []schema.GroupVersionKind{
+			{Group: "imageregistry.operator.openshift.io", Version: "v1", Kind: "Config"},
+			{Group: "config.openshift.io", Version: "v1", Kind: "Infrastructure"},
+			{Group: "config.openshift.io", Version: "v1", Kind: "DNS"},
+			{Group: "config.openshift.io", Version: "v1", Kind: "Ingress"},
+			{Group: "config.openshift.io", Version: "v1", Kind: "Network"},
+			{Group: "config.openshift.io", Version: "v1", Kind: "Proxy"},
+			{Group: "config.openshift.io", Version: "v1", Kind: "Build"},
+			{Group: "config.openshift.io", Version: "v1", Kind: "Image"},
+			{Group: "config.openshift.io", Version: "v1", Kind: "Project"},
+			{Group: "config.openshift.io", Version: "v1", Kind: "ClusterVersion"},
+			{Group: "config.openshift.io", Version: "v1", Kind: "FeatureGate"},
+			{Group: "config.openshift.io", Version: "v1", Kind: "ClusterOperator"},
+			{Group: "config.openshift.io", Version: "v1", Kind: "OperatorHub"},
+			{Group: "operator.openshift.io", Version: "v1", Kind: "Network"},
+			{Group: "operator.openshift.io", Version: "v1", Kind: "CloudCredential"},
+		},
+	}
+	if capabilities.IsIngressCapabilityEnabled(caps) {
+		availabilityProberOpts.RequiredAPIs = append(availabilityProberOpts.RequiredAPIs, schema.GroupVersionKind{Group: "operator.openshift.io", Version: "v1", Kind: "IngressController"})
+	}
+	return availabilityProberOpts
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ingressoperator/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ingressoperator/component.go
@@ -3,6 +3,7 @@ package ingressoperator
 import (
 	oapiv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/oapi"
 	"github.com/openshift/hypershift/support/azureutil"
+	"github.com/openshift/hypershift/support/capabilities"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/util"
 
@@ -40,6 +41,7 @@ func (r *ingressOperator) NeedsManagementKASAccess() bool {
 func NewComponent() component.ControlPlaneComponent {
 	return component.NewDeploymentComponent(ComponentName, &ingressOperator{}).
 		WithAdaptFunction(adaptDeployment).
+		WithPredicate(isIngressCapabilityEnabled).
 		WithManifestAdapter(
 			"podmonitor.yaml",
 			component.WithAdaptFunction(adaptPodMonitor),
@@ -76,6 +78,12 @@ func NewComponent() component.ControlPlaneComponent {
 			KubeconfingVolumeName:   "admin-kubeconfig",
 		}).
 		Build()
+}
+
+func isIngressCapabilityEnabled(cpContext component.WorkloadContext) (bool, error) {
+	return capabilities.IsIngressCapabilityEnabled(
+		cpContext.HCP.Spec.Capabilities,
+	), nil
 }
 
 func isAroHCP(cpContext component.WorkloadContext) bool {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/config.go
@@ -28,7 +28,7 @@ func adaptConfigMap(cpContext component.WorkloadContext, cm *corev1.ConfigMap) e
 		return fmt.Errorf("unable to decode existing openshift route controller manager configuration: %w", err)
 	}
 
-	adaptConfig(config, cpContext.HCP.Spec.Configuration)
+	adaptConfig(config, cpContext.HCP.Spec.Configuration, cpContext.HCP.Spec.Capabilities)
 	configStr, err := util.SerializeResource(config, api.Scheme)
 	if err != nil {
 		return fmt.Errorf("failed to serialize openshift route controller manager configuration: %w", err)
@@ -38,7 +38,7 @@ func adaptConfigMap(cpContext component.WorkloadContext, cm *corev1.ConfigMap) e
 	return nil
 }
 
-func adaptConfig(cfg *openshiftcpv1.OpenShiftControllerManagerConfig, configuration *hyperv1.ClusterConfiguration) {
+func adaptConfig(cfg *openshiftcpv1.OpenShiftControllerManagerConfig, configuration *hyperv1.ClusterConfiguration, caps *hyperv1.Capabilities) {
 	// network config
 	if cidrs := configuration.GetAutoAssignCIDRs(); len(cidrs) > 0 {
 		cfg.Ingress.IngressIPNetworkCIDR = cidrs[0]

--- a/control-plane-operator/hostedclusterconfigoperator/cmd.go
+++ b/control-plane-operator/hostedclusterconfigoperator/cmd.go
@@ -219,7 +219,7 @@ func (o *HostedClusterConfigOperator) Run(ctx context.Context) error {
 	}
 	cfg := operator.CfgFromFile(o.TargetKubeconfig)
 	cpConfig := ctrl.GetConfigOrDie()
-	mgr := operator.Mgr(cfg, cpConfig, o.Namespace)
+	mgr := operator.Mgr(ctx, cfg, cpConfig, o.Namespace, o.HostedControlPlaneName)
 	mgr.GetLogger().Info("Starting hosted-cluster-config-operator", "version", supportedversion.String())
 	cpCluster, err := cluster.New(cpConfig, func(opt *cluster.Options) {
 		opt.Cache = cache.Options{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/machine/machine_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/machine/machine_test.go
@@ -63,6 +63,11 @@ func TestReconcileDefaultIngressEndpoints(t *testing.T) {
 					GenerateID: "foobar",
 				},
 			},
+			Capabilities: &hyperv1.Capabilities{
+				Enabled: []hyperv1.OptionalCapability{
+					hyperv1.IngressCapability,
+				},
+			},
 		},
 	}
 

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas/admissionpolicies.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas/admissionpolicies.go
@@ -8,6 +8,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/nodepool"
+	"github.com/openshift/hypershift/support/capabilities"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/upsert"
 
@@ -92,11 +93,15 @@ func reconcileConfigValidatingAdmissionPolicy(ctx context.Context, hcp *hyperv1.
 		"featuregates",
 		"images",
 		"imagecontentpolicies",
-		"ingresses",
 		"proxies",
 		"schedulers",
 		"networks",
 		"oauths",
+	}
+
+	//Only include "ingresses" in the policy if the ingress capability is enabled.
+	if capabilities.IsIngressCapabilityEnabled(hcp.Spec.Capabilities) {
+		configResources = append(configResources, "ingresses")
 	}
 
 	if hcp.Spec.OLMCatalogPlacement == hyperv1.ManagementOLMCatalogPlacement {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/rbac.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/rbac.go
@@ -1,9 +1,19 @@
 package manifests
 
 import (
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+var RbacCapabilityMap = map[string]hyperv1.OptionalCapability{
+	"system:openshift:openshift-controller-manager:ingress-to-route-controller/ClusterRole":        hyperv1.IngressCapability,
+	"openshift-route-controller-manager/openshift-route-controllers/Role":                          hyperv1.IngressCapability,
+	"system:openshift:openshift-controller-manager:ingress-to-route-controller/ClusterRoleBinding": hyperv1.IngressCapability,
+	"openshift-route-controller-manager/openshift-route-controllers/RoleBinding":                   hyperv1.IngressCapability,
+	// add others as needed
+}
 
 func CSRApproverClusterRole() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -598,12 +598,12 @@ func TestDestroyCloudResources(t *testing.T) {
 		}
 	}
 
-	verifyCleanupWebhook := func(g *WithT, c client.Client) {
+	verifyCleanupWebhook := func(g *WithT, c client.Client, hcp *hyperv1.HostedControlPlane) {
 		wh := manifests.ResourceCreationBlockerWebhook()
 		err := c.Get(context.Background(), client.ObjectKeyFromObject(wh), wh)
 		g.Expect(err).ToNot(HaveOccurred())
 		expected := manifests.ResourceCreationBlockerWebhook()
-		reconcileCreationBlockerWebhook(expected)
+		reconcileCreationBlockerWebhook(expected, hcp)
 		g.Expect(wh.Webhooks).To(BeEquivalentTo(expected.Webhooks))
 	}
 
@@ -868,7 +868,7 @@ func TestDestroyCloudResources(t *testing.T) {
 			}
 			_, err := r.destroyCloudResources(context.Background(), fakeHCP)
 			g.Expect(err).ToNot(HaveOccurred())
-			verifyCleanupWebhook(g, guestClient)
+			verifyCleanupWebhook(g, guestClient, fakeHCP)
 			if test.verify != nil {
 				test.verify(g, guestClient, uncachedClient)
 			}
@@ -985,7 +985,7 @@ func TestReconcileClusterVersionWithDisabledCapabilities(t *testing.T) {
 			ClusterID: "test-cluster-id",
 			Capabilities: &hyperv1.Capabilities{
 				Disabled: []hyperv1.OptionalCapability{
-					hyperv1.ImageRegistryCapability, hyperv1.OpenShiftSamplesCapability, hyperv1.InsightsCapability, hyperv1.ConsoleCapability, hyperv1.NodeTuningCapability,
+					hyperv1.ImageRegistryCapability, hyperv1.OpenShiftSamplesCapability, hyperv1.InsightsCapability, hyperv1.ConsoleCapability, hyperv1.NodeTuningCapability, hyperv1.IngressCapability,
 				},
 			},
 		},
@@ -1042,7 +1042,7 @@ func TestReconcileClusterVersionWithDisabledCapabilities(t *testing.T) {
 			//configv1.ClusterVersionCapabilityConsole,
 			configv1.ClusterVersionCapabilityDeploymentConfig,
 			// configv1.ClusterVersionCapabilityImageRegistry,
-			configv1.ClusterVersionCapabilityIngress,
+			//configv1.ClusterVersionCapabilityIngress,
 			//configv1.ClusterVersionCapabilityInsights,
 			configv1.ClusterVersionCapabilityMachineAPI,
 			//configv1.ClusterVersionCapabilityNodeTuning,

--- a/control-plane-operator/hostedclusterconfigoperator/operator/config.go
+++ b/control-plane-operator/hostedclusterconfigoperator/operator/config.go
@@ -8,6 +8,9 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
+	resourcemanifests "github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
+	hyperapi "github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/capabilities"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/labelenforcingclient"
 	"github.com/openshift/hypershift/support/releaseinfo"
@@ -78,11 +81,57 @@ type HostedClusterConfigOperatorConfig struct {
 	kubeClient kubeclient.Interface
 }
 
-func Mgr(cfg, cpConfig *rest.Config, namespace string) ctrl.Manager {
+func Mgr(ctx context.Context, cfg, cpConfig *rest.Config, namespace string, hcpName string) ctrl.Manager {
+	ct, err := client.New(cpConfig, client.Options{Scheme: hyperapi.Scheme})
+	if err != nil {
+		panic(fmt.Sprintf("failed to create client: %v", err))
+	}
+	hcp := resourcemanifests.HostedControlPlane(namespace, hcpName)
+	if err = ct.Get(ctx, client.ObjectKeyFromObject(hcp), hcp); err != nil {
+		panic(fmt.Sprintf("unable to get HCP: %v", err))
+	}
+
 	cfg.UserAgent = config.HCCOUserAgent
 	allSelector := cache.ByObject{
 		Label: labels.Everything(),
 	}
+
+	byObject := map[client.Object]cache.ByObject{
+		&corev1.Namespace{}:           allSelector,
+		&configv1.Infrastructure{}:    allSelector,
+		&configv1.DNS{}:               allSelector,
+		&configv1.Ingress{}:           allSelector,
+		&operatorv1.Network{}:         allSelector,
+		&configv1.Network{}:           allSelector,
+		&configv1.Proxy{}:             allSelector,
+		&configv1.Build{}:             allSelector,
+		&configv1.Image{}:             allSelector,
+		&configv1.Project{}:           allSelector,
+		&configv1.ClusterVersion{}:    allSelector,
+		&configv1.FeatureGate{}:       allSelector,
+		&configv1.ClusterOperator{}:   allSelector,
+		&configv1.OperatorHub{}:       allSelector,
+		&operatorv1.CloudCredential{}: allSelector,
+		&admissionregistrationv1.ValidatingWebhookConfiguration{}: allSelector,
+		&admissionregistrationv1.MutatingWebhookConfiguration{}:   allSelector,
+		&operatorv1.Storage{}:               allSelector,
+		&operatorv1.CSISnapshotController{}: allSelector,
+		&operatorv1.ClusterCSIDriver{}:      allSelector,
+
+		// Needed for inplace upgrader.
+		&corev1.Node{}: allSelector,
+
+		// Needed for resource cleanup
+		&corev1.Service{}:               allSelector,
+		&corev1.PersistentVolume{}:      allSelector,
+		&corev1.PersistentVolumeClaim{}: allSelector,
+		&imageregistryv1.Config{}:       allSelector,
+	}
+
+	if capabilities.IsIngressCapabilityEnabled(hcp.Spec.Capabilities) {
+		byObject[&operatorv1.IngressController{}] = allSelector
+	}
+
 	leaseDuration := time.Second * 60
 	renewDeadline := time.Second * 40
 	retryPeriod := time.Second * 15
@@ -113,38 +162,7 @@ func Mgr(cfg, cpConfig *rest.Config, namespace string) ctrl.Manager {
 		},
 		Cache: cache.Options{
 			DefaultLabelSelector: cacheLabelSelector(),
-			ByObject: map[client.Object]cache.ByObject{
-				&corev1.Namespace{}:           allSelector,
-				&configv1.Infrastructure{}:    allSelector,
-				&configv1.DNS{}:               allSelector,
-				&configv1.Ingress{}:           allSelector,
-				&operatorv1.Network{}:         allSelector,
-				&configv1.Network{}:           allSelector,
-				&configv1.Proxy{}:             allSelector,
-				&configv1.Build{}:             allSelector,
-				&configv1.Image{}:             allSelector,
-				&configv1.Project{}:           allSelector,
-				&configv1.ClusterVersion{}:    allSelector,
-				&configv1.FeatureGate{}:       allSelector,
-				&configv1.ClusterOperator{}:   allSelector,
-				&configv1.OperatorHub{}:       allSelector,
-				&operatorv1.CloudCredential{}: allSelector,
-				&admissionregistrationv1.ValidatingWebhookConfiguration{}: allSelector,
-				&admissionregistrationv1.MutatingWebhookConfiguration{}:   allSelector,
-				&operatorv1.Storage{}:               allSelector,
-				&operatorv1.CSISnapshotController{}: allSelector,
-				&operatorv1.ClusterCSIDriver{}:      allSelector,
-
-				// Needed for inplace upgrader.
-				&corev1.Node{}: allSelector,
-
-				// Needed for resource cleanup
-				&corev1.Service{}:               allSelector,
-				&corev1.PersistentVolume{}:      allSelector,
-				&corev1.PersistentVolumeClaim{}: allSelector,
-				&operatorv1.IngressController{}: allSelector,
-				&imageregistryv1.Config{}:       allSelector,
-			},
+			ByObject:             byObject,
 		},
 		Scheme: api.Scheme,
 	})

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -466,7 +466,7 @@ func NewStartCommand() *cobra.Command {
 			CertRotationScale:                       certRotationScale,
 			EnableCVOManagementClusterMetricsAccess: enableCVOManagementClusterMetricsAccess,
 			ImageMetadataProvider:                   imageMetaDataProvider,
-		}).SetupWithManager(mgr, upsert.New(enableCIDebugOutput).CreateOrUpdate); err != nil {
+		}).SetupWithManager(mgr, upsert.New(enableCIDebugOutput).CreateOrUpdate, hcp); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "hosted-control-plane")
 			os.Exit(1)
 		}

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -3543,7 +3543,7 @@ Once set, this field cannot be changed.</p>
 <em>(Optional)</em>
 <p>disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
 Once set, this field cannot be changed.</p>
-<p>Note: Disabling &lsquo;openshift-samples&rsquo;,&lsquo;Insights&rsquo;, &lsquo;Console&rsquo;, &lsquo;NodeTuning&rsquo; are only supported in OpenShift versions 4.20 and above.</p>
+<p>Note: Disabling &lsquo;openshift-samples&rsquo;,&lsquo;Insights&rsquo;, &lsquo;Console&rsquo;, &lsquo;NodeTuning&rsquo;, &lsquo;Ingress&rsquo; are only supported in OpenShift versions 4.20 and above.</p>
 </td>
 </tr>
 </tbody>
@@ -9750,6 +9750,8 @@ ClusterVersionOperatorSpec
 </tr><tr><td><p>&#34;Console&#34;</p></td>
 <td></td>
 </tr><tr><td><p>&#34;ImageRegistry&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;Ingress&#34;</p></td>
 <td></td>
 </tr><tr><td><p>&#34;Insights&#34;</p></td>
 <td></td>

--- a/support/capabilities/hosted_control_plane_capabilities.go
+++ b/support/capabilities/hosted_control_plane_capabilities.go
@@ -24,6 +24,19 @@ func IsNodeTuningCapabilityEnabled(capabilities *hyperv1.Capabilities) bool {
 	return true
 }
 
+// IsIngressCapabilityEnabled returns true if the Ingress capability is enabled, or false if disabled.
+func IsIngressCapabilityEnabled(capabilities *hyperv1.Capabilities) bool {
+	if capabilities == nil {
+		return true
+	}
+	for _, disabledCap := range capabilities.Disabled {
+		if disabledCap == hyperv1.IngressCapability {
+			return false
+		}
+	}
+	return true
+}
+
 // HasDisabledCapabilities returns true if any capabilities are disabled; otherwise, it returns false.
 func HasDisabledCapabilities(capabilities *hyperv1.Capabilities) bool {
 	if capabilities == nil {

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -148,6 +148,57 @@ func TestOnCreateAPIUX(t *testing.T) {
 						expectedErrorSubstring: "Capabilities can not be both enabled and disabled at once.",
 					},
 					{
+						name: "when Ingress capability is disabled but Console capability is enabled, it should fail",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.Capabilities = &hyperv1.Capabilities{
+								Enabled: []hyperv1.OptionalCapability{
+									hyperv1.ConsoleCapability,
+								},
+								Disabled: []hyperv1.OptionalCapability{
+									hyperv1.IngressCapability,
+								},
+							}
+						},
+						expectedErrorSubstring: "Ingress capability can only be disabled if Console capability is also disabled",
+					},
+					{
+						name: "when both Ingress and Console capabilities are disabled, it should pass",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.Capabilities = &hyperv1.Capabilities{
+								Disabled: []hyperv1.OptionalCapability{
+									hyperv1.IngressCapability,
+									hyperv1.ConsoleCapability,
+								},
+							}
+						},
+						expectedErrorSubstring: "",
+					},
+					{
+						name: "when neither Ingress nor Console capability is disabled, it should pass",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.Capabilities = &hyperv1.Capabilities{
+								Disabled: []hyperv1.OptionalCapability{
+									hyperv1.ImageRegistryCapability,
+								},
+							}
+						},
+						expectedErrorSubstring: "",
+					},
+					{
+						name: "when Ingress capability is enabled but Console capability is disabled, it should pass",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.Capabilities = &hyperv1.Capabilities{
+								Enabled: []hyperv1.OptionalCapability{
+									hyperv1.IngressCapability,
+								},
+								Disabled: []hyperv1.OptionalCapability{
+									hyperv1.ConsoleCapability,
+								},
+							}
+						},
+						expectedErrorSubstring: "",
+					},
+					{
 						name: "when baseDomain has invalid chars it should fail",
 						mutateInput: func(hc *hyperv1.HostedCluster) {
 							hc.Spec.DNS.BaseDomain = "@foo"
@@ -1420,7 +1471,8 @@ func TestCreateClusterCustomConfig(t *testing.T) {
 					},
 				},
 			}
-			// Disable Console only for versions >= 4.20 due to OCPBUGS-57129 — the Hypershift-specific deployment is missing the capability.openshift.io/name: Console annotation.
+			// Disable Console only for versions >= 4.20 due to OCPBUGS-57129 — the HyperShift-specific deployment is missing the capability.openshift.io/name: Console annotation.
+			// Additionally, due to OCPBUGS-58422, we currently allow disabling Ingress only if Console is also disabled, so Ingress is also disabled for versions >= 4.20.
 			disabledCaps := []hyperv1.OptionalCapability{
 				hyperv1.ImageRegistryCapability,
 				hyperv1.OpenShiftSamplesCapability,
@@ -1428,7 +1480,7 @@ func TestCreateClusterCustomConfig(t *testing.T) {
 				hyperv1.NodeTuningCapability,
 			}
 			if e2eutil.IsGreaterThanOrEqualTo(e2eutil.Version420) {
-				disabledCaps = append(disabledCaps, hyperv1.ConsoleCapability)
+				disabledCaps = append(disabledCaps, hyperv1.ConsoleCapability, hyperv1.IngressCapability)
 			}
 
 			hc.Spec.Capabilities = &hyperv1.Capabilities{
@@ -1471,6 +1523,9 @@ func TestCreateClusterCustomConfig(t *testing.T) {
 
 		// ensure NodeTuning component is disabled
 		e2eutil.EnsureNodeTuningCapabilityDisabled(ctx, t, clients, mgtClient, hostedCluster)
+
+		// ensure ingress component is disabled
+		e2eutil.EnsureIngressCapabilityDisabled(ctx, t, clients, mgtClient, hostedCluster)
 	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, "custom-config", globalOpts.ServiceAccountSigningKey)
 }
 

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -2808,3 +2808,86 @@ func EnsureNodeTuningCapabilityDisabled(ctx context.Context, t *testing.T, clien
 		t.Log("NodeTuning capability disabled validation completed successfully")
 	})
 }
+
+// EnsureIngressCapabilityDisabled validates the expectations for when IngressCapability is Disabled
+func EnsureIngressCapabilityDisabled(ctx context.Context, t *testing.T, clients *GuestClients, mgmtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+	t.Run("EnsureIngressCapabilityDisabled", func(t *testing.T) {
+		AtLeast(t, Version420)
+		g := NewWithT(t)
+
+		// Check guest cluster - ingress cluster operator should not exist
+		_, err := clients.CfgClient.ConfigV1().ClusterOperators().Get(ctx, "ingress", metav1.GetOptions{})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("clusteroperators.config.openshift.io \"ingress\" not found"))
+
+		// Check guest cluster - openshift-ingress-operator namespace should not exist
+		_, err = clients.KubeClient.CoreV1().Namespaces().Get(ctx, "openshift-ingress-operator", metav1.GetOptions{})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("namespaces \"openshift-ingress-operator\" not found"))
+
+		// Check guest cluster - openshift-ingress namespace should not exist
+		_, err = clients.KubeClient.CoreV1().Namespaces().Get(ctx, "openshift-ingress", metav1.GetOptions{})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("namespaces \"openshift-ingress\" not found"))
+
+		// Check guest cluster - openshift-ingress-canary namespace should not exist
+		_, err = clients.KubeClient.CoreV1().Namespaces().Get(ctx, "openshift-ingress-canary", metav1.GetOptions{})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("namespaces \"openshift-ingress-canary\" not found"))
+
+		// Check management cluster - no ingress-operator deployment in HCP namespace
+		hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
+		var deploymentList appsv1.DeploymentList
+		err = mgmtClient.List(ctx, &deploymentList, crclient.InNamespace(hcpNamespace), crclient.MatchingLabels{"app": "ingress-operator"})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(deploymentList.Items).To(BeEmpty(), "expected no ingress-operator deployment in management cluster HCP namespace")
+
+		// Check management cluster - no ingress-operator pods in HCP namespace
+		var podList corev1.PodList
+		err = mgmtClient.List(ctx, &podList, crclient.InNamespace(hcpNamespace), crclient.MatchingLabels{"app": "ingress-operator"})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(podList.Items).To(BeEmpty(), "expected no ingress-operator pods in management cluster HCP namespace")
+
+		// Check guest cluster - no IngressController resources should exist
+		_, err = clients.KubeClient.RESTClient().Get().
+			AbsPath("/apis/operator.openshift.io/v1/ingresscontrollers").
+			DoRaw(ctx)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("the server could not find the requested resource"), "expected IngressController API to not be available when ingress capability is disabled")
+
+		// Check guest cluster - no DNSRecord resources should exist
+		_, err = clients.KubeClient.RESTClient().Get().
+			AbsPath("/apis/ingress.operator.openshift.io/v1/dnsrecords").
+			DoRaw(ctx)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("the server could not find the requested resource"), "expected DNSRecord API to not be available when ingress capability is disabled")
+
+		// Check guest cluster - no GatewayClass resources should exist
+		_, err = clients.KubeClient.RESTClient().Get().
+			AbsPath("/apis/gateway.networking.k8s.io/v1/gatewayclasses").
+			DoRaw(ctx)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("the server could not find the requested resource"), "expected GatewayClass API to not be available when ingress capability is disabled")
+
+		// Check guest cluster - no Gateway resources should exist
+		_, err = clients.KubeClient.RESTClient().Get().
+			AbsPath("/apis/gateway.networking.k8s.io/v1/gateways").
+			DoRaw(ctx)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("the server could not find the requested resource"), "expected Gateway API to not be available when ingress capability is disabled")
+
+		// Check guest cluster - no HTTPRoute resources should exist
+		_, err = clients.KubeClient.RESTClient().Get().
+			AbsPath("/apis/gateway.networking.k8s.io/v1/httproutes").
+			DoRaw(ctx)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("the server could not find the requested resource"), "expected HTTPRoute API to not be available when ingress capability is disabled")
+
+		// Check guest cluster - no ReferenceGrant resources should exist
+		_, err = clients.KubeClient.RESTClient().Get().
+			AbsPath("/apis/gateway.networking.k8s.io/v1beta1/referencegrants").
+			DoRaw(ctx)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("the server could not find the requested resource"), "expected ReferenceGrant API to not be available when ingress capability is disabled")
+	})
+}

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -379,7 +379,7 @@ const (
 	PruneRetentionPolicy RetentionPolicy = "Prune"
 )
 
-// +kubebuilder:validation:Enum=ImageRegistry;openshift-samples;Insights;baremetal;Console;NodeTuning
+// +kubebuilder:validation:Enum=ImageRegistry;openshift-samples;Insights;baremetal;Console;NodeTuning;Ingress
 type OptionalCapability string
 
 const ImageRegistryCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityImageRegistry)
@@ -388,6 +388,7 @@ const InsightsCapability OptionalCapability = OptionalCapability(configv1.Cluste
 const BaremetalCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityBaremetal)
 const ConsoleCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityConsole)
 const NodeTuningCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityNodeTuning)
+const IngressCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityIngress)
 
 // capabilities allows enabling or disabling optional components at install time.
 // When this is not supplied, the cluster will use the DefaultCapabilitySet defined for the respective
@@ -406,16 +407,19 @@ type Capabilities struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Enabled is immutable. Changes might result in unpredictable and disruptive behavior."
 	Enabled []OptionalCapability `json:"enabled,omitempty"`
 
+	// TODO: Remove the validation that requires the Ingress capability to be disabled only when Console is also disabled, once OCPBUGS-58422 is resolved by the console team
+
 	// disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
 	// Once set, this field cannot be changed.
 	//
-	// Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
+	// Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning', 'Ingress' are only supported in OpenShift versions 4.20 and above.
 	//
 	// +listType=atomic
 	// +immutable
 	// +optional
 	// +kubebuilder:validation:MaxItems=25
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="Disabled is immutable. Changes might result in unpredictable and disruptive behavior."
+	// +kubebuilder:validation:XValidation:rule="!self.exists(cap, cap == 'Ingress') || self.exists(cap, cap == 'Console')",message="Ingress capability can only be disabled if Console capability is also disabled"
 	Disabled []OptionalCapability `json:"disabled,omitempty"`
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is part of the task for expanding support for disabling openshift capabilities in hypershift. This change adds support for disabling the Ingress capability, who managed by both CPO and CVO. Additional capabilities will be supported in future updates.

**Checklist**
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [X] This change includes unit tests.