### PR TITLE
OCPBUGS-61291: fix(test): run TestHAEtcdChaos validations

### DIFF
--- a/test/e2e/chaos_test.go
+++ b/test/e2e/chaos_test.go
@@ -43,24 +43,11 @@ func TestHAEtcdChaos(t *testing.T) {
 	clusterOpts.NodePoolReplicas = 0
 
 	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
-		t.Run("SingleMemberRecovery", func(t *testing.T) {
-			t.Parallel()
-			testSingleMemberRecovery(ctx, mgtClient, hostedCluster)
-		})
-		t.Run("KillRandomMembers", func(t *testing.T) {
-			t.Parallel()
-			testKillRandomMembers(ctx, mgtClient, hostedCluster)
-		})
-		t.Run("KillAllMembers", func(t *testing.T) {
-			t.Parallel()
-			testKillAllMembers(ctx, mgtClient, hostedCluster)
-		})
-		t.Run("SingleMemberRecoveryWithCorruption", func(t *testing.T) {
-			testEtcdMemberCorruption(ctx, mgtClient, hostedCluster)
-		})
-		t.Run("SingleMissingMemberRecovery", func(t *testing.T) {
-			testEtcdMemberMissing(ctx, mgtClient, hostedCluster)
-		})
+		t.Run("SingleMemberRecovery", testSingleMemberRecovery(ctx, mgtClient, hostedCluster))
+		t.Run("KillRandomMembers", testKillRandomMembers(ctx, mgtClient, hostedCluster))
+		t.Run("KillAllMembers", testKillAllMembers(ctx, mgtClient, hostedCluster))
+		t.Run("SingleMemberRecoveryWithCorruption", testEtcdMemberCorruption(ctx, mgtClient, hostedCluster))
+		t.Run("SingleMissingMemberRecovery", testEtcdMemberMissing(ctx, mgtClient, hostedCluster))
 
 	}).Execute(&clusterOpts, hyperv1.NonePlatform, globalOpts.ArtifactDir, "ha-etcd-chaos", globalOpts.ServiceAccountSigningKey)
 }


### PR DESCRIPTION
TestHAEtcdChaos validations were not actually running, giving a false green

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored chaos test execution to run sequentially instead of in parallel, simplifying subtest registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->