### PR TITLE
OCPBUGS-60190: chore: Improve security context uid allocation to reuse released uids

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -27,7 +27,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -2057,57 +2056,8 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 }
 
 const (
-	DefaultSecurityContextUIDAnnnotation = "hypershift.openshift.io/default-security-context-uid"
-	ControlPlaneNamespaceLabelKey        = "hypershift.openshift.io/hosted-control-plane"
+	ControlPlaneNamespaceLabelKey = "hypershift.openshift.io/hosted-control-plane"
 )
-
-var securityContextUIDCheckMutex sync.Mutex
-var maxSecurityContextUIDCache int64
-
-// getNextAvailableSecurityContextUID returns the next available UID for a control plane namespace.
-// If no cache is set, it loops over existing namespaces, find the highest SecurityContext UID and returns that + 1.
-// When SCCs are available, this feature is implemented by https://github.com/openshift/cluster-policy-controller/blob/3e7538547c8f209c72083097a4ebaada6e9c46c5/pkg/security/controller/namespace_scc_allocation_controller.go#L148
-func getNextAvailableSecurityContextUID(ctx context.Context, c client.Client) (int64, error) {
-	securityContextUIDCheckMutex.Lock()
-	defer securityContextUIDCheckMutex.Unlock()
-
-	if maxSecurityContextUIDCache != 0 {
-		maxSecurityContextUIDCache++
-		return maxSecurityContextUIDCache, nil
-	}
-
-	// If cache is not set, loop over existing namespaces, find the highest SCC UID and returns that + 1.
-	labelSelector := labels.SelectorFromSet(labels.Set{
-		ControlPlaneNamespaceLabelKey: "true",
-	})
-
-	namespaceList := &corev1.NamespaceList{}
-	if err := c.List(ctx, namespaceList, &client.ListOptions{
-		LabelSelector: labelSelector,
-	}); err != nil {
-		return 0, err
-	}
-
-	var maxUID int64 = controlplanecomponent.DefaultSecurityContextUID - 1
-	for _, ns := range namespaceList.Items {
-		uidInput, ok := ns.Annotations[DefaultSecurityContextUIDAnnnotation]
-		if !ok {
-			continue
-		}
-
-		uid, err := strconv.ParseInt(uidInput, 10, 64)
-		if err != nil {
-			continue
-		}
-
-		if uid > maxUID {
-			maxUID = uid
-		}
-	}
-
-	maxSecurityContextUIDCache = maxUID + 1
-	return maxSecurityContextUIDCache, nil
-}
 
 // annotationsForCertRenewal returns a set of annotations to set based on the current state of the KAS
 // serving certificate. These could include the annotation to restart control plane pods.

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"reflect"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -61,7 +60,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	interceptor "sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -4611,159 +4609,6 @@ func TestReconcileAdditionalTrustBundle(t *testing.T) {
 					Namespace: controlPlaneNamespace,
 				}, destConfigMap)
 				g.Expect(errors2.IsNotFound(err)).To(BeTrue())
