### PR TITLE
OCPBUGS-60907: Update Azure overrides to include HC deletion time bug fix

### DIFF
--- a/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
+++ b/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
@@ -2,13 +2,13 @@ platforms:
   azure:
     overrides:
       - version: 4.19.7
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-19@sha256:ef4b4fcaec0d781ad497b6060adef2b0dbcd5d5c59eda27a90f0e2f9595128c4
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-19@sha256:186af820bf5af3ecb03dec657cfc6a778dac6d49b32dae420e20cd8ef1dc786b
       - version: 4.19.8
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-19@sha256:ef4b4fcaec0d781ad497b6060adef2b0dbcd5d5c59eda27a90f0e2f9595128c4
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-19@sha256:186af820bf5af3ecb03dec657cfc6a778dac6d49b32dae420e20cd8ef1dc786b
       - version: 4.19.9
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-19@sha256:ef4b4fcaec0d781ad497b6060adef2b0dbcd5d5c59eda27a90f0e2f9595128c4
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-19@sha256:186af820bf5af3ecb03dec657cfc6a778dac6d49b32dae420e20cd8ef1dc786b
       - version: 4.19.10
-        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-19@sha256:ef4b4fcaec0d781ad497b6060adef2b0dbcd5d5c59eda27a90f0e2f9595128c4
+        cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-19@sha256:186af820bf5af3ecb03dec657cfc6a778dac6d49b32dae420e20cd8ef1dc786b
   aws:
     overrides:
     # Beginning of OCPBUGS-48519 overrides 4.15 section


### PR DESCRIPTION
**What this PR does / why we need it**:
Update platforms.azure overrides to use control-plane-operator-4-19 image sha256:186af820bf5af3ecb03dec657cfc6a778dac6d49b32dae420e20cd8ef1dc786b for OCP 4.19.7 through 4.19.10.

The commit sha for this image matches the merged bug fix in `release-4.19`, https://github.com/openshift/hypershift/commits/release-4.19.
```
% oc image info quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-19@sha256:186af820bf5af3ecb03dec657cfc6a778dac6d49b32dae420e20cd8ef1dc786b -a ~/all-the-pull-secrets.json | grep vcs-ref
               vcs-ref=65425ce33300f9334c5b9354e2bcd7b96ee18da0
```

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
N/A

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Azure control plane operator image reference for versions 4.19.7–4.19.10 to the latest digest.
  * All other Azure override settings remain unchanged.
  * No changes to AWS overrides.
  * This aligns Azure platform overrides with current release artifacts; no user-visible behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->