### PR TITLE
OCPBUGS-61687: fix(capi-provider): use single replica deployment for aws and azure

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/capi-provider/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/capi-provider/deployment.yaml
@@ -2,20 +2,4 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: capi-provider
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: capi-provider-controller-manager
-      control-plane: capi-provider-controller-manager
-  strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
-  template:
-    metadata:
-      labels:
-        app: capi-provider-controller-manager
-        control-plane: capi-provider-controller-manager
-    spec: {}
+spec: {}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -109,6 +109,7 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hy
 
 	defaultMode := int32(0640)
 	deploymentSpec := &appsv1.DeploymentSpec{
+		Replicas: ptr.To[int32](1),
 		Template: corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				TerminationGracePeriodSeconds: ptr.To[int64](10),

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
@@ -93,6 +93,7 @@ func (a Azure) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hy
 	}
 	defaultMode := int32(0640)
 	deploymentSpec := &appsv1.DeploymentSpec{
+		Replicas: ptr.To[int32](1),
 		Template: corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				TerminationGracePeriodSeconds: ptr.To[int64](10),

--- a/hypershift-operator/controllers/hostedcluster/testdata/capi-provider/zz_fixture_TestReconcileComponents.yaml
+++ b/hypershift-operator/controllers/hostedcluster/testdata/capi-provider/zz_fixture_TestReconcileComponents.yaml
@@ -10,17 +10,13 @@ metadata:
   namespace: hcp-namespace
   resourceVersion: "1"
 spec:
-  replicas: 2
+  replicas: 1
   revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: capi-provider-controller-manager
       control-plane: capi-provider-controller-manager
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-    type: RollingUpdate
+  strategy: {}
   template:
     metadata:
       annotations:

--- a/hypershift-operator/controllers/hostedcluster/testdata/capi-provider/zz_fixture_TestReconcileComponents_component.yaml
+++ b/hypershift-operator/controllers/hostedcluster/testdata/capi-provider/zz_fixture_TestReconcileComponents_component.yaml
@@ -14,7 +14,7 @@ status:
     status: "False"
     type: Available
   - lastTransitionTime: null
-    message: 'Waiting for deployment capi-provider rollout to finish: 0 out of 2 new
+    message: 'Waiting for deployment capi-provider rollout to finish: 0 out of 1 new
       replicas have been updated'
     reason: WaitingForRolloutComplete
     status: "False"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix capi-provider deployment replicas to be 1 for both AWS and Azure platforms.

- Remove unused replicas and deployment strategy from YAML template
- Update test fixtures to reflect single replica configuration

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.