### PR TITLE
CNTRLPLANE-1190: Support control plane overrides by platform

### DIFF
--- a/docs/content/contribute/cpo-overrides.md
+++ b/docs/content/contribute/cpo-overrides.md
@@ -1,0 +1,167 @@
+# CPO Overrides Configuration Guide
+
+## Overview
+
+The CPO (Control Plane Operator) overrides mechanism allows you to specify custom Control Plane Operator images for specific OpenShift versions and platforms. This is particularly useful for applying hotfixes and patches before they're officially released.
+
+## Configuration File Structure
+
+The CPO overrides are configured using a YAML file with the following structure:
+
+```yaml
+platforms:
+  aws:
+    overrides:
+      - version: "4.17.9"
+        cpoImage: "quay.io/hypershift/control-plane-operator:4.17.9"
+      - version: "4.17.8"
+        cpoImage: "quay.io/hypershift/control-plane-operator:4.17.8"
+    testing:
+      latest: "quay.io/openshift-release-dev/ocp-release:4.17.9-x86_64"
+      previous: "quay.io/openshift-release-dev/ocp-release:4.17.8-x86_64"
+  azure:
+    overrides:
+      - version: "4.16.17"
+        cpoImage: "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1a50894aafa6b750bf890ef147a20699ff5b807e586d15506426a8a615580797"
+      - version: "4.16.18"
+        cpoImage: "quay.io/hypershift/hypershift-cpo:patch"
+```
+
+## Configuration Elements
+
+### Platforms Section
+
+The top-level `platforms` section contains platform-specific configurations. Currently supported platforms:
+
+- **`aws`**: Amazon Web Services
+- **`azure`**: Microsoft Azure
+
+Each platform section is optional. If a platform is not configured, the default CPO image from the OpenShift release will be used.
+
+### Platform Configuration
+
+Each platform can contain:
+
+#### `overrides` (Array)
+A list of version-specific CPO image overrides:
+
+- **`version`** (string): The exact OpenShift version (e.g., "4.17.9", "4.16.17")
+- **`cpoImage`** (string): The full container image reference to use for this version
+
+#### `testing` (Object, Optional)
+Configuration for automated testing:
+
+- **`latest`** (string): The latest OpenShift release image for testing
+- **`previous`** (string): The previous OpenShift release image for testing
+
+## Configuration Examples
+
+### Basic Platform-Specific Override
+
+```yaml
+platforms:
+  aws:
+    overrides:
+      - version: "4.17.9"
+        cpoImage: "quay.io/myorg/custom-cpo-aws:4.17.9"
+```
+
+### Multiple Versions and Platforms
+
+```yaml
+platforms:
+  aws:
+    overrides:
+      - version: "4.17.9"
+        cpoImage: "quay.io/hypershift/control-plane-operator-aws:4.17.9"
+      - version: "4.17.8"
+        cpoImage: "quay.io/hypershift/control-plane-operator-aws:4.17.8"
+      - version: "4.16.15"
+        cpoImage: "quay.io/hotfix/cpo-aws:4.16.15-hotfix"
+    testing:
+      latest: "quay.io/openshift-release-dev/ocp-release:4.17.9-x86_64"
+      previous: "quay.io/openshift-release-dev/ocp-release:4.17.8-x86_64"
+  azure:
+    overrides:
+      - version: "4.17.9"
+        cpoImage: "quay.io/hypershift/control-plane-operator-azure:4.17.9"
+      - version: "4.16.20"
+        cpoImage: "quay.io/security-fix/cpo-azure:4.16.20-security"
+```
+
+## How It Works
+
+### Image Resolution Process
+
+1. **Override Check**: When a HostedCluster is created or updated, the system checks if CPO overrides are enabled
+2. **Platform Lookup**: The system looks up overrides for the specific platform (case-insensitive)
+3. **Version Match**: If the platform exists, it searches for an exact version match
+4. **Fallback**: If no override is found, the default CPO image from the OpenShift release is used
+
+### Platform Handling
+
+- Platform names are **case-insensitive** (`AWS`, `aws`, `Aws` all work)
+- Unknown platforms return empty string (graceful degradation)
+- Missing platforms in configuration are handled safely (no panics)
+
+## Enabling CPO Overrides
+
+CPO overrides are controlled by an environment variable on the HyperShift operator:
+
+```bash
+export ENABLE_CPO_OVERRIDES=1
+```
+
+When this environment variable is set to `1`, the override system is activated. Without this variable, all overrides are ignored and default images are used.
+
+## File Locations
+
+The override configuration files are embedded in the binary at build time:
+
+`hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml`
+
+
+## Best Practices
+
+### Version Management
+- Use exact version strings (e.g., "4.17.9", not "4.17.x")
+- Keep override lists sorted by version for maintainability
+
+### Image References
+- Use full image references including registry and tag/digest
+- Prefer digest references for production overrides for immutability
+
+### Platform Configuration
+- Only configure platforms that need overrides
+- Keep platform-specific testing configurations separate
+- Document the purpose of each override in comments
+
+### Testing
+- The test section allows specifying a pair of release images to use for a single hypershift e2e test run. Currently only a single pair can be specified per platform. If multiple releases need to be tested, create a clone of your override PR and specify a different pair of images to test in the clone. The clone shouldn't be merged, it should
+only be used for testing.
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Override Not Applied**
+   - Check if `ENABLE_CPO_OVERRIDES=1` is set
+   - Verify platform name matches exactly (case-insensitive)
+   - Confirm version string is exact match
+
+2. **Image Pull Failures**
+   - Verify image exists and is accessible
+   - Check image registry authentication
+   - Validate image digest/tag is correct
+
+3. **Platform Not Found**
+   - Returns empty string (safe fallback)
+   - Check platform configuration in YAML
+   - Verify platform name spelling
+
+
+## Security/Production Considerations
+
+- Only use trusted image registries for CPO overrides
+- Validate override images are signed and verified
+- If multiple architectures are supported in the data plane, ensure that override image references point to multi-arch repositories that have all architectures supported in the data plane.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -309,4 +309,5 @@ nav:
   - 'Run Tests': contribute/run-tests.md
   - 'Develop in Cluster': contribute/develop_in_cluster.md
   - 'Run hypershift-operator locally': contribute/run-hypershift-operator-locally.md
