### PR TITLE
Enable MutatingAdmissionPolicy runtime config

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/config.go
@@ -242,6 +242,9 @@ func generateConfig(p KubeAPIServerConfigParams) (*kcpv1.KubeAPIServerConfig, er
 		if gate == "DynamicResourceAllocation=true" {
 			runtimeConfig = append(runtimeConfig, "resource.k8s.io/v1beta1=true")
 		}
+		if gate == "MutatingAdmissionPolicy=true" {
+			runtimeConfig = append(runtimeConfig, "admissionregistration.k8s.io/v1alpha1=true")
+		}
 	}
 	args.Set("runtime-config", runtimeConfig...)
 	args.Set("service-account-issuer", p.ServiceAccountIssuerURL)

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/config_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/config_test.go
@@ -556,6 +556,20 @@ func TestGenerateConfig(t *testing.T) {
 				},
 			),
 		},
+		{
+			name: "with MutatingAdmissionPolicy feature gate enabled",
+			params: KubeAPIServerConfigParams{
+				FeatureGates: []string{
+					"MutatingAdmissionPolicy=true",
+				},
+			},
+			expected: modifyKasConfig(defaultKASConfig(),
+				func(kasc *kcpv1.KubeAPIServerConfig) {
+					kasc.APIServerArguments["runtime-config"] = append(kcpv1.Arguments{"admissionregistration.k8s.io/v1alpha1=true"}, kasc.APIServerArguments["runtime-config"]...)
+					kasc.APIServerArguments["feature-gates"] = append(kcpv1.Arguments{"MutatingAdmissionPolicy=true"}, kasc.APIServerArguments["feature-gates"]...)
+				},
+			),
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
**What this PR does / why we need it**:

To complement https://github.com/openshift/cluster-kube-apiserver-operator/pull/1854, we need to enable the admissionregistration alpha group when the MutatingAdmissionPolicy gate is enabled.

The MAP gate is not enabled by default upstream yet but we are intending to enable it downstream for testing and development of tech preview features.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.