### PR TITLE
OCPBUGS-60637: feat(cpo): add UID security context to CSO deployment

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/storage/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/storage/deployment.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"strconv"
+
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
@@ -28,6 +30,12 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 					Name:  "ARO_HCP_SECRET_PROVIDER_CLASS_FOR_FILE",
 					Value: config.ManagedAzureFileCSISecretStoreProviderClassName,
 				})
+		}
+
+		// We set this so cluster-storage-operator knows which User ID to run the CSI controller pods as.
+		// This is needed when these pods are run on a management cluster that is non-OpenShift such as AKS.
+		if cpContext.SetDefaultSecurityContext {
+			c.Env = append(c.Env, corev1.EnvVar{Name: "RUN_AS_USER", Value: strconv.Itoa(int(cpContext.DefaultSecurityContextUID))})
 		}
 	})
 

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -3639,11 +3639,7 @@ func EnsureSecurityContextUID(t *testing.T, ctx context.Context, client crclient
 			// Skip pods that are known exceptions for SecurityContext UID validation
 			name := pod.Name
 			switch {
-			case strings.HasPrefix(name, "azure-disk-csi-driver-controller"),
-				strings.HasPrefix(name, "azure-file-csi-driver-controller"),
-				strings.HasPrefix(name, "azure-disk-csi-driver-operator"),
-				strings.HasPrefix(name, "azure-file-csi-driver-operator"),
-				strings.HasPrefix(name, "network-node-identity"),
+			case strings.HasPrefix(name, "network-node-identity"),
 				strings.HasPrefix(name, "ovnkube-control-plane"):
 				continue
 			}


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

CSI operator should respect `RUN_AS_USER` env variable to set UID security context on operator and CSI controller pods. CSO needs to have this variable set first before it can be seen by it's operands.

Also removes test exceptions to enable checking UID for operands that did not support this feature before.

Has to be merged *after* the following PRs have been merged: 
- https://github.com/openshift/csi-operator/pull/431
- https://github.com/openshift/cluster-storage-operator/pull/616

**Which issue(s) this PR fixes** :
[OCPBUGS-60637](https://issues.redhat.com/browse/OCPBUGS-60637)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.