### PR TITLE
NO-JIRA: Update-overrides for ARO HCP Fixes

### DIFF
--- a/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
+++ b/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
@@ -1,14 +1,14 @@
 platforms:
   azure:
     overrides:
-      - version: 4.19.6
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-19@sha256:e0810e84e6c12968847cee3c18311ab3226b1dcd3b176d2606399af7ce187633
       - version: 4.19.7
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-19@sha256:e0810e84e6c12968847cee3c18311ab3226b1dcd3b176d2606399af7ce187633
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-19@sha256:ef4b4fcaec0d781ad497b6060adef2b0dbcd5d5c59eda27a90f0e2f9595128c4
       - version: 4.19.8
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-19@sha256:e0810e84e6c12968847cee3c18311ab3226b1dcd3b176d2606399af7ce187633
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-19@sha256:ef4b4fcaec0d781ad497b6060adef2b0dbcd5d5c59eda27a90f0e2f9595128c4
       - version: 4.19.9
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-19@sha256:e0810e84e6c12968847cee3c18311ab3226b1dcd3b176d2606399af7ce187633
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-19@sha256:ef4b4fcaec0d781ad497b6060adef2b0dbcd5d5c59eda27a90f0e2f9595128c4
+      - version: 4.19.10
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-19@sha256:ef4b4fcaec0d781ad497b6060adef2b0dbcd5d5c59eda27a90f0e2f9595128c4
   aws:
     overrides:
     # Beginning of OCPBUGS-48519 overrides 4.15 section


### PR DESCRIPTION
**What this PR does / why we need it**:
Update overrides to point the CPO image at a version containing:
- Caching Azure KMS TokenCredential for ARO HCP
- Dynamic securityContext UID for missing 4.19 components

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.