### PR TITLE
NO-JIRA: fix(test): support external oidc settings on non-aws platform

### DIFF
--- a/test/e2e/util/hypershift_framework.go
+++ b/test/e2e/util/hypershift_framework.go
@@ -332,10 +332,13 @@ func (h *hypershiftTest) createHostedCluster(opts *PlatformAgnosticOptions, plat
 							},
 						},
 					}
+				}
 
-					if opts.ExtOIDCConfig != nil {
-						v.Spec.Configuration.Authentication = opts.ExtOIDCConfig.GetAuthenticationConfig()
+				if opts.ExtOIDCConfig != nil {
+					if v.Spec.Configuration == nil {
+						v.Spec.Configuration = &hyperv1.ClusterConfiguration{}
 					}
+					v.Spec.Configuration.Authentication = opts.ExtOIDCConfig.GetAuthenticationConfig()
 				}
 			}
 		}


### PR DESCRIPTION
support azure external oidc test