### PR TITLE
CNTRLPLANE-1113: Add renovate configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ tools/bin
 
 # Mocked interface generate through mockgen
 *_mock.go
+
+# dev
+dev/

--- a/.tekton/hypershift-operator-main-pull-request.yaml
+++ b/.tekton/hypershift-operator-main-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "main"
-      && files.all.exists(x, !x.matches('^(?:docs|examples|enhancements|contrib)/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE)$'))
+      && files.all.exists(x, !x.matches('^(?:docs|examples|enhancements|contrib)/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|renovate\.json)$'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: hypershift-operator

--- a/.tekton/hypershift-operator-main-push.yaml
+++ b/.tekton/hypershift-operator-main-push.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "main"
-      && files.all.exists(x, !x.matches('^(?:docs|examples|enhancements|contrib)/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE)$'))
+      && files.all.exists(x, !x.matches('^(?:docs|examples|enhancements|contrib)/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|renovate\.json)$'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: hypershift-operator

--- a/.tekton/hypershift-operator-main-tag.yaml
+++ b/.tekton/hypershift-operator-main-tag.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch.matches("refs/tags/v0.1.*")
-      && files.all.exists(x, !x.matches('^(?:docs|examples|enhancements|contrib)/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE)$'))
+      && files.all.exists(x, !x.matches('^(?:docs|examples|enhancements|contrib)/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|renovate\.json)$'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: hypershift-operator

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "tekton": {
+        "branchConcurrentLimit": 10,
+        "extends": [
+            "github>konflux-ci/mintmaker-presets:update-fedora-to-stable"
+        ]
+    }
+  }


### PR DESCRIPTION
## What this PR does / why we need it
- Includes `renovate.json` in the root of the repo containing branchConcurrentLimit set to 10 in order to avoid flood the repository branches
- Include `dev/` folder to the gitIgnore

## References
- https://docs.renovatebot.com/configuration-options/#branchconcurrentlimit
- https://konflux.pages.redhat.com/docs/users/patterns/keep-remote-pipelines-up-to-date.html#potential-drawbacks