### PR TITLE
OCPBUGS-60152: test/e2e: enable EnsureAppLabel check for 4.19

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -2895,7 +2895,7 @@ func EnsureCustomTolerations(t *testing.T, ctx context.Context, client crclient.
 
 func EnsureAppLabel(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("EnsureAppLabel", func(t *testing.T) {
-		AtLeast(t, Version420)
+		AtLeast(t, Version419)
 
 		hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 		podList := &corev1.PodList{}


### PR DESCRIPTION
Now that the app label fixes have been merged, enable the EnsureAppLabel against 4.19 to verify the fix.

xref
https://github.com/openshift/cluster-storage-operator/pull/604
https://github.com/openshift/hypershift/pull/6636

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test gating to include platform version 4.19, broadening test coverage across supported environments.
  * Ensures validation continues to run on applicable versions without altering runtime behavior.
  * No changes to user-visible features or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->