### PR TITLE
MGMT-20793: Enable Disabling NodeTuning Capability

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -379,7 +379,7 @@ const (
 	PruneRetentionPolicy RetentionPolicy = "Prune"
 )
 
-// +kubebuilder:validation:Enum=ImageRegistry;openshift-samples;Insights;baremetal;Console
+// +kubebuilder:validation:Enum=ImageRegistry;openshift-samples;Insights;baremetal;Console;NodeTuning
 type OptionalCapability string
 
 const ImageRegistryCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityImageRegistry)
@@ -387,6 +387,7 @@ const OpenShiftSamplesCapability OptionalCapability = OptionalCapability(configv
 const InsightsCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityInsights)
 const BaremetalCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityBaremetal)
 const ConsoleCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityConsole)
+const NodeTuningCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityNodeTuning)
 
 // capabilities allows enabling or disabling optional components at install time.
 // When this is not supplied, the cluster will use the DefaultCapabilitySet defined for the respective
@@ -408,7 +409,7 @@ type Capabilities struct {
 	// disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
 	// Once set, this field cannot be changed.
 	//
-	// Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+	// Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
 	//
 	// +listType=atomic
 	// +immutable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -161,7 +161,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -169,6 +169,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -188,6 +189,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -208,7 +208,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -216,6 +216,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -235,6 +236,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -161,7 +161,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -169,6 +169,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -188,6 +189,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -161,7 +161,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -169,6 +169,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -188,6 +189,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -161,7 +161,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -169,6 +169,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -188,6 +189,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -161,7 +161,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -169,6 +169,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -188,6 +189,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -161,7 +161,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -169,6 +169,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -188,6 +189,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -161,7 +161,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -169,6 +169,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -188,6 +189,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -161,7 +161,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -169,6 +169,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -188,6 +189,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -161,7 +161,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -169,6 +169,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -188,6 +189,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -129,7 +129,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -137,6 +137,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -156,6 +157,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -176,7 +176,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -184,6 +184,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -203,6 +204,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -129,7 +129,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -137,6 +137,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -156,6 +157,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -129,7 +129,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -137,6 +137,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -156,6 +157,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -129,7 +129,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -137,6 +137,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -156,6 +157,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -129,7 +129,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -137,6 +137,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -156,6 +157,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -129,7 +129,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -137,6 +137,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -156,6 +157,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -129,7 +129,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -137,6 +137,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -156,6 +157,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -129,7 +129,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -137,6 +137,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -156,6 +157,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -129,7 +129,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -137,6 +137,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -156,6 +157,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -108,8 +108,8 @@ func bindCoreOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
 	flags.StringVar(&opts.PausedUntil, "pausedUntil", opts.PausedUntil, "If a date is provided in RFC3339 format, HostedCluster creation is paused until that date. If the boolean true is provided, HostedCluster creation is paused until the field is removed.")
 	flags.StringVar(&opts.ReleaseStream, "release-stream", opts.ReleaseStream, "The OCP release stream for the cluster (e.g. 4-stable-multi), this flag is ignored if release-image is set")
 	flags.StringVar(&opts.FeatureSet, "feature-set", opts.FeatureSet, "The predefined feature set to use for the cluster (TechPreviewNoUpgrade or DevPreviewNoUpgrade)")
-	flags.StringSliceVar(&opts.DisableClusterCapabilities, "disable-cluster-capabilities", nil, "Optional cluster capabilities to disable. The only currently supported values are ImageRegistry,openshift-samples,Insights,baremetal,Console.")
-	flags.StringSliceVar(&opts.EnableClusterCapabilities, "enable-cluster-capabilities", nil, "Optional cluster capabilities to enable. The only currently supported values are ImageRegistry,openshift-samples,Insights,baremetal.")
+	flags.StringSliceVar(&opts.DisableClusterCapabilities, "disable-cluster-capabilities", nil, "Optional cluster capabilities to disable. The only currently supported values are ImageRegistry,openshift-samples,Insights,baremetal,Console,NodeTuning.")
+	flags.StringSliceVar(&opts.EnableClusterCapabilities, "enable-cluster-capabilities", nil, "Optional cluster capabilities to enable. The only currently supported values are ImageRegistry,openshift-samples,Insights,baremetal,Console,NodeTuning.")
 	flags.StringVar(&opts.KubeAPIServerDNSName, "kas-dns-name", opts.KubeAPIServerDNSName, "The custom DNS name for the kube-apiserver service. Make sure the DNS name is valid and addressable.")
 }
 
