### PR TITLE
OCPBUGS-58505: [release-4.16] Add missing service network DNS entries to KAS cert

### DIFF
--- a/support/pki/kas.go
+++ b/support/pki/kas.go
@@ -33,6 +33,8 @@ func GetKASServerCertificatesSANs(externalAPIAddress, internalAPIAddress string,
 		"openshift.default",
 		"openshift.default.svc",
 		"openshift.default.svc.cluster.local",
+		fmt.Sprintf("%s.%s.svc", svc.Name, svc.Namespace),
+		fmt.Sprintf("%s.%s.svc.cluster.local", svc.Name, svc.Namespace),
 	}
 	apiServerIPs := []string{
 		"127.0.0.1",


### PR DESCRIPTION
**What this PR does / why we need it**:
PR #6114 backported code that did not include the service network DNS entries for the kube apiserver. This was ok in releases 4.17 and newer because in those releases a separate certificate is created to serve those service network DNS entries. However in 4.16 and older, there is only one serving certificate for the kube apiserver. This resulted in clients like ACM failing to communicate with the kube apiserver because they use the service network endpoint to install the klusterlet in the hosted cluster. This fix adds the missing entries back into the dns names of the KAS serving certificate.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.