### PR TITLE
NO-JIRA: fix(cmd): match infraID exactly on OIDC provider delete

### DIFF
--- a/cmd/infra/aws/destroy_iam.go
+++ b/cmd/infra/aws/destroy_iam.go
@@ -122,7 +122,10 @@ func (o *DestroyIAMOptions) DestroyOIDCResources(ctx context.Context, iamClient 
 	}
 
 	for _, provider := range oidcProviderList.OpenIDConnectProviderList {
-		if strings.Contains(*provider.Arn, o.InfraID) {
+		// OIDC Provider ARN is of the form arn:aws:iam::<account-id>:oidc-provider/hypershift-ci-2-oidc.s3.us-east-1.amazonaws.com/<infra-id>
+		arnTokens := strings.Split(*provider.Arn, "/")
+		arnInfraID := arnTokens[len(arnTokens)-1]
+		if arnInfraID == o.InfraID {
 			_, err := iamClient.DeleteOpenIDConnectProvider(&iam.DeleteOpenIDConnectProviderInput{
 				OpenIDConnectProviderArn: provider.Arn,
 			})


### PR DESCRIPTION
The current code just looks for the `infraID` anywhere an candiate OIDC Provider ARN.  This can lead to deletion of the wrong provider if the `infraID` is a substring of another cluster's `infraID`. For example, `test` and `test-2`.  If infra for `test` is destroyed, it might delete the provider for `test-2`.

This PR switches to an exact match on the `infraID` since we have the required information to do this.