### PR TITLE
NO-JIRA: test(e2e): add new test for external OIDC

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -99,6 +99,15 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.HOInstallationOptions.PlatformMonitoring, "e2e.platform-monitoring", "All", "The option for enabling platform cluster monitoring when installing the HyperShift Operator. Valid values are: None, OperatorOnly, All. This is a HyperShift Operator installation option")
 	flag.BoolVar(&globalOpts.RunUpgradeTest, "upgrade.run-tests", false, "Run HyperShift Operator upgrade test")
 
+	// external OIDC configuration
+	flag.StringVar(&globalOpts.ExternalOIDCProvider, "e2e.external-oidc-provider", "", "if not null, enable external OIDC config with provider. supported value: keycloak, azure")
+	flag.StringVar(&globalOpts.ExternalOIDCCliClientID, "e2e.external-oidc-cli-client-id", "", "cli client ID for external OIDC. This id is needed if you set external oidc in spec.configuration")
+	flag.StringVar(&globalOpts.ExternalOIDCConsoleClientID, "e2e.external-oidc-console-client-id", "", "console client ID for external OIDC. This id is needed if you set external oidc in spec.configuration")
+	flag.StringVar(&globalOpts.ExternalOIDCIssuerURL, "e2e.external-oidc-issuer-url", "", "external OIDC issuer URL. This id is needed if you set external oidc in spec.configuration")
+	flag.StringVar(&globalOpts.ExternalOIDCConsoleSecret, "e2e.external-oidc-console-secret", "", "external OIDC console secret. This is needed if you set external oidc in spec.configuration for the console")
+	flag.StringVar(&globalOpts.ExternalOIDCCABundleFile, "e2e.external-oidc-ca-bundle-file", "", "external OIDC issuer issuerCertificateAuthority")
+	flag.StringVar(&globalOpts.ExternalOIDCTestUsers, "e2e.external-oidc-test-users", "", "external OIDC test users to login the cluster by the external oidc")
+
 	// AWS specific flags
 	flag.BoolVar(&globalOpts.ConfigurableClusterOptions.AWSMultiArch, "e2e.aws-multi-arch", false, "Enable multi arch for aws clusters")
 	flag.StringVar(&globalOpts.ConfigurableClusterOptions.AWSCredentialsFile, "e2e.aws-credentials-file", "", "path to AWS credentials")

--- a/test/e2e/external_oidc_test.go
+++ b/test/e2e/external_oidc_test.go
@@ -1,0 +1,47 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+)
+
+func TestExternalOIDC(t *testing.T) {
+	e2eutil.AtLeast(t, e2eutil.Version419)
+	if os.Getenv("TECH_PREVIEW_NO_UPGRADE") != "true" {
+		t.Skipf("Only tested when CI sets TECH_PREVIEW_NO_UPGRADE=true and the Hypershift Operator is installed with --tech-preview-no-upgrade")
+	}
+
+	if globalOpts.ExternalOIDCProvider == "" {
+		t.Skipf("skip external OIDC test if e2e.external-oidc-provider is not provided")
+	}
+
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(testContext)
+	defer cancel()
+
+	clusterOpts := globalOpts.DefaultClusterOptions(t)
+
+	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+		t.Run("[OCPFeatureGate:ExternalOIDC] test keycloak external OIDC", func(t *testing.T) {
+			g := NewWithT(t)
+			t.Logf("begin to test external OIDC %s", globalOpts.ExternalOIDCProvider)
+			g.Expect(hostedCluster.Spec.Configuration).NotTo(BeNil())
+			g.Expect(hostedCluster.Spec.Configuration.Authentication).NotTo(BeNil())
+			g.Expect(hostedCluster.Spec.Configuration.Authentication.OIDCProviders).NotTo(BeEmpty())
+			clientCfg := e2eutil.WaitForGuestRestConfig(t, ctx, mgtClient, hostedCluster)
+			e2eutil.ChangeClientForKeycloakExtOIDC(t, ctx, clientCfg, clusterOpts.ExtOIDCConfig)
+			t.Logf("successfully get oidc user client")
+		})
+	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, "external-oidc", globalOpts.ServiceAccountSigningKey)
+}

