### PR TITLE
CNTRLPLANE-1332: docs(azure): add self-managed cluster setup documentation

### DIFF
--- a/docs/content/how-to/azure/azure-workload-identity-setup.md
+++ b/docs/content/how-to/azure/azure-workload-identity-setup.md
@@ -1,0 +1,266 @@
+# Azure Workload Identity Setup for Self-Managed Clusters
+
+!!! note "Developer Preview in OCP 4.21"
+    
+    Self-managed Azure HostedClusters are available as a Developer Preview feature in OpenShift Container Platform 4.21.
+
+This document describes how to set up Azure Workload Identities and OIDC issuer for self-managed Azure HostedClusters.
+
+!!! warning "Persistent Resource Groups"
+    
+    When setting up workload identities and OIDC issuer for the first time, create them in a **persistent resource group** that will not be deleted when individual clusters are destroyed. This allows you to reuse the same workload identities and OIDC issuer across multiple HostedClusters, reducing setup time and avoiding unnecessary resource recreation.
+    
+    - Use a persistant resource group like `os4-common`.
+    - This resource group should be separate from the cluster-specific resource groups that get created and deleted with each HostedCluster.
+    - The OIDC issuer storage account should also be created in this persistent resource group.
+
+## Prerequisites
+
+- Azure CLI (`az`) installed and configured
+- `jq` command-line JSON processor
+- Cloud Credential Operator (CCO) tool installed
+- Appropriate Azure permissions
+
+## Create Azure Workload Identities
+
+Create managed identities for each OpenShift component that needs Azure access:
+
+```bash
+# Set environment variables
+PERSISTENT_RG_NAME="os4-common"  # Use persistent resource group
+LOCATION="eastus"
+CLUSTER_NAME="my-self-managed-cluster"
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+
+# Create persistent resource group (if it doesn't exist)
+az group create --name $PERSISTENT_RG_NAME --location $LOCATION
+
+# Create managed identities for each component
+declare -A COMPONENTS=(
+    ["image-registry"]="cluster-image-registry-operator"
+    ["ingress"]="cluster-ingress-operator"  
+    ["file-csi"]="cluster-storage-operator-file"
+    ["disk-csi"]="cluster-storage-operator-disk"
+    ["nodepool-mgmt"]="cluster-api-provider-azure"
+    ["cloud-provider"]="azure-cloud-provider"
+    ["network"]="cluster-network-operator"
+)
+
+# Create managed identities and capture client IDs
+declare -A CLIENT_IDS
+for component in "${!COMPONENTS[@]}"; do
+    echo "Creating managed identity for $component..."
+    CLIENT_ID=$(az identity create \
+        --name "${CLUSTER_NAME}-${component}" \
+        --resource-group $PERSISTENT_RG_NAME \
+        --query clientId -o tsv)
+    CLIENT_IDS[$component]=$CLIENT_ID
+    echo "Created identity ${CLUSTER_NAME}-${component} with client ID: $CLIENT_ID"
+done
+```
+
+## Create Workload Identities Configuration File
+
+Create a JSON file with all the workload identity client IDs:
+
+```bash
+cat <<EOF > workload-identities.json
+{
+  "imageRegistry": {
+    "clientID": "${CLIENT_IDS[image-registry]}"
+  },
+  "ingress": {
+    "clientID": "${CLIENT_IDS[ingress]}"
+  },
+  "file": {
+    "clientID": "${CLIENT_IDS[file-csi]}"
+  },
+  "disk": {
+    "clientID": "${CLIENT_IDS[disk-csi]}"
+  },
+  "nodePoolManagement": {
+    "clientID": "${CLIENT_IDS[nodepool-mgmt]}"
+  },
+  "cloudProvider": {
+    "clientID": "${CLIENT_IDS[cloud-provider]}"
+  },
+  "network": {
+    "clientID": "${CLIENT_IDS[network]}"
+  }
+}
+EOF
+```
+
+## Configure OIDC Issuer
+
+Use the Cloud Credential Operator (CCO) tool to create the OIDC issuer:
+
+```bash
+# Set OIDC issuer variables (reusing variables from previous steps)
+OIDC_STORAGE_ACCOUNT_NAME="yourstorageaccount"
+TENANT_ID="your-tenant-id"
+# SUBSCRIPTION_ID and PERSISTENT_RG_NAME already set from previous section
+# Create an RSA key pair and save the private and public key
+ccoctl azure create-key-pair  
+
+SA_TOKEN_ISSUER_PRIVATE_KEY_PATH="/path/to/serviceaccount-signer.private"
+SA_TOKEN_ISSUER_PUBLIC_KEY_PATH="/path/to/serviceaccount-signer.public"
+
+# Create OIDC issuer using CCO tool in os4-common resource group
+ccoctl azure create-oidc-issuer \
+    --oidc-resource-group-name ${PERSISTENT_RG_NAME} \
+    --tenant-id ${TENANT_ID} \
+    --region ${LOCATION} \
+    --name ${OIDC_STORAGE_ACCOUNT_NAME} \
+    --subscription-id ${SUBSCRIPTION_ID} \
+    --public-key-file ${SA_TOKEN_ISSUER_PUBLIC_KEY_PATH}
+
+# Set OIDC issuer URL
+OIDC_ISSUER_URL="https://${OIDC_STORAGE_ACCOUNT_NAME}.blob.core.windows.net/${OIDC_STORAGE_ACCOUNT_NAME}"
+```
+
+## Set Up Federated Identity Credentials
+
+Configure federated identity credentials for each workload identity. These establish trust between Azure Entra ID and the specific service accounts in your HostedCluster:
+
+```bash
+# Define workload identity names (matching those created earlier)
+# These should match the managed identities created in the previous section
+AZURE_DISK_MI_NAME="${CLUSTER_NAME}-disk-csi"
+AZURE_FILE_MI_NAME="${CLUSTER_NAME}-file-csi"
+IMAGE_REGISTRY_MI_NAME="${CLUSTER_NAME}-image-registry"
+INGRESS_MI_NAME="${CLUSTER_NAME}-ingress"
+CLOUD_PROVIDER_MI_NAME="${CLUSTER_NAME}-cloud-provider"
+NODE_POOL_MANAGEMENT_MI_NAME="${CLUSTER_NAME}-nodepool-mgmt"
+NETWORK_MI_NAME="${CLUSTER_NAME}-network"
+
+# Azure Disk CSI Driver federated credentials
+az identity federated-credential create \
+    --name "${AZURE_DISK_MI_NAME}-fed-id-node" \
+    --identity-name "${AZURE_DISK_MI_NAME}" \
+    --resource-group "${PERSISTENT_RG_NAME}" \
+    --issuer "${OIDC_ISSUER_URL}" \
+    --subject system:serviceaccount:openshift-cluster-csi-drivers:azure-disk-csi-driver-node-sa \
+    --audience openshift
+
+az identity federated-credential create \
+    --name "${AZURE_DISK_MI_NAME}-fed-id-operator" \
+    --identity-name "${AZURE_DISK_MI_NAME}" \
+    --resource-group "${PERSISTENT_RG_NAME}" \
+    --issuer "${OIDC_ISSUER_URL}" \
+    --subject system:serviceaccount:openshift-cluster-csi-drivers:azure-disk-csi-driver-operator \
+    --audience openshift
+
+az identity federated-credential create \
+    --name "${AZURE_DISK_MI_NAME}-fed-id-controller" \
+    --identity-name "${AZURE_DISK_MI_NAME}" \
+    --resource-group "${PERSISTENT_RG_NAME}" \
+    --issuer "${OIDC_ISSUER_URL}" \
+    --subject system:serviceaccount:openshift-cluster-csi-drivers:azure-disk-csi-driver-controller-sa \
+    --audience openshift
+
+# Azure File CSI Driver federated credentials
+az identity federated-credential create \
+    --name "${AZURE_FILE_MI_NAME}-fed-id-node" \
+    --identity-name "${AZURE_FILE_MI_NAME}" \
+    --resource-group "${PERSISTENT_RG_NAME}" \
+    --issuer "${OIDC_ISSUER_URL}" \
+    --subject system:serviceaccount:openshift-cluster-csi-drivers:azure-file-csi-driver-node-sa \
+    --audience openshift
+
+az identity federated-credential create \
+    --name "${AZURE_FILE_MI_NAME}-fed-id-operator" \
+    --identity-name "${AZURE_FILE_MI_NAME}" \
+    --resource-group "${PERSISTENT_RG_NAME}" \
+    --issuer "${OIDC_ISSUER_URL}" \
+    --subject system:serviceaccount:openshift-cluster-csi-drivers:azure-file-csi-driver-operator \
+    --audience openshift
+
+az identity federated-credential create \
+    --name "${AZURE_FILE_MI_NAME}-fed-id-controller" \
+    --identity-name "${AZURE_FILE_MI_NAME}" \
+    --resource-group "${PERSISTENT_RG_NAME}" \
+    --issuer "${OIDC_ISSUER_URL}" \
+    --subject system:serviceaccount:openshift-cluster-csi-drivers:azure-file-csi-driver-controller-sa \
+    --audience openshift
+
+# Image Registry federated credentials
+az identity federated-credential create \
+    --name "${IMAGE_REGISTRY_MI_NAME}-fed-id-registry" \
+    --identity-name "${IMAGE_REGISTRY_MI_NAME}" \
+    --resource-group "${PERSISTENT_RG_NAME}" \
+    --issuer "${OIDC_ISSUER_URL}" \
+    --subject system:serviceaccount:openshift-image-registry:registry \
+    --audience openshift
+
+az identity federated-credential create \
+    --name "${IMAGE_REGISTRY_MI_NAME}-fed-id-operator" \
+    --identity-name "${IMAGE_REGISTRY_MI_NAME}" \
+    --resource-group "${PERSISTENT_RG_NAME}" \
+    --issuer "${OIDC_ISSUER_URL}" \
+    --subject system:serviceaccount:openshift-image-registry:cluster-image-registry-operator \
+    --audience openshift
+
+# Ingress Operator federated credential
+az identity federated-credential create \
+    --name "${INGRESS_MI_NAME}-fed-id" \
+    --identity-name "${INGRESS_MI_NAME}" \
+    --resource-group "${PERSISTENT_RG_NAME}" \
+    --issuer "${OIDC_ISSUER_URL}" \
+    --subject system:serviceaccount:openshift-ingress-operator:ingress-operator \
+    --audience openshift
+
+# Cloud Provider federated credential
+az identity federated-credential create \
+    --name "${CLOUD_PROVIDER_MI_NAME}-fed-id" \
+    --identity-name "${CLOUD_PROVIDER_MI_NAME}" \
+    --resource-group "${PERSISTENT_RG_NAME}" \
+    --issuer "${OIDC_ISSUER_URL}" \
+    --subject system:serviceaccount:kube-system:azure-cloud-provider \
+    --audience openshift
+
+# Node Pool Management federated credential
+az identity federated-credential create \
+    --name "${NODE_POOL_MANAGEMENT_MI_NAME}-fed-id" \
+    --identity-name "${NODE_POOL_MANAGEMENT_MI_NAME}" \
+    --resource-group "${PERSISTENT_RG_NAME}" \
+    --issuer "${OIDC_ISSUER_URL}" \
+    --subject system:serviceaccount:kube-system:capi-provider \
+    --audience openshift
+
+# Network Operator federated credential
+az identity federated-credential create \
+    --name "${NETWORK_MI_NAME}-fed-id" \
+    --identity-name "${NETWORK_MI_NAME}" \
+    --resource-group "${PERSISTENT_RG_NAME}" \
+    --issuer "${OIDC_ISSUER_URL}" \
+    --subject system:serviceaccount:openshift-cloud-network-config-controller:cloud-network-config-controller \
+    --audience openshift
+```
+
+!!! note "Service Account Mapping"
+    
+    Each federated identity credential maps a specific Azure managed identity to an OpenShift service account. The service accounts listed above are the default service accounts used by various OpenShift components for Azure integration.
+
+## Verification
+
+Verify the setup:
+
+```bash
+# List created managed identities
+az identity list --resource-group $PERSISTENT_RG_NAME --output table
+
+# Verify federated credentials for one identity
+az identity federated-credential list \
+    --identity-name "${AZURE_DISK_MI_NAME}" \
+    --resource-group $PERSISTENT_RG_NAME
+
+# Test OIDC issuer accessibility
+curl -s "${OIDC_ISSUER_URL}/.well-known/openid-configuration" | jq .
+```
+
+## Next Steps
+
+After setting up workload identities, you can proceed to:
+
+- [Setup Azure Management Cluster for HyperShift](setup-management-cluster.md)

