### PR TITLE
OCPBUGS-61482: fix(proxy): ensure URLs have scheme before proxy resolution

### DIFF
--- a/konnectivity-https-proxy/cmd.go
+++ b/konnectivity-https-proxy/cmd.go
@@ -198,8 +198,12 @@ func shouldDialDirectFunc(connectDirectlyToCloudAPIs bool, isCloudAPI func(strin
 				return true, nil
 			}
 		}
-
-		proxyURL, err := userProxyFunc(u)
+		// If the scheme is missing, set it to https
+		localURL := *u
+		if localURL.Scheme == "" {
+			localURL.Scheme = "https"
+		}
+		proxyURL, err := userProxyFunc(&localURL)
 		if err != nil {
 			return false, err
 		}

--- a/konnectivity-https-proxy/cmd_test.go
+++ b/konnectivity-https-proxy/cmd_test.go
@@ -5,71 +5,98 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
+
+	"golang.org/x/net/http/httpproxy"
 )
 
 func TestShouldDialDirectFunc(t *testing.T) {
+	u := func(s string) *url.URL {
+		u, err := url.Parse("https://" + s)
+		if err != nil {
+			panic(err)
+		}
+		return u
+	}
+	withoutScheme := func(s string) *url.URL {
+		u, err := url.Parse("https://" + s)
+		if err != nil {
+			panic(err)
+		}
+		u.Scheme = ""
+		return u
+	}
 	tests := []struct {
 		name                       string
 		connectDirectlyToCloudAPIs bool
-		isCloudAPI                 bool
-		emptyProxyURL              bool
-		expected                   bool
+		requestURL                 *url.URL
+		proxyNotConfigured         bool
+		expectedDialDirectly       bool
 	}{
 		{
 			name:                       "cloud API",
 			connectDirectlyToCloudAPIs: true,
-			isCloudAPI:                 true,
-			expected:                   true,
+			requestURL:                 u("cloudapi.com"),
+			expectedDialDirectly:       true,
 		},
 		{
-			name:                       "not cloud API",
+			name:                       "not cloud API, proxy configured",
 			connectDirectlyToCloudAPIs: true,
-			isCloudAPI:                 false,
-			expected:                   false,
+			requestURL:                 u("example.com"),
+			expectedDialDirectly:       false,
 		},
 		{
-			name:                       "not cloud API, no proxy URL",
+			name:                       "not cloud API, matches noProxy",
 			connectDirectlyToCloudAPIs: true,
-			isCloudAPI:                 false,
-			emptyProxyURL:              true,
-			expected:                   true,
+			requestURL:                 u("dontproxy.com"),
+			expectedDialDirectly:       true,
 		},
 		{
-			name:                       "not cloud API, has proxy URL",
+			name:                       "not cloud API, no proxy configured",
 			connectDirectlyToCloudAPIs: true,
-			isCloudAPI:                 false,
-			emptyProxyURL:              false,
-			expected:                   false,
+			requestURL:                 u("example.com"),
+			proxyNotConfigured:         true,
+			expectedDialDirectly:       true,
+		},
+		{
+			name:                       "not cloud API, url has no scheme",
+			connectDirectlyToCloudAPIs: true,
+			requestURL:                 withoutScheme("example.com"),
+			expectedDialDirectly:       false,
 		},
 		{
 			name:                       "do not connect directly to cloud APIs",
 			connectDirectlyToCloudAPIs: false,
-			isCloudAPI:                 true,
-			expected:                   false,
+			requestURL:                 u("cloudapi.com"),
+			expectedDialDirectly:       false,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			isCloudAPI := func(string) bool {
-				return tc.isCloudAPI
+			isCloudAPI := func(s string) bool {
+				return strings.HasSuffix(s, "cloudapi.com")
 			}
+			userProxyConfig := &httpproxy.Config{
+				HTTPProxy:  "http://proxy.example.com:3128",
+				HTTPSProxy: "https://proxy.example.com:3128",
+				NoProxy:    "dontproxy.com",
+			}
+			proxyConfigFunc := userProxyConfig.ProxyFunc()
 			userProxyFunc := func(u *url.URL) (*url.URL, error) {
-				if tc.emptyProxyURL {
+				if tc.proxyNotConfigured {
 					return nil, nil
 				}
-				return u, nil
+				return proxyConfigFunc(u)
 			}
 			g := NewGomegaWithT(t)
-			proxyURL, err := url.Parse("http://proxy.example.com:3128")
-			g.Expect(err).NotTo(HaveOccurred())
 			f := shouldDialDirectFunc(tc.connectDirectlyToCloudAPIs, isCloudAPI, userProxyFunc)
-			result, err := f(proxyURL)
+			result, err := f(tc.requestURL)
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(result).To(Equal(tc.expected))
+			g.Expect(result).To(Equal(tc.expectedDialDirectly))
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensure that request URL scheme is set before calling the function to determine if the request should be proxied. Most of the time the URL on the reuqest does not have a scheme, which results in the request not being proxied when it should be.

This fixes a regression introduced by
https://github.com/openshift/hypershift/pull/6207
The line that was forcing the scheme did not get included in the refactored code:
https://github.com/openshift/hypershift/pull/6207/files#diff-3cac822ca922efb3139322e3504be609cdf661749116ceda0bb40100f66e7563L176

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [OCPBUGS-61482](https://issues.redhat.com/browse/OCPBUGS-61482)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.