+  - 'CPO Overrides': contribute/cpo-overrides.md
   - 'Contribute to docs': contribute/contribute-docs.md

--- a/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
+++ b/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
@@ -1,218 +1,220 @@
-overrides:
-  # Beginning of OCPBUGS-48519 overrides 4.15 section
-  # Using ocp-release:4.15.45-multi
-  - version: 4.15.0
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.1
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.2
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.3
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.4
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.5
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.6
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.7
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.8
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.9
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.10
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.11
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.12
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.13
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.14
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.15
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.16
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.17
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.18
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.19
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.20
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.21
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.22
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.23
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.24
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.25
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.26
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.27
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.28
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.29
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.30
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.31
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.32
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.33
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.34
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.35
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.36
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.37
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.38
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.39
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.40
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.41
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.42
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.43
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  - version: 4.15.44
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
-  # End of OCPBUGS-48519 overrides 4.15 section
-  # Beginning of OCPBUGS-48519 overrides 4.16 section
-  # Using ocp-release:4.16.34-multi
-  - version: 4.16.0
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.1
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.2
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.3
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.4
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.5
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.6
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.7
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.8
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.9
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.10
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.11
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.12
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.13
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.14
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.15
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.16
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.17
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.18
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.19
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.20
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.21
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.22
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.23
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.24
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.25
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.26
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.27
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.28
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.29
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.30
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.31
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.32
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  - version: 4.16.33
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
-  # End of OCPBUGS-48519 overrides 4.16 section
-  # Beginning of OCPBUGS-48519 overrides 4.17 section
-  # Using ocp-release:4.17.15-multi
-  - version: 4.17.0
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
-  - version: 4.17.1
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
-  - version: 4.17.2
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
-  - version: 4.17.3
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
-  - version: 4.17.4
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
-  - version: 4.17.5
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
-  - version: 4.17.6
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
-  - version: 4.17.7
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
-  - version: 4.17.8
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
-  - version: 4.17.9
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
-  - version: 4.17.10
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
-  - version: 4.17.11
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
-  - version: 4.17.12
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
-  - version: 4.17.13
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
-  - version: 4.17.14
-    cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
-  # End of OCPBUGS-48519 overrides 4.17 section
-  # End of OCPBUGS-48519 overrides
-  # Beginning of OCPBUGS-58837 overrides
-  # Beginning of OCPBUGS-58837 overrides 4.15 section
-  - version: 4.15.53
-    cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/openshift-cert-hotfix-415-multi:ab45f5df65f19c9e4db4977b0d756c8d87baff0a 
-  - version: 4.15.54
-    cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/openshift-cert-hotfix-415-multi:ab45f5df65f19c9e4db4977b0d756c8d87baff0a 
-  # End of OCPBUGS-58837 overrides 4.15 section
-  # Beginning of OCPBUGS-58837 overrides 4.15 section
-  - version: 4.16.43
-    cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-cert-hotfix-416-multi:2d2e6071841bb12ff1f41c457889bb44b6fb1cf7
-  # End of OCPBUGS-58837 overrides 4.15 section
-  # End of OCPBUGS-58837 overrides
-testing:
-  # Update the image refs below to indicate which images should be used for CPO override
-  # testing. Currently, we only test one latest/previous combination. In the future, we 
-  # may be able to test multiple combinations at a time. To test more than one, update
-  # the referenced images before each e2e test run.
-  latest: quay.io/openshift-release-dev/ocp-release:4.15.53-x86_64
-  previous: quay.io/openshift-release-dev/ocp-release:4.15.52-x86_64
+platforms:
+  aws:
+    overrides:
+    # Beginning of OCPBUGS-48519 overrides 4.15 section
+    # Using ocp-release:4.15.45-multi
+    - version: 4.15.0
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.1
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.2
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.3
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.4
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.5
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.6
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.7
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.8
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.9
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.10
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.11
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.12
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.13
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.14
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.15
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.16
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.17
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.18
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.19
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.20
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.21
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.22
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.23
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.24
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.25
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.26
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.27
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.28
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.29
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.30
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.31
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.32
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.33
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.34
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.35
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.36
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.37
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.38
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.39
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.40
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.41
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.42
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.43
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    - version: 4.15.44
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:10562af6cc5f0f9c61b9831792b9e371af6e660de4e3c56a5e4e8ef849219fc9
+    # End of OCPBUGS-48519 overrides 4.15 section
+    # Beginning of OCPBUGS-48519 overrides 4.16 section
+    # Using ocp-release:4.16.34-multi
+    - version: 4.16.0
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.1
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.2
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.3
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.4
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.5
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.6
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.7
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.8
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.9
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.10
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.11
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.12
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.13
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.14
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.15
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.16
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.17
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.18
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.19
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.20
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.21
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.22
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.23
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.24
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.25
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.26
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.27
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.28
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.29
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.30
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.31
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.32
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    - version: 4.16.33
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+    # End of OCPBUGS-48519 overrides 4.16 section
+    # Beginning of OCPBUGS-48519 overrides 4.17 section
+    # Using ocp-release:4.17.15-multi
+    - version: 4.17.0
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
+    - version: 4.17.1
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
+    - version: 4.17.2
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
+    - version: 4.17.3
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
+    - version: 4.17.4
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
+    - version: 4.17.5
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
+    - version: 4.17.6
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
+    - version: 4.17.7
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
+    - version: 4.17.8
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
+    - version: 4.17.9
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
+    - version: 4.17.10
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
+    - version: 4.17.11
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
+    - version: 4.17.12
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
+    - version: 4.17.13
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
+    - version: 4.17.14
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
+    # End of OCPBUGS-48519 overrides 4.17 section
+    # End of OCPBUGS-48519 overrides
+    # Beginning of OCPBUGS-58837 overrides
+    # Beginning of OCPBUGS-58837 overrides 4.15 section
+    - version: 4.15.53
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/openshift-cert-hotfix-415-multi:ab45f5df65f19c9e4db4977b0d756c8d87baff0a 
+    - version: 4.15.54
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/openshift-cert-hotfix-415-multi:ab45f5df65f19c9e4db4977b0d756c8d87baff0a 
+    # End of OCPBUGS-58837 overrides 4.15 section
+    # Beginning of OCPBUGS-58837 overrides 4.15 section
+    - version: 4.16.43
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-cert-hotfix-416-multi:2d2e6071841bb12ff1f41c457889bb44b6fb1cf7
+    # End of OCPBUGS-58837 overrides 4.15 section
+    # End of OCPBUGS-58837 overrides
+    testing:
+    # Update the image refs below to indicate which images should be used for CPO override
+    # testing. Currently, we only test one latest/previous combination. In the future, we 
+    # may be able to test multiple combinations at a time. To test more than one, update
+    # the referenced images before each e2e test run.
+      latest: quay.io/openshift-release-dev/ocp-release:4.15.53-x86_64
+      previous: quay.io/openshift-release-dev/ocp-release:4.15.52-x86_64

