### PR TITLE
ACM-21713: fix(konflux): go-toolset runs as default(1001)

### DIFF
--- a/Containerfile.control-plane
+++ b/Containerfile.control-plane
@@ -2,7 +2,7 @@ FROM registry.redhat.io/rhel9/go-toolset:1.23.6-1745588370 AS builder
 
 WORKDIR /hypershift
 
-COPY . .
+COPY --chown=default . .
 
 RUN make control-plane-operator \
   && make control-plane-pki-operator

--- a/hack/tools/git-hooks/cpo-containerfiles-in-sync.sh
+++ b/hack/tools/git-hooks/cpo-containerfiles-in-sync.sh
@@ -3,7 +3,7 @@ echo >&2 "Processing " "$@"
 
 eval_cmd=("diff")
 for f in "$@"; do
-  eval_cmd+=("<(sed -e '/^FROM /d' \"$f\")")
+  eval_cmd+=("<(sed -e '/^FROM /d' -e '/COPY .* \. \./d' -e '/COPY \. \./d' \"$f\")")
 done
 
 eval "${eval_cmd[*]}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Since the Red Hat catalog go-toolset runs as a user with id = 1001, we need to make sure that the COPY instruction reflects that.


**Which issue(s) this PR fixes**:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.