### PR TITLE
NO-JIRA: refactor(azure): extract AKS managed identity setup into separate script

### DIFF
--- a/contrib/managed-azure/setup_aks_cluster.sh
+++ b/contrib/managed-azure/setup_aks_cluster.sh
@@ -20,8 +20,6 @@ az group create \
 --name ${AKS_RG} \
 --location ${LOCATION}
 
-az identity create --name $AKS_CP_MI_NAME --resource-group $PERSISTENT_RG_NAME
-az identity create --name $AKS_KUBELET_MI_NAME --resource-group $PERSISTENT_RG_NAME
 export AKS_CP_MI_ID=$(az identity show --name $AKS_CP_MI_NAME --resource-group $PERSISTENT_RG_NAME --query id -o tsv)
 export AKS_KUBELET_MI_ID=$(az identity show --name $AKS_KUBELET_MI_NAME --resource-group $PERSISTENT_RG_NAME --query id -o tsv)
 

--- a/contrib/managed-azure/setup_aks_mi.sh
+++ b/contrib/managed-azure/setup_aks_mi.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -x
+
+# Prerequisites.
+PREFIX="${PREFIX:-}"
+PERSISTENT_RG_NAME="${PERSISTENT_RG_NAME:-}"
+
+# Local.
+AKS_CP_MI_NAME="${PREFIX}-aks-mi"
+AKS_KUBELET_MI_NAME="${PREFIX}-aks-kubelet-mi"
+
+az identity create --name $AKS_CP_MI_NAME --resource-group $PERSISTENT_RG_NAME
+az identity create --name $AKS_KUBELET_MI_NAME --resource-group $PERSISTENT_RG_NAME
+
+set +x

--- a/contrib/managed-azure/setup_all.sh
+++ b/contrib/managed-azure/setup_all.sh
@@ -21,6 +21,7 @@ if [[ "$1" == "--first-time" ]]; then
   "${SCRIPT_DIR}/setup_MIv3_kv.sh"
   "${SCRIPT_DIR}/setup_oidc_provider.sh"
   "${SCRIPT_DIR}/setup_dataplane_identities.sh"
+  "${SCRIPT_DIR}/setup_aks_mi.sh"
 fi
 
 # Per-cluster setup scripts


### PR DESCRIPTION
- Move managed identity creation from setup_aks_cluster.sh to setup_aks_mi.sh
- Add setup_aks_mi.sh to first-time setup flow in setup_all.sh
- Improves modularity and reusability of Azure identity setup

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.