### PR TITLE
OCPBUGS-59194: fix(OCPBUGS-59194): Allow HCCO to set registry managementState to Removed

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/admissionpolicies.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/admissionpolicies.go
@@ -56,7 +56,7 @@ func reconcileRegistryConfigManagementStateValidatingAdmissionPolicy(ctx context
 		"configs",
 	}
 
-	denyRemovedManagementStateValidation.Expression = "object.spec.managementState != 'Removed'"
+	denyRemovedManagementStateValidation.Expression = "object.spec.managementState != 'Removed' || request.userInfo.username == 'system:hosted-cluster-config'"
 	registryConfigManagementStateAdmissionPolicy.Validations = []k8sadmissionv1.Validation{denyRemovedManagementStateValidation}
 	registryConfigManagementStateAdmissionPolicy.MatchConstraints = constructPolicyMatchConstraints(registryConfigManagementStateResources, registryConfigManagementStateAPIVersion, registryConfigManagementStateAPIGroup, []k8sadmissionv1.OperationType{"CREATE", "UPDATE"})
 	if err := registryConfigManagementStateAdmissionPolicy.reconcileAdmissionPolicy(ctx, client, createOrUpdate); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
The validating admission policy was preventing the hosted-cluster-config-operator from setting the registry operator managementState to 'Removed' during cluster deletion, blocking proper cleanup of cloud resources.

Added exception for system:hosted-cluster-config user to allow HCCO to perform legitimate cleanup operations while still preventing regular users from disabling the registry using the old method.

**Which issue(s) this PR fixes**:
Fixes OCPBUGS-59194

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.