### PR TITLE
OCPBUGS-60936:fix(hccp): remove immutable field from kubeletconfigmap

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -2451,6 +2451,11 @@ func (r *reconciler) reconcileKubeletConfig(ctx context.Context) error {
 				Namespace: ConfigManagedNamespace,
 			},
 		}
+
+		if err := r.deleteImmutableConfigMapIfNeeded(ctx, log, hostedClusterCM); err != nil {
+			return err
+		}
+
 		if result, err := r.CreateOrUpdate(ctx, r.client, hostedClusterCM, func() error {
 			return mutateKubeletConfig(&cm, hostedClusterCM)
 		}); err != nil {
@@ -2480,8 +2485,29 @@ func (r *reconciler) reconcileKubeletConfig(ctx context.Context) error {
 	return nil
 }
 
+// deleteImmutableConfigMapIfNeeded checks if a ConfigMap exists and is immutable,
+// and deletes it if necessary to allow recreation as a mutable ConfigMap.
+// This handles migration from immutable ConfigMaps to mutable ones.
+func (r *reconciler) deleteImmutableConfigMapIfNeeded(ctx context.Context, log logr.Logger, cm *corev1.ConfigMap) error {
+	existingCM := &corev1.ConfigMap{}
+	if err := r.client.Get(ctx, client.ObjectKeyFromObject(cm), existingCM); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get ConfigMap %s: %w", client.ObjectKeyFromObject(cm).String(), err)
+	}
+
+	if existingCM.Immutable != nil && *existingCM.Immutable {
+		log.Info("deleting immutable KubeletConfig ConfigMap to recreate as mutable", "configMap", client.ObjectKeyFromObject(existingCM).String())
+		if _, err := util.DeleteIfNeeded(ctx, r.client, existingCM); err != nil {
+			return fmt.Errorf("failed to delete immutable ConfigMap %s: %w", client.ObjectKeyFromObject(existingCM).String(), err)
+		}
+	}
+
+	return nil
+}
+
 func mutateKubeletConfig(controlPlaneConfigMap, hostedClusterConfigMap *corev1.ConfigMap) error {
-	hostedClusterConfigMap.Immutable = ptr.To(true)
 	hostedClusterConfigMap.Labels = labels.Merge(hostedClusterConfigMap.Labels, map[string]string{
 		nodepool.KubeletConfigConfigMapLabel: "true",
 		hyperv1.NodePoolLabel:                controlPlaneConfigMap.Labels[hyperv1.NodePoolLabel],


### PR DESCRIPTION
**What this PR does / why we need it**:
When kubeletconfig is changing due to manual user changes, or due to performance profile changes, hccp should catch up and mirror the changes to the hosted cluster.

When setting the kubeletconfig configmap as immutable, the controller failed to update the configmap with the following error: `ConfigMap "<config-map-name>" is invalid: data: Forbidden: field is immutable when immutable is set`.

Setting the ConfigMap as immutable was redundant because in case of undesired change, hccp will reconcile the ConfigMap and update it to its desired state, so it's safe to remove it.

NOTE: It’s still possible for the ConfigMap on the hosted cluster side to be tampered with, but accepting this small risk is a reasonable trade-off to ensure the system functions correctly.

**Which issue(s) this PR fixes** 
Fixes # OCPBUGS-60936

**Checklist**
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kubelet configuration updates now propagate to hosted clusters without requiring ConfigMap recreation, simplifying updates and day‑2 operations.

* **Bug Fixes**
  * Removed an immutability restriction on the hosted KubeletConfig mirror so updates can be applied smoothly during cluster lifecycle, reducing operational friction and update failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->