### PR TITLE
OCPBUGS-61066: fix(cpo/ingress): do not set aws-load-balancer-subnets on private router Service

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -281,6 +281,8 @@ const (
 
 	// AWSLoadBalancerSubnetsAnnotation allows specifying the subnets to use for control plane load balancers
 	// in the AWS platform. These subnets only apply to private load balancers.
+	// Deprecated: Subnets should not be specified for the private load balancer. This results in
+	// private link creation failures. The annotation has no effect.
 	AWSLoadBalancerSubnetsAnnotation = "hypershift.openshift.io/aws-load-balancer-subnets"
 
 	// AWSLoadBalancerTargetNodesAnnotation allows specifying label selectors to choose target nodes for

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -31,11 +31,6 @@ func ReconcileRouterService(svc *corev1.Service, internal, crossZoneLoadBalancin
 		if crossZoneLoadBalancingEnabled {
 			svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"] = "true"
 		}
-		if internal {
-			// Only the internal nlb should get private subnets assigned.
-			// The external nlb should use the default public subnets.
-			util.ApplyAWSLoadBalancerSubnetsAnnotation(svc, hcp)
-		}
 		util.ApplyAWSLoadBalancerTargetNodesAnnotation(svc, hcp)
 	}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router_test.go
@@ -1,0 +1,46 @@
+package ingress
+
+import (
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// When HCP has AWSLoadBalancerSubnetsAnnotation it should not set Service subnets annotation
+func TestReconcileRouterService_DoesNotApplySubnetsAnnotation(t *testing.T) {
+	// Given a HostedControlPlane on AWS with the subnets annotation set
+	hcp := &hyperv1.HostedControlPlane{}
+	hcp.Spec.Platform.Type = hyperv1.AWSPlatform
+	hcp.Annotations = map[string]string{
+		hyperv1.AWSLoadBalancerSubnetsAnnotation: "subnet-123,subnet-456",
+	}
+
+	// And an empty Service to reconcile
+	svc := &corev1.Service{}
+
+	// When reconciling the router service
+	if err := ReconcileRouterService(svc, true /* internal */, true /* cross-zone */, hcp); err != nil {
+		t.Fatalf("ReconcileRouterService returned error: %v", err)
+	}
+
+	// Then the AWS subnets annotation must NOT be set on the Service
+	const subnetsKey = "service.beta.kubernetes.io/aws-load-balancer-subnets"
+	if svc.Annotations != nil {
+		if _, exists := svc.Annotations[subnetsKey]; exists {
+			t.Fatalf("expected %q annotation to be absent, but it was set to %q", subnetsKey, svc.Annotations[subnetsKey])
+		}
+	}
+
+	// And the Service should still be configured as an internal NLB on AWS
+	if got := svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"]; got != "nlb" {
+		t.Fatalf("expected NLB annotation to be 'nlb', got %q", got)
+	}
+	if got := svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-internal"]; got != "true" {
+		t.Fatalf("expected internal LB annotation to be 'true', got %q", got)
+	}
+	if got := svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"]; got != "true" {
+		t.Fatalf("expected cross-zone load balancing annotation to be 'true', got %q", got)
+	}
+}

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -418,19 +418,6 @@ func ParseNodeSelector(str string) map[string]string {
 	return result
 }
 
-func ApplyAWSLoadBalancerSubnetsAnnotation(svc *corev1.Service, hcp *hyperv1.HostedControlPlane) {
-	if hcp.Spec.Platform.Type != hyperv1.AWSPlatform {
-		return
-	}
-	if svc.Annotations == nil {
-		svc.Annotations = make(map[string]string)
-	}
-	subnets, ok := hcp.Annotations[hyperv1.AWSLoadBalancerSubnetsAnnotation]
-	if ok {
-		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-subnets"] = subnets
-	}
-}
-
 func ApplyAWSLoadBalancerTargetNodesAnnotation(svc *corev1.Service, hcp *hyperv1.HostedControlPlane) {
 	if hcp.Spec.Platform.Type != hyperv1.AWSPlatform {
 		return

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -281,6 +281,8 @@ const (
 
 	// AWSLoadBalancerSubnetsAnnotation allows specifying the subnets to use for control plane load balancers
 	// in the AWS platform. These subnets only apply to private load balancers.
+	// Deprecated: Subnets should not be specified for the private load balancer. This results in
+	// private link creation failures. The annotation has no effect.
 	AWSLoadBalancerSubnetsAnnotation = "hypershift.openshift.io/aws-load-balancer-subnets"
 
 	// AWSLoadBalancerTargetNodesAnnotation allows specifying label selectors to choose target nodes for


### PR DESCRIPTION
**What this PR does / why we need it**:
The private router Service should not force explicit AWS subnet IDs. Let AWS select appropriate private subnets based on the internal NLB scheme and cluster tags. Setting the subnets annotation on the router prevents private link endpoint creation when the endpoint lands on subnets that do not match the subnets specified for the load balancer.

- Remove use of HCP aws-load-balancer-subnets annotation from router Service
- Delete now-unused ApplyAWSLoadBalancerSubnetsAnnotation helper
- Keep NLB type, internal scheme, and cross-zone settings unchanged
- Mark the AWSLoadBalancerSubnetsAnnotation as deprecated in the API docs

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-61066](https://issues.redhat.com/browse/OCPBUGS-61066)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.