### PR TITLE
[release-4.15] OCPBUGS-60488: feat(validations): add wildcard support to DNS SAN conflict detection

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -273,6 +273,10 @@ const (
 
 	// ManagementPlatformAnnotation specifies the infrastructure platform of the underlying management cluster
 	ManagementPlatformAnnotation = "hypershift.openshift.io/management-platform"
+
+	// SkipKASCertificateConflicSANValidation allows skipping the validation of the KAS certificate SANs so they do not conflict with ServicePublishingStrategy Hostname.
+	// This annotation is useful as a escape hatch, that IBM could use.
+	SkipKASConflicSANValidation = "hypershift.openshift.io/skip-kas-conflict-san-validation"
 )
 
 // HostedClusterSpec is the desired behavior of a HostedCluster.

--- a/hypershift-operator/controllers/hostedcluster/validations/ocpapiserver.go
+++ b/hypershift-operator/controllers/hostedcluster/validations/ocpapiserver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/pem"
 	"fmt"
+	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
@@ -14,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -30,6 +32,7 @@ func ValidateOCPAPIServerSANs(ctx context.Context, hc *hyperv1.HostedCluster, cl
 		entryCertIPs      = make([]string, 0)
 		kasNames          = make([]string, 0)
 		kasIPs            = make([]string, 0)
+		log               = ctrl.LoggerFrom(ctx)
 	)
 
 	// At this point, maybe the HCP is not there yet
@@ -49,6 +52,16 @@ func ValidateOCPAPIServerSANs(ctx context.Context, hc *hyperv1.HostedCluster, cl
 					return errs
 				}
 			}
+		}
+
+		if _, exists := hc.Annotations[hyperv1.SkipKASConflicSANValidation]; exists {
+			log.Info("Skipping KAS certificate SANs validation due to annotation", "annotation", hyperv1.SkipKASConflicSANValidation)
+			return errs
+		}
+
+		if hc.Spec.Platform.AWS != nil && (hc.Spec.Platform.AWS.EndpointAccess == hyperv1.Private || hc.Spec.Platform.AWS.EndpointAccess == hyperv1.PublicAndPrivate) {
+			log.Info("Skipping KAS certificate SANs validation due to AWS endpoint access value", "endpointAccess", hc.Spec.Platform.AWS.EndpointAccess)
+			return errs
 		}
 
 		kasNames, kasIPs, err = supportpki.GetKASServerCertificatesSANs("", fmt.Sprintf("api.%s.hypershift.local", hc.Name), []string{}, "", hc.Namespace)
@@ -153,11 +166,86 @@ func appendEntriesIfNotExists(slice []string, entries []string) []string {
 	return slice
 }
 
