### PR TITLE
OCPBUGS-61462: temporarily use v4.20 catalogs

### DIFF
--- a/support/catalogs/images.go
+++ b/support/catalogs/images.go
@@ -171,6 +171,10 @@ func computeCatalogImages(releaseVersion func() (*semver.Version, error), imageE
 
 	for catalog := range catalogs {
 		catalogVersion := *version
+		// Start at 4.20 until the 4.21 catalog images works properly
+		if catalogVersion.Minor > 20 {
+			catalogVersion.Minor = 20
+		}
 		for i := range supportedVersions {
 			for _, registry := range registries {
 				testImage := fmt.Sprintf("%s/%s:v%d.%d", registry, catalogImageNames[catalog], catalogVersion.Major, catalogVersion.Minor)


### PR DESCRIPTION
v4.21 catalogs have a filesystem permissions error that are causing HCP to fail to deploy.

Temporarily use v4.20 catalogs until this is fixed.