### PR TITLE
fix(OCPBUGS-56249): add generate rule dependecy to lint-fix makefile …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ lint: $(GOLANGCI_LINT)
 	cd api && $(GOLANGCI_LINT) run --config ./.golangci.yml -v
 
 .PHONY: lint-fix
-lint-fix: $(GOLANGCI_LINT)
+lint-fix: $(GOLANGCI_LINT) generate
 	$(GOLANGCI_LINT) run --config ./.golangci.yml --fix -v
 	cd api && $(GOLANGCI_LINT) run --config ./.golangci.yml --fix -v
 


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR adds a generate dependecy to lint-fix. In case generate rule has never invoked lint-fix fails because of lack of golang generated code (for example mocks)

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #OCPBUGS-56249

No docs provided and no unit test since this only change makefile