### PR TITLE
OCPBUGS-59959: Set explicit FSGroup and RunAsUser for etcd when there's no SCC

### DIFF
--- a/support/controlplane-component/defaults.go
+++ b/support/controlplane-component/defaults.go
@@ -130,10 +130,12 @@ func (c *controlPlaneWorkload[T]) setDefaultOptions(cpContext ControlPlaneContex
 	}
 
 	// set default security context for the pod.
-	// ETCD component is excluded as it fails to create data dir on AKS if we set the default security context.
-	if c.Name() != etcdComponentName && cpContext.SetDefaultSecurityContext {
+	if cpContext.SetDefaultSecurityContext {
 		podTemplateSpec.Spec.SecurityContext = &corev1.PodSecurityContext{
 			RunAsUser: ptr.To[int64](DefaultSecurityContextUser),
+		}
+		if c.Name() == etcdComponentName {
+			podTemplateSpec.Spec.SecurityContext.FSGroup = ptr.To[int64](DefaultSecurityContextUser)
 		}
 	}
 


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
Without this, when there's no SCC as in ibm/aks, the etcd pod runs as root


**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.