### PR TITLE
MGMT-20826: Add CLI validation to ensure Console is disabled when Ingress is disabled

### DIFF
--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -731,6 +731,11 @@ func (opts *RawCreateOptions) Validate(ctx context.Context) (*ValidatedCreateOpt
 		}
 	}
 
+	disabledCaps := sets.NewString(opts.DisableClusterCapabilities...)
+	if disabledCaps.Has(string(hyperv1.IngressCapability)) && !disabledCaps.Has(string(hyperv1.ConsoleCapability)) {
+		return nil, fmt.Errorf("ingress capability can only be disabled if Console capability is also disabled")
+	}
+
 	if len(opts.KubeAPIServerDNSName) > 0 {
 		if err := validation.IsDNS1123Subdomain(opts.KubeAPIServerDNSName); len(err) > 0 {
 			return nil, fmt.Errorf("KubeAPIServerDNSName failed DNS validation: %s", strings.Join(err[:], " "))

--- a/cmd/cluster/core/create_test.go
+++ b/cmd/cluster/core/create_test.go
@@ -298,6 +298,61 @@ func TestValidate(t *testing.T) {
 			},
 			expectedErr: "",
 		},
+		{
+			name: "fails when ingress is disabled but console is not disabled",
+			rawOpts: &RawCreateOptions{
+				Name:                       "test-hc",
+				Namespace:                  "test-hc",
+				PullSecretFile:             pullSecretFile,
+				Arch:                       "amd64",
+				DisableClusterCapabilities: []string{"Ingress"},
+			},
+			expectedErr: "ingress capability can only be disabled if Console capability is also disabled",
+		},
+		{
+			name: "passes when both ingress and console are disabled",
+			rawOpts: &RawCreateOptions{
+				Name:                       "test-hc",
+				Namespace:                  "test-hc",
+				PullSecretFile:             pullSecretFile,
+				Arch:                       "amd64",
+				DisableClusterCapabilities: []string{"Ingress", "Console"},
+			},
+			expectedErr: "",
+		},
+		{
+			name: "passes when only console is disabled without ingress",
+			rawOpts: &RawCreateOptions{
+				Name:                       "test-hc",
+				Namespace:                  "test-hc",
+				PullSecretFile:             pullSecretFile,
+				Arch:                       "amd64",
+				DisableClusterCapabilities: []string{"Console"},
+			},
+			expectedErr: "",
+		},
+		{
+			name: "passes when ingress and console are disabled along with other capabilities",
+			rawOpts: &RawCreateOptions{
+				Name:                       "test-hc",
+				Namespace:                  "test-hc",
+				PullSecretFile:             pullSecretFile,
+				Arch:                       "amd64",
+				DisableClusterCapabilities: []string{"Ingress", "Console", "ImageRegistry"},
+			},
+			expectedErr: "",
+		},
+		{
+			name: "fails when ingress is disabled with other capabilities but console is not disabled",
+			rawOpts: &RawCreateOptions{
+				Name:                       "test-hc",
+				Namespace:                  "test-hc",
+				PullSecretFile:             pullSecretFile,
+				Arch:                       "amd64",
+				DisableClusterCapabilities: []string{"Ingress", "ImageRegistry"},
+			},
+			expectedErr: "ingress capability can only be disabled if Console capability is also disabled",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Although CEL validation already exists, it was decided to add this validation to the CLI as well, for platforms where the infra is created before applying the HC.

**Checklist**
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [X] This change includes unit tests.