### PR TITLE
[release-4.19] OCPBUGS-59101: Configure ClusterServiceLoadBalancerHea…

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/providerconfig.go
@@ -18,7 +18,8 @@ const configTemplate = `[Global]
 Zone = %s
 VPC = %s
 KubernetesClusterID = %s
-SubnetID = %s`
+SubnetID = %s
+ClusterServiceLoadBalancerHealthProbeMode = Shared`
 
 func (p *AWSParams) ReconcileCloudConfig(cm *corev1.ConfigMap) error {
 	util.EnsureOwnerRef(cm, p.OwnerRef)

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-aws/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-aws/zz_fixture_TestControlPlaneComponents.yaml
@@ -26,7 +26,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token
-        component.hypershift.openshift.io/config-hash: 53b6605a
+        component.hypershift.openshift.io/config-hash: 6cd2cf9e
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-aws/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-aws/zz_fixture_TestControlPlaneComponents_TechPreviewNoUpgrade.yaml
@@ -26,7 +26,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token
-        component.hypershift.openshift.io/config-hash: 53b6605a
+        component.hypershift.openshift.io/config-hash: 6cd2cf9e
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cloud-controller-manager-aws/config.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cloud-controller-manager-aws/config.yaml
@@ -6,6 +6,7 @@ data:
     VPC = %s
     KubernetesClusterID = %s
     SubnetID = %s
+    ClusterServiceLoadBalancerHealthProbeMode = Shared
 kind: ConfigMap
 metadata:
   name: aws-cloud-config

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/aws/testdata/zz_fixture_TestConfig.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/aws/testdata/zz_fixture_TestConfig.yaml
@@ -6,6 +6,7 @@ data:
     VPC = my-vpc
     KubernetesClusterID = my-infra-ID
     SubnetID = my-subnet-ID
+    ClusterServiceLoadBalancerHealthProbeMode = Shared
 kind: ConfigMap
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
…lthProbeMode as Shared

This is a manual cherry-pick of [pull/6099](https://github.com/openshift/hypershift/pull/6099) where it also modifies the configuration for CPO v1. Choosing CPO v1 vs. v2 is possible via annotation `hypershift.openshift.io/cpo-v2` so this PR fixes both versions.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes [OCPBUGS-59101](https://issues.redhat.com/browse/OCPBUGS-59101)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.