### PR TITLE
NO-JIRA: wrap EnsureKubeAPIDNSNameCustomCert and EnsureGlobalPullSecret in their own test

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1531,185 +1531,186 @@ func EnsureGuestWebhooksValidated(t *testing.T, ctx context.Context, guestClient
 }
 
 func EnsureGlobalPullSecret(t *testing.T, ctx context.Context, mgmtClient crclient.Client, entryHostedCluster *hyperv1.HostedCluster) error {
-	AtLeast(t, Version420)
+	t.Run("EnsureGlobalPullSecret", func(t *testing.T) {
+		AtLeast(t, Version419)
+		if entryHostedCluster.Spec.Platform.Type != hyperv1.AzurePlatform {
+			t.Skip("test only supported on platform ARO")
+		}
 
-	if entryHostedCluster.Spec.Platform.Type != hyperv1.AzurePlatform {
-		t.Skip("test only supported on platform ARO")
-	}
+		var (
+			dummyImageTagMultiarch = "quay.io/hypershift/sleep:multiarch"
+			dummyImageTag12        = "quay.io/hypershift/sleep:1.2.0"
+			err                    error
 
-	var (
-		dummyImageTagMultiarch = "quay.io/hypershift/sleep:multiarch"
-		dummyImageTag12        = "quay.io/hypershift/sleep:1.2.0"
-		err                    error
+			// Additional Pull Secret
+			additionalPullSecretName            = "additional-pull-secret"
+			additionalPullSecretNamespace       = "kube-system"
+			pullSecretNamespace                 = "openshift-config"
+			additionalPullSecretDummyData       = []byte(`{"auths": {"quay.io": {"auth": "YWRtaW46cGFzc3dvcmQ="}}}`)
+			additionalPullSecretReadOnlyE2EData = []byte(`{"auths": {"quay.io": {"auth": "aHlwZXJzaGlmdCtlMmVfcmVhZG9ubHk6R1U2V0ZDTzVaVkJHVDJPREE1VVAxT0lCOVlNMFg2TlY0UkZCT1lJSjE3TDBWOFpTVlFGVE5BS0daNTNNQVAzRA=="}}}`)
+			oldglobalPullSecretData             []byte
+			dsImage                             string
+			g                                   = NewWithT(t)
+		)
 
-		// Additional Pull Secret
-		additionalPullSecretName            = "additional-pull-secret"
-		additionalPullSecretNamespace       = "kube-system"
-		pullSecretNamespace                 = "openshift-config"
-		additionalPullSecretDummyData       = []byte(`{"auths": {"quay.io": {"auth": "YWRtaW46cGFzc3dvcmQ="}}}`)
-		additionalPullSecretReadOnlyE2EData = []byte(`{"auths": {"quay.io": {"auth": "aHlwZXJzaGlmdCtlMmVfcmVhZG9ubHk6R1U2V0ZDTzVaVkJHVDJPREE1VVAxT0lCOVlNMFg2TlY0UkZCT1lJSjE3TDBWOFpTVlFGVE5BS0daNTNNQVAzRA=="}}}`)
-		oldglobalPullSecretData             []byte
-		dsImage                             string
-	)
-	g := NewWithT(t)
+		guestClient := WaitForGuestClient(t, ctx, mgmtClient, entryHostedCluster)
 
-	guestClient := WaitForGuestClient(t, ctx, mgmtClient, entryHostedCluster)
+		// Create the additional-pull-secret secret in the DataPlane using the dummy pull secret.
+		// The dummy pull secret is authorized to pull restricted images.
+		err = createAdditionalPullSecret(ctx, guestClient, additionalPullSecretDummyData, additionalPullSecretName, additionalPullSecretNamespace)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to create additional-pull-secret secret")
 
-	// Create the additional-pull-secret secret in the DataPlane using the dummy pull secret.
-	// The dummy pull secret is authorized to pull restricted images.
-	err = createAdditionalPullSecret(ctx, guestClient, additionalPullSecretDummyData, additionalPullSecretName, additionalPullSecretNamespace)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to create additional-pull-secret secret")
-
-	// Check if HCCO generates the GlobalPullSecret secret in the kube-system namespace in the DataPlane
-	t.Run("Check if GlobalPullSecret secret is in the right place at Dataplane", func(t *testing.T) {
-		globalPullSecret := hccomanifests.GlobalPullSecret()
-		g.Eventually(func() error {
-			if err := guestClient.Get(ctx, client.ObjectKey{Name: globalPullSecret.Name, Namespace: globalPullSecret.Namespace}, globalPullSecret); err != nil {
-				return err
-			}
-			g.Expect(globalPullSecret.Data).NotTo(BeEmpty(), "global-pull-secret secret is empty")
-			g.Expect(globalPullSecret.Data[corev1.DockerConfigJsonKey]).NotTo(BeEmpty(), "global-pull-secret secret is empty")
-			oldglobalPullSecretData = globalPullSecret.Data[corev1.DockerConfigJsonKey]
-			return nil
-		}, 30*time.Second, 5*time.Second).Should(Succeed(), "global-pull-secret secret is not present")
-	})
-
-	// Check if the additional RBAC is present in the DataPlane
-	t.Run("Check if the additional RBAC is present in the DataPlane", func(t *testing.T) {
-		g.Eventually(func() error {
-			// Check RBAC in kube-system and openshift-config namespace
-			role := hccomanifests.GlobalPullSecretSyncerRole(additionalPullSecretNamespace)
-			if err := guestClient.Get(ctx, client.ObjectKey{Name: role.Name, Namespace: role.Namespace}, role); err != nil {
-				return err
-			}
-
-			roleBinding := hccomanifests.GlobalPullSecretSyncerRoleBinding(additionalPullSecretNamespace)
-			if err := guestClient.Get(ctx, client.ObjectKey{Name: roleBinding.Name, Namespace: roleBinding.Namespace}, roleBinding); err != nil {
-				return err
-			}
-
-			openshiftConfigRole := hccomanifests.GlobalPullSecretSyncerRole(pullSecretNamespace)
-			if err := guestClient.Get(ctx, client.ObjectKey{Name: openshiftConfigRole.Name, Namespace: openshiftConfigRole.Namespace}, openshiftConfigRole); err != nil {
-				return err
-			}
-
-			openshiftConfigRoleBinding := hccomanifests.GlobalPullSecretSyncerRoleBinding(pullSecretNamespace)
-			if err := guestClient.Get(ctx, client.ObjectKey{Name: openshiftConfigRoleBinding.Name, Namespace: openshiftConfigRoleBinding.Namespace}, openshiftConfigRoleBinding); err != nil {
-				return err
-			}
-
-			serviceAccount := hccomanifests.GlobalPullSecretSyncerServiceAccount()
-			if err := guestClient.Get(ctx, client.ObjectKey{Name: serviceAccount.Name, Namespace: serviceAccount.Namespace}, serviceAccount); err != nil {
-				return err
-			}
-
-			return nil
-		}, 30*time.Second, 5*time.Second).Should(Succeed(), "RBAC is not present")
-	})
-
-	// Check if the DaemonSet is present in the DataPlane
-	t.Run("Check if the DaemonSet is present in the DataPlane", func(t *testing.T) {
-		g.Eventually(func() error {
-			daemonSet := hccomanifests.GlobalPullSecretDaemonSet()
-			if err := guestClient.Get(ctx, client.ObjectKey{Name: daemonSet.Name, Namespace: daemonSet.Namespace}, daemonSet); err != nil {
-				return err
-			}
-			dsImage = daemonSet.Spec.Template.Spec.Containers[0].Image
-			return nil
-		}, 30*time.Second, 5*time.Second).Should(Succeed(), "DaemonSet is not present")
-	})
-
-	// Check if we can pull restricted images
-	t.Run("Check if we can pull restricted images, should fail", func(t *testing.T) {
-		g.Eventually(func() error {
+		// Check if HCCO generates the GlobalPullSecret secret in the kube-system namespace in the DataPlane
+		t.Run("Check if GlobalPullSecret secret is in the right place at Dataplane", func(t *testing.T) {
 			globalPullSecret := hccomanifests.GlobalPullSecret()
-			if err := guestClient.Get(ctx, client.ObjectKey{Name: globalPullSecret.Name, Namespace: globalPullSecret.Namespace}, globalPullSecret); err != nil {
-				return err
-			}
-			pullSecretData := globalPullSecret.Data[corev1.DockerConfigJsonKey]
-			_, _, _, err := registryclient.GetMetadata(ctx, dummyImageTagMultiarch, pullSecretData)
-			if err == nil {
-				return fmt.Errorf("succeeded to get metadata for restricted image, should fail")
-			}
-			return nil
-		}, 1*time.Minute, 5*time.Second).Should(Succeed(), "should not be able to get repo setup")
-	})
-
-	// Create a pod which uses the restricted image, should fail
-	t.Run("Create a pod which uses the restricted image, should fail", func(t *testing.T) {
-		shouldFail := true
-		runAndCheckPod(t, ctx, guestClient, dummyImageTagMultiarch, additionalPullSecretNamespace, "global-pull-secret-fail", shouldFail)
-	})
-
-	// Modify the additional-pull-secret secret in the DataPlane
-	t.Run("Modify the additional-pull-secret secret in the DataPlane by adding the valid pull secret", func(t *testing.T) {
-		additionalPullSecret := hccomanifests.AdditionalPullSecret()
-		err := guestClient.Get(ctx, client.ObjectKey{Name: additionalPullSecret.Name, Namespace: additionalPullSecret.Namespace}, additionalPullSecret)
-		g.Expect(err).NotTo(HaveOccurred(), "failed to get additional-pull-secret secret")
-		additionalPullSecret.Data[corev1.DockerConfigJsonKey] = additionalPullSecretReadOnlyE2EData
-		err = guestClient.Update(ctx, additionalPullSecret)
-		g.Expect(err).NotTo(HaveOccurred(), "failed to update additional-pull-secret secret")
-	})
-
-	// Check if GlobalPullSecret secret is updated in the DataPlane
-	t.Run("Check if GlobalPullSecret secret is updated in the DataPlane", func(t *testing.T) {
-		globalPullSecret := hccomanifests.GlobalPullSecret()
-		g.Eventually(func() error {
-			if err := guestClient.Get(ctx, client.ObjectKey{Name: globalPullSecret.Name, Namespace: globalPullSecret.Namespace}, globalPullSecret); err != nil {
-				return err
-			}
-			g.Expect(globalPullSecret.Data[corev1.DockerConfigJsonKey]).NotTo(BeEmpty(), "global-pull-secret secret is empty")
-			if bytes.Equal(globalPullSecret.Data[corev1.DockerConfigJsonKey], oldglobalPullSecretData) {
-				return fmt.Errorf("global-pull-secret secret is equal to the old global-pull-secret secret, should be different")
-			}
-			return nil
-		}, 30*time.Second, 5*time.Second).Should(Succeed(), "global-pull-secret secret is not updated")
-	})
-
-	// Check if we can pull other restricted images, should succeed
-	t.Run("Check if we can pull other restricted images, should succeed", func(t *testing.T) {
-		g.Eventually(func() error {
-			globalPullSecret := hccomanifests.GlobalPullSecret()
-			if err := guestClient.Get(ctx, client.ObjectKey{Name: globalPullSecret.Name, Namespace: globalPullSecret.Namespace}, globalPullSecret); err != nil {
-				return err
-			}
-			pullSecretData := globalPullSecret.Data[corev1.DockerConfigJsonKey]
-			_, _, _, err := registryclient.GetMetadata(ctx, dummyImageTag12, pullSecretData)
-			if err != nil {
-				return fmt.Errorf("failed to get metadata for restricted image: %v", err)
-			}
-			return nil
-		}, 1*time.Minute, 5*time.Second).Should(Succeed(), "should be able to pull other restricted images")
-	})
-
-	// Check if we can run a pod with the restricted image
-	t.Run("Create a pod which uses the restricted image, should succeed", func(t *testing.T) {
-		shouldFail := false
-		runAndCheckPod(t, ctx, guestClient, dummyImageTag12, additionalPullSecretNamespace, "global-pull-secret-success", shouldFail)
-	})
-
-	// Delete the additional-pull-secret secret in the DataPlane
-	t.Log("Deleting the additional-pull-secret secret in the DataPlane")
-	err = guestClient.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: additionalPullSecretName, Namespace: additionalPullSecretNamespace}})
-	g.Expect(err).NotTo(HaveOccurred(), "failed to delete additional-pull-secret secret")
-
-	// Check if the GlobalPullSecret secret is deleted in the DataPlane
-	t.Run("Check if the GlobalPullSecret secret is deleted in the DataPlane", func(t *testing.T) {
-		g.Eventually(func() error {
-			globalPullSecret := hccomanifests.GlobalPullSecret()
-			if err := guestClient.Get(ctx, client.ObjectKey{Name: globalPullSecret.Name, Namespace: globalPullSecret.Namespace}, globalPullSecret); err != nil {
-				if !apierrors.IsNotFound(err) {
+			g.Eventually(func() error {
+				if err := guestClient.Get(ctx, client.ObjectKey{Name: globalPullSecret.Name, Namespace: globalPullSecret.Namespace}, globalPullSecret); err != nil {
 					return err
 				}
+				g.Expect(globalPullSecret.Data).NotTo(BeEmpty(), "global-pull-secret secret is empty")
+				g.Expect(globalPullSecret.Data[corev1.DockerConfigJsonKey]).NotTo(BeEmpty(), "global-pull-secret secret is empty")
+				oldglobalPullSecretData = globalPullSecret.Data[corev1.DockerConfigJsonKey]
 				return nil
-			}
-			return fmt.Errorf("global-pull-secret secret is still present")
-		}, 30*time.Second, 5*time.Second).Should(Succeed(), "global-pull-secret secret is still present")
-	})
+			}, 30*time.Second, 5*time.Second).Should(Succeed(), "global-pull-secret secret is not present")
+		})
 
-	// Check if the config.json is updated in all of the nodes
-	t.Run("Check if the config.json is correct in all of the nodes", func(t *testing.T) {
-		VerifyKubeletConfigWithDaemonSet(t, ctx, guestClient, dsImage)
+		// Check if the additional RBAC is present in the DataPlane
+		t.Run("Check if the additional RBAC is present in the DataPlane", func(t *testing.T) {
+			g.Eventually(func() error {
+				// Check RBAC in kube-system and openshift-config namespace
+				role := hccomanifests.GlobalPullSecretSyncerRole(additionalPullSecretNamespace)
+				if err := guestClient.Get(ctx, client.ObjectKey{Name: role.Name, Namespace: role.Namespace}, role); err != nil {
+					return err
+				}
+
+				roleBinding := hccomanifests.GlobalPullSecretSyncerRoleBinding(additionalPullSecretNamespace)
+				if err := guestClient.Get(ctx, client.ObjectKey{Name: roleBinding.Name, Namespace: roleBinding.Namespace}, roleBinding); err != nil {
+					return err
+				}
+
+				openshiftConfigRole := hccomanifests.GlobalPullSecretSyncerRole(pullSecretNamespace)
+				if err := guestClient.Get(ctx, client.ObjectKey{Name: openshiftConfigRole.Name, Namespace: openshiftConfigRole.Namespace}, openshiftConfigRole); err != nil {
+					return err
+				}
+
+				openshiftConfigRoleBinding := hccomanifests.GlobalPullSecretSyncerRoleBinding(pullSecretNamespace)
+				if err := guestClient.Get(ctx, client.ObjectKey{Name: openshiftConfigRoleBinding.Name, Namespace: openshiftConfigRoleBinding.Namespace}, openshiftConfigRoleBinding); err != nil {
+					return err
+				}
+
+				serviceAccount := hccomanifests.GlobalPullSecretSyncerServiceAccount()
+				if err := guestClient.Get(ctx, client.ObjectKey{Name: serviceAccount.Name, Namespace: serviceAccount.Namespace}, serviceAccount); err != nil {
+					return err
+				}
+
+				return nil
+			}, 30*time.Second, 5*time.Second).Should(Succeed(), "RBAC is not present")
+		})
+
+		// Check if the DaemonSet is present in the DataPlane
+		t.Run("Check if the DaemonSet is present in the DataPlane", func(t *testing.T) {
+			g.Eventually(func() error {
+				daemonSet := hccomanifests.GlobalPullSecretDaemonSet()
+				if err := guestClient.Get(ctx, client.ObjectKey{Name: daemonSet.Name, Namespace: daemonSet.Namespace}, daemonSet); err != nil {
+					return err
+				}
+				dsImage = daemonSet.Spec.Template.Spec.Containers[0].Image
+				return nil
+			}, 30*time.Second, 5*time.Second).Should(Succeed(), "DaemonSet is not present")
+		})
+
+		// Check if we can pull restricted images
+		t.Run("Check if we can pull restricted images, should fail", func(t *testing.T) {
+			g.Eventually(func() error {
+				globalPullSecret := hccomanifests.GlobalPullSecret()
+				if err := guestClient.Get(ctx, client.ObjectKey{Name: globalPullSecret.Name, Namespace: globalPullSecret.Namespace}, globalPullSecret); err != nil {
+					return err
+				}
+				pullSecretData := globalPullSecret.Data[corev1.DockerConfigJsonKey]
+				_, _, _, err := registryclient.GetMetadata(ctx, dummyImageTagMultiarch, pullSecretData)
+				if err == nil {
+					return fmt.Errorf("succeeded to get metadata for restricted image, should fail")
+				}
+				return nil
+			}, 1*time.Minute, 5*time.Second).Should(Succeed(), "should not be able to get repo setup")
+		})
+
+		// Create a pod which uses the restricted image, should fail
+		t.Run("Create a pod which uses the restricted image, should fail", func(t *testing.T) {
+			shouldFail := true
+			runAndCheckPod(t, ctx, guestClient, dummyImageTagMultiarch, additionalPullSecretNamespace, "global-pull-secret-fail", shouldFail)
+		})
+
+		// Modify the additional-pull-secret secret in the DataPlane
+		t.Run("Modify the additional-pull-secret secret in the DataPlane by adding the valid pull secret", func(t *testing.T) {
+			additionalPullSecret := hccomanifests.AdditionalPullSecret()
+			err := guestClient.Get(ctx, client.ObjectKey{Name: additionalPullSecret.Name, Namespace: additionalPullSecret.Namespace}, additionalPullSecret)
+			g.Expect(err).NotTo(HaveOccurred(), "failed to get additional-pull-secret secret")
+			additionalPullSecret.Data[corev1.DockerConfigJsonKey] = additionalPullSecretReadOnlyE2EData
+			err = guestClient.Update(ctx, additionalPullSecret)
+			g.Expect(err).NotTo(HaveOccurred(), "failed to update additional-pull-secret secret")
+		})
+
+		// Check if GlobalPullSecret secret is updated in the DataPlane
+		t.Run("Check if GlobalPullSecret secret is updated in the DataPlane", func(t *testing.T) {
+			globalPullSecret := hccomanifests.GlobalPullSecret()
+			g.Eventually(func() error {
+				if err := guestClient.Get(ctx, client.ObjectKey{Name: globalPullSecret.Name, Namespace: globalPullSecret.Namespace}, globalPullSecret); err != nil {
+					return err
+				}
+				g.Expect(globalPullSecret.Data[corev1.DockerConfigJsonKey]).NotTo(BeEmpty(), "global-pull-secret secret is empty")
+				if bytes.Equal(globalPullSecret.Data[corev1.DockerConfigJsonKey], oldglobalPullSecretData) {
+					return fmt.Errorf("global-pull-secret secret is equal to the old global-pull-secret secret, should be different")
+				}
+				return nil
+			}, 30*time.Second, 5*time.Second).Should(Succeed(), "global-pull-secret secret is not updated")
+		})
+
+		// Check if we can pull other restricted images, should succeed
+		t.Run("Check if we can pull other restricted images, should succeed", func(t *testing.T) {
+			g.Eventually(func() error {
+				globalPullSecret := hccomanifests.GlobalPullSecret()
+				if err := guestClient.Get(ctx, client.ObjectKey{Name: globalPullSecret.Name, Namespace: globalPullSecret.Namespace}, globalPullSecret); err != nil {
+					return err
+				}
+				pullSecretData := globalPullSecret.Data[corev1.DockerConfigJsonKey]
+				_, _, _, err := registryclient.GetMetadata(ctx, dummyImageTag12, pullSecretData)
+				if err != nil {
+					return fmt.Errorf("failed to get metadata for restricted image: %v", err)
+				}
+				return nil
+			}, 1*time.Minute, 5*time.Second).Should(Succeed(), "should be able to pull other restricted images")
+		})
+
+		// Check if we can run a pod with the restricted image
+		t.Run("Create a pod which uses the restricted image, should succeed", func(t *testing.T) {
+			shouldFail := false
+			runAndCheckPod(t, ctx, guestClient, dummyImageTag12, additionalPullSecretNamespace, "global-pull-secret-success", shouldFail)
+		})
+
+		// Delete the additional-pull-secret secret in the DataPlane
+		t.Log("Deleting the additional-pull-secret secret in the DataPlane")
+		err = guestClient.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: additionalPullSecretName, Namespace: additionalPullSecretNamespace}})
+		g.Expect(err).NotTo(HaveOccurred(), "failed to delete additional-pull-secret secret")
+
+		// Check if the GlobalPullSecret secret is deleted in the DataPlane
+		t.Run("Check if the GlobalPullSecret secret is deleted in the DataPlane", func(t *testing.T) {
+			g.Eventually(func() error {
+				globalPullSecret := hccomanifests.GlobalPullSecret()
+				if err := guestClient.Get(ctx, client.ObjectKey{Name: globalPullSecret.Name, Namespace: globalPullSecret.Namespace}, globalPullSecret); err != nil {
+					if !apierrors.IsNotFound(err) {
+						return err
+					}
+					return nil
+				}
+				return fmt.Errorf("global-pull-secret secret is still present")
+			}, 30*time.Second, 5*time.Second).Should(Succeed(), "global-pull-secret secret is still present")
+		})
+
+		// Check if the config.json is updated in all of the nodes
+		t.Run("Check if the config.json is correct in all of the nodes", func(t *testing.T) {
+			VerifyKubeletConfigWithDaemonSet(t, ctx, guestClient, dsImage)
+		})
 	})
 
 	return nil
