### PR TITLE
NO-JIRA: fix(api): enhance API NodePool's API docs

### DIFF
--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -97,14 +97,19 @@ type NodePoolSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')",message="clusterName must consist of lowercase alphanumeric characters or '-', start and end with an alphanumeric character, and be between 1 and 253 characters"
 	ClusterName string `json:"clusterName"`
 
-	// release specifies the OCP release used for the NodePool. This informs the
-	// ignition configuration for machines which includes the kubelet version, as well as other platform specific
-	// machine properties (e.g. an AMI on the AWS platform).
-	// It's not supported to use a release in a NodePool which minor version skew against the Control Plane release is bigger than N-2. Although there's no enforcement that prevents this from happening.
-	// Attempting to use a release with a bigger skew might result in unpredictable behaviour.
-	// Attempting to use a release higher than the HosterCluster one will result in the NodePool being degraded and the ValidReleaseImage condition being false.
-	// Attempting to use a release lower than the current NodePool y-stream will result in the NodePool being degraded and the ValidReleaseImage condition being false.
-	// Changing this field will trigger a NodePool rollout.
+	// release specifies the OCP release used for this NodePool. It drives the machine ignition configuration (including
+	// the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).
+	//
+	// Version-skew rules and effects:
+	//   - The minor-version skew relative to the control-plane release must be <= N-2.
+	//     This is not currently enforced, but exceeding this limit is unsupported and
+	//     may lead to unpredictable behavior.
+	//   - If the specified release is higher than the HostedCluster's release, the
+	//     NodePool will be degraded and the ValidReleaseImage condition will be false.
+	//   - If the specified release is lower than the NodePool's current y-stream,
+	//     the NodePool will be degraded and the ValidReleaseImage condition will be false.
+	//
+	// Changing this field triggers a NodePool rollout.
 	// +rollout
 	// +required
 	Release Release `json:"release"`

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
@@ -1295,14 +1295,19 @@ spec:
                 type: object
               release:
                 description: |-
-                  release specifies the OCP release used for the NodePool. This informs the
-                  ignition configuration for machines which includes the kubelet version, as well as other platform specific
-                  machine properties (e.g. an AMI on the AWS platform).
-                  It's not supported to use a release in a NodePool which minor version skew against the Control Plane release is bigger than N-2. Although there's no enforcement that prevents this from happening.
-                  Attempting to use a release with a bigger skew might result in unpredictable behaviour.
-                  Attempting to use a release higher than the HosterCluster one will result in the NodePool being degraded and the ValidReleaseImage condition being false.
-                  Attempting to use a release lower than the current NodePool y-stream will result in the NodePool being degraded and the ValidReleaseImage condition being false.
-                  Changing this field will trigger a NodePool rollout.
+                  release specifies the OCP release used for this NodePool. It drives the machine ignition configuration (including
+                  the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).
+
+                  Version-skew rules and effects:
+                    - The minor-version skew relative to the control-plane release must be <= N-2.
+                      This is not currently enforced, but exceeding this limit is unsupported and
+                      may lead to unpredictable behavior.
+                    - If the specified release is higher than the HostedCluster's release, the
+                      NodePool will be degraded and the ValidReleaseImage condition will be false.
+                    - If the specified release is lower than the NodePool's current y-stream,
+                      the NodePool will be degraded and the ValidReleaseImage condition will be false.
+
+                  Changing this field triggers a NodePool rollout.
                 properties:
                   image:
                     description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
@@ -1481,14 +1481,19 @@ spec:
                 type: object
               release:
                 description: |-
-                  release specifies the OCP release used for the NodePool. This informs the
-                  ignition configuration for machines which includes the kubelet version, as well as other platform specific
-                  machine properties (e.g. an AMI on the AWS platform).
-                  It's not supported to use a release in a NodePool which minor version skew against the Control Plane release is bigger than N-2. Although there's no enforcement that prevents this from happening.
-                  Attempting to use a release with a bigger skew might result in unpredictable behaviour.
-                  Attempting to use a release higher than the HosterCluster one will result in the NodePool being degraded and the ValidReleaseImage condition being false.
-                  Attempting to use a release lower than the current NodePool y-stream will result in the NodePool being degraded and the ValidReleaseImage condition being false.
-                  Changing this field will trigger a NodePool rollout.
+                  release specifies the OCP release used for this NodePool. It drives the machine ignition configuration (including
+                  the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).
+
+                  Version-skew rules and effects:
+                    - The minor-version skew relative to the control-plane release must be <= N-2.
+                      This is not currently enforced, but exceeding this limit is unsupported and
+                      may lead to unpredictable behavior.
+                    - If the specified release is higher than the HostedCluster's release, the
+                      NodePool will be degraded and the ValidReleaseImage condition will be false.
+                    - If the specified release is lower than the NodePool's current y-stream,
+                      the NodePool will be degraded and the ValidReleaseImage condition will be false.
+
+                  Changing this field triggers a NodePool rollout.
                 properties:
                   image:
                     description: |-

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -1484,14 +1484,19 @@ spec:
                 type: object
               release:
                 description: |-
