### PR TITLE
CNTRLPLANE-1423: feat(konflux): tag MCE HO images with latest

### DIFF
--- a/.tekton/hypershift-release-mce-29-push.yaml
+++ b/.tekton/hypershift-release-mce-29-push.yaml
@@ -40,6 +40,9 @@ spec:
     value: "true"
   - name: path-context
     value: .
+  - name: additional-tags
+    value:
+    - "latest"
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to simplify Multi Cluster Engine HyperShift Operator image discovery in Quality Engineering verification, let's tag the built images in Konflux so it is always evident which is the latest build.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes # [CNTRLPLANE-1423](https://issues.redhat.com//browse/CNTRLPLANE-1423)

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.