### PR TITLE
WIP: chore(shared-ingress): Always allow /healthz KAS endpoint when AllowdCIDRBlocks

### DIFF
--- a/sharedingress-config-generator/router_config.template
+++ b/sharedingress-config-generator/router_config.template
@@ -55,6 +55,9 @@ frontend external-dns
   acl is_{{ .Name }} req_ssl_sni -i {{ .HostName }}
   {{- if .AllowedCIDRs }}
   acl is_{{ .Name }}_request_allowed src {{ .AllowedCIDRs }}
+    {{- if .AllowedEndpoints }}
+  acl is_{{ .Name }}_request_allowed path_beg -i {{ .AllowedEndpoints }}
+    {{- end }}
   {{- end }}
   {{- end }}
 

--- a/sharedingress-config-generator/testdata/zz_fixture_TestGenerateConfig_When_there_s_two_HostedClusters_with_all_their_Routes_and_SVCs_it_should_generate_the_config_with_frontends_and_backends_for_both.cfg
+++ b/sharedingress-config-generator/testdata/zz_fixture_TestGenerateConfig_When_there_s_two_HostedClusters_with_all_their_Routes_and_SVCs_it_should_generate_the_config_with_frontends_and_backends_for_both.cfg
@@ -55,6 +55,7 @@ frontend external-dns
   acl is_test-hc2-konnectivity_request_allowed src 1.1.1.1/32 192.168.1.1/24
   acl is_test-hc2-apiserver req_ssl_sni -i kube-apiserver-public.example.com
   acl is_test-hc2-apiserver_request_allowed src 1.1.1.1/32 192.168.1.1/24
+  acl is_test-hc2-apiserver_request_allowed path_beg -i /healthz
   acl is_test-hc2-oauth req_ssl_sni -i oauth-public.example.com
   acl is_test-hc2-oauth_request_allowed src 1.1.1.1/32 192.168.1.1/24
   use_backend test-hc1-ignition if is_test-hc1-ignition

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -2968,6 +2968,11 @@ func ensureAPIServerAllowedCIDRs(ctx context.Context, t *testing.T, g Gomega, mg
 		} else {
 			g.Expect(err).To(HaveOccurred(), "kube-apiserver should not be reachable")
 		}
+
+		// validate that KAS /healthz endpoint is always reachable
+		result := guestClient.RESTClient().Get().AbsPath("/healthz").Do(ctx)
+		g.Expect(result.Error()).ToNot(HaveOccurred())
+
 	}).WithContext(ctx).WithTimeout(time.Minute * 3).WithPolling(time.Second * 5).Should(Succeed())
 
 }


### PR DESCRIPTION



**What this PR does / why we need it**:
This allows CPO KAS rountrip health check through the shared proxy to always pass when even when AllowedCIDRBlocks is set.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.