### PR TITLE
CNTRLPLANE-385: programmatically enable readonlyRootFilesystem

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/catalog-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_catalog_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/catalog-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_catalog_operator_deployment.yaml
@@ -26,6 +26,7 @@ spec:
     metadata:
       annotations:
         alpha.image.policy.openshift.io/resolve-names: '*'
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -114,6 +115,8 @@ spec:
           requests:
             cpu: 10m
             memory: 80Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /srv-cert
@@ -125,6 +128,8 @@ spec:
         - mountPath: /etc/openshift/kubeconfig
           name: kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         command:
@@ -139,6 +144,8 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
@@ -147,6 +154,8 @@ spec:
           name: konnectivity-proxy-cert
         - mountPath: /etc/konnectivity/proxy-ca
           name: konnectivity-proxy-ca
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -193,4 +202,6 @@ spec:
       - configMap:
           name: konnectivity-ca-bundle
         name: konnectivity-proxy-ca
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/catalog-operator/zz_fixture_TestControlPlaneComponents_catalog_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/catalog-operator/zz_fixture_TestControlPlaneComponents_catalog_operator_deployment.yaml
@@ -26,6 +26,7 @@ spec:
     metadata:
       annotations:
         alpha.image.policy.openshift.io/resolve-names: '*'
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -114,6 +115,8 @@ spec:
           requests:
             cpu: 10m
             memory: 80Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /srv-cert
@@ -125,6 +128,8 @@ spec:
         - mountPath: /etc/openshift/kubeconfig
           name: kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         command:
@@ -139,6 +144,8 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
@@ -147,6 +154,8 @@ spec:
           name: konnectivity-proxy-cert
         - mountPath: /etc/konnectivity/proxy-ca
           name: konnectivity-proxy-ca
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -193,4 +202,6 @@ spec:
       - configMap:
           name: konnectivity-ca-bundle
         name: konnectivity-proxy-ca
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/certified-operators-catalog/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_certified_operators_catalog_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/certified-operators-catalog/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_certified_operators_catalog_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         alpha.image.policy.openshift.io/resolve-names: '*'
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: utilities,catalog-content
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: utilities,catalog-content,tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -102,6 +102,8 @@ spec:
           requests:
             cpu: 10m
             memory: 160Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         startupProbe:
           exec:
             command:
@@ -116,6 +118,8 @@ spec:
         volumeMounts:
         - mountPath: /extracted-catalog
           name: catalog-content
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - args:
         - /bin/copy-content
@@ -164,4 +168,6 @@ spec:
         name: utilities
       - emptyDir: {}
         name: catalog-content
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/certified-operators-catalog/zz_fixture_TestControlPlaneComponents_certified_operators_catalog_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/certified-operators-catalog/zz_fixture_TestControlPlaneComponents_certified_operators_catalog_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         alpha.image.policy.openshift.io/resolve-names: '*'
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: utilities,catalog-content
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: utilities,catalog-content,tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -102,6 +102,8 @@ spec:
           requests:
             cpu: 10m
             memory: 160Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         startupProbe:
           exec:
             command:
@@ -116,6 +118,8 @@ spec:
         volumeMounts:
         - mountPath: /extracted-catalog
           name: catalog-content
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - args:
         - /bin/copy-content
@@ -164,4 +168,6 @@ spec:
         name: utilities
       - emptyDir: {}
         name: catalog-content
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-aws/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cloud_controller_manager_aws_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-aws/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cloud_controller_manager_aws_deployment.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token,tmp-dir
         component.hypershift.openshift.io/config-hash: 6cd2cf9e
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -90,6 +90,8 @@ spec:
           requests:
             cpu: 75m
             memory: 60Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/cloud
@@ -102,6 +104,8 @@ spec:
           name: cloud-creds
         - mountPath: /var/run/secrets/openshift/serviceaccount
           name: cloud-token
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --token-audience=openshift
         - --service-account-namespace=kube-system
@@ -118,12 +122,16 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/secrets/openshift/serviceaccount
           name: cloud-token
         - mountPath: /etc/kubernetes
           name: kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule
@@ -154,4 +162,6 @@ spec:
       - emptyDir:
           medium: Memory
         name: cloud-token
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-aws/zz_fixture_TestControlPlaneComponents_cloud_controller_manager_aws_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-aws/zz_fixture_TestControlPlaneComponents_cloud_controller_manager_aws_deployment.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token,tmp-dir
         component.hypershift.openshift.io/config-hash: 6cd2cf9e
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -90,6 +90,8 @@ spec:
           requests:
             cpu: 75m
             memory: 60Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/cloud
@@ -102,6 +104,8 @@ spec:
           name: cloud-creds
         - mountPath: /var/run/secrets/openshift/serviceaccount
           name: cloud-token
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --token-audience=openshift
         - --service-account-namespace=kube-system
@@ -118,12 +122,16 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/secrets/openshift/serviceaccount
           name: cloud-token
         - mountPath: /etc/kubernetes
           name: kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule
@@ -154,4 +162,6 @@ spec:
       - emptyDir:
           medium: Memory
         name: cloud-token
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-azure/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cloud_controller_manager_azure_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-azure/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cloud_controller_manager_azure_deployment.yaml
@@ -25,6 +25,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: d3b0276c
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -84,12 +85,16 @@ spec:
           requests:
             cpu: 75m
             memory: 60Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/cloud
           name: cloud-config
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule
@@ -109,4 +114,6 @@ spec:
         secret:
           defaultMode: 416
           secretName: azure-cloud-config
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-azure/zz_fixture_TestControlPlaneComponents_cloud_controller_manager_azure_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-azure/zz_fixture_TestControlPlaneComponents_cloud_controller_manager_azure_deployment.yaml
@@ -25,6 +25,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: d3b0276c
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -84,12 +85,16 @@ spec:
           requests:
             cpu: 75m
             memory: 60Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/cloud
           name: cloud-config
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule
@@ -109,4 +114,6 @@ spec:
         secret:
           defaultMode: 416
           secretName: azure-cloud-config
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-kubevirt/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cloud_controller_manager_kubevirt_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-kubevirt/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cloud_controller_manager_kubevirt_deployment.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: b833e1fe
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -95,12 +96,16 @@ spec:
           requests:
             cpu: 75m
             memory: 60Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/cloud
           name: cloud-config
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       serviceAccountName: kubevirt-cloud-controller-manager
       tolerations:
@@ -121,4 +126,6 @@ spec:
           defaultMode: 420
           name: kubevirt-cloud-config
         name: cloud-config
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-kubevirt/zz_fixture_TestControlPlaneComponents_cloud_controller_manager_kubevirt_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-kubevirt/zz_fixture_TestControlPlaneComponents_cloud_controller_manager_kubevirt_deployment.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: b833e1fe
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -95,12 +96,16 @@ spec:
           requests:
             cpu: 75m
             memory: 60Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/cloud
           name: cloud-config
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       serviceAccountName: kubevirt-cloud-controller-manager
       tolerations:
@@ -121,4 +126,6 @@ spec:
           defaultMode: 420
           name: kubevirt-cloud-config
         name: cloud-config
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-openstack/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cloud_controller_manager_openstack_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-openstack/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cloud_controller_manager_openstack_deployment.yaml
@@ -26,6 +26,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 1cdcee0c
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -89,6 +90,8 @@ spec:
           requests:
             cpu: 200m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
@@ -100,6 +103,8 @@ spec:
         - mountPath: /etc/openstack/secret
           name: secret-occm
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule
@@ -129,4 +134,6 @@ spec:
           - key: clouds.yaml
             path: clouds.yaml
           secretName: fake-cloud-credentials-secret
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-openstack/zz_fixture_TestControlPlaneComponents_cloud_controller_manager_openstack_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-openstack/zz_fixture_TestControlPlaneComponents_cloud_controller_manager_openstack_deployment.yaml
@@ -26,6 +26,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 1cdcee0c
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -89,6 +90,8 @@ spec:
           requests:
             cpu: 200m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
@@ -100,6 +103,8 @@ spec:
         - mountPath: /etc/openstack/secret
           name: secret-occm
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule
@@ -129,4 +134,6 @@ spec:
           - key: clouds.yaml
             path: clouds.yaml
           secretName: fake-cloud-credentials-secret
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-powervs/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cloud_controller_manager_powervs_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-powervs/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cloud_controller_manager_powervs_deployment.yaml
@@ -24,6 +24,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 774b434c
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -102,6 +103,8 @@ spec:
           requests:
             cpu: 75m
             memory: 60Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes
