### PR TITLE
STOR-1064: fix(cpo): add missing image to env replacement

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
@@ -158,7 +158,7 @@ spec:
         - name: TOOLS_IMAGE
           value: tools
         - name: VOLUME_DATA_SOURCE_VALIDATOR_IMAGE
-          value: quay.io/openshift/origin-volume-data-source-validator:latest
+          value: volume-data-source-validator
         image: cluster-storage-operator
         imagePullPolicy: IfNotPresent
         name: cluster-storage-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_deployment.yaml
@@ -158,7 +158,7 @@ spec:
         - name: TOOLS_IMAGE
           value: tools
         - name: VOLUME_DATA_SOURCE_VALIDATOR_IMAGE
-          value: quay.io/openshift/origin-volume-data-source-validator:latest
+          value: volume-data-source-validator
         image: cluster-storage-operator
         imagePullPolicy: IfNotPresent
         name: cluster-storage-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/storage/envreplace.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/storage/envreplace.go
@@ -57,6 +57,7 @@ var (
 		"MANILA_DRIVER_CONTROL_PLANE_IMAGE":               "csi-driver-manila",
 		"LIVENESS_PROBE_CONTROL_PLANE_IMAGE":              "csi-livenessprobe",
 		"KUBE_RBAC_PROXY_CONTROL_PLANE_IMAGE":             "kube-rbac-proxy",
+		"VOLUME_DATA_SOURCE_VALIDATOR_IMAGE":              "volume-data-source-validator",
 		"TOOLS_IMAGE":                                     "tools",
 	}
 )


### PR DESCRIPTION
This is a fixup of cd6ef8ad6 where this replacement was missed.

The CI job `hypershift-aws-e2e-external` keeps failing, probably because the replacement does not work well without this reference in envreplace.go: 

```
      - name: KUBE_RBAC_PROXY_CONTROL_PLANE_IMAGE
          value: registry.build10.ci.openshift.org/ci-op-yxlifx2r/stable@sha256:6e23a1d8ce238f26b9816945b6b59ba49dae0590cff9ce0cd9715dfec413b74d
        - name: TOOLS_IMAGE
          value: registry.build10.ci.openshift.org/ci-op-yxlifx2r/stable@sha256:928d1c0675b4799d67406c6ab27c64525321dcc745ea3ad4d2049c4642757115
        - name: VOLUME_DATA_SOURCE_VALIDATOR_IMAGE
          value: quay.io/openshift/origin-volume-data-source-validator:latest
```

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_cluster-storage-operator/592/pull-ci-openshift-cluster-storage-operator-main-hypershift-aws-e2e-external/1958726942966419456/artifacts/hypershift-aws-e2e-external/hypershift-aws-run-e2e-external/artifacts/TestAutoscaling/namespaces/e2e-clusters-lwtmq-autoscaling-kbj97/apps/deployments/cluster-storage-operator.yaml

/cc @openshift/openshift-team-hypershift @bryan-cox 