--- a/hypershift-operator/controlplaneoperator-overrides/assets/overrides_sample.yaml
+++ b/hypershift-operator/controlplaneoperator-overrides/assets/overrides_sample.yaml
@@ -1,8 +1,17 @@
-overrides:
-- version: 4.16.17
-  cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1a50894aafa6b750bf890ef147a20699ff5b807e586d15506426a8a615580797
-- version: 4.16.18
-  cpoImage: quay.io/hypershift/hypershift-cpo:patch
-testing:
-  latest: quay.io/openshift-release-dev/ocp-release:4.16.17-x86_64
-  previous: quay.io/openshift-release-dev/ocp-release:4.16.16-x86_64
+platforms:
+  aws:
+    overrides:
+    - version: 4.17.9
+      cpoImage: quay.io/hypershift/control-plane-operator:4.17.9
+    - version: 4.17.8
+      cpoImage: quay.io/hypershift/control-plane-operator:4.17.8
+    testing:
+      latest: quay.io/openshift-release-dev/ocp-release:4.17.9-x86_64
+      previous: quay.io/openshift-release-dev/ocp-release:4.17.8-x86_64
+  azure:
+    overrides:
+    - version: 4.16.17
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1a50894aafa6b750bf890ef147a20699ff5b807e586d15506426a8a615580797
+    - version: 4.16.18
+      cpoImage: quay.io/hypershift/hypershift-cpo:patch
+