@@ -110,6 +113,8 @@ spec:
           name: ccm-config
         - mountPath: /etc/vpc
           name: cloud-creds
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       terminationGracePeriodSeconds: 90
       tolerations:
@@ -133,4 +138,6 @@ spec:
       - name: cloud-creds
         secret:
           defaultMode: 416
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-powervs/zz_fixture_TestControlPlaneComponents_cloud_controller_manager_powervs_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-controller-manager-powervs/zz_fixture_TestControlPlaneComponents_cloud_controller_manager_powervs_deployment.yaml
@@ -24,6 +24,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 774b434c
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -102,6 +103,8 @@ spec:
           requests:
             cpu: 75m
             memory: 60Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes
@@ -110,6 +113,8 @@ spec:
           name: ccm-config
         - mountPath: /etc/vpc
           name: cloud-creds
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       terminationGracePeriodSeconds: 90
       tolerations:
@@ -133,4 +138,6 @@ spec:
       - name: cloud-creds
         secret:
           defaultMode: 416
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-credential-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cloud_credential_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-credential-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cloud_credential_operator_deployment.yaml
@@ -25,6 +25,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 741638a5741638a5741638a5741638a5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -82,10 +83,13 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes
           name: service-account-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -118,4 +122,6 @@ spec:
         secret:
           defaultMode: 416
           secretName: cloud-credential-operator-service-account-kubeconfig
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-credential-operator/zz_fixture_TestControlPlaneComponents_cloud_credential_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cloud-credential-operator/zz_fixture_TestControlPlaneComponents_cloud_credential_operator_deployment.yaml
@@ -25,6 +25,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 741638a5741638a5741638a5741638a5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -82,10 +83,13 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes
           name: service-account-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -118,4 +122,6 @@ spec:
         secret:
           defaultMode: 416
           secretName: cloud-credential-operator-service-account-kubeconfig
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_autoscaler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_autoscaler_deployment.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -123,10 +124,14 @@ spec:
           requests:
             cpu: 10m
             memory: 60Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /mnt/kubeconfig
           name: kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -162,4 +167,6 @@ spec:
           - key: value
             path: target-kubeconfig
           secretName: -kubeconfig
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/zz_fixture_TestControlPlaneComponents_cluster_autoscaler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/zz_fixture_TestControlPlaneComponents_cluster_autoscaler_deployment.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -123,10 +124,14 @@ spec:
           requests:
             cpu: 10m
             memory: 60Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /mnt/kubeconfig
           name: kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -162,4 +167,6 @@ spec:
           - key: value
             path: target-kubeconfig
           secretName: -kubeconfig
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-image-registry-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_image_registry_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-image-registry-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_image_registry_operator_deployment.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token,apiserver-token
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token,apiserver-token,tmp-dir
         component.hypershift.openshift.io/config-hash: 87ecf31a
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -122,6 +122,8 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/certificate/ca
@@ -132,6 +134,8 @@ spec:
           name: cloud-token
         - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
           name: apiserver-token
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --token-audience=openshift
         - --service-account-namespace=openshift-image-registry
@@ -148,12 +152,16 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/secrets/openshift/serviceaccount
           name: cloud-token
         - mountPath: /etc/kubernetes
           name: kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --token-audience=
         - --service-account-namespace=openshift-image-registry
@@ -170,12 +178,16 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/secrets/openshift/serviceaccount
           name: apiserver-token
         - mountPath: /etc/kubernetes
           name: kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule
@@ -205,4 +217,6 @@ spec:
       - emptyDir:
           medium: Memory
         name: apiserver-token
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-image-registry-operator/zz_fixture_TestControlPlaneComponents_cluster_image_registry_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-image-registry-operator/zz_fixture_TestControlPlaneComponents_cluster_image_registry_operator_deployment.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token,apiserver-token
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token,apiserver-token,tmp-dir
         component.hypershift.openshift.io/config-hash: 87ecf31a
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -122,6 +122,8 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/certificate/ca
@@ -132,6 +134,8 @@ spec:
           name: cloud-token
         - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
           name: apiserver-token
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --token-audience=openshift
         - --service-account-namespace=openshift-image-registry
@@ -148,12 +152,16 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/secrets/openshift/serviceaccount
           name: cloud-token
         - mountPath: /etc/kubernetes
           name: kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --token-audience=
         - --service-account-namespace=openshift-image-registry
@@ -170,12 +178,16 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/secrets/openshift/serviceaccount
           name: apiserver-token
         - mountPath: /etc/kubernetes
           name: kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule
@@ -205,4 +217,6 @@ spec:
       - emptyDir:
           medium: Memory
         name: apiserver-token
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_network_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_network_operator_deployment.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: configs,client-token
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: configs,client-token,tmp-dir
         component.hypershift.openshift.io/config-hash: 87ecf31a
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
@@ -162,6 +162,8 @@ spec:
           requests:
             cpu: 10m
             memory: 100Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /configs
@@ -170,6 +172,8 @@ spec:
           name: client-token
         - mountPath: /etc/certificate/ca
           name: ca-bundle
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --service-account-namespace
         - openshift-network-operator
@@ -191,12 +195,16 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/client-token
           name: client-token
         - mountPath: /etc/kubernetes
           name: hosted-etc-kube
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         - --disable-resolver=true
@@ -212,6 +220,8 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
@@ -220,6 +230,8 @@ spec:
           name: konnectivity-proxy-cert
         - mountPath: /etc/konnectivity/proxy-ca
           name: konnectivity-proxy-ca
+        - mountPath: /tmp
+          name: tmp-dir
       dnsPolicy: ClusterFirst
       initContainers:
       - command:
@@ -364,4 +376,6 @@ spec:
       - configMap:
           name: konnectivity-ca-bundle
         name: konnectivity-proxy-ca
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/zz_fixture_TestControlPlaneComponents_cluster_network_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/zz_fixture_TestControlPlaneComponents_cluster_network_operator_deployment.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: configs,client-token
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: configs,client-token,tmp-dir
         component.hypershift.openshift.io/config-hash: 87ecf31a
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
@@ -162,6 +162,8 @@ spec:
           requests:
             cpu: 10m
             memory: 100Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /configs
@@ -170,6 +172,8 @@ spec:
           name: client-token
         - mountPath: /etc/certificate/ca
           name: ca-bundle
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --service-account-namespace
         - openshift-network-operator
@@ -191,12 +195,16 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/client-token
           name: client-token
         - mountPath: /etc/kubernetes
           name: hosted-etc-kube
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         - --disable-resolver=true
@@ -212,6 +220,8 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
@@ -220,6 +230,8 @@ spec:
           name: konnectivity-proxy-cert
         - mountPath: /etc/konnectivity/proxy-ca
           name: konnectivity-proxy-ca
+        - mountPath: /tmp
+          name: tmp-dir
       dnsPolicy: ClusterFirst
       initContainers:
       - command:
@@ -364,4 +376,6 @@ spec:
       - configMap:
           name: konnectivity-ca-bundle
         name: konnectivity-proxy-ca
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-node-tuning-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_node_tuning_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-node-tuning-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_node_tuning_operator_deployment.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
@@ -104,6 +105,8 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/secrets
@@ -114,6 +117,8 @@ spec:
           name: trusted-ca
         - mountPath: /etc/kubernetes
           name: hosted-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       restartPolicy: Always
       serviceAccount: cluster-node-tuning-operator
@@ -148,4 +153,6 @@ spec:
         secret:
           defaultMode: 416
           secretName: service-network-admin-kubeconfig
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-node-tuning-operator/zz_fixture_TestControlPlaneComponents_cluster_node_tuning_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-node-tuning-operator/zz_fixture_TestControlPlaneComponents_cluster_node_tuning_operator_deployment.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
@@ -104,6 +105,8 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/secrets
@@ -114,6 +117,8 @@ spec:
           name: trusted-ca
         - mountPath: /etc/kubernetes
           name: hosted-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       restartPolicy: Always
       serviceAccount: cluster-node-tuning-operator
@@ -148,4 +153,6 @@ spec:
         secret:
           defaultMode: 416
           secretName: service-network-admin-kubeconfig
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-policy-controller/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_policy_controller_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-policy-controller/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_policy_controller_deployment.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: bf593c91
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -96,6 +97,8 @@ spec:
           requests:
             cpu: 10m
             memory: 200Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/client-ca
