### PR TITLE
OCPBUGS-60149: [release-4.17] Always compress and encode payload in token secret for inplace upgrades

### DIFF
--- a/ignition-server/controllers/tokensecret_controller.go
+++ b/ignition-server/controllers/tokensecret_controller.go
@@ -305,7 +305,16 @@ func (r *TokenSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	patch := tokenSecret.DeepCopy()
-	patch.Data[TokenSecretPayloadKey] = payload
+
+	// In inplace upgrade, compress and encode payload for inplace upgrader to consume.
+	if string(hyperv1.UpgradeTypeInPlace) == tokenSecret.Annotations[TokenSecretNodePoolUpgradeType] {
+		compressedAndEncodedPayload, err := util.CompressAndEncode(payload)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to compress and encode payload: %w", err)
+		}
+		patch.Data[TokenSecretPayloadKey] = compressedAndEncodedPayload.Bytes()
+	}
+	// In replace upgrade, ensure the payload is not stored in the secret.
 	if string(hyperv1.UpgradeTypeReplace) == tokenSecret.Annotations[TokenSecretNodePoolUpgradeType] {
 		delete(patch.Data, TokenSecretPayloadKey)
 	}

--- a/ignition-server/controllers/tokensecret_controller_test.go
+++ b/ignition-server/controllers/tokensecret_controller_test.go
@@ -92,6 +92,8 @@ func TestReconcile(t *testing.T) {
 					Namespace: "test",
 					Annotations: map[string]string{
 						TokenSecretAnnotation: "true",
+						// Use inplace upgrade type to test that the payload is compressed and encoded.
+						TokenSecretNodePoolUpgradeType: string(hyperv1.UpgradeTypeInPlace),
 					},
 					CreationTimestamp: metav1.Now(),
 				},
@@ -144,7 +146,9 @@ func TestReconcile(t *testing.T) {
 				g.Expect(freshSecret.Annotations[TokenSecretTokenGenerationTime]).ToNot(BeEmpty())
 
 				// Validate data for conditions
-				g.Expect(freshSecret.Data[TokenSecretPayloadKey]).To(BeEquivalentTo(fakePayload))
+				inplacePayload, err := util.DecodeAndDecompress(freshSecret.Data[TokenSecretPayloadKey])
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(inplacePayload.String()).To(BeEquivalentTo(fakePayload))
 				g.Expect(freshSecret.Data[TokenSecretReasonKey]).To(BeEquivalentTo(hyperv1.AsExpectedReason))
 				g.Expect(freshSecret.Data[TokenSecretMessageKey]).To(BeEquivalentTo("Payload generated successfully"))
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Without compressing we are more likely to hit 1mb CM size limit. We need to follow up with something that scales better

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Cherry-pick of https://github.com/openshift/hypershift/pull/6721

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.