### PR TITLE
OCPSTRAT-2173: feat(hcco): add support for hosted OIDC client secrets

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -362,6 +362,19 @@ const (
 	// a process to check if the different components in the DataPlane are working as expected. Checks:
 	// - Validates the monitoring stack is properly working after restoration, if not HCCO will restart the prometheus-k8s pods.
 	HostedClusterRestoredFromBackupAnnotation = "hypershift.openshift.io/restored-from-backup"
+
+	// HostedClusterSourcedAnnotation is set to true on Secret and ConfigMap resources to designate them as
+	// hosted-cluster-sourced resources. This means that the hosted cluster version of these resources is the source of
+	// truth and the management cluster version will be just empty resources that have this annotation. This is useful
+	// to enable day-two configuration use cases where such resources are expected to be provided by the end-user after
+	// the cluster creation, and, due to certain restrictions, those resources include sensitive data that can't live
+	// on the control-plane. Setting this annotation will instruct HyperShift to skip creating this resource on the hosted
+	// cluster and to not override any changes done later on the hosted cluster version of this resource.
+	//
+	// This annotation can only be set on empty resources and currently it's only honored when set on secrets that are
+	// referenced in the HostedCluster `spec.configuration.authentication.oidcProviders[*].oidcClients[*].clientSecret`
+	// and only for the ARO-HCP platform.
+	HostedClusterSourcedAnnotation = "hypershift.openshift.io/hosted-cluster-sourced"
 )
 
 // RetentionPolicy defines the policy for handling resources associated with a cluster when the cluster is deleted.

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1239,6 +1239,10 @@ func (r *reconciler) reconcileAuthOIDC(ctx context.Context, hcp *hyperv1.HostedC
 						errs = append(errs, fmt.Errorf("failed to get OIDCClient secret %s: %w", oidcClient.ClientSecret.Name, err))
 						continue
 					}
+					if azureutil.IsAroHCP() && util.HasAnnotationWithValue(&src, hyperv1.HostedClusterSourcedAnnotation, "true") {
+						// This is a day-2 secret. We shouldn't copy it, instead it'll be provided by the end-user on the hosted cluster.
+						continue
+					}
 					dest := corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      oidcClient.ClientSecret.Name,
@@ -1254,6 +1258,7 @@ func (r *reconciler) reconcileAuthOIDC(ctx context.Context, hcp *hyperv1.HostedC
 					})
 					if err != nil {
 						errs = append(errs, fmt.Errorf("failed to reconcile OIDCClient secret %s: %w", dest.Name, err))
+
 					}
 				}
 			}

--- a/support/azureutil/azureutil.go
+++ b/support/azureutil/azureutil.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"testing"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/config"
@@ -184,6 +185,11 @@ func GetResourceGroupInfo(ctx context.Context, rgName string, subscriptionID str
 // IsAroHCP returns true if the managed service environment variable is set to ARO-HCP
 func IsAroHCP() bool {
 	return os.Getenv("MANAGED_SERVICE") == hyperv1.AroHCP
+}
+
+// SetAsAroHCPTest sets the proper environment variable for the test, designating this is an ARO-HCP environment
+func SetAsAroHCPTest(t *testing.T) {
+	t.Setenv("MANAGED_SERVICE", hyperv1.AroHCP)
 }
 
 func GetKeyVaultAuthorizedUser() string {

--- a/support/util/annotations.go
+++ b/support/util/annotations.go
@@ -1,0 +1,12 @@
+package util
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// HasAnnotationWithValue checks if a Kubernetes object has a specific annotation with a given value.
+func HasAnnotationWithValue(obj metav1.Object, key, expectedValue string) bool {
+	annotations := obj.GetAnnotations()
+	val, ok := annotations[key]
+	return ok && val == expectedValue
+}

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -362,6 +362,19 @@ const (
 	// a process to check if the different components in the DataPlane are working as expected. Checks:
 	// - Validates the monitoring stack is properly working after restoration, if not HCCO will restart the prometheus-k8s pods.
 	HostedClusterRestoredFromBackupAnnotation = "hypershift.openshift.io/restored-from-backup"
+
+	// HostedClusterSourcedAnnotation is set to true on Secret and ConfigMap resources to designate them as
+	// hosted-cluster-sourced resources. This means that the hosted cluster version of these resources is the source of
+	// truth and the management cluster version will be just empty resources that have this annotation. This is useful
+	// to enable day-two configuration use cases where such resources are expected to be provided by the end-user after
+	// the cluster creation, and, due to certain restrictions, those resources include sensitive data that can't live
+	// on the control-plane. Setting this annotation will instruct HyperShift to skip creating this resource on the hosted
+	// cluster and to not override any changes done later on the hosted cluster version of this resource.
+	//
+	// This annotation can only be set on empty resources and currently it's only honored when set on secrets that are
+	// referenced in the HostedCluster `spec.configuration.authentication.oidcProviders[*].oidcClients[*].clientSecret`
+	// and only for the ARO-HCP platform.
+	HostedClusterSourcedAnnotation = "hypershift.openshift.io/hosted-cluster-sourced"
 )
 
 // RetentionPolicy defines the policy for handling resources associated with a cluster when the cluster is deleted.


### PR DESCRIPTION
**What this PR does / why we need it**:

add support for hosted OIDC client secrets to be used as day-2 secrets. 

**Which issue(s) this PR fixes**:
Fixes #[OCPSTRAT-2173](https://issues.redhat.com//browse/OCPSTRAT-2173)

This PR is based on #6367 

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.