### PR TITLE
CNTRLPLANE-1364: feat: enable global pull secret for ROSA HCP

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -292,6 +292,9 @@ const (
 	// It is not set by the end-user.
 	DisableClusterAutoscalerAnnotation = "hypershift.openshift.io/disable-cluster-autoscaler"
 
+	// ROSA-HCP represents the ROSA HCP managed service offering
+	RosaHCP = "ROSA-HCP"
+
 	// AroHCP represents the ARO HCP managed service offering
 	AroHCP = "ARO-HCP"
 

--- a/control-plane-operator/hostedclusterconfigoperator/cmd.go
+++ b/control-plane-operator/hostedclusterconfigoperator/cmd.go
@@ -32,6 +32,8 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/operator"
 	hyperapi "github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/awsutil"
+	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/labelenforcingclient"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/supportedversion"
@@ -282,7 +284,7 @@ func (o *HostedClusterConfigOperator) Run(ctx context.Context) error {
 	}
 
 	controllersToRun := map[string]operator.ControllerSetupFunc{}
-	if o.platformType == string(hyperv1.AzurePlatform) {
+	if azureutil.IsAroHCP() || awsutil.IsROSAHCP() {
 		controllersToRun[globalps.ControllerName] = globalps.Setup
 	}
 

--- a/support/awsutil/tags.go
+++ b/support/awsutil/tags.go
@@ -1,0 +1,47 @@
+package awsutil
+
+import (
+	"os"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+)
+
+// FindResourceTagByKey searches for a resource tag with the specified key in the given slice of AWSResourceTags.
+// Returns the tag if found, nil otherwise.
+func FindResourceTagByKey(tags []hyperv1.AWSResourceTag, key string) *hyperv1.AWSResourceTag {
+	for i := range tags {
+		if tags[i].Key == key {
+			return &tags[i]
+		}
+	}
+	return nil
+}
+
+// HasResourceTagWithValue checks if a resource tag exists with the specified key and value.
+// Returns true if the tag exists with the exact key-value pair, false otherwise.
+func HasResourceTagWithValue(tags []hyperv1.AWSResourceTag, key, value string) bool {
+	tag := FindResourceTagByKey(tags, key)
+	return tag != nil && tag.Value == value
+}
+
+// GetResourceTagValue retrieves the value of a resource tag with the specified key.
+// Returns the value if found, empty string otherwise.
+func GetResourceTagValue(tags []hyperv1.AWSResourceTag, key string) string {
+	tag := FindResourceTagByKey(tags, key)
+	if tag != nil {
+		return tag.Value
+	}
+	return ""
+}
+
+// IsROSAHCPFromTags checks if the cluster is a ROSA HCP (Red Hat OpenShift Service on AWS Hosted Control Plane)
+// by looking for the specific tag combination.
+func IsROSAHCPFromTags(tags []hyperv1.AWSResourceTag) bool {
+	return HasResourceTagWithValue(tags, "red-hat-clustertype", "rosa")
+}
+
+// IsROSAHCP checks if the cluster is a ROSA HCP (Red Hat OpenShift Service on AWS Hosted Control Plane)
+// by looking for the MANAGED_SERVICE key to match the ROSA-HCP value.
+func IsROSAHCP() bool {
+	return os.Getenv("MANAGED_SERVICE") == hyperv1.RosaHCP
+}

--- a/support/awsutil/tags_test.go
+++ b/support/awsutil/tags_test.go
@@ -1,0 +1,228 @@
+package awsutil
+
+import (
+	"os"
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+)
+
+func TestFindResourceTagByKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		tags     []hyperv1.AWSResourceTag
+		key      string
+		expected *hyperv1.AWSResourceTag
+	}{
+		{
+			name: "find existing tag",
+			tags: []hyperv1.AWSResourceTag{
+				{Key: "key1", Value: "value1"},
+				{Key: "key2", Value: "value2"},
+			},
+			key:      "key1",
+			expected: &hyperv1.AWSResourceTag{Key: "key1", Value: "value1"},
+		},
+		{
+			name: "tag not found",
+			tags: []hyperv1.AWSResourceTag{
+				{Key: "key1", Value: "value1"},
+			},
+			key:      "nonexistent",
+			expected: nil,
+		},
+		{
+			name:     "empty tags slice",
+			tags:     []hyperv1.AWSResourceTag{},
+			key:      "key1",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FindResourceTagByKey(tt.tags, tt.key)
+			if tt.expected == nil {
+				if result != nil {
+					t.Errorf("Expected nil, got %+v", result)
+				}
+			} else {
+				if result == nil {
+					t.Errorf("Expected %+v, got nil", tt.expected)
+				} else if result.Key != tt.expected.Key || result.Value != tt.expected.Value {
+					t.Errorf("Expected %+v, got %+v", tt.expected, result)
+				}
+			}
+		})
+	}
+}
+
+func TestHasResourceTagWithValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		tags     []hyperv1.AWSResourceTag
+		key      string
+		value    string
+		expected bool
+	}{
+		{
+			name: "tag exists with correct value",
+			tags: []hyperv1.AWSResourceTag{
+				{Key: "key1", Value: "value1"},
+				{Key: "key2", Value: "value2"},
+			},
+			key:      "key1",
+			value:    "value1",
+			expected: true,
+		},
+		{
+			name: "tag exists with wrong value",
+			tags: []hyperv1.AWSResourceTag{
+				{Key: "key1", Value: "value1"},
+			},
+			key:      "key1",
+			value:    "wrongvalue",
+			expected: false,
+		},
+		{
+			name: "tag does not exist",
+			tags: []hyperv1.AWSResourceTag{
+				{Key: "key1", Value: "value1"},
+			},
+			key:      "nonexistent",
+			value:    "value1",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := HasResourceTagWithValue(tt.tags, tt.key, tt.value)
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestGetResourceTagValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		tags     []hyperv1.AWSResourceTag
+		key      string
+		expected string
+	}{
+		{
+			name: "get existing tag value",
+			tags: []hyperv1.AWSResourceTag{
+				{Key: "key1", Value: "value1"},
+				{Key: "key2", Value: "value2"},
+			},
+			key:      "key1",
+			expected: "value1",
+		},
+		{
+			name: "tag not found",
+			tags: []hyperv1.AWSResourceTag{
+				{Key: "key1", Value: "value1"},
+			},
+			key:      "nonexistent",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetResourceTagValue(tt.tags, tt.key)
+			if result != tt.expected {
+				t.Errorf("Expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestIsROSAHCPFromTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		tags     []hyperv1.AWSResourceTag
+		expected bool
+	}{
+		{
+			name: "ROSA HCP tags present",
+			tags: []hyperv1.AWSResourceTag{
+				{Key: "red-hat-clustertype", Value: "rosa"},
+				{Key: "other-tag", Value: "other-value"},
+			},
+			expected: true,
+		},
+		{
+			name: "ROSA HCP tag with wrong value",
+			tags: []hyperv1.AWSResourceTag{
+				{Key: "red-hat-clustertype", Value: "not-rosa"},
+			},
+			expected: false,
+		},
+		{
+			name: "ROSA HCP tag not present",
+			tags: []hyperv1.AWSResourceTag{
+				{Key: "other-tag", Value: "other-value"},
+			},
+			expected: false,
+		},
+		{
+			name:     "empty tags",
+			tags:     []hyperv1.AWSResourceTag{},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsROSAHCPFromTags(tt.tags)
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestIsROSAHCP(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected bool
+	}{
+		{
+			name:     "ROSA HCP environment variable set",
+			envValue: hyperv1.RosaHCP,
+			expected: true,
+		},
+		{
+			name:     "different environment variable value",
+			envValue: "ARO-HCP",
+			expected: false,
+		},
+		{
+			name:     "environment variable not set",
+			envValue: "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variable for test
+			if tt.envValue != "" {
+				os.Setenv("MANAGED_SERVICE", tt.envValue)
+				defer os.Unsetenv("MANAGED_SERVICE")
+			} else {
+				os.Unsetenv("MANAGED_SERVICE")
+			}
+
+			result := IsROSAHCP()
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1715,8 +1715,8 @@ func EnsureGuestWebhooksValidated(t *testing.T, ctx context.Context, guestClient
 func EnsureGlobalPullSecret(t *testing.T, ctx context.Context, mgmtClient crclient.Client, entryHostedCluster *hyperv1.HostedCluster) error {
 	t.Run("EnsureGlobalPullSecret", func(t *testing.T) {
 		AtLeast(t, Version419)
-		if entryHostedCluster.Spec.Platform.Type != hyperv1.AzurePlatform {
-			t.Skip("test only supported on platform ARO")
+		if entryHostedCluster.Spec.Platform.Type != hyperv1.AzurePlatform && entryHostedCluster.Spec.Platform.Type != hyperv1.AWSPlatform {
+			t.Skip("test only supported on platform ARO and AWS")
 		}
 
 		var (

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -292,6 +292,9 @@ const (
 	// It is not set by the end-user.
 	DisableClusterAutoscalerAnnotation = "hypershift.openshift.io/disable-cluster-autoscaler"
 
+	// ROSA-HCP represents the ROSA HCP managed service offering
+	RosaHCP = "ROSA-HCP"
+
 	// AroHCP represents the ARO HCP managed service offering
 	AroHCP = "ARO-HCP"
 


### PR DESCRIPTION
## What this PR does / why we need it
- Enable global pull secret for ROSA HCP.
- Add RosaHCP constant and helper functions for AWS resource tag evaluation.
- Replace manual tag iteration with reusable helper functions in deployment controller.
- Update hosted cluster config operator to use managed service detection for controller setup.
- Enable E2E on AWS for GlobalPullSecret functionality

## Which issue(s) this PR fixes:
- Fixes #[CNTRLPLANE-1364](https://issues.redhat.com/browse/CNTRLPLANE-1364)