### PR TITLE
[WIP] NO-JIRA: feat(claude): add custom command for Kubernetes cluster error analysis

### DIFF
--- a/.claude/commands/analyze.md
+++ b/.claude/commands/analyze.md
@@ -5,10 +5,16 @@ argument-hint: Pass URL of json file with errors
 ---
 
 # General instructions
-- Use curl to download the file with Kubernetes errors from $1
-- Simplify errors in the JSON file
-- Provide the most possible solution in a step by step style in no more than 280 characters.
-- Do not aggregate multiple errors into one
+- Use curl to download the file with Kubernetes errors from $1. Only allow HTTPS URLs (reject http).
+- When fetching, use: curl -fsSL --max-time 20 --retry 3 --retry-connrefused --proto '=https' --max-filesize 10M "$1".
+- Validate that the payload is JSON; if not, abort with a short error.
+- Abort if Content-Type is not application/json.
+- Simplify errors in the JSON file.
+- Provide the most possible solution in a step by step style in no more than 280 characters per error.
+- Never print values from Sensitive.Unmasked; use Sensitive.Masked or redact entirely.
+- Do not aggregate multiple errors into one.
+- Prefer non-destructive steps first; include one verify step after each fix (e.g., kubectl get/describe, rollout status).
+- Do not execute kubectl/cloud commands; only suggest them with clear verification steps.
 
 # Output format
 
@@ -36,7 +42,7 @@ argument-hint: Pass URL of json file with errors
           "KubernetesDoc": "",
           "Sensitive": [
             {
-              "Unmasked": "ip-10-0-137-33.ec2.internal",
+              "Unmasked": "[REDACTED]",
               "Masked": "dTQ3eEM2K3VxJF1RSV1vfV5KRi1ZLHhYOip2"
             }
           ]
@@ -46,12 +52,13 @@ argument-hint: Pass URL of json file with errors
           "KubernetesDoc": "",
           "Sensitive": [
             {
-              "Unmasked": "ip-10-0-137-33.ec2.internal",
+              "Unmasked": "[REDACTED]",
               "Masked": "XV4hcChubEwnJkJScz1HcmdvOlIqQm1weF0t"
             }
           ]
         }
       ]
     }
+  ]
 }
 ```


### PR DESCRIPTION
  Adds a new Claude Code custom command /analyze that downloads and analyzes
  Kubernetes cluster errors from a provided URL, then formats the errors by
  resource type with actionable solutions.

  The command processes JSON error data and provides:
  - Categorized errors by Kubernetes resource types (Node, Deployment, etc.)
  - Specific error descriptions for each resource
  - Targeted troubleshooting steps and kubectl commands for resolution

  The command is automatically available when running Claude within the
Hypershift project.

  Example usage includes analyzing node kubelet issues, deployment replica
  problems, unused ConfigMaps, webhook configuration errors, and AWS
  credential issues with LoadBalancer services.

  Usage: /analyze <URL_to_json_file>

Example output:
```
> /analyze is running…
https://gist.githubusercontent.com/mgencur/04bf9830ea6877731de7fb9f65f02e71/raw/29d25494386d4a12a5465b814f208a0aa4781543/gistfile1.txt
  ⎿  Allowed 2 tools for this command

● I'll analyze the Kubernetes errors from the provided URL. Let me start by downloading and examining the file.

● Bash(curl -s
"https://gist.githubusercontent.com/mgencur/04bf9830ea6877731de7fb9f65f02e71/raw/29d25494386d4a12a5465b814f208a0aa4781543/gistfile1.txt" -o
      /tmp/k8s_err…)
  ⎿  (No content)

● Read(/tmp/k8s_errors.json)
  ⎿  Read 3925 lines (ctrl+r to expand)

● Now I'll analyze the JSON and format the errors by Kind with solutions:

● Kubernetes Error Analysis

  Node

  Node//ip-10-0-137-33.ec2.internal: ip-10-0-137-33.ec2.internal
Error: Kubelet stopped posting node status causing MemoryPressure, DiskPressure, PIDPressure, and Ready conditions
  Solution:
  • Restart kubelet service: sudo systemctl restart kubelet
  • Check node logs: journalctl -u kubelet -f
  • Verify node connectivity to API server

