### PR TITLE
STOR-1064: add validator image to CSO manifest

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
@@ -157,6 +157,8 @@ spec:
           value: kube-rbac-proxy
         - name: TOOLS_IMAGE
           value: tools
+        - name: VOLUME_DATA_SOURCE_VALIDATOR_IMAGE
+          value: quay.io/openshift/origin-volume-data-source-validator:latest
         image: cluster-storage-operator
         imagePullPolicy: IfNotPresent
         name: cluster-storage-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
@@ -157,6 +157,8 @@ spec:
           value: kube-rbac-proxy
         - name: TOOLS_IMAGE
           value: tools
+        - name: VOLUME_DATA_SOURCE_VALIDATOR_IMAGE
+          value: quay.io/openshift/origin-volume-data-source-validator:latest
         image: cluster-storage-operator
         imagePullPolicy: IfNotPresent
         name: cluster-storage-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-storage-operator/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-storage-operator/deployment.yaml
@@ -111,6 +111,8 @@ spec:
           value: quay.io/openshift/origin-kube-rbac-proxy:latest
         - name: TOOLS_IMAGE
           value: quay.io/openshift/origin-tools:latest
+        - name: VOLUME_DATA_SOURCE_VALIDATOR_IMAGE
+          value: quay.io/openshift/origin-volume-data-source-validator:latest
         image: cluster-storage-operator
         imagePullPolicy: IfNotPresent
         name: cluster-storage-operator


### PR DESCRIPTION
We're adding a new image and controller to CSO and it seems like I need to reflect this in hypershift manifest for CSO as well because hypershift CI jobs are currently failing due to missing image: https://github.com/openshift/cluster-storage-operator/pull/592#issuecomment-3206818015

/cc @openshift/openshift-team-hypershift 