### PR TITLE
OCPBUGS-57660: [release-4.19] CORENET-6094: CNO: add FRR-k8s image

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -101,6 +101,7 @@ type Images struct {
 	CLI                          string
 	CLIControlPlane              string
 	Socks5Proxy                  string
+	FRR                          string
 }
 
 type Params struct {
@@ -155,6 +156,7 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 			CLI:                          userReleaseImageProvider.GetImage("cli"),
 			CLIControlPlane:              releaseImageProvider.GetImage("cli"),
 			Socks5Proxy:                  releaseImageProvider.GetImage("socks5-proxy"),
+			FRR:                          userReleaseImageProvider.GetImage("metallb-frr"),
 		},
 		ReleaseVersion:          version,
 		AvailabilityProberImage: releaseImageProvider.GetImage(util.AvailabilityProberImageName),
@@ -747,5 +749,6 @@ func buildCNOEnvVars(envVars []corev1.EnvVar, params Params) []corev1.EnvVar {
 		{Name: "CLI_CONTROL_PLANE_IMAGE", Value: params.Images.CLIControlPlane},
 		{Name: "SOCKS5_PROXY_IMAGE", Value: params.Images.Socks5Proxy},
 		{Name: "OPENSHIFT_RELEASE_IMAGE", Value: params.DeploymentConfig.AdditionalAnnotations[hyperv1.ReleaseImageAnnotation]},
+		{Name: "FRR_K8S_IMAGE", Value: params.Images.FRR},
 	}...)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_No_private_apiserver_connectivity__proxy_apiserver_address_is_set.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_No_private_apiserver_connectivity__proxy_apiserver_address_is_set.yaml
@@ -87,6 +87,7 @@ spec:
         - name: CLI_CONTROL_PLANE_IMAGE
         - name: SOCKS5_PROXY_IMAGE
         - name: OPENSHIFT_RELEASE_IMAGE
+        - name: FRR_K8S_IMAGE
         imagePullPolicy: IfNotPresent
         name: cluster-network-operator
         resources:

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Preserve_existing_resources.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Preserve_existing_resources.yaml
@@ -87,6 +87,7 @@ spec:
         - name: CLI_CONTROL_PLANE_IMAGE
         - name: SOCKS5_PROXY_IMAGE
         - name: OPENSHIFT_RELEASE_IMAGE
+        - name: FRR_K8S_IMAGE
         imagePullPolicy: IfNotPresent
         name: cluster-network-operator
         resources:

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Private_apiserver_connectivity__proxy_apiserver_address_is_unset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Private_apiserver_connectivity__proxy_apiserver_address_is_unset.yaml
@@ -85,6 +85,7 @@ spec:
         - name: CLI_CONTROL_PLANE_IMAGE
         - name: SOCKS5_PROXY_IMAGE
         - name: OPENSHIFT_RELEASE_IMAGE
+        - name: FRR_K8S_IMAGE
         imagePullPolicy: IfNotPresent
         name: cluster-network-operator
         resources:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/zz_fixture_TestControlPlaneComponents.yaml
@@ -151,6 +151,8 @@ spec:
           value: networking-console-plugin
         - name: CLI_IMAGE
           value: cli
+        - name: FRR_K8S_IMAGE
+          value: metallb-frr
         - name: PROXY_INTERNAL_APISERVER_ADDRESS
           value: "true"
         image: cluster-network-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -151,6 +151,8 @@ spec:
           value: networking-console-plugin
         - name: CLI_IMAGE
           value: cli
+        - name: FRR_K8S_IMAGE
+          value: metallb-frr
         - name: PROXY_INTERNAL_APISERVER_ADDRESS
           value: "true"
         image: cluster-network-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cno/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cno/deployment.go
@@ -111,6 +111,7 @@ func buildCNOEnvVars(cpContext component.WorkloadContext) ([]corev1.EnvVar, erro
 		{Name: "NETWORK_CHECK_TARGET_IMAGE", Value: userReleaseImageProvider.GetImage("cluster-network-operator")},
 		{Name: "NETWORKING_CONSOLE_PLUGIN_IMAGE", Value: userReleaseImageProvider.GetImage("networking-console-plugin")},
 		{Name: "CLI_IMAGE", Value: userReleaseImageProvider.GetImage("cli")},
+		{Name: "FRR_K8S_IMAGE", Value: userReleaseImageProvider.GetImage("metallb-frr")},
 	}
 
 	if !util.IsPrivateHCP(hcp) {


### PR DESCRIPTION
Manual backport of https://github.com/openshift/hypershift/pull/6290. 
Adds FRR image to both places building the CNO env vars.
Builds on https://github.com/openshift/hypershift/pull/6359.