### PR TITLE
[release-4.19] CNTRLPLANE-1034: sharedingress: Add support for kube-apiserver whitelist CIDRs

### DIFF
--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -2459,13 +2459,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -2495,13 +2495,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -2450,13 +2450,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -2471,13 +2471,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -2692,13 +2692,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -2846,13 +2846,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -2468,13 +2468,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -2526,13 +2526,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -2602,13 +2602,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -2450,13 +2450,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -2358,13 +2358,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -2394,13 +2394,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -2349,13 +2349,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -2370,13 +2370,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -2591,13 +2591,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -2745,13 +2745,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -2367,13 +2367,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -2425,13 +2425,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -2501,13 +2501,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -2349,13 +2349,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
@@ -3161,13 +3161,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
@@ -2873,13 +2873,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
@@ -3072,13 +3072,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
@@ -3060,13 +3060,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
@@ -2772,13 +2772,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
@@ -2971,13 +2971,22 @@ spec:
                           rule: self == oldSelf
                       allowedCIDRBlocks:
                         description: |-
-                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+                          allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
                           If not specified, traffic is allowed from all addresses.
-                          This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges
+                          This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+                          For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+                          If the platform does not support LoadBalancerSourceRanges, this field may have no effect.
                         items:
-                          pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
+                          maxLength: 43
                           type: string
+                          x-kubernetes-validations:
+                          - message: cidr must be a valid IPv4 or IPv6 CIDR notation
+                              (e.g., 192.168.1.0/24 or 2001:db8::/64)
+                            rule: self.matches('^((\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2})$')
+                              || self.matches('^([0-9a-fA-F]{0,4}:){2,7}([0-9a-fA-F]{0,4})?/[0-9]{1,3}$')
+                        maxItems: 50
                         type: array
+                        x-kubernetes-list-type: set
                       port:
                         description: |-
                           port is the port at which the APIServer is exposed inside a node. Other

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -7,6 +7,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/events"
 	"github.com/openshift/hypershift/support/util"
@@ -84,8 +85,11 @@ func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingSt
 	default:
 		return fmt.Errorf("invalid publishing strategy for Kube API server service: %s", strategy.Type)
 	}
-	svc.Spec.LoadBalancerSourceRanges = apiAllowedCIDRBlocks
 	svc.Spec.Ports[0] = portSpec
+
+	if !azureutil.IsAroHCP() {
+		svc.Spec.LoadBalancerSourceRanges = apiAllowedCIDRBlocks
+	}
 	return nil
 }
 

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1132,9 +1132,12 @@ This value is immutable.</p>
 </em>
 </td>
 <td>
-<p>allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer
+<em>(Optional)</em>
+<p>allowedCIDRBlocks is an allow list of CIDR blocks that can access the APIServer.
 If not specified, traffic is allowed from all addresses.
-This depends on underlying support by the cloud provider for Service LoadBalancerSourceRanges</p>
+This field is enforced for ARO (Azure Red Hat OpenShift) via the shared-ingress HAProxy.
+For platforms other than ARO, the enforcement depends on whether the underlying cloud provider supports the Service LoadBalancerSourceRanges field.
+If the platform does not support LoadBalancerSourceRanges, this field may have no effect.</p>
 </td>
 </tr>
 </tbody>
@@ -4174,6 +4177,7 @@ APIServerNetworking
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>apiServer contains advanced network settings for the API server that affect
 how the APIServer is exposed inside a hosted cluster node.</p>
 </td>

--- a/hypershift-operator/controllers/sharedingress/router_config.template
+++ b/hypershift-operator/controllers/sharedingress/router_config.template
@@ -30,10 +30,16 @@ frontend dataplane-kas-svc
 
   {{- range .Backends }}
   acl is_{{ .Name }} var(sess.cluster_id) -m str {{ .ClusterID }}
+  {{- if .AllowedCIDRs }}
+  acl is_{{ .Name }}_request_allowed src {{ .AllowedCIDRs }}
   {{- end }}
+  {{- end }}
+
   {{- range .Backends }}
-  use_backend {{ .Name }} if is_{{ .Name }}
+  use_backend {{ .Name }} if is_{{ .Name }}{{ if .AllowedCIDRs }} is_{{ .Name }}_request_allowed{{ end }}
   {{- end }}
+
+  default_backend no-match
 
 # Frontends support any traffic coming from external DNS.
 frontend external-dns
@@ -41,12 +47,22 @@ frontend external-dns
   tcp-request inspect-delay 5s
   tcp-request content accept if { req_ssl_hello_type 1 }
 
+  tcp-request content set-var(sess.src_ip) src
+
+  log-format "%{+Q}o\ src_ip = %[var(sess.src_ip)], %ci:%cp / %si:%sp -> %fi:%fp [%t] %ft %b/%s %Tw/%Tc/%Tt %B %ts %ac/%fc/%bc/%sc/%rc %sq/%bq"
+
   {{- range .ExternalDNSBackends }}
   acl is_{{ .Name }} req_ssl_sni -i {{ .HostName }}
+  {{- if .AllowedCIDRs }}
+  acl is_{{ .Name }}_request_allowed src {{ .AllowedCIDRs }}
   {{- end }}
+  {{- end }}
+
   {{- range .ExternalDNSBackends }}
-  use_backend {{ .Name }} if is_{{ .Name }}
+  use_backend {{ .Name }} if is_{{ .Name }}{{ if .AllowedCIDRs }} is_{{ .Name }}_request_allowed{{ end }}
   {{- end }}