-			}
-		})
-	}
-}
-
-func TestGetNextAvailableSecurityContextUID(t *testing.T) {
-	// Setup test cases
-	tests := []struct {
-		name        string
-		namespaces  []corev1.Namespace
-		expectedUID int64
-		expectErr   bool
-	}{
-		{
-			name:        "when no namespaces, it should return default",
-			namespaces:  []corev1.Namespace{},
-			expectedUID: controlplanecomponent.DefaultSecurityContextUID,
-			expectErr:   false,
-		},
-		{
-			name: "when there are multiple namespaces, it should pick the highest and return that +1",
-			namespaces: []corev1.Namespace{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "ns1",
-						Labels: map[string]string{
-							ControlPlaneNamespaceLabelKey: "true",
-						},
-						Annotations: map[string]string{
-							DefaultSecurityContextUIDAnnnotation: "1000123456",
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "ns2",
-						Labels: map[string]string{
-							ControlPlaneNamespaceLabelKey: "true",
-						},
-						Annotations: map[string]string{
-							DefaultSecurityContextUIDAnnnotation: "1000123499",
-						},
-					},
-				},
-			},
-			expectedUID: 1000123500,
-			expectErr:   false,
-		},
-		{
-			name: "when there are namespaces with invalid annotation it should be ignored",
-			namespaces: []corev1.Namespace{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "ns1",
-						Labels: map[string]string{
-							ControlPlaneNamespaceLabelKey: "true",
-						},
-						Annotations: map[string]string{
-							DefaultSecurityContextUIDAnnnotation: "notanumber",
-						},
-					},
-				},
-			},
-			expectedUID: controlplanecomponent.DefaultSecurityContextUID,
-			expectErr:   false,
-		},
-		{
-			name: "when there are namespaces without the control plane label it should be ignored",
-			namespaces: []corev1.Namespace{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "ns1",
-						Annotations: map[string]string{
-							DefaultSecurityContextUIDAnnnotation: "1000123456",
-						},
-					},
-				},
-			},
-			expectedUID: controlplanecomponent.DefaultSecurityContextUID,
-			expectErr:   false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			g := NewWithT(t)
-
-			objs := []crclient.Object{}
-			for i := range tc.namespaces {
-				ns := tc.namespaces[i]
-				objs = append(objs, &ns)
-			}
-			fakeClient := fake.NewClientBuilder().
-				WithScheme(api.Scheme).
-				WithObjects(objs...).
-				Build()
-
-			// Reset the cache for each test.
-			maxSecurityContextUIDCache = 0
-			uid, err := getNextAvailableSecurityContextUID(context.Background(), fakeClient)
-			if tc.expectErr && err == nil {
-				t.Errorf("expected error but got none")
-				return
-			}
-			if !tc.expectErr && err != nil {
-				t.Errorf("unexpected error: %v", err)
-				return
-			}
-			if !tc.expectErr && err == nil && uid != tc.expectedUID {
-				t.Errorf("expected UID %d, got %d", tc.expectedUID, uid)
-			}
-
-			// Now make subsequent calls and check they each get a value using the cache.
-			if !tc.expectErr && err == nil {
-				// Wrap the List method to panic if called again (should only be called on the first invocation)
-				fakeClient = fake.NewClientBuilder().
-					WithScheme(api.Scheme).
-					WithInterceptorFuncs(interceptor.Funcs{
-						List: func(ctx context.Context, client crclient.WithWatch, list crclient.ObjectList, opts ...crclient.ListOption) error {
-							t.Errorf("client.List should not be called after the first getNextAvailableSecurityContextUID call")
-							return nil
-						},
-					}).WithObjects(objs...).
-					Build()
-
-				var wg sync.WaitGroup
-				results := make(chan int64, 3)
-				for i := 0; i < 3; i++ {
-					wg.Add(1)
-					go func() {
-						defer wg.Done()
-						uid, err := getNextAvailableSecurityContextUID(context.Background(), fakeClient)
-						if err != nil {
-							t.Errorf("unexpected error: %v", err)
-						}
-						results <- uid
-					}()
-				}
-				wg.Wait()
-				close(results)
-
-				// All UIDs should be unique.
-				seen := make(map[int64]bool)
-				for uid := range results {
-					if seen[uid] {
-						t.Errorf("duplicate UID returned: %d", uid)
-					}
-					seen[uid] = true
-				}
-				g.Expect(seen).To(HaveKey(uid+1), "expected to see UID %d in results", uid+1)
-				g.Expect(seen).To(HaveKey(uid+2), "expected to see UID %d in results", uid+2)
-				g.Expect(seen).To(HaveKey(uid+3), "expected to see UID %d in results", uid+3)
-				g.Expect(seen).To(HaveLen(3), "expected to see 3 unique UIDs")
 			}
 		})
 	}

