### PR TITLE
OCPBUGS-59759: fix(konflux): Add missing backslash for dot escaping

### DIFF
--- a/.tekton/hypershift-operator-main-pull-request.yaml
+++ b/.tekton/hypershift-operator-main-pull-request.yaml
@@ -11,7 +11,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "main"
-      && files.all.exists(x, !x.matches('^(?:docs|examples|enhancements|contrib)/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|renovate\.json)$'))
+      && files.all.exists(x, !x.matches('^(?:docs|examples|enhancements|contrib)/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|renovate\\.json)$'))
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: hypershift-operator

--- a/.tekton/hypershift-operator-main-push.yaml
+++ b/.tekton/hypershift-operator-main-push.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "main"
-      && files.all.exists(x, !x.matches('^(?:docs|examples|enhancements|contrib)/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|renovate\.json)$'))
+      && files.all.exists(x, !x.matches('^(?:docs|examples|enhancements|contrib)/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|renovate\\.json)$'))
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: hypershift-operator

--- a/.tekton/hypershift-operator-main-tag.yaml
+++ b/.tekton/hypershift-operator-main-tag.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch.matches("refs/tags/v0.1.*")
-      && files.all.exists(x, !x.matches('^(?:docs|examples|enhancements|contrib)/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|renovate\.json)$'))
+      && files.all.exists(x, !x.matches('^(?:docs|examples|enhancements|contrib)/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE|renovate\\.json)$'))
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: hypershift-operator


### PR DESCRIPTION
**What this PR does / why we need it**:

In the renovate introducing commit, instead of two backslashes there was a single one, making the CEL checks fail.

**Which issue(s) this PR fixes**:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.