### PR TITLE
CNTRLPLANE-1016: Support day2 tags changes for AWS default SecurityGroup

### DIFF
--- a/api/hypershift/v1beta1/aws.go
+++ b/api/hypershift/v1beta1/aws.go
@@ -32,11 +32,12 @@ type AWSNodePoolPlatform struct {
 	// +optional
 	RootVolume *Volume `json:"rootVolume,omitempty"`
 
-	// ResourceTags is an optional list of additional tags to apply to AWS node
-	// instances.
+	// resourceTags is an optional list of additional tags to apply to AWS node
+	// instances. Changes to this field will be propagated in-place to AWS EC2 instances and their initial EBS volumes.
+	// Volumes created by the storage operator and attached to instances after they are created do not get these tags applied.
 	//
-	// These will be merged with HostedCluster scoped tags, and HostedCluster tags
-	// take precedence in case of conflicts.
+	// These will be merged with HostedCluster scoped tags, which take precedence in case of conflicts.
+	// These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
 	//
 	// See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for
 	// information on tagging AWS resources. AWS supports a maximum of 50 tags per
@@ -230,6 +231,10 @@ type AWSPlatformSpec struct {
 	// information on tagging AWS resources. AWS supports a maximum of 50 tags per
 	// resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
 	// for the user.
+	// Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+	// These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+	// Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+	// These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
 	//
 	// +kubebuilder:validation:MaxItems=25
 	// +optional

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -2758,6 +2758,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -2794,6 +2794,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -2774,6 +2774,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -2770,6 +2770,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -2991,6 +2991,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -3145,6 +3145,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -2767,6 +2767,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -2825,6 +2825,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -2901,6 +2901,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -2749,6 +2749,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -2642,6 +2642,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -2678,6 +2678,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -2658,6 +2658,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -2654,6 +2654,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -2875,6 +2875,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -3029,6 +3029,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -2651,6 +2651,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -2709,6 +2709,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -2785,6 +2785,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -2633,6 +2633,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
@@ -433,11 +433,12 @@ spec:
                         type: object
                       resourceTags:
                         description: |-
-                          ResourceTags is an optional list of additional tags to apply to AWS node
-                          instances.
+                          resourceTags is an optional list of additional tags to apply to AWS node
+                          instances. Changes to this field will be propagated in-place to AWS EC2 instances and their initial EBS volumes.
+                          Volumes created by the storage operator and attached to instances after they are created do not get these tags applied.
 
-                          These will be merged with HostedCluster scoped tags, and HostedCluster tags
-                          take precedence in case of conflicts.
+                          These will be merged with HostedCluster scoped tags, which take precedence in case of conflicts.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
 
                           See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/CapacityReservation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/CapacityReservation.yaml
@@ -457,11 +457,12 @@ spec:
                         type: object
                       resourceTags:
                         description: |-
-                          ResourceTags is an optional list of additional tags to apply to AWS node
-                          instances.
+                          resourceTags is an optional list of additional tags to apply to AWS node
+                          instances. Changes to this field will be propagated in-place to AWS EC2 instances and their initial EBS volumes.
+                          Volumes created by the storage operator and attached to instances after they are created do not get these tags applied.
 
-                          These will be merged with HostedCluster scoped tags, and HostedCluster tags
-                          take precedence in case of conflicts.
+                          These will be merged with HostedCluster scoped tags, which take precedence in case of conflicts.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
 
                           See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
@@ -433,11 +433,12 @@ spec:
                         type: object
                       resourceTags:
                         description: |-
-                          ResourceTags is an optional list of additional tags to apply to AWS node
-                          instances.
+                          resourceTags is an optional list of additional tags to apply to AWS node
+                          instances. Changes to this field will be propagated in-place to AWS EC2 instances and their initial EBS volumes.
+                          Volumes created by the storage operator and attached to instances after they are created do not get these tags applied.
 
-                          These will be merged with HostedCluster scoped tags, and HostedCluster tags
-                          take precedence in case of conflicts.
+                          These will be merged with HostedCluster scoped tags, which take precedence in case of conflicts.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
 
                           See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
@@ -3485,6 +3485,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
@@ -3172,6 +3172,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
@@ -3396,6 +3396,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
@@ -3369,6 +3369,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
@@ -3056,6 +3056,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
@@ -3280,6 +3280,10 @@ spec:
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per
                           resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
                           for the user.
+                          Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+                          These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+                          Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -460,11 +460,12 @@ spec:
                         type: object
                       resourceTags:
                         description: |-
-                          ResourceTags is an optional list of additional tags to apply to AWS node
-                          instances.
+                          resourceTags is an optional list of additional tags to apply to AWS node
+                          instances. Changes to this field will be propagated in-place to AWS EC2 instances and their initial EBS volumes.
+                          Volumes created by the storage operator and attached to instances after they are created do not get these tags applied.
 
-                          These will be merged with HostedCluster scoped tags, and HostedCluster tags
-                          take precedence in case of conflicts.
+                          These will be merged with HostedCluster scoped tags, which take precedence in case of conflicts.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
 
                           See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -436,11 +436,12 @@ spec:
                         type: object
                       resourceTags:
                         description: |-
-                          ResourceTags is an optional list of additional tags to apply to AWS node
-                          instances.
+                          resourceTags is an optional list of additional tags to apply to AWS node
+                          instances. Changes to this field will be propagated in-place to AWS EC2 instances and their initial EBS volumes.
+                          Volumes created by the storage operator and attached to instances after they are created do not get these tags applied.
 
-                          These will be merged with HostedCluster scoped tags, and HostedCluster tags
-                          take precedence in case of conflicts.
+                          These will be merged with HostedCluster scoped tags, which take precedence in case of conflicts.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
 
                           See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -460,11 +460,12 @@ spec:
                         type: object
                       resourceTags:
                         description: |-
-                          ResourceTags is an optional list of additional tags to apply to AWS node
-                          instances.
+                          resourceTags is an optional list of additional tags to apply to AWS node
+                          instances. Changes to this field will be propagated in-place to AWS EC2 instances and their initial EBS volumes.
+                          Volumes created by the storage operator and attached to instances after they are created do not get these tags applied.
 
-                          These will be merged with HostedCluster scoped tags, and HostedCluster tags
-                          take precedence in case of conflicts.
+                          These will be merged with HostedCluster scoped tags, which take precedence in case of conflicts.
+                          These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
 
                           See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for
                           information on tagging AWS resources. AWS supports a maximum of 50 tags per

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -3,6 +3,7 @@ package hostedcontrolplane
 import (
 	"context"
 	crand "crypto/rand"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -158,6 +159,12 @@ import (
 )
 
 const (
+	// LastAppliedSecurityGroupTagsAnnotation is an annotation that stores the last applied security group tags for the hosted cluster.
+	// This is used to track changes to security group tags and ensure that tags changes are applied to the default security group.
+	// The value is a JSON string containing the tags.
+	// Example: {"Name": "my-cluster", "Environment": "production"}
+	LastAppliedSecurityGroupTagsAnnotation = "hypershift.openshift.io/last-applied-security-group-tags"
+
 	finalizer                              = "hypershift.openshift.io/finalizer"
 	DefaultAdminKubeconfigKey              = "kubeconfig"
 	ImageStreamAutoscalerImage             = "cluster-autoscaler"
@@ -1445,7 +1452,7 @@ func (r *HostedControlPlaneReconciler) reconcile(ctx context.Context, hostedCont
 
 	r.Log.Info("Reconciling default security group")
 	if err := r.reconcileDefaultSecurityGroup(ctx, hostedControlPlane); err != nil {
-		return fmt.Errorf("failed to reconcile default security group")
+		return fmt.Errorf("failed to reconcile default security group: %w", err)
 	}
 
 	// TODO: consider using a side container in the etcd pod instead.
@@ -5277,10 +5284,52 @@ func (r *HostedControlPlaneReconciler) reconcileDefaultSecurityGroup(ctx context
 		// Not AWS platform, skip
 		return nil
 	}
+
 	if hcp.Status.Platform != nil && hcp.Status.Platform.AWS != nil && hcp.Status.Platform.AWS.DefaultWorkerSecurityGroupID != "" {
-		// Security group has already been created, nothing to do
+		// Security group has already been created, update tags if necessary and return.
+		lastAppliedTags, err := getLastAppliedSecurityGroupTags(hcp)
+		if err != nil {
+			return fmt.Errorf("failed to get last applied security group tags annotation: %w", err)
+		}
+
+		// if we failed to apply the annotation prviously, fallback to fetching the current tags from the SG resource directly.
+		if lastAppliedTags == nil {
+			sg, err := supportawsutil.GetSecurityGroupById(r.ec2Client, hcp.Status.Platform.AWS.DefaultWorkerSecurityGroupID)
+			if err != nil {
+				return fmt.Errorf("failed to get default security group: %w", err)
+			}
+			lastAppliedTags = supportawsutil.EC2TagsToMap(sg.Tags)
+		}
+
+		desiredTags := awsSecurityGroupTags(hcp)
+		changed, deleted, isDifferent := util.MapsDiff(lastAppliedTags, desiredTags)
+		if !isDifferent {
+			return nil
+		}
+
+		logger.Info("Security group tags have changed", "changed", changed, "deleted", deleted)
+		if err := supportawsutil.UpdateResourceTags(r.ec2Client, hcp.Status.Platform.AWS.DefaultWorkerSecurityGroupID, changed, deleted); err != nil {
+			if supportawsutil.IsPermissionsError(err) {
+				logger.Info("insufficient permissions to update security group tags", "sg", hcp.Status.Platform.AWS.DefaultWorkerSecurityGroupID)
+				return nil
+			}
+			return err
+		}
+
+		// Update the last-applied-security-group-tags annotation on the HCP with the tags applied to the SG.
+		// This is used to track changes to the tags and update them if necessary.
+		if err := util.UpdateObject(ctx, r.Client, hcp, func() error {
+			if err := updateLastAppliedSecurityGroupTagsAnnotation(hcp, desiredTags); err != nil {
+				return fmt.Errorf("failed to update last applied security group tags annotation")
+			}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("failed to update HostedControlPlane object: %w", err)
+		}
+
 		return nil
 	}
+
 	validProvider := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ValidAWSIdentityProvider))
 	if validProvider == nil || validProvider.Status != metav1.ConditionTrue {
 		logger.Info("Identity provider not ready. Skipping security group creation.")
@@ -5289,7 +5338,7 @@ func (r *HostedControlPlaneReconciler) reconcileDefaultSecurityGroup(ctx context
 
 	originalHCP := hcp.DeepCopy()
 	var condition *metav1.Condition
-	sgID, creationErr := createAWSDefaultSecurityGroup(ctx, r.ec2Client, hcp)
+	sgID, appliedTags, creationErr := createAWSDefaultSecurityGroup(ctx, r.ec2Client, hcp)
 	if creationErr != nil {
 		condition = &metav1.Condition{
 			Type:    string(hyperv1.AWSDefaultSecurityGroupCreated),
@@ -5298,6 +5347,18 @@ func (r *HostedControlPlaneReconciler) reconcileDefaultSecurityGroup(ctx context
 			Reason:  hyperv1.AWSErrorReason,
 		}
 	} else {
+		// Ensure the last-applied-security-group-tags annotation is set on the HCP on SG creation.
+		// This is used to track changes to the tags and update them if necessary.
+		if err := util.UpdateObject(ctx, r.Client, hcp, func() error {
+			if err := updateLastAppliedSecurityGroupTagsAnnotation(hcp, appliedTags); err != nil {
+				return fmt.Errorf("failed to update last applied security group tags annotation")
+			}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("failed to update HostedControlPlane object: %w", err)
+		}
+		originalHCP = hcp.DeepCopy()
+
 		condition = &metav1.Condition{
 			Type:    string(hyperv1.AWSDefaultSecurityGroupCreated),
 			Status:  metav1.ConditionTrue,
@@ -5336,13 +5397,12 @@ func awsSecurityGroupName(infraID string) string {
 	return fmt.Sprintf("%s-default-sg", infraID)
 }
 
-func createAWSDefaultSecurityGroup(ctx context.Context, ec2Client ec2iface.EC2API, hcp *hyperv1.HostedControlPlane) (string, error) {
+func createAWSDefaultSecurityGroup(ctx context.Context, ec2Client ec2iface.EC2API, hcp *hyperv1.HostedControlPlane) (string, map[string]string, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
 	var (
-		vpcID          = hcp.Spec.Platform.AWS.CloudProviderConfig.VPC
-		infraID        = hcp.Spec.InfraID
-		additionalTags = hcp.Spec.Platform.AWS.ResourceTags
+		vpcID   = hcp.Spec.Platform.AWS.CloudProviderConfig.VPC
+		infraID = hcp.Spec.InfraID
 	)
 
 	// Validate VPC exists
@@ -5351,15 +5411,15 @@ func createAWSDefaultSecurityGroup(ctx context.Context, ec2Client ec2iface.EC2AP
 	})
 	if err != nil {
 		logger.Error(err, "Failed to describe vpc", "vpcID", vpcID)
-		return "", fmt.Errorf("failed to describe vpc %s, code %s", vpcID, supportawsutil.AWSErrorCode(err))
+		return "", nil, fmt.Errorf("failed to describe vpc %s, code %s", vpcID, supportawsutil.AWSErrorCode(err))
 	}
 	if len(vpcResult.Vpcs) == 0 {
-		return "", fmt.Errorf("vpc %s not found", vpcID)
+		return "", nil, fmt.Errorf("vpc %s not found", vpcID)
 	}
 
 	if len(hcp.Spec.Networking.MachineNetwork) == 0 {
 		// Should never happen
-		return "", errors.New("failed to extract machine CIDR while creating default security group: hostedcontrolplane.spec.networking.machineNetwork length is 0")
+		return "", nil, errors.New("failed to extract machine CIDR while creating default security group: hostedcontrolplane.spec.networking.machineNetwork length is 0")
 	}
 	machineCIDRs := make([]string, len(hcp.Spec.Networking.MachineNetwork))
 	for i, mNet := range hcp.Spec.Networking.MachineNetwork {
@@ -5369,7 +5429,7 @@ func createAWSDefaultSecurityGroup(ctx context.Context, ec2Client ec2iface.EC2AP
 	// Search for an existing default worker security group and create one if not found
 	describeSGResult, err := ec2Client.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{Filters: awsSecurityGroupFilters(infraID)})
 	if err != nil {
-		return "", fmt.Errorf("cannot list security groups, code: %s", supportawsutil.AWSErrorCode(err))
+		return "", nil, fmt.Errorf("cannot list security groups, code: %s", supportawsutil.AWSErrorCode(err))
 	}
 	sgID := ""
 	var sg *ec2.SecurityGroup
@@ -5377,41 +5437,11 @@ func createAWSDefaultSecurityGroup(ctx context.Context, ec2Client ec2iface.EC2AP
 		sg = describeSGResult.SecurityGroups[0]
 		sgID = awssdk.StringValue(sg.GroupId)
 	}
+
+	var tags map[string]string
 	if sgID == "" {
 		// Create a security group if one is not found
-
-		tagKeys := sets.NewString()
-		var tags []*ec2.Tag
-		for _, tag := range additionalTags {
-			tagKeys.Insert(tag.Key)
-			tags = append(tags, &ec2.Tag{
-				Key:   awssdk.String(tag.Key),
-				Value: awssdk.String(tag.Value),
-			})
-		}
-		clusterKey := fmt.Sprintf("kubernetes.io/cluster/%s", infraID)
-		if !tagKeys.Has(clusterKey) {
-			tags = append(tags, &ec2.Tag{
-				Key:   awssdk.String(clusterKey),
-				Value: awssdk.String("owned"),
-			})
-		}
-		if !tagKeys.Has("Name") {
-			tags = append(tags, &ec2.Tag{
-				Key:   awssdk.String("Name"),
-				Value: awssdk.String(awsSecurityGroupName(infraID)),
-			})
-		}
-
-		if hcp.Spec.AutoNode != nil && hcp.Spec.AutoNode.Provisioner.Name == hyperv1.ProvisionerKarpeneter &&
-			hcp.Spec.AutoNode.Provisioner.Karpenter.Platform == hyperv1.AWSPlatform {
-			if !tagKeys.Has("karpenter.sh/discovery") {
-				tags = append(tags, &ec2.Tag{
-					Key:   awssdk.String("karpenter.sh/discovery"),
-					Value: awssdk.String(infraID),
-				})
-			}
-		}
+		tags = awsSecurityGroupTags(hcp)
 
 		createSGResult, err := ec2Client.CreateSecurityGroup(&ec2.CreateSecurityGroupInput{
 			GroupName:   awssdk.String(awsSecurityGroupName(infraID)),
@@ -5420,12 +5450,12 @@ func createAWSDefaultSecurityGroup(ctx context.Context, ec2Client ec2iface.EC2AP
 			TagSpecifications: []*ec2.TagSpecification{
 				{
 					ResourceType: awssdk.String("security-group"),
-					Tags:         tags,
+					Tags:         supportawsutil.MapToEC2Tags(tags),
 				},
 			},
 		})
 		if err != nil {
-			return "", fmt.Errorf("failed to create security group, code: %s", supportawsutil.AWSErrorCode(err))
+			return "", nil, fmt.Errorf("failed to create security group, code: %s", supportawsutil.AWSErrorCode(err))
 		}
 		sgID = awssdk.StringValue(createSGResult.GroupId)
 
@@ -5434,17 +5464,20 @@ func createAWSDefaultSecurityGroup(ctx context.Context, ec2Client ec2iface.EC2AP
 			GroupIds: []*string{awssdk.String(sgID)},
 		}
 		if err = ec2Client.WaitUntilSecurityGroupExistsWithContext(ctx, describeSGInput); err != nil {
-			return "", fmt.Errorf("failed to find created security group (id: %s), code: %s", sgID, supportawsutil.AWSErrorCode(err))
+			return "", nil, fmt.Errorf("failed to find created security group (id: %s), code: %s", sgID, supportawsutil.AWSErrorCode(err))
 		}
 
 		describeSGResult, err = ec2Client.DescribeSecurityGroups(describeSGInput)
 		if err != nil || len(describeSGResult.SecurityGroups) == 0 {
-			return "", fmt.Errorf("failed to fetch security group (id: %s), code: %s", sgID, supportawsutil.AWSErrorCode(err))
+			return "", nil, fmt.Errorf("failed to fetch security group (id: %s), code: %s", sgID, supportawsutil.AWSErrorCode(err))
 		}
 
 		sg = describeSGResult.SecurityGroups[0]
 		logger.Info("Created security group", "id", sgID)
+	} else {
+		tags = supportawsutil.EC2TagsToMap(sg.Tags)
 	}
+
 	ingressPermissions := supportawsutil.DefaultWorkerSGIngressRules(machineCIDRs, sgID, awssdk.StringValue(sg.OwnerId))
 	_, err = ec2Client.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
 		GroupId:       awssdk.String(sgID),
@@ -5452,11 +5485,68 @@ func createAWSDefaultSecurityGroup(ctx context.Context, ec2Client ec2iface.EC2AP
 	})
 	if err != nil {
 		if supportawsutil.AWSErrorCode(err) != "InvalidPermission.Duplicate" {
-			return "", fmt.Errorf("failed to set security group ingress rules, code: %s", supportawsutil.AWSErrorCode(err))
+			return "", nil, fmt.Errorf("failed to set security group ingress rules, code: %s", supportawsutil.AWSErrorCode(err))
 		}
 		logger.Info("WARNING: got duplicate permissions error when setting security group ingress permissions", "sgID", sgID)
 	}
-	return sgID, nil
+	return sgID, tags, nil
+}
+
+func updateLastAppliedSecurityGroupTagsAnnotation(hcp *hyperv1.HostedControlPlane, tags map[string]string) error {
+	if hcp.Annotations == nil {
+		hcp.Annotations = make(map[string]string)
+	}
+
+	jsonTags, err := json.Marshal(tags)
+	if err != nil {
+		return err
+	}
+
+	hcp.Annotations[LastAppliedSecurityGroupTagsAnnotation] = string(jsonTags)
+	return nil
+}
+
+func getLastAppliedSecurityGroupTags(hcp *hyperv1.HostedControlPlane) (map[string]string, error) {
+	tagsAnnotation, ok := hcp.Annotations[LastAppliedSecurityGroupTagsAnnotation]
+	if !ok {
+		return nil, nil
+	}
+
+	tags := make(map[string]string)
+	if err := json.Unmarshal([]byte(tagsAnnotation), &tags); err != nil {
+		return nil, err
+	}
+	return tags, nil
+}
+
+func awsSecurityGroupTags(hcp *hyperv1.HostedControlPlane) map[string]string {
+	var (
+		infraID        = hcp.Spec.InfraID
+		additionalTags = hcp.Spec.Platform.AWS.ResourceTags
+	)
+
+	tags := map[string]string{}
+	for _, tag := range additionalTags {
+		tags[tag.Key] = tag.Value
+	}
+
+	clusterKey := fmt.Sprintf("kubernetes.io/cluster/%s", infraID)
+	if _, exist := tags[clusterKey]; !exist {
+		tags[clusterKey] = "owned"
+	}
+
+	if _, exist := tags["Name"]; !exist {
+		tags["Name"] = awsSecurityGroupName(infraID)
+	}
+
+	if hcp.Spec.AutoNode != nil && hcp.Spec.AutoNode.Provisioner.Name == hyperv1.ProvisionerKarpeneter &&
+		hcp.Spec.AutoNode.Provisioner.Karpenter.Platform == hyperv1.AWSPlatform {
+		if _, exist := tags["karpenter.sh/discovery"]; !exist {
+			tags["karpenter.sh/discovery"] = infraID
+		}
+	}
+
+	return tags
 }
 
 func (r *HostedControlPlaneReconciler) destroyAWSDefaultSecurityGroup(ctx context.Context, hcp *hyperv1.HostedControlPlane) (string, error) {

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -1984,6 +1984,92 @@ func TestControlPlaneComponents(t *testing.T) {
 
 }
 
+func TestAWSSecurityGroupTags(t *testing.T) {
+	tests := []struct {
+		name         string
+		hcp          *hyperv1.HostedControlPlane
+		expectedTags map[string]string
+	}{
+		{
+			name: "No additional tags, no AutoNode",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					InfraID: "test-infra",
+					Platform: hyperv1.PlatformSpec{
+						AWS: &hyperv1.AWSPlatformSpec{
+							ResourceTags: []hyperv1.AWSResourceTag{},
+						},
+					},
+				},
+			},
+			expectedTags: map[string]string{
+				"kubernetes.io/cluster/test-infra": "owned",
+				"Name":                             "test-infra-default-sg",
+			},
+		},
+		{
+			name: "Additional tags override Name and cluster key",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					InfraID: "myinfra",
+					Platform: hyperv1.PlatformSpec{
+						AWS: &hyperv1.AWSPlatformSpec{
+							ResourceTags: []hyperv1.AWSResourceTag{
+								{Key: "Name", Value: "custom-name"},
+								{Key: "kubernetes.io/cluster/myinfra", Value: "shared"},
+								{Key: "foo", Value: "bar"},
+							},
+						},
+					},
+				},
+			},
+			expectedTags: map[string]string{
+				"Name":                          "custom-name",
+				"kubernetes.io/cluster/myinfra": "shared",
+				"foo":                           "bar",
+			},
+		},
+		{
+			name: "AutoNode with Karpenter AWS adds karpenter.sh/discovery",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					InfraID: "karpenter-infra",
+					Platform: hyperv1.PlatformSpec{
+						AWS: &hyperv1.AWSPlatformSpec{},
+					},
+					AutoNode: &hyperv1.AutoNode{
+						Provisioner: &hyperv1.ProvisionerConfig{
+							Name: hyperv1.ProvisionerKarpeneter,
+							Karpenter: &hyperv1.KarpenterConfig{
+								Platform: hyperv1.AWSPlatform,
+							},
+						},
+					},
+				},
+			},
+			expectedTags: map[string]string{
+				"kubernetes.io/cluster/karpenter-infra": "owned",
+				"Name":                                  "karpenter-infra-default-sg",
+				"karpenter.sh/discovery":                "karpenter-infra",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := awsSecurityGroupTags(tc.hcp)
+			if len(got) != len(tc.expectedTags) {
+				t.Errorf("expected %d tags, got %d: %v", len(tc.expectedTags), len(got), got)
+			}
+			for k, v := range tc.expectedTags {
+				if got[k] != v {
+					t.Errorf("expected tag %q=%q, got %q", k, v, got[k])
+				}
+			}
+		})
+	}
+}
+
 //go:embed testdata/featuregate-generator/feature-gate.yaml
 var testFeatureGateYAML string
 

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1494,10 +1494,11 @@ Volume
 </td>
 <td>
 <em>(Optional)</em>
-<p>ResourceTags is an optional list of additional tags to apply to AWS node
-instances.</p>
-<p>These will be merged with HostedCluster scoped tags, and HostedCluster tags
-take precedence in case of conflicts.</p>
+<p>resourceTags is an optional list of additional tags to apply to AWS node
+instances. Changes to this field will be propagated in-place to AWS EC2 instances and their initial EBS volumes.
+Volumes created by the storage operator and attached to instances after they are created do not get these tags applied.</p>
+<p>These will be merged with HostedCluster scoped tags, which take precedence in case of conflicts.
+These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.</p>
 <p>See <a href="https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html">https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html</a> for
 information on tagging AWS resources. AWS supports a maximum of 50 tags per
 resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
@@ -1613,7 +1614,11 @@ for the cluster. See
 <a href="https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html">https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html</a> for
 information on tagging AWS resources. AWS supports a maximum of 50 tags per
 resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
-for the user.</p>
+for the user.
+Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.</p>
 </td>
 </tr>
 <tr>

--- a/support/awsutil/errorcode.go
+++ b/support/awsutil/errorcode.go
@@ -6,10 +6,21 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
+const (
+	AuthFailure           = "AuthFailure"
+	UnauthorizedOperation = "UnauthorizedOperation"
+)
+
 func AWSErrorCode(err error) string {
 	var awsErr awserr.Error
 	if errors.As(err, &awsErr) {
 		return awsErr.Code()
 	}
 	return "Unknown"
+}
+
+// IsPermissionsError returns true if on aws permission errors.
+func IsPermissionsError(err error) bool {
+	code := AWSErrorCode(err)
+	return code == AuthFailure || code == UnauthorizedOperation
 }

--- a/support/util/maps.go
+++ b/support/util/maps.go
@@ -1,0 +1,34 @@
+package util
+
+// MapsDiff compares two maps and returns a map of changed/created keys with their new values, a map of deleted keys,
+// and a boolean indicating if there are any differences.
+func MapsDiff(current, input map[string]string) (changed map[string]string, deleted map[string]string, different bool) {
+	deleted = make(map[string]string)
+	changed = make(map[string]string)
+	different = false
+
+	for k, v := range current {
+		newValue, exists := input[k]
+		// If the key is not in the input map, marke it as deleted
+		if !exists {
+			deleted[k] = v
+			different = true
+			continue
+		}
+
+		// If the value is different, mark it as changed
+		if newValue != v {
+			changed[k] = newValue
+			different = true
+		}
+	}
+
+	for k, v := range input {
+		if _, exists := current[k]; !exists {
+			changed[k] = v
+			different = true
+		}
+	}
+
+	return changed, deleted, different
+}

--- a/support/util/maps_test.go
+++ b/support/util/maps_test.go
@@ -1,0 +1,77 @@
+package util
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestMapsDiff(t *testing.T) {
+	g := NewWithT(t)
+	tests := []struct {
+		name              string
+		current           map[string]string
+		input             map[string]string
+		expectedChanged   map[string]string
+		expectedDeleted   map[string]string
+		expectedDifferent bool
+	}{
+		{
+			name:              "Nil maps",
+			current:           nil,
+			input:             nil,
+			expectedChanged:   map[string]string{},
+			expectedDeleted:   map[string]string{},
+			expectedDifferent: false,
+		},
+		{
+			name:              "Nil current, non-empty input",
+			current:           nil,
+			input:             map[string]string{"x": "y"},
+			expectedChanged:   map[string]string{"x": "y"},
+			expectedDeleted:   map[string]string{},
+			expectedDifferent: true,
+		},
+		{
+			name:              "Nil input, non-empty current",
+			current:           map[string]string{"x": "y"},
+			input:             nil,
+			expectedChanged:   map[string]string{},
+			expectedDeleted:   map[string]string{"x": "y"},
+			expectedDifferent: true,
+		},
+		{
+			name:              "Multiple changes and deletions",
+			current:           map[string]string{"a": "1", "b": "2", "c": "3"},
+			input:             map[string]string{"a": "2", "d": "4"},
+			expectedChanged:   map[string]string{"a": "2", "d": "4"},
+			expectedDeleted:   map[string]string{"b": "2", "c": "3"},
+			expectedDifferent: true,
+		},
+		{
+			name:              "Empty string values",
+			current:           map[string]string{"a": "", "b": "2"},
+			input:             map[string]string{"a": "", "b": ""},
+			expectedChanged:   map[string]string{"b": ""},
+			expectedDeleted:   map[string]string{},
+			expectedDifferent: true,
+		},
+		{
+			name:              "Same keys, different order",
+			current:           map[string]string{"a": "1", "b": "2"},
+			input:             map[string]string{"b": "2", "a": "1"},
+			expectedChanged:   map[string]string{},
+			expectedDeleted:   map[string]string{},
+			expectedDifferent: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			changed, deleted, different := MapsDiff(tc.current, tc.input)
+			g.Expect(changed).To(Equal(tc.expectedChanged), "Changed: expected %v, got %v", tc.expectedChanged, changed)
+			g.Expect(deleted).To(Equal(tc.expectedDeleted), "Deleted: expected %v, got %v", tc.expectedDeleted, deleted)
+			g.Expect(different).To(Equal(tc.expectedDifferent), "Different: expected %v, got %v", tc.expectedDifferent, different)
+		})
+	}
+}

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	kubeclient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -78,6 +79,21 @@ func CopyConfigMap(cm, source *corev1.ConfigMap) {
 	for k, v := range source.Data {
 		cm.Data[k] = v
 	}
+}
+
+func UpdateObject[T client.Object](ctx context.Context, c client.Client, obj T, mutate func() error) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+			return err
+		}
+
+		original := obj.DeepCopyObject().(T)
+		if err := mutate(); err != nil {
+			return err
+		}
+
+		return c.Patch(ctx, obj, client.MergeFrom(original))
+	})
 }
 
 func DeleteIfNeededWithOptions(ctx context.Context, c client.Client, o client.Object, opts ...client.DeleteOption) (exists bool, err error) {

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/aws.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/aws.go
@@ -32,11 +32,12 @@ type AWSNodePoolPlatform struct {
 	// +optional
 	RootVolume *Volume `json:"rootVolume,omitempty"`
 
-	// ResourceTags is an optional list of additional tags to apply to AWS node
-	// instances.
+	// resourceTags is an optional list of additional tags to apply to AWS node
+	// instances. Changes to this field will be propagated in-place to AWS EC2 instances and their initial EBS volumes.
+	// Volumes created by the storage operator and attached to instances after they are created do not get these tags applied.
 	//
-	// These will be merged with HostedCluster scoped tags, and HostedCluster tags
-	// take precedence in case of conflicts.
+	// These will be merged with HostedCluster scoped tags, which take precedence in case of conflicts.
+	// These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
 	//
 	// See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for
 	// information on tagging AWS resources. AWS supports a maximum of 50 tags per
@@ -230,6 +231,10 @@ type AWSPlatformSpec struct {
 	// information on tagging AWS resources. AWS supports a maximum of 50 tags per
 	// resource. OpenShift reserves 25 tags for its use, leaving 25 tags available
 	// for the user.
+	// Changes to this field will be propagated in-place to AWS resources (VPC Endpoints, EC2 instances, initial EBS volumes and default/endpoint security groups).
+	// These tags will be propagated to the infrastructure CR in the guest cluster, where other OCP operators might choose to honor this input to reconcile AWS resources created by them.
+	// Please consult the official documentation for a list of all AWS resources that support in-place tag updates.
+	// These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
 	//
 	// +kubebuilder:validation:MaxItems=25
 	// +optional


### PR DESCRIPTION
**What this PR does / why we need it**:
manual backport of https://github.com/openshift/hypershift/pull/6320, https://github.com/openshift/hypershift/pull/6603 and https://github.com/openshift/hypershift/pull/6615

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.