@@ -106,6 +109,8 @@ spec:
           name: kubeconfig
         - mountPath: /etc/kubernetes/certs
           name: serving-cert
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -144,4 +149,6 @@ spec:
           defaultMode: 420
           name: client-ca
         name: client-ca
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-policy-controller/zz_fixture_TestControlPlaneComponents_cluster_policy_controller_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-policy-controller/zz_fixture_TestControlPlaneComponents_cluster_policy_controller_deployment.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 01d4f76f
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -96,6 +97,8 @@ spec:
           requests:
             cpu: 10m
             memory: 200Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/client-ca
@@ -106,6 +109,8 @@ spec:
           name: kubeconfig
         - mountPath: /etc/kubernetes/certs
           name: serving-cert
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -144,4 +149,6 @@ spec:
           defaultMode: 420
           name: client-ca
         name: client-ca
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
@@ -24,6 +24,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         openshift.io/required-scc: restricted-v2
@@ -174,10 +175,13 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/guest-kubeconfig
           name: guest-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -214,4 +218,6 @@ spec:
         secret:
           defaultMode: 416
           secretName: service-network-admin-kubeconfig
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
@@ -24,6 +24,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         openshift.io/required-scc: restricted-v2
@@ -174,10 +175,13 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/guest-kubeconfig
           name: guest-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -214,4 +218,6 @@ spec:
         secret:
           defaultMode: 416
           secretName: service-network-admin-kubeconfig
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -29,7 +29,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: payload,update-payloads
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: payload,update-payloads,tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -103,6 +103,8 @@ spec:
           requests:
             cpu: 20m
             memory: 70Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/openshift/kubeconfig
@@ -113,6 +115,8 @@ spec:
           name: server-crt
         - mountPath: /etc/cvo/updatepayloads
           name: update-payloads
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -356,4 +360,6 @@ spec:
         secret:
           defaultMode: 416
           secretName: cvo-server
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -29,7 +29,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: payload,update-payloads
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: payload,update-payloads,tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -103,6 +103,8 @@ spec:
           requests:
             cpu: 20m
             memory: 70Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/openshift/kubeconfig
@@ -113,6 +115,8 @@ spec:
           name: server-crt
         - mountPath: /etc/cvo/updatepayloads
           name: update-payloads
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -356,4 +360,6 @@ spec:
         secret:
           defaultMode: 416
           secretName: cvo-server
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/community-operators-catalog/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_community_operators_catalog_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/community-operators-catalog/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_community_operators_catalog_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         alpha.image.policy.openshift.io/resolve-names: '*'
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: utilities,catalog-content
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: utilities,catalog-content,tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -102,6 +102,8 @@ spec:
           requests:
             cpu: 10m
             memory: 160Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         startupProbe:
           exec:
             command:
@@ -116,6 +118,8 @@ spec:
         volumeMounts:
         - mountPath: /extracted-catalog
           name: catalog-content
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - args:
         - /bin/copy-content
@@ -164,4 +168,6 @@ spec:
         name: utilities
       - emptyDir: {}
         name: catalog-content
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/community-operators-catalog/zz_fixture_TestControlPlaneComponents_community_operators_catalog_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/community-operators-catalog/zz_fixture_TestControlPlaneComponents_community_operators_catalog_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         alpha.image.policy.openshift.io/resolve-names: '*'
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: utilities,catalog-content
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: utilities,catalog-content,tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -102,6 +102,8 @@ spec:
           requests:
             cpu: 10m
             memory: 160Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         startupProbe:
           exec:
             command:
@@ -116,6 +118,8 @@ spec:
         volumeMounts:
         - mountPath: /extracted-catalog
           name: catalog-content
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - args:
         - /bin/copy-content
@@ -164,4 +168,6 @@ spec:
         name: utilities
       - emptyDir: {}
         name: catalog-content
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_deployment.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -96,11 +97,15 @@ spec:
           requests:
             cpu: 10m
             memory: 80Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/pki/ca-trust/extracted/pem
           name: openshift-config-managed-trusted-ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       serviceAccount: control-plane-pki-operator
       serviceAccountName: control-plane-pki-operator
@@ -122,4 +127,6 @@ spec:
           name: openshift-config-managed-trusted-ca-bundle
           optional: true
         name: openshift-config-managed-trusted-ca-bundle
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_deployment.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -96,11 +97,15 @@ spec:
           requests:
             cpu: 10m
             memory: 80Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/pki/ca-trust/extracted/pem
           name: openshift-config-managed-trusted-ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       serviceAccount: control-plane-pki-operator
       serviceAccountName: control-plane-pki-operator
@@ -122,4 +127,6 @@ spec:
           name: openshift-config-managed-trusted-ca-bundle
           optional: true
         name: openshift-config-managed-trusted-ca-bundle
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_deployment.yaml
@@ -25,6 +25,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
@@ -89,10 +90,13 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/guest-kubeconfig
           name: guest-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -129,4 +133,6 @@ spec:
         secret:
           defaultMode: 416
           secretName: service-network-admin-kubeconfig
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_deployment.yaml
@@ -25,6 +25,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
@@ -89,10 +90,13 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/guest-kubeconfig
           name: guest-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -129,4 +133,6 @@ spec:
         secret:
           defaultMode: 416
           secretName: service-network-admin-kubeconfig
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/dns-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_dns_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/dns-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_dns_operator_deployment.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 741638a5741638a5741638a5741638a5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
@@ -85,10 +86,14 @@ spec:
           requests:
             cpu: 10m
             memory: 29Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes
           name: service-account-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -122,4 +127,6 @@ spec:
         secret:
           defaultMode: 416
           secretName: dns-operator-service-account-kubeconfig
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/dns-operator/zz_fixture_TestControlPlaneComponents_dns_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/dns-operator/zz_fixture_TestControlPlaneComponents_dns_operator_deployment.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 741638a5741638a5741638a5741638a5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
@@ -85,10 +86,14 @@ spec:
           requests:
             cpu: 10m
             memory: 29Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes
           name: service-account-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -122,4 +127,6 @@ spec:
         secret:
           defaultMode: 416
           secretName: dns-operator-service-account-kubeconfig
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cluster-state
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cluster-state,tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -168,6 +168,8 @@ spec:
           requests:
             cpu: 300m
             memory: 600Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         startupProbe:
           failureThreshold: 18
           httpGet:
@@ -191,6 +193,8 @@ spec:
           name: etcd-ca
         - mountPath: /etc/etcd/clusterstate
           name: cluster-state
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - grpc-proxy
         - start
@@ -217,6 +221,8 @@ spec:
           requests:
             cpu: 40m
             memory: 200Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/etcd/tls/peer
@@ -227,6 +233,8 @@ spec:
           name: etcd-ca
         - mountPath: /etc/etcd/tls/etcd-metrics-ca
           name: etcd-metrics-ca
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - readyz
         - --target=https://localhost:2379
@@ -249,6 +257,8 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/etcd/tls/server
@@ -257,6 +267,8 @@ spec:
           name: client-tls
         - mountPath: /etc/etcd/tls/etcd-ca
           name: etcd-ca
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - args:
         - -c
@@ -373,6 +385,8 @@ spec:
         name: etcd-metrics-ca
       - emptyDir: {}
         name: cluster-state
+      - emptyDir: {}
+        name: tmp-dir
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cluster-state
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cluster-state,tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -168,6 +168,8 @@ spec:
           requests:
             cpu: 300m
             memory: 600Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         startupProbe:
           failureThreshold: 18
           httpGet:
@@ -191,6 +193,8 @@ spec:
           name: etcd-ca
         - mountPath: /etc/etcd/clusterstate
           name: cluster-state
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - grpc-proxy
         - start
@@ -217,6 +221,8 @@ spec:
           requests:
             cpu: 40m
             memory: 200Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/etcd/tls/peer
@@ -227,6 +233,8 @@ spec:
           name: etcd-ca
         - mountPath: /etc/etcd/tls/etcd-metrics-ca
           name: etcd-metrics-ca
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - readyz
         - --target=https://localhost:2379
@@ -249,6 +257,8 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/etcd/tls/server
@@ -257,6 +267,8 @@ spec:
           name: client-tls
         - mountPath: /etc/etcd/tls/etcd-ca
           name: etcd-ca
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - args:
         - -c
@@ -373,6 +385,8 @@ spec:
         name: etcd-metrics-ca
       - emptyDir: {}
         name: cluster-state
