### PR TITLE
OCPBUGS-61825: test(e2e,kubevirt): skip break-glass-credentials on kubevirt

### DIFF
--- a/test/integration/control_plane_pki_operator.go
+++ b/test/integration/control_plane_pki_operator.go
@@ -39,6 +39,9 @@ import (
 
 func RunTestControlPlanePKIOperatorBreakGlassCredentials(t *testing.T, ctx context.Context, hostedCluster *hypershiftv1beta1.HostedCluster, mgmt, guest *framework.Clients) {
 	t.Run("break-glass-credentials", func(t *testing.T) {
+		if hostedCluster.Spec.Platform.Type == hypershiftv1beta1.KubevirtPlatform {
+			t.Skip("skipping break-glass credentials test on KubeVirt platform")
+		}
 		// control-plane-pki-operator is only available in 4.15 and later
 		e2eutil.AtLeast(t, e2eutil.Version415)
 		hostedControlPlaneNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)


### PR DESCRIPTION
This test does not apply to the kubevirt platform, as it's a managed service side feature.

<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.