### PR TITLE
CNTRLPLANE-1270: Fix ProjectDevelopmentStreamTemplates

### DIFF
--- a/contrib/konflux/cpo_4_19_stream.yaml
+++ b/contrib/konflux/cpo_4_19_stream.yaml
@@ -1,0 +1,11 @@
+apiVersion: projctl.konflux.dev/v1beta1
+kind: ProjectDevelopmentStream
+metadata:
+  name: control-plane-operator-v4-19
+spec:
+  project: crt-redhat-acm-tenant
+  template:
+    name: hypershift-cpo-template
+    values:
+    - name: version
+      value: "4.19"

--- a/contrib/konflux/cpo_development_stream_template.yaml
+++ b/contrib/konflux/cpo_development_stream_template.yaml
@@ -23,12 +23,15 @@ spec:
     kind: Component
     metadata:
       annotations:
+        build.appstudio.openshift.io/request: configure-pac
         build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
-        build.appstudio.openshift.io/status: '{"pac":{"state":"enabled","merge-url":"https://github.com/openshift/hypershift/pull/1","configuration-time":"Mon, 11 Aug 2025 08:59:18 UTC"},"message":"done"}'
+        git-provider: github
+        git-provider-url: https://github.com
       name: control-plane-operator-{{.versionName}}
     spec:
       application: "control-plane-operator-{{.versionName}}"
       componentName: "control-plane-operator-{{.versionName}}"
+      containerImage: "quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-{{.versionName}}"
       source:
         git:
           context: ./
@@ -43,6 +46,8 @@ spec:
       labels:
         appstudio.redhat.com/application: control-plane-operator-{{.versionName}}
         appstudio.redhat.com/component: control-plane-operator-{{.versionName}}
+      annotations:
+        image-controller.appstudio.redhat.com/update-component-image: 'true'
     spec:
       image:
         name: crt-redhat-acm-tenant/control-plane-operator-{{.versionName}}

--- a/contrib/konflux/ho_development_stream_template.yaml
+++ b/contrib/konflux/ho_development_stream_template.yaml
@@ -23,13 +23,16 @@ spec:
     kind: Component
     metadata:
       annotations:
+        build.appstudio.openshift.io/request: configure-pac
         build.appstudio.openshift.io/pipeline: '{"name":"docker-build-multi-platform-oci-ta","bundle":"latest"}'
-        build.appstudio.openshift.io/status: '{"pac":{"state":"enabled","merge-url":"https://github.com/openshift/hypershift/pull/1","configuration-time":"Mon, 11 Aug 2025 08:59:18 UTC"},"message":"done"}'
+        git-provider: github
+        git-provider-url: https://github.com
         mintmaker.appstudio.redhat.com/disabled: "true"
       name: hypershift-operator-hotfix-{{.versionName}}
     spec:
       application: "hypershift-operator-hotfix-{{.versionName}}"
       componentName: "hypershift-operator-hotfix-{{.versionName}}"
+      containerImage: "quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-operator-hotfix-{{.versionName}}"
       source:
         git:
           context: ./
@@ -44,6 +47,8 @@ spec:
       labels:
         appstudio.redhat.com/application: hypershift-operator-hotfix-{{.versionName}}
         appstudio.redhat.com/component: hypershift-operator-hotfix-{{.versionName}}
+      annotations:
+        image-controller.appstudio.redhat.com/update-component-image: 'true'
     spec:
       image:
         name: crt-redhat-acm-tenant/hypershift-operator-hotfix-{{.versionName}}


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit:
* Fixes the templates so that the PR for the pipelines is correctly created by konflux
* Adds a ProjectDevelopmentStream for CPO 4.19

**Which issue(s) this PR fixes**:
Fixes #[CNTRLPLANE-1270](https://issues.redhat.com//browse/CNTRLPLANE-1270)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.