### PR TITLE
CNTRLPLANE-1364: feat: enable global pull secret for AWS

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/cmd.go
+++ b/control-plane-operator/hostedclusterconfigoperator/cmd.go
@@ -282,7 +282,7 @@ func (o *HostedClusterConfigOperator) Run(ctx context.Context) error {
 	}
 
 	controllersToRun := map[string]operator.ControllerSetupFunc{}
-	if o.platformType == string(hyperv1.AzurePlatform) {
+	if o.platformType == string(hyperv1.AzurePlatform) || o.platformType == string(hyperv1.AWSPlatform) {
 		controllersToRun[globalps.ControllerName] = globalps.Setup
 	}
 

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1715,8 +1715,14 @@ func EnsureGuestWebhooksValidated(t *testing.T, ctx context.Context, guestClient
 func EnsureGlobalPullSecret(t *testing.T, ctx context.Context, mgmtClient crclient.Client, entryHostedCluster *hyperv1.HostedCluster) error {
 	t.Run("EnsureGlobalPullSecret", func(t *testing.T) {
 		AtLeast(t, Version419)
-		if entryHostedCluster.Spec.Platform.Type != hyperv1.AzurePlatform {
-			t.Skip("test only supported on platform ARO")
+		// TODO (jparrill): Change check of release version `releaseVersion.GT(Version420)` to `releaseVersion.GE(Version420)`
+		// during the backport to 4.20 of this PR https://github.com/openshift/hypershift/pull/6736
+		if entryHostedCluster.Spec.Platform.Type != hyperv1.AzurePlatform && entryHostedCluster.Spec.Platform.Type != hyperv1.AWSPlatform {
+			t.Skip("test only supported on platform ARO or AWS")
+		}
+
+		if entryHostedCluster.Spec.Platform.Type == hyperv1.AWSPlatform && releaseVersion.LE(Version420) {
+			t.Skip("AWS platform not supported on version 4.20 or less")
 		}
 
 		var (


### PR DESCRIPTION
## What this PR does / why we need it
- Enable global pull secret for ROSA HCP.
- Enabled E2E for AWS plaform

## Which issue(s) this PR fixes:
- Fixes #[CNTRLPLANE-1364](https://issues.redhat.com/browse/CNTRLPLANE-1364)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Enabled global pull secret management on AWS platforms, matching existing support on Azure.

- Tests
  - Expanded end-to-end coverage to validate global pull secret behavior on AWS and Azure; test gating updated so these checks run on AWS/Azure for newer releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->