### PR TITLE
[release-4.18] OCPBUGS-61904: resolve MIRRORED_RELEASE_IMAGE flapping

### DIFF
--- a/support/globalconfig/imagecontentsource.go
+++ b/support/globalconfig/imagecontentsource.go
@@ -133,8 +133,18 @@ func getImageDigestMirrorSets(ctx context.Context, client crclient.Client) (map[
 		for _, imageDigestMirror := range item.Spec.ImageDigestMirrors {
 			source := imageDigestMirror.Source
 
+			// Skip empty sources
+			if source == "" {
+				continue
+			}
+
 			for n := range imageDigestMirror.Mirrors {
-				idmsRegistryOverrides[source] = append(idmsRegistryOverrides[source], string(imageDigestMirror.Mirrors[n]))
+				mirror := string(imageDigestMirror.Mirrors[n])
+				// Skip empty mirrors
+				if mirror == "" {
+					continue
+				}
+				idmsRegistryOverrides[source] = append(idmsRegistryOverrides[source], mirror)
 			}
 		}
 	}
@@ -163,8 +173,21 @@ func getImageContentSourcePolicies(ctx context.Context, client crclient.Client) 
 		for _, mirror := range item.Spec.RepositoryDigestMirrors {
 			source := mirror.Source
 
-			for n := range mirror.Mirrors {
-				icspRegistryOverrides[source] = append(icspRegistryOverrides[source], mirror.Mirrors[n])
+			// Skip empty sources
+			if source == "" {
+				continue
+			}
+
+			// Filter out empty mirrors
+			var validMirrors []string
+			for _, m := range mirror.Mirrors {
+				if m != "" {
+					validMirrors = append(validMirrors, m)
+				}
+			}
+
+			if len(validMirrors) > 0 {
+				icspRegistryOverrides[source] = append(icspRegistryOverrides[source], validMirrors...)
 			}
 		}
 	}

--- a/support/releaseinfo/registry_image_content_policies.go
+++ b/support/releaseinfo/registry_image_content_policies.go
@@ -48,6 +48,8 @@ func (p *ProviderWithOpenShiftImageRegistryOverridesDecorator) Lookup(ctx contex
 		}
 	}
 
+	// Reset mirrored release image when falling back to original
+	p.mirroredReleaseImage = ""
 	return p.Delegate.Lookup(ctx, image, pullSecret)
 }
 

--- a/support/util/imagemetadata_test.go
+++ b/support/util/imagemetadata_test.go
@@ -164,7 +164,8 @@ func TestGetManifest(t *testing.T) {
 			}
 
 			if tc.validateCache {
-				_, exists := manifestsCache.Get(tc.expectedDigest)
+				// The cache is indexed by the full image reference, not just the digest
+				_, exists := manifestsCache.Get(tc.imageRef)
 				g.Expect(exists).To(BeTrue())
 			}
 		})
@@ -417,7 +418,7 @@ func TestSeekOverride(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to read manifests file: %v", err)
 			}
-			imgRef := seekOverride(ctx, tc.overrides, tc.imageRef, pullSecret)
+			imgRef := SeekOverride(ctx, tc.overrides, tc.imageRef, pullSecret)
 			g.Expect(imgRef).To(Equal(tc.expectedImgRef), fmt.Sprintf("Expected image reference to be equal to: %v, \nbut got: %v", tc.expectedImgRef, imgRef))
 		})
 	}

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -295,6 +295,11 @@ func ConvertImageRegistryOverrideStringToMap(envVar string) map[string][]string 
 		registry := registryMirror[0]
 		mirror := registryMirror[1]
 
+		// Skip empty registry or mirror entries
+		if registry == "" || mirror == "" {
+			continue
+		}
+
 		imageRegistryOverrides[registry] = append(imageRegistryOverrides[registry], mirror)
 	}
 

--- a/support/util/util_test.go
+++ b/support/util/util_test.go
@@ -591,6 +591,10 @@ func TestGetImageArchitecture(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
+			// Clear caches to avoid interference between tests
+			imageMetadataCache.Clear()
+			manifestsCache.Clear()
+			digestCache.Clear()
 			arch, err := getImageArchitecture(context.TODO(), tc.image, tc.pullSecretBytes, tc.imageMetadataProvider)
 			if tc.expectErr {
 				g.Expect(err).To(HaveOccurred())


### PR DESCRIPTION
This is manual cherry-pick of https://github.com/openshift/hypershift/pull/6825.

> ⚠️ **Warning**: This is not a quick cherry-pick, some of the things has been adjusted because of the CPOv2 migration, so if you're doing the PR review, please do it with that in mind

- Fixes [OCPBUGS-61904](https://issues.redhat.com/browse/OCPBUGS-61904)

/cherrypick release-4.17

