### PR TITLE
CORENET-6229: Use networking.advertiseAddress for CNO apiserver override for IBMCloud PlatformType

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cno/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cno/deployment.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
@@ -78,6 +79,9 @@ func buildCNOEnvVars(cpContext component.WorkloadContext) ([]corev1.EnvVar, erro
 	if util.IsPrivateHCP(hcp) {
 		apiServerAddress = fmt.Sprintf("api.%s.hypershift.local", hcp.Name)
 		apiServerPort = util.APIPortForLocalZone(util.IsLBKAS(hcp))
+	} else if hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
+		apiServerAddress = *hcp.Spec.Networking.APIServer.AdvertiseAddress
+		apiServerPort = *hcp.Spec.Networking.APIServer.Port
 	}
 
 	cnoEnv := []corev1.EnvVar{


### PR DESCRIPTION
**What this PR does / why we need it**:
This tells the cluster network operator to use the HostedCluster Spec.Networking.APIServer.AdvertiseAddress and Port when connecting to the apiserver on clusters in IBM Cloud.  This is needed so that OVN (and probably other components) does not try to use the external apiserver URLs, which might either be blocked by firewall rules or using named certificates which OVN doesn't handle.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # https://issues.redhat.com/browse/CORENET-6229

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.