-                  release specifies the OCP release used for the NodePool. This informs the
-                  ignition configuration for machines which includes the kubelet version, as well as other platform specific
-                  machine properties (e.g. an AMI on the AWS platform).
-                  It's not supported to use a release in a NodePool which minor version skew against the Control Plane release is bigger than N-2. Although there's no enforcement that prevents this from happening.
-                  Attempting to use a release with a bigger skew might result in unpredictable behaviour.
-                  Attempting to use a release higher than the HosterCluster one will result in the NodePool being degraded and the ValidReleaseImage condition being false.
-                  Attempting to use a release lower than the current NodePool y-stream will result in the NodePool being degraded and the ValidReleaseImage condition being false.
-                  Changing this field will trigger a NodePool rollout.
+                  release specifies the OCP release used for this NodePool. It drives the machine ignition configuration (including
+                  the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).
+
+                  Version-skew rules and effects:
+                    - The minor-version skew relative to the control-plane release must be <= N-2.
+                      This is not currently enforced, but exceeding this limit is unsupported and
+                      may lead to unpredictable behavior.
+                    - If the specified release is higher than the HostedCluster's release, the
+                      NodePool will be degraded and the ValidReleaseImage condition will be false.
+                    - If the specified release is lower than the NodePool's current y-stream,
+                      the NodePool will be degraded and the ValidReleaseImage condition will be false.
+
+                  Changing this field triggers a NodePool rollout.
                 properties:
                   image:
                     description: |-

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -1298,14 +1298,19 @@ spec:
                 type: object
               release:
                 description: |-
-                  release specifies the OCP release used for the NodePool. This informs the
-                  ignition configuration for machines which includes the kubelet version, as well as other platform specific
-                  machine properties (e.g. an AMI on the AWS platform).
-                  It's not supported to use a release in a NodePool which minor version skew against the Control Plane release is bigger than N-2. Although there's no enforcement that prevents this from happening.
-                  Attempting to use a release with a bigger skew might result in unpredictable behaviour.
-                  Attempting to use a release higher than the HosterCluster one will result in the NodePool being degraded and the ValidReleaseImage condition being false.
-                  Attempting to use a release lower than the current NodePool y-stream will result in the NodePool being degraded and the ValidReleaseImage condition being false.
-                  Changing this field will trigger a NodePool rollout.
+                  release specifies the OCP release used for this NodePool. It drives the machine ignition configuration (including
+                  the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).
+
+                  Version-skew rules and effects:
+                    - The minor-version skew relative to the control-plane release must be <= N-2.
+                      This is not currently enforced, but exceeding this limit is unsupported and
+                      may lead to unpredictable behavior.
+                    - If the specified release is higher than the HostedCluster's release, the
+                      NodePool will be degraded and the ValidReleaseImage condition will be false.
+                    - If the specified release is lower than the NodePool's current y-stream,
+                      the NodePool will be degraded and the ValidReleaseImage condition will be false.
+
+                  Changing this field triggers a NodePool rollout.
                 properties:
                   image:
                     description: |-

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -1484,14 +1484,19 @@ spec:
                 type: object
               release:
                 description: |-
-                  release specifies the OCP release used for the NodePool. This informs the
-                  ignition configuration for machines which includes the kubelet version, as well as other platform specific
-                  machine properties (e.g. an AMI on the AWS platform).
-                  It's not supported to use a release in a NodePool which minor version skew against the Control Plane release is bigger than N-2. Although there's no enforcement that prevents this from happening.
-                  Attempting to use a release with a bigger skew might result in unpredictable behaviour.
-                  Attempting to use a release higher than the HosterCluster one will result in the NodePool being degraded and the ValidReleaseImage condition being false.
-                  Attempting to use a release lower than the current NodePool y-stream will result in the NodePool being degraded and the ValidReleaseImage condition being false.
-                  Changing this field will trigger a NodePool rollout.
+                  release specifies the OCP release used for this NodePool. It drives the machine ignition configuration (including
+                  the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).
+
+                  Version-skew rules and effects:
+                    - The minor-version skew relative to the control-plane release must be <= N-2.
+                      This is not currently enforced, but exceeding this limit is unsupported and
+                      may lead to unpredictable behavior.
+                    - If the specified release is higher than the HostedCluster's release, the
+                      NodePool will be degraded and the ValidReleaseImage condition will be false.
+                    - If the specified release is lower than the NodePool's current y-stream,
+                      the NodePool will be degraded and the ValidReleaseImage condition will be false.
+
+                  Changing this field triggers a NodePool rollout.
                 properties:
                   image:
                     description: |-

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -815,14 +815,17 @@ Release
 </em>
 </td>
 <td>
