### PR TITLE
NO-JIRA: fix(test/e2e): add KCM leader elect failure msg to isLeaderElectionFailure

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -732,7 +732,7 @@ func isLeaderElectionFailure(ctx context.Context, guestClient *kubeclient.Client
 		return false
 	}
 
-	return strings.Contains(buf.String(), "leader election lost")
+	return strings.Contains(buf.String(), "election lost")
 }
 
 func NoticePreemptionOrFailedScheduling(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {


### PR DESCRIPTION
The kube-controller-manager emit a slightly different message when it loses the leader lease. `leaderelection lost` vs leader election lost`. This PR broadens the failure substring to include both.