### PR TITLE
Revert "OCPBUGS-56701: Update the LookupDefaultOCPVersion function to use the multi-arch release API"

### DIFF
--- a/cmd/cluster/agent/create_test.go
+++ b/cmd/cluster/agent/create_test.go
@@ -2,14 +2,11 @@ package agent
 
 import (
 	"context"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/openshift/hypershift/cmd/cluster/core"
-	"github.com/openshift/hypershift/cmd/util"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/testutil"
 	"github.com/openshift/hypershift/test/integration/framework"
@@ -23,7 +20,6 @@ func TestCreateCluster(t *testing.T) {
 	utilrand.Seed(1234567890)
 	certs.UnsafeSeed(1234567890)
 	ctx := framework.InterruptableContext(context.Background())
-	t.Setenv("FAKE_CLIENT", "true")
 
 	tempDir := t.TempDir()
 
@@ -32,46 +28,6 @@ func TestCreateCluster(t *testing.T) {
 	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
 		t.Fatalf("failed to write pullSecret: %v", err)
 	}
-
-	supportedVersionsCM := testutil.CreateSupportedVersionsConfigMap()
-
-	// Set up fake client objects for the test
-	util.SetFakeClientObjects(supportedVersionsCM)
-	defer util.ClearFakeClientObjects()
-
-	// Mock HTTP server that returns release tags
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		response := `{
-					"name": "4-stable-multi",
-					"tags": [
-						{
-							"name": "4.19.0",
-							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.19.0-multi",
-							"downloadURL": "https://example.com/4.19.0"
-						},
-						{
-							"name": "4.18.5",
-							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.5-multi",
-							"downloadURL": "https://example.com/4.18.5"
-						},
-						{
-							"name": "4.18.0",
-							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.0-multi",
-							"downloadURL": "https://example.com/4.18.0"
-						}
-					]
-				}`
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte(response))
-		if err != nil {
-			t.Fatalf("failed to write response: %v", err)
-		}
-	}))
-	defer mockServer.Close()
-
-	// Set the environment variable to override the release URL template with the mock server
-	t.Setenv("HYPERSHIFT_RELEASE_URL_TEMPLATE", mockServer.URL+"/api/v1/releasestream/%s/tags")
 
 	for _, testCase := range []struct {
 		name string

--- a/cmd/cluster/agent/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/agent/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -78,7 +78,7 @@ spec:
   pullSecret:
     name: example-pull-secret
   release:
-    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
+    image: ""
   secretEncryption:
     aescbc:
       activeKey:
@@ -134,7 +134,7 @@ spec:
     agent: {}
     type: Agent
   release:
-    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
+    image: ""
   replicas: 0
 status:
   replicas: 0

--- a/cmd/cluster/aws/create_test.go
+++ b/cmd/cluster/aws/create_test.go
@@ -3,8 +3,6 @@ package aws
 import (
 	"context"
 	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -168,46 +166,6 @@ func TestCreateCluster(t *testing.T) {
 	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
 		t.Fatalf("failed to write pullSecret: %v", err)
 	}
-
-	supportedVersionsCM := testutil.CreateSupportedVersionsConfigMap()
-
-	// Set up fake client objects for the test
-	util.SetFakeClientObjects(supportedVersionsCM)
-	defer util.ClearFakeClientObjects()
-
-	// Mock HTTP server that returns release tags
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		response := `{
-					"name": "4-stable-multi",
-					"tags": [
-						{
-							"name": "4.19.0",
-							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.19.0-multi",
-							"downloadURL": "https://example.com/4.19.0"
-						},
-						{
-							"name": "4.18.5",
-							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.5-multi",
-							"downloadURL": "https://example.com/4.18.5"
-						},
-						{
-							"name": "4.18.0",
-							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.0-multi",
-							"downloadURL": "https://example.com/4.18.0"
-						}
-					]
-				}`
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte(response))
-		if err != nil {
-			t.Fatalf("failed to write response: %v", err)
-		}
-	}))
-	defer mockServer.Close()
-
-	// Set the environment variable to override the release URL template with the mock server
-	t.Setenv("HYPERSHIFT_RELEASE_URL_TEMPLATE", mockServer.URL+"/api/v1/releasestream/%s/tags")
 
 	for _, testCase := range []struct {
 		name string

--- a/cmd/cluster/aws/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/aws/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -80,7 +80,7 @@ spec:
   pullSecret:
     name: example-pull-secret
   release:
-    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
+    image: ""
   secretEncryption:
     kms:
       aws:
@@ -135,7 +135,7 @@ spec:
         id: fakeSubnetID
     type: AWS
   release:
-    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
+    image: ""
   replicas: 0
 status:
   replicas: 0

--- a/cmd/cluster/aws/testdata/zz_fixture_TestCreateCluster_minimal_with_KubeAPIServerDNSName.yaml
+++ b/cmd/cluster/aws/testdata/zz_fixture_TestCreateCluster_minimal_with_KubeAPIServerDNSName.yaml
@@ -70,7 +70,7 @@ spec:
   pullSecret:
     name: example-pull-secret
   release:
-    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
+    image: ""
   secretEncryption:
     kms:
       aws:
@@ -125,7 +125,7 @@ spec:
         id: fakeSubnetID
     type: AWS
   release:
-    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
+    image: ""
   replicas: 0
 status:
   replicas: 0

--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -35,7 +35,6 @@ const (
 
 func DefaultOptions(client crclient.Client, log logr.Logger) (*RawCreateOptions, error) {
 	rawCreateOptions := &RawCreateOptions{
-		client:       client,
 		Location:     "eastus",
 		NodePoolOpts: azurenodepool.DefaultOptions(),
 	}
@@ -79,8 +78,6 @@ func BindDeveloperOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
 }
 
 type RawCreateOptions struct {
-	client crclient.Client
-
 	CredentialsFile                  string
 	Location                         string
 	EncryptionKeyID                  string
@@ -534,7 +531,7 @@ func CreateInfraOptions(ctx context.Context, azureOpts *ValidatedCreateOptions, 
 	rhcosImage := azureOpts.RHCOSImage
 	if rhcosImage == "" && azureOpts.MarketplacePublisher == "" {
 		var err error
-		rhcosImage, err = lookupRHCOSImage(ctx, opts.Arch, opts.ReleaseImage, opts.ReleaseStream, opts.PullSecretFile, azureOpts.client)
+		rhcosImage, err = lookupRHCOSImage(ctx, opts.Arch, opts.ReleaseImage, opts.ReleaseStream, opts.PullSecretFile)
 		if err != nil {
 			return azureinfra.CreateInfraOptions{}, fmt.Errorf("failed to retrieve RHCOS image: %w", err)
 		}
@@ -562,17 +559,12 @@ func CreateInfraOptions(ctx context.Context, azureOpts *ValidatedCreateOptions, 
 }
 
 // lookupRHCOSImage looks up a release image and extracts the RHCOS VHD image based on the nodepool arch
-func lookupRHCOSImage(ctx context.Context, arch, image, releaseStream, pullSecretFile string, client crclient.Client) (string, error) {
-	var err error
-
-	if client == nil {
-		client, err = util.GetClient()
+func lookupRHCOSImage(ctx context.Context, arch, image, releaseStream, pullSecretFile string) (string, error) {
+	if len(image) == 0 && len(releaseStream) != 0 {
+		client, err := util.GetClient()
 		if err != nil {
 			return "", fmt.Errorf("failed to get client: %w", err)
 		}
-	}
-
-	if len(image) == 0 {
 		defaultVersion, err := supportedversion.LookupDefaultOCPVersion(ctx, releaseStream, client)
 		if err != nil {
 			return "", fmt.Errorf("failed to lookup OCP release image for release stream, %s: %w", releaseStream, err)

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -108,7 +108,7 @@ spec:
   pullSecret:
     name: example-pull-secret
   release:
-    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
+    image: ""
   secretEncryption:
     aescbc:
       activeKey:
@@ -159,7 +159,7 @@ spec:
       vmSize: Standard_D4s_v3
     type: Azure
   release:
-    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
+    image: ""
   replicas: 0
 status:
   replicas: 0

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_KubeAPIServerDNSName.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_KubeAPIServerDNSName.yaml
@@ -109,7 +109,7 @@ spec:
   pullSecret:
     name: example-pull-secret
   release:
-    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
+    image: ""
   secretEncryption:
     aescbc:
       activeKey:
@@ -160,7 +160,7 @@ spec:
       vmSize: Standard_D4s_v3
     type: Azure
   release:
-    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
+    image: ""
   replicas: 0
 status:
   replicas: 0

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_zones.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_zones.yaml
@@ -108,7 +108,7 @@ spec:
   pullSecret:
     name: example-pull-secret
   release:
-    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
+    image: ""
   secretEncryption:
     aescbc:
       activeKey:
@@ -160,7 +160,7 @@ spec:
       vmSize: Standard_D4s_v3
     type: Azure
   release:
-    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
+    image: ""
   replicas: 0
 status:
   replicas: 0
@@ -192,7 +192,7 @@ spec:
       vmSize: Standard_D4s_v3
     type: Azure
   release:
-    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
+    image: ""
   replicas: 0
 status:
   replicas: 0

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_disabled_capabilities.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_disabled_capabilities.yaml
@@ -110,7 +110,7 @@ spec:
   pullSecret:
     name: example-pull-secret
   release:
-    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
+    image: ""
   secretEncryption:
     aescbc:
       activeKey:
@@ -161,7 +161,7 @@ spec:
       vmSize: Standard_D4s_v3
     type: Azure
   release:
-    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
+    image: ""
   replicas: 0
 status:
   replicas: 0

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -228,7 +228,7 @@ func (r *resources) asObjects() []crclient.Object {
 func prototypeResources(ctx context.Context, opts *CreateOptions) (*resources, error) {
 	prototype := &resources{}
 	// allow client side defaulting when release image is empty but release stream is set.
-	if len(opts.ReleaseImage) == 0 {
+	if len(opts.ReleaseImage) == 0 && len(opts.ReleaseStream) != 0 {
 		client, err := util.GetClient()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get client: %w", err)

--- a/cmd/cluster/core/create_test.go
+++ b/cmd/cluster/core/create_test.go
@@ -2,8 +2,6 @@ package core
 
 import (
 	"context"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,8 +9,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
-	"github.com/openshift/hypershift/cmd/util"
-	"github.com/openshift/hypershift/support/testutil"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
 	"github.com/openshift/hypershift/support/util/fakeimagemetadataprovider"
 
@@ -164,42 +160,6 @@ func TestAsObjects(t *testing.T) {
 
 func TestPrototypeResources(t *testing.T) {
 	g := NewWithT(t)
-	t.Setenv("FAKE_CLIENT", "true")
-
-	// Set up fake client objects for the test
-	supportedVersionsCM := testutil.CreateSupportedVersionsConfigMap()
-	util.SetFakeClientObjects(supportedVersionsCM)
-	defer util.ClearFakeClientObjects()
-
-	// Mock HTTP server that returns release tags
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		response := `{
-			"name": "4-stable-multi",
-			"tags": [
-				{
-					"name": "4.19.0",
-					"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.19.0-multi",
-					"downloadURL": "https://example.com/4.19.0"
-				},
-				{
-					"name": "4.18.5", 
-					"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.5-multi",
-					"downloadURL": "https://example.com/4.18.5"
-				}
-			]
-		}`
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte(response))
-		if err != nil {
-			t.Fatalf("failed to write response: %v", err)
-		}
-	}))
-	defer mockServer.Close()
-
-	// Set the environment variable to override the release URL template with the mock server
-	t.Setenv("HYPERSHIFT_RELEASE_URL_TEMPLATE", mockServer.URL+"/api/v1/releasestream/%s/tags")
-
 	opts := &CreateOptions{
 		completedCreateOptions: &completedCreateOptions{
 			ValidatedCreateOptions: &ValidatedCreateOptions{

--- a/cmd/cluster/kubevirt/create_test.go
+++ b/cmd/cluster/kubevirt/create_test.go
@@ -2,8 +2,6 @@ package kubevirt
 
 import (
 	"context"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,7 +9,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/openshift/hypershift/cmd/cluster/core"
-	"github.com/openshift/hypershift/cmd/util"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/testutil"
 	"github.com/openshift/hypershift/test/integration/framework"
@@ -132,46 +129,6 @@ func TestCreateCluster(t *testing.T) {
 	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
 		t.Fatalf("failed to write pullSecret: %v", err)
 	}
-
-	supportedVersionsCM := testutil.CreateSupportedVersionsConfigMap()
-
-	// Set up fake client objects for the test
-	util.SetFakeClientObjects(supportedVersionsCM)
-	defer util.ClearFakeClientObjects()
-
-	// Mock HTTP server that returns release tags
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		response := `{
-					"name": "4-stable-multi",
-					"tags": [
-						{
-							"name": "4.19.0",
-							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.19.0-multi",
-							"downloadURL": "https://example.com/4.19.0"
-						},
-						{
-							"name": "4.18.5",
-							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.5-multi",
-							"downloadURL": "https://example.com/4.18.5"
-						},
-						{
-							"name": "4.18.0",
-							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.0-multi",
-							"downloadURL": "https://example.com/4.18.0"
-						}
-					]
-				}`
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte(response))
-		if err != nil {
-			t.Fatalf("failed to write response: %v", err)
-		}
-	}))
-	defer mockServer.Close()
-
-	// Set the environment variable to override the release URL template with the mock server
-	t.Setenv("HYPERSHIFT_RELEASE_URL_TEMPLATE", mockServer.URL+"/api/v1/releasestream/%s/tags")
 
 	for _, testCase := range []struct {
 		name string

--- a/cmd/cluster/kubevirt/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/kubevirt/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -65,7 +65,7 @@ spec:
   pullSecret:
     name: example-pull-secret
   release:
-    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
+    image: ""
   secretEncryption:
     aescbc:
       activeKey:
@@ -117,7 +117,7 @@ spec:
         type: Persistent
     type: KubeVirt
   release:
-    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
+    image: ""
   replicas: 0
 status:
   replicas: 0

--- a/cmd/cluster/none/create_test.go
+++ b/cmd/cluster/none/create_test.go
@@ -2,14 +2,11 @@ package none
 
 import (
 	"context"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/openshift/hypershift/cmd/cluster/core"
-	"github.com/openshift/hypershift/cmd/util"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/testutil"
 	"github.com/openshift/hypershift/test/integration/framework"
@@ -24,53 +21,12 @@ func TestCreateCluster(t *testing.T) {
 	certs.UnsafeSeed(1234567890)
 	ctx := framework.InterruptableContext(context.Background())
 	tempDir := t.TempDir()
-	t.Setenv("FAKE_CLIENT", "true")
 
 	pullSecretFile := filepath.Join(tempDir, "pull-secret.json")
 
 	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
 		t.Fatalf("failed to write pullSecret: %v", err)
 	}
-
-	supportedVersionsCM := testutil.CreateSupportedVersionsConfigMap()
-
-	// Set up fake client objects for the test
-	util.SetFakeClientObjects(supportedVersionsCM)
-	defer util.ClearFakeClientObjects()
-
-	// Mock HTTP server that returns release tags
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		response := `{
-					"name": "4-stable-multi",
-					"tags": [
-						{
-							"name": "4.19.0",
-							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.19.0-multi",
-							"downloadURL": "https://example.com/4.19.0"
-						},
-						{
-							"name": "4.18.5",
-							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.5-multi",
-							"downloadURL": "https://example.com/4.18.5"
-						},
-						{
-							"name": "4.18.0",
-							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.0-multi",
-							"downloadURL": "https://example.com/4.18.0"
-						}
-					]
-				}`
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte(response))
-		if err != nil {
-			t.Fatalf("failed to write response: %v", err)
-		}
-	}))
-	defer mockServer.Close()
-
-	// Set the environment variable to override the release URL template with the mock server
-	t.Setenv("HYPERSHIFT_RELEASE_URL_TEMPLATE", mockServer.URL+"/api/v1/releasestream/%s/tags")
 
 	for _, testCase := range []struct {
 		name string

--- a/cmd/cluster/none/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/none/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -63,7 +63,7 @@ spec:
   pullSecret:
     name: example-pull-secret
   release:
-    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
+    image: ""
   secretEncryption:
     aescbc:
       activeKey:
@@ -118,7 +118,7 @@ spec:
   platform:
     type: None
   release:
-    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
+    image: ""
   replicas: 0
 status:
   replicas: 0

--- a/cmd/cluster/openstack/create_test.go
+++ b/cmd/cluster/openstack/create_test.go
@@ -2,15 +2,12 @@ package openstack
 
 import (
 	"context"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/openshift/hypershift/cmd/cluster/core"
-	"github.com/openshift/hypershift/cmd/util"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/testutil"
 	"github.com/openshift/hypershift/test/integration/framework"
@@ -75,40 +72,6 @@ func TestCreateCluster(t *testing.T) {
 	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
 		t.Fatalf("failed to write pullSecret: %v", err)
 	}
-
-	// Set up fake client objects for the test
-	supportedVersionsCM := testutil.CreateSupportedVersionsConfigMap()
-	util.SetFakeClientObjects(supportedVersionsCM)
-	defer util.ClearFakeClientObjects()
-
-	// Mock HTTP server that returns release tags
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		response := `{
-			"name": "4-stable-multi",
-			"tags": [
-				{
-					"name": "4.19.0",
-					"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.19.0-multi",
-					"downloadURL": "https://example.com/4.19.0"
-				},
-				{
-					"name": "4.18.5", 
-					"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.5-multi",
-					"downloadURL": "https://example.com/4.18.5"
-				}
-			]
-		}`
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte(response))
-		if err != nil {
-			t.Fatalf("failed to write response: %v", err)
-		}
-	}))
-	defer mockServer.Close()
-
-	// Set the environment variable to override the release URL template with the mock server
-	t.Setenv("HYPERSHIFT_RELEASE_URL_TEMPLATE", mockServer.URL+"/api/v1/releasestream/%s/tags")
 
 	for _, testCase := range []struct {
 		name string

--- a/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/openstack/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -81,7 +81,7 @@ spec:
   pullSecret:
     name: example-pull-secret
   release:
-    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
+    image: ""
   secretEncryption:
     aescbc:
       activeKey:
@@ -126,7 +126,7 @@ spec:
       imageName: rhcos
     type: OpenStack
   release:
-    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
+    image: ""
   replicas: 0
 status:
   replicas: 0

--- a/cmd/cluster/powervs/create_test.go
+++ b/cmd/cluster/powervs/create_test.go
@@ -3,15 +3,12 @@ package powervs
 import (
 	"context"
 	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	powervsinfra "github.com/openshift/hypershift/cmd/infra/powervs"
-	"github.com/openshift/hypershift/cmd/util"
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/testutil"
 	"github.com/openshift/hypershift/test/integration/framework"
@@ -92,46 +89,6 @@ func TestCreateCluster(t *testing.T) {
 	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
 		t.Fatalf("failed to write pullSecret: %v", err)
 	}
-
-	supportedVersionsCM := testutil.CreateSupportedVersionsConfigMap()
-
-	// Set up fake client objects for the test
-	util.SetFakeClientObjects(supportedVersionsCM)
-	defer util.ClearFakeClientObjects()
-
-	// Mock HTTP server that returns release tags
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		response := `{
-					"name": "4-stable-multi",
-					"tags": [
-						{
-							"name": "4.19.0",
-							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.19.0-multi",
-							"downloadURL": "https://example.com/4.19.0"
-						},
-						{
-							"name": "4.18.5",
-							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.5-multi",
-							"downloadURL": "https://example.com/4.18.5"
-						},
-						{
-							"name": "4.18.0",
-							"pullSpec": "quay.io/openshift-release-dev/ocp-release:4.18.0-multi",
-							"downloadURL": "https://example.com/4.18.0"
-						}
-					]
-				}`
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte(response))
-		if err != nil {
-			t.Fatalf("failed to write response: %v", err)
-		}
-	}))
-	defer mockServer.Close()
-
-	// Set the environment variable to override the release URL template with the mock server
-	t.Setenv("HYPERSHIFT_RELEASE_URL_TEMPLATE", mockServer.URL+"/api/v1/releasestream/%s/tags")
 
 	for _, testCase := range []struct {
 		name string

--- a/cmd/cluster/powervs/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/powervs/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -116,7 +116,7 @@ spec:
   pullSecret:
     name: example-pull-secret
   release:
-    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
+    image: ""
   secretEncryption:
     aescbc:
       activeKey:
@@ -163,7 +163,7 @@ spec:
       systemType: s922
     type: PowerVS
   release:
-    image: quay.io/openshift-release-dev/ocp-release:4.19.0-multi
+    image: ""
   replicas: 0
 status:
   replicas: 0

--- a/cmd/util/client.go
+++ b/cmd/util/client.go
@@ -20,19 +20,6 @@ const (
 	DeleteWithClusterLabelName = "hypershift.openshift.io/safe-to-delete-with-cluster"
 )
 
-// testFakeClientObjects holds objects to be included in fake clients for testing
-var testFakeClientObjects []crclient.Object
-
-// SetFakeClientObjects sets the objects to be included in fake clients for testing
-func SetFakeClientObjects(objects ...crclient.Object) {
-	testFakeClientObjects = objects
-}
-
-// ClearFakeClientObjects clears the test fake client objects
-func ClearFakeClientObjects() {
-	testFakeClientObjects = nil
-}
-
 // GetConfig creates a REST config from current context
 func GetConfig() (*rest.Config, error) {
 	cfg, err := cr.GetConfig()
@@ -47,11 +34,7 @@ func GetConfig() (*rest.Config, error) {
 // GetClient creates a controller-runtime client for Kubernetes
 func GetClient() (crclient.Client, error) {
 	if os.Getenv("FAKE_CLIENT") == "true" {
-		builder := fake.NewClientBuilder().WithScheme(hyperapi.Scheme)
-		if len(testFakeClientObjects) > 0 {
-			builder = builder.WithObjects(testFakeClientObjects...)
-		}
-		return builder.Build(), nil
+		return fake.NewFakeClient(), nil
 	}
 
 	config, err := GetConfig()

--- a/support/supportedversion/version.go
+++ b/support/supportedversion/version.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"runtime/debug"
 	"strings"
 
@@ -23,15 +22,10 @@ import (
 )
 
 // https://docs.ci.openshift.org/docs/getting-started/useful-links/#services
-const multiArchReleaseURLTemplate = "https://multi.ocp.releases.ci.openshift.org/api/v1/releasestream/%s/tags"
-
-// getMultiArchReleaseURLTemplate returns the release URL template, checking for an environment variable override first
-func getMultiArchReleaseURLTemplate() string {
-	if envURL := os.Getenv("HYPERSHIFT_RELEASE_URL_TEMPLATE"); envURL != "" {
-		return envURL
-	}
-	return multiArchReleaseURLTemplate
-}
+const (
+	multiArchReleaseURLTemplate = "https://multi.ocp.releases.ci.openshift.org/api/v1/releasestream/%s/tags"
+	releaseURLTemplate          = "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/%s/latest"
+)
 
 // LatestSupportedVersion is the latest minor OCP version supported by the
 // HyperShift operator.
@@ -164,17 +158,6 @@ func getOCPVersion(releaseURL string) (ocpVersion, error) {
 	return version, nil
 }
 
-// LookupDefaultOCPVersion retrieves the default OCP version from multi-arch release streams.
-// It supports two modes of operation:
-//
-//  1. When releaseStream is empty: Uses the default release stream and looks up supported OCP versions
-//     from the HyperShift operator's ConfigMap to find the latest supported version that is not a
-//     release candidate. This ensures compatibility with the current HyperShift operator version.
-//
-//  2. When releaseStream is provided: Uses the specified release stream to retrieve the OCP version
-//     directly from the multi-arch release API.
-//
-// The function defaults to multi-arch release streams for broader architecture support.
 func LookupDefaultOCPVersion(ctx context.Context, releaseStream string, client crclient.Client) (ocpVersion, error) {
 	var (
 		version    ocpVersion
@@ -185,11 +168,11 @@ func LookupDefaultOCPVersion(ctx context.Context, releaseStream string, client c
 	if len(releaseStream) == 0 {
 		// No release stream was provided, so we will look up the supported OCP versions from the HO and use the latest
 		// release image from the multi-arch release stream that is not a release candidate.
-		releaseURL = fmt.Sprintf(getMultiArchReleaseURLTemplate(), config.DefaultReleaseStream)
+		releaseURL = fmt.Sprintf(multiArchReleaseURLTemplate, config.DefaultReleaseStream)
 		version, err = retrieveSupportedOCPVersion(ctx, releaseURL, client)
 	} else {
 		// We look up the release URL based on the user provided release stream.
-		releaseURL = fmt.Sprintf(getMultiArchReleaseURLTemplate(), releaseStream)
+		releaseURL = fmt.Sprintf(releaseURLTemplate, releaseStream)
 		version, err = getOCPVersion(releaseURL)
 	}
 
@@ -273,7 +256,7 @@ func GetSupportedOCPVersions(ctx context.Context, namespace string, client crcli
 
 	if supportedVersions == nil {
 		// Fetch the supported versions ConfigMap from the specified namespace
-		supportedVersions = manifests.ConfigMap(namespace)
+		supportedVersions := manifests.ConfigMap(namespace)
 		if err := client.Get(ctx, crclient.ObjectKeyFromObject(supportedVersions), supportedVersions); err != nil {
 			return SupportedVersions{}, "", fmt.Errorf("failed to find supported versions on the server: %v", err)
 		}

--- a/support/supportedversion/version_test.go
+++ b/support/supportedversion/version_test.go
@@ -23,53 +23,6 @@ import (
 	"github.com/blang/semver"
 )
 
-func TestGetMultiArchReleaseURLTemplate(t *testing.T) {
-	testCases := []struct {
-		name        string
-		envValue    string
-		setEnv      bool
-		expectedURL string
-	}{
-		{
-			name:        "returns default URL when environment variable is not set",
-			setEnv:      false,
-			expectedURL: multiArchReleaseURLTemplate,
-		},
-		{
-			name:        "returns custom URL when environment variable is set",
-			envValue:    "https://custom.example.com/api/v1/releasestream/%s/tags",
-			setEnv:      true,
-			expectedURL: "https://custom.example.com/api/v1/releasestream/%s/tags",
-		},
-		{
-			name:        "returns default URL when environment variable is empty string",
-			envValue:    "",
-			setEnv:      true,
-			expectedURL: multiArchReleaseURLTemplate,
-		},
-		{
-			name:        "returns mock server URL when set for testing",
-			envValue:    "http://localhost:8080/mock/%s",
-			setEnv:      true,
-			expectedURL: "http://localhost:8080/mock/%s",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
-
-			// Set up environment for test case using t.Setenv (automatically handles cleanup)
-			if tc.setEnv {
-				t.Setenv("HYPERSHIFT_RELEASE_URL_TEMPLATE", tc.envValue)
-			}
-
-			result := getMultiArchReleaseURLTemplate()
-			g.Expect(result).To(Equal(tc.expectedURL))
-		})
-	}
-}
-
 func TestSupportedVersions(t *testing.T) {
 	g := NewGomegaWithT(t)
 	g.Expect(Supported()).To(Equal([]string{"4.20", "4.19", "4.18", "4.17", "4.16", "4.15", "4.14"}))

--- a/support/testutil/testutil.go
+++ b/support/testutil/testutil.go
@@ -9,7 +9,6 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -177,20 +176,4 @@ func MatchExpected(expected any, opts ...cmp.Option) types.GomegaMatcher {
 	return WithTransform(func(actual any) string {
 		return cmp.Diff(actual, expected, opts...)
 	}, BeEmpty())
-
-}
-
-// CreateSupportedVersionsConfigMap creates a ConfigMap with supported OpenShift versions for testing
-func CreateSupportedVersionsConfigMap() *corev1.ConfigMap {
-	return &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "supported-versions",
-			Namespace: "test",
-			Labels:    map[string]string{"hypershift.openshift.io/supported-versions": "true"},
-		},
-		Data: map[string]string{
-			"server-version":     "test-server",
-			"supported-versions": `{"versions":["4.19", "4.18", "4.17", "4.16", "4.15", "4.14"]}`,
-		},
-	}
 }


### PR DESCRIPTION
A PR was originally introduced here - openshift/hypershift#6353

It is being reverted because caused the AWS e2e to fail as the AWS management cluster could not be created because no release image could be found.

This PR is now reverting openshift/hypershift#6353. Before it is remerged, we will make sure the AWS e2e passes with it.