### PR TITLE
OCPBUGS-61941: fix(ingress): add LoadBalancerSourceRanges support for external router service

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1393,6 +1393,7 @@ func (r *HostedControlPlaneReconciler) reconcileHCPRouterServices(ctx context.Co
 	if sharedingress.UseSharedIngress() || hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
 		return nil
 	}
+
 	// Create the Service type LB internal for private endpoints.
 	pubSvc := manifests.RouterPublicService(hcp.Namespace)
 	if util.IsPrivateHCP(hcp) {

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router_test.go
@@ -4,8 +4,10 @@ import (
 	"testing"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/util"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // When HCP has AWSLoadBalancerSubnetsAnnotation it should NOT set Service subnets annotation.
@@ -49,4 +51,73 @@ func TestReconcileRouterServiceAnnotations(t *testing.T) {
 	if got := svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-target-node-labels"]; got != targetNodesLabel {
 		t.Fatalf("expected target node labels annotation to be '%s', got %q", targetNodesLabel, got)
 	}
+}
+
+// Test that LoadBalancerSourceRanges is applied for external router services with allowedCIDRBlocks
+func TestReconcileRouterService_AppliesLoadBalancerSourceRanges(t *testing.T) {
+	// Test case 1: External router service should have LoadBalancerSourceRanges set
+	t.Run("external router service sets LoadBalancerSourceRanges", func(t *testing.T) {
+		// Given a HostedControlPlane on AWS with allowedCIDRBlocks
+		hcp := &hyperv1.HostedControlPlane{}
+		hcp.Spec.Platform.Type = hyperv1.AWSPlatform
+		hcp.Spec.Networking.APIServer = &hyperv1.APIServerNetworking{
+			AllowedCIDRBlocks: []hyperv1.CIDRBlock{"10.0.0.0/8", "192.168.1.0/24"},
+		}
+
+		svc := &corev1.Service{}
+
+		// When reconciling an external router service
+		if err := ReconcileRouterService(svc, false /* internal */, true /* cross-zone */, hcp); err != nil {
+			t.Fatalf("ReconcileRouterService returned error: %v", err)
+		}
+
+		// Then LoadBalancerSourceRanges should be set to match AllowedCIDRBlocks
+		expectedCIDRs := sets.New(util.AllowedCIDRBlocks(hcp)...)
+		actualCIDRs := sets.New(svc.Spec.LoadBalancerSourceRanges...)
+
+		if !expectedCIDRs.Equal(actualCIDRs) {
+			t.Fatalf("expected LoadBalancerSourceRanges to be %v, got %v", expectedCIDRs.UnsortedList(), actualCIDRs.UnsortedList())
+		}
+	})
+
+	// Test case 2: Internal router service should NOT have LoadBalancerSourceRanges set
+	t.Run("internal router service does not set LoadBalancerSourceRanges", func(t *testing.T) {
+		// Given a HostedControlPlane on AWS with allowedCIDRBlocks
+		hcp := &hyperv1.HostedControlPlane{}
+		hcp.Spec.Platform.Type = hyperv1.AWSPlatform
+		hcp.Spec.Networking.APIServer = &hyperv1.APIServerNetworking{
+			AllowedCIDRBlocks: []hyperv1.CIDRBlock{"10.0.0.0/8", "192.168.1.0/24"},
+		}
+
+		svc := &corev1.Service{}
+
+		// When reconciling an internal router service
+		if err := ReconcileRouterService(svc, true /* internal */, true /* cross-zone */, hcp); err != nil {
+			t.Fatalf("ReconcileRouterService returned error: %v", err)
+		}
+
+		// Then LoadBalancerSourceRanges should NOT be set (since it's internal)
+		if len(svc.Spec.LoadBalancerSourceRanges) > 0 {
+			t.Fatalf("expected LoadBalancerSourceRanges to be empty for internal router, got %v", svc.Spec.LoadBalancerSourceRanges)
+		}
+	})
+
+	// Test case 3: External router service with no allowedCIDRBlocks should not set LoadBalancerSourceRanges
+	t.Run("external router service with no allowedCIDRBlocks does not set LoadBalancerSourceRanges", func(t *testing.T) {
+		// Given a HostedControlPlane on AWS with no allowedCIDRBlocks
+		hcp := &hyperv1.HostedControlPlane{}
+		hcp.Spec.Platform.Type = hyperv1.AWSPlatform
+
+		svc := &corev1.Service{}
+
+		// When reconciling an external router service
+		if err := ReconcileRouterService(svc, false /* internal */, true /* cross-zone */, hcp); err != nil {
+			t.Fatalf("ReconcileRouterService returned error: %v", err)
+		}
+
+		// Then LoadBalancerSourceRanges should NOT be set
+		if len(svc.Spec.LoadBalancerSourceRanges) > 0 {
+			t.Fatalf("expected LoadBalancerSourceRanges to be empty when no allowedCIDRBlocks provided, got %v", svc.Spec.LoadBalancerSourceRanges)
+		}
+	})
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -20,12 +20,8 @@ const (
 )
 
 func NewKubeAPIServerServiceParams(hcp *hyperv1.HostedControlPlane) *KubeAPIServerServiceParams {
-	var allowedCIDRBlocks []string
-	for _, block := range util.AllowedCIDRBlocks(hcp) {
-		allowedCIDRBlocks = append(allowedCIDRBlocks, string(block))
-	}
 	return &KubeAPIServerServiceParams{
-		AllowedCIDRBlocks: allowedCIDRBlocks,
+		AllowedCIDRBlocks: util.AllowedCIDRBlocks(hcp),
 		OwnerReference:    config.ControllerOwnerRef(hcp),
 	}
 }

--- a/support/util/networking.go
+++ b/support/util/networking.go
@@ -104,9 +104,13 @@ func AdvertiseAddressWithDefault(hcp *hyperv1.HostedControlPlane, defaultValue s
 	return defaultValue
 }
 
-func AllowedCIDRBlocks(hcp *hyperv1.HostedControlPlane) []hyperv1.CIDRBlock {
+func AllowedCIDRBlocks(hcp *hyperv1.HostedControlPlane) []string {
 	if hcp != nil && hcp.Spec.Networking.APIServer != nil {
-		return hcp.Spec.Networking.APIServer.AllowedCIDRBlocks
+		var allowedCIDRBlocks []string
+		for _, block := range hcp.Spec.Networking.APIServer.AllowedCIDRBlocks {
+			allowedCIDRBlocks = append(allowedCIDRBlocks, string(block))
+		}
+		return allowedCIDRBlocks
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This enables CIDR restrictions for when kube-apiserver is using Router publishing strategy with External DNS where external clients access the kube-apiserver through the public router load balancer, providing the same access control via the kube-apiserver Loadbalancer service.

Changes:
- Apply LoadBalancerSourceRanges only to external (non-internal) router services
- Added comprehensive test coverage for all scenarios


**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.