### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for hypershift-release-mce-29

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -18,7 +18,8 @@ COPY --from=builder /hypershift/bin/hypershift \
 
 ENTRYPOINT ["/usr/bin/hypershift"]
 
-LABEL name="multicluster-engine/hypershift-operator"
+LABEL name="multicluster-engine/hypershift-rhel9-operator"
+LABEL cpe="cpe:/a:redhat:multicluster_engine:2.9::el9"
 LABEL description="HyperShift Operator is an operator to manage the lifecycle of Hosted Clusters"
 LABEL summary="HyperShift Operator"
 LABEL url="https://catalog.redhat.com/software/containers/multicluster-engine/hypershift-rhel9-operator/"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
