### PR TITLE
OCPBUGS-58837: Override CPO image to apply KAS certificate hotfix

### DIFF
--- a/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
+++ b/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
@@ -209,3 +209,10 @@ overrides:
     cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-cert-hotfix-416-multi:2d2e6071841bb12ff1f41c457889bb44b6fb1cf7
   # End of OCPBUGS-58837 overrides 4.15 section
   # End of OCPBUGS-58837 overrides
+testing:
+  # Update the image refs below to indicate which images should be used for CPO override
+  # testing. Currently, we only test one latest/previous combination. In the future, we 
+  # may be able to test multiple combinations at a time. To test more than one, update
+  # the referenced images before each e2e test run.
+  latest: quay.io/openshift-release-dev/ocp-release:4.15.53-x86_64
+  previous: quay.io/openshift-release-dev/ocp-release:4.15.52-x86_64

--- a/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
+++ b/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
@@ -197,3 +197,15 @@ overrides:
     cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
   # End of OCPBUGS-48519 overrides 4.17 section
   # End of OCPBUGS-48519 overrides
+  # Beginning of OCPBUGS-58837 overrides
+  # Beginning of OCPBUGS-58837 overrides 4.15 section
+  - version: 4.15.53
+    cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/openshift-cert-hotfix-415-multi:ab45f5df65f19c9e4db4977b0d756c8d87baff0a 
+  - version: 4.15.54
+    cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/openshift-cert-hotfix-415-multi:ab45f5df65f19c9e4db4977b0d756c8d87baff0a 
+  # End of OCPBUGS-58837 overrides 4.15 section
+  # Beginning of OCPBUGS-58837 overrides 4.15 section
+  - version: 4.16.43
+    cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-cert-hotfix-416-multi:2d2e6071841bb12ff1f41c457889bb44b6fb1cf7
+  # End of OCPBUGS-58837 overrides 4.15 section
+  # End of OCPBUGS-58837 overrides


### PR DESCRIPTION
**What this PR does / why we need it**:
Applies the fix delivered with PRs #6393 and #6394 to to OCP versions 4.15.53, 4.15.54 and 4.16.43

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-58837](https://issues.redhat.com/browse/OCPBUGS-58837)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.