### PR TITLE
CNTRLPLANE-1113: feat(ci): Add renovate config to ignore go.mod/sum updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ tools/bin
 
 # Mocked interface generate through mockgen
 *_mock.go
+
+# Dev
+dev/

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "enabled": true,
+    "enabledManagers": ["tekton"],
+    "packageRules": [
+        {
+            "matchManagers": ["gomod"],
+            "enabled": false
+        },
+        {
+            "matchFileNames": ["go.mod", "go.sum"],
+            "enabled": false
+        }
+    ],
+    "tekton": {
+        "branchConcurrentLimit": 10,
+        "extends": [
+            "github>konflux-ci/mintmaker-presets:update-fedora-to-stable"
+        ]
+    }
+}


### PR DESCRIPTION
## What this PR does / why we need it

Update renovate config to:
- Ignore go.mod updates in branch
- Still catch the Tekton updates from Konflux

Also ignored dev folder in .gitignore