### PR TITLE
OCPBUGS-60602: Cache Azure KMS TokenCredential for ARO HCP and clarify CPO credentials cache naming

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -146,6 +146,7 @@ const (
 	hcpNotReadyRequeueInterval = 15 * time.Second
 
 	cpoAzureCredentials = "CPOAzureCredentials"
+	kmsAzureCredentials = "KMSAzureCredentials"
 )
 
 type HostedControlPlaneReconciler struct {
@@ -179,6 +180,7 @@ type HostedControlPlaneReconciler struct {
 	EnableCVOManagementClusterMetricsAccess bool
 	ImageMetadataProvider                   util.ImageMetadataProvider
 	cpoAzureCredentialsLoaded               sync.Map
+	kmsAzureCredentialsLoaded               sync.Map
 }
 
 func (r *HostedControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager, createOrUpdate upsert.CreateOrUpdateFN, hcp *hyperv1.HostedControlPlane) error {
@@ -3253,6 +3255,14 @@ func (r *HostedControlPlaneReconciler) validateAWSKMSConfig(ctx context.Context,
 }
 
 func (r *HostedControlPlaneReconciler) validateAzureKMSConfig(ctx context.Context, hcp *hyperv1.HostedControlPlane) {
+	var (
+		cred azcore.TokenCredential
+		ok   bool
+		err  error
+	)
+
+	log := ctrl.LoggerFrom(ctx)
+
 	if hcp.Spec.SecretEncryption == nil || hcp.Spec.SecretEncryption.KMS == nil || hcp.Spec.SecretEncryption.KMS.Azure == nil {
 		condition := metav1.Condition{
 			Type:               string(hyperv1.ValidAzureKMSConfig),
@@ -3266,13 +3276,31 @@ func (r *HostedControlPlaneReconciler) validateAzureKMSConfig(ctx context.Contex
 	}
 	azureKmsSpec := hcp.Spec.SecretEncryption.KMS.Azure
 
-	// Retrieve the KMS UserAssignedCredentials path
-	credentialsPath := config.ManagedAzureCredentialsPathForKMS + hcp.Spec.SecretEncryption.KMS.Azure.KMS.CredentialsSecretName
-	cred, err := dataplane.NewUserAssignedIdentityCredential(ctx, credentialsPath, dataplane.WithClientOpts(azcore.ClientOptions{Cloud: cloud.AzurePublic}))
-	if err != nil {
-		conditions.SetFalseCondition(hcp, hyperv1.ValidAzureKMSConfig, hyperv1.InvalidAzureCredentialsReason,
-			fmt.Sprintf("failed to obtain azure client credentials: %v", err))
-		return
+	if hyperazureutil.IsAroHCP() {
+		key := hcp.Namespace + kmsAzureCredentials
+
+		// We need to only store the Azure credentials once and reuse them after that.
+		storedCreds, found := r.kmsAzureCredentialsLoaded.Load(key)
+		if !found {
+			// Retrieve the KMS UserAssignedCredentials path
+			credentialsPath := config.ManagedAzureCredentialsPathForKMS + hcp.Spec.SecretEncryption.KMS.Azure.KMS.CredentialsSecretName
+			cred, err := dataplane.NewUserAssignedIdentityCredential(ctx, credentialsPath, dataplane.WithClientOpts(azcore.ClientOptions{Cloud: cloud.AzurePublic}))
+			if err != nil {
+				conditions.SetFalseCondition(hcp, hyperv1.ValidAzureKMSConfig, hyperv1.InvalidAzureCredentialsReason,
+					fmt.Sprintf("failed to obtain azure client credentials: %v", err))
+				return
+			}
+			r.kmsAzureCredentialsLoaded.Store(key, cred)
+			log.Info("Storing new UserAssignedManagedIdentity credentials for KMS to authenticate to Azure")
+		} else {
+			cred, ok = storedCreds.(azcore.TokenCredential)
+			if !ok {
+				conditions.SetFalseCondition(hcp, hyperv1.ValidAzureKMSConfig, hyperv1.InvalidAzureCredentialsReason,
+					fmt.Sprintf("expected %T to be a TokenCredential", storedCreds))
+				return
+			}
+			log.Info("Reusing existing UserAssignedManagedIdentity credentials for KMS to authenticate to Azure")
+		}
 	}
 
 	azureKeyVaultDNSSuffix, err := hyperazureutil.GetKeyVaultDNSSuffixFromCloudType(hcp.Spec.Platform.Azure.Cloud)


### PR DESCRIPTION
**What this PR does / why we need it**:

- Caches the Azure KMS TokenCredential per namespace when running on ARO HCP to avoid repeated credential creation and external calls during reconcile, improving performance.
- Clarifies naming for the control-plane-operator’s Azure credentials cache to reduce ambiguity and improve readability.
- Behavior is unchanged for non-ARO environments.

Changes include:
- Add kmsAzureCredentials key and kmsAzureCredentialsLoaded cache in HostedControlPlaneReconciler.
- Update validateAzureKMSConfig to Load/Store the cached credential when IsAroHCP().
- Improve log messages to explicitly reference KMS and CPO flows.
- Rename constants/fields: azureCredentials → cpoAzureCredentials, azureCredentialsLoaded → cpoAzureCredentialsLoaded.

**Which issue(s) this PR fixes**:
- Fixes OCPBUGS-60602

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.