--- a/hypershift-operator/controlplaneoperator-overrides/overrides_test.go
+++ b/hypershift-operator/controlplaneoperator-overrides/overrides_test.go
@@ -9,22 +9,34 @@ import (
 )
 
 func TestCPOImage(t *testing.T) {
-	overrides = fakeOverrides()
-	initOverridesByVersion()
 	tests := []struct {
+		platform string
 		version  string
 		expected string
 	}{
 		{
+			platform: "AWS",
 			version:  "4.17.8",
-			expected: "quay.io/hypershift/control-plane-operator:4.17.8",
+			expected: "quay.io/hypershift/control-plane-operator-aws:4.17.8",
 		},
 		{
-			version:  "4.15.9",
-			expected: "quay.io/hypershift/control-plane-operator:4.15.9",
+			platform: "aws",
+			version:  "4.17.9",
+			expected: "quay.io/hypershift/control-plane-operator-aws:4.17.9",
 		},
 		{
+			platform: "Azure",
+			version:  "4.17.9",
+			expected: "quay.io/hypershift/control-plane-operator-azure:4.17.9",
+		},
+		{
+			platform: "aws",
 			version:  "4.13.9",
+			expected: "",
+		},
+		{
+			platform: "foo",
+			version:  "4.17.9",
 			expected: "",
 		},
 	}
@@ -32,50 +44,79 @@ func TestCPOImage(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("test-%d", i+1), func(t *testing.T) {
 			g := NewWithT(t)
-			actual := CPOImage(test.version)
+			actual := getCPOImage(test.platform, test.version, getOverridesByPlatformAndVersion(fakeOverrides()))
 			g.Expect(actual).To(Equal(test.expected))
 		})
 	}
 }
 
 func TestLatestOverrideTestReleases(t *testing.T) {
-	overrides = fakeOverrides()
-	initOverridesByVersion()
 	g := NewWithT(t)
-	resultLatest, resultPrevious := LatestOverrideTestReleases()
+	resultLatest, resultPrevious := overrideTestReleases("aws", fakeOverrides())
 	g.Expect(resultLatest).To(Equal("quay.io/openshift-release-dev/ocp-release:4.17.9-x86_64"))
 	g.Expect(resultPrevious).To(Equal("quay.io/openshift-release-dev/ocp-release:4.17.8-x86_64"))
 }
 
