### PR TITLE
NO-JIRA: docs(create-jira-items): document OCPBUGS issue creation and default versions

### DIFF
--- a/.cursor/rules/create-jira-items.mdc
+++ b/.cursor/rules/create-jira-items.mdc
@@ -33,8 +33,10 @@ It answers the questions - How do we typically refer to this issue?
 
 A summary is needed for the following Jira issue types: Outcomes, Features, Initiatives, Epics, Stories, Spikes, Tasks, Bugs, Tickets, Risks, Sub-Tasks.
 
-### Description
+### Setting Versions
+For any Jira story or task, unless specified differently from the user, the target version should always be openshift-4.21.
 
+For any OCPBUGS Jira issue, the `affected version/s` and `target version` (also known as customfield_12319940) fields should default to 4.21.
 
 ## Instructions on specific Jira Issue components
  <!-- Adapted from https://spaces.redhat.com/spaces/CIAO/pages/195636942/Story+Guidelines -->
@@ -106,4 +108,13 @@ Determining Amount of Acceptance Criteria - you have enough AC when:
 TBD
 
 ## Creating a bug ticket
-TBD
+The summary, component, and affects version/s fields are required for all OCPBUGS Jira issues.
+
+The description should include the following content:
+- Description of problem:
+- Version-Release number of selected component (if applicable):
+- How reproducible:
+- Steps to Reproduce:
+- Actual results:
+- Expected results:
+- Additional info:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR:
- Adds guidance for creating OpenShift Bugs (OCPBUGS) issues
- Notes required fields (summary, component, affected version/s)
- Adds bug report template (problem, versions, reproducibility, steps, actual vs expected, additional info)
- Sets defaults for affected and target versions to 4.21

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
N/A

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Setting Versions" guidance: default target/affected versions set to 4.21 for stories/tasks and OCPBUG issues unless overridden.
  * Clarified bug ticket requirements: summary, component, and affects version/s are mandatory.
  * Standardized description template: problem, version-release, reproducibility, steps, actual/expected results, additional info. No code/runtime changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->