### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for hypershift-cli-mce-29

### DIFF
--- a/Containerfile.cli
+++ b/Containerfile.cli
@@ -29,6 +29,7 @@ LABEL name="multicluster-engine/hypershift-cli-rhel9" \
       url="https://catalog.redhat.com/software/containers/multicluster-engine/hypershift-cli-rhel9/" \
       version="4.19" \
       com.redhat.component="multicluster-engine-hypershift-cli-container" \
+      cpe="cpe:/a:redhat:multicluster_engine:2.9::el9" \
       io.openshift.tags="data,images" \
       io.k8s.display-name="multicluster-engine-hypershift-cli" \
       io.k8s.description="HyperShift HCP CLI for managing the lifecycle of Hosted Clusters via the command line."


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