+
+  default_backend no-match
 
 listen health_check_http_url
   bind :::9444 v4v6
@@ -62,5 +78,8 @@ backend {{ .Name }}
 # Backends support any traffic coming from external DNS.
 {{- range .ExternalDNSBackends }}
 backend {{ .Name }}
-  server {{ .Name }} {{ .DestinationServiceIP }}:{{.DestinationPort}}
+  server {{ .Name }} {{ .SVCIP }}:{{.SVCPort}}
 {{- end}}
+
+backend no-match
+  tcp-request content reject

--- a/hypershift-operator/controllers/sharedingress/testdata/zz_fixture_TestGenerateConfig_When_there_s_two_HostedClusters_with_all_their_Routes_and_SVCs_it_should_generate_the_config_with_frontends_and_backends_for_both.cfg
+++ b/hypershift-operator/controllers/sharedingress/testdata/zz_fixture_TestGenerateConfig_When_there_s_two_HostedClusters_with_all_their_Routes_and_SVCs_it_should_generate_the_config_with_frontends_and_backends_for_both.cfg
@@ -29,30 +29,42 @@ frontend dataplane-kas-svc
   log-format "%{+Q}o\ cluster_id = %[var(sess.cluster_id)], %ci:%cp -> %fi:%fp [%t] %ft %b/%s %Tw/%Tc/%Tt %B %ts %ac/%fc/%bc/%sc/%rc %sq/%bq"
   acl is_test-hc1-kube-apiserver var(sess.cluster_id) -m str hc1-UUID
   acl is_test-hc2-kube-apiserver var(sess.cluster_id) -m str hc2-UUID
+  acl is_test-hc2-kube-apiserver_request_allowed src 1.1.1.1/32 192.168.1.1/24
   use_backend test-hc1-kube-apiserver if is_test-hc1-kube-apiserver
-  use_backend test-hc2-kube-apiserver if is_test-hc2-kube-apiserver
+  use_backend test-hc2-kube-apiserver if is_test-hc2-kube-apiserver is_test-hc2-kube-apiserver_request_allowed
+
+  default_backend no-match
 
 # Frontends support any traffic coming from external DNS.
 frontend external-dns
   bind :::8443 v4v6
   tcp-request inspect-delay 5s
   tcp-request content accept if { req_ssl_hello_type 1 }
+
+  tcp-request content set-var(sess.src_ip) src
+
+  log-format "%{+Q}o\ src_ip = %[var(sess.src_ip)], %ci:%cp / %si:%sp -> %fi:%fp [%t] %ft %b/%s %Tw/%Tc/%Tt %B %ts %ac/%fc/%bc/%sc/%rc %sq/%bq"
   acl is_test-hc1-ignition req_ssl_sni -i ignition-server.example.com
   acl is_test-hc1-konnectivity req_ssl_sni -i konnectivity.example.com
   acl is_test-hc1-apiserver req_ssl_sni -i kube-apiserver-public.example.com
   acl is_test-hc1-oauth req_ssl_sni -i oauth-public.example.com
+  acl is_test-hc1-apiserver-custom req_ssl_sni -i kube-apiserver-public-custom.example.com
   acl is_test-hc2-ignition req_ssl_sni -i ignition-server.example.com
   acl is_test-hc2-konnectivity req_ssl_sni -i konnectivity.example.com
   acl is_test-hc2-apiserver req_ssl_sni -i kube-apiserver-public.example.com
+  acl is_test-hc2-apiserver_request_allowed src 1.1.1.1/32 192.168.1.1/24
   acl is_test-hc2-oauth req_ssl_sni -i oauth-public.example.com
   use_backend test-hc1-ignition if is_test-hc1-ignition
   use_backend test-hc1-konnectivity if is_test-hc1-konnectivity
   use_backend test-hc1-apiserver if is_test-hc1-apiserver
   use_backend test-hc1-oauth if is_test-hc1-oauth
+  use_backend test-hc1-apiserver-custom if is_test-hc1-apiserver-custom
   use_backend test-hc2-ignition if is_test-hc2-ignition
   use_backend test-hc2-konnectivity if is_test-hc2-konnectivity
-  use_backend test-hc2-apiserver if is_test-hc2-apiserver
+  use_backend test-hc2-apiserver if is_test-hc2-apiserver is_test-hc2-apiserver_request_allowed
   use_backend test-hc2-oauth if is_test-hc2-oauth
+
+  default_backend no-match
 
 listen health_check_http_url
   bind :::9444 v4v6
@@ -74,6 +86,8 @@ backend test-hc1-apiserver
   server test-hc1-apiserver 4.4.4.4:6443
 backend test-hc1-oauth
   server test-hc1-oauth 3.3.3.3:6443
+backend test-hc1-apiserver-custom
+  server test-hc1-apiserver-custom 4.4.4.4:6443
 backend test-hc2-ignition
   server test-hc2-ignition 1.1.1.1:443
 backend test-hc2-konnectivity
@@ -82,3 +96,6 @@ backend test-hc2-apiserver
   server test-hc2-apiserver 4.4.4.4:6443
 backend test-hc2-oauth
   server test-hc2-oauth 3.3.3.3:6443
+
+backend no-match
+  tcp-request content reject


### PR DESCRIPTION
**What this PR does / why we need it**:
manual backport of https://github.com/openshift/hypershift/pull/6366

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.