### PR TITLE
OCPBUGS-56701: Update the LookupDefaultOCPVersion function to use the multi-arch release API

### DIFF
--- a/cmd/cluster/agent/create_test.go
+++ b/cmd/cluster/agent/create_test.go
@@ -2,11 +2,14 @@ package agent
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/cmd/util"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/testutil"
 	"github.com/openshift/hypershift/test/integration/framework"
@@ -20,6 +23,7 @@ func TestCreateCluster(t *testing.T) {
 	utilrand.Seed(1234567890)
 	certs.UnsafeSeed(1234567890)
 	ctx := framework.InterruptableContext(context.Background())
+	t.Setenv("FAKE_CLIENT", "true")
 
 	tempDir := t.TempDir()
 
@@ -28,6 +32,46 @@ func TestCreateCluster(t *testing.T) {
 	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
 		t.Fatalf("failed to write pullSecret: %v", err)
 	}
+
+	supportedVersionsCM := testutil.CreateSupportedVersionsConfigMap()
+
+	// Set up fake client objects for the test
+	util.SetFakeClientObjects(supportedVersionsCM)
+	defer util.ClearFakeClientObjects()
+
+	// Mock HTTP server that returns release tags
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := `{
+					"name": "4-stable-multi",
+					"tags": [
+						{
+							"name": "4.19.0",
+							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.19.0-multi",
+							"downloadURL": "https://example.com/4.19.0"
+						},
+						{
+							"name": "4.18.5",
+							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.5-multi",
+							"downloadURL": "https://example.com/4.18.5"
+						},
+						{
+							"name": "4.18.0",
+							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.0-multi",
+							"downloadURL": "https://example.com/4.18.0"
+						}
+					]
+				}`
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(response))
+		if err != nil {
+			t.Fatalf("failed to write response: %v", err)
+		}
+	}))
+	defer mockServer.Close()
+
+	// Set the environment variable to override the release URL template with the mock server
+	t.Setenv("HYPERSHIFT_RELEASE_URL_TEMPLATE", mockServer.URL+"/api/v1/releasestream/%s/tags")
 
 	for _, testCase := range []struct {
 		name string

--- a/cmd/cluster/agent/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/agent/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -78,7 +78,7 @@ spec:
   pullSecret:
     name: example-pull-secret
   release:
-    image: ""
+    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
   secretEncryption:
     aescbc:
       activeKey:
@@ -134,7 +134,7 @@ spec:
     agent: {}
     type: Agent
   release:
-    image: ""
+    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
   replicas: 0
 status:
   replicas: 0

--- a/cmd/cluster/aws/create_test.go
+++ b/cmd/cluster/aws/create_test.go
@@ -3,6 +3,8 @@ package aws
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -166,6 +168,46 @@ func TestCreateCluster(t *testing.T) {
 	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
 		t.Fatalf("failed to write pullSecret: %v", err)
 	}
+
+	supportedVersionsCM := testutil.CreateSupportedVersionsConfigMap()
+
+	// Set up fake client objects for the test
+	util.SetFakeClientObjects(supportedVersionsCM)
+	defer util.ClearFakeClientObjects()
+
+	// Mock HTTP server that returns release tags
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := `{
+					"name": "4-stable-multi",
+					"tags": [
+						{
+							"name": "4.19.0",
+							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.19.0-multi",
+							"downloadURL": "https://example.com/4.19.0"
+						},
+						{
+							"name": "4.18.5",
+							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.5-multi",
+							"downloadURL": "https://example.com/4.18.5"
+						},
+						{
+							"name": "4.18.0",
+							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.0-multi",
+							"downloadURL": "https://example.com/4.18.0"
+						}
+					]
+				}`
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(response))
+		if err != nil {
+			t.Fatalf("failed to write response: %v", err)
+		}
+	}))
+	defer mockServer.Close()
+
+	// Set the environment variable to override the release URL template with the mock server
+	t.Setenv("HYPERSHIFT_RELEASE_URL_TEMPLATE", mockServer.URL+"/api/v1/releasestream/%s/tags")
 
 	for _, testCase := range []struct {
 		name string

--- a/cmd/cluster/aws/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/aws/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -80,7 +80,7 @@ spec:
   pullSecret:
     name: example-pull-secret
   release:
-    image: ""
+    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
   secretEncryption:
     kms:
       aws:
@@ -135,7 +135,7 @@ spec:
         id: fakeSubnetID
     type: AWS
   release:
-    image: ""
+    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
   replicas: 0
 status:
   replicas: 0

--- a/cmd/cluster/aws/testdata/zz_fixture_TestCreateCluster_minimal_with_KubeAPIServerDNSName.yaml
+++ b/cmd/cluster/aws/testdata/zz_fixture_TestCreateCluster_minimal_with_KubeAPIServerDNSName.yaml
@@ -70,7 +70,7 @@ spec:
   pullSecret:
     name: example-pull-secret
   release:
-    image: ""
+    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
   secretEncryption:
     kms:
       aws:
@@ -125,7 +125,7 @@ spec:
         id: fakeSubnetID
     type: AWS
   release:
-    image: ""
+    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
   replicas: 0
 status:
   replicas: 0

--- a/cmd/cluster/azure/create_test.go
+++ b/cmd/cluster/azure/create_test.go
@@ -3,6 +3,8 @@ package azure
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,14 +13,12 @@ import (
 	azureinfra "github.com/openshift/hypershift/cmd/infra/azure"
 	azurenodepool "github.com/openshift/hypershift/cmd/nodepool/azure"
 	"github.com/openshift/hypershift/cmd/util"
-	"github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/testutil"
 	"github.com/openshift/hypershift/test/integration/framework"
 
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
 
 	"github.com/go-logr/logr"
@@ -71,6 +71,46 @@ func TestCreateCluster(t *testing.T) {
 	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
 		t.Fatalf("failed to write pullSecret: %v", err)
 	}
+
+	supportedVersionsCM := testutil.CreateSupportedVersionsConfigMap()
+
+	// Set up fake client objects for the test
+	util.SetFakeClientObjects(supportedVersionsCM)
+	defer util.ClearFakeClientObjects()
+
+	// Mock HTTP server that returns release tags
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := `{
+				"name": "4-stable-multi",
+				"tags": [
+					{
+						"name": "4.19.0",
+						"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.19.0-multi",
+						"downloadURL": "https://example.com/4.19.0"
+					},
+					{
+						"name": "4.18.5",
+						"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.5-multi",
+						"downloadURL": "https://example.com/4.18.5"
+					},
+					{
+						"name": "4.18.0",
+						"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.0-multi",
+						"downloadURL": "https://example.com/4.18.0"
+					}
+				]
+			}`
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(response))
+		if err != nil {
+			t.Fatalf("failed to write response: %v", err)
+		}
+	}))
+	defer mockServer.Close()
+
+	// Set the environment variable to override the release URL template with the mock server
+	t.Setenv("HYPERSHIFT_RELEASE_URL_TEMPLATE", mockServer.URL+"/api/v1/releasestream/%s/tags")
 
 	for _, testCase := range []struct {
 		name string
@@ -169,12 +209,11 @@ func TestCreateCluster(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			fakeClient := fake.NewClientBuilder().WithScheme(api.Scheme).Build()
 			log := logr.Logger{}
 			flags := pflag.NewFlagSet(testCase.name, pflag.ContinueOnError)
 			coreOpts := core.DefaultOptions()
 			core.BindDeveloperOptions(coreOpts, flags)
-			azureOpts, err := DefaultOptions(fakeClient, log)
+			azureOpts, err := DefaultOptions(nil, log)
 			if err != nil {
 				t.Fatal("failed to create azure options: ", err)
 			}

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -108,7 +108,7 @@ spec:
   pullSecret:
     name: example-pull-secret
   release:
-    image: ""
+    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
   secretEncryption:
     aescbc:
       activeKey:
@@ -159,7 +159,7 @@ spec:
       vmSize: Standard_D4s_v3
     type: Azure
   release:
-    image: ""
+    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
   replicas: 0
 status:
   replicas: 0

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_KubeAPIServerDNSName.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_KubeAPIServerDNSName.yaml
@@ -109,7 +109,7 @@ spec:
   pullSecret:
     name: example-pull-secret
   release:
-    image: ""
+    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
   secretEncryption:
     aescbc:
       activeKey:
@@ -160,7 +160,7 @@ spec:
       vmSize: Standard_D4s_v3
     type: Azure
   release:
-    image: ""
+    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
   replicas: 0
 status:
   replicas: 0

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_zones.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_zones.yaml
@@ -108,7 +108,7 @@ spec:
   pullSecret:
     name: example-pull-secret
   release:
-    image: ""
+    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
   secretEncryption:
     aescbc:
       activeKey:
@@ -160,7 +160,7 @@ spec:
       vmSize: Standard_D4s_v3
     type: Azure
   release:
-    image: ""
+    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
   replicas: 0
 status:
   replicas: 0
@@ -192,7 +192,7 @@ spec:
       vmSize: Standard_D4s_v3
     type: Azure
   release:
-    image: ""
+    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
   replicas: 0
 status:
   replicas: 0

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_disabled_capabilities.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_disabled_capabilities.yaml
@@ -110,7 +110,7 @@ spec:
   pullSecret:
     name: example-pull-secret
   release:
-    image: ""
+    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
   secretEncryption:
     aescbc:
       activeKey:
@@ -161,7 +161,7 @@ spec:
       vmSize: Standard_D4s_v3
     type: Azure
   release:
-    image: ""
+    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
   replicas: 0
 status:
   replicas: 0

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -228,7 +228,7 @@ func (r *resources) asObjects() []crclient.Object {
 func prototypeResources(ctx context.Context, opts *CreateOptions) (*resources, error) {
 	prototype := &resources{}
 	// allow client side defaulting when release image is empty but release stream is set.
-	if len(opts.ReleaseImage) == 0 && len(opts.ReleaseStream) != 0 {
+	if len(opts.ReleaseImage) == 0 {
 		client, err := util.GetClient()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get client: %w", err)

--- a/cmd/cluster/kubevirt/create_test.go
+++ b/cmd/cluster/kubevirt/create_test.go
@@ -2,6 +2,8 @@ package kubevirt
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/cmd/util"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/testutil"
 	"github.com/openshift/hypershift/test/integration/framework"
@@ -129,6 +132,46 @@ func TestCreateCluster(t *testing.T) {
 	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
 		t.Fatalf("failed to write pullSecret: %v", err)
 	}
+
+	supportedVersionsCM := testutil.CreateSupportedVersionsConfigMap()
+
+	// Set up fake client objects for the test
+	util.SetFakeClientObjects(supportedVersionsCM)
+	defer util.ClearFakeClientObjects()
+
+	// Mock HTTP server that returns release tags
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := `{
+					"name": "4-stable-multi",
+					"tags": [
+						{
+							"name": "4.19.0",
+							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.19.0-multi",
+							"downloadURL": "https://example.com/4.19.0"
+						},
+						{
+							"name": "4.18.5",
+							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.5-multi",
+							"downloadURL": "https://example.com/4.18.5"
+						},
+						{
+							"name": "4.18.0",
+							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.0-multi",
+							"downloadURL": "https://example.com/4.18.0"
+						}
+					]
+				}`
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(response))
+		if err != nil {
+			t.Fatalf("failed to write response: %v", err)
+		}
+	}))
+	defer mockServer.Close()
+
+	// Set the environment variable to override the release URL template with the mock server
+	t.Setenv("HYPERSHIFT_RELEASE_URL_TEMPLATE", mockServer.URL+"/api/v1/releasestream/%s/tags")
 
 	for _, testCase := range []struct {
 		name string

--- a/cmd/cluster/kubevirt/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/kubevirt/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -65,7 +65,7 @@ spec:
   pullSecret:
     name: example-pull-secret
   release:
-    image: ""
+    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
   secretEncryption:
     aescbc:
       activeKey:
@@ -117,7 +117,7 @@ spec:
         type: Persistent
     type: KubeVirt
   release:
-    image: ""
+    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
   replicas: 0
 status:
   replicas: 0

--- a/cmd/cluster/none/create_test.go
+++ b/cmd/cluster/none/create_test.go
@@ -2,11 +2,14 @@ package none
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/cmd/util"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/testutil"
 	"github.com/openshift/hypershift/test/integration/framework"
@@ -21,12 +24,53 @@ func TestCreateCluster(t *testing.T) {
 	certs.UnsafeSeed(1234567890)
 	ctx := framework.InterruptableContext(context.Background())
 	tempDir := t.TempDir()
+	t.Setenv("FAKE_CLIENT", "true")
 
 	pullSecretFile := filepath.Join(tempDir, "pull-secret.json")
 
 	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
 		t.Fatalf("failed to write pullSecret: %v", err)
 	}
+
+	supportedVersionsCM := testutil.CreateSupportedVersionsConfigMap()
+
+	// Set up fake client objects for the test
+	util.SetFakeClientObjects(supportedVersionsCM)
+	defer util.ClearFakeClientObjects()
+
+	// Mock HTTP server that returns release tags
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := `{
+					"name": "4-stable-multi",
+					"tags": [
+						{
+							"name": "4.19.0",
+							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.19.0-multi",
+							"downloadURL": "https://example.com/4.19.0"
+						},
+						{
+							"name": "4.18.5",
+							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.5-multi",
+							"downloadURL": "https://example.com/4.18.5"
+						},
+						{
+							"name": "4.18.0",
+							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.0-multi",
+							"downloadURL": "https://example.com/4.18.0"
+						}
+					]
+				}`
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(response))
+		if err != nil {
+			t.Fatalf("failed to write response: %v", err)
+		}
+	}))
+	defer mockServer.Close()
+
+	// Set the environment variable to override the release URL template with the mock server
+	t.Setenv("HYPERSHIFT_RELEASE_URL_TEMPLATE", mockServer.URL+"/api/v1/releasestream/%s/tags")
 
 	for _, testCase := range []struct {
 		name string

--- a/cmd/cluster/none/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/none/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -63,7 +63,7 @@ spec:
   pullSecret:
     name: example-pull-secret
   release:
-    image: ""
+    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
   secretEncryption:
     aescbc:
       activeKey:
@@ -118,7 +118,7 @@ spec:
   platform:
     type: None
   release:
-    image: ""
+    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
   replicas: 0
 status:
   replicas: 0

--- a/cmd/cluster/openstack/create_test.go
+++ b/cmd/cluster/openstack/create_test.go
@@ -2,12 +2,15 @@ package openstack
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/cmd/util"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/testutil"
 	"github.com/openshift/hypershift/test/integration/framework"
@@ -72,6 +75,40 @@ func TestCreateCluster(t *testing.T) {
 	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
 		t.Fatalf("failed to write pullSecret: %v", err)
 	}
+
+	// Set up fake client objects for the test
+	supportedVersionsCM := testutil.CreateSupportedVersionsConfigMap()
+	util.SetFakeClientObjects(supportedVersionsCM)
+	defer util.ClearFakeClientObjects()
+
+	// Mock HTTP server that returns release tags
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := `{
+			"name": "4-stable-multi",
+			"tags": [
+				{
+					"name": "4.19.0",
+					"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.19.0-multi",
+					"downloadURL": "https://example.com/4.19.0"
+				},
+				{
+					"name": "4.18.5", 
+					"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.5-multi",
+					"downloadURL": "https://example.com/4.18.5"
+				}
+			]
+		}`
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(response))
+		if err != nil {
+			t.Fatalf("failed to write response: %v", err)
+		}
+	}))
+	defer mockServer.Close()
+
+	// Set the environment variable to override the release URL template with the mock server
+	t.Setenv("HYPERSHIFT_RELEASE_URL_TEMPLATE", mockServer.URL+"/api/v1/releasestream/%s/tags")
 
 	for _, testCase := range []struct {
 		name string

--- a/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -81,7 +81,7 @@ spec:
   pullSecret:
     name: example-pull-secret
   release:
-    image: ""
+    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
   secretEncryption:
     aescbc:
       activeKey:
@@ -126,7 +126,7 @@ spec:
       imageName: rhcos
     type: OpenStack
   release:
-    image: ""
+    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
   replicas: 0
 status:
   replicas: 0

--- a/cmd/cluster/powervs/create_test.go
+++ b/cmd/cluster/powervs/create_test.go
@@ -3,12 +3,15 @@ package powervs
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	powervsinfra "github.com/openshift/hypershift/cmd/infra/powervs"
+	"github.com/openshift/hypershift/cmd/util"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/testutil"
 	"github.com/openshift/hypershift/test/integration/framework"
@@ -89,6 +92,46 @@ func TestCreateCluster(t *testing.T) {
 	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
 		t.Fatalf("failed to write pullSecret: %v", err)
 	}
+
+	supportedVersionsCM := testutil.CreateSupportedVersionsConfigMap()
+
+	// Set up fake client objects for the test
+	util.SetFakeClientObjects(supportedVersionsCM)
+	defer util.ClearFakeClientObjects()
+
+	// Mock HTTP server that returns release tags
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := `{
+					"name": "4-stable-multi",
+					"tags": [
+						{
+							"name": "4.19.0",
+							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.19.0-multi",
+							"downloadURL": "https://example.com/4.19.0"
+						},
+						{
+							"name": "4.18.5",
+							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.5-multi",
+							"downloadURL": "https://example.com/4.18.5"
+						},
+						{
+							"name": "4.18.0",
+							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.0-multi",
+							"downloadURL": "https://example.com/4.18.0"
+						}
+					]
+				}`
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(response))
+		if err != nil {
+			t.Fatalf("failed to write response: %v", err)
+		}
+	}))
+	defer mockServer.Close()
+
+	// Set the environment variable to override the release URL template with the mock server
+	t.Setenv("HYPERSHIFT_RELEASE_URL_TEMPLATE", mockServer.URL+"/api/v1/releasestream/%s/tags")
 
 	for _, testCase := range []struct {
 		name string

--- a/cmd/cluster/powervs/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/powervs/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -116,7 +116,7 @@ spec:
   pullSecret:
     name: example-pull-secret
   release:
-    image: ""
+    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
   secretEncryption:
     aescbc:
       activeKey:
@@ -163,7 +163,7 @@ spec:
       systemType: s922
     type: PowerVS
   release:
-    image: ""
+    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
   replicas: 0
 status:
   replicas: 0

--- a/support/supportedversion/version.go
+++ b/support/supportedversion/version.go
@@ -22,10 +22,7 @@ import (
 )
 
 // https://docs.ci.openshift.org/docs/getting-started/useful-links/#services
-const (
-	multiArchReleaseURLTemplate = "https://multi.ocp.releases.ci.openshift.org/api/v1/releasestream/%s/tags"
-	releaseURLTemplate          = "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/%s/latest"
-)
+const multiArchReleaseURLTemplate = "https://multi.ocp.releases.ci.openshift.org/api/v1/releasestream/%s/tags"
 
 // LatestSupportedVersion is the latest minor OCP version supported by the
 // HyperShift operator.
@@ -158,6 +155,17 @@ func getOCPVersion(releaseURL string) (ocpVersion, error) {
 	return version, nil
 }
 
+// LookupDefaultOCPVersion retrieves the default OCP version from multi-arch release streams.
+// It supports two modes of operation:
+//
+//  1. When releaseStream is empty: Uses the default release stream and looks up supported OCP versions
+//     from the HyperShift operator's ConfigMap to find the latest supported version that is not a
+//     release candidate. This ensures compatibility with the current HyperShift operator version.
+//
+//  2. When releaseStream is provided: Uses the specified release stream to retrieve the OCP version
+//     directly from the multi-arch release API.
+//
+// The function defaults to multi-arch release streams for broader architecture support.
 func LookupDefaultOCPVersion(ctx context.Context, releaseStream string, client crclient.Client) (ocpVersion, error) {
 	var (
 		version    ocpVersion
@@ -172,7 +180,7 @@ func LookupDefaultOCPVersion(ctx context.Context, releaseStream string, client c
 		version, err = retrieveSupportedOCPVersion(ctx, releaseURL, client)
 	} else {
 		// We look up the release URL based on the user provided release stream.
-		releaseURL = fmt.Sprintf(releaseURLTemplate, releaseStream)
+		releaseURL = fmt.Sprintf(multiArchReleaseURLTemplate, releaseStream)
 		version, err = getOCPVersion(releaseURL)
 	}
 

--- a/support/supportedversion/version.go
+++ b/support/supportedversion/version.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"runtime/debug"
 	"strings"
 
@@ -23,6 +24,14 @@ import (
 
 // https://docs.ci.openshift.org/docs/getting-started/useful-links/#services
 const multiArchReleaseURLTemplate = "https://multi.ocp.releases.ci.openshift.org/api/v1/releasestream/%s/tags"
+
+// getMultiArchReleaseURLTemplate returns the release URL template, checking for an environment variable override first
+func getMultiArchReleaseURLTemplate() string {
+	if envURL := os.Getenv("HYPERSHIFT_RELEASE_URL_TEMPLATE"); envURL != "" {
+		return envURL
+	}
+	return multiArchReleaseURLTemplate
+}
 
 // LatestSupportedVersion is the latest minor OCP version supported by the
 // HyperShift operator.
@@ -176,11 +185,11 @@ func LookupDefaultOCPVersion(ctx context.Context, releaseStream string, client c
 	if len(releaseStream) == 0 {
 		// No release stream was provided, so we will look up the supported OCP versions from the HO and use the latest
 		// release image from the multi-arch release stream that is not a release candidate.
-		releaseURL = fmt.Sprintf(multiArchReleaseURLTemplate, config.DefaultReleaseStream)
+		releaseURL = fmt.Sprintf(getMultiArchReleaseURLTemplate(), config.DefaultReleaseStream)
 		version, err = retrieveSupportedOCPVersion(ctx, releaseURL, client)
 	} else {
 		// We look up the release URL based on the user provided release stream.
-		releaseURL = fmt.Sprintf(multiArchReleaseURLTemplate, releaseStream)
+		releaseURL = fmt.Sprintf(getMultiArchReleaseURLTemplate(), releaseStream)
 		version, err = getOCPVersion(releaseURL)
 	}
 

--- a/support/supportedversion/version.go
+++ b/support/supportedversion/version.go
@@ -273,7 +273,7 @@ func GetSupportedOCPVersions(ctx context.Context, namespace string, client crcli
 
 	if supportedVersions == nil {
 		// Fetch the supported versions ConfigMap from the specified namespace
-		supportedVersions := manifests.ConfigMap(namespace)
+		supportedVersions = manifests.ConfigMap(namespace)
 		if err := client.Get(ctx, crclient.ObjectKeyFromObject(supportedVersions), supportedVersions); err != nil {
 			return SupportedVersions{}, "", fmt.Errorf("failed to find supported versions on the server: %v", err)
 		}

--- a/support/supportedversion/version_test.go
+++ b/support/supportedversion/version_test.go
@@ -23,6 +23,53 @@ import (
 	"github.com/blang/semver"
 )
 
+func TestGetMultiArchReleaseURLTemplate(t *testing.T) {
+	testCases := []struct {
+		name        string
+		envValue    string
+		setEnv      bool
+		expectedURL string
+	}{
+		{
+			name:        "returns default URL when environment variable is not set",
+			setEnv:      false,
+			expectedURL: multiArchReleaseURLTemplate,
+		},
+		{
+			name:        "returns custom URL when environment variable is set",
+			envValue:    "https://custom.example.com/api/v1/releasestream/%s/tags",
+			setEnv:      true,
+			expectedURL: "https://custom.example.com/api/v1/releasestream/%s/tags",
+		},
+		{
+			name:        "returns default URL when environment variable is empty string",
+			envValue:    "",
+			setEnv:      true,
+			expectedURL: multiArchReleaseURLTemplate,
+		},
+		{
+			name:        "returns mock server URL when set for testing",
+			envValue:    "http://localhost:8080/mock/%s",
+			setEnv:      true,
+			expectedURL: "http://localhost:8080/mock/%s",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			// Set up environment for test case using t.Setenv (automatically handles cleanup)
+			if tc.setEnv {
+				t.Setenv("HYPERSHIFT_RELEASE_URL_TEMPLATE", tc.envValue)
+			}
+
+			result := getMultiArchReleaseURLTemplate()
+			g.Expect(result).To(Equal(tc.expectedURL))
+		})
+	}
+}
+
 func TestSupportedVersions(t *testing.T) {
 	g := NewGomegaWithT(t)
 	g.Expect(Supported()).To(Equal([]string{"4.20", "4.19", "4.18", "4.17", "4.16", "4.15", "4.14"}))

--- a/support/testutil/testutil.go
+++ b/support/testutil/testutil.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -176,4 +177,20 @@ func MatchExpected(expected any, opts ...cmp.Option) types.GomegaMatcher {
 	return WithTransform(func(actual any) string {
 		return cmp.Diff(actual, expected, opts...)
 	}, BeEmpty())
+
+}
+
+// CreateSupportedVersionsConfigMap creates a ConfigMap with supported OpenShift versions for testing
+func CreateSupportedVersionsConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "supported-versions",
+			Namespace: "test",
+			Labels:    map[string]string{"hypershift.openshift.io/supported-versions": "true"},
+		},
+		Data: map[string]string{
+			"server-version":     "test-server",
+			"supported-versions": `{"versions":["4.19", "4.18", "4.17", "4.16", "4.15", "4.14"]}`,
+		},
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the LookupDefaultOCPVersion function to use the multi-arch release API when a release stream is provided. This ensures consistency between when a release stream is provided and when it is not. We should also default to multi-arch whenever possible.

**Which issue(s) this PR fixes**:
Fixes https://issues.redhat.com/browse/OCPBUGS-56701

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.