### PR TITLE
OCPBUGS-61828: refactor FeatureGate status check

### DIFF
--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	configv1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -69,44 +68,7 @@ func TestUpgradeControlPlane(t *testing.T) {
 		err = mgtClient.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
 		g.Expect(err).NotTo(HaveOccurred(), "failed to get hostedcluster")
 
-		t.Run("Verifying featureGate status has entries for the same versions as clusterVersion", func(t *testing.T) {
-			e2eutil.AtLeast(t, e2eutil.Version419)
-
-			g := NewWithT(t)
-
-			clusterVersion := &configv1.ClusterVersion{}
-			err = guestClient.Get(ctx, crclient.ObjectKey{Name: "version"}, clusterVersion)
-			g.Expect(err).NotTo(HaveOccurred(), "failed to get ClusterVersion resource")
-
-			featureGate := &configv1.FeatureGate{}
-			err = guestClient.Get(ctx, crclient.ObjectKey{Name: "cluster"}, featureGate)
-			g.Expect(err).NotTo(HaveOccurred(), "failed to get FeatureGate resource")
-
-			clusterVersions := make(map[string]bool)
-			for _, history := range clusterVersion.Status.History {
-				clusterVersions[history.Version] = true
-			}
-
-			// check that each version in the ClusterVersion history has a corresponding entry in FeatureGate status.
-			for version := range clusterVersions {
-				found := false
-				for _, details := range featureGate.Status.FeatureGates {
-					if details.Version == version {
-						found = true
-						break
-					}
-				}
-				if !found {
-					t.Errorf("version %s found in ClusterVersion history but missing in FeatureGate status", version)
-				}
-			}
-			g.Expect(len(featureGate.Status.FeatureGates)).To(Equal(len(clusterVersion.Status.History)),
-				"Expected the same number of entries in FeatureGate status (%d) as in ClusterVersion history (%d)",
-				len(featureGate.Status.FeatureGates), len(clusterVersion.Status.History))
-
-			t.Log("Validation passed")
-		})
-
+		e2eutil.EnsureFeatureGateStatus(t, ctx, guestClient)
 		e2eutil.EnsureNodeCountMatchesNodePoolReplicas(t, ctx, mgtClient, guestClient, hostedCluster.Spec.Platform.Type, hostedCluster.Namespace)
 		e2eutil.EnsureNoCrashingPods(t, ctx, mgtClient, hostedCluster)
 		e2eutil.EnsureMachineDeploymentGeneration(t, ctx, mgtClient, hostedCluster, 1)

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -1845,7 +1845,7 @@ func TestCreateCluster(t *testing.T) {
 
 	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 		// Sanity check the cluster by waiting for the nodes to report ready
-		_ = e2eutil.WaitForGuestClient(t, ctx, mgtClient, hostedCluster)
+		guestClient := e2eutil.WaitForGuestClient(t, ctx, mgtClient, hostedCluster)
 
 		t.Logf("fetching mgmt kubeconfig")
 		mgmtCfg, err := e2eutil.GetConfig()
@@ -1871,6 +1871,7 @@ func TestCreateCluster(t *testing.T) {
 		e2eutil.EnsureCustomLabels(t, ctx, mgtClient, hostedCluster)
 		e2eutil.EnsureCustomTolerations(t, ctx, mgtClient, hostedCluster)
 		e2eutil.EnsureAppLabel(t, ctx, mgtClient, hostedCluster)
+		e2eutil.EnsureFeatureGateStatus(t, ctx, guestClient)
 
 		// ensure KAS DNS name is configured with a KAS Serving cert
 		e2eutil.EnsureKubeAPIDNSNameCustomCert(t, ctx, mgtClient, hostedCluster)


### PR DESCRIPTION
The existing check does not work with the pruning behavior of kas-bootstrapper.  The only version assured to be in the FeatureGate status is the most recent Completed version in the ClusterVersion history i.e. the currently running version.

FeatureGate status pruning by `kas-bootstrap`
https://github.com/openshift/hypershift/blob/b8db9eda2b7852e1bf2f416b2c954e1ff12bddde/kas-bootstrap/kas_boostrap.go#L127-L131