### PR TITLE
OCPBUGS-57626: order ICSPs for determinism of OPENSHIFT_IMG_OVERRIDES

### DIFF
--- a/support/globalconfig/imagecontentsource.go
+++ b/support/globalconfig/imagecontentsource.go
@@ -3,6 +3,8 @@ package globalconfig
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/capabilities"
@@ -158,6 +160,15 @@ func getImageContentSourcePolicies(ctx context.Context, client crclient.Client) 
 	if len(imageContentSourcePolicies.Items) > 0 {
 		log.Info("Detected ImageContentSourcePolicy Custom Resources. ImageContentSourcePolicy will be deprecated in favor of ImageDigestMirrorSet. See https://issues.redhat.com/browse/OCPNODE-1258 for more details.")
 	}
+
+	// Sort the items by name to ensure consistent ordering
+	sort.Slice(imageContentSourcePolicies.Items, func(i, j int) bool {
+		// This sorts ascending by name, so we can unit test the output.
+		// The fake client, unlike the actual kubernetes client, returns
+		// items in descending order by name.  By inverting the returned
+		// sorting order, we can unit test that the output is deterministic.
+		return strings.Compare(imageContentSourcePolicies.Items[i].Name, imageContentSourcePolicies.Items[j].Name) > 0
+	})
 
 	// For each image content source policy in the management cluster, map the source with each of its mirrors
 	for _, item := range imageContentSourcePolicies.Items {

--- a/support/globalconfig/imagecontentsource_test.go
+++ b/support/globalconfig/imagecontentsource_test.go
@@ -14,6 +14,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,7 +36,7 @@ func TestGetAllImageRegistryMirrors(t *testing.T) {
 			name: "validate ImageRegistryMirrors with only ICSP",
 			icsp: createFakeICSP(),
 			expectedResult: map[string][]string{
-				"registry1": {"mirror1", "mirror2"},
+				"registry1": {"icsp-registry-mirrors-2/mirror1", "icsp-registry-mirrors-2/mirror2", "icsp-registry-mirrors-1/mirror1", "icsp-registry-mirrors-1/mirror2"},
 				"registry2": {"mirror1", "mirror2"},
 				"registry3.sample.com/samplens/sampleimage@sha256:123456": {
 					"mirroricsp3.sample.com/samplens/sampleimage@sha256:123456",
@@ -63,7 +64,7 @@ func TestGetAllImageRegistryMirrors(t *testing.T) {
 			expectedResult: map[string][]string{
 				"registry1.sample.com/samplens/sampleimage@sha256:123456": {"mirror1.sample.com/samplens/sampleimage@sha256:123456", "mirror1.sample.com/samplens/sampleimage@sha256:123456"},
 				"registry2.sample.com/samplens/sampleimage@sha256:123456": {"mirror2.sample.com/samplens/sampleimage@sha256:123456", "mirror2.sample.com/samplens/sampleimage@sha256:123456"},
-				"registry1": {"mirror1", "mirror2"},
+				"registry1": {"icsp-registry-mirrors-2/mirror1", "icsp-registry-mirrors-2/mirror2", "icsp-registry-mirrors-1/mirror1", "icsp-registry-mirrors-1/mirror2"},
 				"registry2": {"mirror1", "mirror2"},
 				"registry3.sample.com/samplens/sampleimage@sha256:123456": {
 					"mirror3.sample.com/samplens/sampleimage@sha256:123456",
@@ -123,11 +124,14 @@ func createFakeICSP() *operatorv1alpha1.ImageContentSourcePolicyList {
 	return &operatorv1alpha1.ImageContentSourcePolicyList{
 		Items: []operatorv1alpha1.ImageContentSourcePolicy{
 			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "icsp-registry-mirrors-1",
+				},
 				Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
 					RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
 						{
 							Source:  "registry1",
-							Mirrors: []string{"mirror1", "mirror2"},
+							Mirrors: []string{"icsp-registry-mirrors-1/mirror1", "icsp-registry-mirrors-1/mirror2"},
 						},
 						{
 							Source:  "registry2",
@@ -139,6 +143,19 @@ func createFakeICSP() *operatorv1alpha1.ImageContentSourcePolicyList {
 								"mirroricsp3.sample.com/samplens/sampleimage@sha256:123456",
 								"mirroricsp3.sample.com/samplens/sampleimage@sha256:123456",
 							},
+						},
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "icsp-registry-mirrors-2",
+				},
+				Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
+					RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{
+						{
+							Source:  "registry1",
+							Mirrors: []string{"icsp-registry-mirrors-2/mirror1", "icsp-registry-mirrors-2/mirror2"},
 						},
 					},
 				},
@@ -222,7 +239,7 @@ func TestReconcileMgmtImageRegistryOverrides(t *testing.T) {
 					},
 				},
 				OpenShiftImageRegistryOverrides: map[string][]string{
-					"registry1": {"mirror1", "mirror2"},
+					"registry1": {"icsp-registry-mirrors-2/mirror1", "icsp-registry-mirrors-2/mirror2", "icsp-registry-mirrors-1/mirror1", "icsp-registry-mirrors-1/mirror2"},
 					"registry2": {"mirror1", "mirror2"},
 					"registry1.sample.com/samplens/sampleimage@sha256:123456": {
 						"mirror1.sample.com/samplens/sampleimage@sha256:123456",
@@ -242,7 +259,7 @@ func TestReconcileMgmtImageRegistryOverrides(t *testing.T) {
 			},
 			expectedMetadata: &hyperutil.RegistryClientImageMetadataProvider{
 				OpenShiftImageRegistryOverrides: map[string][]string{
-					"registry1": {"mirror1", "mirror2"},
+					"registry1": {"icsp-registry-mirrors-2/mirror1", "icsp-registry-mirrors-2/mirror2", "icsp-registry-mirrors-1/mirror1", "icsp-registry-mirrors-1/mirror2"},
 					"registry2": {"mirror1", "mirror2"},
 					"registry1.sample.com/samplens/sampleimage@sha256:123456": {
 						"mirror1.sample.com/samplens/sampleimage@sha256:123456",


### PR DESCRIPTION
If there are multiple ICSPs configured in the mgmt cluster, the List is not determinstic and the ICSPs can be returned in any order.  This can lead to redeployment of the CPO when reordering on the OPENSHIFT_IMG_OVERRIDES occurs.

This change sorts the ICSPs by name so that OPENSHIFT_IMG_OVERRIDES is deterministic.