### PR TITLE
OCPBUGS-58299: remove annotation is not working

### DIFF
--- a/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
@@ -477,6 +477,9 @@ func applyJsonPatches(nodePool *hyperv1.NodePool, hcluster *hyperv1.HostedCluste
 		}
 	}
 
+	// Clear the annotations map so that decoding will not leave stale keys
+	tmplt.Spec.Template.ObjectMeta.Annotations = nil
+
 	buff = bytes.NewBuffer(templateBytes)
 	enc := json.NewDecoder(buff)
 


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

The JSON patch was working, but Go's map decoding behavior left stale keys in the Annotations map.
By clearing the map before decoding, the struct now matches the patched JSON, and the test passes.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-58299](https://issues.redhat.com/browse/OCPBUGS-58299)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.