### PR TITLE
[release-4.20] OCPBUGS-61066: fix: propagate AWSLoadBalancerTargetNodesAnnotation to HCP

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2215,6 +2215,7 @@ func reconcileHostedControlPlaneAnnotations(hcp *hyperv1.HostedControlPlane, hcl
 		hyperv1.KubeAPIServerGOMemoryLimitAnnotation,
 		hyperv1.RequestServingNodeAdditionalSelectorAnnotation,
 		hyperv1.AWSLoadBalancerSubnetsAnnotation,
+		hyperv1.AWSLoadBalancerTargetNodesAnnotation,
 		hyperv1.ManagementPlatformAnnotation,
 		hyperv1.KubeAPIServerVerbosityLevelAnnotation,
 		hyperv1.KubeAPIServerMaximumRequestsInFlight,


### PR DESCRIPTION
Backport of https://github.com/openshift/hypershift/pull/6823

**What this PR does / why we need it**:

* Add AWSLoadBalancerTargetNodesAnnotation to the list of mirrored annotations in reconcileHostedControlPlaneAnnotations. This enables AWS load balancer target node configurations set on HostedCluster resources to be properly propagated to their corresponding HostedControlPlane resources.
* Propagate osd-fleet-manager.openshift.io/paired-nodes label from
request-serving nodes and set it as
service.beta.kubernetes.io/aws-load-balancer-target-node-labels
annotation on HC.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes [OCPBUGS-61066](https://issues.redhat.com/browse/OCPBUGS-61066)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.