### PR TITLE
OCPSTRAT-1654: feat: Add HostUsers to cpo managed pods

### DIFF
--- a/support/controlplane-component/defaults.go
+++ b/support/controlplane-component/defaults.go
@@ -155,6 +155,8 @@ func (c *controlPlaneWorkload[T]) setDefaultOptions(cpContext ControlPlaneContex
 		podTemplateSpec.Spec.NodeSelector = hcp.Spec.NodeSelector
 	}
 
+	podTemplateSpec.Spec.HostUsers = ptr.To(false)
+
 	c.setLabels(podTemplateSpec, hcp)
 	c.setAnnotations(podTemplateSpec, hcp)
 	c.setControlPlaneIsolation(podTemplateSpec, hcp)


### PR DESCRIPTION
This is nice security improvement for containers to use their own user namespace. It only applies on >= 4.20
https://kubernetes.io/docs/tasks/configure-pod-container/user-namespaces/ https://kubernetes.io/blog/2025/04/25/userns-enabled-by-default/

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.