+      - emptyDir: {}
+        name: tmp-dir
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/featuregate-generator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_featuregate_generator_job.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/featuregate-generator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_featuregate_generator_job.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: manifests,work
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: manifests,work,tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -74,10 +74,14 @@ spec:
           requests:
             cpu: 30m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /manifests
           name: manifests
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - args:
         - |-
@@ -144,4 +148,6 @@ spec:
         name: manifests
       - emptyDir: {}
         name: work
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/featuregate-generator/zz_fixture_TestControlPlaneComponents_featuregate_generator_job.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/featuregate-generator/zz_fixture_TestControlPlaneComponents_featuregate_generator_job.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: manifests,work
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: manifests,work,tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -74,10 +74,14 @@ spec:
           requests:
             cpu: 30m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /manifests
           name: manifests
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - args:
         - |-
@@ -143,4 +147,6 @@ spec:
         name: manifests
       - emptyDir: {}
         name: work
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_hosted_cluster_config_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_hosted_cluster_config_operator_deployment.yaml
@@ -25,6 +25,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -125,6 +126,8 @@ spec:
           requests:
             cpu: 60m
             memory: 80Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/cluster-signer-ca
@@ -136,6 +139,8 @@ spec:
         - mountPath: /etc/pki/ca-trust/extracted/pem
           name: openshift-config-managed-trusted-ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -201,4 +206,6 @@ spec:
           name: openshift-config-managed-trusted-ca-bundle
           optional: true
         name: openshift-config-managed-trusted-ca-bundle
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/zz_fixture_TestControlPlaneComponents_hosted_cluster_config_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/zz_fixture_TestControlPlaneComponents_hosted_cluster_config_operator_deployment.yaml
@@ -25,6 +25,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -125,6 +126,8 @@ spec:
           requests:
             cpu: 60m
             memory: 80Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/cluster-signer-ca
@@ -136,6 +139,8 @@ spec:
         - mountPath: /etc/pki/ca-trust/extracted/pem
           name: openshift-config-managed-trusted-ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -201,4 +206,6 @@ spec:
           name: openshift-config-managed-trusted-ca-bundle
           optional: true
         name: openshift-config-managed-trusted-ca-bundle
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -118,12 +119,15 @@ spec:
           capabilities:
             add:
             - NET_BIND_SERVICE
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/ssl/serving-cert
           name: serving-cert
         - mountPath: /etc/ssl/root-ca
           name: root-ca
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule
@@ -143,4 +147,6 @@ spec:
           defaultMode: 420
           name: root-ca
         name: root-ca
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server-proxy/zz_fixture_TestControlPlaneComponents_ignition_server_proxy_deployment.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -118,12 +119,15 @@ spec:
           capabilities:
             add:
             - NET_BIND_SERVICE
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/ssl/serving-cert
           name: serving-cert
         - mountPath: /etc/ssl/root-ca
           name: root-ca
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule
@@ -143,4 +147,6 @@ spec:
           defaultMode: 420
           name: root-ca
         name: root-ca
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: payloads,bootstrap-manifests,manifests,shared
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: payloads,bootstrap-manifests,manifests,shared,tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -135,6 +135,8 @@ spec:
           requests:
             cpu: 10m
             memory: 40Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/secrets/ignition/serving-cert
@@ -150,6 +152,8 @@ spec:
         - mountPath: /etc/pki/ca-trust/extracted/pem
           name: openshift-config-managed-trusted-ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - args:
         - -c
@@ -224,4 +228,6 @@ spec:
           name: openshift-config-managed-trusted-ca-bundle
           optional: true
         name: openshift-config-managed-trusted-ca-bundle
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/zz_fixture_TestControlPlaneComponents_ignition_server_deployment.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: payloads,bootstrap-manifests,manifests,shared
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: payloads,bootstrap-manifests,manifests,shared,tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -135,6 +135,8 @@ spec:
           requests:
             cpu: 10m
             memory: 40Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/secrets/ignition/serving-cert
@@ -150,6 +152,8 @@ spec:
         - mountPath: /etc/pki/ca-trust/extracted/pem
           name: openshift-config-managed-trusted-ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - args:
         - -c
@@ -223,4 +227,6 @@ spec:
           name: openshift-config-managed-trusted-ca-bundle
           optional: true
         name: openshift-config-managed-trusted-ca-bundle
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token,tmp-dir
         component.hypershift.openshift.io/config-hash: 741638a5741638a5741638a5741638a5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
@@ -98,12 +98,16 @@ spec:
           requests:
             cpu: 10m
             memory: 80Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes
           name: service-account-kubeconfig
         - mountPath: /var/run/secrets/openshift/serviceaccount
           name: cloud-token
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         - --connect-directly-to-cloud-apis=true
@@ -119,6 +123,8 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
@@ -127,6 +133,8 @@ spec:
           name: konnectivity-proxy-cert
         - mountPath: /etc/konnectivity/proxy-ca
           name: konnectivity-proxy-ca
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --token-audience=openshift
         - --service-account-namespace=openshift-ingress-operator
@@ -143,12 +151,16 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/secrets/openshift/serviceaccount
           name: cloud-token
         - mountPath: /etc/kubernetes
           name: admin-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -194,4 +206,6 @@ spec:
       - emptyDir:
           medium: Memory
         name: cloud-token
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
@@ -25,7 +25,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token,tmp-dir
         component.hypershift.openshift.io/config-hash: 741638a5741638a5741638a5741638a5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
@@ -98,12 +98,16 @@ spec:
           requests:
             cpu: 10m
             memory: 80Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes
           name: service-account-kubeconfig
         - mountPath: /var/run/secrets/openshift/serviceaccount
           name: cloud-token
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         - --connect-directly-to-cloud-apis=true
@@ -119,6 +123,8 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
@@ -127,6 +133,8 @@ spec:
           name: konnectivity-proxy-cert
         - mountPath: /etc/konnectivity/proxy-ca
           name: konnectivity-proxy-ca
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --token-audience=openshift
         - --service-account-namespace=openshift-ingress-operator
@@ -143,12 +151,16 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/secrets/openshift/serviceaccount
           name: cloud-token
         - mountPath: /etc/kubernetes
           name: admin-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -194,4 +206,6 @@ spec:
       - emptyDir:
           medium: Memory
         name: cloud-token
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -130,6 +131,8 @@ spec:
           requests:
             cpu: 40m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         startupProbe:
           failureThreshold: 60
           httpGet:
@@ -145,6 +148,8 @@ spec:
           name: agent-certs
         - mountPath: /etc/konnectivity/ca
           name: konnectivity-ca
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule
@@ -164,4 +169,6 @@ spec:
           defaultMode: 420
           name: konnectivity-ca-bundle
         name: konnectivity-ca
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/konnectivity-agent/zz_fixture_TestControlPlaneComponents_konnectivity_agent_deployment.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -130,6 +131,8 @@ spec:
           requests:
             cpu: 40m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         startupProbe:
           failureThreshold: 60
           httpGet:
@@ -145,6 +148,8 @@ spec:
           name: agent-certs
         - mountPath: /etc/konnectivity/ca
           name: konnectivity-ca
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule
@@ -164,4 +169,6 @@ spec:
           defaultMode: 420
           name: konnectivity-ca-bundle
         name: konnectivity-ca
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: bootstrap-manifests,logs
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: bootstrap-manifests,logs,tmp-dir
         component.hypershift.openshift.io/config-hash: 19dc307e1d8949e2360eec7552ebd36a741638a5741638a5741638a5741638a58a2366b58dde8f0fc825c12fe7e69167
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -134,6 +134,8 @@ spec:
           requests:
             cpu: 350m
             memory: 2Gi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/certs/aggregator-ca
@@ -174,6 +176,8 @@ spec:
           name: server-private-crt
         - mountPath: /etc/kubernetes/secrets/svcacct-key
           name: svcacct-key
+        - mountPath: /tmp
+          name: tmp-dir
         workingDir: /var/log/kube-apiserver
       - command:
         - /usr/bin/control-plane-operator
@@ -190,12 +194,16 @@ spec:
           requests:
             cpu: 10m
             memory: 10Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /work
           name: bootstrap-manifests
         - mountPath: /var/secrets/localhost-kubeconfig
           name: localhost-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --logtostderr=true
         - --log-file-max-size=0
@@ -260,6 +268,8 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/konnectivity/cluster
@@ -268,6 +278,8 @@ spec:
           name: konnectivity-ca
         - mountPath: /etc/konnectivity/server
           name: server-certs
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - -c
         - |
