### PR TITLE
OCPBUGS-59842: Set etcd cli default timeout to 60s

### DIFF
--- a/etcd-defrag/etcddefrag_controller.go
+++ b/etcd-defrag/etcddefrag_controller.go
@@ -25,6 +25,7 @@ import (
 )
 
 const (
+	defaultClientTimeout                   = 60 * time.Second
 	pollWaitDuration                       = 2 * time.Second
 	pollTimeoutDuration                    = 60 * time.Second
 	maxDefragFailuresBeforeDegrade         = 3
@@ -116,6 +117,10 @@ https://github.com/openshift/cluster-etcd-operator/tree/master/pkg/etcdcli
 
 func (r *DefragController) runDefrag(ctx context.Context) error {
 	// Do not defrag if any of the cluster members are unhealthy.
+	// need to set etcd cli timeout as it may be stuck by the network or server
+	// set the defaultClientTImeout just as equal to 60s, to be compatible with pollTimeoutDuration
+	ctx, cancel := context.WithTimeout(ctx, defaultClientTimeout)
+	defer cancel()
 	members, err := r.etcdClient.MemberList(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
Fix potential etcd client stuck phenomenon

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #
https://issues.redhat.com/browse/OCPBUGS-59842

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.