### PR TITLE
NO-JIRA: test: remove CPOv2 annotation from upgrade test

### DIFF
--- a/test/e2e/upgrade_hypershift_operator_test.go
+++ b/test/e2e/upgrade_hypershift_operator_test.go
@@ -74,8 +74,6 @@ func TestUpgradeHyperShiftOperator(t *testing.T) {
 				obj.Labels = make(map[string]string)
 			}
 			obj.Labels[hostedClusterUpgradeTestLabel] = "true"
-			// TODO: remove when the switch to CPOv2 is merged and the new HO version is used as the init image for this test.
-			obj.Annotations["hypershift.openshift.io/cpo-v2"] = "true"
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove temporary hypershift.openshift.io/cpo-v2 annotation and related
TODO comment from the HyperShift operator upgrade test.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.