@@ -293,10 +305,14 @@ spec:
           requests:
             cpu: 5m
             memory: 10Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/log/kube-apiserver
           name: logs
+        - mountPath: /tmp
+          name: tmp-dir
       - command:
         - /usr/bin/aws-pod-identity-webhook
         - --annotation-prefix=eks.amazonaws.com
@@ -315,12 +331,16 @@ spec:
           requests:
             cpu: 10m
             memory: 25Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/app/certs
           name: aws-pod-identity-webhook-serving-certs
         - mountPath: /var/run/app/kubeconfig
           name: aws-pod-identity-webhook-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - args:
         - -c
@@ -556,4 +576,6 @@ spec:
         secret:
           defaultMode: 416
           secretName: aws-pod-identity-webhook-kubeconfig
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: bootstrap-manifests,logs
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: bootstrap-manifests,logs,tmp-dir
         component.hypershift.openshift.io/config-hash: 19dc307e1d8949e2360eec7552ebd36a741638a5741638a5741638a5741638a58a2366b599376ce0c825c12fe7e69167
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -134,6 +134,8 @@ spec:
           requests:
             cpu: 350m
             memory: 2Gi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/certs/aggregator-ca
@@ -174,6 +176,8 @@ spec:
           name: server-private-crt
         - mountPath: /etc/kubernetes/secrets/svcacct-key
           name: svcacct-key
+        - mountPath: /tmp
+          name: tmp-dir
         workingDir: /var/log/kube-apiserver
       - command:
         - /usr/bin/control-plane-operator
@@ -190,12 +194,16 @@ spec:
           requests:
             cpu: 10m
             memory: 10Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /work
           name: bootstrap-manifests
         - mountPath: /var/secrets/localhost-kubeconfig
           name: localhost-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --logtostderr=true
         - --log-file-max-size=0
@@ -260,6 +268,8 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/konnectivity/cluster
@@ -268,6 +278,8 @@ spec:
           name: konnectivity-ca
         - mountPath: /etc/konnectivity/server
           name: server-certs
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - -c
         - |
@@ -293,10 +305,14 @@ spec:
           requests:
             cpu: 5m
             memory: 10Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/log/kube-apiserver
           name: logs
+        - mountPath: /tmp
+          name: tmp-dir
       - command:
         - /usr/bin/aws-pod-identity-webhook
         - --annotation-prefix=eks.amazonaws.com
@@ -315,12 +331,16 @@ spec:
           requests:
             cpu: 10m
             memory: 25Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/app/certs
           name: aws-pod-identity-webhook-serving-certs
         - mountPath: /var/run/app/kubeconfig
           name: aws-pod-identity-webhook-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - args:
         - -c
@@ -554,4 +574,6 @@ spec:
         secret:
           defaultMode: 416
           secretName: aws-pod-identity-webhook-kubeconfig
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_controller_manager_deployment.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: logs,certs
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: logs,certs,tmp-dir
         component.hypershift.openshift.io/config-hash: 1252551487ecf31a87ecf31acb8019bfd6265674
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -249,6 +249,8 @@ spec:
           requests:
             cpu: 100m
             memory: 600Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/kubernetes
@@ -269,6 +271,8 @@ spec:
           name: server-crt
         - mountPath: /etc/kubernetes/certs/service-signer
           name: service-signer
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -325,4 +329,6 @@ spec:
           defaultMode: 420
           name: recycler-config
         name: recycler-config
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents_kube_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents_kube_controller_manager_deployment.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: logs,certs
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: logs,certs,tmp-dir
         component.hypershift.openshift.io/config-hash: 1252551487ecf31a87ecf31acb8019bfd6265674
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -250,6 +250,8 @@ spec:
           requests:
             cpu: 100m
             memory: 600Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/kubernetes
@@ -270,6 +272,8 @@ spec:
           name: server-crt
         - mountPath: /etc/kubernetes/certs/service-signer
           name: service-signer
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -326,4 +330,6 @@ spec:
           defaultMode: 420
           name: recycler-config
         name: recycler-config
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cert-work
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cert-work,tmp-dir
         component.hypershift.openshift.io/config-hash: 022a8a3acb8019bf
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -204,6 +204,8 @@ spec:
           requests:
             cpu: 25m
             memory: 150Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/kubernetes
@@ -212,6 +214,8 @@ spec:
           name: kubeconfig
         - mountPath: /etc/kubernetes/config
           name: scheduler-config
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -244,4 +248,6 @@ spec:
         secret:
           defaultMode: 416
           secretName: kube-scheduler-kubeconfig
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cert-work
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cert-work,tmp-dir
         component.hypershift.openshift.io/config-hash: 022a8a3acb8019bf
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -205,6 +205,8 @@ spec:
           requests:
             cpu: 25m
             memory: 150Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/kubernetes
@@ -213,6 +215,8 @@ spec:
           name: kubeconfig
         - mountPath: /etc/kubernetes/config
           name: scheduler-config
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -245,4 +249,6 @@ spec:
         secret:
           defaultMode: 416
           secretName: kube-scheduler-kubeconfig
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-csi-controller/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kubevirt_csi_controller_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-csi-controller/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kubevirt_csi_controller_deployment.yaml
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir,tmp-dir
         component.hypershift.openshift.io/config-hash: 741638a5741638a5741638a5741638a5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -98,12 +98,16 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
         - mountPath: /var/run/secrets/tenantcluster
           name: service-account-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --csi-address=$(ADDRESS)
         - --default-fstype=ext4
@@ -121,12 +125,16 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
         - mountPath: /var/run/secrets/tenantcluster
           name: service-account-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --csi-address=$(ADDRESS)
         - --v=5
@@ -143,12 +151,16 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
         - mountPath: /var/run/secrets/tenantcluster
           name: service-account-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --csi-address=/csi/csi.sock
         - --probe-timeout=3s
@@ -160,12 +172,16 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
         - mountPath: /var/run/secrets/tenantcluster
           name: service-account-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --v=5
         - --csi-address=/csi/csi.sock
@@ -178,6 +194,8 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
@@ -185,6 +203,8 @@ spec:
           name: socket-dir
         - mountPath: /var/run/secrets/tenantcluster
           name: service-account-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --v=5
         - --csi-address=/csi/csi.sock
@@ -198,6 +218,8 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
@@ -205,6 +227,8 @@ spec:
           name: socket-dir
         - mountPath: /var/run/secrets/tenantcluster
           name: service-account-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       serviceAccount: kubevirt-csi
       tolerations:
@@ -223,4 +247,6 @@ spec:
         secret:
           defaultMode: 416
           secretName: kubevirt-csi-controller-service-account-kubeconfig
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-csi-controller/zz_fixture_TestControlPlaneComponents_kubevirt_csi_controller_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kubevirt-csi-controller/zz_fixture_TestControlPlaneComponents_kubevirt_csi_controller_deployment.yaml
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir,tmp-dir
         component.hypershift.openshift.io/config-hash: 741638a5741638a5741638a5741638a5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -98,12 +98,16 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
         - mountPath: /var/run/secrets/tenantcluster
           name: service-account-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --csi-address=$(ADDRESS)
         - --default-fstype=ext4
@@ -121,12 +125,16 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
         - mountPath: /var/run/secrets/tenantcluster
           name: service-account-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --csi-address=$(ADDRESS)
         - --v=5
@@ -143,12 +151,16 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/lib/csi/sockets/pluginproxy/
           name: socket-dir
         - mountPath: /var/run/secrets/tenantcluster
           name: service-account-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --csi-address=/csi/csi.sock
         - --probe-timeout=3s
@@ -160,12 +172,16 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /csi
           name: socket-dir
         - mountPath: /var/run/secrets/tenantcluster
           name: service-account-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --v=5
         - --csi-address=/csi/csi.sock
@@ -178,6 +194,8 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
@@ -185,6 +203,8 @@ spec:
           name: socket-dir
         - mountPath: /var/run/secrets/tenantcluster
           name: service-account-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --v=5
         - --csi-address=/csi/csi.sock
@@ -198,6 +218,8 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
@@ -205,6 +227,8 @@ spec:
           name: socket-dir
         - mountPath: /var/run/secrets/tenantcluster
           name: service-account-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       serviceAccount: kubevirt-csi
       tolerations:
