### PR TITLE
test(e2e): skip kubevirt pods in EnsureReadOnlyRootFilesystem

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1571,6 +1571,8 @@ func EnsureReadOnlyRootFilesystem(t *testing.T, ctx context.Context, hostClient 
 			{label: "app", value: "network-node-identity"}:            {},
 			{label: "app", value: "ovnkube-control-plane"}:            {},
 			{label: "app", value: "cloud-network-config-controller"}:  {},
+			{label: "app", value: "vmi-console-debug"}:                {},
+			{label: "kubevirt.io", value: "virt-launcher"}:            {}, // virt-launcher pods have no app label
 		}
 
 		for _, pod := range hcpPods.Items {


### PR DESCRIPTION
For platform kubevirt, some pods are created by kubevirt in the HCP. This pods do not comply with readOnlyRootFilesystem: true.

Skip these pods during the check.

`periodic-ci-openshift-hypershift-release-4.20-periodics-e2e-kubevirt-aws-ovn` broken since