### PR TITLE
OCPBUGS-60376: fix token rotation causing Karpenter to stop working

### DIFF
--- a/api/karpenter/v1beta1/karpenter_types.go
+++ b/api/karpenter/v1beta1/karpenter_types.go
@@ -13,6 +13,15 @@ const (
 	// KarpenterProviderAWSImage overrides the Karpenter AWS provider image to use for
 	// a HostedControlPlane with AutoNode enabled.
 	KarpenterProviderAWSImage = "hypershift.openshift.io/karpenter-provider-aws-image"
+
+	// KarpenterNodePoolName is the name of the hyperv1.NodePool associated with Karpenter.
+	KarpenterNodePool = "karpenter"
+
+	// TokenSecretNodePoolAnnotation is used to annotate the Karpenter token secret with its hyperv1.NodePool namespaced name.
+	TokenSecretNodePoolAnnotation = "hypershift.openshift.io/nodePool"
+
+	// UserDataAMILabel is a label set in the userData secret generated for karpenter instances.
+	UserDataAMILabel = "hypershift.openshift.io/ami"
 )
 
 // Subnet contains resolved Subnet selector values utilized for node launch

--- a/hypershift-operator/controllers/hostedcluster/karpenter.go
+++ b/hypershift-operator/controllers/hostedcluster/karpenter.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hyperkarpenterv1 "github.com/openshift/hypershift/api/karpenter/v1beta1"
 	karpenteroperatorv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/nodepool"
 	haproxy "github.com/openshift/hypershift/hypershift-operator/controllers/nodepool/apiserver-haproxy"
@@ -68,7 +69,7 @@ spec:
 
 	nodePool := &hyperv1.NodePool{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "karpenter",
+			Name:      hyperkarpenterv1.KarpenterNodePool,
 			Namespace: hcluster.Namespace,
 		},
 		Spec: hyperv1.NodePoolSpec{

--- a/karpenter-operator/controllers/karpenter/assets/assets.go
+++ b/karpenter-operator/controllers/karpenter/assets/assets.go
@@ -5,6 +5,7 @@ import (
 )
 
 const DefaultKarpenterProviderAWSImage = "public.ecr.aws/karpenter/controller:1.2.3"
+const EC2NodeClassDefault = "default"
 
 const (
 	// Karpenter Metrics

--- a/karpenter-operator/controllers/karpenter/karpenter_controller.go
+++ b/karpenter-operator/controllers/karpenter/karpenter_controller.go
@@ -196,7 +196,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			}
 			// Wait until all NodePools are deleted before removing the finalizer
 			if len(nodePoolList.Items) > 0 {
-				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+				log.Info("Waiting for NodePools to be deleted, requeueing...", "count", len(nodePoolList.Items))
+				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 			}
 
 			nodeClaimList := &karpenterv1.NodeClaimList{}
@@ -205,7 +206,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				return ctrl.Result{}, fmt.Errorf("failed to list NodeClaims: %w", err)
 			}
 			if len(nodeClaimList.Items) > 0 {
-				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+				log.Info("Waiting for NodeClaims to be deleted, requeueing...", "count", len(nodeClaimList.Items))
+				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 			}
 
 			originalHCP := hcp.DeepCopy()
