### PR TITLE
NO-JIRA: ci(dev-cluster): Fix dev token secret annotation

### DIFF
--- a/contrib/ci/dev-namespace-template.yaml
+++ b/contrib/ci/dev-namespace-template.yaml
@@ -19,8 +19,8 @@ objects:
   metadata:
     name: ${NAME}-dev-token
     namespace: ${NAME}
-  annotations:
-    kubernetes.io/service-account.name: ${NAME}-dev
+    annotations:
+      kubernetes.io/service-account.name: ${NAME}-dev
   type: kubernetes.io/service-account-token
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role


### PR DESCRIPTION
**What this PR does / why we need it**:
The indentation of the annotation on the dev token secret was wrong, causing the template creation to fail.

Now the secret is created correctly when applying the template.


**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.