### PR TITLE
OCPBUGS-43824: Help fix flaky NTO tests

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_controller_manager_deployment.yaml
@@ -108,6 +108,8 @@ spec:
         - --cluster-signing-duration=17520h
         - --tls-cert-file=/etc/kubernetes/certs/server/tls.crt
         - --tls-private-key-file=/etc/kubernetes/certs/server/tls.key
+        - --terminated-pod-gc-threshold=1000
+        - --concurrent-gc-syncs=5
         - --cluster-cidr=10.132.0.0/14
         - --service-cluster-ip-range=
         - --node-monitor-grace-period=50s
@@ -240,9 +242,12 @@ spec:
           successThreshold: 1
           timeoutSeconds: 10
         resources:
+          limits:
+            cpu: "1"
+            memory: 1Gi
           requests:
-            cpu: 60m
-            memory: 400Mi
+            cpu: 100m
+            memory: 600Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/kubernetes

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents_kube_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents_kube_controller_manager_deployment.yaml
@@ -108,6 +108,8 @@ spec:
         - --cluster-signing-duration=17520h
         - --tls-cert-file=/etc/kubernetes/certs/server/tls.crt
         - --tls-private-key-file=/etc/kubernetes/certs/server/tls.key
+        - --terminated-pod-gc-threshold=1000
+        - --concurrent-gc-syncs=5
         - --cluster-cidr=10.132.0.0/14
         - --service-cluster-ip-range=
         - --node-monitor-grace-period=50s
@@ -241,9 +243,12 @@ spec:
           successThreshold: 1
           timeoutSeconds: 10
         resources:
+          limits:
+            cpu: "1"
+            memory: 1Gi
           requests:
-            cpu: 60m
-            memory: 400Mi
+            cpu: 100m
+            memory: 600Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/kubernetes

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-controller-manager/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-controller-manager/deployment.yaml
@@ -48,6 +48,8 @@ spec:
         - --cluster-signing-duration=17520h
         - --tls-cert-file=/etc/kubernetes/certs/server/tls.crt
         - --tls-private-key-file=/etc/kubernetes/certs/server/tls.key
+        - --terminated-pod-gc-threshold=1000
+        - --concurrent-gc-syncs=5
         command:
         - hyperkube
         - kube-controller-manager
@@ -79,8 +81,11 @@ spec:
           timeoutSeconds: 10
         resources:
           requests:
-            cpu: 60m
-            memory: 400Mi
+            cpu: 100m
+            memory: 600Mi
+          limits:
+            cpu: 1000m
+            memory: 1Gi
         volumeMounts:
         - mountPath: /var/run/kubernetes
           name: certs

--- a/test/e2e/util/client.go
+++ b/test/e2e/util/client.go
@@ -16,8 +16,10 @@ func GetConfig() (*rest.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	cfg.QPS = 100
-	cfg.Burst = 100
+	// Increased QPS and Burst to handle multiple parallel tests and polling operations
+	// Previous values (QPS=100, Burst=100) were insufficient for concurrent NodePool polling
+	cfg.QPS = 200
+	cfg.Burst = 300
 	cfg.Timeout = 5 * time.Minute
 	return cfg, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

1. Example of issue 1 - rate limiting in https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.20-periodics-e2e-aks/1947567107805810688
2. Example of issue 2 - KCM restarting during node cleanup - https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.20-periodics-e2e-aks/1947478585400889344

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.