### PR TITLE
feat(cmd/dump): add CronJobs to dump

### DIFF
--- a/cmd/cluster/core/dump.go
+++ b/cmd/cluster/core/dump.go
@@ -76,6 +76,7 @@ var (
 		&appsv1.ReplicaSet{},
 		&appsv1.StatefulSet{},
 		&batchv1.Job{},
+		&batchv1.CronJob{},
 		&corev1.ConfigMap{},
 		&corev1.Endpoints{},
 		&corev1.Event{},


### PR DESCRIPTION
While attempting to verify a change to the olm-collect-profiles I noticed that CronJobs are not included in the hosted cluster dump.
