### PR TITLE
[OCPBUGS-61299]:Fix vpc share doesn't work with public-only when crea…

### DIFF
--- a/cmd/infra/aws/create.go
+++ b/cmd/infra/aws/create.go
@@ -575,9 +575,11 @@ func (o *CreateInfraOptions) shareSubnets(ctx context.Context, l logr.Logger, vp
 	privateSubnetIDsToShare := make([]*string, 0, len(output.Zones))
 	publicSubnetIDsToShare := make([]*string, 0, len(publicSubnetIDs))
 	allSubnetIDsToShare := make([]*string, 0, len(output.Zones)+len(publicSubnetIDs))
-
-	for _, zone := range output.Zones {
-		privateSubnetIDsToShare = append(privateSubnetIDsToShare, aws.String(zone.SubnetID))
+	//if publicOnly=true, the zone.SubnetID is the same as publicSubnetID. Skip this to avoid duplicate publicSubnetIDs will be added to allSubnetIDsToShare
+	if !output.PublicOnly {
+		for _, zone := range output.Zones {
+			privateSubnetIDsToShare = append(privateSubnetIDsToShare, aws.String(zone.SubnetID))
+		}
 	}
 	for _, subnetID := range publicSubnetIDs {
 		publicSubnetIDsToShare = append(publicSubnetIDsToShare, aws.String(subnetID))


### PR DESCRIPTION
…te hypershift aws cluster

**What this PR does / why we need it**:
To fix Fix vpc share doesn't work with public-only when create hypershift aws cluster

**Which issue(s) this PR fixes** *
https://issues.redhat.com/browse/OCPBUGS-61299