@@ -713,6 +713,7 @@ func (opts *RawCreateOptions) Validate(ctx context.Context) (*ValidatedCreateOpt
 		string(hyperv1.InsightsCapability),
 		string(hyperv1.BaremetalCapability),
 		string(hyperv1.ConsoleCapability),
+		string(hyperv1.NodeTuningCapability),
 	)
 	if len(opts.DisableClusterCapabilities) > 0 {
 		for _, capability := range opts.DisableClusterCapabilities {

--- a/cmd/cluster/core/create_test.go
+++ b/cmd/cluster/core/create_test.go
@@ -266,6 +266,17 @@ func TestValidate(t *testing.T) {
 			expectedErr: "",
 		},
 		{
+			name: "passes with NodeTuning capability",
+			rawOpts: &RawCreateOptions{
+				Name:                       "test-hc",
+				Namespace:                  "test-hc",
+				PullSecretFile:             pullSecretFile,
+				Arch:                       "amd64",
+				DisableClusterCapabilities: []string{"NodeTuning"},
+			},
+			expectedErr: "",
+		},
+		{
 			name: "fails with an invalid DNS name as KubeAPIServerDNSName",
 			rawOpts: &RawCreateOptions{
 				Name:                 "test-hc",

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
@@ -211,7 +211,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -219,6 +219,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -238,6 +239,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
@@ -164,7 +164,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -172,6 +172,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -191,6 +192,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
@@ -211,7 +211,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -219,6 +219,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -238,6 +239,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
@@ -179,7 +179,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -187,6 +187,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -206,6 +207,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
@@ -132,7 +132,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -140,6 +140,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -159,6 +160,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
@@ -179,7 +179,7 @@ spec:
                       disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
                       Once set, this field cannot be changed.
 
-                      Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+                      Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
                     items:
                       enum:
                       - ImageRegistry
@@ -187,6 +187,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array
@@ -206,6 +207,7 @@ spec:
                       - Insights
                       - baremetal
                       - Console
+                      - NodeTuning
                       type: string
                     maxItems: 25
                     type: array

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/nto/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/nto/component.go
@@ -2,6 +2,7 @@ package nto
 
 import (
 	oapiv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/oapi"
+	"github.com/openshift/hypershift/support/capabilities"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 )
 
@@ -32,10 +33,17 @@ func (r *clusterNodeTuningOperator) NeedsManagementKASAccess() bool {
 func NewComponent() component.ControlPlaneComponent {
 	return component.NewDeploymentComponent(ComponentName, &clusterNodeTuningOperator{}).
 		WithAdaptFunction(adaptDeployment).
+		WithPredicate(isNodeTuningCapabilityEnabled).
 		WithManifestAdapter(
 			"servicemonitor.yaml",
 			component.WithAdaptFunction(adaptServiceMonitor),
 		).
 		WithDependencies(oapiv2.ComponentName).
 		Build()
+}
+
+func isNodeTuningCapabilityEnabled(cpContext component.WorkloadContext) (bool, error) {
+	return capabilities.IsNodeTuningCapabilityEnabled(
+		cpContext.HCP.Spec.Capabilities,
+	), nil
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -985,7 +985,7 @@ func TestReconcileClusterVersionWithDisabledCapabilities(t *testing.T) {
 			ClusterID: "test-cluster-id",
 			Capabilities: &hyperv1.Capabilities{
 				Disabled: []hyperv1.OptionalCapability{
-					hyperv1.ImageRegistryCapability, hyperv1.OpenShiftSamplesCapability, hyperv1.InsightsCapability, hyperv1.ConsoleCapability,
+					hyperv1.ImageRegistryCapability, hyperv1.OpenShiftSamplesCapability, hyperv1.InsightsCapability, hyperv1.ConsoleCapability, hyperv1.NodeTuningCapability,
 				},
 			},
 		},
@@ -1045,7 +1045,7 @@ func TestReconcileClusterVersionWithDisabledCapabilities(t *testing.T) {
 			configv1.ClusterVersionCapabilityIngress,
 			//configv1.ClusterVersionCapabilityInsights,
 			configv1.ClusterVersionCapabilityMachineAPI,
-			configv1.ClusterVersionCapabilityNodeTuning,
+			//configv1.ClusterVersionCapabilityNodeTuning,
 			configv1.ClusterVersionCapabilityOperatorLifecycleManager,
 			configv1.ClusterVersionCapabilityOperatorLifecycleManagerV1,
 			configv1.ClusterVersionCapabilityStorage,

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -3543,7 +3543,7 @@ Once set, this field cannot be changed.</p>
 <em>(Optional)</em>
 <p>disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
 Once set, this field cannot be changed.</p>
-<p>Note: Disabling &lsquo;openshift-samples&rsquo;,&lsquo;Insights&rsquo;, &lsquo;Console&rsquo; are only supported in OpenShift versions 4.20 and above.</p>
+<p>Note: Disabling &lsquo;openshift-samples&rsquo;,&lsquo;Insights&rsquo;, &lsquo;Console&rsquo;, &lsquo;NodeTuning&rsquo; are only supported in OpenShift versions 4.20 and above.</p>
 </td>
 </tr>
 </tbody>
@@ -9764,6 +9764,8 @@ ClusterVersionOperatorSpec
 </tr><tr><td><p>&#34;ImageRegistry&#34;</p></td>
 <td></td>
 </tr><tr><td><p>&#34;Insights&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;NodeTuning&#34;</p></td>
 <td></td>
 </tr><tr><td><p>&#34;openshift-samples&#34;</p></td>
 <td></td>

--- a/hypershift-operator/controllers/nodepool/config.go
+++ b/hypershift-operator/controllers/nodepool/config.go
@@ -13,6 +13,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	"github.com/openshift/hypershift/support/backwardcompat"
+	"github.com/openshift/hypershift/support/capabilities"
 	"github.com/openshift/hypershift/support/globalconfig"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	supportutil "github.com/openshift/hypershift/support/util"
@@ -93,7 +94,7 @@ func NewConfigGenerator(ctx context.Context, client client.Client, hostedCluster
 		cg.rolloutConfig.additionalTrustBundleName = hostedCluster.Spec.AdditionalTrustBundle.Name
 	}
 
-	mcoRawConfig, err := cg.generateMCORawConfig(ctx)
+	mcoRawConfig, err := cg.generateMCORawConfig(ctx, hostedCluster.Spec.Capabilities)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +134,7 @@ func (cg *ConfigGenerator) Version() string {
 }
 
 // generateMCORawConfig generates a mco consumable artifact of the mco Config.
-func (cg *ConfigGenerator) generateMCORawConfig(ctx context.Context) (configsRaw string, err error) {
+func (cg *ConfigGenerator) generateMCORawConfig(ctx context.Context, caps *hyperv1.Capabilities) (configsRaw string, err error) {
 	var configs []corev1.ConfigMap
 
 	// Look for core ignition configs in the control plane namespace.
@@ -149,12 +150,14 @@ func (cg *ConfigGenerator) generateMCORawConfig(ctx context.Context) (configsRaw
 	}
 	configs = append(configs, userConfig...)
 
-	// Look for NTO generated MachineConfigs from the hosted control plane namespace
-	nodeTuningGeneratedConfigs, err := getNTOGeneratedConfig(ctx, cg)
-	if err != nil {
-		return "", err
+	if capabilities.IsNodeTuningCapabilityEnabled(caps) {
+		// Look for NTO generated MachineConfigs from the hosted control plane namespace
+		nodeTuningGeneratedConfigs, err := getNTOGeneratedConfig(ctx, cg)
+		if err != nil {
+			return "", err
+		}
+		configs = append(configs, nodeTuningGeneratedConfigs...)
 	}
-	configs = append(configs, nodeTuningGeneratedConfigs...)
 
 	return cg.parse(configs)
 }

--- a/hypershift-operator/controllers/nodepool/config_test.go
+++ b/hypershift-operator/controllers/nodepool/config_test.go
@@ -1436,7 +1436,7 @@ status:
 				cg.haproxyRawConfig = haproxyIgnititionConfig
 			}
 
-			got, err := cg.generateMCORawConfig(context.Background())
+			got, err := cg.generateMCORawConfig(context.Background(), hc.Spec.Capabilities)
 			if tc.error {
 				g.Expect(err).To(HaveOccurred())
 				if tc.missingCoreConfig {

--- a/support/capabilities/hosted_control_plane_capabilities.go
+++ b/support/capabilities/hosted_control_plane_capabilities.go
@@ -11,6 +11,19 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
+// IsNodeTuningCapabilityEnabled returns true if the NodeTuning capability is enabled, or false if disabled.
+func IsNodeTuningCapabilityEnabled(capabilities *hyperv1.Capabilities) bool {
+	if capabilities == nil {
+		return true
+	}
+	for _, disabledCap := range capabilities.Disabled {
+		if disabledCap == hyperv1.NodeTuningCapability {
+			return false
+		}
+	}
+	return true
+}
+
 // HasDisabledCapabilities returns true if any capabilities are disabled; otherwise, it returns false.
 func HasDisabledCapabilities(capabilities *hyperv1.Capabilities) bool {
 	if capabilities == nil {

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -1425,6 +1425,7 @@ func TestCreateClusterCustomConfig(t *testing.T) {
 				hyperv1.ImageRegistryCapability,
 				hyperv1.OpenShiftSamplesCapability,
 				hyperv1.InsightsCapability,
+				hyperv1.NodeTuningCapability,
 			}
 			if e2eutil.IsGreaterThanOrEqualTo(e2eutil.Version420) {
 				disabledCaps = append(disabledCaps, hyperv1.ConsoleCapability)
@@ -1467,6 +1468,9 @@ func TestCreateClusterCustomConfig(t *testing.T) {
 
 		// ensure console component is disabled
 		e2eutil.EnsureConsoleCapabilityDisabled(ctx, t, g, clients)
+
+		// ensure NodeTuning component is disabled
+		e2eutil.EnsureNodeTuningCapabilityDisabled(ctx, t, clients, mgtClient, hostedCluster)
 	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, "custom-config", globalOpts.ServiceAccountSigningKey)
 }
 

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -379,7 +379,7 @@ const (
 	PruneRetentionPolicy RetentionPolicy = "Prune"
 )
 
-// +kubebuilder:validation:Enum=ImageRegistry;openshift-samples;Insights;baremetal;Console
+// +kubebuilder:validation:Enum=ImageRegistry;openshift-samples;Insights;baremetal;Console;NodeTuning
 type OptionalCapability string
 
 const ImageRegistryCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityImageRegistry)
@@ -387,6 +387,7 @@ const OpenShiftSamplesCapability OptionalCapability = OptionalCapability(configv
 const InsightsCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityInsights)
 const BaremetalCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityBaremetal)
 const ConsoleCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityConsole)
+const NodeTuningCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityNodeTuning)
 
 // capabilities allows enabling or disabling optional components at install time.
 // When this is not supplied, the cluster will use the DefaultCapabilitySet defined for the respective
@@ -408,7 +409,7 @@ type Capabilities struct {
 	// disabled when specified, explicitly disables the specified capabilitíes on the hosted cluster.
 	// Once set, this field cannot be changed.
 	//
-	// Note: Disabling 'openshift-samples','Insights', 'Console' are only supported in OpenShift versions 4.20 and above.
+	// Note: Disabling 'openshift-samples','Insights', 'Console', 'NodeTuning' are only supported in OpenShift versions 4.20 and above.
 	//
 	// +listType=atomic
 	// +immutable


### PR DESCRIPTION
This PR is part of the task for expanding support for disabling openshift capabilities in hypershift. This change adds support for disabling the NodeTuning capability, who managed by both CPO and CVO.

**Checklist**
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [X] This change includes unit tests.