### PR TITLE
fix(disable-psa): disable PSA check for 4.20

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -981,7 +981,7 @@ func EnsureMachineDeploymentGeneration(t *testing.T, ctx context.Context, hostCl
 
 func EnsurePSANotPrivileged(t *testing.T, ctx context.Context, guestClient crclient.Client) {
 	t.Run("EnsurePSANotPrivileged", func(t *testing.T) {
-		AtLeast(t, Version420)
+		AtLeast(t, Version421)
 		testNamespaceName := "e2e-psa-check"
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
PSA was disabled for 4.20 so don't check EnsurePSANotPrivileged

prereq for https://github.com/openshift/hypershift/pull/6830