### PR TITLE
OCPBUGS-62128: hcco: sync watched resource types to availability-prober

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_hosted_cluster_config_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_hosted_cluster_config_operator_deployment.yaml
@@ -164,6 +164,9 @@ spec:
         - --required-api=config.openshift.io,v1,OperatorHub
         - --required-api=operator.openshift.io,v1,Network
         - --required-api=operator.openshift.io,v1,CloudCredential
+        - --required-api=operator.openshift.io,v1,Storage
+        - --required-api=operator.openshift.io,v1,CSISnapshotController
+        - --required-api=operator.openshift.io,v1,ClusterCSIDriver
         - --required-api=operator.openshift.io,v1,IngressController
         image: availability-prober
         imagePullPolicy: IfNotPresent

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_hosted_cluster_config_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_hosted_cluster_config_operator_deployment.yaml
@@ -163,6 +163,9 @@ spec:
         - --required-api=config.openshift.io,v1,OperatorHub
         - --required-api=operator.openshift.io,v1,Network
         - --required-api=operator.openshift.io,v1,CloudCredential
+        - --required-api=operator.openshift.io,v1,Storage
+        - --required-api=operator.openshift.io,v1,CSISnapshotController
+        - --required-api=operator.openshift.io,v1,ClusterCSIDriver
         - --required-api=operator.openshift.io,v1,IngressController
         image: availability-prober
         imagePullPolicy: IfNotPresent

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/zz_fixture_TestControlPlaneComponents_hosted_cluster_config_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/hosted-cluster-config-operator/zz_fixture_TestControlPlaneComponents_hosted_cluster_config_operator_deployment.yaml
@@ -163,6 +163,9 @@ spec:
         - --required-api=config.openshift.io,v1,OperatorHub
         - --required-api=operator.openshift.io,v1,Network
         - --required-api=operator.openshift.io,v1,CloudCredential
+        - --required-api=operator.openshift.io,v1,Storage
+        - --required-api=operator.openshift.io,v1,CSISnapshotController
+        - --required-api=operator.openshift.io,v1,ClusterCSIDriver
         - --required-api=operator.openshift.io,v1,IngressController
         image: availability-prober
         imagePullPolicy: IfNotPresent

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/configoperator/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/configoperator/component.go
@@ -76,6 +76,9 @@ func hccpAvailabilityProberOpts(caps *hyperv1.Capabilities) util.AvailabilityPro
 			{Group: "config.openshift.io", Version: "v1", Kind: "OperatorHub"},
 			{Group: "operator.openshift.io", Version: "v1", Kind: "Network"},
 			{Group: "operator.openshift.io", Version: "v1", Kind: "CloudCredential"},
+			{Group: "operator.openshift.io", Version: "v1", Kind: "Storage"},
+			{Group: "operator.openshift.io", Version: "v1", Kind: "CSISnapshotController"},
+			{Group: "operator.openshift.io", Version: "v1", Kind: "ClusterCSIDriver"},
 		},
 	}
 	if capabilities.IsIngressCapabilityEnabled(caps) {


### PR DESCRIPTION
Sync watched `operatorv1` types to the `availability-prober` to avoid pod restarts.

Should match https://github.com/openshift/hypershift/blob/50d0c75ade41649e5b267b737f8622c554725021/control-plane-operator/hostedclusterconfigoperator/operator/config.go#L99-L133

Example failed HCCO log that flaked https://github.com/openshift/hypershift/pull/6872
```
panic: failed to create controller manager: failed to determine if *v1.CSISnapshotController is namespaced: failed to get restmapping: no matches for kind "CSISnapshotController" in version "operator.openshift.io/v1"

goroutine 1 [running]:
github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/operator.Mgr({0x806aee0, 0xc000ed0f00}, 0xc00107e908, 0xc00107efc8, {0x7ffc979f07f9, 0x26}, {0x7ffc979f0869, 0x13})
```