### PR TITLE
SREP-715: New option to dump data plane content through the kube API server service exposed in HCP namespaces

### DIFF
--- a/cmd/cluster/core/dump.go
+++ b/cmd/cluster/core/dump.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"os/exec"
 	"path"
@@ -167,7 +167,6 @@ func NewDumpCommand() *cobra.Command {
 	cmd.MarkFlagsMutuallyExclusive("dump-guest-cluster", "dump-guest-cluster-through-kube-service")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		rand.New(rand.NewSource(time.Now().UnixNano()))
 		if err := DumpCluster(cmd.Context(), opts); err != nil {
 			opts.Log.Error(err, "Error")
 			return err
@@ -203,7 +202,7 @@ func dumpGuestCluster(ctx context.Context, opts *DumpOptions) error {
 	if opts.DumpGuestClusterThroughKubeService {
 		localPort = -1 // Indicates connection via kube-apiserver service instead of port-forward
 	} else {
-		localPort = rand.Intn(45000-32767) + 32767
+		localPort = rand.IntN(45000-32767) + 32767
 		podToForward, err := supportforwarder.GetRunningKubeAPIServerPod(ctx, c, cpNamespace)
 		if err != nil {
 			return fmt.Errorf("failed to get running kube-apiserver pod for guest cluster: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Port forwarding is not possible as debug handlers are disabled on MC clusters. As a result data plane content (including worker nodes logs) is currently failing to be dumped.

The new `--dump-guest-cluster-through-kube-service` can be used to by-pass that limitation by targeting the `kube-apiserver` service exposed by HCP namespaces.
Remark that it is only suitable to use that option when:
- Within a MC cluster (i.e. in a pod which has access to the service)
- The MC cluster has the debug handlers disabled

**Which issue(s) this PR fixes**
Contributes to [SREP-715](https://issues.redhat.com//browse/SREP-715)

Next steps are:
- Change following call to use that new option (once the `hypershift` CLI is released to be deployed on the stolostron image): https://github.com/stolostron/must-gather/blob/b7d9c20b996811aa02f5d432bbdda43fb7e37b33/collection-scripts/gather_utils#L135
- Use the stolostron image there: https://github.com/openshift/osdctl/blob/9abf1be8ec5c5029fc3ea97c4e083c30748ee278/cmd/hcp/mustgather/mustGather.go#L198

**Checklist**
- [X] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.