### PR TITLE
OCPBUGS-59547: Remove code associated with Managed Identity v2 for ARO HCP for 4.19

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/config.go
@@ -51,7 +51,7 @@ func adaptConfigSecret(cpContext component.WorkloadContext, secret *corev1.Secre
 }
 
 func adaptSecretProvider(cpContext component.WorkloadContext, secretProvider *secretsstorev1.SecretProviderClass) error {
-	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, cpContext.HCP.Spec.Platform.Azure.ManagedIdentities.ControlPlane.CloudProvider, true)
+	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, cpContext.HCP.Spec.Platform.Azure.ManagedIdentities.ControlPlane.CloudProvider)
 	return nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cno/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cno/azure.go
@@ -9,6 +9,6 @@ import (
 
 func adaptAzureSecretProvider(cpContext component.WorkloadContext, secretProvider *secretsstorev1.SecretProviderClass) error {
 	managedIdentity := cpContext.HCP.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Network
-	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, managedIdentity, true)
+	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, managedIdentity)
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ingressoperator/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ingressoperator/azure.go
@@ -9,6 +9,6 @@ import (
 
 func adaptAzureSecretProvider(cpContext component.WorkloadContext, secretProvider *secretsstorev1.SecretProviderClass) error {
 	managedIdentity := cpContext.HCP.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Ingress
-	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, managedIdentity, true)
+	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, managedIdentity)
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms/azure.go
@@ -249,6 +249,6 @@ func buildVolumeKMSSecretStore(v *corev1.Volume) {
 
 func AdaptAzureSecretProvider(cpContext component.WorkloadContext, secretProvider *secretsstorev1.SecretProviderClass) error {
 	managedIdentity := cpContext.HCP.Spec.SecretEncryption.KMS.Azure.KMS
-	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, managedIdentity, true)
+	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, managedIdentity)
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/registryoperator/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/registryoperator/azure.go
@@ -9,6 +9,6 @@ import (
 
 func adaptAzureSecretProvider(cpContext component.WorkloadContext, secretProvider *secretsstorev1.SecretProviderClass) error {
 	managedIdentity := cpContext.HCP.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ImageRegistry
-	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, managedIdentity, true)
+	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, managedIdentity)
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/storage/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/storage/azure.go
@@ -52,7 +52,7 @@ func adaptAzureCSIDiskSecret(cpContext component.WorkloadContext, secret *corev1
 
 func adaptAzureCSIDiskSecretProvider(cpContext component.WorkloadContext, secretProvider *secretsstorev1.SecretProviderClass) error {
 	managedIdentity := cpContext.HCP.Spec.Platform.Azure.ManagedIdentities.ControlPlane.Disk
-	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, managedIdentity, true)
+	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, managedIdentity)
 	return nil
 }
 
@@ -63,6 +63,6 @@ func adaptAzureCSIFileSecret(cpContext component.WorkloadContext, secret *corev1
 
 func adaptAzureCSIFileSecretProvider(cpContext component.WorkloadContext, secretProvider *secretsstorev1.SecretProviderClass) error {
 	managedIdentity := cpContext.HCP.Spec.Platform.Azure.ManagedIdentities.ControlPlane.File
-	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, managedIdentity, true)
+	secretproviderclass.ReconcileManagedAzureSecretProviderClass(secretProvider, cpContext.HCP, managedIdentity)
 	return nil
 }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -1913,16 +1913,10 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
 		}
 	case hyperv1.AzurePlatform:
-		// TODO - MIv3 - this release version check can be removed once 4.18 and 4.19 both support MIv3
-		hcVersion := releaseImageVersion
-		hcVersion.Pre = nil
-		hcVersion.Build = nil
-
 		// Reconcile CPO SecretProviderClass CR
 		cpoSecretProviderClass := cpomanifests.ManagedAzureSecretProviderClass(config.ManagedAzureCPOSecretProviderClassName, hcp.Namespace)
 		if _, err = createOrUpdate(ctx, r, cpoSecretProviderClass, func() error {
-			// TODO - MIv3 - this release version check can be removed once 4.18 and 4.19 both support MIv3
-			secretproviderclass.ReconcileManagedAzureSecretProviderClass(cpoSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ControlPlaneOperator, hcVersion.GE(config.Version419))
+			secretproviderclass.ReconcileManagedAzureSecretProviderClass(cpoSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ControlPlaneOperator)
 			return nil
 		}); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile control plane operator secret provider class: %w", err)
