### PR TITLE
[release-4.19] OCPBUGS-61407: fix: Do not admit OAuth route by private router unless…

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/route.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/route.go
@@ -37,9 +37,5 @@ func (ign *ignitionServer) adaptRoute(cpContext component.WorkloadContext, route
 	if strategy.Route != nil {
 		hostname = strategy.Route.Hostname
 	}
-	return util.ReconcileExternalRoute(route, hostname, ign.defaultIngressDomain, ComponentName, labelHCPRoutes(hcp))
-}
-
-func labelHCPRoutes(hcp *hyperv1.HostedControlPlane) bool {
-	return util.IsPrivateHCP(hcp) || util.IsPublicKASWithDNS(hcp)
+	return util.ReconcileExternalRoute(route, hostname, ign.defaultIngressDomain, ComponentName, util.UseDedicatedDNSForIgnition(hcp))
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy/route.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy/route.go
@@ -33,9 +33,5 @@ func (ign *ignitionServerProxy) adaptRoute(cpContext component.WorkloadContext, 
 	if strategy.Route != nil {
 		hostname = strategy.Route.Hostname
 	}
-	return util.ReconcileExternalRoute(route, hostname, ign.defaultIngressDomain, ComponentName, labelHCPRoutes(hcp))
-}
-
-func labelHCPRoutes(hcp *hyperv1.HostedControlPlane) bool {
-	return util.IsPrivateHCP(hcp) || util.IsPublicKASWithDNS(hcp)
+	return util.ReconcileExternalRoute(route, hostname, ign.defaultIngressDomain, ComponentName, util.UseDedicatedDNSForIgnition(hcp))
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
@@ -56,5 +56,5 @@ func useHCPRouter(cpContext component.WorkloadContext) (bool, error) {
 	if sharedingress.UseSharedIngress() {
 		return false, nil
 	}
-	return util.IsPrivateHCP(cpContext.HCP) || util.IsPublicKASWithDNS(cpContext.HCP), nil
+	return util.IsPrivateHCP(cpContext.HCP) || util.IsPublicWithDNS(cpContext.HCP), nil
 }

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -4688,6 +4688,10 @@ func (r *HostedClusterReconciler) validateAWSConfig(hc *hyperv1.HostedCluster) e
 		if !hyperutil.UseDedicatedDNSForKASByHC(hc) && kasPublishingStrategy.Type != hyperv1.LoadBalancer {
 			errs = append(errs, fmt.Errorf("service type %v with publishing strategy %v is not supported, use Route or LoadBalancer", hyperv1.APIServer, kasPublishingStrategy.Type))
 		}
+		// When using dedicated DNS, the KAS should be exposed as Route.
+		if hyperutil.IsPublicWithDNSByHC(hc) && hyperutil.IsLBKASByHC(hc) {
+			errs = append(errs, fmt.Errorf("service type %v with publishing strategy %v is not supported when any service specifies external DNS, use Route", hyperv1.APIServer, kasPublishingStrategy.Type))
+		}
 	}
 
 	return utilerrors.NewAggregate(errs)

--- a/support/util/visibility.go
+++ b/support/util/visibility.go
@@ -37,6 +37,16 @@ func IsPublicHC(hc *hyperv1.HostedCluster) bool {
 	return access == hyperv1.PublicAndPrivate || access == hyperv1.Public
 }
 
-func IsPublicKASWithDNS(hostedControlPlane *hyperv1.HostedControlPlane) bool {
-	return IsPublicHCP(hostedControlPlane) && UseDedicatedDNSforKAS(hostedControlPlane)
+func IsPublicWithDNS(hcp *hyperv1.HostedControlPlane) bool {
+	return IsPublicHCP(hcp) && (UseDedicatedDNS(hcp, hyperv1.APIServer) ||
+		UseDedicatedDNS(hcp, hyperv1.OAuthServer) ||
+		UseDedicatedDNS(hcp, hyperv1.Konnectivity) ||
+		UseDedicatedDNS(hcp, hyperv1.Ignition))
+}
+
+func IsPublicWithDNSByHC(hc *hyperv1.HostedCluster) bool {
+	return IsPublicHC(hc) && (UseDedicatedDNSByHC(hc, hyperv1.APIServer) ||
+		UseDedicatedDNSByHC(hc, hyperv1.OAuthServer) ||
+		UseDedicatedDNSByHC(hc, hyperv1.Konnectivity) ||
+		UseDedicatedDNSByHC(hc, hyperv1.Ignition))
 }


### PR DESCRIPTION
… it has external DNS

Manual cherry-pick of https://github.com/openshift/hypershift/pull/6218

**What this PR does / why we need it**:

* Label the OAuth Route for admission by the private router only if the OAuth endpoint has hostname (external DNS). This fixes the case when KAS is exposed as LoadBalancer and OAuth via Route without specifying external DNS.
* In order to fix the previous point, label routes for admission by the private router independently from each other (previously, all routes were labeled based on KAS Route)
* Expose private HCP router service if the endpoint access is Private or any endpoint exposes Route with external DNS. (previously it took into account just KAS Route). This fixes the missing routerCanonicalHostname on OAuth Route when KAS has LoadBalancer strategy and OAuth has Route *with* external DNS.
* Add unit test for renconciling OAuth Service and Routes

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.