### PR TITLE
[release-4.19] OCPSTRAT-2173: feat(hcco): add support for hosted OIDC client secrets

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -357,6 +357,19 @@ const (
 	// AWSMachinePublicIPs, if set to "true", results in an AWS machine template that creates machines with public IPs
 	// WARNING: This option is for development and testing purposes only
 	AWSMachinePublicIPs = "hypershift.openshift.io/aws-machine-public-ips"
+
+	// HostedClusterSourcedAnnotation is set to true on Secret and ConfigMap resources to designate them as
+	// hosted-cluster-sourced resources. This means that the hosted cluster version of these resources is the source of
+	// truth and the management cluster version will be just empty resources that have this annotation. This is useful
+	// to enable day-two configuration use cases where such resources are expected to be provided by the end-user after
+	// the cluster creation, and, due to certain restrictions, those resources include sensitive data that can't live
+	// on the control-plane. Setting this annotation will instruct HyperShift to skip creating this resource on the hosted
+	// cluster and to not override any changes done later on the hosted cluster version of this resource.
+	//
+	// This annotation can only be set on empty resources and currently it's only honored when set on secrets that are
+	// referenced in the HostedCluster `spec.configuration.authentication.oidcProviders[*].oidcClients[*].clientSecret`
+	// and only for the ARO-HCP platform.
+	HostedClusterSourcedAnnotation = "hypershift.openshift.io/hosted-cluster-sourced"
 )
 
 // RetentionPolicy defines the policy for handling resources associated with a cluster when the cluster is deleted.

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1156,10 +1156,16 @@ func (r *reconciler) reconcileAuthOIDC(ctx context.Context, hcp *hyperv1.HostedC
 				log.Info("OIDC client secret is empty, skipping reconciliation", "component", oidcClient.ComponentName)
 				continue
 			}
+
 			var src corev1.Secret
 			err := r.cpClient.Get(ctx, client.ObjectKey{Namespace: hcp.Namespace, Name: oidcClient.ClientSecret.Name}, &src)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("failed to get OIDCClient secret %s: %w", oidcClient.ClientSecret.Name, err))
