### PR TITLE
[release-4.19] OCPBUGS-58683:fix(hcco): Don't use a default OIDC client secret name when no secret name is provided 

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1150,7 +1150,8 @@ func (r *reconciler) reconcileAuthOIDC(ctx context.Context, hcp *hyperv1.HostedC
 
 		// Copy OIDCClient Secrets into openshift-config namespace
 		for _, oidcClient := range provider.OIDCClients {
-			// If the secret name is empty, we assume the guest cluster admin is going to create this secret manually
+			// Public OIDC clients have no secrets, so the secret name will be the empty string since ClientSecret is
+			// optional and not a pointer
 			if oidcClient.ClientSecret.Name == "" {
 				log.Info("OIDC client secret is empty, skipping reconciliation", "component", oidcClient.ComponentName)
 				continue

--- a/support/globalconfig/authentication.go
+++ b/support/globalconfig/authentication.go
@@ -1,17 +1,11 @@
 package globalconfig
 
 import (
-	"fmt"
-
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 
 	configv1 "github.com/openshift/api/config/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
-
-const (
-	postInstallClientSecretSuffix = "post-install-client-secret"
 )
 
 func AuthenticationConfiguration() *configv1.Authentication {
@@ -27,12 +21,5 @@ func ReconcileAuthenticationConfiguration(authentication *configv1.Authenticatio
 		authentication.Spec = *config.Authentication
 	}
 	authentication.Spec.ServiceAccountIssuer = issuerURL
-	for i := range authentication.Spec.OIDCProviders {
-		for j, client := range authentication.Spec.OIDCProviders[i].OIDCClients {
-			if client.ClientSecret.Name == "" {
-				authentication.Spec.OIDCProviders[i].OIDCClients[j].ClientSecret.Name = fmt.Sprintf("%s-%s", client.ComponentName, postInstallClientSecretSuffix)
-			}
-		}
-	}
 	return nil
 }

--- a/support/globalconfig/authentication_test.go
+++ b/support/globalconfig/authentication_test.go
@@ -1,7 +1,6 @@
 package globalconfig
 
 import (
-	"fmt"
 	"testing"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -68,7 +67,7 @@ func TestReconcileAuthenticationConfiguration(t *testing.T) {
 				},
 				issuerURL: "https://example.com/issuer",
 			},
-			secretName: fmt.Sprintf("%s-%s", "test-client", postInstallClientSecretSuffix),
+			secretName: "",
 		},
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it

Effectively, this is  back-port of two PRs: #6365 and #6367 .

This change does the following:
- Removes the secret defaulting logic for OIDC clients with no secret name.
- Adds unit tests for the reconcileAuthOIDC function.

The functionality originally intended by #6296 will be introduced in a different way in a separate PR. 

There's currently a draft PR for it on main #6375 

## Which issue(s) this PR fixes

Fixes OCPBUGS-58683

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.