### PR TITLE
NO-JIRA: feat(claude): add e2e-analyze command for CI failure analysis

### DIFF
--- a/.claude/commands/e2e-analyze.md
+++ b/.claude/commands/e2e-analyze.md
@@ -1,25 +1,26 @@
 ---
 description: "Analyze test errors"
-allowed-tools: ["Read", "Bash:curl", "Bash:gcloud"]
-argument-hint: Pass URL of a CI run as $1 and the test name as $2
+allowed-tools: ["Read", "Bash(curl)", "Bash(gcloud)", "Bash(echo:*)", "Bash(ls:*)", "Bash(find:*)", "Bash(grep:*)", "Bash(test:*)"]
+argument-hint: Pass URL of a CI run as $1, the test name as $2 and target directory for artifacts as $3
 ---
 
 # General instructions
 
-- Validate that "$1" includes a 19-digit number.
-- Use the 19-digit number from "$1" as variable {BUILD_NUMBER}.
+- Validate that "$3" is an existing directory; fail if it is not. Do NOT create the directory.
+- Extract {BUILD_NUMBER} from "$1" by matching a 10–20 digit sequence; fail if none is found.
+- Use the extracted number as {BUILD_NUMBER}.
 - Use curl to download the file build-log.txt under "$1". Only allow HTTPS URLs (reject HTTP).
-- When fetching, use: `curl -fsSL --max-time 20 --retry 3 --retry-connrefused --proto '=https' --max-filesize 100M "$1"`.
-- The build-log.txt file contains e2e failures, store the artifacts related to failure "$2" under /tmp/ci-artifacts/{BUILD_NUMBER} to determine a possible root cause for the failure.
-- Use "gcloud storage" command to fetch given artifacts and make sure to use {BUILD_NUMBER} in URLs.
+- When fetching, use: `curl -fsSL --max-time 20 --retry 3 --retry-connrefused --proto '=https' --max-filesize 100M "${1}/build-log.txt"`.
+- The build-log.txt file contains e2e failures, store the artifacts related to failure "$2" under directory specified by "$3" to determine a possible root cause for the failure.
+- Use the "gcloud storage" command to fetch given artifacts under "$3" and make sure to use {BUILD_NUMBER} in URLs.
 - Provide evidence for the failure.
 - Try to find additional evidence. For example, in logs and events.
-- Do not delete downloaded artifacts in cleanup phase.
+- Do not delete downloaded artifacts during the cleanup phase.
 
 # Output format
 
 - The output should be formatted as:
-  ```
+  ```text
   Error: {Error message here}
   Summary: {Failure analysis here}
   Evidence: {Evidence here}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add Claude command to analyze e2e test failures from CI builds.
The command downloads build logs and artifacts to determine root causes of test failures with structured evidence output.
Usage in the Hypershift project:
* Start `claude`
* Call `/e2e-analyze <URL to CI job> <test name> <target artifact dir>`
(Example: `/e2e-analyze https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/6706/pull-ci-openshift-hypershift-main-e2e-aks/1961100231621742592 TestCreateClusterCustomConfig /tmp/ci-artifacts/`)

Here's output from a few different CI jobs. It works better with E2E tests from Hypershift repo. It is not so successful with OpenShift conformance tests which reside in a different repository:

### E2E Test Failure 1