+				continue
+			}
+
+			if azureutil.IsAroHCP() && util.HasAnnotationWithValue(&src, hyperv1.HostedClusterSourcedAnnotation, "true") {
+				// This is a day-2 secret. We shouldn't copy it, instead it'll be provided by the end-user on the hosted cluster.
 				continue
 			}
 			dest := corev1.Secret{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/nodepool"
+	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/globalconfig"
 	fakereleaseprovider "github.com/openshift/hypershift/support/releaseinfo/fake"
 	supportutil "github.com/openshift/hypershift/support/util"
@@ -33,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/utils/ptr"
 
@@ -1404,6 +1406,7 @@ func TestReconcileAuthOIDC(t *testing.T) {
 		expectOIDCClientSecrets []string
 		expectErrors            bool
 		expectedErrorMessages   []string
+		setAROHCP               bool
 	}{
 		"when OAuth is enabled, should not copy OIDC resources": {
 			inputHCP: &hyperv1.HostedControlPlane{
@@ -1668,6 +1671,105 @@ func TestReconcileAuthOIDC(t *testing.T) {
 			expectOIDCClientSecrets: []string{"console-client-secret"},
 			expectErrors:            false,
 		},
+		"when OAuth is disabled with OIDC provider with a hosted-cluster-sourced annotated client secret and ARO-HCP platform, should not copy the client secret": {
+			inputHCP: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testHCPName,
+					Namespace: testNamespace,
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						Authentication: &configv1.AuthenticationSpec{
+							Type: configv1.AuthenticationTypeOIDC,
+							OIDCProviders: []configv1.OIDCProvider{
+								{
+									Name: "test-oidc-provider",
+									Issuer: configv1.TokenIssuer{
+										URL: "https://example.com",
+									},
+									OIDCClients: []configv1.OIDCClientConfig{
+										{
+											ComponentName:      "console",
+											ComponentNamespace: "openshift-console",
+											ClientID:           "console-client",
+											ClientSecret: configv1.SecretNameReference{
+												Name: "console-client-secret",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			inputCPObjects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "console-client-secret",
+						Namespace: testNamespace,
+						Annotations: map[string]string{
+							hyperv1.HostedClusterSourcedAnnotation: "true",
+						},
+					},
+				},
+			},
+			expectIssuerCAConfigMap: false,
+			expectOIDCClientSecrets: []string{},
+			expectErrors:            false,
+			setAROHCP:               true,
+		},
+		"when OAuth is disabled with OIDC provider and not ARO-HCP platform, setting hosted-cluster-sourced annotation on a client secret should not skip copying the secret": {
+			inputHCP: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testHCPName,
+					Namespace: testNamespace,
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						Authentication: &configv1.AuthenticationSpec{
+							Type: configv1.AuthenticationTypeOIDC,
+							OIDCProviders: []configv1.OIDCProvider{
+								{
+									Name: "test-oidc-provider",
+									Issuer: configv1.TokenIssuer{
+										URL: "https://example.com",
+									},
+									OIDCClients: []configv1.OIDCClientConfig{
+										{
+											ComponentName:      "console",
+											ComponentNamespace: "openshift-console",
+											ClientID:           "console-client",
+											ClientSecret: configv1.SecretNameReference{
+												Name: "console-client-secret",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			inputCPObjects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "console-client-secret",
+						Namespace: testNamespace,
+						Annotations: map[string]string{
+							hyperv1.HostedClusterSourcedAnnotation: "true",
+						},
+					},
+					Data: map[string][]byte{
+						"clientSecret": []byte("console-secret-value"),
+					},
+				},
+			},
+			expectIssuerCAConfigMap: false,
+			expectOIDCClientSecrets: []string{"console-client-secret"},
+			expectErrors:            false,
+			setAROHCP:               false,
+		},
 		"when OAuth is disabled but CA configmap is missing, should return error": {
 			inputHCP: &hyperv1.HostedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1855,6 +1957,10 @@ func TestReconcileAuthOIDC(t *testing.T) {
 				CreateOrUpdateProvider: &simpleCreateOrUpdater{},
 			}
 
+			if test.setAROHCP {
+				azureutil.SetAsAroHCPTest(t)
+			}
+
 			// Verify that CA configmaps and OIDC client secrets don't exist in hosted cluster before reconciliation
 			if test.expectIssuerCAConfigMap {
 				provider := test.inputHCP.Spec.Configuration.Authentication.OIDCProviders[0]
@@ -1937,6 +2043,18 @@ func TestReconcileAuthOIDC(t *testing.T) {
 						Name:      provider.Issuer.CertificateAuthority.Name,
 					}, caConfigMap)
 					g.Expect(errors.IsNotFound(err)).To(BeTrue())
+				}
+			}
+			// Verify that no unexpected client secrets were copied
+			secretList := &corev1.SecretList{}
+			err = hcClient.List(ctx, secretList, client.InNamespace(ConfigNamespace))
+			g.Expect(err).ToNot(HaveOccurred())
+
+			expectedSecrets := sets.New(test.expectOIDCClientSecrets...)
+
+			for _, secret := range secretList.Items {
+				if !expectedSecrets.Has(secret.Name) {
+					t.Errorf("unexpected OIDC client secret copied: %s", secret.Name)
 				}
 			}
 		})

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/controlplaneoperator"
 	kvinfra "github.com/openshift/hypershift/kubevirtexternalinfra"
 	"github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/capabilities"
 	fakecapabilities "github.com/openshift/hypershift/support/capabilities/fake"
 	"github.com/openshift/hypershift/support/config"
@@ -4208,6 +4209,107 @@ func TestReconcileCAPIManagerDeployment(t *testing.T) {
 			// Verify other expected configurations
 			g.Expect(deployment.Spec.Template.Spec.ServiceAccountName).To(Equal(sa.Name))
 			g.Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal(image))
+		})
+	}
+}
+
+func TestEnsureHostedResroucesAreEmpty(t *testing.T) {
+	// Setup test cases
+	testCases := []struct {
+		name          string
+		setAROHCP     bool
+		annotations   map[string]string
+		secretContent map[string][]byte
+		expectError   bool
+		errorMessage  string
+	}{
+		{
+			name:          "non-ARO-HCP environment should pass",
+			setAROHCP:     false,
+			annotations:   map[string]string{hyperv1.HostedClusterSourcedAnnotation: "true"},
+			secretContent: map[string][]byte{"key": []byte("value")},
+			expectError:   false,
+		},
+		{
+			name:          "ARO-HCP without annotation should pass",
+			setAROHCP:     true,
+			annotations:   nil,
+			secretContent: map[string][]byte{"key": []byte("value")},
+			expectError:   false,
+		},
+		{
+			name:          "ARO-HCP with annotation but empty secret should pass",
+			setAROHCP:     true,
+			annotations:   map[string]string{hyperv1.HostedClusterSourcedAnnotation: "true"},
+			secretContent: map[string][]byte{},
+			expectError:   false,
+		},
+		{
+			name:          "ARO-HCP with annotation and non-empty secret should fail",
+			setAROHCP:     true,
+			annotations:   map[string]string{hyperv1.HostedClusterSourcedAnnotation: "true"},
+			secretContent: map[string][]byte{"key": []byte("value")},
+			expectError:   true,
+			errorMessage:  "secret test-secret is not empty. Secrets annotated with hypershift.openshift.io/hosted-cluster-sourced must be empty",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setAROHCP {
+				azureutil.SetAsAroHCPTest(t)
+			}
+			// Create the test namespace
+			namespace := "test-namespace"
+			secretName := "test-secret"
+
+			// Create a HostedCluster
+			hcluster := &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: namespace,
+				},
+			}
+
+			// Create a Secret that would exist in the cluster
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        secretName,
+					Namespace:   namespace,
+					Annotations: tc.annotations,
+				},
+				Data: tc.secretContent,
+			}
+
+			// Create a fake client with proper scheme
+			scheme := api.Scheme
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(hcluster, secret).
+				Build()
+
+			// Create a Secret to be validated (this would be the object passed to ensureHostedResroucesAreEmpty)
+			validateSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        secretName,
+					Namespace:   namespace,
+					Annotations: tc.annotations,
+				},
+			}
+
+			// Run the function being tested
+			err := ensureHostedResourcesAreEmpty(context.Background(), fakeClient, hcluster, validateSecret)
+
+			// Check the result
+			if tc.expectError && err == nil {
+				t.Errorf("expected error but got none")
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			}
+			if tc.expectError && err != nil && !strings.Contains(err.Error(), tc.errorMessage) {
+				t.Errorf("expected error message to contain %q but got: %v", tc.errorMessage, err)
+			}
 		})
 	}
 }

