### PR TITLE
OCPBUGS-56430: Fix restarting prometheus Sts after HCP restoration

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/recovery/recovery.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/recovery/recovery.go
@@ -31,7 +31,7 @@ func RecoverMonitoringStack(ctx context.Context, hcp *hyperv1.HostedControlPlane
 		return fmt.Errorf("prometheus statefulSet is still starting, rescheduling reconciliation: %w", err)
 	}
 
-	if prometheusSts.Status.ReadyReplicas < prometheusSts.Status.Replicas {
+	if prometheusSts.Status.AvailableReplicas < prometheusSts.Status.Replicas {
 		log.Info("Prometheus statefulSet not ready, deleting pods")
 		stsPods := &corev1.PodList{}
 		if err := c.List(ctx, stsPods, client.InNamespace(monitoringStackNS), client.MatchingLabels(prometheusSts.Spec.Selector.MatchLabels)); err != nil {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -724,7 +724,6 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 
 	// Reconcile hostedCluster recovery if the hosted cluster was restored from backup
 	if _, exists := hcp.Annotations[hyperv1.HostedClusterRestoredFromBackupAnnotation]; exists {
-		originalHCP := hcp.DeepCopy()
 		condition := &metav1.Condition{
 			Type:   string(hyperv1.HostedClusterRestoredFromBackup),
 			Reason: hyperv1.RecoveryFinishedReason,
@@ -736,9 +735,12 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 			condition.Message = fmt.Sprintf("Hosted cluster recovery not finished: %v", err)
 
 			meta.SetStatusCondition(&hcp.Status.Conditions, *condition)
-			if err := r.cpClient.Status().Patch(ctx, hcp, client.MergeFromWithOptions(originalHCP, client.MergeFromWithOptimisticLock{})); err != nil {
+			if _, err := r.CreateOrUpdate(ctx, r.client, hcp, func() error {
+				return nil
+			}); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to update status on hcp for hosted cluster recovery: %w. Condition error message: %v", err, condition.Message)
 			}
+
 			return ctrl.Result{RequeueAfter: 120 * time.Second}, errors.NewAggregate(errs)
 		}
 
@@ -746,7 +748,9 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 		condition.Status = metav1.ConditionTrue
 		condition.Message = "Hosted cluster recovery finished"
 		meta.SetStatusCondition(&hcp.Status.Conditions, *condition)
-		if err := r.cpClient.Status().Patch(ctx, hcp, client.MergeFromWithOptions(originalHCP, client.MergeFromWithOptimisticLock{})); err != nil {
+		if _, err := r.CreateOrUpdate(ctx, r.client, hcp, func() error {
+			return nil
+		}); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update status on hcp for hosted cluster recovery: %w. Condition error message: %v", err, condition.Message)
 		}
 	}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1379,14 +1379,19 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 				hclusterAnnotations := hcluster.GetAnnotations()
 				delete(hclusterAnnotations, hyperv1.HostedClusterRestoredFromBackupAnnotation)
 				hcluster.SetAnnotations(hclusterAnnotations)
-				if err := r.Update(ctx, hcluster); err != nil {
+				_, err := createOrUpdate(ctx, r.Client, hcluster, func() error {
+					return nil
+				})
+				if err != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to remove annotations %v: %w", string(hyperv1.HostedClusterRestoredFromBackup), err)
 				}
 			}
 
 			// Persist status updates
 			meta.SetStatusCondition(&hcluster.Status.Conditions, *freshCondition)
-			if err := r.Client.Status().Update(ctx, hcluster); err != nil {
+			if _, err := createOrUpdate(ctx, r.Client, hcluster, func() error {
+				return nil
+			}); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to update status %v: %w", string(hyperv1.HostedClusterRestoredFromBackup), err)
 			}
 		}


### PR DESCRIPTION
## What this PR does / why we need it
- During the bug verification, ROSA people find the STS monitoring pods were not restarting as expected. This is due to ReadyReplicas is not a state that STS has from the beginning but AvailableReplicas.
- Fixed another bug regarding the ResourceGeneration of the status be cause it was being updated in every reconciliation loop.

## Which issue(s) this PR fixes
- Fixes [OCPBUGS-56430](https://issues.redhat.com/browse/OCPBUGS-56430)
