### PR TITLE
OCPBUGS-61499: fix(control-plane): remove resource limits from kube-controller-manager

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_controller_manager_deployment.yaml
@@ -243,9 +243,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 10
         resources:
-          limits:
-            cpu: "1"
-            memory: 1Gi
           requests:
             cpu: 100m
             memory: 600Mi

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents_kube_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-controller-manager/zz_fixture_TestControlPlaneComponents_kube_controller_manager_deployment.yaml
@@ -244,9 +244,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 10
         resources:
-          limits:
-            cpu: "1"
-            memory: 1Gi
           requests:
             cpu: 100m
             memory: 600Mi

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-controller-manager/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-controller-manager/deployment.yaml
@@ -84,9 +84,6 @@ spec:
           requests:
             cpu: 100m
             memory: 600Mi
-          limits:
-            cpu: 1000m
-            memory: 1Gi
         volumeMounts:
         - mountPath: /var/run/kubernetes
           name: certs


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove CPU and memory limits from kube-controller-manager deployment to allow setting larger resource requests in rosa.
Partially reverts #6480

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #[OCPBUGS-61499](https://issues.redhat.com/browse/OCPBUGS-61499)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.