### PR TITLE
NO-JIRA: Handle SIGTERM in all of the commands

### DIFF
--- a/etcd-defrag/main.go
+++ b/etcd-defrag/main.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/signal"
-	"syscall"
 	"time"
 
 	hyperapi "github.com/openshift/hypershift/support/api"
@@ -38,13 +36,7 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.Namespace, "namespace", os.Getenv("MY_NAMESPACE"), "The namespace this operator lives in (required)")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		ctx, cancel := context.WithCancel(context.Background())
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGINT)
-		go func() {
-			<-sigs
-			cancel()
-		}()
+		ctx := ctrl.SetupSignalHandler()
 
 		if err := run(ctx, opts); err != nil {
 			log.Fatal(err)

--- a/ignition-server/cmd/start.go
+++ b/ignition-server/cmd/start.go
@@ -8,9 +8,7 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"os/signal"
 	"regexp"
-	"syscall"
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -98,13 +96,7 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.FeatureGateManifest, "feature-gate-manifest", opts.FeatureGateManifest, "Path to a rendered featuregates.config.openshift.io/v1 file")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		ctx, cancel := context.WithCancel(context.Background())
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGINT)
-		go func() {
-			<-sigs
-			cancel()
-		}()
+		ctx := ctrl.SetupSignalHandler()
 
 		// TODO: Add an fsnotify watcher to cancel the context and trigger a restart
 		// if any of the secret data has changed.

--- a/kas-bootstrap/main.go
+++ b/kas-bootstrap/main.go
@@ -4,11 +4,10 @@ package kasbootstrap
 // It will apply some CRDs rendered by the cluster-config-operator and update the featureGate CR status by appending the git FeatureGate status.
 
 import (
-	"context"
 	"log"
 	"os"
-	"os/signal"
-	"syscall"
+
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/spf13/cobra"
 )
@@ -29,13 +28,7 @@ func NewRunCommand() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&opts.ResourcesPath, "resources-path", "", "The path to all resources that should be applied and the rendered featureGate CR to reconcile.")
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		ctx, cancel := context.WithCancel(context.Background())
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGINT)
-		go func() {
-			<-sigs
-			cancel()
-		}()
+		ctx := ctrl.SetupSignalHandler()
 
 		if err := run(ctx, opts); err != nil {
 			log.Fatal(err)

--- a/sync-fg-configmap/update.go
+++ b/sync-fg-configmap/update.go
@@ -7,13 +7,12 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/signal"
-	"syscall"
 
 	cmdutil "github.com/openshift/hypershift/cmd/util"
 
 	corev1 "k8s.io/api/core/v1"
 
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/spf13/cobra"
@@ -44,13 +43,7 @@ func NewRunCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.Name, "name", opts.Name, "The name of the feature gate configmap.")
 	cmd.Flags().StringVar(&opts.PayloadVersion, "payload-version", opts.PayloadVersion, "The payload version of the control plane.")
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		ctx, cancel := context.WithCancel(context.Background())
-		sigs := make(chan os.Signal, 1)
-		signal.Notify(sigs, syscall.SIGINT)
-		go func() {
-			<-sigs
-			cancel()
-		}()
+		ctx := ctrl.SetupSignalHandler()
 
 		if err := opts.run(ctx); err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubernetes sends a SIGTERM on termination, so pods can gracefully shut down. A few commands doesn't handle this.

This PR switches the signal handling to use `ctrl.SetupSignalHandler()` everywhere. This function returns a context that is canceled on SIGINT and also on SIGTERM. Most other commands use this.


**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified shutdown handling to use a standard signal-based cancellable context for the process lifecycle.
* **Bug Fixes**
  * More reliable graceful termination, reducing missed interrupts and hang scenarios.
  * Ensures consistent cleanup and exit behavior across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->