### PR TITLE
CNTRLPLANE-1397: feat(konflux): tag MCE HO images with latest

### DIFF
--- a/.tekton/hypershift-release-mce-210-push.yaml
+++ b/.tekton/hypershift-release-mce-210-push.yaml
@@ -564,6 +564,9 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+        - 'latest'
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to simplify Multi Cluster Engine HyperShift Operator image discovery in Quality Engineering verification, let's tag the built images in Konflux so it is always evident which is the latest build.

**Which issue(s) this PR fixes**:
Fixes #[CNTRLPLANE-1397](https://issues.redhat.com//browse/CNTRLPLANE-1397)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.