### PR TITLE
Fix OCPBUGS-54720: HCP payload doesn't respect multiple

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/deployment.go
@@ -2,15 +2,18 @@ package ignitionserver
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"maps"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
 	"github.com/openshift/hypershift/support/api"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/proxy"
+	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
 	"github.com/openshift/hypershift/support/util"
 
@@ -19,6 +22,9 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (ign *ignitionServer) adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
@@ -50,7 +56,12 @@ func (ign *ignitionServer) adaptDeployment(cpContext component.WorkloadContext, 
 		})
 	}
 
-	registryOverrides, err := ign.getRegistryOverrides(cpContext.ReleaseImageProvider)
+	pullSecret := common.PullSecret(cpContext.HCP.Namespace)
+	if err := cpContext.Client.Get(cpContext.Context, client.ObjectKeyFromObject(pullSecret), pullSecret); err != nil {
+		return err
+	}
+	pullSecretBytes := pullSecret.Data[corev1.DockerConfigJsonKey]
+	registryOverrides, err := ign.getRegistryOverrides(context.Background(), cpContext.ReleaseImageProvider, pullSecretBytes)
 	if err != nil {
 		return err
 	}
@@ -89,7 +100,7 @@ func (ign *ignitionServer) adaptDeployment(cpContext component.WorkloadContext, 
 	return nil
 }
 
-func (ign *ignitionServer) getRegistryOverrides(imageProvider imageprovider.ReleaseImageProvider) (map[string]string, error) {
+func (ign *ignitionServer) getRegistryOverrides(ctx context.Context, imageProvider imageprovider.ReleaseImageProvider, pullSecret []byte) (map[string]string, error) {
 	configAPIImage := imageProvider.GetImage("cluster-config-api")
 	machineConfigOperatorImage := imageProvider.GetImage("machine-config-operator")
 	clusterAuthenticationOperatorImage := imageProvider.GetImage("cluster-authentication-operator")
@@ -99,15 +110,15 @@ func (ign *ignitionServer) getRegistryOverrides(imageProvider imageprovider.Rele
 
 	// Determine if we need to override the machine config operator and cluster config operator
 	// images based on image mappings present in management cluster.
-	overrideConfigAPIImage, err := lookupMappedImage(ocpRegistryMapping, configAPIImage)
+	overrideConfigAPIImage, err := lookupMappedImage(ctx, ocpRegistryMapping, configAPIImage, pullSecret)
 	if err != nil {
 		return nil, err
 	}
-	overrideMachineConfigOperatorImage, err := lookupMappedImage(ocpRegistryMapping, machineConfigOperatorImage)
+	overrideMachineConfigOperatorImage, err := lookupMappedImage(ctx, ocpRegistryMapping, machineConfigOperatorImage, pullSecret)
 	if err != nil {
 		return nil, err
 	}
-	overrideClusterAuthenticationOperatorImage, err := lookupMappedImage(ocpRegistryMapping, clusterAuthenticationOperatorImage)
+	overrideClusterAuthenticationOperatorImage, err := lookupMappedImage(ctx, ocpRegistryMapping, clusterAuthenticationOperatorImage, pullSecret)
 	if err != nil {
 		return nil, err
 	}
@@ -126,15 +137,23 @@ func (ign *ignitionServer) getRegistryOverrides(imageProvider imageprovider.Rele
 	return registryOverrides, nil
 }
 
-func lookupMappedImage(ocpOverrides map[string][]string, image string) (string, error) {
+func lookupMappedImage(ctx context.Context, ocpOverrides map[string][]string, image string, pullSecret []byte) (string, error) {
+	log := ctrl.LoggerFrom(ctx)
 	ref, err := reference.Parse(image)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse image (%s): %w", image, err)
 	}
 	for source, replacements := range ocpOverrides {
 		if ref.AsRepository().String() == source {
-			newRef := fmt.Sprintf("%s@%s", replacements[0], ref.ID)
-			return newRef, nil
+			for _, replacement := range replacements {
+				newRef := fmt.Sprintf("%s@%s", replacement, ref.ID)
+				// Verify mirror image availability.
+				if _, _, _, err = registryclient.GetMetadata(ctx, newRef, pullSecret); err == nil {
+					return newRef, nil
+				}
+				log.Info("WARNING: The current mirrors image is unavailable, continue Scanning multiple mirrors", "error", err.Error(), "mirror image", ref)
+				continue
+			}
 		}
 	}
 	return image, nil

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/deployment_test.go
@@ -1,0 +1,59 @@
+package ignitionserver
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestLookupMappedImage(t *testing.T) {
+	testsCases := []struct {
+		name        string
+		overrides   map[string][]string
+		image       string
+		expectedImg string
+	}{
+		{
+			name:        "no overrides provided",
+			overrides:   map[string][]string{},
+			image:       "quay.io/openshift-release-dev/ocp-release:4.15.0-rc.0-multi",
+			expectedImg: "quay.io/openshift-release-dev/ocp-release:4.15.0-rc.0-multi",
+		},
+		{
+			name: "exact repository match found, and multiple mirrors",
+			overrides: map[string][]string{
+				"quay.io/openshift-release-dev/ocp-release": {
+					"myregistry1.io/openshift-release-dev/ocp-release",
+					"quay.io/openshifttest/ocp-release",
+				},
+			},
+			image:       "quay.io/openshift-release-dev/ocp-release@sha256:b272d47dded73ec8d9eb01a8e39cd62a453d2799c1785ecd538aa8cd15693bf0",
+			expectedImg: "quay.io/openshifttest/ocp-release@sha256:b272d47dded73ec8d9eb01a8e39cd62a453d2799c1785ecd538aa8cd15693bf0",
+		},
+		{
+			name: "repository match not found",
+			overrides: map[string][]string{
+				"quay.io/openshift-release-dev/ocp-release": {
+					"myregistry1.io/openshift-release-dev/ocp-release",
+				},
+			},
+			image:       "quay.io/test-namespace/testimage:latest",
+			expectedImg: "quay.io/test-namespace/testimage:latest",
+		},
+	}
+
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			g := NewGomegaWithT(t)
+			pullSecret, err := os.ReadFile("../../../../../hack/dev/fakePullSecret.json")
+			if err != nil {
+				t.Fatalf("failed to read pull secret file: %v", err)
+			}
+			img, _ := lookupMappedImage(ctx, tc.overrides, tc.image, pullSecret)
+			g.Expect(img).To(Equal(tc.expectedImg), fmt.Sprintf("Expected image reference to be equal to: %s, \nbut got: %s", tc.expectedImg, img))
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
+ Enhance registry override to properly handle multiple mirrors
+ Add image availability verification and fallback mechanism

**Which issue(s) this PR fixes** 
Fixes # OCPBUGS-54720

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.