+// isDNSNameMatch checks if a DNS name matches a pattern, supporting wildcards.
+// Wildcards are only allowed at the beginning of a domain and can only match one label.
+// Examples:
+// - "*.example.com" matches "sub.example.com" but not "sub.sub.example.com"
+// - "*.foo.bar.com" matches "baz.foo.bar.com" but not "qux.baz.foo.bar.com"
+func isDNSNameMatch(name, pattern string) bool {
+	// Early return for exact matches
+	if name == pattern {
+		return true
+	}
+
+	// Early return for non-wildcard patterns
+	if !strings.HasPrefix(pattern, "*.") {
+		return false
+	}
+
+	// Extract the domain part after the wildcard
+	wildcardDomain := pattern[2:] // Remove "*."
+
+	// Early return if name doesn't end with the wildcard domain
+	if !strings.HasSuffix(name, wildcardDomain) {
+		return false
+	}
+
+	// Split both names into labels for comparison
+	nameLabels := strings.Split(name, ".")
+	wildcardLabels := strings.Split(wildcardDomain, ".")
+
+	// Wildcard can only match one label, so name must have exactly one more label
+	if len(nameLabels) != len(wildcardLabels)+1 {
+		return false
+	}
+
+	// Verify that all wildcard labels match the corresponding name labels
+	// Skip the first name label (which is what the wildcard matches)
+	return slicesEqual(nameLabels[1:], wildcardLabels)
+}
+
+// isDNSNameConflicting checks if two DNS names conflict, considering wildcards.
+// A conflict occurs if either name matches the other pattern.
+func isDNSNameConflicting(name1, name2 string) bool {
+	return isDNSNameMatch(name1, name2) || isDNSNameMatch(name2, name1)
+}
+
 func checkConflictingSANs(customEntries []string, kasSANEntries []string, entryType string) error {
 	for _, customEntry := range customEntries {
-		if containsString(kasSANEntries, customEntry) {
-			return fmt.Errorf("conflicting %s found in KAS SANs. Configuration is invalid", entryType)
+		// Check for exact matches first
+		if sliceContains(kasSANEntries, customEntry) {
+			return fmt.Errorf("conflicting %s found in KAS SANs. kasEntries: %s, customEntry: %s. The configuration is invalid because the custom %s is conflicting with the KAS SANs", entryType, kasSANEntries, customEntry, entryType)
+		}
+
+		// Check for wildcard matches
+		for _, kasEntry := range kasSANEntries {
+			if isDNSNameConflicting(customEntry, kasEntry) {
+				return fmt.Errorf("conflicting %s found in KAS SANs. kasEntry: %s, customEntry: %s. The configuration is invalid because the custom %s is conflicting with the KAS SANs", entryType, kasEntry, customEntry, entryType)
+			}
 		}
 	}
 	return nil
+}
+
+// sliceContains checks if a slice contains a specific string
+func sliceContains(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// slicesEqual checks if two string slices are equal
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/hypershift-operator/controllers/hostedcluster/validations/ocpapiserver_test.go
+++ b/hypershift-operator/controllers/hostedcluster/validations/ocpapiserver_test.go
@@ -148,7 +148,7 @@ func TestValidateOCPAPIServerSANs(t *testing.T) {
 				},
 			},
 			expectedErrors: field.ErrorList{
-				field.Invalid(field.NewPath("custom serving cert"), []string{"test-conflicting-kas-san.example.com"}, "conflicting DNS names found in KAS SANs. Configuration is invalid"),
+				field.Invalid(field.NewPath("custom serving cert"), []string{"test-conflicting-kas-san.example.com"}, "conflicting DNS names found in KAS SANs. kasEntries: [localhost kubernetes kubernetes.default kubernetes.default.svc kubernetes.default.svc.cluster.local kube-apiserver openshift openshift.default openshift.default.svc openshift.default.svc.cluster.local kube-apiserver.clusters.svc kube-apiserver.clusters.svc.cluster.local  api.test.hypershift.local kube-apiserver.clusters-jparrill-hosted.svc kube-apiserver.clusters-jparrill-hosted.svc.cluster.local test-conflicting-kas-san.example.com], customEntry: test-conflicting-kas-san.example.com. The configuration is invalid because the custom DNS names is conflicting with the KAS SANs"),
 			},
 		},
 		{
@@ -288,6 +288,127 @@ func TestAppendEntriesIfNotExists(t *testing.T) {
 	}
 }
 
