### PR TITLE
OCPBUGS-57957: Increase MaxItems for Mirrors and ImageContentSources

### DIFF
--- a/api/hypershift/v1beta1/hosted_controlplane.go
+++ b/api/hypershift/v1beta1/hosted_controlplane.go
@@ -189,7 +189,7 @@ type HostedControlPlaneSpec struct {
 
 	// imageContentSources lists sources/repositories for the release-image content.
 	// +optional
-	// +kubebuilder:validation:MaxItems=25
+	// +kubebuilder:validation:MaxItems=255
 	ImageContentSources []ImageContentSource `json:"imageContentSources,omitempty"`
 
 	// additionalTrustBundle references a ConfigMap containing a PEM-encoded X.509 certificate bundle

--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -782,7 +782,7 @@ type ImageContentSource struct {
 	//
 	// +optional
 	// +immutable
-	// +kubebuilder:validation:MaxItems=25
+	// +kubebuilder:validation:MaxItems=255
 	// +listType=set
 	// +kubebuilder:validation:items:MaxLength=255
 	Mirrors []string `json:"mirrors,omitempty"`

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -2382,7 +2382,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -2420,7 +2420,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -2373,7 +2373,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -2394,7 +2394,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -2709,7 +2709,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -2863,7 +2863,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -2391,7 +2391,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -2449,7 +2449,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -2525,7 +2525,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -2373,7 +2373,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -2304,7 +2304,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:
@@ -2316,7 +2316,7 @@ spec:
                   required:
                   - source
                   type: object
-                maxItems: 25
+                maxItems: 255
                 type: array
               infraID:
                 description: infraID is the unique id that identifies the cluster

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -2342,7 +2342,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:
@@ -2354,7 +2354,7 @@ spec:
                   required:
                   - source
                   type: object
-                maxItems: 25
+                maxItems: 255
                 type: array
               infraID:
                 description: infraID is the unique id that identifies the cluster

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -2295,7 +2295,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:
@@ -2307,7 +2307,7 @@ spec:
                   required:
                   - source
                   type: object
-                maxItems: 25
+                maxItems: 255
                 type: array
               infraID:
                 description: infraID is the unique id that identifies the cluster

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -2316,7 +2316,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:
@@ -2328,7 +2328,7 @@ spec:
                   required:
                   - source
                   type: object
-                maxItems: 25
+                maxItems: 255
                 type: array
               infraID:
                 description: infraID is the unique id that identifies the cluster

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -2631,7 +2631,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:
@@ -2643,7 +2643,7 @@ spec:
                   required:
                   - source
                   type: object
-                maxItems: 25
+                maxItems: 255
                 type: array
               infraID:
                 description: infraID is the unique id that identifies the cluster

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -2785,7 +2785,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:
@@ -2797,7 +2797,7 @@ spec:
                   required:
                   - source
                   type: object
-                maxItems: 25
+                maxItems: 255
                 type: array
               infraID:
                 description: infraID is the unique id that identifies the cluster

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -2313,7 +2313,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:
@@ -2325,7 +2325,7 @@ spec:
                   required:
                   - source
                   type: object
-                maxItems: 25
+                maxItems: 255
                 type: array
               infraID:
                 description: infraID is the unique id that identifies the cluster

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -2371,7 +2371,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:
@@ -2383,7 +2383,7 @@ spec:
                   required:
                   - source
                   type: object
-                maxItems: 25
+                maxItems: 255
                 type: array
               infraID:
                 description: infraID is the unique id that identifies the cluster

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -2447,7 +2447,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:
@@ -2459,7 +2459,7 @@ spec:
                   required:
                   - source
                   type: object
-                maxItems: 25
+                maxItems: 255
                 type: array
               infraID:
                 description: infraID is the unique id that identifies the cluster

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -2295,7 +2295,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:
@@ -2307,7 +2307,7 @@ spec:
                   required:
                   - source
                   type: object
-                maxItems: 25
+                maxItems: 255
                 type: array
               infraID:
                 description: infraID is the unique id that identifies the cluster

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
@@ -3180,7 +3180,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
@@ -2890,7 +2890,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
@@ -3091,7 +3091,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
@@ -3102,7 +3102,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:
@@ -3114,7 +3114,7 @@ spec:
                   required:
                   - source
                   type: object
-                maxItems: 25
+                maxItems: 255
                 type: array
               infraID:
                 description: infraID is the unique id that identifies the cluster

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
@@ -2812,7 +2812,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:
@@ -2824,7 +2824,7 @@ spec:
                   required:
                   - source
                   type: object
-                maxItems: 25
+                maxItems: 255
                 type: array
               infraID:
                 description: infraID is the unique id that identifies the cluster

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
@@ -3013,7 +3013,7 @@ spec:
                       items:
                         maxLength: 255
                         type: string
-                      maxItems: 25
+                      maxItems: 255
                       type: array
                       x-kubernetes-list-type: set
                     source:
@@ -3025,7 +3025,7 @@ spec:
                   required:
                   - source
                   type: object
-                maxItems: 25
+                maxItems: 255
                 type: array
               infraID:
                 description: infraID is the unique id that identifies the cluster

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hosted_controlplane.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hosted_controlplane.go
@@ -189,7 +189,7 @@ type HostedControlPlaneSpec struct {
 
 	// imageContentSources lists sources/repositories for the release-image content.
 	// +optional
-	// +kubebuilder:validation:MaxItems=25
+	// +kubebuilder:validation:MaxItems=255
 	ImageContentSources []ImageContentSource `json:"imageContentSources,omitempty"`
 
 	// additionalTrustBundle references a ConfigMap containing a PEM-encoded X.509 certificate bundle

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -782,7 +782,7 @@ type ImageContentSource struct {
 	//
 	// +optional
 	// +immutable
-	// +kubebuilder:validation:MaxItems=25
+	// +kubebuilder:validation:MaxItems=255
 	// +listType=set
 	// +kubebuilder:validation:items:MaxLength=255
 	Mirrors []string `json:"mirrors,omitempty"`


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
Increase MaxItems for ImageContentSources on
HostedControlPlaneSpec to match the number on HostedClusterSpec.
Also increase the MaxSize for mirrors to the same number,
number 25 is too limiting given the fact that standalone OpenShift
doesn't have any limit.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes [OCPBUGS-57957](https://issues.redhat.com/browse/OCPBUGS-57957)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.