--- a/test/e2e/util/external_oidc.go
+++ b/test/e2e/util/external_oidc.go
@@ -1,0 +1,334 @@
+package util
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/gob"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configv1typedclient "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+
+	kauthnv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kauthnv1typedclient "k8s.io/client-go/kubernetes/typed/authentication/v1"
+	"k8s.io/client-go/rest"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ProviderType string
+
+const (
+	ProviderAzure    ProviderType = "azure"
+	ProviderKeycloak ProviderType = "keycloak"
+)
+
+type ExtOIDCConfig struct {
+	ExternalOIDCProvider     ProviderType
+	OIDCProviderName         string
+	CliClientID              string
+	ConsoleClientID          string
+	IssuerURL                string
+	GroupPrefix              string
+	UserPrefix               string
+	ConsoleClientSecretName  string
+	ConsoleClientSecretValue string
+
+	// format: “user1:psw1,user2:psw2”, it is used for keycloak oidc
+	TestUsers string
+
+	// for oidcProviders.issuer.issuerCertificateAuthority
+	IssuerCAConfigmapName string
+	IssuerCABundleFile    string
+}
+
+func GetExtOIDCConfig(provider, cliClientID, consoleClientID, issuerURL, consoleSecret, issuerCABundleFile, testUsers string) *ExtOIDCConfig {
+	return &ExtOIDCConfig{
+		ExternalOIDCProvider:     ProviderType(provider),
+		OIDCProviderName:         provider + " oidc server",
+		CliClientID:              cliClientID,
+		ConsoleClientID:          consoleClientID,
+		IssuerURL:                issuerURL,
+		GroupPrefix:              "oidc-groups-test:",
+		UserPrefix:               "oidc-user-test:",
+		ConsoleClientSecretName:  "console-secret",
+		ConsoleClientSecretValue: consoleSecret,
+		IssuerCAConfigmapName:    "oidc-ca",
+		IssuerCABundleFile:       issuerCABundleFile,
+		TestUsers:                testUsers,
+	}
+}
+
+func (config *ExtOIDCConfig) GetAuthenticationConfig() *configv1.AuthenticationSpec {
+	return &configv1.AuthenticationSpec{
+		Type: configv1.AuthenticationTypeOIDC,
+		OIDCProviders: []configv1.OIDCProvider{
+			{
+				Name: config.OIDCProviderName,
+				Issuer: configv1.TokenIssuer{
+					Audiences: []configv1.TokenAudience{
+						configv1.TokenAudience(config.CliClientID),
+						configv1.TokenAudience(config.ConsoleClientID),
+					},
+					URL: config.IssuerURL,
+					CertificateAuthority: configv1.ConfigMapNameReference{
+						Name: config.IssuerCAConfigmapName,
+					},
+				},
+				OIDCClients: []configv1.OIDCClientConfig{
+					{
+						ClientID: config.ConsoleClientID,
+						ClientSecret: configv1.SecretNameReference{
+							Name: config.ConsoleClientSecretName,
+						},
+						ComponentName:      "console",
+						ComponentNamespace: "openshift-console",
+						ExtraScopes:        []string{"email"},
+					},
+				},
+				ClaimMappings: configv1.TokenClaimMappings{
+					Groups: configv1.PrefixedClaimMapping{
+						TokenClaimMapping: configv1.TokenClaimMapping{
+							Claim: "groups",
+						},
+						Prefix: config.GroupPrefix,
+					},
+					Username: configv1.UsernameClaimMapping{
+						TokenClaimMapping: configv1.TokenClaimMapping{
+							Claim: "email",
+						},
+						PrefixPolicy: configv1.Prefix,
+						Prefix: &configv1.UsernamePrefix{
+							PrefixString: config.UserPrefix,
+						},
+					},
+					UID: &configv1.TokenClaimOrExpressionMapping{
+						Expression: `"testuid-" + claims.sub + "-uidtest"`,
+					},
+					Extra: []configv1.ExtraMapping{
+						{
+							Key:             "extratest.openshift.com/bar",
+							ValueExpression: `"extra-test-mark"`,
+						},
+						{
+							Key:             "extratest.openshift.com/foo",
+							ValueExpression: "claims.email",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// ValidateAuthenticationSpec validates the external OIDC configuration and the expected HostedCluster authentication configuration before running the test
+func ValidateAuthenticationSpec(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, config *ExtOIDCConfig) {
+	g := NewWithT(t)
+
+	// check auth config
+	g.Expect(config).NotTo(BeNil())
+	g.Expect(config.IssuerURL).NotTo(BeEmpty())
+	g.Expect(config.CliClientID).NotTo(BeEmpty())
+	g.Expect(config.ConsoleClientID).NotTo(BeEmpty())
+	g.Expect(config.TestUsers).NotTo(BeEmpty())
+	g.Expect(config.ConsoleClientSecretName).NotTo(BeEmpty())
+	g.Expect(config.IssuerCABundleFile).NotTo(BeEmpty())
+	_, err := os.Stat(config.IssuerCABundleFile)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// check hosted cluster auth configuration
+	g.Expect(hostedCluster.Spec.Configuration).NotTo(BeNil())
+	g.Expect(hostedCluster.Spec.Configuration.Authentication).NotTo(BeNil())
+	actualAuth := hostedCluster.Spec.Configuration.Authentication
+	g.Expect(actualAuth.OIDCProviders).NotTo(BeEmpty())
+	g.Expect(actualAuth.OIDCProviders[0].ClaimMappings.Extra).NotTo(BeEmpty())
+	g.Expect(actualAuth.OIDCProviders[0].ClaimMappings.UID).NotTo(BeNil())
+
+	secret := &corev1.Secret{}
+	err = client.Get(ctx, crclient.ObjectKey{
+		Name:      config.ConsoleClientSecretName,
+		Namespace: hostedCluster.Namespace,
+	}, secret)
+	g.Expect(err).NotTo(HaveOccurred())
+	for _, client := range actualAuth.OIDCProviders[0].OIDCClients {
+		if client.ClientID == config.ConsoleClientID {
+			g.Expect(client.ClientSecret.Name).Should(Equal(secret.Name))
+		}
+	}
+
+	cm := &corev1.ConfigMap{}
+	err = client.Get(ctx, crclient.ObjectKey{
+		Name:      config.IssuerCAConfigmapName,
+		Namespace: hostedCluster.Namespace,
+	}, cm)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(actualAuth.OIDCProviders[0].Issuer.CertificateAuthority.Name).Should(Equal(cm.Name))
+}
+
+// IsExternalOIDCCluster checks if the cluster is using external OIDC.
+func IsExternalOIDCCluster(t *testing.T, ctx context.Context, clientCfg *rest.Config) (bool, error) {
+	configv1Client, err := configv1typedclient.NewForConfig(clientCfg)
+	if err != nil {
+		return false, err
+	}
+	authConfig, err := configv1Client.Authentications().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	t.Logf("Found authentication type used: %v", authConfig.Spec.Type)
+	return authConfig.Spec.Type == configv1.AuthenticationTypeOIDC, nil
+}
+
+// ChangeClientForKeycloakExtOIDC changes the guest client using a keycloak user config
+func ChangeClientForKeycloakExtOIDC(t *testing.T, ctx context.Context, clientCfg *rest.Config, authConfig *ExtOIDCConfig) crclient.Client {
+	g := NewWithT(t)
+	newConfig := ChangeUserForKeycloakExtOIDC(t, ctx, clientCfg, authConfig)
+	client, err := crclient.New(newConfig, crclient.Options{Scheme: scheme})
+	g.Expect(err).NotTo(HaveOccurred(), "could not create guest client using the new config")
+	return client
+}
+
+// ChangeUserForKeycloakExtOIDC changes the user of current CLI session for a Keycloak external OIDC cluster
+func ChangeUserForKeycloakExtOIDC(t *testing.T, ctx context.Context, clientCfg *rest.Config, authConfig *ExtOIDCConfig) *rest.Config {
+	g := NewWithT(t)
+	g.Expect(authConfig).NotTo(BeNil())
+	g.Expect(authConfig.ExternalOIDCProvider).Should(Equal(ProviderKeycloak))
+	isExternalOIDCCluster, err := IsExternalOIDCCluster(t, ctx, clientCfg)
+	g.Expect(err).NotTo(HaveOccurred(), "Failed to check if the cluster's authentication config is OIDC")
+	g.Expect(isExternalOIDCCluster).To(BeTrue(), "The cluster's authentication config is not OIDC")
+
+	// KEYCLOAK_TEST_USERS has format like "user1:password1,user2:password2,...,usern:passwordn" and n (i.e. 50) is enough for parallel running cases
+	re := regexp.MustCompile(`([^:,]+):([^,]+)`)
+	testUsers := re.FindAllStringSubmatch(authConfig.TestUsers, -1)
+	usersTotal := len(testUsers)
+	var username, password string
+
+	// Pick a random user for current running case to use
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	userIndex := r.Intn(usersTotal)
+	username = testUsers[userIndex][1]
+	g.Expect(username).NotTo(BeEmpty())
+	password = testUsers[userIndex][2]
+	g.Expect(password).NotTo(BeEmpty())
+	t.Logf("Random test user for use: '%s'.", username)
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+	requestURL := authConfig.IssuerURL + "/protocol/openid-connect/token"
+	oidcClientID := authConfig.CliClientID
+	g.Expect(oidcClientID).NotTo(BeEmpty())
+	formData := url.Values{
+		"client_id":  []string{oidcClientID},
+		"grant_type": []string{"password"},
+		"password":   []string{password},
+		"scope":      []string{"openid email profile"},
+		"username":   []string{username},
+	}
+
+	response, err := httpClient.PostForm(requestURL, formData)
+	g.Expect(err).NotTo(HaveOccurred())
+	defer response.Body.Close()
+	g.Expect(response.StatusCode).To(Equal(http.StatusOK))
+
+	body, err := io.ReadAll(response.Body)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var respMap map[string]interface{}
+	err = json.Unmarshal(body, &respMap)
+	g.Expect(err).NotTo(HaveOccurred())
+	idToken, ok := respMap["id_token"].(string)
+	g.Expect(ok).To(BeTrue(), "id_token not found or not a string")
+	refreshToken, ok := respMap["refresh_token"].(string)
+	g.Expect(ok).To(BeTrue(), "refresh_token not found or not a string")
+
+	tokenCache := fmt.Sprintf(`{"id_token":"%s","refresh_token":"%s"}`, idToken, refreshToken)
+	// The CI job that uses Keycloak external OIDC already sets Keycloak token lifetime proper to run case.
+	// "type Key" is copied from https://github.com/openshift/oc/blob/master/pkg/cli/gettoken/tokencache/tokencache.go
+	// We must keep the def of "type Key" as exactly same as original oc repo so that EncodeToString generates correct output
+	type Key struct {
+		IssuerURL string
+		ClientID  string
+	}
+
+	key := Key{IssuerURL: authConfig.IssuerURL, ClientID: oidcClientID}
+	s := sha256.New()
+	e := gob.NewEncoder(s)
+	err = e.Encode(&key)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	tokenCacheFile := hex.EncodeToString(s.Sum(nil))
+	rootDir := os.Getenv("SHARED_DIR")
+	tokenCacheDir, err := os.MkdirTemp(rootDir, username)
+	t.Cleanup(func() {
+		_ = os.RemoveAll(tokenCacheDir)
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	err = os.Mkdir(tokenCacheDir+"/oc", 0700)
+	g.Expect(err).NotTo(HaveOccurred())
+	err = os.WriteFile(filepath.Join(tokenCacheDir, "oc", tokenCacheFile), []byte(tokenCache), 0600)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	clientConfigForExtOIDCUser := GetClientConfigForKeycloakOIDCUser(clientCfg, authConfig, tokenCacheDir)
+	authClient, err := kauthnv1typedclient.NewForConfig(clientConfigForExtOIDCUser)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	selfSubjectReview, err := authClient.SelfSubjectReviews().Create(ctx, &kauthnv1.SelfSubjectReview{}, metav1.CreateOptions{})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	t.Logf("Detected external OIDC cluster using Keycloak as the provider. The user is now %q", selfSubjectReview.Status.UserInfo.Username)
+	return clientConfigForExtOIDCUser
+}
+
+// GetClientConfigForKeycloakOIDCUser gets a client config for an external OIDC cluster
+func GetClientConfigForKeycloakOIDCUser(clientCfg *rest.Config, authConfig *ExtOIDCConfig, tokenCacheDir string) *rest.Config {
+	userClientConfig := rest.AnonymousClientConfig(rest.CopyConfig(clientCfg))
+	args := []string{
+		"get-token",
+		"--issuer-url=" + authConfig.IssuerURL,
+		"--client-id=" + authConfig.CliClientID,
+		"--extra-scopes=email,profile",
+		"--callback-address=127.0.0.1:8080",
+		"--certificate-authority=" + authConfig.IssuerCABundleFile,
+	}
+
+	userClientConfig.ExecProvider = &clientcmdapi.ExecConfig{
+		APIVersion: "client.authentication.k8s.io/v1",
+		Command:    "oc",
+		Args:       args,
+		// We can't use os.Setenv("KUBECACHEDIR", tokenCacheDir), so we use "ExecEnvVar" that ensures each
+		// single user has unique cache path to avoid the parallel running users mess up the same cache path,
+		// because the cache file name is decided by the issuer URL & client ID provided in CLI
+		Env: []clientcmdapi.ExecEnvVar{
+			{Name: "KUBECACHEDIR", Value: tokenCacheDir},
+		},
+		InstallHint:        "Please be sure that oc is defined in $PATH to be executed as credentials exec plugin",
+		InteractiveMode:    clientcmdapi.IfAvailableExecInteractiveMode,
+		ProvideClusterInfo: false,
+	}
+
+	return userClientConfig
+}

--- a/test/e2e/util/hypershift_framework.go
+++ b/test/e2e/util/hypershift_framework.go
@@ -47,6 +47,8 @@ type PlatformAgnosticOptions struct {
 	AzurePlatform     azure.RawCreateOptions
 	PowerVSPlatform   powervs.RawCreateOptions
 	OpenStackPlatform openstack.RawCreateOptions
+
+	ExtOIDCConfig *ExtOIDCConfig
 }
 
 type hypershiftTestFunc func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster)
@@ -128,6 +130,10 @@ func (h *hypershiftTest) before(hostedCluster *hyperv1.HostedCluster, opts *Plat
 			} else {
 				ValidatePublicCluster(t, h.ctx, h.client, hostedCluster, opts)
 			}
+		}
+
+		if opts.ExtOIDCConfig != nil && opts.ExtOIDCConfig.ExternalOIDCProvider == ProviderKeycloak {
+			ValidateAuthenticationSpec(t, h.ctx, h.client, hostedCluster, opts.ExtOIDCConfig)
 		}
 	})
 }
@@ -253,6 +259,37 @@ func (h *hypershiftTest) createHostedCluster(opts *PlatformAgnosticOptions, plat
 		err = h.client.Create(h.ctx, serviceAccountSigningKeySecret)
 		g.Expect(err).NotTo(HaveOccurred(), "failed to create serviceAccountSigningKeySecret")
 
+		// create external oidc secret and configmap
+		if opts.ExtOIDCConfig != nil {
+			consoleClientSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      opts.ExtOIDCConfig.ConsoleClientSecretName,
+					Namespace: namespace.Name,
+				},
+				Type: corev1.SecretTypeOpaque,
+				StringData: map[string]string{
+					"clientSecret": opts.ExtOIDCConfig.ConsoleClientSecretValue,
+				},
+			}
+			err := h.client.Create(h.ctx, consoleClientSecret)
+			g.Expect(err).NotTo(HaveOccurred(), "failed to create external oidc secret")
+
+			caData, err := os.ReadFile(opts.ExtOIDCConfig.IssuerCABundleFile)
+			g.Expect(err).NotTo(HaveOccurred(), "failed to read external oidc issuer ca bundle file")
+
+			oidcCAConfigmap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      opts.ExtOIDCConfig.IssuerCAConfigmapName,
+					Namespace: namespace.Name,
+				},
+				Data: map[string]string{
+					"ca-bundle.crt": string(caData),
+				},
+			}
+			err = h.client.Create(h.ctx, oidcCAConfigmap)
+			g.Expect(err).NotTo(HaveOccurred(), "failed to create external oidc issuer ca configmap")
+		}
+
 		originalBeforeApply := opts.BeforeApply
 		opts.BeforeApply = func(o crclient.Object) {
 			if originalBeforeApply != nil {
@@ -277,6 +314,10 @@ func (h *hypershiftTest) createHostedCluster(opts *PlatformAgnosticOptions, plat
 								},
 							},
 						},
+					}
+
+					if opts.ExtOIDCConfig != nil {
+						v.Spec.Configuration.Authentication = opts.ExtOIDCConfig.GetAuthenticationConfig()
 					}
 				}
 			}

