### PR TITLE
OCPBUGS-43824: fix(control-plane): widen kube-controller-manager leader-election timeouts

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_controller_manager_deployment.yaml
@@ -99,8 +99,9 @@ spec:
         - --kube-api-qps=150
         - --leader-elect-resource-lock=leases
         - --leader-elect=true
-        - --leader-elect-renew-deadline=12s
-        - --leader-elect-retry-period=3s
+        - --leader-elect-lease-duration=137s
+        - --leader-elect-renew-deadline=107s
+        - --leader-elect-retry-period=26s
         - --root-ca-file=/etc/kubernetes/certs/root-ca/ca.crt
         - --secure-port=10257
         - --service-account-private-key-file=/etc/kubernetes/certs/service-signer/service-account.key

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents_kube_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents_kube_controller_manager_deployment.yaml
@@ -99,8 +99,9 @@ spec:
         - --kube-api-qps=150
         - --leader-elect-resource-lock=leases
         - --leader-elect=true
-        - --leader-elect-renew-deadline=12s
-        - --leader-elect-retry-period=3s
+        - --leader-elect-lease-duration=137s
+        - --leader-elect-renew-deadline=107s
+        - --leader-elect-retry-period=26s
         - --root-ca-file=/etc/kubernetes/certs/root-ca/ca.crt
         - --secure-port=10257
         - --service-account-private-key-file=/etc/kubernetes/certs/service-signer/service-account.key

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-controller-manager/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-controller-manager/deployment.yaml
@@ -39,8 +39,9 @@ spec:
         - --kube-api-qps=150
         - --leader-elect-resource-lock=leases
         - --leader-elect=true
-        - --leader-elect-renew-deadline=12s
-        - --leader-elect-retry-period=3s
+        - --leader-elect-lease-duration=137s
+        - --leader-elect-renew-deadline=107s
+        - --leader-elect-retry-period=26s
         - --root-ca-file=/etc/kubernetes/certs/root-ca/ca.crt
         - --secure-port=10257
         - --service-account-private-key-file=/etc/kubernetes/certs/service-signer/service-account.key


### PR DESCRIPTION
**What this PR does / why we need it**:
Hosted-cluster kube-controller-manager was rendered with a narrow 12 s renew-deadline / 3 s retry-period.  Under the bursty workload of the NTO tests a single lease-renew PUT could exceed that window, the controller stepped down, the pod restarted, and “EnsureNoCrashingPods” failed.

Changes applied:
• deployment asset:
    --leader-elect-lease-duration=137s
    --leader-elect-renew-deadline=107s
    --leader-elect-retry-period=26s
• updated both kube-controller-manager fixtures to keep tests in sync.

These values align KCM with the defaults already used by cloud-controller-manager, cluster-autoscaler, etc., eliminating the spurious restart and stabilizing the NTO e2e tests.

**Which issue(s) this PR fixes**:
Fixes OCPBUGS-43824

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.