### PR TITLE
OCPBUGS-61048: test(e2e): add autoscaler deployment verification to autoscaling test

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -876,7 +876,7 @@ func EnsureOAPIMountsTrustBundle(t *testing.T, ctx context.Context, mgmtClient c
 			}), "no volume named proxy-additional-trust-bundle found in openshift-apiserver pod")
 		}
 
-		_, err = RunCommandInPod(ctx, mgmtClient, "openshift-apiserver", hcpNs, command, "openshift-apiserver", 0)
+		_, err = RunCommandInPod(ctx, mgmtClient, "openshift-apiserver", hcpNs, command, "openshift-apiserver", 1*time.Minute)
 		g.Expect(err).ToNot(HaveOccurred(), "failed to run command in pod: %v", err)
 	})
 


### PR DESCRIPTION
Add additional verification step to ensure the autoscaler deployment has the correct balancing ignore label configuration and is ready before proceeding with workload generation.

This provides more comprehensive validation of autoscaling setup by checking both the NodePool condition and the actual deployment configuration.


Assisted-by: claude-3-5-sonnet-20241022 (via Cursor)


**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-61048
