### PR TITLE
CNTRLPLANE-1370: feat(supportedversion): add OCP 4.21 support; update e2e constants and tests

### DIFF
--- a/support/supportedversion/version.go
+++ b/support/supportedversion/version.go
@@ -32,7 +32,7 @@ const (
 // NOTE: The .0 (z release) should be ignored. It's only here to support
 // semver parsing.
 var (
-	LatestSupportedVersion = semver.MustParse("4.20.0")
+	LatestSupportedVersion = semver.MustParse("4.21.0")
 	MinSupportedVersion    = semver.MustParse("4.14.0")
 )
 

--- a/support/supportedversion/version_test.go
+++ b/support/supportedversion/version_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestSupportedVersions(t *testing.T) {
 	g := NewGomegaWithT(t)
-	g.Expect(Supported()).To(Equal([]string{"4.20", "4.19", "4.18", "4.17", "4.16", "4.15", "4.14"}))
+	g.Expect(Supported()).To(Equal([]string{"4.21", "4.20", "4.19", "4.18", "4.17", "4.16", "4.15", "4.14"}))
 }
 
 func TestIsValidReleaseVersion(t *testing.T) {

--- a/test/e2e/util/version.go
+++ b/test/e2e/util/version.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	// y-stream versions supported by e2e in main
+	Version421 = semver.MustParse("4.21.0")
 	Version420 = semver.MustParse("4.20.0")
 	Version419 = semver.MustParse("4.19.0")
 	Version418 = semver.MustParse("4.18.0")
@@ -29,6 +30,7 @@ func init() {
 	// Ensure that the version constants are valid semver versions
 	// This is a compile-time check to ensure that the versions are valid
 	// semver versions.
+	_ = Version421
 	_ = Version420
 	_ = Version419
 	_ = Version418


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR:
- Bump LatestSupportedVersion to 4.21.0
- Include 4.21 in Supported() test expectations
- Add Version421 constant in e2e version util with compile-time check

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes CNTRLPLANE-1370

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.