@@ -1735,368 +1736,369 @@ func createAdditionalPullSecret(ctx context.Context, guestClient crclient.Client
 }
 
 func EnsureKubeAPIDNSNameCustomCert(t *testing.T, ctx context.Context, mgmtClient crclient.Client, entryHostedCluster *hyperv1.HostedCluster) {
-	AtLeast(t, Version419)
+	t.Run("EnsureKubeAPIDNSNameCustomCert", func(t *testing.T) {
+		AtLeast(t, Version419)
 
-	// Skip for kubevirt HostedClusters
-	if entryHostedCluster.Spec.Platform.Type == hyperv1.KubevirtPlatform {
-		t.Skip("Skipping EnsureKubeAPIDNSNameCustomCert test for kubevirt")
-	}
-
-	var (
-		hcKASCustomKubeconfigSecretName string
-
-		serviceDomain        = "service.ci.hypershift.devcluster.openshift.com"
-		isAzure              = entryHostedCluster.Spec.Platform.Type == hyperv1.AzurePlatform
-		retryTimeout         = 5 * time.Minute
-		dnsResolutionTimeout = 30 * time.Minute
-		kasDeploymentTimeout = 30 * time.Minute
-
-		// Using domain name filtered by the external-dns deployment in CI
-		customApiServerHost     = fmt.Sprintf("api-custom-cert-%s.%s", entryHostedCluster.Spec.InfraID, serviceDomain)
-		hcpNamespace            = manifests.HostedControlPlaneNamespace(entryHostedCluster.Namespace, entryHostedCluster.Name)
-		kasCustomCertSecretName = fmt.Sprintf("%s-kas-custom-cert", entryHostedCluster.Name)
-	)
-
-	if isAzure {
-		serviceDomain = "aks-e2e.hypershift.azure.devcluster.openshift.com"
-		customApiServerHost = fmt.Sprintf("api-custom-cert-%s.%s", entryHostedCluster.Spec.InfraID, serviceDomain)
-
-		// Based on sample test evidence: ~40% failure rate due to internal DNS lag after external resolution
-		// Use retries instead of proactive waiting for better efficiency
-		retryTimeout = 10 * time.Minute // Extended retry for the kubeconfig test
-		t.Log("Using Azure-specific retry strategy for DNS propagation race condition")
-	}
-
-	g := NewWithT(t)
-	if !util.IsPublicHC(entryHostedCluster) {
-		return
-	}
-
-	// Generate a custom certificate for the KAS
-	t.Log("Generating custom certificate with DNS name", customApiServerHost)
-	customCert, customKey, err := GenerateCustomCertificate([]string{customApiServerHost}, 24*time.Hour)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to generate custom certificate")
-
-	// Create secret with the custom certificate
-	t.Log("Creating custom certificate secret")
-	customCertSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      kasCustomCertSecretName,
-			Namespace: entryHostedCluster.Namespace,
-		},
-		Data: map[string][]byte{
-			"tls.crt": customCert,
-			"tls.key": customKey,
-		},
-	}
-	err = mgmtClient.Create(ctx, customCertSecret)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to create custom certificate secret")
-
-	// update HC with a KubeAPIDNSName and KAS custom serving cert
-	hc := entryHostedCluster.DeepCopy()
-	t.Log("Updating hosted cluster with KubeAPIDNSName and KAS custom serving cert")
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		// Get the latest version of the object
-		latestHC := &hyperv1.HostedCluster{}
-		if err := mgmtClient.Get(ctx, client.ObjectKeyFromObject(hc), latestHC); err != nil {
-			return err
+		// Skip for kubevirt HostedClusters
+		if entryHostedCluster.Spec.Platform.Type == hyperv1.KubevirtPlatform {
+			t.Skip("Skipping EnsureKubeAPIDNSNameCustomCert test for kubevirt")
 		}
 
-		// update the KubeAPIDNSName
-		latestHC.Spec.KubeAPIServerDNSName = customApiServerHost
+		var (
+			hcKASCustomKubeconfigSecretName string
 
-		// update the KAS custom serving cert
-		if latestHC.Spec.Configuration == nil {
-			latestHC.Spec.Configuration = &hyperv1.ClusterConfiguration{}
-		}
-		if latestHC.Spec.Configuration.APIServer == nil {
-			latestHC.Spec.Configuration.APIServer = &configv1.APIServerSpec{}
-		}
+			serviceDomain        = "service.ci.hypershift.devcluster.openshift.com"
+			isAzure              = entryHostedCluster.Spec.Platform.Type == hyperv1.AzurePlatform
+			retryTimeout         = 5 * time.Minute
+			dnsResolutionTimeout = 30 * time.Minute
+			kasDeploymentTimeout = 30 * time.Minute
 
-		namedCertificate := configv1.APIServerNamedServingCert{
-			Names: []string{customApiServerHost},
-			ServingCertificate: configv1.SecretNameReference{
-				Name: kasCustomCertSecretName,
-			},
-		}
-
-		if len(latestHC.Spec.Configuration.APIServer.ServingCerts.NamedCertificates) == 0 {
-			latestHC.Spec.Configuration.APIServer.ServingCerts.NamedCertificates = []configv1.APIServerNamedServingCert{namedCertificate}
-		} else {
-			latestHC.Spec.Configuration.APIServer.ServingCerts.NamedCertificates = append(latestHC.Spec.Configuration.APIServer.ServingCerts.NamedCertificates, namedCertificate)
-		}
-
-		return mgmtClient.Update(ctx, latestHC)
-	})
-	g.Expect(err).NotTo(HaveOccurred(), "failed to update hosted cluster")
-
-	t.Log("Getting custom kubeconfig client")
-	customApiServerURL := fmt.Sprintf("https://%s:%s", customApiServerHost, "443")
-	kasCustomKubeconfigClient, kbCrclient := GetCustomKubeconfigClients(t, ctx, mgmtClient, entryHostedCluster, customApiServerURL)
-
-	// wait for the KubeAPIDNSName to be reconciled
-	t.Log("waiting for the KubeAPIDNSName to be reconciled")
-	_ = WaitForCustomKubeconfig(t, ctx, mgmtClient, entryHostedCluster)
-
-	// Get HC and HCP updated
-	err = mgmtClient.Get(ctx, client.ObjectKeyFromObject(hc), hc)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to get updated HostedCluster")
-
-	hcp := &hyperv1.HostedControlPlane{}
-	err = mgmtClient.Get(ctx, types.NamespacedName{Namespace: hcpNamespace, Name: entryHostedCluster.Name}, hcp)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to get updated HostedControlPlane")
-
-	// Find the external name destination for the KAS Service
-	t.Log("Finding the external name destination for the KAS Service")
-	var externalNameDestination string
-	if entryHostedCluster.Spec.Services != nil {
-		for _, service := range entryHostedCluster.Spec.Services {
-			fmt.Printf("service: %+v\n", service)
-			switch service.Service {
-			case hyperv1.APIServer:
-				switch service.Type {
-				case hyperv1.Route:
-					if service.Route != nil && len(service.Route.Hostname) > 0 {
-						externalNameDestination = service.Route.Hostname
-						break
-					}
-				case hyperv1.LoadBalancer:
-					if service.LoadBalancer != nil && len(service.LoadBalancer.Hostname) > 0 {
-						externalNameDestination = service.LoadBalancer.Hostname
-						break
-					}
-				case hyperv1.NodePort:
-					if service.NodePort != nil && len(service.NodePort.Address) > 0 && service.NodePort.Port != 0 {
-						externalNameDestination = fmt.Sprintf("%s:%d", service.NodePort.Address, service.NodePort.Port)
-						break
-					}
-				}
-			default:
-				t.Log("service custom DNS name not found, using the control plane endpoint")
-				hcp := &hyperv1.HostedControlPlane{}
-				err = mgmtClient.Get(ctx, types.NamespacedName{Namespace: hcpNamespace, Name: entryHostedCluster.Name}, hcp)
-				g.Expect(err).NotTo(HaveOccurred(), "failed to get updated HostedControlPlane")
-				g.Expect(hcp.Status.ControlPlaneEndpoint.Host).NotTo(BeEmpty(), "failed to get the control plane endpoint")
-				externalNameDestination = hcp.Status.ControlPlaneEndpoint.Host
-			}
-		}
-	}
-	g.Expect(externalNameDestination).NotTo(BeEmpty(), "failed to get the external name destination")
-
-	// Create a new KAS Service to be used by the external-dns deployment in CI
-	t.Logf("Creating a new KAS Service to be used by the external-dns deployment in CI with the custom DNS name %s", customApiServerHost)
-	svc := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kube-apiserver-private-external",
-			Namespace: hcpNamespace,
-			Annotations: map[string]string{
-				"external-dns.alpha.kubernetes.io/hostname": customApiServerHost,
-				"external-dns.alpha.kubernetes.io/ttl":      "30",
-			},
-		},
-		Spec: corev1.ServiceSpec{
-			ExternalName: externalNameDestination,
-			Type:         corev1.ServiceTypeExternalName,
-		},
-	}
-
-	err = mgmtClient.Create(ctx, svc)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to update KAS Service")
-
-	// Wait until the URL is resolvable. This can take a long time to become accessible.
-	start := time.Now()
-	g.Eventually(func() error {
-		t.Logf("[%s] Waiting until the URL is resolvable: %s", time.Now().Format(time.RFC3339), customApiServerHost)
-		_, err := net.LookupIP(customApiServerHost)
-		if err != nil {
-			return fmt.Errorf("failed to resolve the custom DNS name: %v", err)
-		}
-		t.Logf("resolved the custom DNS name after %s\n", time.Since(start))
-		return nil
-	}, dnsResolutionTimeout, 10*time.Second).Should(Succeed(), "failed to resolve the custom DNS name")
-
-	// Wait until the KAS Deployment is ready
-	t.Log("Waiting until the KAS Deployment is ready")
-	g.Eventually(func() bool {
-		kubeAPIServerDeployment := &appsv1.Deployment{}
-		err = mgmtClient.Get(ctx, types.NamespacedName{Namespace: hcpNamespace, Name: "kube-apiserver"}, kubeAPIServerDeployment)
-		if err != nil {
-			return false
-		}
-		return util.IsDeploymentReady(ctx, kubeAPIServerDeployment)
-	}, kasDeploymentTimeout, 10*time.Second).Should(BeTrue(), "failed to ensure KAS Deployment is ready")
-
-	// KAS deployment readiness should ensure certificate configuration is loaded
-	// If certificate loading becomes an issue, we'll see TLS errors (not DNS errors)
-
-	t.Run("EnsureCustomAdminKubeconfigStatusExists", func(t *testing.T) {
-		g := NewWithT(t)
-		t.Log("Checking CustomAdminKubeconfigStatus are present")
-		g.Expect(hcp.Status.CustomKubeconfig).ToNot(BeNil(), "HostedControlPlaneKASCustomKubeconfigis nil")
-		g.Expect(hc.Status.CustomKubeconfig).ToNot(BeNil(), "HostedClusterKASCustomKubeconfigis nil")
-		hcKASCustomKubeconfigSecretName = hc.Status.CustomKubeconfig.Name
-	})
-	t.Run("EnsureCustomAdminKubeconfigExists", func(t *testing.T) {
-		g := NewWithT(t)
-		// Get KASCustomKubeconfig secret from HCP Namespace
-		t.Log("Checking CustomAdminKubeconfigs are present")
-		hcpKASCustomKubeconfig := cpomanifests.KASCustomKubeconfigSecret(hcpNamespace, nil)
-		err := mgmtClient.Get(ctx, client.ObjectKeyFromObject(hcpKASCustomKubeconfig), hcpKASCustomKubeconfig)
-		g.Expect(err).ToNot(HaveOccurred(), "failed to get KAS custom kubeconfig secret")
-		g.Expect(hc.Status.CustomKubeconfig).ToNot(BeNil(), "KASCustomKubeconfig is nil")
-
-		// Get KASCustomKubeconfig secret from HC Namespace
-		hcCustomKubeconfigSecret := &corev1.Secret{}
-		err = mgmtClient.Get(ctx, types.NamespacedName{Namespace: hc.Namespace, Name: hc.Status.CustomKubeconfig.Name}, hcCustomKubeconfigSecret)
-		g.Expect(err).ToNot(HaveOccurred(), "failed to get KAS custom kubeconfig secret from HC namespace")
-	})
-	t.Run("EnsureCustomAdminKubeconfigReachesTheKAS", func(t *testing.T) {
-		g := NewWithT(t)
-		t.Log("Checking CustomAdminKubeconfig reaches the KAS")
-		if isAzure {
-			t.Log("Using extended retry timeout for Azure DNS propagation")
-		}
-		// Add retry logic for DNS-related failures with platform-specific timeout
-		g.Eventually(func() error {
-			cv := &configv1.ClusterVersion{}
-			err := kbCrclient.Get(ctx, types.NamespacedName{Name: "version"}, cv)
-			if err != nil {
-				// Check if this is a DNS-related error
-				if strings.Contains(err.Error(), "no such host") || strings.Contains(err.Error(), "dial tcp") ||
-					strings.Contains(err.Error(), "failed to get API group resources") {
-					t.Logf("DNS resolution issue detected, retrying: %v", err)
-					return err
-				}
-				// For non-DNS errors, fail immediately
-				return fmt.Errorf("non-DNS error occurred: %w", err)
-			}
-			t.Logf("Successfully verified custom kubeconfig can reach KAS")
-			return nil
-		}, retryTimeout, 10*time.Second).Should(Succeed(), "failed to get HostedCluster ClusterVersion with KAS custom kubeconfig")
-	})
-	t.Run("EnsureCustomAdminKubeconfigInfraStatusIsUpdated", func(t *testing.T) {
-		g := NewWithT(t)
-		t.Log("Checking CustomAdminKubeconfig Infrastructure status is updated")
-		EventuallyObject(t, ctx, "a successful connection to the custom DNS guest API server",
-			func(ctx context.Context) (*authenticationv1.SelfSubjectReview, error) {
-				return kasCustomKubeconfigClient.AuthenticationV1().SelfSubjectReviews().Create(ctx, &authenticationv1.SelfSubjectReview{}, metav1.CreateOptions{})
-			}, nil, WithTimeout(30*time.Minute),
+			// Using domain name filtered by the external-dns deployment in CI
+			customApiServerHost     = fmt.Sprintf("api-custom-cert-%s.%s", entryHostedCluster.Spec.InfraID, serviceDomain)
+			hcpNamespace            = manifests.HostedControlPlaneNamespace(entryHostedCluster.Namespace, entryHostedCluster.Name)
+			kasCustomCertSecretName = fmt.Sprintf("%s-kas-custom-cert", entryHostedCluster.Name)
 		)
-		infra := &configv1.Infrastructure{}
-		err := kbCrclient.Get(ctx, types.NamespacedName{Name: "cluster"}, infra)
-		g.Expect(err).ToNot(HaveOccurred(), "failed to get HostedCluster Infrastructure with KAS custom kubeconfig")
-		g.Expect(infra.Status.APIServerURL).To(ContainSubstring(hc.Spec.KubeAPIServerDNSName), "Infrastructure APIServerURL does not contains the KubeAPIServerDNSName set in the HostedCluster")
-	})
 
