### PR TITLE
webhook: Replace "delete" by "remove" for jpatch

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook.go
@@ -286,7 +286,7 @@ func validateJsonAnnotation(annotations map[string]string) error {
 			kind := p.Kind()
 			if kind == "unknown" {
 				return fmt.Errorf("wrong json patch structure in the %q annotation: missing op field", hyperv1.JSONPatchAnnotation)
-			} else if kind != "delete" {
+			} else if kind != "remove" {
 				v, err := p.ValueInterface()
 				if err != nil {
 					return fmt.Errorf("wrong json patch structure in the %q annotation: %w, %v", hyperv1.JSONPatchAnnotation, err, v)

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_webhook_test.go
@@ -204,6 +204,14 @@ func TestValidateJsonAnnotation(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "valid remove without value",
+			annotations: map[string]string{
+				v1beta1.JSONPatchAnnotation: `[{"op": "remove","path": "/spec/template/metadata/annotations/kubevirt.io~1allow-pod-bridge-network-live-migration"}]`,
+			},
+			expectError: false,
+		},
+
+		{
 			name: "not an array",
 			annotations: map[string]string{
 				v1beta1.JSONPatchAnnotation: `{"op": "replace","path": "/spec/domain/cpu/cores","value": 3}`,
@@ -235,6 +243,13 @@ func TestValidateJsonAnnotation(t *testing.T) {
 			name: "missing value",
 			annotations: map[string]string{
 				v1beta1.JSONPatchAnnotation: `[{"op": "replace","path": "/spec/domain/cpu/cores"}]`,
+			},
+			expectError: true,
+		},
+		{
+			name: "bad operation",
+			annotations: map[string]string{
+				v1beta1.JSONPatchAnnotation: `[{"op": "delete","path": "/spec/domain/cpu/cores", "value": "1"}]`,
 			},
 			expectError: true,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
The json patch validation introduced at [1] is expecting the operation "delete" to skip checking if the field "value" is parth of the json patch, this is no accurate since there is no such "delete" operation json patch spec only has the "remove" operation and is the one that can be created without "value" field.

[1] https://github.com/openshift/hypershift/pull/3197

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.