### PR TITLE
OCPBUGS-61260: allow karpenter-operator to support rhobs monitoring

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/karpenter-operator/role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/karpenter-operator/role.yaml
@@ -70,6 +70,7 @@ rules:
       - "*"
   - apiGroups:
       - "monitoring.coreos.com"
+      - "monitoring.rhobs"
     resources:
       - "podmonitors"
     verbs:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment.go
@@ -1,8 +1,11 @@
 package karpenteroperator
 
 import (
+	"os"
+
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/rhobsmonitoring"
 	"github.com/openshift/hypershift/support/util"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -52,6 +55,14 @@ func (karp *KarpenterOperatorOptions) adaptDeployment(cpContext component.Worklo
 			c.Args = append(c.Args,
 				"--control-plane-operator-image="+karp.ControlPlaneOperatorImage,
 			)
+			if os.Getenv(rhobsmonitoring.EnvironmentVariable) == "1" {
+				c.Env = append(c.Env,
+					corev1.EnvVar{
+						Name:  rhobsmonitoring.EnvironmentVariable,
+						Value: "1",
+					},
+				)
+			}
 		})
 	}
 


### PR DESCRIPTION
This commit allows the karpenter-operator to support rhobs monitoring for the karpenter pod when enabled.

This will allow it to deserialize the correct custom resource for the karpenter pod monitors, since the karpenter-operator manages the karpenter controlplanecomponent through it's own control plane v2 context.

Fixes: [AUTOSCALE-332](https://issues.redhat.com/browse/AUTOSCALE-332)

Based on https://github.com/openshift/hypershift/pull/6238 and its followdown.
Related to https://github.com/openshift/hypershift/pull/6206 and https://github.com/openshift/hypershift/pull/6187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Expanded monitoring compatibility: PodMonitor resources from an additional monitoring API group are now supported, improving integration across more environments.
  - Optional observability toggle: setting a designated environment variable to “1” is now propagated into the Karpenter operator container, enabling the related monitoring integration when desired.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->