### PR TITLE
OCPBUGS-57316: hypershift version in CLI returns panics for Server Version when HyperShift operator is deployed

### DIFF
--- a/support/supportedversion/version.go
+++ b/support/supportedversion/version.go
@@ -256,7 +256,7 @@ func GetSupportedOCPVersions(ctx context.Context, namespace string, client crcli
 
 	if supportedVersions == nil {
 		// Fetch the supported versions ConfigMap from the specified namespace
-		supportedVersions := manifests.ConfigMap(namespace)
+		supportedVersions = manifests.ConfigMap(namespace)
 		if err := client.Get(ctx, crclient.ObjectKeyFromObject(supportedVersions), supportedVersions); err != nil {
 			return SupportedVersions{}, "", fmt.Errorf("failed to find supported versions on the server: %v", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR ensures that `manifests.ConfigMap()` is correctly assigned to `supportedVersions` in the `GetSupportedOCPVersions()` function. This prevents the panic caused by `hypershift version` when retrieving the Server Version.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-57316](https://issues.redhat.com/browse/OCPBUGS-57316)
Blocking #[CNTRLPLANE-262](https://issues.redhat.com/browse/CNTRLPLANE-262)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.