+func TestIsDNSNameMatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		dnsName  string
+		pattern  string
+		expected bool
+	}{
+		// Exact matches
+		{
+			name:     "exact match - simple domain",
+			dnsName:  "example.com",
+			pattern:  "example.com",
+			expected: true,
+		},
+		{
+			name:     "exact match - subdomain",
+			dnsName:  "sub.example.com",
+			pattern:  "sub.example.com",
+			expected: true,
+		},
+		{
+			name:     "exact match - multiple subdomains",
+			dnsName:  "a.b.c.example.com",
+			pattern:  "a.b.c.example.com",
+			expected: true,
+		},
+		{
+			name:     "no match - different domains",
+			dnsName:  "example.com",
+			pattern:  "other.com",
+			expected: false,
+		},
+		{
+			name:     "no match - different subdomains",
+			dnsName:  "sub.example.com",
+			pattern:  "other.example.com",
+			expected: false,
+		},
+		// Wildcard matches
+		{
+			name:     "wildcard match - single level",
+			dnsName:  "sub.example.com",
+			pattern:  "*.example.com",
+			expected: true,
+		},
+		{
+			name:     "wildcard match - multiple levels",
+			dnsName:  "baz.foo.bar.com",
+			pattern:  "*.foo.bar.com",
+			expected: true,
+		},
+		{
+			name:     "wildcard no match - too many levels",
+			dnsName:  "sub.sub.example.com",
+			pattern:  "*.example.com",
+			expected: false,
+		},
+		{
+			name:     "wildcard no match - too few levels",
+			dnsName:  "example.com",
+			pattern:  "*.example.com",
+			expected: false,
+		},
+		{
+			name:     "wildcard no match - different domain",
+			dnsName:  "sub.example.com",
+			pattern:  "*.other.com",
+			expected: false,
+		},
+		{
+			name:     "wildcard no match - partial domain match",
+			dnsName:  "sub.example.com",
+			pattern:  "*.example.org",
+			expected: false,
+		},
+		// Edge cases
+		{
+			name:     "wildcard pattern not at start",
+			dnsName:  "example.com",
+			pattern:  "example.*.com",
+			expected: false,
+		},
+		{
+			name:     "wildcard pattern at end",
+			dnsName:  "example.com",
+			pattern:  "*.com",
+			expected: true,
+		},
+		{
+			name:     "empty strings",
+			dnsName:  "",
+			pattern:  "",
+			expected: true,
+		},
+		{
+			name:     "empty dnsName",
+			dnsName:  "",
+			pattern:  "*.example.com",
+			expected: false,
+		},
+		{
+			name:     "empty pattern",
+			dnsName:  "example.com",
+			pattern:  "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result := isDNSNameMatch(tt.dnsName, tt.pattern)
+			g.Expect(result).To(Equal(tt.expected),
+				"DNS name '%s' should %s match pattern '%s'",
+				tt.dnsName,
+				map[bool]string{true: "", false: "not"}[tt.expected],
+				tt.pattern)
+		})
+	}
+}
+
 func TestCheckConflictingSANs(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -316,6 +437,62 @@ func TestCheckConflictingSANs(t *testing.T) {
 			kasSANEntries: []string{},
 			entryType:     "DNS names",
 			expectError:   false,
+		},
+		{
+			name:          "wildcard conflicts - custom entry matches KAS wildcard",
+			customEntries: []string{"sub.example.com"},
+			kasSANEntries: []string{"*.example.com"},
+			entryType:     "DNS names",
+			expectError:   true,
+		},
+		{
+			name:          "wildcard conflicts - custom wildcard matches KAS entry",
+			customEntries: []string{"*.example.com"},
+			kasSANEntries: []string{"sub.example.com"},
+			entryType:     "DNS names",
+			expectError:   true,
+		},
+		{
+			name:          "wildcard conflicts - both wildcards with same domain",
+			customEntries: []string{"*.example.com"},
+			kasSANEntries: []string{"*.example.com"},
+			entryType:     "DNS names",
+			expectError:   true,
+		},
+		{
+			name:          "wildcard conflicts - custom entry matches KAS wildcard with subdomain",
+			customEntries: []string{"baz.foo.bar.com"},
+			kasSANEntries: []string{"*.foo.bar.com"},
+			entryType:     "DNS names",
+			expectError:   true,
+		},
+		{
+			name:          "no wildcard conflicts - custom entry doesn't match KAS wildcard",
+			customEntries: []string{"sub.sub.example.com"},
+			kasSANEntries: []string{"*.example.com"},
+			entryType:     "DNS names",
+			expectError:   false,
+		},
+		{
+			name:          "no wildcard conflicts - different domains",
+			customEntries: []string{"sub.example.com"},
+			kasSANEntries: []string{"*.other.com"},
+			entryType:     "DNS names",
+			expectError:   false,
+		},
+		{
+			name:          "no wildcard conflicts - custom wildcard doesn't match KAS entry",
+			customEntries: []string{"*.example.com"},
+			kasSANEntries: []string{"other.com"},
+			entryType:     "DNS names",
+			expectError:   false,
+		},
+		{
+			name:          "mixed conflicts - exact match and wildcard match",
+			customEntries: []string{"exact.example.com", "sub.example.com"},
+			kasSANEntries: []string{"exact.example.com", "*.example.com"},
+			entryType:     "DNS names",
+			expectError:   true,
 		},
 	}
 
@@ -453,6 +630,12 @@ func sampleHostedCluster() *hyperv1.HostedCluster {
 			Namespace: "clusters",
 		},
 		Spec: hyperv1.HostedClusterSpec{
+			Platform: hyperv1.PlatformSpec{
+				Type: hyperv1.AWSPlatform,
+				AWS: &hyperv1.AWSPlatformSpec{
+					EndpointAccess: hyperv1.Public,
+				},
+			},
 			Configuration: &hyperv1.ClusterConfiguration{
 				APIServer: &configv1.APIServerSpec{
 					ServingCerts: configv1.APIServerServingCerts{


### PR DESCRIPTION
## What this PR does / why we need it
- Manual backport of https://github.com/openshift/hypershift/pull/6651

## Additional code
- Removed slice library due to we use go1.20 and implemented similar ad-hoc functions