### PR TITLE
OCPBUGS-59886: Add selinux-warning-controller to KCM

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_controller_manager_deployment.yaml
@@ -92,6 +92,7 @@ spec:
         - --controllers=-ttl
         - --controllers=-bootstrapsigner
         - --controllers=-tokencleaner
+        - --controllers=selinux-warning-controller
         - --enable-dynamic-provisioning=true
         - --flex-volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec
         - --pv-recycler-pod-template-filepath-nfs=/etc/kubernetes/recycler-config/recycler-pod.yaml

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents_kube_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents_kube_controller_manager_deployment.yaml
@@ -92,6 +92,7 @@ spec:
         - --controllers=-ttl
         - --controllers=-bootstrapsigner
         - --controllers=-tokencleaner
+        - --controllers=selinux-warning-controller
         - --enable-dynamic-provisioning=true
         - --flex-volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec
         - --pv-recycler-pod-template-filepath-nfs=/etc/kubernetes/recycler-config/recycler-pod.yaml

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-controller-manager/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-controller-manager/deployment.yaml
@@ -32,6 +32,7 @@ spec:
         - --controllers=-ttl
         - --controllers=-bootstrapsigner
         - --controllers=-tokencleaner
+        - --controllers=selinux-warning-controller
         - --enable-dynamic-provisioning=true
         - --flex-volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec
         - --pv-recycler-pod-template-filepath-nfs=/etc/kubernetes/recycler-config/recycler-pod.yaml


### PR DESCRIPTION
selinux-warning-controller is an controller that emits warnings about Pods with wrong SELinux labels. It's opt-in upstream, because upstream clusters typically don't run with SELinux and it would be just waste of memory and CPU.

OpenShift need the controller running, because it has SELinux enabled, and it provides better UX for our users.

And we run e2e tests that expect the controller running, see [OCPBUGS-59886](https://issues.redhat.com/browse/OCPBUGS-59886).

A similar change has been done to standalone OCP: https://github.com/openshift/cluster-kube-controller-manager-operator/pull/834