Node//ip-10-0-143-152.ec2.internal: ip-10-0-143-152.ec2.internalError: Kubelet stopped posting node status causing MemoryPressure,
  DiskPressure, PIDPressure, and Ready conditions
  Solution:
  • Restart kubelet service: sudo systemctl restart kubelet
  • Check node logs: journalctl -u kubelet -f
  • Verify node connectivity to API server

  Deployment

  Deployment/openshift-kube-storage-version-migrator/migrator: migrator
  Error: 1 replica desired but 0 available with status running
  Solution:
• Check pod status: kubectl get pods -n
openshift-kube-storage-version-migrator
• Review deployment logs: kubectl logs -n
openshift-kube-storage-version-migrator deployment/migrator • Scale deployment: kubectl scale deployment migrator -n openshift-kube-storage-version-migrator --replicas=1

Deployment/openshift-monitoring/cluster-monitoring-operator: cluster-monitoring-operator
  Error: 1 replica desired but 0 available with status running
  Solution:
  • Check pod status: kubectl get pods -n openshift-monitoring
• Review logs: kubectl logs -n openshift-monitoring deployment/cluster-monitoring-operator
• Restart deployment: kubectl rollout restart
deployment/cluster-monitoring-operator -n openshift-monitoring

Deployment/openshift-monitoring/prometheus-operator: prometheus-operator
  Error: 1 replica desired but 0 available with status running
  Solution:
  • Check pod status: kubectl get pods -n openshift-monitoring
• Review logs: kubectl logs -n openshift-monitoring deployment/prometheus-operator
• Restart deployment: kubectl rollout restart
deployment/prometheus-operator -n openshift-monitoring

Deployment/openshift-network-diagnostics/network-check-source: network-check-source
  Error: 1 replica desired but 0 available with status running
  Solution:
  • Check pod status: kubectl get pods -n openshift-network-diagnostics
• Review logs: kubectl logs -n openshift-network-diagnostics deployment/network-check-source
• Restart deployment: kubectl rollout restart
deployment/network-check-source -n openshift-network-diagnostics

  ConfigMap

  ConfigMap/default/kube-root-ca.crt: kube-root-ca.crt
  Error: ConfigMap is not used by any pods in the namespace
  Solution:
• Check if pods need this CA: kubectl get pods -n default -o yaml | grep kube-root-ca
  • Review pod configurations requiring CA certificates
• Delete unused ConfigMap: kubectl delete configmap kube-root-ca.crt -n default

  ConfigMap/openshift-config-managed/admin-gates: admin-gates
  Error: ConfigMap is not used by any pods and is empty
  Solution:
  • Review OpenShift admin gate configurations
  • Check if feature gates are needed: kubectl get featuregates
• Delete if unused: kubectl delete configmap admin-gates -n openshift-config-managed

  ValidatingWebhookConfiguration

ValidatingWebhookConfiguration//vwb.performance.openshift.io: vwb.performance.openshift.io
Error: No active pods found within service
performance-addon-operator-service as mapped to by Validating Webhook
  Solution:
• Check service endpoints: kubectl get endpoints
performance-addon-operator-service -n
openshift-cluster-node-tuning-operator
• Scale performance operator: kubectl scale deployment performance-addon-operator -n openshift-cluster-node-tuning-operator --replicas=1
  • Update webhook configuration with correct service

  Service

  Service/openshift-ingress/router-default: router-default
Error: AWS credentials invalid - cannot retrieve verification key from identity provider for LoadBalancer
  Solution:
• Check AWS IRSA configuration: kubectl get serviceaccount -n openshift-ingress
  • Verify IAM role trust policy allows web identity
  • Update AWS credential configuration: aws sts get-caller-identity
  • Recreate service account with correct annotations
```

**What this PR does / why we need it**:

Se above. It's a tool for easier analysis of errors in the cluster.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new guide for an "Analyze errors" command to process Kubernetes error JSON.
  * Includes usage instructions for fetching a JSON URL (HTTPS-only), allowed tools, and an argument hint.
  * Specifies validation rules, per-error simplification, and privacy handling for sensitive values.
  * Defines output format: sections per Kind with Error and concise, bulleted Solutions (≤280 chars) and verification steps.
  * Includes a representative example JSON payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->