### PR TITLE
ho: exclude kube-apiserver-custom fake route from admission

### DIFF
--- a/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
+++ b/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
@@ -139,9 +139,6 @@ func (r *SharedIngressReconciler) generateConfig(ctx context.Context) (string, [
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "kube-apiserver-custom",
 					Namespace: hcpNamespace,
-					Labels: map[string]string{
-						util.HCPRouteLabel: "true",
-					},
 				},
 				Spec: routev1.RouteSpec{
 					Host: hc.Spec.KubeAPIServerDNSName,


### PR DESCRIPTION
https://github.com/openshift/hypershift/pull/6338 introduced a fake Route (i.e. not existing in the KAS) add KubeAPIServerDNSName support to the shared ingress router.  However, that list of Routes is later used to admit the Routes, which fails on the fake Route as it does not exist.

This commit removes the HCP label from the fake Route, which causes it to be skipped during the admission code.