### PR TITLE
CNTRLPLANE-946: test(e2e): Add e2e test for ExternalOIDCWithUIDAndExtra feature set

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -236,7 +236,7 @@ func main(m *testing.M) int {
 	}
 
 	// Everything's okay to run tests
-	log.Info("executing e2e tests", "options", globalOpts)
+	log.Info("executing e2e tests")
 	return m.Run()
 }
 

--- a/test/e2e/external_oidc_test.go
+++ b/test/e2e/external_oidc_test.go
@@ -9,10 +9,17 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	configv1 "github.com/openshift/api/config/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+
+	kauthnv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kauthnv1typedclient "k8s.io/client-go/kubernetes/typed/authentication/v1"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestExternalOIDC(t *testing.T) {
@@ -42,6 +49,79 @@ func TestExternalOIDC(t *testing.T) {
 			clientCfg := e2eutil.WaitForGuestRestConfig(t, ctx, mgtClient, hostedCluster)
 			e2eutil.ChangeClientForKeycloakExtOIDC(t, ctx, clientCfg, clusterOpts.ExtOIDCConfig)
 			t.Logf("successfully get oidc user client")
+		})
+	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, "external-oidc", globalOpts.ServiceAccountSigningKey)
+}
+
+func TestExternalOIDCTechPreview(t *testing.T) {
+	e2eutil.AtLeast(t, e2eutil.Version419)
+	if os.Getenv("TECH_PREVIEW_NO_UPGRADE") != "true" {
+		t.Skipf("Only tested when CI sets TECH_PREVIEW_NO_UPGRADE=true and the Hypershift Operator is installed with --tech-preview-no-upgrade")
+	}
+
+	if globalOpts.ExternalOIDCProvider == "" {
+		t.Skipf("skip external OIDC test if e2e.external-oidc-provider is not provided")
+	}
+
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(testContext)
+	defer cancel()
+
+	clusterOpts := globalOpts.DefaultClusterOptions(t)
+	clusterOpts.FeatureSet = string(configv1.TechPreviewNoUpgrade)
+	clusterOpts.NodePoolReplicas = 1
+
+	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+		t.Logf("begin to test external OIDC with TechPreviewNoUpgrade enabled %s", globalOpts.ExternalOIDCProvider)
+		g.Expect(hostedCluster.Spec.Configuration).NotTo(BeNil())
+		g.Expect(hostedCluster.Spec.Configuration.Authentication).NotTo(BeNil())
+		g.Expect(hostedCluster.Spec.Configuration.Authentication.OIDCProviders).NotTo(BeEmpty())
+		clientCfg := e2eutil.WaitForGuestRestConfig(t, ctx, mgtClient, hostedCluster)
+		authKubeConfig := e2eutil.ChangeUserForKeycloakExtOIDC(t, ctx, clientCfg, clusterOpts.ExtOIDCConfig)
+		authClient, err := kauthnv1typedclient.NewForConfig(authKubeConfig)
+		g.Expect(err).NotTo(HaveOccurred())
+		selfSubjectReview, err := authClient.SelfSubjectReviews().Create(ctx, &kauthnv1.SelfSubjectReview{}, metav1.CreateOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		t.Logf("selfSubjectReview %+v", selfSubjectReview)
+
+		t.Run("[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] Test external OIDC userInfo username", func(t *testing.T) {
+			g := NewWithT(t)
+			t.Logf("begin to test external OIDC with external OIDC userInfo username")
+			g.Expect(selfSubjectReview.Status.UserInfo.Username).NotTo(BeEmpty())
+			g.Expect(selfSubjectReview.Status.UserInfo.Username).Should(ContainSubstring(clusterOpts.ExtOIDCConfig.UserPrefix))
+		})
+
+		t.Run("[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] Test external OIDC userInfo Groups", func(t *testing.T) {
+			g := NewWithT(t)
+			t.Logf("begin to test external OIDC userInfo Groups")
+			g.Expect(selfSubjectReview.Status.UserInfo.Groups).NotTo(BeEmpty())
+			g.Expect(selfSubjectReview.Status.UserInfo.Groups).Should(ContainElements(ContainSubstring(clusterOpts.ExtOIDCConfig.GroupPrefix)))
+		})
+
+		t.Run("[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] Test external OIDC userInfo UID", func(t *testing.T) {
+			g := NewWithT(t)
+			t.Logf("begin to test external OIDC userInfo UID")
+			g.Expect(selfSubjectReview.Status.UserInfo.UID).NotTo(BeEmpty())
+			g.Expect(selfSubjectReview.Status.UserInfo.UID).Should(ContainSubstring(e2eutil.ExternalOIDCUIDExpressionPrefix))
+			g.Expect(selfSubjectReview.Status.UserInfo.UID).Should(ContainSubstring(e2eutil.ExternalOIDCUIDExpressionSubfix))
+		})
+
+		t.Run("[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] Test external OIDC userInfo Extra", func(t *testing.T) {
+			g := NewWithT(t)
+			t.Logf("begin to test external OIDC userInfo Extra")
+			g.Expect(selfSubjectReview.Status.UserInfo.Extra).NotTo(BeEmpty())
+			g.Expect(selfSubjectReview.Status.UserInfo.Extra).Should(HaveKey(e2eutil.ExternalOIDCExtraKeyBar))
+			g.Expect(selfSubjectReview.Status.UserInfo.Extra).Should(HaveKey(e2eutil.ExternalOIDCExtraKeyFoo))
+		})
+
+		t.Run("[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] Test external OIDC: check co status using oauth client", func(t *testing.T) {
+			g := NewWithT(t)
+			t.Logf("begin to test for checking co status")
+			client, err := configv1client.NewForConfig(authKubeConfig)
+			g.Expect(err).NotTo(HaveOccurred())
+			_, err = client.ConfigV1().ClusterOperators().Get(ctx, "image-registry", metav1.GetOptions{})
+			g.Expect(err).To(HaveOccurred())
 		})
 	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, "external-oidc", globalOpts.ServiceAccountSigningKey)
 }