-func TestLoadOverrides(t *testing.T) {
+func TestLoadOverridesSample(t *testing.T) {
 	g := NewWithT(t)
 	o, err := loadOverrides(overridesSampleYAML)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(o).ToNot(BeNil())
-	g.Expect(o.Overrides).To(HaveLen(2))
-	g.Expect(o.Testing.Previous).To(Equal("quay.io/openshift-release-dev/ocp-release:4.16.16-x86_64"))
-	g.Expect(o.Testing.Latest).To(Equal("quay.io/openshift-release-dev/ocp-release:4.16.17-x86_64"))
-	g.Expect(o.Overrides[1].Version).To(Equal("4.16.18"))
-	g.Expect(o.Overrides[1].CPOImage).To(Equal("quay.io/hypershift/hypershift-cpo:patch"))
-	g.Expect(o.Overrides[0].Version).To(Equal("4.16.17"))
-	g.Expect(o.Overrides[0].CPOImage).To(Equal("quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1a50894aafa6b750bf890ef147a20699ff5b807e586d15506426a8a615580797"))
+	g.Expect(o.Platforms.AWS.Testing.Previous).To(Equal("quay.io/openshift-release-dev/ocp-release:4.17.8-x86_64"))
+	g.Expect(o.Platforms.AWS.Testing.Latest).To(Equal("quay.io/openshift-release-dev/ocp-release:4.17.9-x86_64"))
+
+	g.Expect(o.Platforms.AWS.Overrides).To(HaveLen(2))
+	g.Expect(o.Platforms.AWS.Overrides[0].Version).To(Equal("4.17.9"))
+	g.Expect(o.Platforms.AWS.Overrides[0].CPOImage).To(Equal("quay.io/hypershift/control-plane-operator:4.17.9"))
+	g.Expect(o.Platforms.AWS.Overrides[1].Version).To(Equal("4.17.8"))
+	g.Expect(o.Platforms.AWS.Overrides[1].CPOImage).To(Equal("quay.io/hypershift/control-plane-operator:4.17.8"))
+}
+
+func TestLoadOverrides(t *testing.T) {
+	g := NewWithT(t)
+	o, err := loadOverrides(overridesYAML)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(o).ToNot(BeNil())
+	g.Expect(o.Platforms.AWS.Overrides).ToNot(BeEmpty())
+}
+
+func TestExistingOverride(t *testing.T) {
+	g := NewWithT(t)
+	result := CPOImage("aws", "4.15.53")
+	g.Expect(result).To(Equal("quay.io/redhat-user-workloads/crt-redhat-acm-tenant/openshift-cert-hotfix-415-multi:ab45f5df65f19c9e4db4977b0d756c8d87baff0a"))
 }
 
 func fakeOverrides() *CPOOverrides {
 	result := &CPOOverrides{
-		Testing: CPOOverrideTestReleases{
-			Latest:   "quay.io/openshift-release-dev/ocp-release:4.17.9-x86_64",
-			Previous: "quay.io/openshift-release-dev/ocp-release:4.17.8-x86_64",
+		Platforms: CPOPlatforms{
+			AWS: &CPOPlatformOverrides{
+				Testing: &CPOOverrideTestReleases{
+					Latest:   "quay.io/openshift-release-dev/ocp-release:4.17.9-x86_64",
+					Previous: "quay.io/openshift-release-dev/ocp-release:4.17.8-x86_64",
+				},
+			},
+			Azure: &CPOPlatformOverrides{
+				Testing: &CPOOverrideTestReleases{
+					Latest:   "quay.io/openshift-release-dev/ocp-release:4.17.9-x86_64",
+					Previous: "quay.io/openshift-release-dev/ocp-release:4.17.8-x86_64",
+				},
+			},
 		},
 	}
-	for _, minor := range []int{15, 16, 17} {
-		for patch := range 10 {
-			result.Overrides = append(result.Overrides, CPOOverride{
-				Version:  fmt.Sprintf("4.%d.%d", minor, patch),
-				CPOImage: fmt.Sprintf("quay.io/hypershift/control-plane-operator:4.%d.%d", minor, patch),
-			})
+	generateOverrides := func(platform string) []CPOOverride {
+		result := []CPOOverride{}
+		for _, minor := range []int{15, 16, 17} {
+			for patch := range 10 {
+				result = append(result, CPOOverride{
+					Version:  fmt.Sprintf("4.%d.%d", minor, patch),
+					CPOImage: fmt.Sprintf("quay.io/hypershift/control-plane-operator-%s:4.%d.%d", platform, minor, patch),
+				})
+			}
 		}
+		return result
 	}
+	result.Platforms.AWS.Overrides = generateOverrides("aws")
+	result.Platforms.Azure.Overrides = generateOverrides("azure")
 	return result
 }
 

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -622,7 +622,7 @@ func GetControlPlaneOperatorImage(ctx context.Context, hc *hyperv1.HostedCluster
 		return "", err
 	}
 	if controlplaneoperatoroverrides.IsOverridesEnabled() {
-		overrideImage := controlplaneoperatoroverrides.CPOImage(version.String())
+		overrideImage := controlplaneoperatoroverrides.CPOImage(string(hc.Spec.Platform.Type), version.String())
 		if overrideImage != "" {
 			return overrideImage, nil
 		}

--- a/test/e2e/util/options.go
+++ b/test/e2e/util/options.go
@@ -377,7 +377,7 @@ func (o *Options) DefaultPowerVSOptions() powervs.RawCreateOptions {
 func (o *Options) Complete() error {
 
 	if shouldTestCPOOverride() {
-		o.LatestReleaseImage, o.PreviousReleaseImage = controlplaneoperatoroverrides.LatestOverrideTestReleases()
+		o.LatestReleaseImage, o.PreviousReleaseImage = controlplaneoperatoroverrides.LatestOverrideTestReleases(string(o.Platform))
 	}
 
 	if len(o.LatestReleaseImage) == 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
Modifies the CPO override file format to allow specifying a platform for the overrides. The file should contain the lower case platform name and the list of version overrides for that platform.

This is needed to support CPO overrides that are specific to ARO deployments of the HyperShift operator and are different from the ROSA deployments.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[CNTRLPLANE-1190](https://issues.redhat.com/browse/CNTRLPLANE-1190)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.