--- a/test/e2e/util/options.go
+++ b/test/e2e/util/options.go
@@ -76,6 +76,15 @@ type Options struct {
 	HOInstallationOptions HyperShiftOperatorInstallOptions
 	// RunUpgradeTest is set to run HyperShift Operator upgrade test
 	RunUpgradeTest bool
+
+	// external oidc for authentication in spec.configurations
+	ExternalOIDCProvider        string
+	ExternalOIDCCliClientID     string
+	ExternalOIDCConsoleClientID string
+	ExternalOIDCIssuerURL       string
+	ExternalOIDCConsoleSecret   string
+	ExternalOIDCCABundleFile    string
+	ExternalOIDCTestUsers       string
 }
 
 type HyperShiftOperatorInstallOptions struct {
@@ -212,6 +221,12 @@ func (o *Options) DefaultClusterOptions(t *testing.T) PlatformAgnosticOptions {
 
 	if len(o.ConfigurableClusterOptions.ClusterCIDR) != 0 {
 		createOption.ClusterCIDR = o.ConfigurableClusterOptions.ClusterCIDR
+	}
+
+	// set external OIDC if enabled
+	if o.ExternalOIDCProvider != "" {
+		createOption.ExtOIDCConfig = GetExtOIDCConfig(o.ExternalOIDCProvider, o.ExternalOIDCCliClientID, o.ExternalOIDCConsoleClientID,
+			o.ExternalOIDCIssuerURL, o.ExternalOIDCConsoleSecret, o.ExternalOIDCCABundleFile, o.ExternalOIDCTestUsers)
 	}
 
 	return createOption

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -287,6 +287,14 @@ func WaitForGuestKubeConfig(t *testing.T, ctx context.Context, client crclient.C
 	return data
 }
 
+func WaitForGuestRestConfig(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) *rest.Config {
+	g := NewWithT(t)
+	guestKubeConfigSecretData := WaitForGuestKubeConfig(t, ctx, client, hostedCluster)
+	guestConfig, err := clientcmd.RESTConfigFromKubeConfig(guestKubeConfigSecretData)
+	g.Expect(err).NotTo(HaveOccurred(), "couldn't load guest rest config")
+	return guestConfig
+}
+
 func WaitForGuestClient(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) crclient.Client {
 	g := NewWithT(t)
 	guestKubeConfigSecretData := WaitForGuestKubeConfig(t, ctx, client, hostedCluster)


### PR DESCRIPTION
* Added external OIDC e2e test based on keycloak service
* Test passed in my local env
* This is a new test added with new parameters. It should not affect the existing test cases in the prow job.
* By default, the new external oidc case should be skipped due the the empty value of new parameter `e2e.external-oidc-provider`
```
=== RUN   TestExternalOIDC/Main
=== RUN   TestExternalOIDC/Main/[OCPFeatureGate:ExternalOIDC]_test_keycloak_external_OIDC
    external_oidc_test.go:38: begin to test external OIDC keycloak
    util.go:252: Waiting for kubeconfig to be published for HostedCluster e2e-clusters-rndq5/external-oidc-tqhpr
    eventually.go:224: observed *v1beta1.HostedCluster e2e-clusters-rndq5/external-oidc-tqhpr valid at RV 153448 after 525ms: expected a kubeconfig reference in status
    util.go:252: Successfully waited for kubeconfig to be published for HostedCluster e2e-clusters-rndq5/external-oidc-tqhpr in 525ms
    util.go:269: Waiting for kubeconfig secret to have data
    eventually.go:224: observed *v1.Secret e2e-clusters-rndq5/external-oidc-tqhpr-admin-kubeconfig valid at RV 146645 after 275ms: expected secret to contain kubeconfig in data
    util.go:269: Successfully waited for kubeconfig secret to have data in 275ms
    external_oidc.go:195: Found authentication type used: OIDC
    external_oidc.go:230: Random test user for use: 'keycloak-testuser-26'.
    external_oidc.go:296: Detected external OIDC cluster using Keycloak as the provider. The user is now "oidc-user-test:keycloak-testuser-26@example.com"
    external_oidc_test.go:44: successfully get oidc user client
...
=== RUN   TestExternalOIDC/Teardown

    journals.go:198: Successfully copied machine journals to TestExternalOIDC/machine-journals
    hypershift_framework.go:395: Waiting for HostedCluster e2e-clusters-rndq5/external-oidc-tqhpr to be destroyed
    fixture.go:340: SUCCESS: found no remaining guest resources
    hypershift_framework.go:423: Destroyed cluster. Namespace: e2e-clusters-rndq5, name: external-oidc-tqhpr
    util.go:152: Deleting namespace e2e-clusters-rndq5
    util.go:170: Waiting for namespace e2e-clusters-rndq5 to be finalized
    util.go:187: Deleted namespace e2e-clusters-rndq5
    hypershift_framework.go:378: archiving TestExternalOIDC/hostedcluster-external-oidc-tqhpr to TestExternalOIDC/hostedcluster.tar.gz
=== RUN   TestExternalOIDC/PostTeardown
=== RUN   TestExternalOIDC/PostTeardown/ValidateMetricsAreExposed
=== NAME  TestExternalOIDC
    hypershift_framework.go:186: skipping teardown, already called
--- PASS: TestExternalOIDC (2396.46s)
...
        --- PASS: TestExternalOIDC/PostTeardown/ValidateMetricsAreExposed (9.10s)
PASS
{"level":"info","ts":"2025-07-30T19:28:49+08:00","msg":"Deleted OIDC provider","providerARN":"arn:aws:iam::301721915996:oidc-provider/heli-test-02.s3.us-east-2.amazonaws.com/e2e-oidc-provider-p9pl5"}
```
*  local check on the test cluster status
```
$ oc get hc -A
NAMESPACE            NAME                  VERSION                              KUBECONFIG                             PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
e2e-clusters-rndq5   external-oidc-tqhpr   4.20.0-0.nightly-2025-07-20-021531   external-oidc-tqhpr-admin-kubeconfig   Completed   True        False         The hosted control plane is available

$ oc get hc  external-oidc-tqhpr -n e2e-clusters-rndq5 -ojsonpath='{.spec.configuration}' | jq
{
  "authentication": {
    "oauthMetadata": {
      "name": ""
    },
    "oidcProviders": [
      {
        "claimMappings": {
          "extra": [
            {
              "key": "extratest.openshift.com/bar",
              "valueExpression": "\"extra-test-mark\""
            },
            {
              "key": "extratest.openshift.com/foo",
              "valueExpression": "claims.email"
            }
          ],
          "groups": {
            "claim": "groups",
            "prefix": "oidc-groups-test:"
          },
          "uid": {
            "expression": "\"testuid-\" + claims.sub + \"-uidtest\""
          },
          "username": {
            "claim": "email",
            "prefix": {
              "prefixString": "oidc-user-test:"
            },
            "prefixPolicy": "Prefix"
          }
        },
        "issuer": {
          "audiences": [
            "oc-cli-test",
            "console-test"
          ],
          "issuerCertificateAuthority": {
            "name": "oidc-ca"
          },
          "issuerURL": "https://keycloak-keycloak.apps.heli-0730.qe.devcluster.openshift.com/realms/master"
        },
        "name": "keycloak oidc server",
        "oidcClients": [
          {
            "clientID": "console-test",
            "clientSecret": {
              "name": "console-secret"
            },
            "componentName": "console",
            "componentNamespace": "openshift-console",
            "extraScopes": [
              "email"
            ]
          }
        ]
      }
    ],
    "serviceAccountIssuer": "",
    "type": "OIDC"
  },
  "ingress": {
    "domain": "",
    "loadBalancer": {
      "platform": {
        "aws": {
          "type": "NLB"
        },
        "type": "AWS"
      }
    }
  }
}
```