@@ -283,7 +285,7 @@ func (r *Reconciler) reconcileOpenshiftEC2NodeClassDefault(ctx context.Context, 
 	log := ctrl.LoggerFrom(ctx)
 
 	ec2NodeClass := &hyperkarpenterv1.OpenshiftEC2NodeClass{}
-	ec2NodeClass.SetName("default")
+	ec2NodeClass.SetName(assets.EC2NodeClassDefault)
 
 	op, err := r.CreateOrUpdate(ctx, r.GuestClient, ec2NodeClass, func() error {
 		ec2NodeClass.Spec = hyperkarpenterv1.OpenshiftEC2NodeClassSpec{

--- a/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller_test.go
+++ b/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller_test.go
@@ -19,6 +19,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
 func TestReconcileEC2NodeClass(t *testing.T) {
@@ -28,7 +29,7 @@ func TestReconcileEC2NodeClass(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				userDataAMILabel: "ami-123",
+				hyperkarpenterv1.UserDataAMILabel: "ami-123",
 			},
 		},
 	}
@@ -242,6 +243,147 @@ func TestGetUserDataSecret(t *testing.T) {
 			g.Expect(secret).NotTo(BeNil())
 
 			g.Expect(secret.Name).To(Equal("newer-secret"))
+		})
+	}
+}
+
+func TestUserDataSecretPredicate(t *testing.T) {
+	testCases := []struct {
+		name           string
+		namespace      string
+		secret         *corev1.Secret
+		eventType      string
+		expectedResult bool
+	}{
+		{
+			name:      "should accept Create event for karpenter secret in correct namespace",
+			namespace: "test-namespace",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "karpenter-secret",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						hyperv1.NodePoolLabel: "clusters/karpenter",
+					},
+				},
+			},
+			eventType:      "Create",
+			expectedResult: true,
+		},
+		{
+			name:      "should accept Update event for karpenter secret in correct namespace",
+			namespace: "test-namespace",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "karpenter-secret",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						hyperv1.NodePoolLabel: "clusters/karpenter",
+					},
+				},
+			},
+			eventType:      "Update",
+			expectedResult: true,
+		},
+		{
+			name:      "should reject Delete event for karpenter secret",
+			namespace: "test-namespace",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "karpenter-secret",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						hyperv1.NodePoolLabel: "clusters/karpenter",
+					},
+				},
+			},
+			eventType:      "Delete",
+			expectedResult: false,
+		},
+		{
+			name:      "should reject Generic event for karpenter secret",
+			namespace: "test-namespace",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "karpenter-secret",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						hyperv1.NodePoolLabel: "clusters/karpenter",
+					},
+				},
+			},
+			eventType:      "Generic",
+			expectedResult: false,
+		},
+		{
+			name:      "should reject secret in wrong namespace",
+			namespace: "test-namespace",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "karpenter-secret",
+					Namespace: "wrong-namespace",
+					Annotations: map[string]string{
+						hyperv1.NodePoolLabel: "clusters/karpenter",
+					},
+				},
+			},
+			eventType:      "Create",
+			expectedResult: false,
+		},
+		{
+			name:      "should reject secret without incorrect NodePoolLabel annotation",
+			namespace: "test-namespace",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-secret",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						hyperv1.NodePoolLabel: "clusters/other",
+					},
+				},
+			},
+			eventType:      "Create",
+			expectedResult: false,
+		},
+		{
+			name:      "should reject secret without NodePoolLabel annotation",
+			namespace: "test-namespace",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "regular-secret",
+					Namespace: "test-namespace",
+				},
+			},
+			eventType:      "Create",
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			r := &EC2NodeClassReconciler{
+				Namespace: tc.namespace,
+			}
+
+			pred := r.userDataSecretPredicate()
+
+			var result bool
+			switch tc.eventType {
+			case "Create":
+				result = pred.Create(event.CreateEvent{Object: tc.secret})
+			case "Update":
+				result = pred.Update(event.UpdateEvent{ObjectNew: tc.secret, ObjectOld: tc.secret})
+			case "Delete":
+				result = pred.Delete(event.DeleteEvent{Object: tc.secret})
+			case "Generic":
+				result = pred.Generic(event.GenericEvent{Object: tc.secret})
+			default:
+				t.Fatalf("invalid event type: %s", tc.eventType)
+			}
+
+			g.Expect(result).To(Equal(tc.expectedResult))
 		})
 	}
 }

--- a/karpenter-operator/main.go
+++ b/karpenter-operator/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	hyperkarpenterv1 "github.com/openshift/hypershift/api/karpenter/v1beta1"
 	"github.com/openshift/hypershift/karpenter-operator/controllers/karpenter"
 	"github.com/openshift/hypershift/karpenter-operator/controllers/nodeclass"
 	hyperapi "github.com/openshift/hypershift/support/api"
@@ -23,8 +22,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	karpenterapis "sigs.k8s.io/karpenter/pkg/apis"
-	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
 	"github.com/spf13/cobra"
 )
