### PR TITLE
CNTRLPLANE-995: Fix incorrect usage of util.UpdateObject

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2869,7 +2869,7 @@ func (r *HostedControlPlaneReconciler) reconcileDefaultSecurityGroup(ctx context
 
 		// Update the last-applied-security-group-tags annotation on the HCP with the tags applied to the SG.
 		// This is used to track changes to the tags and update them if necessary.
-		if err := util.UpdateObject(ctx, r.Client, hcp, func(obj *hyperv1.HostedControlPlane) error {
+		if err := util.UpdateObject(ctx, r.Client, hcp, func() error {
 			if err := updateLastAppliedSecurityGroupTagsAnnotation(hcp, desiredTags); err != nil {
 				return fmt.Errorf("failed to update last applied security group tags annotation")
 			}
@@ -2900,7 +2900,7 @@ func (r *HostedControlPlaneReconciler) reconcileDefaultSecurityGroup(ctx context
 	} else {
 		// Ensure the last-applied-security-group-tags annotation is set on the HCP on SG creation.
 		// This is used to track changes to the tags and update them if necessary.
-		if err := util.UpdateObject(ctx, r.Client, hcp, func(obj *hyperv1.HostedControlPlane) error {
+		if err := util.UpdateObject(ctx, r.Client, hcp, func() error {
 			if err := updateLastAppliedSecurityGroupTagsAnnotation(hcp, appliedTags); err != nil {
 				return fmt.Errorf("failed to update last applied security group tags annotation")
 			}
@@ -2908,6 +2908,7 @@ func (r *HostedControlPlaneReconciler) reconcileDefaultSecurityGroup(ctx context
 		}); err != nil {
 			return fmt.Errorf("failed to update HostedControlPlane object: %w", err)
 		}
+		originalHCP = hcp.DeepCopy()
 
 		condition = &metav1.Condition{
 			Type:    string(hyperv1.AWSDefaultSecurityGroupCreated),

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -81,14 +81,14 @@ func CopyConfigMap(cm, source *corev1.ConfigMap) {
 	}
 }
 
-func UpdateObject[T client.Object](ctx context.Context, c client.Client, original T, mutate func(obj T) error) error {
+func UpdateObject[T client.Object](ctx context.Context, c client.Client, obj T, mutate func() error) error {
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		if err := c.Get(ctx, client.ObjectKeyFromObject(original), original); err != nil {
+		if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
 			return err
 		}
 
-		obj := original.DeepCopyObject().(T)
-		if err := mutate(obj); err != nil {
+		original := obj.DeepCopyObject().(T)
+		if err := mutate(); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Simplifies util.UpdateObject by removing the obj parmater from mutate to avoid misuse. Callers can now update the passed in obj directly.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.