### PR TITLE
OCPBUGS-57336: fix(hostedcluster): remove additionalTrustBundle from hcp when removed from HostedCluster

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/healthcheck.go
@@ -27,7 +27,7 @@ func GetHealthcheckEndpointForRoute(externalRoute *routev1.Route, hcp *hyperv1.H
 
 	if sharedingress.UseSharedIngress() &&
 		hcp.Spec.Networking.APIServer != nil && len(hcp.Spec.Networking.APIServer.AllowedCIDRBlocks) > 0 {
-		// When there's AllowedCIDRBlocks input, we have no guarantees the healthcheck can rountrip through the haproxy load balancer.
+		// When there's AllowedCIDRBlocks input, we have no guarantees the healthcheck can roundtrip through the haproxy load balancer.
 		// Hence we use KubeAPIServerService as a best effort.
 		endpoint = manifests.KubeAPIServerService("").Name
 		port = config.KASSVCPort

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2347,6 +2347,8 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 	}
 	if hcluster.Spec.AdditionalTrustBundle != nil {
 		hcp.Spec.AdditionalTrustBundle = &corev1.LocalObjectReference{Name: controlplaneoperator.UserCABundle(hcp.Namespace).Name}
+	} else {
+		hcp.Spec.AdditionalTrustBundle = nil
 	}
 	if hcluster.Spec.SecretEncryption != nil {
 		hcp.Spec.SecretEncryption = hcluster.Spec.SecretEncryption.DeepCopy()

--- a/test/e2e/nodepool_additionalTrustBundlePropagation_test.go
+++ b/test/e2e/nodepool_additionalTrustBundlePropagation_test.go
@@ -10,7 +10,10 @@ import (
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
+	"github.com/openshift/hypershift/support/util"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -107,5 +110,71 @@ func (k *AdditionalTrustBundlePropagationTest) Run(t *testing.T, nodePool hyperv
 			e2eutil.WithInterval(10*time.Second), e2eutil.WithTimeout(20*time.Minute),
 		)
 
+		t.Logf("Updating hosted cluster by removing additional trust bundle.")
+		if err = e2eutil.UpdateObject(t, k.ctx, k.mgmtClient, k.hostedCluster, func(obj *hyperv1.HostedCluster) {
+			obj.Spec.AdditionalTrustBundle = nil
+		}); err != nil {
+			t.Fatalf("failed to update HostedCluster with additional trust bundle: %v", err)
+		}
+
+		// Ensure the control plane operator deployment is updated and no longer mounts the additional trust bundle configmap
+		controlPlaneOperatorDeployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "control-plane-operator",
+				Namespace: manifests.HostedControlPlaneNamespace(k.hostedCluster.Namespace, k.hostedCluster.Name),
+			},
+		}
+		e2eutil.EventuallyObject(t, k.ctx, "Waiting for control plane operator deployment to be updated",
+			func(ctx context.Context) (*appsv1.Deployment, error) {
+				err := k.mgmtClient.Get(ctx, crclient.ObjectKeyFromObject(controlPlaneOperatorDeployment), controlPlaneOperatorDeployment)
+				return controlPlaneOperatorDeployment, err
+			},
+			[]e2eutil.Predicate[*appsv1.Deployment]{
+				func(obj *appsv1.Deployment) (bool, string, error) {
+					volumes := obj.Spec.Template.Spec.Volumes
+					for _, volume := range volumes {
+						if volume.ConfigMap != nil && volume.ConfigMap.Name == "trusted-ca" {
+							return false, "Additional trust bundle configmap is still included in CPO", nil
+						}
+					}
+					if ready := util.IsDeploymentReady(k.ctx, obj); !ready {
+						return false, "Deployment is not ready", nil
+					}
+					return true, "Additional trust bundle configmap is not included in CPO", nil
+				},
+			},
+		)
+
+		e2eutil.EventuallyObject(t, k.ctx, fmt.Sprintf("Waiting for NodePool %s/%s to begin updating", nodePool.Namespace, nodePool.Name),
+			func(ctx context.Context) (*hyperv1.NodePool, error) {
+				err := k.mgmtClient.Get(ctx, crclient.ObjectKeyFromObject(&nodePool), &nodePool)
+				return &nodePool, err
+			},
+			[]e2eutil.Predicate[*hyperv1.NodePool]{
+				e2eutil.ConditionPredicate[*hyperv1.NodePool](e2eutil.Condition{
+					Type:   hyperv1.NodePoolUpdatingConfigConditionType,
+					Status: metav1.ConditionTrue,
+				}),
+			},
+			e2eutil.WithInterval(10*time.Second), e2eutil.WithTimeout(5*time.Minute),
+		)
+
+		e2eutil.EventuallyObject(t, k.ctx, fmt.Sprintf("Waiting for NodePool %s/%s to stop updating", nodePool.Namespace, nodePool.Name),
+			func(ctx context.Context) (*hyperv1.NodePool, error) {
+				err := k.mgmtClient.Get(ctx, crclient.ObjectKeyFromObject(&nodePool), &nodePool)
+				return &nodePool, err
+			},
+			[]e2eutil.Predicate[*hyperv1.NodePool]{
+				e2eutil.ConditionPredicate[*hyperv1.NodePool](e2eutil.Condition{
+					Type:   hyperv1.NodePoolUpdatingConfigConditionType,
+					Status: metav1.ConditionFalse,
+				}),
+				e2eutil.ConditionPredicate[*hyperv1.NodePool](e2eutil.Condition{
+					Type:   hyperv1.NodePoolAllNodesHealthyConditionType,
+					Status: metav1.ConditionTrue,
+				}),
+			},
+			e2eutil.WithInterval(10*time.Second), e2eutil.WithTimeout(20*time.Minute),
+		)
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow up to #6504

Ensures that additionalTrustBundle reference is removed from HostedControlPlane when it has been removed from HostedCluster.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-57336](https://issues.redhat.com/browse/OCPBUGS-57336)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.