### PR TITLE
NO-JIRA: fix: set terminationMessagePolicy to FallbackToLogsOnError for olm-collect-profiles

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/olm-collect-profiles.cronjob.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/olm-collect-profiles.cronjob.yaml
@@ -34,6 +34,7 @@ spec:
                 requests:
                   cpu: 10m
                   memory: 80Mi
+              terminationMessagePolicy: FallbackToLogsOnError
           volumes:
             - name: config-volume
               configMap:


### PR DESCRIPTION
All pods on the hosted control plane should have the terminationMessagePolicy set to FallbackToLogsOnError. This pod was missed because it is only sometimes present on in the HCP during the test run depending on its random cron schedule.

https://github.com/openshift/hypershift/pull/6291 merged yesterday and this is causing flakes in 4.19 tests.