--- a/test/e2e/util/external_oidc.go
+++ b/test/e2e/util/external_oidc.go
@@ -40,6 +40,13 @@ type ProviderType string
 const (
 	ProviderAzure    ProviderType = "azure"
 	ProviderKeycloak ProviderType = "keycloak"
+
+	ExternalOIDCUIDExpressionPrefix        = "testuid-"
+	ExternalOIDCUIDExpressionSubfix        = "-uidtest"
+	ExternalOIDCExtraKeyBar                = "extratest.openshift.com/bar"
+	ExternalOIDCExtraKeyBarValueExpression = "extra-test-mark"
+	ExternalOIDCExtraKeyFoo                = "extratest.openshift.com/foo"
+	ExternalOIDCExtraKeyFooValueExpression = "claims.email" // This is a variable, not a string literal
 )
 
 type ExtOIDCConfig struct {
@@ -122,16 +129,16 @@ func (config *ExtOIDCConfig) GetAuthenticationConfig() *configv1.AuthenticationS
 						},
 					},
 					UID: &configv1.TokenClaimOrExpressionMapping{
-						Expression: `"testuid-" + claims.sub + "-uidtest"`,
+						Expression: fmt.Sprintf(`"%s" + claims.sub + "%s"`, ExternalOIDCUIDExpressionPrefix, ExternalOIDCUIDExpressionSubfix),
 					},
 					Extra: []configv1.ExtraMapping{
 						{
-							Key:             "extratest.openshift.com/bar",
-							ValueExpression: `"extra-test-mark"`,
+							Key:             ExternalOIDCExtraKeyBar,
+							ValueExpression: fmt.Sprintf(`"%s"`, ExternalOIDCExtraKeyBarValueExpression),
 						},
 						{
-							Key:             "extratest.openshift.com/foo",
-							ValueExpression: "claims.email",
+							Key:             ExternalOIDCExtraKeyFoo,
+							ValueExpression: ExternalOIDCExtraKeyFooValueExpression,
 						},
 					},
 				},


### PR DESCRIPTION
Add e2e test for external OIDC ExternalOIDCWithUIDAndExtraClaimMappings feature set in HostedCluster
It is for the GA of external oidc ExternalOIDCWithUIDAndExtraClaimMappings 
The related periodical job in the prow is https://github.com/openshift/release/pull/67531

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.   
- [x] This change includes unit tests.

** local test passed **
```
=== RUN   TestExternalOIDCTechPreview/Main
    external_oidc_test.go:76: begin to test external OIDC with TechPreviewNoUpgrade enabled keycloak
...
    external_oidc_test.go:86: selfSubjectReview &SelfSubjectReview{ObjectMeta:{      0 2025-08-11 17:36:01 +0800 CST <nil> <nil> map[] map[] [] [] []},Status:SelfSubjectReviewStatus{UserInfo:UserInfo{Username:oidc-user-test:keycloak-testuser-45@example.com,UID:testuid-89d38910-ff64-4c79-b38b-d0f345f19581-uidtest,Groups:[oidc-groups-test:keycloak-testgroup-1 system:authenticated],Extra:map[string]ExtraValue{authentication.kubernetes.io/credential-id: [JTI=6bf0159f-f0e2-45f9-bf42-ea1534ff3007],extratest.openshift.com/bar: [extra-test-mark],extratest.openshift.com/foo: [keycloak-testuser-45@example.com],},},},}
=== RUN   TestExternalOIDCTechPreview/Main/[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings]_Test_external_OIDC_userInfo_username
    external_oidc_test.go:90: begin to test external OIDC with external OIDC userInfo username
=== RUN   TestExternalOIDCTechPreview/Main/[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings]_Test_external_OIDC_userInfo_Groups
    external_oidc_test.go:97: begin to test external OIDC userInfo Groups
=== RUN   TestExternalOIDCTechPreview/Main/[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings]_Test_external_OIDC_userInfo_UID
    external_oidc_test.go:104: begin to test external OIDC userInfo UID
=== RUN   TestExternalOIDCTechPreview/Main/[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings]_Test_external_OIDC_userInfo_Extra
    external_oidc_test.go:112: begin to test external OIDC userInfo Extra
=== RUN   TestExternalOIDCTechPreview/Main/[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings]_Test_external_OIDC:_check_co_status_using_oauth_client
    external_oidc_test.go:120: begin to test for checking co status
=== RUN   TestExternalOIDCTechPreview/EnsureHostedCluster
=== RUN   TestExternalOIDCTechPreview/EnsureHostedCluster/EnsurePayloadArchSetCorrectly
```