[Link to CI run](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_hypershift/6731/pull-ci-openshift-hypershift-main-e2e-aws/1962527613477982208)
#### Command
`/e2e-analyze https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_hypershift/6731/pull-ci-openshift-hypershift-main-e2e-aws/1962527613477982208 TestUpgradeControlPlane/EnsureHostedCluster/EnsureNetworkPolicies/EnsureLimitedEgressTrafficToManagementKAS`
#### Result:
<p>
  Error: unable to upgrade connection: container not found ("manager")
  
  Summary: The test failure was caused by a timing issue during cluster upgrade. The test attempted to exec into the "manager" container of a
  cluster-api pod to verify network policy compliance, but the pod was being terminated and replaced as part of the upgrade process. The test caught
   the cluster-api pod (cluster-api-765bfccf98-jk8fk) during container termination, resulting in a "container not found" error.

  Evidence: Build log shows the exact error: "util.go:1065: cluster api pod was unexpectedly not allowed to reach the management KAS. stdOut: .
  stdErr: unable to upgrade connection: container not found (\"manager\")". The cluster-api deployment and network policies were correctly
  configured - the pod had the required label "hypershift.openshift.io/need-management-kas-access: true" and should have been allowed to reach the
  management KAS.
  
  Additional evidence: Pod events show cluster-api-765bfccf98-jk8fk was being terminated at 16:00:35Z with "Stopping container manager" event, while
   a new pod cluster-api-765bfccf98-r2hwx was simultaneously being created. The management-kas network policy correctly excludes pods with the
  "hypershift.openshift.io/need-management-kas-access" label from egress restrictions. The new cluster-api pod was successfully running and
  performing leader election, indicating the network connectivity itself was functional.
</p>

### E2E Test Failure 2

[Link to CI run](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/6704/pull-ci-openshift-hypershift-main-e2e-aws-autonode/1961093807483129856)
#### Command
`/e2e-analyze https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/6704/pull-ci-openshift-hypershift-main-e2e-aws-autonode/1961093807483129856 TestKarpenter/EnsureHostedCluster/ValidateMetricsAreExposed`
#### Result:
<p>
Error: TestKarpenter/EnsureHostedCluster/ValidateMetricsAreExposed test failed due to missing karpenter_build_info metric

  Summary: The test failed because it could not find the expected "karpenter_build_info" metric from the Karpenter metrics endpoint. After 30
  attempts over 300 seconds, the test timed out with a context deadline exceeded error. The root cause appears to be a Kubernetes version
  compatibility issue where the Karpenter version is not compatible with Kubernetes 1.33, which may be preventing proper metrics initialization and
  exposure.

  Evidence:
  - Test failure in /tmp/ci-artifacts/1961093807483129856/junit.xml line 7: Test ran for 300 seconds before failing
  - Repeated error messages: "Expected results for metric 'karpenter_build_info', found none" (30+ times)
  - Final error: "couldn't obtain any metrics: failed to list Pods: client rate limiter Wait returned an error: context deadline exceeded"
  - Karpenter deployment shows 1 ready replica with metrics port 8080 exposed
  - Metrics server confirmed started: "Serving metrics server" on bindAddress ":8080"

  Additional evidence:
  - Critical compatibility error in karpenter logs /tmp/ci-artifacts/1961093807483129856/TestKarpenter/TestKarpenter/namespaces/e2e-clusters-j56nz-k
  arpenter-sdgx5/core/pods/logs/karpenter-dbf8b947f-9kzgw-karpenter.log:85: "karpenter version is not compatible with K8s version 1.33"
  - Karpenter version detected as "b37141b-dirty" with "unspecified" version in logs
  - Despite version incompatibility, Karpenter started successfully with all controllers running
  - The version compatibility check failure likely prevented the karpenter_build_info metric from being properly registered or exposed
  - Test infrastructure suggests this was an e2e-aws-autonode test with Karpenter integration testing
</p>

### E2E Test Failure 3

[Link to CI run](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/6706/pull-ci-openshift-hypershift-main-e2e-aks/1961100231621742592)
#### Command
`/e2e-analyze https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/6706/pull-ci-openshift-hypershift-main-e2e-aks/1961100231621742592 TestCreateClusterCustomConfig`
#### Result:
<p>
Error: TestCreateClusterCustomConfig failed due to invalid Azure encryption key identifier configuration

  Summary: The test failed immediately upon execution because the Azure encryption key identifier provided was a local file path
  /etc/hypershift-ci-jobs-azurecreds/aks-kms-key instead of a proper Azure Key Vault URI. The validation logic expected a URI format that includes a
   host component (like https://keyvault.vault.azure.net/keys/keyname), but received a local filesystem path. This appears to be a CI configuration
  issue where the wrong format was provided for the --e2e.azure-encryption-key-id parameter.

  Evidence:
  - Test failure in /tmp/ci-artifacts/1961100231621742592/junit.xml line 7-8: failed to get azure encryption key info: %w invalid encryption key 
  identifier "/etc/hypershift-ci-jobs-azurecreds/aks-kms-key": missing host
  - Test failed immediately with 0.000000 time duration, indicating early validation failure
  - Error occurred at create_cluster_test.go:1953 during Azure encryption key info retrieval

  Additional evidence:
  - Build log shows the problematic parameter: --e2e.azure-encryption-key-id=/etc/hypershift-ci-jobs-azurecreds/aks-kms-key
  - CI configuration sets KMS_ARGS+='--e2e.azure-encryption-key-id=/etc/hypershift-ci-jobs-azurecreds/aks-kms-key '
  - The path /etc/hypershift-ci-jobs-azurecreds/aks-kms-key is a local file path in the CI environment, not an Azure Key Vault URI
  - Azure KMS encryption keys should typically be in format like https://<keyvault-name>.vault.azure.net/keys/<key-name>/<version>
  - The test was expecting to validate custom encryption configuration for Azure hosted clusters
  - Other Azure-related credentials and configuration files are properly referenced from the same /etc/hypershift-ci-jobs-azurecreds/ directory
</p>

### Conformance Test Failure

[Link to CI run](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/68540/rehearse-68540-periodic-ci-openshift-hypershift-release-4.21-periodics-e2e-aws-ovn-conformance/1962434203760988160)
#### Command
`/e2e-analyze https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/68540/rehearse-68540-periodic-ci-openshift-hypershift-release-4.21-periodics-e2e-aws-ovn-conformance/1962434203760988160 "The openshift-console downloads pods [apigroup:console.openshift.io] should be scheduled on different nodes"`
#### Result:
<p>
Error: The openshift-console downloads pods scheduling test failed with Status: 12

  Summary: The test "[sig-scheduling][Early] The openshift-console downloads pods [apigroup:console.openshift.io] should be scheduled on different
  nodes [Skipped:SingleReplicaTopology]" failed during execution. Despite having [Skipped:SingleReplicaTopology] in its name (which is part of the
  test identifier, not a skip condition), the test actually ran and failed rather than being skipped.

  Evidence:
  - Test failure found in /tmp/ci-artifacts/1962434203760988160/test-failures-summary_20250901-092736.json
  - Test status: 12 (failed)
  - Test name: [sig-scheduling][Early] The openshift-console downloads pods [apigroup:console.openshift.io] should be scheduled on different nodes 
  [Skipped:SingleReplicaTopology] [Suite:openshift/conformance/parallel]
  - The test was part of the conformance test suite and was expected to verify that console downloads pods are scheduled on different nodes

  Additional evidence:
  - Build artifacts successfully downloaded from gs://test-platform-results/pr-logs/pull/openshift_release/68540/rehearse-68540-periodic-ci-openshif
  t-hypershift-release-4.21-periodics-e2e-aws-ovn-conformance/1962434203760988160
  - Build log indicates this was part of a periodic OpenShift Hypershift e2e test run with OVN networking
  - The failure occurred in a conformance test context, suggesting the issue may be related to pod scheduling constraints or cluster topology
  configuration
</p>

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide for a CLI command to analyze CI end-to-end test failures.
  * Describes three positional inputs (CI run URL, test name, artifact directory) and requires the artifact directory to exist.
  * Explains secure retrieval of build logs and targeted artifact download using the extracted build number from the CI URL.
  * Notes that collected artifacts are preserved after analysis.
  * Provides a structured output format (Error, Summary, Evidence, Additional evidence) with an example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->