--- a/hypershift-operator/controllers/hostedcluster/security_context_uid.go
+++ b/hypershift-operator/controllers/hostedcluster/security_context_uid.go
@@ -1,0 +1,104 @@
+package hostedcluster
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	controlplanecomponent "github.com/openshift/hypershift/support/controlplane-component"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// DefaultSecurityContextUIDAnnnotation is used to store the allocated UID in namespace annotations
+	DefaultSecurityContextUIDAnnnotation = "hypershift.openshift.io/default-security-context-uid"
+	// minSecurityContextUID is the starting point for UID allocation
+	minSecurityContextUID = controlplanecomponent.DefaultSecurityContextUID
+	// maxSecurityContextUIDs is the maximum number of UIDs we'll allocate
+	maxSecurityContextUIDs = 10000
+	// refreshInterval is how often we refresh the allocator state from namespaces
+	refreshInterval = 8 * time.Hour
+)
+
+// securityContextUIDAllocator manages allocation of UIDs for control plane namespaces
+type securityContextUIDAllocator struct {
+	sync.Mutex
+	// allocatedUIDs tracks which UIDs are in use
+	allocatedUIDs map[int64]struct{}
+	// initialized indicates if the allocator has been initialized from existing namespaces
+	initialized bool
+	// lastRefresh tracks when we last refreshed from namespaces
+	lastRefresh time.Time
+}
+
+var globalUIDAllocator = &securityContextUIDAllocator{
+	allocatedUIDs: make(map[int64]struct{}),
+}
+
+// initializeFromNamespaces scans existing namespaces to initialize the allocator
+func (a *securityContextUIDAllocator) initializeFromNamespaces(ctx context.Context, c client.Client) error {
+	labelSelector := labels.SelectorFromSet(labels.Set{
+		ControlPlaneNamespaceLabelKey: "true",
+	})
+
+	namespaceList := &corev1.NamespaceList{}
+	if err := c.List(ctx, namespaceList, &client.ListOptions{
+		LabelSelector: labelSelector,
+	}); err != nil {
+		return err
+	}
+
+	// Clear existing allocations before refreshing
+	a.allocatedUIDs = make(map[int64]struct{})
+
+	for _, ns := range namespaceList.Items {
+		uidStr, ok := ns.Annotations[DefaultSecurityContextUIDAnnnotation]
+		if !ok {
+			continue
+		}
+		uid, err := strconv.ParseInt(uidStr, 10, 64)
+		if err != nil {
+			continue
+		}
+		if uid >= minSecurityContextUID && uid < minSecurityContextUID+maxSecurityContextUIDs {
+			a.allocatedUIDs[uid] = struct{}{}
+		}
+	}
+	a.initialized = true
+	a.lastRefresh = time.Now()
+	return nil
+}
+
+// allocateUID allocates a new UID or returns an error if none available
+func (a *securityContextUIDAllocator) allocateUID(ctx context.Context, c client.Client) (int64, error) {
+	a.Lock()
+	defer a.Unlock()
+
+	// Initialize if not initialized or refresh if it's time
+	if !a.initialized || time.Since(a.lastRefresh) > refreshInterval {
+		if err := a.initializeFromNamespaces(ctx, c); err != nil {
+			return 0, err
+		}
+	}
+
+	// Always scan from the beginning to prefer lower UIDs
+	for uid := minSecurityContextUID; uid < minSecurityContextUID+maxSecurityContextUIDs; uid++ {
+		if _, inUse := a.allocatedUIDs[uid]; !inUse {
+			a.allocatedUIDs[uid] = struct{}{}
+			return uid, nil
+		}
+	}
+
+	return 0, fmt.Errorf("no free UIDs available in range %d to %d", minSecurityContextUID, minSecurityContextUID+maxSecurityContextUIDs-1)
+}
+
+// getNextAvailableSecurityContextUID returns the next available UID for a control plane namespace
+func getNextAvailableSecurityContextUID(ctx context.Context, c client.Client) (int64, error) {
+	return globalUIDAllocator.allocateUID(ctx, c)
+}

