### PR TITLE
OCPBUGS-61936: fix(capi-provider): wait for infrastructure resource before startup

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/capi_provider/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/capi_provider/component.go
@@ -44,7 +44,10 @@ func NewComponent(deploymentSpec *appsv1.DeploymentSpec, platformPolicyRules []r
 	return component.NewDeploymentComponent(ComponentName, capi).
 		WithAdaptFunction(capi.adaptDeployment).
 		WithPredicate(predicate).
-		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{}).
+		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{
+			KubeconfigVolumeName:          "svc-kubeconfig",
+			WaitForInfrastructureResource: true,
+		}).
 		WithManifestAdapter(
 			"role.yaml",
 			component.WithAdaptFunction(capi.adaptRole),

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
@@ -99,6 +99,15 @@ func (p Kubevirt) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ 
 							},
 						},
 					},
+					{
+						Name: "svc-kubeconfig",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								DefaultMode: &defaultMode,
+								SecretName:  "service-network-admin-kubeconfig",
+							},
+						},
+					},
 				},
 				Containers: []corev1.Container{
 					{
@@ -116,6 +125,10 @@ func (p Kubevirt) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ 
 								Name:      "capi-webhooks-tls",
 								ReadOnly:  true,
 								MountPath: "/tmp/k8s-webhook-server/serving-certs",
+							},
+							{
+								Name:      "svc-kubeconfig",
+								MountPath: "/etc/kubernetes",
 							},
 						},
 						Env: []corev1.EnvVar{

--- a/hypershift-operator/controllers/hostedcluster/testdata/capi-provider/zz_fixture_TestReconcileComponents.yaml
+++ b/hypershift-operator/controllers/hostedcluster/testdata/capi-provider/zz_fixture_TestReconcileComponents.yaml
@@ -137,11 +137,16 @@ spec:
         - availability-prober
         - --target
         - https://kube-apiserver:6443/readyz
+        - --kubeconfig=/var/kubeconfig/kubeconfig
+        - --wait-for-infrastructure-resource
         image: availability-prober
         imagePullPolicy: IfNotPresent
         name: availability-prober
         resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/kubeconfig
+          name: svc-kubeconfig
       priorityClassName: hypershift-control-plane
       serviceAccountName: capi-provider
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
## What this PR does / why we need it

The CAPZ (Cluster API Provider Azure) pod was experiencing startup failures
with 'connection refused' errors when attempting to connect to the API server
before the cluster infrastructure was fully initialized.

This change adds `WaitForInfrastructureResource: true` to the availability prober
configuration for the capi-provider component, ensuring the init container waits
for the Infrastructure/cluster resource to be available with a populated
infrastructureName before allowing the CAPZ controller to start.

This `WaitForInfrastructureResource: true` setting requires the `svc-kubeconfig`
to be mounted into the deployment so the component can query the infrastructure resource.

This prevents the controller from attempting REST API discovery operations
before the control plane is ready to serve infrastructure-related requests,
eliminating the race condition that caused pod restarts.

## Which issue(s) this PR fixes
- Fixes #[OCPBUGS-61936](https://issues.redhat.com/browse/OCPBUGS-61936)

## Additional Info

- For the job `periodic-ci-openshift-hypershift-release-4.21-periodics-e2e-aks-multi-x-ax`

|Index|Status|
|---|---|
|1|🟢|
|2|🟢|
|3|🟢|
|4|🟢|