### PR TITLE
OCPBUGS-60100: fix: add dynamic security context uid to 4.19 missing components

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/azure/params.go
@@ -19,7 +19,7 @@ type AzureParams struct {
 	SecretProviderClassName string                  `json:"secretProviderClassName"`
 }
 
-func NewAzureParams(hcp *hyperv1.HostedControlPlane) *AzureParams {
+func NewAzureParams(hcp *hyperv1.HostedControlPlane, setDefaultSecurityContext bool) *AzureParams {
 	if hcp.Spec.Platform.Azure == nil {
 		return nil
 	}
@@ -43,8 +43,11 @@ func NewAzureParams(hcp *hyperv1.HostedControlPlane) *AzureParams {
 	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
 		p.DeploymentConfig.Scheduling.PriorityClass = hcp.Annotations[hyperv1.ControlPlanePriorityClass]
 	}
+
 	p.DeploymentConfig.SetDefaults(hcp, ccmLabels(), ptr.To(1))
 	p.DeploymentConfig.SetRestartAnnotation(hcp.ObjectMeta)
+
+	p.DeploymentConfig.SetDefaultSecurityContext = setDefaultSecurityContext
 
 	return p
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -443,8 +443,12 @@ func ReconcileDeployment(dep *appsv1.Deployment, params Params, platformType hyp
 
 	// If CP is running on kube cluster, pass user ID for CNO to run its managed services with
 	if params.DeploymentConfig.SetDefaultSecurityContext {
+		uid, err := config.GetSecurityContextUID()
+		if err != nil {
+			return fmt.Errorf("failed to get security context UID: %w", err)
+		}
 		cnoEnv = append(cnoEnv, corev1.EnvVar{
-			Name: "RUN_AS_USER", Value: strconv.Itoa(config.DefaultSecurityContextUser),
+			Name: "RUN_AS_USER", Value: strconv.Itoa(int(uid)),
 		})
 	}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -4973,7 +4973,7 @@ func (r *HostedControlPlaneReconciler) reconcileCloudControllerManager(ctx conte
 		}
 	case hyperv1.AzurePlatform:
 		// Set up the params
-		p := azure.NewAzureParams(hcp)
+		p := azure.NewAzureParams(hcp, r.SetDefaultSecurityContext)
 
 		// Reconcile CCM ServiceAccount
 		ownerRef := config.OwnerRefFrom(hcp)

--- a/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ignitionserver/ignitionserver.go
@@ -739,18 +739,17 @@ func reconcileDeployment(deployment *appsv1.Deployment,
 		util.DeploymentAddOpenShiftTrustedCABundleConfigMap(deployment)
 	}
 
-	// set security context
-	if !managementClusterHasCapabilitySecurityContextConstraint {
-		deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-			RunAsUser: ptr.To[int64](config.DefaultSecurityContextUser),
-		}
-	}
-
 	deploymentConfig := config.DeploymentConfig{
 		AdditionalLabels: map[string]string{
 			config.NeedManagementKASAccessLabel: "true",
 		},
 	}
+
+	// set security context
+	if !managementClusterHasCapabilitySecurityContextConstraint {
+		deploymentConfig.SetDefaultSecurityContext = true
+	}
+
 	deploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
 	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
 		deploymentConfig.Scheduling.PriorityClass = hcp.Annotations[hyperv1.ControlPlanePriorityClass]
@@ -872,14 +871,12 @@ haproxy -f /tmp/haproxy.conf
 		util.DeploymentAddTrustBundleVolume(hcp.Spec.AdditionalTrustBundle, deployment)
 	}
 
+	deploymentConfig := config.DeploymentConfig{}
 	// set security context
 	if !managementClusterHasCapabilitySecurityContextConstraint {
-		deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-			RunAsUser: ptr.To[int64](config.DefaultSecurityContextUser),
-		}
+		deploymentConfig.SetDefaultSecurityContext = true
 	}
 
-	deploymentConfig := config.DeploymentConfig{}
 	deploymentConfig.Scheduling.PriorityClass = config.DefaultPriorityClass
 	if hcp.Annotations[hyperv1.ControlPlanePriorityClass] != "" {
 		deploymentConfig.Scheduling.PriorityClass = hcp.Annotations[hyperv1.ControlPlanePriorityClass]

--- a/support/config/deployment.go
+++ b/support/config/deployment.go
@@ -211,7 +211,7 @@ var (
 	DefaultSecurityContextUID       = int64(1001)
 )
 
-func getSecurityContextUID() (int64, error) {
+func GetSecurityContextUID() (int64, error) {
 	uidInput := os.Getenv(DefaultSecurityContextUIDEnvVar)
 	if uidInput == "" {
 		return DefaultSecurityContextUID, nil
@@ -226,7 +226,7 @@ func getSecurityContextUID() (int64, error) {
 
 func (c *DeploymentConfig) setDefaultSecurityContextForPod(spec *corev1.PodSpec, statefulSet bool) {
 	if c.SetDefaultSecurityContext {
-		uid, err := getSecurityContextUID()
+		uid, err := GetSecurityContextUID()
 		if err != nil {
 			uid = DefaultSecurityContextUID
 		}


### PR DESCRIPTION
This was introduced in 4.20 via
https://github.com/openshift/hypershift/pull/6520
https://github.com/openshift/hypershift/pull/6612
And in 4.19 via
https://github.com/openshift/hypershift/pull/6592

This PR add some missing components for 4.19

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.