--- a/hypershift-operator/controllers/hostedcluster/security_context_uid_test.go
+++ b/hypershift-operator/controllers/hostedcluster/security_context_uid_test.go
@@ -1,0 +1,340 @@
+package hostedcluster
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/support/api"
+	controlplanecomponent "github.com/openshift/hypershift/support/controlplane-component"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	interceptor "sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestGetNextAvailableSecurityContextUID(t *testing.T) {
+	// Setup test cases
+	tests := []struct {
+		name                        string
+		namespaces                  []corev1.Namespace
+		expectedUID                 int64
+		expectedFor3SubsequentCalls []int64
+		expectErr                   bool
+	}{
+		{
+			name:                        "when no namespaces, it should return first available UID",
+			namespaces:                  []corev1.Namespace{},
+			expectedUID:                 controlplanecomponent.DefaultSecurityContextUID,
+			expectedFor3SubsequentCalls: []int64{controlplanecomponent.DefaultSecurityContextUID + 1, controlplanecomponent.DefaultSecurityContextUID + 2, controlplanecomponent.DefaultSecurityContextUID + 3},
+			expectErr:                   false,
+		},
+		{
+			name: "when there are multiple namespaces, it should allocate the lower available UID",
+			namespaces: []corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns1",
+						Labels: map[string]string{
+							ControlPlaneNamespaceLabelKey: "true",
+						},
+						Annotations: map[string]string{
+							DefaultSecurityContextUIDAnnnotation: "1001",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns2",
+						Labels: map[string]string{
+							ControlPlaneNamespaceLabelKey: "true",
+						},
+						Annotations: map[string]string{
+							DefaultSecurityContextUIDAnnnotation: "1005",
+						},
+					},
+				},
+			},
+			expectedUID:                 1002,
+			expectedFor3SubsequentCalls: []int64{1003, 1004, 1006},
+			expectErr:                   false,
+		},
+		{
+			name: "when there are namespaces with invalid annotation it should be ignored",
+			namespaces: []corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns1",
+						Labels: map[string]string{
+							ControlPlaneNamespaceLabelKey: "true",
+						},
+						Annotations: map[string]string{
+							DefaultSecurityContextUIDAnnnotation: "notanumber",
+						},
+					},
+				},
+			},
+			expectedUID:                 controlplanecomponent.DefaultSecurityContextUID,
+			expectedFor3SubsequentCalls: []int64{controlplanecomponent.DefaultSecurityContextUID + 1, controlplanecomponent.DefaultSecurityContextUID + 2, controlplanecomponent.DefaultSecurityContextUID + 3},
+			expectErr:                   false,
+		},
+		{
+			name: "when there are namespaces without the control plane label it should be ignored",
+			namespaces: []corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns1",
+						Annotations: map[string]string{
+							DefaultSecurityContextUIDAnnnotation: "1000123456",
+						},
+					},
+				},
+			},
+			expectedUID:                 controlplanecomponent.DefaultSecurityContextUID,
+			expectedFor3SubsequentCalls: []int64{controlplanecomponent.DefaultSecurityContextUID + 1, controlplanecomponent.DefaultSecurityContextUID + 2, controlplanecomponent.DefaultSecurityContextUID + 3},
+			expectErr:                   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			// Reset the global allocator for each test
+			globalUIDAllocator = &securityContextUIDAllocator{
+				allocatedUIDs: make(map[int64]struct{}),
+			}
+
+			objs := []crclient.Object{}
+			for i := range tc.namespaces {
+				ns := tc.namespaces[i]
+				objs = append(objs, &ns)
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(api.Scheme).
+				WithObjects(objs...).
+				Build()
+
+			uid, err := getNextAvailableSecurityContextUID(context.Background(), fakeClient)
+			if tc.expectErr && err == nil {
+				t.Errorf("expected error but got none")
+				return
+			}
+			if !tc.expectErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if !tc.expectErr && err == nil && uid != tc.expectedUID {
+				t.Errorf("expected UID %d, got %d", tc.expectedUID, uid)
+			}
+
+			// Now make subsequent calls and check they each get a sequential value
+			if !tc.expectErr && err == nil {
+				// Wrap the List method to panic if called again (should only be called on the first invocation)
+				fakeClient = fake.NewClientBuilder().
+					WithScheme(api.Scheme).
+					WithInterceptorFuncs(interceptor.Funcs{
+						List: func(ctx context.Context, client crclient.WithWatch, list crclient.ObjectList, opts ...crclient.ListOption) error {
+							t.Errorf("client.List should not be called after the first getNextAvailableSecurityContextUID call")
+							return nil
+						},
+					}).WithObjects(objs...).
+					Build()
+
+				var wg sync.WaitGroup
+				results := make(chan int64, 3)
+				for i := 0; i < 3; i++ {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						uid, err := getNextAvailableSecurityContextUID(context.Background(), fakeClient)
+						if err != nil {
+							t.Errorf("unexpected error: %v", err)
+						}
+						results <- uid
+					}()
+				}
+				wg.Wait()
+				close(results)
+
+				// All UIDs should be unique and sequential
+				seen := make(map[int64]bool)
+				for uid := range results {
+					if seen[uid] {
+						t.Errorf("duplicate UID returned: %d", uid)
+					}
+					seen[uid] = true
+				}
+
+				g.Expect(seen).To(HaveKeyWithValue(tc.expectedFor3SubsequentCalls[0], true))
+				g.Expect(seen).To(HaveKeyWithValue(tc.expectedFor3SubsequentCalls[1], true))
+				g.Expect(seen).To(HaveKeyWithValue(tc.expectedFor3SubsequentCalls[2], true))
+			}
+		})
+	}
+}
+
+func TestInitializeFromNamespaces(t *testing.T) {
+	tests := []struct {
+		name               string
+		namespaces         []corev1.Namespace
+		expectedAllocated  []int64
+		expectedInitalized bool
+	}{
+		{
+			name:               "when namespace list is empty, it should initialize with no allocations",
+			namespaces:         []corev1.Namespace{},
+			expectedAllocated:  []int64{},
+			expectedInitalized: true,
+		},
+		{
+			name: "when namespaces have control plane label and valid UIDs, it should load those UIDs",
+			namespaces: []corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns1",
+						Labels: map[string]string{
+							ControlPlaneNamespaceLabelKey: "true",
+						},
+						Annotations: map[string]string{
+							DefaultSecurityContextUIDAnnnotation: "1001",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns2",
+						Labels: map[string]string{
+							ControlPlaneNamespaceLabelKey: "true",
+						},
+						Annotations: map[string]string{
+							DefaultSecurityContextUIDAnnnotation: "1005",
+						},
+					},
+				},
+			},
+			expectedAllocated:  []int64{1001, 1005},
+			expectedInitalized: true,
+		},
+		{
+			name: "when namespaces lack control plane label, it should ignore them",
+			namespaces: []corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns1",
+						Annotations: map[string]string{
+							DefaultSecurityContextUIDAnnnotation: "1001",
+						},
+					},
+				},
+			},
+			expectedAllocated:  []int64{},
+			expectedInitalized: true,
+		},
+		{
+			name: "when namespaces have invalid UID annotations, it should ignore those UIDs",
+			namespaces: []corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns1",
+						Labels: map[string]string{
+							ControlPlaneNamespaceLabelKey: "true",
+						},
+						Annotations: map[string]string{
+							DefaultSecurityContextUIDAnnnotation: "notanumber",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns2",
+						Labels: map[string]string{
+							ControlPlaneNamespaceLabelKey: "true",
+						},
+						Annotations: map[string]string{
+							DefaultSecurityContextUIDAnnnotation: "1005",
+						},
+					},
+				},
+			},
+			expectedAllocated:  []int64{1005},
+			expectedInitalized: true,
+		},
+		{
+			name: "when namespaces have UIDs outside valid range, it should ignore those UIDs",
+			namespaces: []corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns1",
+						Labels: map[string]string{
+							ControlPlaneNamespaceLabelKey: "true",
+						},
+						Annotations: map[string]string{
+							DefaultSecurityContextUIDAnnnotation: "999", // Below min
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns2",
+						Labels: map[string]string{
+							ControlPlaneNamespaceLabelKey: "true",
+						},
+						Annotations: map[string]string{
+							DefaultSecurityContextUIDAnnnotation: "999999999", // Above max
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns3",
+						Labels: map[string]string{
+							ControlPlaneNamespaceLabelKey: "true",
+						},
+						Annotations: map[string]string{
+							DefaultSecurityContextUIDAnnnotation: "1005", // Valid
+						},
+					},
+				},
+			},
+			expectedAllocated:  []int64{1005},
+			expectedInitalized: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			allocator := &securityContextUIDAllocator{
+				allocatedUIDs: make(map[int64]struct{}),
+			}
+
+			objs := []crclient.Object{}
+			for i := range tc.namespaces {
+				ns := tc.namespaces[i]
+				objs = append(objs, &ns)
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(api.Scheme).
+				WithObjects(objs...).
+				Build()
+
+			err := allocator.initializeFromNamespaces(context.Background(), fakeClient)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(allocator.initialized).To(Equal(tc.expectedInitalized))
+
+			// Convert allocated UIDs to slice for easier comparison
+			allocated := make([]int64, 0, len(allocator.allocatedUIDs))
+			for uid := range allocator.allocatedUIDs {
+				allocated = append(allocated, uid)
+			}
+			g.Expect(allocated).To(ConsistOf(tc.expectedAllocated))
+		})
+	}
+}


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
This is an iterative follow up for https://github.com/openshift/hypershift/pull/6520
Before this, uids would just grow sequentially forever

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.