### PR TITLE
CNTRLPLANE-1455: docs(contribute): consolidate contributing guide; refresh PR template; add landing page

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+---
+title: Contribute to HyperShift
+---
+
+# Contributing to HyperShift
+Thank you for your interest in contributing to HyperShift! HyperShift enables running multiple OpenShift control planes as lightweight, cost-effective hosted clusters. Your contributions help improve this critical infrastructure technology.
+
+The following guidelines will help ensure a smooth contribution process for both contributors and maintainers.
+
+## Prior to Submitting a Pull Request
+1. **Keep changes focused**: Scope commits to one thing and keep them minimal. Separate refactoring from logic changes, and save additional improvements for separate PRs.
+
+2. **Test your changes**: Run `make pre-commit` to update dependencies, build code, verify formatting, and run tests. This prevents CI failures on your PR.
+
+3. **Review before submitting**: Look at your changes from a reviewer's perspective and explain anything that might not be immediately clear in your PR description.
+
+4. **Use proper commit format**: 
+    1. Write commit subjects in [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) (e.g., "Fix bug" not "Fixed bug")
+    2. Follow [conventional commit format](https://www.conventionalcommits.org/) and include "Why" and "How" in commit messages
+
+!!! tip "Install precommit hooks"
+    Install `precommit` to automatically catch issues before committing. This helps catch spelling mistakes, formatting issues, and test failures early in your development process.
+    
+    * [Installation instructions](https://pre-commit.com/#install)
+    * [HyperShift-specific tips](./precommit-hook-help.md)
+
+## Creating a Pull Request
+1. **For small changes** (under 200 lines): Create your change and submit a pull request directly.
+
+2. **For larger changes** (200+ lines): Get feedback on your approach first by opening a GitHub issue or posting in the #project-hypershift Slack channel. This prevents situations where large changes get declined after significant work.
+
+3. **Write a clear PR title**: Prefix with your Jira ticket number (e.g., "OCPBUGS-12345: Fix memory leak in controller"). See [example PR](https://github.com/openshift/hypershift/pull/2233).
+
+4. **Open the PR in draft mode**: Use `/auto-cc` to assign reviewers to your PR in draft mode. Keep the PR in draft mode until:
+
+    - all the required labels are on the PR
+    - all required tests are passing
+
+5. **Explain the value**: Always describe how your change improves the project in the PR description.
+
+!!! note "Release Information"
+    This repository contains code for both the HyperShift Operator and Control Plane Operator (part of OCP payload), which may have different release cadences.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,14 +12,17 @@ In general, please:
 Feel free to delete this comment text block before submitting the PR.
 -->
 
-**What this PR does / why we need it**:
+## What this PR does / why we need it:
 
-**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
-Fixes #
+## Which issue(s) this PR fixes:
+<!--
+(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
+-->
+Fixes 
 
-**Special notes for your reviewer**:
+## Special notes for your reviewer:
 
-**Checklist**
+## Checklist:
 - [ ] Subject and description added to both, commit and PR.
 - [ ] Relevant issues have been referenced.
 - [ ] This change includes docs. 

--- a/docs/content/contribute/index.md
+++ b/docs/content/contribute/index.md
@@ -1,42 +1,20 @@
 ---
-title: Contribute to HyperShift
+title: Contribute
 ---
 
-# Contributing to HyperShift
-Thank you for your interest in contributing to HyperShift! HyperShift enables running multiple OpenShift control planes as lightweight, cost-effective hosted clusters. Your contributions help improve this critical infrastructure technology.
+# Contribute
 
-The following guidelines will help ensure a smooth contribution process for both contributors and maintainers.
+Use these resources to contribute to HyperShift.
 
-## Prior to Submitting a Pull Request
-1. **Keep changes focused**: Scope commits to one thing and keep them minimal. Separate refactoring from logic changes, and save additional improvements for separate PRs.
+- [Contributing guidelines (GitHub)](https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md)
+- [Release Process](release-process.md)
+- [Custom Images](custom-images.md)
+- [Onboard a Platform](onboard-a-platform.md)
+- [Run Tests](run-tests.md)
+- [Develop in Cluster](develop_in_cluster.md)
+- [Run hypershift-operator locally](run-hypershift-operator-locally.md)
+- [CPO Overrides](cpo-overrides.md)
+- [Contribute to docs](contribute-docs.md)
+- [Pre-commit hook help](precommit-hook-help.md)
 
-2. **Test your changes**: Run `make pre-commit` to update dependencies, build code, verify formatting, and run tests. This prevents CI failures on your PR.
 
-3. **Review before submitting**: Look at your changes from a reviewer's perspective and explain anything that might not be immediately clear in your PR description.
-
-4. **Use proper commit format**: 
-    1. Write commit subjects in [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) (e.g., "Fix bug" not "Fixed bug")
-    2. Follow [conventional commit format](https://www.conventionalcommits.org/) and include "Why" and "How" in commit messages
-
-!!! tip "Install precommit hooks"
-    Install `precommit` to automatically catch issues before committing. This helps catch spelling mistakes, formatting issues, and test failures early in your development process.
-    
-    * [Installation instructions](https://pre-commit.com/#install)
-    * [HyperShift-specific tips](./precommit-hook-help.md)
-
-## Creating a Pull Request
-1. **For small changes** (under 200 lines): Create your change and submit a pull request directly.
-
-2. **For larger changes** (200+ lines): Get feedback on your approach first by opening a GitHub issue or posting in the #project-hypershift Slack channel. This prevents situations where large changes get declined after significant work.
-
-3. **Write a clear PR title**: Prefix with your Jira ticket number (e.g., "OCPBUGS-12345: Fix memory leak in controller"). See [example PR](https://github.com/openshift/hypershift/pull/2233).
-
-4. **Open the PR in draft mode**: Use `/auto-cc` to assign reviewers to your PR in draft mode. Keep the PR in draft mode until:
-
-    - all the required labels are on the PR
-    - all required tests are passing
-
-5. **Explain the value**: Always describe how your change improves the project in the PR description.
-
-!!! note "Release Information"
-    This repository contains code for both the HyperShift Operator and Control Plane Operator (part of OCP payload), which may have different release cadences.


### PR DESCRIPTION
**What this PR does / why we need it**:
- Consolidates contributing guidance into `.github/CONTRIBUTING.md` so it’s surfaced by GitHub
- Refreshes the PR template to link to the contributing guide and add reviewer notes
- Adds a landing page for the Contribute docs (`docs/content/contribute/index.md`)
- Updates `docs/mkdocs.yml` navigation to include the new Contribute entry
- Clarifies PR workflow expectations (draft PRs, `/auto-cc`)

**Which issue(s) this PR fixes**:
Fixes [CNTRLPLANE-1455](https://issues.redhat.com//browse/CNTRLPLANE-1455)

**Special notes for your reviewer**:
- Our old PR template referenced our old upstream docs site 🤦🏻 
- Docs-only changes; no code or API modifications
- The third commit contains changes where I moved the previous contributing guidelines to CONTRIBUTING.md for GitHub. The page itself is not new even though it shows as new.

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.