### PR TITLE
CNTRLPLANE-995: Fix Default SG day2 tags feature being triggered without changes

### DIFF
--- a/support/awsutil/errorcode.go
+++ b/support/awsutil/errorcode.go
@@ -6,10 +6,21 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
+const (
+	AuthFailure           = "AuthFailure"
+	UnauthorizedOperation = "UnauthorizedOperation"
+)
+
 func AWSErrorCode(err error) string {
 	var awsErr awserr.Error
 	if errors.As(err, &awsErr) {
 		return awsErr.Code()
 	}
 	return "Unknown"
+}
+
+// IsPermissionsError returns true if on aws permission errors.
+func IsPermissionsError(err error) bool {
+	code := AWSErrorCode(err)
+	return code == AuthFailure || code == UnauthorizedOperation
 }

--- a/support/awsutil/sg.go
+++ b/support/awsutil/sg.go
@@ -276,3 +276,14 @@ func MapToEC2Tags(m map[string]string) []*ec2.Tag {
 	}
 	return tags
 }
+
+func EC2TagsToMap(tags []*ec2.Tag) map[string]string {
+	if len(tags) == 0 {
+		return nil
+	}
+	m := make(map[string]string)
+	for _, tag := range tags {
+		m[*tag.Key] = *tag.Value
+	}
+	return m
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes the issue where failing to update the tags annotation on the HCP, will cause the CPO to try to update the tags on the SG without day2 changes.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.