### PR TITLE
OSASINFRA-3675: Add credentials to openshift-manila-csi-driver namespace for Hypershift

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1687,7 +1687,17 @@ func (r *reconciler) reconcileCloudCredentialSecrets(ctx context.Context, hcp *h
 		caCertData := openstack.GetCACertFromCredentialsSecret(credentialsSecret)
 		errs = append(errs,
 			r.reconcileOpenStackCredentialsSecret(ctx, hcp.Spec.Platform.OpenStack, "openshift-cluster-csi-drivers", "openstack-cloud-credentials", credentialsSecret, caCertData, hcp.Spec.Networking.MachineNetwork),
+			// TODO(dkokkino): Remove the manila-cloud-credentials secret from the openshift-cluster-csi-drivers namespace
+			// once https://github.com/openshift/csi-operator/pull/373 merges.The manila-cloud-credentials secret was previously
+			// used by the secretsyncer, which is being removed in that PR. Going forward, Manila will use the manila-cloud-credentials
+			// secret directly in the openshift-manila-csi-driver namespace.
 			r.reconcileOpenStackCredentialsSecret(ctx, hcp.Spec.Platform.OpenStack, "openshift-cluster-csi-drivers", "manila-cloud-credentials", credentialsSecret, caCertData, hcp.Spec.Networking.MachineNetwork),
+			// TODO(dkokkino): Remove the manila-cloud-credentials secret from the openshift-manila-csi-driver namespace
+			// once Manila assets have been migrated to the openshift-cluster-csi-drivers namespace.
+			// Progress is tracked in OSASINFRA-3677.
+			// After the migration, Manila could use the shared secret openstack-cloud-credentials
+			// instead of manila-cloud-credentials.
+			r.reconcileOpenStackCredentialsSecret(ctx, hcp.Spec.Platform.OpenStack, "openshift-manila-csi-driver", "manila-cloud-credentials", credentialsSecret, caCertData, hcp.Spec.Networking.MachineNetwork),
 			r.reconcileOpenStackCredentialsSecret(ctx, hcp.Spec.Platform.OpenStack, "openshift-image-registry", "installer-cloud-credentials", credentialsSecret, caCertData, hcp.Spec.Networking.MachineNetwork),
 			r.reconcileOpenStackCredentialsSecret(ctx, hcp.Spec.Platform.OpenStack, "openshift-cloud-network-config-controller", "cloud-credentials", credentialsSecret, caCertData, hcp.Spec.Networking.MachineNetwork),
 		)


### PR DESCRIPTION
**What this PR does / why we need it**:

The credentials are already provisioned in the
openshift-manila-csi-driver namespace for standalone deployments via the clouds-credential-operator. However, Hypershift does not use the clouds-credential-operator and instead manages credentials through a reconciliation loop (reconcileCloudCredentialSecrets).

This PR ensures the secret is explicitly added to the openshift-manila-csi-driver namespace for Hypershift deployments.

**Which issue(s) this PR fixes:**
Fixes [OSASINFRA-3675](https://issues.redhat.com/browse/OSASINFRA-3675)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.