### PR TITLE
wait for component rollout in all cases

### DIFF
--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -34,11 +34,6 @@ func TestUpgradeControlPlane(t *testing.T) {
 		// Sanity check the cluster by waiting for the nodes to report ready
 		guestClient := e2eutil.WaitForGuestClient(t, ctx, mgtClient, hostedCluster)
 
-		var startingVersion string
-		if len(hostedCluster.Status.Version.History) > 0 {
-			startingVersion = hostedCluster.Status.Version.History[0].Version
-		}
-
 		// Set the semantic version to the latest release image for version gating tests
 		err := e2eutil.SetReleaseImageVersion(testContext, globalOpts.LatestReleaseImage, globalOpts.ConfigurableClusterOptions.PullSecretFile)
 		if err != nil {
@@ -58,11 +53,6 @@ func TestUpgradeControlPlane(t *testing.T) {
 			}
 		})
 		g.Expect(err).NotTo(HaveOccurred(), "failed update hostedcluster image")
-
-		t.Run("Wait for control plane components to complete rollout", func(t *testing.T) {
-			e2eutil.AtLeast(t, e2eutil.Version420)
-			e2eutil.WaitForControlPlaneComponentRollout(t, ctx, mgtClient, hostedCluster, startingVersion)
-		})
 
 		// Wait for the new rollout to be complete
 		e2eutil.WaitForImageRollout(t, ctx, mgtClient, hostedCluster)

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -538,6 +538,15 @@ func WaitForNReadyNodesWithOptions(t *testing.T, ctx context.Context, client crc
 }
 
 func WaitForImageRollout(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+	var startingVersion string
+	if len(hostedCluster.Status.Version.History) > 0 {
+		startingVersion = hostedCluster.Status.Version.History[0].Version
+	}
+	t.Run("Wait for control plane components to complete rollout", func(t *testing.T) {
+		AtLeast(t, Version420)
+		WaitForControlPlaneComponentRollout(t, ctx, client, hostedCluster, startingVersion)
+	})
+
 	var lastVersionCompletionTime *metav1.Time
 	if hostedCluster.Status.Version != nil &&
 		len(hostedCluster.Status.Version.History) > 0 {


### PR DESCRIPTION
PR #6767 added a check for component rollout only in `TestUpgradeControlPlane` after the upgrade had been triggered.

However, we need to check this on _all_ rollouts in all tests. `WaitForImageRollout()` is the function used for this purpose.

Not waiting is causing the feature gate status to skew wrt the CVO version history.  On `TestUpgradeControlPlane`, the FeatureGate status is missing the `initial` version because the initial rollout is not completing before the upgrade begins.

This moves the new component rollout check into `WaitForImageRollout()` so that we do it for all HC rollouts in all tests.

My theory is that before #6767, both the FeatureGate status _and_ the CVO were missing the `initial` version and, thus, the test passed