-	// removing KubeAPIDNSName from HC
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		// Get the latest version of the object
-		latestHC := &hyperv1.HostedCluster{}
-		if err := mgmtClient.Get(ctx, client.ObjectKeyFromObject(hc), latestHC); err != nil {
-			return err
+		if isAzure {
+			serviceDomain = "aks-e2e.hypershift.azure.devcluster.openshift.com"
+			customApiServerHost = fmt.Sprintf("api-custom-cert-%s.%s", entryHostedCluster.Spec.InfraID, serviceDomain)
+
+			// Based on sample test evidence: ~40% failure rate due to internal DNS lag after external resolution
+			// Use retries instead of proactive waiting for better efficiency
+			retryTimeout = 10 * time.Minute // Extended retry for the kubeconfig test
+			t.Log("Using Azure-specific retry strategy for DNS propagation race condition")
 		}
-		// Apply our changes to the latest version
-		latestHC.Spec.KubeAPIServerDNSName = ""
-		return mgmtClient.Update(ctx, latestHC)
-	})
-	g.Expect(err).NotTo(HaveOccurred(), "failed to update hosted control plane")
 
-	// Remove the annotation from the KAS Service
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		svc := &corev1.Service{}
-		err = mgmtClient.Get(ctx, types.NamespacedName{Namespace: hcpNamespace, Name: "kube-apiserver"}, svc)
-		g.Expect(err).NotTo(HaveOccurred(), "failed to get updated KAS Service")
-		delete(svc.Annotations, "external-dns.alpha.kubernetes.io/hostname")
-		return mgmtClient.Update(ctx, svc)
-	})
-	g.Expect(err).NotTo(HaveOccurred(), "failed to update KAS Service")
-
-	EventuallyObject(t, ctx, "the KAS custom kubeconfig secret to be deleted from HC Namespace",
-		func(ctx context.Context) (*hyperv1.HostedCluster, error) {
-			hc := &hyperv1.HostedCluster{}
-			err := mgmtClient.Get(ctx, types.NamespacedName{Name: entryHostedCluster.Name, Namespace: entryHostedCluster.Namespace}, hc)
-			return hc, err
-		},
-		[]Predicate[*hyperv1.HostedCluster]{
-			func(hostedCluster *hyperv1.HostedCluster) (done bool, reason string, err error) {
-				if hostedCluster.Status.CustomKubeconfig != nil {
-					return false, fmt.Sprintf("HC - KAS custom kubeconfig secret still exists: %s", hostedCluster.Status.CustomKubeconfig.Name), nil
-				}
-				return true, "HC - KAS custom kubeconfig secret disappeared from HC Namespace", nil
-			},
-		}, WithInterval(5*time.Second), WithTimeout(30*time.Minute),
-	)
-
-	EventuallyObject(t, ctx, "the KAS custom kubeconfig secret to be deleted from HCP Namespace",
-		func(ctx context.Context) (*hyperv1.HostedControlPlane, error) {
-			hcp := &hyperv1.HostedControlPlane{}
-			err := mgmtClient.Get(ctx, types.NamespacedName{Name: entryHostedCluster.Name, Namespace: hcpNamespace}, hcp)
-			return hcp, err
-		},
-		[]Predicate[*hyperv1.HostedControlPlane]{
-			func(hcp *hyperv1.HostedControlPlane) (done bool, reason string, err error) {
-				if hcp.Status.CustomKubeconfig != nil {
-					return false, fmt.Sprintf("HCP - KAS custom kubeconfig secret still exists: %s", hcp.Status.CustomKubeconfig.Name), nil
-				}
-				return true, "KAS custom kubeconfig secret disappeared from HCP Namespace", nil
-			},
-		}, WithInterval(5*time.Second), WithTimeout(30*time.Minute),
-	)
-
-	t.Run("EnsureCustomAdminKubeconfigIsRemoved", func(t *testing.T) {
 		g := NewWithT(t)
-		t.Log("Checking CustomAdminKubeconfig are removed")
-		hcpKASCustomKubeconfig := cpomanifests.KASCustomKubeconfigSecret(hcpNamespace, nil)
-		err := mgmtClient.Get(ctx, client.ObjectKeyFromObject(hcpKASCustomKubeconfig), hcpKASCustomKubeconfig)
-		g.Expect(err).To(HaveOccurred(), "KAS custom kubeconfig secret still exists in HCP namespace")
-
-		// Get KASCustomKubeconfig secret from HC Namespace
-		hcKASCustomKubeconfigSecret := &corev1.Secret{}
-		err = mgmtClient.Get(ctx, types.NamespacedName{Namespace: hc.Namespace, Name: hcKASCustomKubeconfigSecretName}, hcKASCustomKubeconfigSecret)
-		g.Expect(err).To(HaveOccurred(), "KAS custom kubeconfig secret still exists in HC namespace")
-	})
-
-	updatedHC := &hyperv1.HostedCluster{}
-	EventuallyObject(t, ctx, "the KAS custom kubeconfig status to be removed",
-		func(ctx context.Context) (*hyperv1.HostedCluster, error) {
-			err := mgmtClient.Get(ctx, types.NamespacedName{Name: entryHostedCluster.Name, Namespace: entryHostedCluster.Namespace}, updatedHC)
-			return updatedHC, err
-		},
-		[]Predicate[*hyperv1.HostedCluster]{
-			func(hostedCluster *hyperv1.HostedCluster) (done bool, reason string, err error) {
-				if updatedHC.Status.CustomKubeconfig != nil {
-					return false, fmt.Sprintf("KAS custom kubeconfig status still exists: %s", updatedHC.Status.CustomKubeconfig), nil
-				}
-				return true, "KAS custom kubeconfig status disappeared", nil
-			},
-		}, WithInterval(5*time.Second), WithTimeout(30*time.Minute),
-	)
-
-	t.Run("EnsureCustomAdminKubeconfigStatusIsRemoved", func(t *testing.T) {
-		g := NewWithT(t)
-		t.Log("Checking CustomAdminKubeconfigStatus are removed")
-		g.Expect(updatedHC.Status.CustomKubeconfig).To(BeNil(), "HostedClusterKASCustomKubeconfigis not nil")
-	})
-
-	// Delete NamedCertificates from the KAS
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latestHC := &hyperv1.HostedCluster{}
-		if err := mgmtClient.Get(ctx, client.ObjectKeyFromObject(hc), latestHC); err != nil {
-			return fmt.Errorf("failed to get latest HostedCluster: %v", err)
+		if !util.IsPublicHC(entryHostedCluster) {
+			return
 		}
-		latestHC.Spec.Configuration.APIServer.ServingCerts.NamedCertificates = []configv1.APIServerNamedServingCert{}
-		return mgmtClient.Update(ctx, latestHC)
+
+		// Generate a custom certificate for the KAS
+		t.Log("Generating custom certificate with DNS name", customApiServerHost)
+		customCert, customKey, err := GenerateCustomCertificate([]string{customApiServerHost}, 24*time.Hour)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to generate custom certificate")
+
+		// Create secret with the custom certificate
+		t.Log("Creating custom certificate secret")
+		customCertSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kasCustomCertSecretName,
+				Namespace: entryHostedCluster.Namespace,
+			},
+			Data: map[string][]byte{
+				"tls.crt": customCert,
+				"tls.key": customKey,
+			},
+		}
+		err = mgmtClient.Create(ctx, customCertSecret)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to create custom certificate secret")
+
+		// update HC with a KubeAPIDNSName and KAS custom serving cert
+		hc := entryHostedCluster.DeepCopy()
+		t.Log("Updating hosted cluster with KubeAPIDNSName and KAS custom serving cert")
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			// Get the latest version of the object
+			latestHC := &hyperv1.HostedCluster{}
+			if err := mgmtClient.Get(ctx, client.ObjectKeyFromObject(hc), latestHC); err != nil {
+				return err
+			}
+
+			// update the KubeAPIDNSName
+			latestHC.Spec.KubeAPIServerDNSName = customApiServerHost
+
+			// update the KAS custom serving cert
+			if latestHC.Spec.Configuration == nil {
+				latestHC.Spec.Configuration = &hyperv1.ClusterConfiguration{}
+			}
+			if latestHC.Spec.Configuration.APIServer == nil {
+				latestHC.Spec.Configuration.APIServer = &configv1.APIServerSpec{}
+			}
+
+			namedCertificate := configv1.APIServerNamedServingCert{
+				Names: []string{customApiServerHost},
+				ServingCertificate: configv1.SecretNameReference{
+					Name: kasCustomCertSecretName,
+				},
+			}
+
+			if len(latestHC.Spec.Configuration.APIServer.ServingCerts.NamedCertificates) == 0 {
+				latestHC.Spec.Configuration.APIServer.ServingCerts.NamedCertificates = []configv1.APIServerNamedServingCert{namedCertificate}
+			} else {
+				latestHC.Spec.Configuration.APIServer.ServingCerts.NamedCertificates = append(latestHC.Spec.Configuration.APIServer.ServingCerts.NamedCertificates, namedCertificate)
+			}
+
+			return mgmtClient.Update(ctx, latestHC)
+		})
+		g.Expect(err).NotTo(HaveOccurred(), "failed to update hosted cluster")
+
+		t.Log("Getting custom kubeconfig client")
+		customApiServerURL := fmt.Sprintf("https://%s:%s", customApiServerHost, "443")
+		kasCustomKubeconfigClient, kbCrclient := GetCustomKubeconfigClients(t, ctx, mgmtClient, entryHostedCluster, customApiServerURL)
+
+		// wait for the KubeAPIDNSName to be reconciled
+		t.Log("waiting for the KubeAPIDNSName to be reconciled")
+		_ = WaitForCustomKubeconfig(t, ctx, mgmtClient, entryHostedCluster)
+
+		// Get HC and HCP updated
+		err = mgmtClient.Get(ctx, client.ObjectKeyFromObject(hc), hc)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to get updated HostedCluster")
+
+		hcp := &hyperv1.HostedControlPlane{}
+		err = mgmtClient.Get(ctx, types.NamespacedName{Namespace: hcpNamespace, Name: entryHostedCluster.Name}, hcp)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to get updated HostedControlPlane")
+
+		// Find the external name destination for the KAS Service
+		t.Log("Finding the external name destination for the KAS Service")
+		var externalNameDestination string
+		if entryHostedCluster.Spec.Services != nil {
+			for _, service := range entryHostedCluster.Spec.Services {
+				fmt.Printf("service: %+v\n", service)
+				switch service.Service {
+				case hyperv1.APIServer:
+					switch service.Type {
+					case hyperv1.Route:
+						if service.Route != nil && len(service.Route.Hostname) > 0 {
+							externalNameDestination = service.Route.Hostname
+							break
+						}
+					case hyperv1.LoadBalancer:
+						if service.LoadBalancer != nil && len(service.LoadBalancer.Hostname) > 0 {
+							externalNameDestination = service.LoadBalancer.Hostname
+							break
+						}
+					case hyperv1.NodePort:
+						if service.NodePort != nil && len(service.NodePort.Address) > 0 && service.NodePort.Port != 0 {
+							externalNameDestination = fmt.Sprintf("%s:%d", service.NodePort.Address, service.NodePort.Port)
+							break
+						}
+					}
+				default:
+					t.Log("service custom DNS name not found, using the control plane endpoint")
+					hcp := &hyperv1.HostedControlPlane{}
+					err = mgmtClient.Get(ctx, types.NamespacedName{Namespace: hcpNamespace, Name: entryHostedCluster.Name}, hcp)
+					g.Expect(err).NotTo(HaveOccurred(), "failed to get updated HostedControlPlane")
+					g.Expect(hcp.Status.ControlPlaneEndpoint.Host).NotTo(BeEmpty(), "failed to get the control plane endpoint")
+					externalNameDestination = hcp.Status.ControlPlaneEndpoint.Host
+				}
+			}
+		}
+		g.Expect(externalNameDestination).NotTo(BeEmpty(), "failed to get the external name destination")
+
+		// Create a new KAS Service to be used by the external-dns deployment in CI
+		t.Logf("Creating a new KAS Service to be used by the external-dns deployment in CI with the custom DNS name %s", customApiServerHost)
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kube-apiserver-private-external",
+				Namespace: hcpNamespace,
+				Annotations: map[string]string{
+					"external-dns.alpha.kubernetes.io/hostname": customApiServerHost,
+					"external-dns.alpha.kubernetes.io/ttl":      "30",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				ExternalName: externalNameDestination,
+				Type:         corev1.ServiceTypeExternalName,
+			},
+		}
+
+		err = mgmtClient.Create(ctx, svc)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to update KAS Service")
+
+		// Wait until the URL is resolvable. This can take a long time to become accessible.
+		start := time.Now()
+		g.Eventually(func() error {
+			t.Logf("[%s] Waiting until the URL is resolvable: %s", time.Now().Format(time.RFC3339), customApiServerHost)
+			_, err := net.LookupIP(customApiServerHost)
+			if err != nil {
+				return fmt.Errorf("failed to resolve the custom DNS name: %v", err)
+			}
+			t.Logf("resolved the custom DNS name after %s\n", time.Since(start))
+			return nil
+		}, dnsResolutionTimeout, 10*time.Second).Should(Succeed(), "failed to resolve the custom DNS name")
+
+		// Wait until the KAS Deployment is ready
+		t.Log("Waiting until the KAS Deployment is ready")
+		g.Eventually(func() bool {
+			kubeAPIServerDeployment := &appsv1.Deployment{}
+			err = mgmtClient.Get(ctx, types.NamespacedName{Namespace: hcpNamespace, Name: "kube-apiserver"}, kubeAPIServerDeployment)
+			if err != nil {
+				return false
+			}
+			return util.IsDeploymentReady(ctx, kubeAPIServerDeployment)
+		}, kasDeploymentTimeout, 10*time.Second).Should(BeTrue(), "failed to ensure KAS Deployment is ready")
+
+		// KAS deployment readiness should ensure certificate configuration is loaded
+		// If certificate loading becomes an issue, we'll see TLS errors (not DNS errors)
+
+		t.Run("EnsureCustomAdminKubeconfigStatusExists", func(t *testing.T) {
+			g := NewWithT(t)
+			t.Log("Checking CustomAdminKubeconfigStatus are present")
+			g.Expect(hcp.Status.CustomKubeconfig).ToNot(BeNil(), "HostedControlPlaneKASCustomKubeconfigis nil")
+			g.Expect(hc.Status.CustomKubeconfig).ToNot(BeNil(), "HostedClusterKASCustomKubeconfigis nil")
+			hcKASCustomKubeconfigSecretName = hc.Status.CustomKubeconfig.Name
+		})
+		t.Run("EnsureCustomAdminKubeconfigExists", func(t *testing.T) {
+			g := NewWithT(t)
+			// Get KASCustomKubeconfig secret from HCP Namespace
+			t.Log("Checking CustomAdminKubeconfigs are present")
+			hcpKASCustomKubeconfig := cpomanifests.KASCustomKubeconfigSecret(hcpNamespace, nil)
+			err := mgmtClient.Get(ctx, client.ObjectKeyFromObject(hcpKASCustomKubeconfig), hcpKASCustomKubeconfig)
+			g.Expect(err).ToNot(HaveOccurred(), "failed to get KAS custom kubeconfig secret")
+			g.Expect(hc.Status.CustomKubeconfig).ToNot(BeNil(), "KASCustomKubeconfig is nil")
+
+			// Get KASCustomKubeconfig secret from HC Namespace
+			hcCustomKubeconfigSecret := &corev1.Secret{}
+			err = mgmtClient.Get(ctx, types.NamespacedName{Namespace: hc.Namespace, Name: hc.Status.CustomKubeconfig.Name}, hcCustomKubeconfigSecret)
+			g.Expect(err).ToNot(HaveOccurred(), "failed to get KAS custom kubeconfig secret from HC namespace")
+		})
+		t.Run("EnsureCustomAdminKubeconfigReachesTheKAS", func(t *testing.T) {
+			g := NewWithT(t)
+			t.Log("Checking CustomAdminKubeconfig reaches the KAS")
+			if isAzure {
+				t.Log("Using extended retry timeout for Azure DNS propagation")
+			}
+			// Add retry logic for DNS-related failures with platform-specific timeout
+			g.Eventually(func() error {
+				cv := &configv1.ClusterVersion{}
+				err := kbCrclient.Get(ctx, types.NamespacedName{Name: "version"}, cv)
+				if err != nil {
+					// Check if this is a DNS-related error
+					if strings.Contains(err.Error(), "no such host") || strings.Contains(err.Error(), "dial tcp") ||
+						strings.Contains(err.Error(), "failed to get API group resources") {
+						t.Logf("DNS resolution issue detected, retrying: %v", err)
+						return err
+					}
+					// For non-DNS errors, fail immediately
+					return fmt.Errorf("non-DNS error occurred: %w", err)
+				}
+				t.Logf("Successfully verified custom kubeconfig can reach KAS")
+				return nil
+			}, retryTimeout, 10*time.Second).Should(Succeed(), "failed to get HostedCluster ClusterVersion with KAS custom kubeconfig")
+		})
+		t.Run("EnsureCustomAdminKubeconfigInfraStatusIsUpdated", func(t *testing.T) {
+			g := NewWithT(t)
+			t.Log("Checking CustomAdminKubeconfig Infrastructure status is updated")
+			EventuallyObject(t, ctx, "a successful connection to the custom DNS guest API server",
+				func(ctx context.Context) (*authenticationv1.SelfSubjectReview, error) {
+					return kasCustomKubeconfigClient.AuthenticationV1().SelfSubjectReviews().Create(ctx, &authenticationv1.SelfSubjectReview{}, metav1.CreateOptions{})
+				}, nil, WithTimeout(30*time.Minute),
+			)
+			infra := &configv1.Infrastructure{}
+			err := kbCrclient.Get(ctx, types.NamespacedName{Name: "cluster"}, infra)
+			g.Expect(err).ToNot(HaveOccurred(), "failed to get HostedCluster Infrastructure with KAS custom kubeconfig")
+			g.Expect(infra.Status.APIServerURL).To(ContainSubstring(hc.Spec.KubeAPIServerDNSName), "Infrastructure APIServerURL does not contains the KubeAPIServerDNSName set in the HostedCluster")
+		})
+
+		// removing KubeAPIDNSName from HC
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			// Get the latest version of the object
+			latestHC := &hyperv1.HostedCluster{}
+			if err := mgmtClient.Get(ctx, client.ObjectKeyFromObject(hc), latestHC); err != nil {
+				return err
+			}
+			// Apply our changes to the latest version
+			latestHC.Spec.KubeAPIServerDNSName = ""
+			return mgmtClient.Update(ctx, latestHC)
+		})
+		g.Expect(err).NotTo(HaveOccurred(), "failed to update hosted control plane")
+
+		// Remove the annotation from the KAS Service
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			svc := &corev1.Service{}
+			err = mgmtClient.Get(ctx, types.NamespacedName{Namespace: hcpNamespace, Name: "kube-apiserver"}, svc)
+			g.Expect(err).NotTo(HaveOccurred(), "failed to get updated KAS Service")
+			delete(svc.Annotations, "external-dns.alpha.kubernetes.io/hostname")
+			return mgmtClient.Update(ctx, svc)
+		})
+		g.Expect(err).NotTo(HaveOccurred(), "failed to update KAS Service")
+
+		EventuallyObject(t, ctx, "the KAS custom kubeconfig secret to be deleted from HC Namespace",
+			func(ctx context.Context) (*hyperv1.HostedCluster, error) {
+				hc := &hyperv1.HostedCluster{}
+				err := mgmtClient.Get(ctx, types.NamespacedName{Name: entryHostedCluster.Name, Namespace: entryHostedCluster.Namespace}, hc)
+				return hc, err
+			},
+			[]Predicate[*hyperv1.HostedCluster]{
+				func(hostedCluster *hyperv1.HostedCluster) (done bool, reason string, err error) {
+					if hostedCluster.Status.CustomKubeconfig != nil {
+						return false, fmt.Sprintf("HC - KAS custom kubeconfig secret still exists: %s", hostedCluster.Status.CustomKubeconfig.Name), nil
+					}
+					return true, "HC - KAS custom kubeconfig secret disappeared from HC Namespace", nil
+				},
+			}, WithInterval(5*time.Second), WithTimeout(30*time.Minute),
+		)
+
+		EventuallyObject(t, ctx, "the KAS custom kubeconfig secret to be deleted from HCP Namespace",
+			func(ctx context.Context) (*hyperv1.HostedControlPlane, error) {
+				hcp := &hyperv1.HostedControlPlane{}
+				err := mgmtClient.Get(ctx, types.NamespacedName{Name: entryHostedCluster.Name, Namespace: hcpNamespace}, hcp)
+				return hcp, err
+			},
+			[]Predicate[*hyperv1.HostedControlPlane]{
+				func(hcp *hyperv1.HostedControlPlane) (done bool, reason string, err error) {
+					if hcp.Status.CustomKubeconfig != nil {
+						return false, fmt.Sprintf("HCP - KAS custom kubeconfig secret still exists: %s", hcp.Status.CustomKubeconfig.Name), nil
+					}
+					return true, "KAS custom kubeconfig secret disappeared from HCP Namespace", nil
+				},
+			}, WithInterval(5*time.Second), WithTimeout(30*time.Minute),
+		)
+
+		t.Run("EnsureCustomAdminKubeconfigIsRemoved", func(t *testing.T) {
+			g := NewWithT(t)
+			t.Log("Checking CustomAdminKubeconfig are removed")
+			hcpKASCustomKubeconfig := cpomanifests.KASCustomKubeconfigSecret(hcpNamespace, nil)
+			err := mgmtClient.Get(ctx, client.ObjectKeyFromObject(hcpKASCustomKubeconfig), hcpKASCustomKubeconfig)
+			g.Expect(err).To(HaveOccurred(), "KAS custom kubeconfig secret still exists in HCP namespace")
+
+			// Get KASCustomKubeconfig secret from HC Namespace
+			hcKASCustomKubeconfigSecret := &corev1.Secret{}
+			err = mgmtClient.Get(ctx, types.NamespacedName{Namespace: hc.Namespace, Name: hcKASCustomKubeconfigSecretName}, hcKASCustomKubeconfigSecret)
+			g.Expect(err).To(HaveOccurred(), "KAS custom kubeconfig secret still exists in HC namespace")
+		})
+
+		updatedHC := &hyperv1.HostedCluster{}
+		EventuallyObject(t, ctx, "the KAS custom kubeconfig status to be removed",
+			func(ctx context.Context) (*hyperv1.HostedCluster, error) {
+				err := mgmtClient.Get(ctx, types.NamespacedName{Name: entryHostedCluster.Name, Namespace: entryHostedCluster.Namespace}, updatedHC)
+				return updatedHC, err
+			},
+			[]Predicate[*hyperv1.HostedCluster]{
+				func(hostedCluster *hyperv1.HostedCluster) (done bool, reason string, err error) {
+					if updatedHC.Status.CustomKubeconfig != nil {
+						return false, fmt.Sprintf("KAS custom kubeconfig status still exists: %s", updatedHC.Status.CustomKubeconfig), nil
+					}
+					return true, "KAS custom kubeconfig status disappeared", nil
+				},
+			}, WithInterval(5*time.Second), WithTimeout(30*time.Minute),
+		)
+
+		t.Run("EnsureCustomAdminKubeconfigStatusIsRemoved", func(t *testing.T) {
+			g := NewWithT(t)
+			t.Log("Checking CustomAdminKubeconfigStatus are removed")
+			g.Expect(updatedHC.Status.CustomKubeconfig).To(BeNil(), "HostedClusterKASCustomKubeconfigis not nil")
+		})
+
+		// Delete NamedCertificates from the KAS
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			latestHC := &hyperv1.HostedCluster{}
+			if err := mgmtClient.Get(ctx, client.ObjectKeyFromObject(hc), latestHC); err != nil {
+				return fmt.Errorf("failed to get latest HostedCluster: %v", err)
+			}
+			latestHC.Spec.Configuration.APIServer.ServingCerts.NamedCertificates = []configv1.APIServerNamedServingCert{}
+			return mgmtClient.Update(ctx, latestHC)
+		})
+		g.Expect(err).NotTo(HaveOccurred(), "failed to update hosted cluster")
+
+		// Delete custom certificate secret
+		t.Log("Deleting custom certificate secret")
+		latestCustomCertSecret := customCertSecret.DeepCopy()
+		err = mgmtClient.Get(ctx, types.NamespacedName{Namespace: hcpNamespace, Name: kasCustomCertSecretName}, latestCustomCertSecret)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to get custom certificate secret")
+		err = mgmtClient.Delete(ctx, latestCustomCertSecret)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to delete custom certificate secret")
 	})
-	g.Expect(err).NotTo(HaveOccurred(), "failed to update hosted cluster")
-
-	// Delete custom certificate secret
-	t.Log("Deleting custom certificate secret")
-	latestCustomCertSecret := customCertSecret.DeepCopy()
-	err = mgmtClient.Get(ctx, types.NamespacedName{Namespace: hcpNamespace, Name: kasCustomCertSecretName}, latestCustomCertSecret)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to get custom certificate secret")
-	err = mgmtClient.Delete(ctx, latestCustomCertSecret)
-	g.Expect(err).NotTo(HaveOccurred(), "failed to delete custom certificate secret")
-
 }
 
 func EnsureAdmissionPolicies(t *testing.T, ctx context.Context, mgmtClient crclient.Client, hc *hyperv1.HostedCluster) {


### PR DESCRIPTION
## What this PR does / why we need it

To have the EnsureGlobalPullSecret and EnsureKubeAPIDNSNameCustomCert make the TestCreateCluster to be skipped. This PR makes sure that would not happen anymore.