@@ -223,4 +247,6 @@ spec:
         secret:
           defaultMode: 416
           secretName: kubevirt-csi-controller-service-account-kubeconfig
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/machine-approver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_machine_approver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/machine-approver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_machine_approver_deployment.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: a53d18cd
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -82,6 +83,8 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
@@ -89,6 +92,8 @@ spec:
           name: kubeconfig
         - mountPath: /var/run/configmaps/config
           name: config
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -124,4 +129,6 @@ spec:
           name: machine-approver-config
           optional: true
         name: config
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/machine-approver/zz_fixture_TestControlPlaneComponents_machine_approver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/machine-approver/zz_fixture_TestControlPlaneComponents_machine_approver_deployment.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: a53d18cd
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -82,6 +83,8 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
@@ -89,6 +92,8 @@ spec:
           name: kubeconfig
         - mountPath: /var/run/configmaps/config
           name: config
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -124,4 +129,6 @@ spec:
           name: machine-approver-config
           optional: true
         name: config
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: logs
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: logs,tmp-dir
         component.hypershift.openshift.io/config-hash: 19dc307e3b105d444ebc1fdd60b54b1d741638a5a0dd232cbcc341c5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -108,6 +108,8 @@ spec:
           requests:
             cpu: 25m
             memory: 40Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/audit-config
@@ -130,6 +132,8 @@ spec:
           name: serving-cert
         - mountPath: /etc/kubernetes/secrets/session
           name: session-secret
+        - mountPath: /tmp
+          name: tmp-dir
         workingDir: /var/run/kubernetes
       - args:
         - -c
@@ -156,10 +160,14 @@ spec:
           requests:
             cpu: 5m
             memory: 10Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/kubernetes
           name: logs
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         - --serving-port=8092
@@ -176,6 +184,8 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
@@ -184,6 +194,8 @@ spec:
           name: konnectivity-proxy-cert
         - mountPath: /etc/konnectivity/proxy-ca
           name: konnectivity-proxy-ca
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         - --resolve-from-guest-cluster-dns=true
@@ -200,6 +212,8 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
@@ -208,6 +222,8 @@ spec:
           name: konnectivity-proxy-cert
         - mountPath: /etc/konnectivity/proxy-ca
           name: konnectivity-proxy-ca
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -275,4 +291,6 @@ spec:
       - configMap:
           name: konnectivity-ca-bundle
         name: konnectivity-proxy-ca
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: logs
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: logs,tmp-dir
         component.hypershift.openshift.io/config-hash: 19dc307e3b105d444ebc1fdd60b54b1d741638a5a0dd232cbcc341c5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -108,6 +108,8 @@ spec:
           requests:
             cpu: 25m
             memory: 40Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/audit-config
@@ -130,6 +132,8 @@ spec:
           name: serving-cert
         - mountPath: /etc/kubernetes/secrets/session
           name: session-secret
+        - mountPath: /tmp
+          name: tmp-dir
         workingDir: /var/run/kubernetes
       - args:
         - -c
@@ -156,10 +160,14 @@ spec:
           requests:
             cpu: 5m
             memory: 10Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/kubernetes
           name: logs
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         - --serving-port=8092
@@ -176,6 +184,8 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
@@ -184,6 +194,8 @@ spec:
           name: konnectivity-proxy-cert
         - mountPath: /etc/konnectivity/proxy-ca
           name: konnectivity-proxy-ca
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         - --resolve-from-guest-cluster-dns=true
@@ -200,6 +212,8 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
@@ -208,6 +222,8 @@ spec:
           name: konnectivity-proxy-cert
         - mountPath: /etc/konnectivity/proxy-ca
           name: konnectivity-proxy-ca
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -275,4 +291,6 @@ spec:
       - configMap:
           name: konnectivity-ca-bundle
         name: konnectivity-proxy-ca
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-collect-profiles/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_olm_collect_profiles_cronjob.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-collect-profiles/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_olm_collect_profiles_cronjob.yaml
@@ -22,6 +22,7 @@ spec:
       template:
         metadata:
           annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
             component.hypershift.openshift.io/config-hash: fe7dc514
             hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
           creationTimestamp: null
@@ -82,12 +83,16 @@ spec:
               requests:
                 cpu: 10m
                 memory: 80Mi
+            securityContext:
+              readOnlyRootFilesystem: true
             terminationMessagePolicy: FallbackToLogsOnError
             volumeMounts:
             - mountPath: /etc/config
               name: config-volume
             - mountPath: /var/run/secrets/serving-cert
               name: secret-volume
+            - mountPath: /tmp
+              name: tmp-dir
           priorityClassName: hypershift-control-plane
           restartPolicy: Never
           serviceAccountName: olm-collect-profiles
@@ -109,5 +114,7 @@ spec:
             secret:
               defaultMode: 416
               secretName: metrics-client
+          - emptyDir: {}
+            name: tmp-dir
   schedule: 41 5 * * *
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-collect-profiles/zz_fixture_TestControlPlaneComponents_olm_collect_profiles_cronjob.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-collect-profiles/zz_fixture_TestControlPlaneComponents_olm_collect_profiles_cronjob.yaml
@@ -22,6 +22,7 @@ spec:
       template:
         metadata:
           annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
             component.hypershift.openshift.io/config-hash: fe7dc514
             hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
           creationTimestamp: null
@@ -82,12 +83,16 @@ spec:
               requests:
                 cpu: 10m
                 memory: 80Mi
+            securityContext:
+              readOnlyRootFilesystem: true
             terminationMessagePolicy: FallbackToLogsOnError
             volumeMounts:
             - mountPath: /etc/config
               name: config-volume
             - mountPath: /var/run/secrets/serving-cert
               name: secret-volume
+            - mountPath: /tmp
+              name: tmp-dir
           priorityClassName: hypershift-control-plane
           restartPolicy: Never
           serviceAccountName: olm-collect-profiles
@@ -109,5 +114,7 @@ spec:
             secret:
               defaultMode: 416
               secretName: metrics-client
+          - emptyDir: {}
+            name: tmp-dir
   schedule: 41 5 * * *
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_olm_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_olm_operator_deployment.yaml
@@ -25,6 +25,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -110,6 +111,8 @@ spec:
           requests:
             cpu: 10m
             memory: 160Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /srv-cert
@@ -121,6 +124,8 @@ spec:
         - mountPath: /etc/openshift/kubeconfig
           name: kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         command:
@@ -135,6 +140,8 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
@@ -143,6 +150,8 @@ spec:
           name: konnectivity-proxy-cert
         - mountPath: /etc/konnectivity/proxy-ca
           name: konnectivity-proxy-ca
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -193,4 +202,6 @@ spec:
       - configMap:
           name: konnectivity-ca-bundle
         name: konnectivity-proxy-ca
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-operator/zz_fixture_TestControlPlaneComponents_olm_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-operator/zz_fixture_TestControlPlaneComponents_olm_operator_deployment.yaml
@@ -25,6 +25,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -110,6 +111,8 @@ spec:
           requests:
             cpu: 10m
             memory: 160Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /srv-cert
@@ -121,6 +124,8 @@ spec:
         - mountPath: /etc/openshift/kubeconfig
           name: kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         command:
@@ -135,6 +140,8 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
@@ -143,6 +150,8 @@ spec:
           name: konnectivity-proxy-cert
         - mountPath: /etc/konnectivity/proxy-ca
           name: konnectivity-proxy-ca
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -193,4 +202,6 @@ spec:
       - configMap:
           name: konnectivity-ca-bundle
         name: konnectivity-proxy-ca
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: work-logs,oas-trust-anchor
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: work-logs,oas-trust-anchor,tmp-dir
         component.hypershift.openshift.io/config-hash: 19dc307e52ebd36a829b997b83c6a3e3
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -125,6 +125,8 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         startupProbe:
           failureThreshold: 30
           httpGet:
@@ -158,6 +160,8 @@ spec:
           name: serving-cert
         - mountPath: /var/log/openshift-apiserver
           name: work-logs
+        - mountPath: /tmp
+          name: tmp-dir
         workingDir: /var/log/openshift-apiserver
       - args:
         - -c
@@ -184,10 +188,14 @@ spec:
           requests:
             cpu: 5m
             memory: 10Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/log/openshift-apiserver
           name: work-logs
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         command:
@@ -202,6 +210,8 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
@@ -210,6 +220,8 @@ spec:
           name: konnectivity-proxy-cert
         - mountPath: /etc/konnectivity/proxy-ca
           name: konnectivity-proxy-ca
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -310,4 +322,6 @@ spec:
       - configMap:
           name: konnectivity-ca-bundle
         name: konnectivity-proxy-ca
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: work-logs,oas-trust-anchor
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: work-logs,oas-trust-anchor,tmp-dir
         component.hypershift.openshift.io/config-hash: 19dc307e41f50a7352ebd36a829b997b
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -125,6 +125,8 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         startupProbe:
           failureThreshold: 30
           httpGet:
@@ -158,6 +160,8 @@ spec:
           name: serving-cert
         - mountPath: /var/log/openshift-apiserver
           name: work-logs
+        - mountPath: /tmp
+          name: tmp-dir
         workingDir: /var/log/openshift-apiserver
       - args:
         - -c
@@ -184,10 +188,14 @@ spec:
           requests:
             cpu: 5m
             memory: 10Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/log/openshift-apiserver
           name: work-logs
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         command:
@@ -202,6 +210,8 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
@@ -210,6 +220,8 @@ spec:
           name: konnectivity-proxy-cert
         - mountPath: /etc/konnectivity/proxy-ca
           name: konnectivity-proxy-ca
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -310,4 +322,6 @@ spec:
       - configMap:
           name: konnectivity-ca-bundle
         name: konnectivity-proxy-ca
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openshift_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openshift_controller_manager_deployment.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: df52ebc7
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -124,6 +125,8 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
@@ -135,6 +138,8 @@ spec:
           name: kubeconfig
         - mountPath: /etc/kubernetes/certs
           name: serving-cert
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule
@@ -162,4 +167,6 @@ spec:
           defaultMode: 420
           name: client-ca
         name: client-ca
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-controller-manager/zz_fixture_TestControlPlaneComponents_openshift_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-controller-manager/zz_fixture_TestControlPlaneComponents_openshift_controller_manager_deployment.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 3c0a48c9
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -124,6 +125,8 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
@@ -135,6 +138,8 @@ spec:
           name: kubeconfig
         - mountPath: /etc/kubernetes/certs
           name: serving-cert
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       tolerations:
       - effect: NoSchedule
@@ -162,4 +167,6 @@ spec:
           defaultMode: 420
           name: client-ca
         name: client-ca
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: work-logs
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: work-logs,tmp-dir
         component.hypershift.openshift.io/config-hash: 19dc307e52ebd36a
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -142,6 +142,8 @@ spec:
           requests:
             cpu: 150m
             memory: 80Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/certs/aggregator-client-ca
@@ -160,6 +162,8 @@ spec:
           name: serving-cert
         - mountPath: /var/log/openshift-oauth-apiserver
           name: work-logs
+        - mountPath: /tmp
+          name: tmp-dir
         workingDir: /var/log/openshift-oauth-apiserver
       - args:
         - -c
@@ -186,10 +190,14 @@ spec:
           requests:
             cpu: 5m
             memory: 10Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/log/openshift-oauth-apiserver
           name: work-logs
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         - --resolve-from-guest-cluster-dns=true
@@ -205,6 +213,8 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
@@ -213,6 +223,8 @@ spec:
           name: konnectivity-proxy-cert
         - mountPath: /etc/konnectivity/proxy-ca
           name: konnectivity-proxy-ca
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -273,4 +285,6 @@ spec:
       - configMap:
           name: konnectivity-ca-bundle
         name: konnectivity-proxy-ca
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: work-logs
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: work-logs,tmp-dir
         component.hypershift.openshift.io/config-hash: 19dc307e52ebd36a
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -142,6 +142,8 @@ spec:
           requests:
             cpu: 150m
             memory: 80Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/certs/aggregator-client-ca
@@ -160,6 +162,8 @@ spec:
           name: serving-cert
         - mountPath: /var/log/openshift-oauth-apiserver
           name: work-logs
+        - mountPath: /tmp
+          name: tmp-dir
         workingDir: /var/log/openshift-oauth-apiserver
       - args:
         - -c
@@ -186,10 +190,14 @@ spec:
           requests:
             cpu: 5m
             memory: 10Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/log/openshift-oauth-apiserver
           name: work-logs
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         - --resolve-from-guest-cluster-dns=true
@@ -205,6 +213,8 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
@@ -213,6 +223,8 @@ spec:
           name: konnectivity-proxy-cert
         - mountPath: /etc/konnectivity/proxy-ca
           name: konnectivity-proxy-ca
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -273,4 +285,6 @@ spec:
       - configMap:
           name: konnectivity-ca-bundle
         name: konnectivity-proxy-ca
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-route-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openshift_route_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-route-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openshift_route_controller_manager_deployment.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 57c9c948
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -124,6 +125,8 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/client-ca
@@ -134,6 +137,8 @@ spec:
           name: kubeconfig
         - mountPath: /etc/kubernetes/certs
           name: serving-cert
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -165,4 +170,6 @@ spec:
           defaultMode: 420
           name: client-ca
         name: client-ca
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-route-controller-manager/zz_fixture_TestControlPlaneComponents_openshift_route_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-route-controller-manager/zz_fixture_TestControlPlaneComponents_openshift_route_controller_manager_deployment.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 57c9c948
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -124,6 +125,8 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/client-ca
@@ -134,6 +137,8 @@ spec:
           name: kubeconfig
         - mountPath: /etc/kubernetes/certs
           name: serving-cert
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -165,4 +170,6 @@ spec:
           defaultMode: 420
           name: client-ca
         name: client-ca
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmpfs
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmpfs,tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -129,6 +129,8 @@ spec:
           requests:
             cpu: 10m
             memory: 250Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
@@ -155,6 +157,8 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
@@ -163,6 +167,8 @@ spec:
           name: konnectivity-proxy-cert
         - mountPath: /etc/konnectivity/proxy-ca
           name: konnectivity-proxy-ca
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -218,4 +224,6 @@ spec:
       - configMap:
           name: konnectivity-ca-bundle
         name: konnectivity-proxy-ca
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmpfs
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmpfs,tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -129,6 +129,8 @@ spec:
           requests:
             cpu: 10m
             memory: 250Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
@@ -155,6 +157,8 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
@@ -163,6 +167,8 @@ spec:
           name: konnectivity-proxy-cert
         - mountPath: /etc/konnectivity/proxy-ca
           name: konnectivity-proxy-ca
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -218,4 +224,6 @@ spec:
       - configMap:
           name: konnectivity-ca-bundle
         name: konnectivity-proxy-ca
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/redhat-marketplace-catalog/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_redhat_marketplace_catalog_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/redhat-marketplace-catalog/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_redhat_marketplace_catalog_deployment.yaml
@@ -27,7 +27,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: utilities,catalog-content
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: utilities,catalog-content,tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -101,6 +101,8 @@ spec:
           requests:
             cpu: 10m
             memory: 340Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         startupProbe:
           exec:
             command:
@@ -115,6 +117,8 @@ spec:
         volumeMounts:
         - mountPath: /extracted-catalog
           name: catalog-content
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - args:
         - /bin/copy-content
@@ -163,4 +167,6 @@ spec:
         name: utilities
       - emptyDir: {}
         name: catalog-content
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/redhat-marketplace-catalog/zz_fixture_TestControlPlaneComponents_redhat_marketplace_catalog_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/redhat-marketplace-catalog/zz_fixture_TestControlPlaneComponents_redhat_marketplace_catalog_deployment.yaml
@@ -27,7 +27,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: utilities,catalog-content
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: utilities,catalog-content,tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -101,6 +101,8 @@ spec:
           requests:
             cpu: 10m
             memory: 340Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         startupProbe:
           exec:
             command:
@@ -115,6 +117,8 @@ spec:
         volumeMounts:
         - mountPath: /extracted-catalog
           name: catalog-content
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - args:
         - /bin/copy-content
@@ -163,4 +167,6 @@ spec:
         name: utilities
       - emptyDir: {}
         name: catalog-content
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/redhat-operators-catalog/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_redhat_operators_catalog_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/redhat-operators-catalog/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_redhat_operators_catalog_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         alpha.image.policy.openshift.io/resolve-names: '*'
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: utilities,catalog-content
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: utilities,catalog-content,tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -102,6 +102,8 @@ spec:
           requests:
             cpu: 10m
             memory: 420Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         startupProbe:
           exec:
             command:
@@ -116,6 +118,8 @@ spec:
         volumeMounts:
         - mountPath: /extracted-catalog
           name: catalog-content
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - args:
         - /bin/copy-content
