### PR TITLE
CNTRLPLANE-1042: Disable createClusterNone for azure and scope down verifyResourceGroupLocationsMatch check

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -880,7 +880,7 @@ func (r *HostedControlPlaneReconciler) validateConfigAndClusterCapabilities(ctx 
 		}
 	}
 
-	if hyperazureutil.IsAroHCP() {
+	if hcp.Spec.Platform.Type == hyperv1.AzurePlatform && hyperazureutil.IsAroHCP() {
 		if err := r.verifyResourceGroupLocationsMatch(ctx, hcp); err != nil {
 			return err
 		}

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -1463,6 +1463,10 @@ func TestCreateClusterCustomConfig(t *testing.T) {
 func TestNoneCreateCluster(t *testing.T) {
 	t.Parallel()
 
+	if globalOpts.Platform == hyperv1.AzurePlatform {
+		t.Skip("test not supported on platform Azure")
+	}
+
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/openshift/release/pull/66655 enables all tests to run on aks-e2e This is failing because of the createClusterNone test. Scoping down verifyResourceGroupLocationsMatch to only run on azure platform is fix that should solve the current failure. Besides this test provides no value and we want to focus on increasing valuable coverage so this PR just disbled it for azure

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[CNTRLPLANE-1042](https://issues.redhat.com//browse/CNTRLPLANE-1042)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.