@@ -82,15 +79,6 @@ func run(ctx context.Context) error {
 	metav1.AddToGroupVersion(scheme, awsKarpanterGroupVersion)
 	scheme.AddKnownTypes(awsKarpanterGroupVersion, &awskarpenterv1.EC2NodeClass{})
 	scheme.AddKnownTypes(awsKarpanterGroupVersion, &awskarpenterv1.EC2NodeClassList{})
-
-	karpanterGroupVersion := schema.GroupVersion{Group: karpenterapis.Group, Version: "v1"}
-	metav1.AddToGroupVersion(scheme, karpanterGroupVersion)
-	scheme.AddKnownTypes(karpanterGroupVersion, &karpenterv1.NodeClaim{})
-	scheme.AddKnownTypes(karpanterGroupVersion, &karpenterv1.NodeClaimList{})
-	scheme.AddKnownTypes(karpanterGroupVersion, &karpenterv1.NodePool{})
-	scheme.AddKnownTypes(karpanterGroupVersion, &karpenterv1.NodePoolList{})
-
-	_ = hyperkarpenterv1.AddToScheme(scheme)
 
 	managementCluster, err := cluster.New(managementKubeconfig, func(opt *cluster.Options) {
 		opt.Cache = cache.Options{

--- a/support/api/scheme.go
+++ b/support/api/scheme.go
@@ -5,6 +5,7 @@ import (
 
 	certificatesv1alpha1 "github.com/openshift/hypershift/api/certificates/v1alpha1"
 	hyperv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hyperkarpenterv1 "github.com/openshift/hypershift/api/karpenter/v1beta1"
 	schedulingv1alpha1 "github.com/openshift/hypershift/api/scheduling/v1alpha1"
 	"github.com/openshift/hypershift/support/rhobsmonitoring"
 
@@ -147,5 +148,6 @@ func init() {
 			&karpenterv1.NodePool{},
 			&karpenterv1.NodePoolList{},
 		)
+		_ = hyperkarpenterv1.AddToScheme(scheme)
 	}
 }

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -2279,12 +2279,15 @@ func ValidateMetrics(t *testing.T, ctx context.Context, client crclient.Client, 
 				}
 				// Karpenter related metrics
 				if metricName == karpenterassets.KarpenterBuildInfoMetricName || metricName == karpenterassets.KarpenterOperatorInfoMetricName {
-					if hc.Spec.AutoNode == nil || hc.Spec.AutoNode.Provisioner.Name != hyperv1.ProvisionerKarpeneter ||
-						hc.Spec.AutoNode.Provisioner.Karpenter.Platform != hyperv1.AWSPlatform || hc.Status.KubeConfig == nil {
-						continue
-					}
-					query = metricName
-					labelKey, labelValue = "", ""
+					// if hc.Spec.AutoNode == nil || hc.Spec.AutoNode.Provisioner.Name != hyperv1.ProvisionerKarpeneter ||
+					// 	hc.Spec.AutoNode.Provisioner.Karpenter.Platform != hyperv1.AWSPlatform || hc.Status.KubeConfig == nil {
+					// 	continue
+					// }
+					// TODO(maxcao13): This doesn't work right now since we no longer query prometheus aggregated metrics
+					// Come back later to enable this when we have a solution.
+					// query = metricName
+					// labelKey, labelValue = "", ""
+					continue
 				}
 
 				if metricName == hcmetrics.HostedClusterManagedAzureInfoMetricName {

--- a/vendor/github.com/openshift/hypershift/api/karpenter/v1beta1/karpenter_types.go
+++ b/vendor/github.com/openshift/hypershift/api/karpenter/v1beta1/karpenter_types.go
@@ -13,6 +13,15 @@ const (
 	// KarpenterProviderAWSImage overrides the Karpenter AWS provider image to use for
 	// a HostedControlPlane with AutoNode enabled.
 	KarpenterProviderAWSImage = "hypershift.openshift.io/karpenter-provider-aws-image"
+
+	// KarpenterNodePoolName is the name of the hyperv1.NodePool associated with Karpenter.
+	KarpenterNodePool = "karpenter"
+
+	// TokenSecretNodePoolAnnotation is used to annotate the Karpenter token secret with its hyperv1.NodePool namespaced name.
+	TokenSecretNodePoolAnnotation = "hypershift.openshift.io/nodePool"
+
+	// UserDataAMILabel is a label set in the userData secret generated for karpenter instances.
+	UserDataAMILabel = "hypershift.openshift.io/ami"
 )
 
 // Subnet contains resolved Subnet selector values utilized for node launch


### PR DESCRIPTION
**What this PR does / why we need it**:
The first commit enables the ec2nodeclass controller to watch the karpenter userData secret
in the management cluster. This allows the userData that is embedded in the ec2nodeclass to be updated
correctly if needed whenever the associated secret is updated. 

It also allows the hostedcluster controller to watch the token secret, so that we can call `token.Reconcile` manually for the karpenter nodepool token.

This was an issue because after the token rotates, if you provision a new workload with karpenter, the node bootstrapping will reference the old token and fail to register as a new node when attempting to contact the ignition server since the userData changes did not trigger karpenter to be aware of the new token. 

---

~The second commit skips token rotation for the karpenter hyperv1.NodePool. Previously, if the token rotates, this
will cause existing Karpenter nodes to drift unnecessarily. 
This is a quick hack. The "correct" way to solve this is to make sure that a change like this do not cause drift in the karpenter-provider-aws code, (maybe as a carry since the way we pass the ignition-config to coreos nodes in hypershift seems very specialized).~

Above is removed. We will resolve that somewhere else but keep it documented in [AUTOSCALE-293](https://issues.redhat.com/browse/AUTOSCALE-293).

---

Second commit just improves some handling and logging in the e2e tests, and fixes up some test logic.

---

Third commit allows hypershift e2e tests to dump Karpenter resources from the guest cluster if they exist. I had to add the hypershift karpenter api to the global scheme to do this. Makes debugging autonode e2e tests a lot easier.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Guest cluster diagnostics now include Karpenter resources when available.
  - Standardized Karpenter user data/AMI labeling and node pool naming via new constants.

- Bug Fixes
  - Karpenter token rotation secrets now reliably trigger HostedCluster reconciliation.
  - Consistent default name applied for EC2NodeClass.

- Refactor
  - EC2NodeClass reconciler watches relevant secret changes for better synchronization.
  - Finalization logs clarified and requeue intervals tuned.

- Tests
  - Stronger end-to-end checks for pod scheduling/readiness with extended timeouts.
  - Added unit tests for secret event filtering logic.

- Chores
  - Runtime scheme aligned with Karpenter APIs; certain metrics validations temporarily skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->