### PR TITLE
OCPBUGS-61438: fix(security): harden konnectivity-agent DaemonSet security context

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/reconcile.go
@@ -160,6 +160,14 @@ func buildKonnectivityWorkerAgentContainer(image, host string, port int32, proxy
 		}
 		c.TerminationMessagePolicy = corev1.TerminationMessageFallbackToLogsOnError
 		c.VolumeMounts = volumeMounts.ContainerMounts(c.Name)
+		c.SecurityContext = &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.To(false),
+			ReadOnlyRootFilesystem:   ptr.To(true),
+			RunAsNonRoot:             ptr.To(true),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+		}
 		c.Resources = corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("50Mi"),


### PR DESCRIPTION
## What this PR does / why we need it
- Add allowPrivilegeEscalation: false to prevent privilege escalation
- Enable readOnlyRootFilesystem: true for immutable container filesystem
- Set runAsNonRoot: true to enforce non-root execution
- Drop all capabilities with capabilities.drop: [ALL]

## Which issue(s) this PR fixes
- Fixes #[OCPBUGS-61438](https://issues.redhat.com/browse/OCPBUGS-61438)