### PR TITLE
[release-4.19] OCPBUGS-60125: fix(OCPBUGS-60125): Allow HCCO to set registry managementState to Removed; delete VAP during HC deletion

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/admissionpolicies.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/admissionpolicies.go
@@ -56,7 +56,7 @@ func reconcileRegistryConfigManagementStateValidatingAdmissionPolicy(ctx context
 		"configs",
 	}
 
-	denyRemovedManagementStateValidation.Expression = "object.spec.managementState != 'Removed'"
+	denyRemovedManagementStateValidation.Expression = "object.spec.managementState != 'Removed' || request.userInfo.username == 'system:hosted-cluster-config'"
 	registryConfigManagementStateAdmissionPolicy.Validations = []k8sadmissionv1.Validation{denyRemovedManagementStateValidation}
 	registryConfigManagementStateAdmissionPolicy.MatchConstraints = constructPolicyMatchConstraints(registryConfigManagementStateResources, registryConfigManagementStateAPIVersion, registryConfigManagementStateAPIGroup, []k8sadmissionv1.OperationType{"CREATE", "UPDATE"})
 	if err := registryConfigManagementStateAdmissionPolicy.reconcileAdmissionPolicy(ctx, client, createOrUpdate); err != nil {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/admissionpolicies.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/admissionpolicies.go
@@ -48,7 +48,12 @@ func ReconcileRegistryConfigValidatingAdmissionPolicies(ctx context.Context, hcp
 	return nil
 }
 
+// reconcileRegistryConfigManagementStateValidatingAdmissionPolicy reconciles the Validating Admission Policy
+// that controls access to the Image Registry config managementState field.
+//
+// During normal operation, it prevents users from setting managementState to 'Removed' except for the HCCO user.
 func reconcileRegistryConfigManagementStateValidatingAdmissionPolicy(ctx context.Context, hcp *hyperv1.HostedControlPlane, client client.Client, createOrUpdate upsert.CreateOrUpdateFN) error {
+	log := ctrl.LoggerFrom(ctx)
 	registryConfigManagementStateAdmissionPolicy := AdmissionPolicy{Name: AdmissionPolicyNameManagementState}
 	registryConfigManagementStateAPIVersion := []string{imageregistryv1.GroupVersion.Version}
 	registryConfigManagementStateAPIGroup := []string{imageregistryv1.GroupVersion.Group}
@@ -56,7 +61,11 @@ func reconcileRegistryConfigManagementStateValidatingAdmissionPolicy(ctx context
 		"configs",
 	}
 
+	// During normal operation, prevent users from setting managementState to Removed
+	// but allow the HCCO user
+	log.Info("Cluster is active, enforcing registry management state admission policy")
 	denyRemovedManagementStateValidation.Expression = "object.spec.managementState != 'Removed' || request.userInfo.username == 'system:hosted-cluster-config'"
+
 	registryConfigManagementStateAdmissionPolicy.Validations = []k8sadmissionv1.Validation{denyRemovedManagementStateValidation}
 	registryConfigManagementStateAdmissionPolicy.MatchConstraints = constructPolicyMatchConstraints(registryConfigManagementStateResources, registryConfigManagementStateAPIVersion, registryConfigManagementStateAPIGroup, []k8sadmissionv1.OperationType{"CREATE", "UPDATE"})
 	if err := registryConfigManagementStateAdmissionPolicy.reconcileAdmissionPolicy(ctx, client, createOrUpdate); err != nil {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/admissionpolicies_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/admissionpolicies_test.go
@@ -3,50 +3,208 @@ package registry
 import (
 	"context"
 	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
-	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
-	"github.com/openshift/hypershift/support/upsert"
+	hyperapi "github.com/openshift/hypershift/support/api"
 
-	admissionv1beta1 "k8s.io/api/admissionregistration/v1"
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+
+	k8sadmissionv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	k8sfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	controllerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func TestReconcileRegistryConfigValidatingAdmissionPolicies(t *testing.T) {
-	ctx := context.Background()
-
-	hcp := &hyperv1.HostedControlPlane{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo",
-			Namespace: "bar",
+func TestReconcileRegistryConfigManagementStateValidatingAdmissionPolicy(t *testing.T) {
+	tests := []struct {
+		name                    string
+		hcp                     *hyperv1.HostedControlPlane
+		expectCreation          bool
+		expectedExpression      string
+		expectedLogMessage      string
+		expectError             bool
+		expectedValidationCount int
+		expectedResourceRules   int
+	}{
+		{
+			name: "When cluster is active it should set expression to restrict managementState",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+					// DeletionTimestamp is zero (not set)
+				},
+			},
+			expectCreation:          true,
+			expectedExpression:      "object.spec.managementState != 'Removed' || request.userInfo.username == 'system:hosted-cluster-config'",
+			expectedLogMessage:      "Cluster is active, enforcing registry management state admission policy",
+			expectError:             false,
+			expectedValidationCount: 1,
+			expectedResourceRules:   1,
 		},
 	}
 
-	fakeClient := k8sfake.NewClientBuilder().
-		WithScheme(api.Scheme).
-		Build()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
 
-	createOrUpdate := upsert.New(true).CreateOrUpdate
+			// Create a fake client
+			scheme := hyperapi.Scheme
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	err := ReconcileRegistryConfigValidatingAdmissionPolicies(ctx, hcp, fakeClient, createOrUpdate)
-	require.NoError(t, err, "expected no error during reconciliation")
+			// Create a mock createOrUpdate function
+			var createdVAP *k8sadmissionv1.ValidatingAdmissionPolicy
+			var createdBinding *k8sadmissionv1.ValidatingAdmissionPolicyBinding
 
-	// validate ValidatingAdmissionPolicy creation
-	vap := &admissionv1beta1.ValidatingAdmissionPolicy{}
-	vapName := AdmissionPolicyNameManagementState
-	err = fakeClient.Get(ctx, client.ObjectKey{Name: vapName}, vap)
-	require.NoError(t, err, "expected ValidatingAdmissionPolicy to be created")
-	require.Len(t, vap.Spec.Validations, 1)
-	require.Contains(t, vap.Spec.Validations[0].Expression, "managementState != 'Removed'")
+			mockCreateOrUpdate := func(ctx context.Context, c client.Client, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
+				if err := f(); err != nil {
+					return controllerutil.OperationResultNone, err
+				}
 
-	// validate ValidatingAdmissionPolicyBinding
-	vapb := &admissionv1beta1.ValidatingAdmissionPolicyBinding{}
-	err = fakeClient.Get(ctx, client.ObjectKey{Name: vapName + "-binding"}, vapb)
-	require.NoError(t, err, "expected ValidatingAdmissionPolicyBinding to be created")
-	require.Equal(t, vapb.Spec.PolicyName, vapName)
+				// Capture the created objects for verification
+				switch o := obj.(type) {
+				case *k8sadmissionv1.ValidatingAdmissionPolicy:
+					createdVAP = o
+				case *k8sadmissionv1.ValidatingAdmissionPolicyBinding:
+					createdBinding = o
+				}
+
+				return controllerutil.OperationResultCreated, nil
+			}
+
+			// Create a context with a logger
+			ctx := ctrl.LoggerInto(context.Background(), ctrl.Log)
+
+			// Call the function
+			err := reconcileRegistryConfigManagementStateValidatingAdmissionPolicy(ctx, tt.hcp, fakeClient, mockCreateOrUpdate)
+
+			// Verify error expectations
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+
+			if !tt.expectCreation {
+				// During deletion, resources should be deleted, not created
+				g.Expect(createdVAP).To(BeNil(), "Did not expect ValidatingAdmissionPolicy to be created during deletion")
+				g.Expect(createdBinding).To(BeNil(), "Did not expect ValidatingAdmissionPolicyBinding to be created during deletion")
+				return
+			}
+
+			// Verify the admission policy was created with correct settings
+			g.Expect(createdVAP).NotTo(BeNil(), "Expected ValidatingAdmissionPolicy to be created")
+
+			// Verify the policy name
+			g.Expect(createdVAP.Name).To(Equal(AdmissionPolicyNameManagementState))
+
+			// Verify validations
+			g.Expect(createdVAP.Spec.Validations).To(HaveLen(tt.expectedValidationCount))
+
+			if len(createdVAP.Spec.Validations) > 0 {
+				validation := createdVAP.Spec.Validations[0]
+				g.Expect(validation.Expression).To(Equal(tt.expectedExpression))
+			}
+
+			// Verify match constraints
+			g.Expect(createdVAP.Spec.MatchConstraints).NotTo(BeNil())
+
+			g.Expect(createdVAP.Spec.MatchConstraints.ResourceRules).To(HaveLen(tt.expectedResourceRules))
+
+			if len(createdVAP.Spec.MatchConstraints.ResourceRules) > 0 {
+				rule := createdVAP.Spec.MatchConstraints.ResourceRules[0]
+
+				// Verify API group
+				g.Expect(rule.Rule.APIGroups).To(HaveLen(1))
+				g.Expect(rule.Rule.APIGroups[0]).To(Equal(imageregistryv1.GroupVersion.Group))
+
+				// Verify API version
+				g.Expect(rule.Rule.APIVersions).To(HaveLen(1))
+				g.Expect(rule.Rule.APIVersions[0]).To(Equal(imageregistryv1.GroupVersion.Version))
+
+				// Verify resources
+				g.Expect(rule.Rule.Resources).To(HaveLen(1))
+				g.Expect(rule.Rule.Resources[0]).To(Equal("configs"))
+
+				// Verify operations
+				expectedOps := []k8sadmissionv1.OperationType{"CREATE", "UPDATE"}
+				g.Expect(rule.Operations).To(HaveLen(len(expectedOps)))
+			}
+
+			// Verify the binding was created
+			g.Expect(createdBinding).NotTo(BeNil(), "Expected ValidatingAdmissionPolicyBinding to be created")
+
+			g.Expect(createdBinding.Spec.PolicyName).To(Equal(AdmissionPolicyNameManagementState))
+
+			g.Expect(createdBinding.Spec.ValidationActions).To(HaveLen(1))
+			g.Expect(createdBinding.Spec.ValidationActions[0]).To(Equal(k8sadmissionv1.Deny))
+		})
+	}
+}
+
+func TestReconcileRegistryConfigValidatingAdmissionPolicies(t *testing.T) {
+	tests := []struct {
+		name        string
+		hcp         *hyperv1.HostedControlPlane
+		expectError bool
+	}{
+		{
+			name: "When reconciliation succeeds it should return no error",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "When cluster is being deleted it should still succeed",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-cluster",
+					Namespace:         "test-namespace",
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			// Create a fake client
+			scheme := hyperapi.Scheme
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+			// Create a mock createOrUpdate function
+			mockCreateOrUpdate := func(ctx context.Context, c client.Client, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
+				if err := f(); err != nil {
+					return controllerutil.OperationResultNone, err
+				}
+				return controllerutil.OperationResultCreated, nil
+			}
+
+			// Create a context with a logger
+			ctx := ctrl.LoggerInto(context.Background(), ctrl.Log)
+
+			// Call the function
+			err := ReconcileRegistryConfigValidatingAdmissionPolicies(ctx, tt.hcp, fakeClient, mockCreateOrUpdate)
+
+			// Verify error expectations
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -272,6 +272,26 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 	}
 
 	if !hcp.DeletionTimestamp.IsZero() {
+		// Delete admission policies during cluster deletion to allow HCCO cleanup operations for ARO HCP
+		if azureutil.IsAroHCP() {
+			registryConfigManagementStateAdmissionPolicy := registry.AdmissionPolicy{Name: registry.AdmissionPolicyNameManagementState}
+			// During cluster deletion, delete the admission policy and its binding to allow CIRO cleanup
+			log.Info("Cluster is being deleted, deleting registry management state admission policy and binding to allow cleanup")
+
+			// Delete binding first to avoid dangling reference
+			binding := manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", registryConfigManagementStateAdmissionPolicy.Name))
+			_, err := util.DeleteIfNeeded(ctx, r.client, binding)
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to delete ValidatingAdmissionPolicyBinding %s: %v", binding.Name, err)
+			}
+
+			// Delete policy
+			vap := manifests.ValidatingAdmissionPolicy(registryConfigManagementStateAdmissionPolicy.Name)
+			if _, err := util.DeleteIfNeeded(ctx, r.client, vap); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to delete ValidatingAdmissionPolicy %s: %v", vap.Name, err)
+			}
+		}
+
 		if shouldCleanupCloudResources(hcp) {
 			log.Info("Cleaning up hosted cluster cloud resources")
 			return r.destroyCloudResources(ctx, hcp)


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual backport of:
- https://github.com/openshift/hypershift/pull/6593
- https://github.com/openshift/hypershift/pull/6616

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.