### PR TITLE
CNTRLPLANE-905: Fix hermetic pipelines for Shared ingress.

### DIFF
--- a/.tekton/hypershift-shared-ingress-main-pull-request.yaml
+++ b/.tekton/hypershift-shared-ingress-main-pull-request.yaml
@@ -11,7 +11,8 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
       && target_branch == "main"
-      && files.all.exists(x, x.matches('^shared-ingress/'))
+      && ( "^shared-ingress/***".pathChanged() ||
+           ".tekton/hypershift-shared-ingress*".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: hypershift-shared-ingress
@@ -33,7 +34,13 @@ spec:
     value:
     - linux/x86_64
   - name: dockerfile
-    value: /shared-ingress/Containerfile
+    value: /Containerfile
+  - name: hermetic
+    value: "true"
+  - name: path-context
+    value: shared-ingress
+  - name: prefetch-input
+    value: '[{"type": "rpm", "path": "shared-ingress"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -187,6 +194,8 @@ spec:
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
+      - name: dev-package-managers
+        value: true
       runAfter:
       - clone-repository
       taskRef:

--- a/.tekton/hypershift-shared-ingress-main-push.yaml
+++ b/.tekton/hypershift-shared-ingress-main-push.yaml
@@ -10,7 +10,8 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
       && target_branch == "main"
-      && files.all.exists(x, x.matches('^shared-ingress/'))
+      && ( "^shared-ingress/***".pathChanged() ||
+           ".tekton/hypershift-shared-ingress*".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: hypershift-shared-ingress
@@ -31,9 +32,13 @@ spec:
     - linux/x86_64
     - linux/arm64
   - name: dockerfile
-    value: /shared-ingress/Containerfile
+    value: /Containerfile
   - name: hermetic
     value: "true"
+  - name: path-context
+    value: shared-ingress
+  - name: prefetch-input
+    value: '[{"type": "rpm", "path": "shared-ingress"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -187,6 +192,8 @@ spec:
         value: $(params.output-image).prefetch
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
+      - name: dev-package-managers
+        value: true
       runAfter:
       - clone-repository
       taskRef:


### PR DESCRIPTION
**What this PR does / why we need it**:

Add hermetic build support for the on-pr pipeline of the shared-ingress. This is necessary because the build is set to hermetic on push and without checking it properly on-pull-request, we might break the pipeline.

**Which issue(s) this PR fixes**:
Fixes #[CNTRLPLANE-905](https://issues.redhat.com//browse/CNTRLPLANE-905)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.