-<p>release specifies the OCP release used for the NodePool. This informs the
-ignition configuration for machines which includes the kubelet version, as well as other platform specific
-machine properties (e.g. an AMI on the AWS platform).
-It&rsquo;s not supported to use a release in a NodePool which minor version skew against the Control Plane release is bigger than N-2. Although there&rsquo;s no enforcement that prevents this from happening.
-Attempting to use a release with a bigger skew might result in unpredictable behaviour.
-Attempting to use a release higher than the HosterCluster one will result in the NodePool being degraded and the ValidReleaseImage condition being false.
-Attempting to use a release lower than the current NodePool y-stream will result in the NodePool being degraded and the ValidReleaseImage condition being false.
-Changing this field will trigger a NodePool rollout.</p>
+<p>release specifies the OCP release used for this NodePool. It drives the machine ignition configuration (including
+the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).</p>
+<p>Version-skew rules and effects:
+- The minor-version skew relative to the control-plane release must be &lt;= N-2.
+This is not currently enforced, but exceeding this limit is unsupported and
+may lead to unpredictable behavior.
+- If the specified release is higher than the HostedCluster&rsquo;s release, the
+NodePool will be degraded and the ValidReleaseImage condition will be false.
+- If the specified release is lower than the NodePool&rsquo;s current y-stream,
+the NodePool will be degraded and the ValidReleaseImage condition will be false.</p>
+<p>Changing this field triggers a NodePool rollout.</p>
 </td>
 </tr>
 <tr>
@@ -9479,14 +9482,17 @@ Release
 </em>
 </td>
 <td>
-<p>release specifies the OCP release used for the NodePool. This informs the
-ignition configuration for machines which includes the kubelet version, as well as other platform specific
-machine properties (e.g. an AMI on the AWS platform).
-It&rsquo;s not supported to use a release in a NodePool which minor version skew against the Control Plane release is bigger than N-2. Although there&rsquo;s no enforcement that prevents this from happening.
-Attempting to use a release with a bigger skew might result in unpredictable behaviour.
-Attempting to use a release higher than the HosterCluster one will result in the NodePool being degraded and the ValidReleaseImage condition being false.
-Attempting to use a release lower than the current NodePool y-stream will result in the NodePool being degraded and the ValidReleaseImage condition being false.
-Changing this field will trigger a NodePool rollout.</p>
+<p>release specifies the OCP release used for this NodePool. It drives the machine ignition configuration (including
+the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).</p>
+<p>Version-skew rules and effects:
+- The minor-version skew relative to the control-plane release must be &lt;= N-2.
+This is not currently enforced, but exceeding this limit is unsupported and
+may lead to unpredictable behavior.
+- If the specified release is higher than the HostedCluster&rsquo;s release, the
+NodePool will be degraded and the ValidReleaseImage condition will be false.
+- If the specified release is lower than the NodePool&rsquo;s current y-stream,
+the NodePool will be degraded and the ValidReleaseImage condition will be false.</p>
+<p>Changing this field triggers a NodePool rollout.</p>
 </td>
 </tr>
 <tr>

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -97,14 +97,19 @@ type NodePoolSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')",message="clusterName must consist of lowercase alphanumeric characters or '-', start and end with an alphanumeric character, and be between 1 and 253 characters"
 	ClusterName string `json:"clusterName"`
 
-	// release specifies the OCP release used for the NodePool. This informs the
-	// ignition configuration for machines which includes the kubelet version, as well as other platform specific
-	// machine properties (e.g. an AMI on the AWS platform).
-	// It's not supported to use a release in a NodePool which minor version skew against the Control Plane release is bigger than N-2. Although there's no enforcement that prevents this from happening.
-	// Attempting to use a release with a bigger skew might result in unpredictable behaviour.
-	// Attempting to use a release higher than the HosterCluster one will result in the NodePool being degraded and the ValidReleaseImage condition being false.
-	// Attempting to use a release lower than the current NodePool y-stream will result in the NodePool being degraded and the ValidReleaseImage condition being false.
-	// Changing this field will trigger a NodePool rollout.
+	// release specifies the OCP release used for this NodePool. It drives the machine ignition configuration (including
+	// the kubelet version) and other platform-specific properties (e.g. an AMI on AWS).
+	//
+	// Version-skew rules and effects:
+	//   - The minor-version skew relative to the control-plane release must be <= N-2.
+	//     This is not currently enforced, but exceeding this limit is unsupported and
+	//     may lead to unpredictable behavior.
+	//   - If the specified release is higher than the HostedCluster's release, the
+	//     NodePool will be degraded and the ValidReleaseImage condition will be false.
+	//   - If the specified release is lower than the NodePool's current y-stream,
+	//     the NodePool will be degraded and the ValidReleaseImage condition will be false.
+	//
+	// Changing this field triggers a NodePool rollout.
 	// +rollout
 	// +required
 	Release Release `json:"release"`


### PR DESCRIPTION
**What this PR does / why we need it**:

Reword and simplify the docs of the 'release' field of the NodePool API


**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified NodePool “release” field description: it drives machine ignition config (including kubelet) and platform-specific properties (e.g., AMI).
  * Added a structured “Version‑skew rules and effects” section: minor-version skew relative to control-plane must be ≤ N-2; exceeding this is unsupported.
  * Documented degradation/ValidReleaseImage behavior when release is higher than HostedCluster’s or lower than the NodePool’s current y-stream.
  * Stated that changing the release field triggers a NodePool rollout; improved terminology consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->