### PR TITLE
CNTRLPLANE-1116: add gitlint support for conventional commit enforcement

### DIFF
--- a/.cursor/rules/code-formatting.mdc
+++ b/.cursor/rules/code-formatting.mdc
@@ -1,0 +1,9 @@
+---
+description: Code formatting rules for the project.
+alwaysApply: true
+---
+# Code Quality and Formatting
+
+- Use `make lint-fix` after writing Go code to automatically fix most linting issues
+- Run `make verify` to verify both linting and tests pass before committing
+- For markdown files, use `make verify-codespell` to catch spelling errors 

--- a/.cursor/rules/git-commit-format.mdc
+++ b/.cursor/rules/git-commit-format.mdc
@@ -1,0 +1,60 @@
+---
+description: generating a conventional commit message when commiting to git
+alwaysApply: false
+---
+
+# Commit Message Formatting Rules
+
+**When to apply**: When generating commit messages or discussing commit practices
+
+## Commit Message Format
+
+Use conventional commits format:
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+Signed-off-by: <name> <email>
+Assisted-by: <model-name> (via Cursor)
+```
+
+## Commit Types
+
+- **feat**: New features
+- **fix**: Bug fixes  
+- **docs**: Documentation changes
+- **style**: Code style changes
+- **refactor**: Code refactoring
+- **test**: Adding/updating tests
+- **chore**: Maintenance tasks
+- **build**: Build system or dependencies
+- **ci**: CI/CD changes
+- **perf**: Performance improvements
+- **revert**: Revert previous commit
+
+## Examples
+
+```bash
+feat(SRVKP-123): Add webhook controller for GitHub integration
+
+Fixes an issue with the webhook controller for GitHub integration
+```
+
+```bash
+fix(controller): Update pipeline reconciliation logic
+
+Resolves issue with concurrent pipeline runs
+```
+
+## Gitlint Integration
+
+- The project uses gitlint to enforce commit message format
+- gitlint can be run by using this command `make run-gitlint`
+- Ensure all commit messages pass gitlint validation
+- Common gitlint rules to follow:
+  - Conventional commit format
+  - Proper line length limits
+  - Required footers
+  - No trailing whitespace

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,14 @@
+# gitlint documentation is found here - https://jorisroovers.com/gitlint/latest/
+# conventional commit documentation is found here - https://www.conventionalcommits.org/en/v1.0.0/
+
+[general]
+contrib=contrib-title-conventional-commits
+
+[contrib-title-conventional-commits]
+types = fix,feat,chore,docs,style,refactor,perf,test,revert,ci,build
+
+[title-max-length]
+line-length=120
+
+[body-max-line-length]
+line-length=120

--- a/docs/content/contribute/index.md
+++ b/docs/content/contribute/index.md
@@ -3,29 +3,35 @@ title: Contribute to HyperShift
 ---
 
 # Contributing to HyperShift
-Thanks for your interest in contributing to HyperShift. Here are some guidelines that help make the process more straightforward for everyone.
+Thank you for your interest in contributing to HyperShift! HyperShift enables running multiple OpenShift control planes as lightweight, cost-effective hosted clusters. Your contributions help improve this critical infrastructure technology.
+
+The following guidelines will help ensure a smooth contribution process for both contributors and maintainers.
 
 ## Prior to Submitting a Pull Request
-1. Prior to committing your code
-   1. Install `precommit`. The precommit hooks run on pre-commit and pre-push. The hooks will catch spelling mistakes,
-   make verify issues, unit test issues, and more.
-        1. Instructions for installing `precommit` can be found [here](https://pre-commit.com/#install).
-        2. Tips on using `precommit` hooks in the HyperShift repo can be found [here](./precommit-hook-help.md).
-   2. Run `make pre-commit`. This updates all Golang and API dependencies, builds the source code, builds the e2e tests, verifies source code format, and runs all unit tests. This will help catch issues before committing so that the verify and unit test CI jobs will not fail on your PR.
-2. Before submitting your pull request on GitHub, look at your changes and try to view them from the eyes of a reviewer.
-    1. Try to find the aspects that might not immediately make sense for someone else and explain them in the pull request description.
-3. Keep commits/changes scoped to one thing and as minimal as possible.
-    1. Always keep refactorings (how we do something) separate from logic changes (what we do).
-    2. If you find additional things along the way that you feel should be improved, do that in a separate pull request.
-    3. This helps ensure that you will get a timely review of your change, as a series of small pull requests is a lot easier to review than one big pull request that changes 10 independent things for independent reasons.
-4. Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit, e.g. `Mark infraID as required` instead of `This patch marks infraID as required`.
-    1. This follows Git’s own built-in conventions; see [github.com/openshift/hypershift/pull/485](https://github.com/openshift/hypershift/pull/485) as an example.
-5. Make sure the "Why" and "How" are included in the message of each commit.
+1. **Keep changes focused**: Scope commits to one thing and keep them minimal. Separate refactoring from logic changes, and save additional improvements for separate PRs.
+
+2. **Test your changes**: Run `make pre-commit` to update dependencies, build code, verify formatting, and run tests. This prevents CI failures on your PR.
+
+3. **Review before submitting**: Look at your changes from a reviewer's perspective and explain anything that might not be immediately clear in your PR description.
+
+4. **Use proper commit format**: 
+    1. Write commit subjects in [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) (e.g., "Fix bug" not "Fixed bug")
+    2. Follow [conventional commit format](https://www.conventionalcommits.org/) and include "Why" and "How" in commit messages
+
+!!! tip "Install precommit hooks"
+    Install `precommit` to automatically catch issues before committing. This helps catch spelling mistakes, formatting issues, and test failures early in your development process.
+    
+    * [Installation instructions](https://pre-commit.com/#install)
+    * [HyperShift-specific tips](./precommit-hook-help.md)
 
 ## Creating a Pull Request
-1. For small changes, you can just do the change and submit a pull request with it.
-2. For bigger changes (more than 200 lines of code diff), do not just do the change but, ask for feedback on the idea and direction of the change first (Either in a GitHub issue or the #project-hypershift channel in the External Red Hat Slack).
-    1. This avoids situations where big changes are submitted that are then declined or never reviewed, which is frustrating for everyone.
-3. Regardless of the size of the change, always explain how the change will improve the project.
-4. Every PR title must be prefixed with the Jira ticket that is addressing e.g. [https://github.com/openshift/hypershift/pull/2233](https://github.com/openshift/hypershift/pull/2233).
-5. This repository is the base code for the Hypershift Operator and the Control Plane Operator (belongs to the OCP payload) so they might have different release cadence.
+1. **For small changes** (under 200 lines): Create your change and submit a pull request directly.
+
+2. **For larger changes** (200+ lines): Get feedback on your approach first by opening a GitHub issue or posting in the #project-hypershift Slack channel. This prevents situations where large changes get declined after significant work.
+
+3. **Write a clear PR title**: Prefix with your Jira ticket number (e.g., "OCPBUGS-12345: Fix memory leak in controller"). See [example PR](https://github.com/openshift/hypershift/pull/2233).
+
+4. **Explain the value**: Always describe how your change improves the project in the PR description.
+
+!!! note "Release Information"
+    This repository contains code for both the HyperShift Operator and Control Plane Operator (part of OCP payload), which may have different release cadences.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR:
- adds gitlint support for conventional commit enforcement
- updates the upstream contribute page to be more concise, improve readability and flow
- adds cursor rules for generating conventional commits

**Which issue(s) this PR fixes**:
Fixes [CNTRLPLANE-1116](https://issues.redhat.com/browse/CNTRLPLANE-1116)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.