### PR TITLE
CNTRLPLANE-1020: Add EnsureGlobalPullSecret to be executed in 4.19 test suite

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1523,7 +1523,7 @@ func EnsureGuestWebhooksValidated(t *testing.T, ctx context.Context, guestClient
 }
 
 func EnsureGlobalPullSecret(t *testing.T, ctx context.Context, mgmtClient crclient.Client, entryHostedCluster *hyperv1.HostedCluster) error {
-	AtLeast(t, Version420)
+	AtLeast(t, Version419)
 
 	if entryHostedCluster.Spec.Platform.Type != hyperv1.AzurePlatform {
 		t.Skip("test only supported on platform ARO")


### PR DESCRIPTION
## What this PR does / why we need it**
This PR makes sure EnsureGlobalPullSecret E2E test can be executed in 4.19 OCP. This PR to fully works need the depending PR bellow to be merged, otherwise could block the CI.

## Which issue(s) this PR fixes
- Fixes #[CNTRLPLANE-1020](https://issues.redhat.com/browse/CNTRLPLANE-1020)

## Depending PRs
- https://github.com/openshift/hypershift/pull/6507