### PR TITLE
[CNTRLPLANE-1034] sharedingress: add support for whitelist cidrs blocks

### DIFF
--- a/hypershift-operator/controllers/sharedingress/router_config.template
+++ b/hypershift-operator/controllers/sharedingress/router_config.template
@@ -30,11 +30,13 @@ frontend dataplane-kas-svc
 
   {{- range .Backends }}
   acl is_{{ .Name }} var(sess.cluster_id) -m str {{ .ClusterID }}
-  acl is_{{ .Name }}_request_allowed src {{ .AllowedCIDR }}
+  {{- if .AllowedCIDRs }}
+  acl is_{{ .Name }}_request_allowed src {{ join .AllowedCIDRs " " }}
+  {{- end }}
   {{- end }}
 
   {{- range .Backends }}
-  use_backend {{ .Name }} if is_{{ .Name }} is_{{ .Name }}_request_allowed
+  use_backend {{ .Name }} if is_{{ .Name }}{{ if .AllowedCIDRs }} is_{{ .Name }}_request_allowed{{ end }}
   {{- end }}
 
   default_backend no-match
@@ -51,10 +53,9 @@ frontend external-dns
 
   {{- range .ExternalDNSBackends }}
   acl is_{{ .Name }} req_ssl_sni -i {{ .HostName }}
-  acl is_{{ .Name }}_request_allowed src 91.47.40.124
   {{- end }}
   {{- range .ExternalDNSBackends }}
-  use_backend {{ .Name }} if is_{{ .Name }} is_{{ .Name }}_request_allowed
+  use_backend {{ .Name }} if is_{{ .Name }}
   {{- end }}
 
 listen health_check_http_url

--- a/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
+++ b/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
@@ -128,10 +128,12 @@ func (r *SharedIngressReconciler) generateConfig(ctx context.Context) (string, [
 
 	namespaces := make([]string, 0, len(hcList.Items))
 	svcsNamespaceToClusterID := make(map[string]string)
+	svcsNamespaceToApiServerNetworking := make(map[string]*hyperv1.APIServerNetworking)
 	for _, hc := range hcList.Items {
 		hcpNamespace := hc.Namespace + "-" + hc.Name
 		namespaces = append(namespaces, hcpNamespace)
 		svcsNamespaceToClusterID[hcpNamespace] = hc.Spec.ClusterID
+		svcsNamespaceToApiServerNetworking[hc.Spec.ClusterID] = hc.Spec.Networking.APIServer
 	}
 
 	// This enables traffic from through external DNS.
@@ -167,7 +169,8 @@ func (r *SharedIngressReconciler) generateConfig(ctx context.Context) (string, [
 		return "", nil, err
 	}
 
-	config, err := generateRouterConfig(svcList, svcsNamespaceToClusterID, routes, svcsNameToIP)
+	config, err := generateRouterConfig(svcList, svcsNamespaceToClusterID, routes, svcsNameToIP,
+		svcsNamespaceToApiServerNetworking)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to generate router config: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch provides an implementation for CIDR blocks whitelisting. 

We propogate CIDR blocks provided by client via HostedCluster's `APIServerNetworking` and utilize those in the HAProxy configuration generated in order to whitelist specific source IPs. 

~~**In case no IPs are provided we will default to `0.0.0.0/0` (i.e. "allow-all").**~~
In case no IPs are provided no ACLs are created in the HAProxy router configuration.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes https://issues.redhat.com/browse/CNTRLPLANE-1034

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.