--- a/support/azureutil/azureutil.go
+++ b/support/azureutil/azureutil.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"testing"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/config"
@@ -184,6 +185,11 @@ func GetResourceGroupInfo(ctx context.Context, rgName string, subscriptionID str
 // IsAroHCP returns true if the managed service environment variable is set to ARO-HCP
 func IsAroHCP() bool {
 	return os.Getenv("MANAGED_SERVICE") == hyperv1.AroHCP
+}
+
+// SetAsAroHCPTest sets the proper environment variable for the test, designating this is an ARO-HCP environment
+func SetAsAroHCPTest(t *testing.T) {
+	t.Setenv("MANAGED_SERVICE", hyperv1.AroHCP)
 }
 
 func GetKeyVaultAuthorizedUser() string {

--- a/support/util/annotations.go
+++ b/support/util/annotations.go
@@ -1,0 +1,12 @@
+package util
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// HasAnnotationWithValue checks if a Kubernetes object has a specific annotation with a given value.
+func HasAnnotationWithValue(obj metav1.Object, key, expectedValue string) bool {
+	annotations := obj.GetAnnotations()
+	val, ok := annotations[key]
+	return ok && val == expectedValue
+}

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -357,6 +357,19 @@ const (
 	// AWSMachinePublicIPs, if set to "true", results in an AWS machine template that creates machines with public IPs
 	// WARNING: This option is for development and testing purposes only
 	AWSMachinePublicIPs = "hypershift.openshift.io/aws-machine-public-ips"
+
+	// HostedClusterSourcedAnnotation is set to true on Secret and ConfigMap resources to designate them as
+	// hosted-cluster-sourced resources. This means that the hosted cluster version of these resources is the source of
+	// truth and the management cluster version will be just empty resources that have this annotation. This is useful
+	// to enable day-two configuration use cases where such resources are expected to be provided by the end-user after
+	// the cluster creation, and, due to certain restrictions, those resources include sensitive data that can't live
+	// on the control-plane. Setting this annotation will instruct HyperShift to skip creating this resource on the hosted
+	// cluster and to not override any changes done later on the hosted cluster version of this resource.
+	//
+	// This annotation can only be set on empty resources and currently it's only honored when set on secrets that are
+	// referenced in the HostedCluster `spec.configuration.authentication.oidcProviders[*].oidcClients[*].clientSecret`
+	// and only for the ARO-HCP platform.
+	HostedClusterSourcedAnnotation = "hypershift.openshift.io/hosted-cluster-sourced"
 )
 
 // RetentionPolicy defines the policy for handling resources associated with a cluster when the cluster is deleted.


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of #6375 

**Which issue(s) this PR fixes**:
Fixes #[OCPSTRAT-2173](https://issues.redhat.com//browse/OCPSTRAT-2173)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.