### PR TITLE
fix(shared-ingress): change the share ingress anti affinity to be RequiredDuringSchedulingIgnoredDuringExecution

### DIFF
--- a/hypershift-operator/controllers/sharedingress/router.go
+++ b/hypershift-operator/controllers/sharedingress/router.go
@@ -66,14 +66,11 @@ func ReconcileRouterDeployment(deployment *appsv1.Deployment, hypershiftOperator
 				AutomountServiceAccountToken: ptr.To(true),
 				Affinity: &corev1.Affinity{
 					PodAntiAffinity: &corev1.PodAntiAffinity{
-						PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 							{
-								Weight: 100,
-								PodAffinityTerm: corev1.PodAffinityTerm{
-									TopologyKey: corev1.LabelTopologyZone,
-									LabelSelector: &metav1.LabelSelector{
-										MatchLabels: hcpRouterLabels(),
-									},
+								TopologyKey: corev1.LabelTopologyZone,
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: hcpRouterLabels(),
 								},
 							},
 						},

--- a/hypershift-operator/controllers/sharedingress/router_test.go
+++ b/hypershift-operator/controllers/sharedingress/router_test.go
@@ -44,16 +44,11 @@ func TestReconcileRouterDeployment(t *testing.T) {
 
 				expectedAffinity := &corev1.Affinity{
 					PodAntiAffinity: &corev1.PodAntiAffinity{
-						PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 							{
-								Weight: 100,
-								PodAffinityTerm: corev1.PodAffinityTerm{
-									LabelSelector: &metav1.LabelSelector{
-										MatchLabels: map[string]string{
-											"app": "router",
-										},
-									},
-									TopologyKey: "topology.kubernetes.io/zone",
+								TopologyKey: corev1.LabelTopologyZone,
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: hcpRouterLabels(),
 								},
 							},
 						},


### PR DESCRIPTION
This ensures no pods are scheduled in the same az and force automation/SREs to allocate capacity

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.