@@ -1931,8 +1925,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		// Reconcile CAPZ SecretProviderClass CR
 		nodepoolMgmtSecretProviderClass := cpomanifests.ManagedAzureSecretProviderClass(config.ManagedAzureNodePoolMgmtSecretProviderClassName, hcp.Namespace)
 		if _, err = createOrUpdate(ctx, r, nodepoolMgmtSecretProviderClass, func() error {
-			// TODO - MIv3 - this release version check can be removed once 4.18 and 4.19 both support MIv3
-			secretproviderclass.ReconcileManagedAzureSecretProviderClass(nodepoolMgmtSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.NodePoolManagement, hcVersion.GE(config.Version419))
+			secretproviderclass.ReconcileManagedAzureSecretProviderClass(nodepoolMgmtSecretProviderClass, hcp, hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.NodePoolManagement)
 			return nil
 		}); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile nodepool management secret provider class: %w", err)
@@ -1942,7 +1935,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 			// Reconcile KMS SecretProviderClass CR
 			kmsSecretProviderClass := cpomanifests.ManagedAzureSecretProviderClass(config.ManagedAzureKMSSecretProviderClassName, hcp.Namespace)
 			if _, err := createOrUpdate(ctx, r, kmsSecretProviderClass, func() error {
-				secretproviderclass.ReconcileManagedAzureSecretProviderClass(kmsSecretProviderClass, hcp, hcp.Spec.SecretEncryption.KMS.Azure.KMS, hcVersion.GE(config.Version419))
+				secretproviderclass.ReconcileManagedAzureSecretProviderClass(kmsSecretProviderClass, hcp, hcp.Spec.SecretEncryption.KMS.Azure.KMS)
 				return nil
 			}); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to reconcile KMS SecretProviderClass: %w", err)

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
@@ -255,39 +255,25 @@ func reconcileAzureCluster(azureCluster *capiazure.AzureCluster, hcluster *hyper
 // reconcileAzureClusterIdentity creates a CAPZ AzureClusterIdentity custom resource using UserAssignedIdentityCredentials
 // as the Azure authentication method. More information on this custom resource type can be found here: https://capz.sigs.k8s.io/topics/identities
 func reconcileAzureClusterIdentity(hc *hyperv1.HostedCluster, azureClusterIdentity *capiazure.AzureClusterIdentity, controlPlaneNamespace string, payloadVersion *semver.Version) error {
-	if payloadVersion.GE(config.Version419) {
-		// Translate the HyperShift cloud value to a valid CAPZ cloud value
-		azureCloudType, err := parseCloudType(hc.Spec.Platform.Azure.Cloud)
-		if err != nil {
-			return err
-		}
-
-		// Create a AzureClusterIdentity with the Azure authentication type UserAssignedIdentityCredentials
-		azureClusterIdentity.Spec = capiazure.AzureClusterIdentitySpec{
-			TenantID:                                 hc.Spec.Platform.Azure.TenantID,
-			UserAssignedIdentityCredentialsCloudType: azureCloudType,
-			UserAssignedIdentityCredentialsPath:      config.ManagedAzureCertificatePath + hc.Spec.Platform.Azure.ManagedIdentities.ControlPlane.NodePoolManagement.CredentialsSecretName,
-			Type:                                     capiazure.UserAssignedIdentityCredential,
-			AllowedNamespaces: &capiazure.AllowedNamespaces{
-				NamespaceList: []string{
-					controlPlaneNamespace,
-				},
-			},
-		}
-	} else {
-		// TODO - MIv3 - this release version check can be removed once 4.18 and 4.19 both support MIv3
-		azureClusterIdentity.Spec = capiazure.AzureClusterIdentitySpec{
-			ClientID: hc.Spec.Platform.Azure.ManagedIdentities.ControlPlane.NodePoolManagement.ClientID,
-			TenantID: hc.Spec.Platform.Azure.TenantID,
-			CertPath: config.ManagedAzureCertificatePath + hc.Spec.Platform.Azure.ManagedIdentities.ControlPlane.NodePoolManagement.CertificateName,
-			Type:     capiazure.ServicePrincipalCertificate,
-			AllowedNamespaces: &capiazure.AllowedNamespaces{
-				NamespaceList: []string{
-					controlPlaneNamespace,
-				},
-			},
-		}
+	// Translate the HyperShift cloud value to a valid CAPZ cloud value
+	azureCloudType, err := parseCloudType(hc.Spec.Platform.Azure.Cloud)
+	if err != nil {
+		return err
 	}
+
+	// Create a AzureClusterIdentity with the Azure authentication type UserAssignedIdentityCredentials
+	azureClusterIdentity.Spec = capiazure.AzureClusterIdentitySpec{
+		TenantID:                                 hc.Spec.Platform.Azure.TenantID,
+		UserAssignedIdentityCredentialsCloudType: azureCloudType,
+		UserAssignedIdentityCredentialsPath:      config.ManagedAzureCertificatePath + hc.Spec.Platform.Azure.ManagedIdentities.ControlPlane.NodePoolManagement.CredentialsSecretName,
+		Type:                                     capiazure.UserAssignedIdentityCredential,
+		AllowedNamespaces: &capiazure.AllowedNamespaces{
+			NamespaceList: []string{
+				controlPlaneNamespace,
+			},
+		},
+	}
+
 	return nil
 }
 

--- a/support/config/constants.go
+++ b/support/config/constants.go
@@ -61,11 +61,7 @@ const (
 	// management cluster's resource group in Azure.
 	AROHCPKeyVaultManagedIdentityClientID = "ARO_HCP_KEY_VAULT_USER_CLIENT_ID"
 
-	ManagedAzureCredentialsFilePath = "MANAGED_AZURE_HCP_CREDENTIALS_FILE_PATH"
-	// TODO - MIv3 - this release version check can be removed once 4.18 and 4.19 both support MIv3
-	ManagedAzureClientIdEnvVarKey            = "ARO_HCP_MI_CLIENT_ID"
-	ManagedAzureTenantIdEnvVarKey            = "ARO_HCP_TENANT_ID"
-	ManagedAzureCertificatePathEnvVarKey     = "ARO_HCP_CLIENT_CERTIFICATE_PATH"
+	ManagedAzureCredentialsFilePath          = "MANAGED_AZURE_HCP_CREDENTIALS_FILE_PATH"
 	ManagedAzureSecretProviderClassEnvVarKey = "ARO_HCP_SECRET_PROVIDER_CLASS"
 	ManagedAzureCertificateMountPath         = "/mnt/certs"
 	ManagedAzureCredentialsMountPathForKMS   = "/mnt/kms"

--- a/support/secretproviderclass/secretproviderclass.go
+++ b/support/secretproviderclass/secretproviderclass.go
@@ -24,14 +24,6 @@ array:
 //
 // https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-identity-access?tabs=azure-portal&pivots=access-with-a-user-assigned-managed-identity
 func ReconcileManagedAzureSecretProviderClass(secretProviderClass *secretsstorev1.SecretProviderClass, hcp *hyperv1.HostedControlPlane, managedIdentity hyperv1.ManagedIdentity, isMIv3 ...bool) {
-	// TODO - MIv3 - this if can be removed once CS supports only CredentialsSecret and it can be passed in directly to formatSecretProviderClassObject; also remove isMIv3 once everything has been converted over in 4.19 and 4.18 to MIv3
-	var secretName string
-	if len(isMIv3) > 0 && isMIv3[0] {
-		secretName = managedIdentity.CredentialsSecretName
-	} else {
-		secretName = managedIdentity.CertificateName
-	}
-
 	secretProviderClass.Spec = secretsstorev1.SecretProviderClassSpec{
 		Provider: "azure",
 		Parameters: map[string]string{
@@ -40,7 +32,7 @@ func ReconcileManagedAzureSecretProviderClass(secretProviderClass *secretsstorev
 			"userAssignedIdentityID": azureutil.GetKeyVaultAuthorizedUser(),
 			"keyvaultName":           hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ManagedIdentitiesKeyVault.Name,
 			"tenantId":               hcp.Spec.Platform.Azure.ManagedIdentities.ControlPlane.ManagedIdentitiesKeyVault.TenantID,
-			"objects":                formatSecretProviderClassObject(secretName, string(managedIdentity.ObjectEncoding)),
+			"objects":                formatSecretProviderClassObject(managedIdentity.CredentialsSecretName, string(managedIdentity.ObjectEncoding)),
 		},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Overall, this PR removes code associated with Managed Identity v2. Specifically, this PR:
 
- updates the reconciliation of any SecretProviderClass CR to only use MIv3
- removes the ability to use ClientCertificate Authentication when reconciling the AzureClusterIdentity
- removes Azure constants associated with Managed Identity v2.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.