### PR TITLE
OCPBUGS-60100: feat: let ARO honour cp namespace annotation for default SC uids in 4.19

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/params.go
@@ -37,7 +37,7 @@ func etcdPodSelector() map[string]string {
 	return map[string]string{"app": "etcd"}
 }
 
-func NewEtcdParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider imageprovider.ReleaseImageProvider) (*EtcdParams, error) {
+func NewEtcdParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider imageprovider.ReleaseImageProvider, setDefaultSecurityContext bool) (*EtcdParams, error) {
 
 	ipv4, err := hyputils.IsIPv4CIDR(hcp.Spec.Networking.ClusterNetwork[0].CIDR.String())
 	if err != nil {
@@ -68,6 +68,8 @@ func NewEtcdParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider imagepr
 	if hcp.Annotations[hyperv1.EtcdPriorityClass] != "" {
 		p.DeploymentConfig.Scheduling.PriorityClass = hcp.Annotations[hyperv1.EtcdPriorityClass]
 	}
+
+	p.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 	p.DeploymentConfig.SetDefaults(hcp, etcdPodSelector(), nil)
 
 	if hcp.Spec.Etcd.Managed == nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/etcd/params_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/etcd/params_test.go
@@ -110,7 +110,7 @@ func TestNewEtcdParams(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			imageProvider := imageprovider.NewFromImages(tt.images)
 			g := NewGomegaWithT(t)
-			p, err := NewEtcdParams(tt.hcp, imageProvider)
+			p, err := NewEtcdParams(tt.hcp, imageProvider, false)
 			g.Expect(err).To(BeNil())
 			g.Expect(p).ToNot(BeNil())
 			g.Expect(p.EtcdImage).To(Equal(tt.images["etcd"]))

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2925,7 +2925,7 @@ func (r *HostedControlPlaneReconciler) reconcileCloudProviderConfig(ctx context.
 }
 
 func (r *HostedControlPlaneReconciler) reconcileManagedEtcd(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider imageprovider.ReleaseImageProvider, createOrUpdate upsert.CreateOrUpdateFN, statefulSet *appsv1.StatefulSet) error {
-	p, err := etcd.NewEtcdParams(hcp, releaseImageProvider)
+	p, err := etcd.NewEtcdParams(hcp, releaseImageProvider, r.SetDefaultSecurityContext)
 	if err != nil {
 		return fmt.Errorf("error creating etcd params")
 	}


### PR DESCRIPTION
This is to let 4.19 clusters honour the annotation introduced by https://github.com/openshift/hypershift/pull/6520 and enable a smooth transitioning from 4.19 to 4.20 for aro clusters

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
Manual cherry-pick of https://github.com/openshift/hypershift/pull/6520

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.