### PR TITLE
OCPBUGS-59914: fix(snapshotcontroller): Add missing VolumeSnapshot API requirement

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_deployment.yaml
@@ -101,6 +101,7 @@ spec:
         - https://kube-apiserver:6443/readyz
         - --kubeconfig=/var/kubeconfig/kubeconfig
         - --required-api=operator.openshift.io,v1,CSISnapshotController
+        - --required-api=snapshot.storage.k8s.io,v1,VolumeSnapshot
         image: availability-prober
         imagePullPolicy: IfNotPresent
         name: availability-prober

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/csi-snapshot-controller-operator/zz_fixture_TestControlPlaneComponents_csi_snapshot_controller_operator_deployment.yaml
@@ -101,6 +101,7 @@ spec:
         - https://kube-apiserver:6443/readyz
         - --kubeconfig=/var/kubeconfig/kubeconfig
         - --required-api=operator.openshift.io,v1,CSISnapshotController
+        - --required-api=snapshot.storage.k8s.io,v1,VolumeSnapshot
         image: availability-prober
         imagePullPolicy: IfNotPresent
         name: availability-prober

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/snapshotcontroller/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/snapshotcontroller/component.go
@@ -42,6 +42,7 @@ func NewComponent() component.ControlPlaneComponent {
 			KubeconfigVolumeName: "guest-kubeconfig",
 			RequiredAPIs: []schema.GroupVersionKind{
 				{Group: "operator.openshift.io", Version: "v1", Kind: "CSISnapshotController"},
+				{Group: "snapshot.storage.k8s.io", Version: "v1", Kind: "VolumeSnapshot"},
 			},
 		}).
 		Build()


### PR DESCRIPTION
**What this PR does / why we need it**:
Add VolumeSnapshot API from snapshot.storage.k8s.io/v1 to the list of required APIs for the snapshot controller component availability prober.

**Which issue(s) this PR fixes**:
OCPBUGS-59914

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.