### PR TITLE
CNTRLPLANE-1371: feat(hostedcluster): implement service account signing key rotation with backup

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -4406,10 +4406,25 @@ func (r *HostedClusterReconciler) reconcileServiceAccountSigningKey(ctx context.
 	}
 	cpSigningKeySecret := controlplaneoperator.ServiceAccountSigningKeySecret(targetNamespace)
 	_, err = createOrUpdate(ctx, r.Client, cpSigningKeySecret, func() error {
-		// Only set the signing key when the key does not already exist
-		if _, hasKey := cpSigningKeySecret.Data[controlplaneoperator.ServiceSignerPrivateKey]; hasKey {
+		existingKeyBytes, hasKey := cpSigningKeySecret.Data[controlplaneoperator.ServiceSignerPrivateKey]
+		if hasKey && bytes.Equal(existingKeyBytes, privateBytes) {
 			return nil
 		}
+
+		// if key exists and does not match, create new backup key secret and override the existing key
+		backupKeySecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: targetNamespace,
+				Name:      cpSigningKeySecret.Name + "-backup",
+			},
+		}
+		if _, err := createOrUpdate(ctx, r.Client, backupKeySecret, func() error {
+			backupKeySecret.Data = cpSigningKeySecret.Data
+			return nil
+		}); err != nil {
+			return fmt.Errorf("failed to create backup key secret %s/%s: %w", backupKeySecret.Namespace, backupKeySecret.Name, err)
+		}
+
 		if cpSigningKeySecret.Data == nil {
 			cpSigningKeySecret.Data = map[string][]byte{}
 		}


### PR DESCRIPTION
Enable safe rotation of service account signing keys by implementing backup functionality. When a signing key changes, the existing key is automatically backed up to a separate secret before the new key is applied.

Changes:
- Compare key bytes instead of just checking existence
- Create backup secret with '-backup' suffix when key rotation occurs
- Preserve existing behavior when keys haven't changed

This ensures hosted clusters can safely rotate signing keys without losing access to tokens signed by previous keys.
**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.