### PR TITLE
[release-4.19] OCPBUGS-60152: add missing app label to some components

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/fg/assets/job.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/fg/assets/job.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   backoffLimit: 5
   template:
+    metadata:
+      labels:
+        app: featuregate-generator
     spec:
       serviceAccountName: control-plane-operator
       restartPolicy: Never

--- a/control-plane-operator/controllers/hostedcontrolplane/fg/testdata/zz_fixture_TestReconcileFeatureGateGenerationJob_no_default_security_context.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/fg/testdata/zz_fixture_TestReconcileFeatureGateGenerationJob_no_default_security_context.yaml
@@ -12,6 +12,7 @@ spec:
         hypershift.openshift.io/release-image: ""
       creationTimestamp: null
       labels:
+        app: featuregate-generator
         hypershift.openshift.io/hosted-control-plane: ""
         hypershift.openshift.io/need-management-kas-access: "true"
     spec:

--- a/control-plane-operator/controllers/hostedcontrolplane/fg/testdata/zz_fixture_TestReconcileFeatureGateGenerationJob_with_default_security_context.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/fg/testdata/zz_fixture_TestReconcileFeatureGateGenerationJob_with_default_security_context.yaml
@@ -12,6 +12,7 @@ spec:
         hypershift.openshift.io/release-image: ""
       creationTimestamp: null
       labels:
+        app: featuregate-generator
         hypershift.openshift.io/hosted-control-plane: ""
         hypershift.openshift.io/need-management-kas-access: "true"
     spec:

--- a/control-plane-operator/controllers/hostedcontrolplane/olm/assets/olm-collect-profiles.cronjob.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/olm/assets/olm-collect-profiles.cronjob.yaml
@@ -7,6 +7,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            app: olm-collect-profiles
         spec:
           serviceAccountName: olm-collect-profiles
           priorityClassName: hypershift-control-plane

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/reconcile.go
@@ -161,6 +161,9 @@ func NewParams(hcp *hyperv1.HostedControlPlane, version string, releaseImageProv
 }
 
 func ReconcileDeployment(deployment *appsv1.Deployment, params Params) error {
+	podLabels := selectorLabels()
+	// Set the app label for the pod but do not add to MatchLabels since it is immutable
+	podLabels["app"] = "cluster-image-registry-operator"
 	deployment.Spec = appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
 			MatchLabels: selectorLabels(),
@@ -170,7 +173,7 @@ func ReconcileDeployment(deployment *appsv1.Deployment, params Params) error {
 		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: selectorLabels(),
+				Labels: podLabels,
 			},
 			Spec: corev1.PodSpec{
 				AutomountServiceAccountToken: ptr.To(false),

--- a/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/registryoperator/testdata/zz_fixture_TestReconcileDeployment.yaml
@@ -21,6 +21,7 @@ spec:
         hypershift.openshift.io/release-image: quay.io/ocp-dev/test-release-image:latest
       creationTimestamp: null
       labels:
+        app: cluster-image-registry-operator
         hypershift.openshift.io/hosted-control-plane: test-namespace
         name: cluster-image-registry-operator
     spec:

--- a/control-plane-operator/controllers/hostedcontrolplane/storage/assets/10_deployment-hypershift.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/storage/assets/10_deployment-hypershift.yaml
@@ -14,6 +14,7 @@ spec:
         openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
+        app: cluster-storage-operator
         name: cluster-storage-operator
     spec:
       containers:


### PR DESCRIPTION
HCM is looking to track per-component logs with the app label but it is missing on a few HCP components.

The PR adds the app label to these components.

Manual backport of https://github.com/openshift/hypershift/pull/6591 for CPOv1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added consistent app labels to pods for feature gate generation, OLM profile collection, image registry operator, and cluster storage operator. This improves pod selection, observability, and compatibility with monitoring and policy tooling without altering runtime behavior.
- Tests
  - Updated test fixtures to reflect the new pod labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->