### PR TITLE
OCPBUGS-43824: test(e2e): detect "leaderelection lost" variant in log checks

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -732,7 +732,7 @@ func isLeaderElectionFailure(ctx context.Context, guestClient *kubeclient.Client
 		return false
 	}
 
-	return strings.Contains(buf.String(), "leader election lost")
+	return strings.Contains(buf.String(), "leader election lost") || strings.Contains(buf.String(), "leaderelection lost")
 }
 
 func NoticePreemptionOrFailedScheduling(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {


### PR DESCRIPTION
**What this PR does / why we need it**:
The isLeaderElectionFailure helper used by E2E tests only matched the string "leader election lost", which meant we occasionally missed leader-election failures logged as "leaderelection lost" (without the space).

Extend the check to catch both formats so tests reliably notice leader election loss events regardless of log wording.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.