### PR TITLE
OCPBUGS-60064: fix(OCPBUGS-60064): add missing app label to some components

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-image-registry-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_image_registry_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-image-registry-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_image_registry_operator_deployment.yaml
@@ -30,6 +30,7 @@ spec:
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
+        app: cluster-image-registry-operator
         hypershift.openshift.io/control-plane-component: cluster-image-registry-operator
         hypershift.openshift.io/hosted-control-plane: hcp-namespace
         name: cluster-image-registry-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-image-registry-operator/zz_fixture_TestControlPlaneComponents_cluster_image_registry_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-image-registry-operator/zz_fixture_TestControlPlaneComponents_cluster_image_registry_operator_deployment.yaml
@@ -30,6 +30,7 @@ spec:
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
+        app: cluster-image-registry-operator
         hypershift.openshift.io/control-plane-component: cluster-image-registry-operator
         hypershift.openshift.io/hosted-control-plane: hcp-namespace
         name: cluster-image-registry-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
@@ -30,6 +30,7 @@ spec:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       creationTimestamp: null
       labels:
+        app: cluster-storage-operator
         hypershift.openshift.io/control-plane-component: cluster-storage-operator
         hypershift.openshift.io/hosted-control-plane: hcp-namespace
         hypershift.openshift.io/need-management-kas-access: "true"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
@@ -30,6 +30,7 @@ spec:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       creationTimestamp: null
       labels:
+        app: cluster-storage-operator
         hypershift.openshift.io/control-plane-component: cluster-storage-operator
         hypershift.openshift.io/hosted-control-plane: hcp-namespace
         hypershift.openshift.io/need-management-kas-access: "true"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/featuregate-generator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_featuregate_generator_job.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/featuregate-generator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_featuregate_generator_job.yaml
@@ -24,6 +24,7 @@ spec:
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
+        app: featuregate-generator
         hypershift.openshift.io/control-plane-component: featuregate-generator
         hypershift.openshift.io/hosted-control-plane: hcp-namespace
         hypershift.openshift.io/need-management-kas-access: "true"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/featuregate-generator/zz_fixture_TestControlPlaneComponents_featuregate_generator_job.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/featuregate-generator/zz_fixture_TestControlPlaneComponents_featuregate_generator_job.yaml
@@ -24,6 +24,7 @@ spec:
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       creationTimestamp: null
       labels:
+        app: featuregate-generator
         hypershift.openshift.io/control-plane-component: featuregate-generator
         hypershift.openshift.io/hosted-control-plane: hcp-namespace
         hypershift.openshift.io/need-management-kas-access: "true"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-collect-profiles/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_olm_collect_profiles_cronjob.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-collect-profiles/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_olm_collect_profiles_cronjob.yaml
@@ -26,6 +26,7 @@ spec:
             hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
           creationTimestamp: null
           labels:
+            app: olm-collect-profiles
             hypershift.openshift.io/control-plane-component: olm-collect-profiles
             hypershift.openshift.io/hosted-control-plane: hcp-namespace
             hypershift.openshift.io/need-management-kas-access: "true"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-collect-profiles/zz_fixture_TestControlPlaneComponents_olm_collect_profiles_cronjob.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-collect-profiles/zz_fixture_TestControlPlaneComponents_olm_collect_profiles_cronjob.yaml
@@ -26,6 +26,7 @@ spec:
             hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
           creationTimestamp: null
           labels:
+            app: olm-collect-profiles
             hypershift.openshift.io/control-plane-component: olm-collect-profiles
             hypershift.openshift.io/hosted-control-plane: hcp-namespace
             hypershift.openshift.io/need-management-kas-access: "true"

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-image-registry-operator/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-image-registry-operator/deployment.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       labels:
+        app: cluster-image-registry-operator
         name: cluster-image-registry-operator
     spec:
       containers:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-storage-operator/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-storage-operator/deployment.yaml
@@ -13,6 +13,7 @@ spec:
         openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
+        app: cluster-storage-operator
         name: cluster-storage-operator
     spec:
       containers:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/featuregate-generator/job.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/featuregate-generator/job.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   backoffLimit: 5
   template:
+    metadata:
+      labels:
+        app: featuregate-generator
     spec:
       serviceAccountName: control-plane-operator
       restartPolicy: Never

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/olm-collect-profiles/cronjob.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/olm-collect-profiles/cronjob.yaml
@@ -7,6 +7,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            app: olm-collect-profiles
         spec:
           serviceAccountName: olm-collect-profiles
           containers:

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -1712,6 +1712,7 @@ func TestCreateCluster(t *testing.T) {
 		e2eutil.EnsureAPIUX(t, ctx, mgtClient, hostedCluster)
 		e2eutil.EnsureCustomLabels(t, ctx, mgtClient, hostedCluster)
 		e2eutil.EnsureCustomTolerations(t, ctx, mgtClient, hostedCluster)
+		e2eutil.EnsureAppLabel(t, ctx, mgtClient, hostedCluster)
 
 		// ensure KAS DNS name is configured with a KAS Serving cert
 		e2eutil.EnsureKubeAPIDNSNameCustomCert(t, ctx, mgtClient, hostedCluster)


### PR DESCRIPTION
HCM is looking to export logs indexed on the app label but it is missing on a few HCP components.

The PR adds the app label to these components.

Components listed in the bug
```
olm-collect-profile
aws-ebs-csi-driver-operator
cluster-image-registry-operator
cluster-storage-operator
```

`aws-ebs-csi-driver-operator` is deployed by the CSO and the change will need to be made there in this PR
https://github.com/openshift/cluster-storage-operator/pull/603