@@ -164,4 +168,6 @@ spec:
         name: utilities
       - emptyDir: {}
         name: catalog-content
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/redhat-operators-catalog/zz_fixture_TestControlPlaneComponents_redhat_operators_catalog_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/redhat-operators-catalog/zz_fixture_TestControlPlaneComponents_redhat_operators_catalog_deployment.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         alpha.image.policy.openshift.io/resolve-names: '*'
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: utilities,catalog-content
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: utilities,catalog-content,tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -102,6 +102,8 @@ spec:
           requests:
             cpu: 10m
             memory: 420Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         startupProbe:
           exec:
             command:
@@ -116,6 +118,8 @@ spec:
         volumeMounts:
         - mountPath: /extracted-catalog
           name: catalog-content
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - args:
         - /bin/copy-content
@@ -164,4 +168,6 @@ spec:
         name: utilities
       - emptyDir: {}
         name: catalog-content
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/router/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_router_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/router/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_router_deployment.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 417672c4
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -110,11 +111,14 @@ spec:
           capabilities:
             add:
             - NET_BIND_SERVICE
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /usr/local/etc/haproxy/haproxy.cfg
           name: config
           subPath: haproxy.cfg
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-api-critical
       tolerations:
       - effect: NoSchedule
@@ -130,4 +134,6 @@ spec:
           defaultMode: 420
           name: router
         name: config
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/router/zz_fixture_TestControlPlaneComponents_router_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/router/zz_fixture_TestControlPlaneComponents_router_deployment.yaml
@@ -28,6 +28,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 417672c4
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -110,11 +111,14 @@ spec:
           capabilities:
             add:
             - NET_BIND_SERVICE
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /usr/local/etc/haproxy/haproxy.cfg
           name: config
           subPath: haproxy.cfg
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-api-critical
       tolerations:
       - effect: NoSchedule
@@ -130,4 +134,6 @@ spec:
           defaultMode: 420
           name: router
         name: config
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/hypershift-operator/controllers/hostedcluster/testdata/capi-provider/zz_fixture_TestReconcileComponents.yaml
+++ b/hypershift-operator/controllers/hostedcluster/testdata/capi-provider/zz_fixture_TestReconcileComponents.yaml
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: token
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: token,tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -96,6 +96,8 @@ spec:
           requests:
             cpu: 10m
             memory: 100Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /home/.aws
@@ -105,6 +107,8 @@ spec:
           readOnly: true
         - mountPath: /var/run/secrets/openshift/serviceaccount
           name: token
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --service-account-namespace=kube-system
         - --service-account-name=capa-controller-manager
@@ -121,12 +125,16 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/secrets/openshift/serviceaccount
           name: token
         - mountPath: /etc/kubernetes
           name: svc-kubeconfig
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -166,4 +174,6 @@ spec:
       - emptyDir:
           medium: Memory
         name: token
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/hypershift-operator/controllers/hostedcluster/testdata/cluster-api/zz_fixture_TestReconcileComponents.yaml
+++ b/hypershift-operator/controllers/hostedcluster/testdata/cluster-api/zz_fixture_TestReconcileComponents.yaml
@@ -24,6 +24,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 741638a5741638a5
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -101,12 +102,16 @@ spec:
           requests:
             cpu: 10m
             memory: 40Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: capi-webhooks-tls
           readOnly: true
+        - mountPath: /tmp
+          name: tmp-dir
       priorityClassName: hypershift-control-plane
       serviceAccount: cluster-api
       serviceAccountName: cluster-api
@@ -124,4 +129,6 @@ spec:
         secret:
           defaultMode: 416
           secretName: capi-webhooks-tls
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/hypershift-operator/controllers/hostedcluster/testdata/control-plane-operator/zz_fixture_TestReconcileComponents.yaml
+++ b/hypershift-operator/controllers/hostedcluster/testdata/control-plane-operator/zz_fixture_TestReconcileComponents.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token,tmp-dir
         component.hypershift.openshift.io/config-hash: ""
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -139,6 +139,8 @@ spec:
           requests:
             cpu: 10m
             memory: 80Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/pki/ca-trust/extracted/pem
@@ -148,6 +150,8 @@ spec:
           name: provider-creds
         - mountPath: /var/run/secrets/openshift/serviceaccount
           name: cloud-token
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --token-audience=openshift
         - --service-account-namespace=kube-system
@@ -165,10 +169,14 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/secrets/openshift/serviceaccount
           name: cloud-token
+        - mountPath: /tmp
+          name: tmp-dir
       imagePullSecrets:
       - name: pull-secret
       priorityClassName: hypershift-control-plane
@@ -199,4 +207,6 @@ spec:
       - emptyDir:
           medium: Memory
         name: cloud-token
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/hypershift-operator/controllers/hostedcluster/testdata/karpenter-operator/zz_fixture_TestReconcileComponents.yaml
+++ b/hypershift-operator/controllers/hostedcluster/testdata/karpenter-operator/zz_fixture_TestReconcileComponents.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token,tmp-dir
         component.hypershift.openshift.io/config-hash: 295d966a
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
@@ -86,6 +86,8 @@ spec:
           requests:
             cpu: 10m
             memory: 60Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /mnt/kubeconfig
@@ -94,6 +96,8 @@ spec:
           name: provider-creds
         - mountPath: /var/run/secrets/openshift/serviceaccount
           name: cloud-token
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - --token-audience=openshift
         - --service-account-namespace=kube-system
@@ -111,10 +115,14 @@ spec:
           requests:
             cpu: 10m
             memory: 30Mi
+        securityContext:
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/secrets/openshift/serviceaccount
           name: cloud-token
+        - mountPath: /tmp
+          name: tmp-dir
       initContainers:
       - command:
         - /usr/bin/control-plane-operator
@@ -153,4 +161,6 @@ spec:
       - emptyDir:
           medium: Memory
         name: cloud-token
+      - emptyDir: {}
+        name: tmp-dir
 status: {}

--- a/support/util/containers.go
+++ b/support/util/containers.go
@@ -70,6 +70,11 @@ const (
 	// AvailabilityProberImageName is the name under which components can find the availability prober
 	// image in the release image.
 	AvailabilityProberImageName = "availability-prober"
+
+	// PodTmpDirMountName is a name for a volume created in each pod by the CPO that gives the pods containers a place to mount and write temporary files to.
+	PodTmpDirMountName = "tmp-dir"
+	// PodTmpDirMountPath is the path that each container created by the CPO will mount the volume PodTmpDirMountName at.
+	PodTmpDirMountPath = "/tmp"
 )
 
 func AvailabilityProber(target string, image string, spec *corev1.PodSpec, o ...AvailabilityProberOpt) {

--- a/test/e2e/util/hypershift_framework.go
+++ b/test/e2e/util/hypershift_framework.go
@@ -149,6 +149,7 @@ func (h *hypershiftTest) after(hostedCluster *hyperv1.HostedCluster, platform hy
 
 		EnsurePayloadArchSetCorrectly(t, context.Background(), h.client, hostedCluster)
 		EnsurePodsWithEmptyDirPVsHaveSafeToEvictAnnotations(t, context.Background(), h.client, hcpNs)
+		EnsureReadOnlyRootFilesystem(t, context.Background(), h.client, hcpNs)
 		EnsureAllContainersHavePullPolicyIfNotPresent(t, context.Background(), h.client, hostedCluster)
 		EnsureAllContainersHaveTerminationMessagePolicyFallbackToLogsOnError(t, context.Background(), h.client, hostedCluster)
 		EnsureHCPContainersHaveResourceRequests(t, context.Background(), h.client, hostedCluster)


### PR DESCRIPTION
What this PR does / why we need it:
Enables readonlyRootFilesystem by default on all hypershift containers to close a potential security loophole where a bad actor could edit the contents of a container for malicious purposes.

Which issue(s) this PR fixes (optional, use fixes #<issue_number>(, fixes #<issue_number>, ...) format, where issue_number might be a GitHub issue, or a Jira story:
Fixes: https://issues.redhat.com/browse/CNTRLPLANE-385

Checklist

- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Control-plane containers now run with read-only root filesystems and a shared ephemeral tmp-dir mounted at /tmp; tmp-dir is marked safe-to-evict for the cluster autoscaler.

* **Tests**
  * Added e2e checks to validate read-only root filesystems, verify tmp-dir mounts, and strengthened version-gated validation of safe-to-evict annotations.

* **Chores**
  * Updated manifests and test fixtures across control-plane components to adopt tmp-dir and the new security defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->