### PR TITLE
Add ability for customer to modify ImageTagMirrorSets and ImageDigestMirrorSources to add customer registries

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -182,3 +182,5 @@ $ go work vendor
 ```
 
 Now when running vscode, open the workspace directory to work with hypershift code.
+
+Add hack for new pr task for copilot


### PR DESCRIPTION
Add the following feature:
Customer Can mirror non-RH registry images by tag using ImageTagMirrorSets
Customer Can mirror non-RH registry images by digest using ImageDigestMirrorSets
Customer has a way to specify IDMS and ITMS in a similar fashion as in OpenShift (https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/images/image-configuration#images-configuration-registry-mirror_image-configuration