### PR TITLE
[release-4.19] OCPBUGS-61677: resolve MIRRORED_RELEASE_IMAGE flapping

### DIFF
--- a/support/globalconfig/imagecontentsource.go
+++ b/support/globalconfig/imagecontentsource.go
@@ -134,8 +134,18 @@ func getImageDigestMirrorSets(ctx context.Context, client crclient.Client) (map[
 		for _, imageDigestMirror := range item.Spec.ImageDigestMirrors {
 			source := imageDigestMirror.Source
 
+			// Skip empty sources
+			if source == "" {
+				continue
+			}
+
 			for n := range imageDigestMirror.Mirrors {
-				idmsRegistryOverrides[source] = append(idmsRegistryOverrides[source], string(imageDigestMirror.Mirrors[n]))
+				mirror := string(imageDigestMirror.Mirrors[n])
+				// Skip empty mirrors
+				if mirror == "" {
+					continue
+				}
+				idmsRegistryOverrides[source] = append(idmsRegistryOverrides[source], mirror)
 			}
 		}
 	}
@@ -164,7 +174,22 @@ func getImageContentSourcePolicies(ctx context.Context, client crclient.Client) 
 		for _, mirror := range item.Spec.RepositoryDigestMirrors {
 			source := mirror.Source
 
-			icspRegistryOverrides[source] = append(icspRegistryOverrides[source], mirror.Mirrors...)
+			// Skip empty sources
+			if source == "" {
+				continue
+			}
+
+			// Filter out empty mirrors
+			var validMirrors []string
+			for _, m := range mirror.Mirrors {
+				if m != "" {
+					validMirrors = append(validMirrors, m)
+				}
+			}
+
+			if len(validMirrors) > 0 {
+				icspRegistryOverrides[source] = append(icspRegistryOverrides[source], validMirrors...)
+			}
 		}
 	}
 

--- a/support/releaseinfo/registry_image_content_policies.go
+++ b/support/releaseinfo/registry_image_content_policies.go
@@ -48,6 +48,8 @@ func (p *ProviderWithOpenShiftImageRegistryOverridesDecorator) Lookup(ctx contex
 		}
 	}
 
+	// Reset mirrored release image when falling back to original
+	p.mirroredReleaseImage = ""
 	return p.Delegate.Lookup(ctx, image, pullSecret)
 }
 

--- a/support/util/imagemetadata.go
+++ b/support/util/imagemetadata.go
@@ -56,7 +56,7 @@ func (r *RegistryClientImageMetadataProvider) ImageMetadata(ctx context.Context,
 	}
 
 	// Get the image repo info based the source/mirrors in the ICSPs/IDMSs
-	ref := seekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret)
+	ref := SeekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret)
 	refPullSpec := ref.String()
 
 	// Check the cache for the image
@@ -100,7 +100,7 @@ func (r *RegistryClientImageMetadataProvider) GetOverride(ctx context.Context, i
 		return nil, fmt.Errorf("failed to parse image reference %q: %w", imageRef, err)
 	}
 
-	ref = seekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret)
+	ref = SeekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret)
 
 	return ref, nil
 }
@@ -133,7 +133,7 @@ func (r *RegistryClientImageMetadataProvider) GetDigest(ctx context.Context, ima
 	}
 
 	// Get the image repo info based the source/mirrors in the ICSPs/IDMSs
-	ref = seekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret)
+	ref = SeekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret)
 	composedRef := ref.String()
 
 	// If the overridden image name is in the cache, return early
@@ -180,7 +180,7 @@ func (r *RegistryClientImageMetadataProvider) GetManifest(ctx context.Context, i
 	}
 
 	// Get the image repo info based the source/mirrors in the ICSPs/IDMSs
-	ref := seekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret)
+	ref := SeekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret)
 
 	// Check the cache for the image
 	if manifest, exists := manifestsCache.Get(ref.String()); exists {
@@ -217,7 +217,7 @@ func (r *RegistryClientImageMetadataProvider) GetMetadata(ctx context.Context, i
 	}
 
 	// Get the image repo info based the source/mirrors in the ICSPs/IDMSs
-	ref = seekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret)
+	ref = SeekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret)
 	composedRef := ref.String()
 
 	return getMetadata(ctx, composedRef, pullSecret)
@@ -438,10 +438,18 @@ func GetPayloadVersion(ctx context.Context, releaseImageProvider releaseinfo.Pro
 	return &version, nil
 }
 
-func seekOverride(ctx context.Context, openshiftImageRegistryOverrides map[string][]string, parsedImageReference reference.DockerImageReference, pullSecret []byte) *reference.DockerImageReference {
+func SeekOverride(ctx context.Context, openshiftImageRegistryOverrides map[string][]string, parsedImageReference reference.DockerImageReference, pullSecret []byte) *reference.DockerImageReference {
 	log := ctrl.LoggerFrom(ctx)
 	for source, mirrors := range openshiftImageRegistryOverrides {
+		// Skip empty sources
+		if source == "" {
+			continue
+		}
 		for _, mirror := range mirrors {
+			// Skip empty mirrors
+			if mirror == "" {
+				continue
+			}
 			ref, overrideFound, err := GetRegistryOverrides(ctx, parsedImageReference, source, mirror)
 			if err != nil {
 				log.Info(fmt.Sprintf("failed to find registry override for image reference %q with source, %s, mirror %s: %s", parsedImageReference, source, mirror, err.Error()))

--- a/support/util/imagemetadata_test.go
+++ b/support/util/imagemetadata_test.go
@@ -426,7 +426,7 @@ func TestSeekOverride(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to read manifests file: %v", err)
 			}
-			imgRef := seekOverride(ctx, tc.overrides, tc.imageRef, pullSecret)
+			imgRef := SeekOverride(ctx, tc.overrides, tc.imageRef, pullSecret)
 			g.Expect(imgRef).To(Equal(tc.expectedImgRef), fmt.Sprintf("Expected image reference to be equal to: %v, \nbut got: %v", tc.expectedImgRef, imgRef))
 		})
 	}

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -357,6 +357,11 @@ func ConvertImageRegistryOverrideStringToMap(envVar string) map[string][]string 
 		registry := registryMirror[0]
 		mirror := registryMirror[1]
 
+		// Skip empty registry or mirror entries
+		if registry == "" || mirror == "" {
+			continue
+		}
+
 		imageRegistryOverrides[registry] = append(imageRegistryOverrides[registry], mirror)
 	}
 


### PR DESCRIPTION
This is manual cherry-pick of https://github.com/openshift/hypershift/pull/6803.
This is done manual due to build errors

/cherrypick release-4.18