--- a/docs/content/how-to/azure/create-self-managed-azure-cluster.md
+++ b/docs/content/how-to/azure/create-self-managed-azure-cluster.md
@@ -1,0 +1,200 @@
+# Create a Self-Managed Azure HostedCluster
+
+!!! note "Developer Preview in OCP 4.21"
+    
+    Self-managed Azure HostedClusters are available as a Developer Preview feature in OpenShift Container Platform 4.21.
+
+This document describes how to create a self-managed Azure HostedCluster using workload identities for authentication.
+
+## Overview
+
+Self-managed Azure HostedClusters use [Azure Workload Identity](https://azure.github.io/azure-workload-identity/docs/) for authentication.
+
+## Prerequisites
+
+Before creating a self-managed Azure HostedCluster, ensure you have:
+
+- Azure CLI (`az`) installed and configured
+- HyperShift CLI binary
+- OpenShift CLI (`oc`) or Kubernetes CLI (`kubectl`)
+- `jq` command-line JSON processor
+- An Azure OpenShift management cluster with HyperShift operator and ExternalDNS installed
+- External DNS configured for the management cluster
+- Azure workload identities and OIDC issuer configured
+- Appropriate Azure permissions (see [Permission Requirements](#permission-requirements))
+
+!!! note "Setup Requirements"
+    
+    This guide assumes you have already completed the workload identity configuration and management cluster setup. Follow these guides in order:
+    
+    1. [Azure Workload Identity Setup](azure-workload-identity-setup.md) - Workload identities and OIDC issuer configuration
+    2. [Setup Azure Management Cluster for HyperShift](setup-management-cluster.md) - ExternalDNS and HyperShift operator installation
+
+### Permission Requirements
+
+Your Azure service principal must have the following permissions:
+
+- **Subscription Level**:
+  - `Contributor` role
+  - `User Access Administrator` role
+- **Microsoft Graph API**:
+  - `Application.ReadWrite.OwnedBy` permission (requires DPTP request in most cases)
+
+## Creating the Self-Managed Azure HostedCluster
+
+### Infrastructure Setup
+
+Before creating the HostedCluster, set up the necessary Azure infrastructure:
+
+!!! note "About PERSISTENT_RG_NAME"
+    In Red Hat environments, a periodic Azure resource "reaper" deletes resources that are not properly tagged or not located in an approved resource group. We frequently use the `os4-common` resource group for shared, long-lived assets (for example, public DNS zones) to avoid accidental cleanup. If you are not in Red Hat infrastructure, set `PERSISTENT_RG_NAME` to any long-lived resource group in your subscription that will not be automatically reaped, or ensure your organization’s required tags/policies are applied. The name does not have to be `os4-common`—use whatever persistent resource group fits your environment.
+
+```bash
+# Set cluster configuration variables
+PREFIX="your-prefix-sm"
+RELEASE_IMAGE="quay.io/openshift-release-dev/ocp-release:XYZ"
+TAG="latest"
+
+LOCATION="eastus"
+MANAGED_RG_NAME="${PREFIX}-managed-rg"
+VNET_RG_NAME="${PREFIX}-customer-vnet-rg"
+NSG_RG_NAME="${PREFIX}-customer-nsg-rg"
+VNET_NAME="${PREFIX}-customer-vnet"
+VNET_SUBNET1="${PREFIX}-customer-subnet-1"
+NSG="${PREFIX}-customer-nsg"
+DNS_ZONE_NAME="your-subdomain.your-parent.dns.zone.com"
+CLUSTER_NAMESPACE="clusters"
+CLUSTER_NAME="${PREFIX}-hc"
+AZURE_CREDS="/path/to/azure/credentials"
+PULL_SECRET="/path/to/pull-secret.json"
+HYPERSHIFT_BINARY_PATH="/path/to/hypershift/bin"
+OIDC_ISSUER_URL="https://yourstorageaccount.blob.core.windows.net/yourstorageaccount"
+SA_TOKEN_ISSUER_PRIVATE_KEY_PATH="/path/to/serviceaccount-signer.private"
+PERSISTENT_RG_NAME="os4-common"
+PARENT_DNS_ZONE="your-parent.dns.zone.com"
+
+# Clean up any previous instances (optional)
+az group delete -n "${VNET_RG_NAME}" --yes --no-wait || true
+az group delete -n "${NSG_RG_NAME}" --yes --no-wait || true
+
+# Create managed resource group
+az group create --name "${MANAGED_RG_NAME}" --location ${LOCATION}
+
+# Create VNET & NSG resource groups
+az group create --name "${VNET_RG_NAME}" --location ${LOCATION}
+az group create --name "${NSG_RG_NAME}" --location ${LOCATION}
+
+# Create network security group
+az network nsg create \
+    --resource-group "${NSG_RG_NAME}" \
+    --name "${NSG}"
+
+# Get NSG ID
+GetNsgID=$(az network nsg list --query "[?name=='${NSG}'].id" -o tsv)
+
+# Create VNet with subnet
+az network vnet create \
+    --name "${VNET_NAME}" \
+    --resource-group "${VNET_RG_NAME}" \
+    --address-prefix 10.0.0.0/16 \
+    --subnet-name "${VNET_SUBNET1}" \
+    --subnet-prefixes 10.0.0.0/24 \
+    --nsg "${GetNsgID}"
+
+# Get VNet and Subnet IDs
+GetVnetID=$(az network vnet list --query "[?name=='${VNET_NAME}'].id" -o tsv)
+GetSubnetID=$(az network vnet subnet show \
+    --vnet-name "${VNET_NAME}" \
+    --name "${VNET_SUBNET1}" \
+    --resource-group "${VNET_RG_NAME}" \
+    --query id --output tsv)
+```
+
+### Create the HostedCluster
+
+!!! note "Federated Identity Prerequisites"
+    
+    Before creating the cluster, ensure that all federated identity credentials have been set up for your workload identities as described in the [Azure Workload Identity Setup](azure-workload-identity-setup.md) guide. The cluster creation will fail if these are not properly configured.
+
+Create the HostedCluster with comprehensive configuration:
+
+```bash
+# Create the HostedCluster
+${HYPERSHIFT_BINARY_PATH}/hypershift create cluster azure \
+    --name "$CLUSTER_NAME" \
+    --namespace "$CLUSTER_NAMESPACE" \
+    --azure-creds $AZURE_CREDS \
+    --location ${LOCATION} \
+    --node-pool-replicas 2 \
+    --base-domain $PARENT_DNS_ZONE \
+    --pull-secret $PULL_SECRET \
+    --generate-ssh \
+    --release-image ${RELEASE_IMAGE} \
+    --external-dns-domain ${DNS_ZONE_NAME} \
+    --resource-group-name "${MANAGED_RG_NAME}" \
+    --vnet-id "${GetVnetID}" \
+    --subnet-id "${GetSubnetID}" \
+    --network-security-group-id "${GetNsgID}" \
+    --sa-token-issuer-private-key-path "${SA_TOKEN_ISSUER_PRIVATE_KEY_PATH}" \
+    --oidc-issuer-url "${OIDC_ISSUER_URL}" \
+    --control-plane-operator-image="quay.io/hypershift/hypershift:${TAG}" \
+    --marketplace-publisher azureopenshift \
+    --marketplace-offer aro4 \
+    --marketplace-sku aro_419 \
+    --marketplace-version 419.6.20250523 \
+    --dns-zone-rg-name ${PERSISTENT_RG_NAME} \
+    --assign-service-principal-roles \
+    --workload-identities-file ./workload-identities.json \
+    --diagnostics-storage-account-type Managed
+```
+
+!!! important "Key Configuration Options"
+    
+    - `--workload-identities-file`: References the workload identities configuration created in the setup guide
+    - `--assign-service-principal-roles`: Automatically assigns required Azure roles to workload identities
+    - `--sa-token-issuer-private-key-path`: Path to the private key for service account token signing
+    - `--oidc-issuer-url`: URL of the OIDC issuer created in the workload identity setup
+    - `--vnet-id`, `--subnet-id`, `--network-security-group-id`: Custom networking infrastructure
+    - `--marketplace-*`: Azure Marketplace image information for ARO-based node images
+    - `--dns-zone-rg-name`: Resource group containing the DNS zone (os4-common)
+    - `--diagnostics-storage-account-type Managed`: Use Azure managed storage for diagnostics
+    - `--control-plane-operator-image`: Custom HyperShift operator image (optional)
+
+## Verification
+
+Check the cluster status and access:
+
+```bash
+# Check HostedCluster status
+oc get hostedcluster $CLUSTER_NAME -n clusters
+
+# Wait for cluster to be available
+oc wait --for=condition=Available hostedcluster/$CLUSTER_NAME -n clusters --timeout=30m
+
+# Get kubeconfig and access the cluster
+hypershift create kubeconfig --name $CLUSTER_NAME > $CLUSTER_NAME-kubeconfig
+export KUBECONFIG=$CLUSTER_NAME-kubeconfig
+oc get nodes
+oc get clusterversion
+```
+
+## Cleanup
+
+To delete the HostedCluster:
+
+```bash
+# Delete the HostedCluster
+hypershift destroy cluster azure \
+    --name $CLUSTER_NAME \
+    --azure-creds $AZURE_CREDS \
+    --resource-group-name $MANAGED_RG_NAME
+```
+
+!!! note "Resource Cleanup"
+    
+    The HyperShift destroy command will clean up the cluster resources. Workload identities and OIDC issuer created during setup can be reused for other clusters or cleaned up separately if no longer needed.
+
+## Related Documentation
+
+1. [Azure Workload Identity Setup](azure-workload-identity-setup.md) - Workload identities and OIDC issuer setup
+2. [Setup Azure Management Cluster for HyperShift](setup-management-cluster.md) - DNS and HyperShift operator setup

--- a/docs/content/how-to/azure/setup-management-cluster.md
+++ b/docs/content/how-to/azure/setup-management-cluster.md
@@ -1,0 +1,156 @@
+# Setup Azure Management Cluster for HyperShift
+
+!!! note "Developer Preview in OCP 4.21"
+    
+    Self-managed Azure HostedClusters are available as a Developer Preview feature in OpenShift Container Platform 4.21.
+
+This document describes how to set up DNS and install the HyperShift operator on your Azure management cluster.
+
+## Prerequisites
+
+- Azure CLI (`az`) installed and configured
+- OpenShift CLI (`oc`) or Kubernetes CLI (`kubectl`)
+- `jq` command-line JSON processor
+- An Azure OpenShift management cluster
+
+## DNS Zone Configuration
+
+Before creating HostedClusters, you need to set up DNS zones and delegate DNS records for your clusters.
+
+!!! note "About PERSISTENT_RG_NAME"
+    In Red Hat environments, a periodic Azure resource "reaper" deletes resources that are not properly tagged or not located in an approved resource group. We frequently use the `os4-common` resource group for shared, long-lived assets (for example, public DNS zones) to avoid accidental cleanup. If you are not in Red Hat infrastructure, set `PERSISTENT_RG_NAME` to any long-lived resource group in your subscription that will not be automatically reaped, or ensure your organization’s required tags/policies are applied. The name does not have to be `os4-common`—use whatever persistent resource group fits your environment.
+
+```bash
+# Set DNS configuration variables
+PARENT_DNS_RG="your-parent-dns-rg"
+PARENT_DNS_ZONE="your-parent.dns.zone.com"
+DNS_RECORD_NAME="your-subdomain"
+PERSISTENT_RG_NAME="os4-common"  # Use persistent resource group
+DNS_ZONE_NAME="your-subdomain.your-parent.dns.zone.com"
+
+az group create \  
+      --name $PERSISTENT_RG_NAME \  
+      --location $LOCATION  
+
+az network dns zone create \  
+        --resource-group $PERSISTENT_RG_NAME \  
+        --name $DNS_ZONE_NAME  
+
+# Delete existing NS record if it exists
+az network dns record-set ns delete \
+    --resource-group $PARENT_DNS_RG \
+    --zone-name $PARENT_DNS_ZONE \
+    --name $DNS_RECORD_NAME -y
+
+# Get name servers from your DNS zone
+name_servers=$(az network dns zone show \
+    --resource-group $PERSISTENT_RG_NAME \
+    --name $DNS_ZONE_NAME \
+    --query nameServers \
+    --output tsv)
+
+# Create array of name servers
+ns_array=()
+while IFS= read -r ns; do
+    ns_array+=("$ns")
+done <<< "$name_servers"
+
+# Add NS records to parent zone
+for ns in "${ns_array[@]}"; do
+    az network dns record-set ns add-record \
+        --resource-group $PARENT_DNS_RG \
+        --zone-name $PARENT_DNS_ZONE \
+        --record-set-name $DNS_RECORD_NAME \
+        --nsdname "$ns"
+done
+```
+
+## External DNS Service Principal Setup
+
+Create a dedicated service principal for External DNS:
+
+```bash
+# Set External DNS configuration
+EXTERNAL_DNS_NEW_SP_NAME="ExternalDnsServicePrincipal"
+SERVICE_PRINCIPAL_FILEPATH="/path/to/azure_mgmt.json"
+PERSISTENT_RG_NAME="hypershift-shared-resources"  # Use persistent resource group
+
+# Create service principal for External DNS
+DNS_SP=$(az ad sp create-for-rbac --name ${EXTERNAL_DNS_NEW_SP_NAME})
+EXTERNAL_DNS_SP_APP_ID=$(echo "$DNS_SP" | jq -r '.appId')
+EXTERNAL_DNS_SP_PASSWORD=$(echo "$DNS_SP" | jq -r '.password')
+
+# Get DNS zone ID
+DNS_ID=$(az network dns zone show \
+    --name ${DNS_ZONE_NAME} \
+    --resource-group ${PERSISTENT_RG_NAME} \
+    --query "id" \
+    --output tsv)
+
+# Assign roles to the service principal
+az role assignment create \
+    --role "Reader" \
+    --assignee "${EXTERNAL_DNS_SP_APP_ID}" \
+    --scope "${DNS_ID}"
+
+az role assignment create \
+    --role "Contributor" \
+    --assignee "${EXTERNAL_DNS_SP_APP_ID}" \
+    --scope "${DNS_ID}"
+
+# Create Azure credentials file
+cat <<-EOF > ${SERVICE_PRINCIPAL_FILEPATH}
+{
+  "tenantId": "$(az account show --query tenantId -o tsv)",
+  "subscriptionId": "$(az account show --query id -o tsv)",
+  "resourceGroup": "$PERSISTENT_RG_NAME",
+  "aadClientId": "$EXTERNAL_DNS_SP_APP_ID",
+  "aadClientSecret": "$EXTERNAL_DNS_SP_PASSWORD"
+}
+EOF
+
+# Create Kubernetes secret for Azure credentials
+kubectl delete secret/azure-config-file --namespace "default" || true
+kubectl create secret generic azure-config-file \
+    --namespace "default" \
+    --from-file ${SERVICE_PRINCIPAL_FILEPATH}
+```
+
+## HyperShift Operator Installation
+
+Install the HyperShift operator with External DNS configuration on your Azure management cluster:
+
+```bash
+# Set installation variables
+TAG="self-managed-2025-09-04-1"  # Use appropriate tag
+PULL_SECRET="/path/to/pull-secret.json"
+HYPERSHIFT_BINARY_PATH="/path/to/hypershift/bin"
+
+# Install HyperShift operator
+${HYPERSHIFT_BINARY_PATH}/hypershift install \
+    --external-dns-provider=azure \
+    --external-dns-credentials ${SERVICE_PRINCIPAL_FILEPATH} \
+    --pull-secret ${PULL_SECRET} \
+    --external-dns-domain-filter ${DNS_ZONE_NAME} \
+    --limit-crd-install Azure \
+    --hypershift-image quay.io/hypershift/hypershift:${TAG}
+```
+
+!!! important "HyperShift Image"
+    
+    Replace the `--hypershift-image` value with the appropriate image for your environment. Or remove this flag completely if not using a custom HyperShift Operator image.
+
+## Verification
+
+After installation, verify that the HyperShift operator and External DNS are running:
+
+```bash
+# Check HyperShift operator and ExternalDNS pods
+oc get pods -n hypershift
+```
+
+## Next Steps
+
+Once the management cluster is set up, you can proceed to:
+
+- [Create a Self-Managed Azure HostedCluster](create-self-managed-azure-cluster.md)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -106,9 +106,14 @@ nav:
         - how-to/aws/troubleshooting/debug-nodes.md
         - how-to/aws/troubleshooting/troubleshooting-disaster-recovery.md
   - 'Azure':
-    - how-to/azure/create-azure-cluster-on-aks.md
-    - how-to/azure/create-azure-cluster-with-options.md
-    - how-to/azure/scheduler.md
+    - 'Managed Azure':
+      - how-to/azure/create-azure-cluster-on-aks.md
+      - how-to/azure/create-azure-cluster-with-options.md
+      - how-to/azure/scheduler.md
+    - 'Self-managed Azure':
+      - how-to/azure/azure-workload-identity-setup.md
+      - how-to/azure/setup-management-cluster.md
+      - how-to/azure/create-self-managed-azure-cluster.md
     - 'Global Pull Secret': how-to/azure/global-pull-secret.md
     - 'Troubleshooting':
         - how-to/azure/troubleshooting/index.md


### PR DESCRIPTION
**What this PR does / why we need it**:
Add comprehensive guides for setting up self-managed Azure HostedClusters:
- Azure workload identity setup with OIDC issuer configuration
- Management cluster setup for HyperShift operator and ExternalDNS
- Self-managed HostedCluster creation with workload identity authentication
- Update mkdocs navigation to organize Azure docs by managed/self-managed

**Which issue(s) this PR fixes**:
Fixes [CNTRLPLANE-1332](https://issues.redhat.com/browse/CNTRLPLANE-1332)

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.