### PR TITLE
OCPBUGS-58335: Support proxy authentication when user/pass is included in URL

### DIFF
--- a/konnectivity-https-proxy/cmd.go
+++ b/konnectivity-https-proxy/cmd.go
@@ -2,6 +2,7 @@ package konnectivityhttpsproxy
 
 import (
 	"crypto/tls"
+	"encoding/base64"
 	"fmt"
 	"net"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/openshift/hypershift/pkg/version"
 	"github.com/openshift/hypershift/support/konnectivityproxy"
+	"github.com/openshift/hypershift/support/util"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
@@ -20,7 +22,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/elazarl/goproxy"
-	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/net/http/httpproxy"
@@ -77,6 +78,7 @@ func NewStartCommand() *cobra.Command {
 
 		var proxyTLS *tls.Config
 		var proxyURLHostPort *string
+		var proxyURLUser *url.Userinfo
 		proxyHostNames := sets.New[string]()
 
 		if len(httpsProxyURL) > 0 {
@@ -85,6 +87,7 @@ func NewStartCommand() *cobra.Command {
 				fmt.Fprintf(os.Stderr, "Error: failed to parse HTTPS proxy URL: %v", err)
 				os.Exit(1)
 			}
+			proxyURLUser = u.User
 			hostName, _, err := net.SplitHostPort(u.Host)
 			if err == nil {
 				proxyHostNames.Insert(hostName)
@@ -148,10 +151,15 @@ func NewStartCommand() *cobra.Command {
 				l.V(4).Info("Should proxy", "url", u)
 				return u, nil
 			},
-			Dial: konnectivityDialer.Dial,
+			Dial:        konnectivityDialer.Dial,
+			DialContext: konnectivityDialer.DialContext,
 		}
 		if httpsProxyURL != "" {
-			httpProxy.ConnectDialWithReq = connectDialFunc(l, httpProxy, httpsProxyURL, opts.ConnectDirectlyToCloudAPIs, konnectivityDialer.IsCloudAPI, userProxyFunc)
+			httpProxy.ConnectDialWithReq = connectDialFunc(
+				shouldDialDirectFunc(opts.ConnectDirectlyToCloudAPIs, konnectivityDialer.IsCloudAPI, userProxyFunc),
+				dialDirectFunc(httpProxy),
+				dialThroughProxyFunc(httpProxy, httpsProxyURL, proxyURLUser),
+			)
 		} else {
 			httpProxy.ConnectDial = nil
 			httpProxy.ConnectDialWithReq = nil
@@ -166,30 +174,56 @@ func NewStartCommand() *cobra.Command {
 	return cmd
 }
 
-func connectDialFunc(log logr.Logger, httpProxy *goproxy.ProxyHttpServer, proxyURL string, connectDirectlyToCloudAPIs bool, isCloudAPI func(string) bool, userProxyFunc func(*url.URL) (*url.URL, error)) func(req *http.Request, network, addr string) (net.Conn, error) {
-	defaultDial := httpProxy.NewConnectDialToProxy(proxyURL)
+type dialFunc func(network, addr string) (net.Conn, error)
+type dialRequestFunc func(req *http.Request, network, addr string) (net.Conn, error)
+
+func dialDirectFunc(httpProxy *goproxy.ProxyHttpServer) dialFunc {
+	// NOTE: the function signature is determined by the goproxy library, it requires the deprecated version
+	// nolint:staticcheck
+	return httpProxy.Tr.Dial
+}
+
+func dialThroughProxyFunc(httpProxy *goproxy.ProxyHttpServer, proxyURL string, proxyURLUser *url.Userinfo) dialFunc {
+	return httpProxy.NewConnectDialToProxyWithHandler(proxyURL, addBasicAuthHeader(proxyURLUser))
+}
+
+func shouldDialDirectFunc(connectDirectlyToCloudAPIs bool, isCloudAPI func(string) bool, userProxyFunc func(*url.URL) (*url.URL, error)) func(*url.URL) (bool, error) {
+	return func(u *url.URL) (bool, error) {
+		if connectDirectlyToCloudAPIs {
+			hostName, err := util.HostFromURL(u.String())
+			if err != nil {
+				return false, err
+			}
+			if isCloudAPI(hostName) {
+				return true, nil
+			}
+		}
+
+		proxyURL, err := userProxyFunc(u)
+		if err != nil {
+			return false, err
+		}
+		return proxyURL == nil, nil
+	}
+}
+
+func addBasicAuthHeader(proxyUser *url.Userinfo) func(req *http.Request) {
+	return func(req *http.Request) {
+		if proxyUser != nil {
+			req.Header.Set("Proxy-Authorization", fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(proxyUser.String()))))
+		}
+	}
+}
+
+func connectDialFunc(shouldDialDirect func(*url.URL) (bool, error), dialDirectly dialFunc, dialThroughProxy dialFunc) dialRequestFunc {
 	return func(req *http.Request, network, addr string) (net.Conn, error) {
-		log.V(4).Info("Connect dial called", "network", network, "address", addr, "URL", req.URL)
-		requestURL := *req.URL
-		// Ensure the request URL scheme is set. This function is only called
-		// for requests to https endpoints.
-		requestURL.Scheme = "https"
-		proxyURL, err := userProxyFunc(&requestURL)
+		shouldDialDirectly, err := shouldDialDirect(req.URL)
 		if err != nil {
 			return nil, err
 		}
-		log.V(4).Info("Determined proxy URL", "url", proxyURL)
-		host, _, err := net.SplitHostPort(requestURL.Host)
-		if err != nil {
-			return nil, err
+		if shouldDialDirectly {
+			return dialDirectly(network, addr)
 		}
-		// If the URL is a cloud API or it should not be proxied, then
-		// send it through the dialer directly.
-		if (connectDirectlyToCloudAPIs && isCloudAPI(host)) || proxyURL == nil {
-			log.V(4).Info("Host is cloud API or should not use a proxy with it, dialing directly through konnectivity")
-			return httpProxy.Tr.Dial(network, addr)
-		}
-		log.V(4).Info("Using proxy to dial", "proxy", proxyURL)
-		return defaultDial(network, addr)
+		return dialThroughProxy(network, addr)
 	}
 }

--- a/konnectivity-https-proxy/cmd_test.go
+++ b/konnectivity-https-proxy/cmd_test.go
@@ -1,0 +1,108 @@
+package konnectivityhttpsproxy
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestShouldDialDirectFunc(t *testing.T) {
+	tests := []struct {
+		name                       string
+		connectDirectlyToCloudAPIs bool
+		isCloudAPI                 bool
+		emptyProxyURL              bool
+		expected                   bool
+	}{
+		{
+			name:                       "cloud API",
+			connectDirectlyToCloudAPIs: true,
+			isCloudAPI:                 true,
+			expected:                   true,
+		},
+		{
+			name:                       "not cloud API",
+			connectDirectlyToCloudAPIs: true,
+			isCloudAPI:                 false,
+			expected:                   false,
+		},
+		{
+			name:                       "not cloud API, no proxy URL",
+			connectDirectlyToCloudAPIs: true,
+			isCloudAPI:                 false,
+			emptyProxyURL:              true,
+			expected:                   true,
+		},
+		{
+			name:                       "not cloud API, has proxy URL",
+			connectDirectlyToCloudAPIs: true,
+			isCloudAPI:                 false,
+			emptyProxyURL:              false,
+			expected:                   false,
+		},
+		{
+			name:                       "do not connect directly to cloud APIs",
+			connectDirectlyToCloudAPIs: false,
+			isCloudAPI:                 true,
+			expected:                   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isCloudAPI := func(string) bool {
+				return tc.isCloudAPI
+			}
+			userProxyFunc := func(u *url.URL) (*url.URL, error) {
+				if tc.emptyProxyURL {
+					return nil, nil
+				}
+				return u, nil
+			}
+			g := NewGomegaWithT(t)
+			proxyURL, err := url.Parse("http://proxy.example.com:3128")
+			g.Expect(err).NotTo(HaveOccurred())
+			f := shouldDialDirectFunc(tc.connectDirectlyToCloudAPIs, isCloudAPI, userProxyFunc)
+			result, err := f(proxyURL)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(result).To(Equal(tc.expected))
+		})
+	}
+}
+
+func TestAddBasicAuthHeader(t *testing.T) {
+	userInfo := url.UserPassword("user", "password")
+	tests := []struct {
+		name           string
+		userInfo       *url.Userinfo
+		expectedHeader string
+	}{
+		{
+			name:           "no userinfo",
+			userInfo:       nil,
+			expectedHeader: "",
+		},
+		{
+			name:           "userinfo present",
+			userInfo:       userInfo,
+			expectedHeader: fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(userInfo.String()))),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			f := addBasicAuthHeader(tc.userInfo)
+			req := &http.Request{
+				Header: http.Header{},
+			}
+			f(req)
+			value := req.Header.Get("Proxy-Authorization")
+			g.Expect(value).To(Equal(tc.expectedHeader))
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

It backports fix  for OCPBUGS-42938 to 4.19 stream

Original PR: https://github.com/openshift/hypershift/pull/6207