### PR TITLE
OCPBUGS-62172: Add Manila, Cinder to list of pods allowed readOnlyRootFileSystem=false

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1630,18 +1630,20 @@ func EnsureReadOnlyRootFilesystem(t *testing.T, ctx context.Context, hostClient 
 		// auditedAppContainersNoRORFS[labelSelector{label: "app", value: "value"}][pod.Spec.Containers[*]] indicates that particular container is allowed to be false.
 		// if a labelSelector is given with an empty map, allow all containers to be false
 		auditedAppContainersNoRORFS := map[labelSelector]map[string]struct{}{
-			{label: "app", value: "azure-disk-csi-driver-controller"}: {},
-			{label: "app", value: "azure-disk-csi-driver-operator"}:   {},
-			{label: "app", value: "azure-file-csi-driver-controller"}: {},
-			{label: "app", value: "azure-file-csi-driver-operator"}:   {},
-			{label: "app", value: "aws-ebs-csi-driver-controller"}:    {},
-			{label: "app", value: "aws-ebs-csi-driver-operator"}:      {},
-			{label: "app", value: "multus-admission-controller"}:      {},
-			{label: "app", value: "network-node-identity"}:            {},
-			{label: "app", value: "ovnkube-control-plane"}:            {},
-			{label: "app", value: "cloud-network-config-controller"}:  {},
-			{label: "app", value: "vmi-console-debug"}:                {},
-			{label: "kubevirt.io", value: "virt-launcher"}:            {}, // virt-launcher pods have no app label
+			{label: "app", value: "azure-disk-csi-driver-controller"}:     {},
+			{label: "app", value: "azure-disk-csi-driver-operator"}:       {},
+			{label: "app", value: "azure-file-csi-driver-controller"}:     {},
+			{label: "app", value: "azure-file-csi-driver-operator"}:       {},
+			{label: "app", value: "aws-ebs-csi-driver-controller"}:        {},
+			{label: "app", value: "aws-ebs-csi-driver-operator"}:          {},
+			{label: "app", value: "openstack-cinder-csi-driver-operator"}: {},
+			{label: "app", value: "manila-csi-driver-operator"}:           {},
+			{label: "app", value: "multus-admission-controller"}:          {},
+			{label: "app", value: "network-node-identity"}:                {},
+			{label: "app", value: "ovnkube-control-plane"}:                {},
+			{label: "app", value: "cloud-network-config-controller"}:      {},
+			{label: "app", value: "vmi-console-debug"}:                    {},
+			{label: "kubevirt.io", value: "virt-launcher"}:                {}, // virt-launcher pods have no app label
 		}
 
 		for _, pod := range hcpPods.Items {
@@ -1670,7 +1672,7 @@ func EnsureReadOnlyRootFilesystem(t *testing.T, ctx context.Context, hostClient 
 		}
 	})
 
-	// By default, we add an emptyDir pod volume named "tmp-dir" and mount it into every container in the pod at /tmp.
+	// By default, we add an emptyDir pod volume and mount it into every container in the pod at /tmp.
 	// This test checks to make sure that every container has this mount, unless manually specified in auditedAppContainerNoTmpDir.
 	t.Run("EnsureReadOnlyRootFilesystemTmpDirMount", func(t *testing.T) {
 		g := NewWithT(t)
@@ -1686,20 +1688,22 @@ func EnsureReadOnlyRootFilesystem(t *testing.T, ctx context.Context, hostClient 
 		// auditedAppContainerNoTmpDir[labelSelector{label: "app", value: "value"}][pod.Spec.Containers[*]] indicates that particular container is allowed to not have the mount
 		// if a labelSelector is given with an empty map, allow all containers to not have it
 		auditedAppContainerNoTmpDir := map[labelSelector]map[string]struct{}{
-			{label: "app", value: "azure-disk-csi-driver-controller"}: {},
-			{label: "app", value: "azure-disk-csi-driver-operator"}:   {},
-			{label: "app", value: "azure-file-csi-driver-controller"}: {},
-			{label: "app", value: "azure-file-csi-driver-operator"}:   {},
-			{label: "app", value: "aws-ebs-csi-driver-controller"}:    {},
-			{label: "app", value: "aws-ebs-csi-driver-operator"}:      {},
-			{label: "app", value: "multus-admission-controller"}:      {},
-			{label: "app", value: "network-node-identity"}:            {},
-			{label: "app", value: "ovnkube-control-plane"}:            {},
-			{label: "app", value: "cloud-network-config-controller"}:  {},
-			{label: "app", value: "vmi-console-debug"}:                {},
-			{label: "kubevirt.io", value: "virt-launcher"}:            {}, // virt-launcher pods have no app label
-			{label: "app", value: "csi-snapshot-controller"}:          {},
-			{label: "app", value: "csi-snapshot-webhook"}:             {},
+			{label: "app", value: "azure-disk-csi-driver-controller"}:       {},
+			{label: "app", value: "azure-disk-csi-driver-operator"}:         {},
+			{label: "app", value: "azure-file-csi-driver-controller"}:       {},
+			{label: "app", value: "azure-file-csi-driver-operator"}:         {},
+			{label: "app", value: "aws-ebs-csi-driver-controller"}:          {},
+			{label: "app", value: "aws-ebs-csi-driver-operator"}:            {},
+			{label: "app", value: "openstack-cinder-csi-driver-controller"}: {},
+			{label: "app", value: "openstack-manila-csi-controllerplugin"}:  {},
+			{label: "app", value: "multus-admission-controller"}:            {},
+			{label: "app", value: "network-node-identity"}:                  {},
+			{label: "app", value: "ovnkube-control-plane"}:                  {},
+			{label: "app", value: "cloud-network-config-controller"}:        {},
+			{label: "app", value: "vmi-console-debug"}:                      {},
+			{label: "kubevirt.io", value: "virt-launcher"}:                  {}, // virt-launcher pods have no app label
+			{label: "app", value: "csi-snapshot-controller"}:                {},
+			{label: "app", value: "csi-snapshot-webhook"}:                   {},
 			{label: "app", value: "packageserver"}: {
 				"packageserver": {}, // the package server was able to enabled readOnlyRootFilesystem without needing to mount /tmp
 			},


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

All CSI operators are currently deployed with `readOnlyRootFilesystem=false` (since https://github.com/openshift/cluster-storage-operator/pull/564). However, while the other platform operators are explicitly whitelisted, OpenStack is not. Likewise, while most other controllers don't mount `/tmp`, the OpenStack providers are missing from *that* whitelist. Correct both oversights.

We also don't universally call the emptyDir mount "tmp-dir" (at least the csi-operator and cluster-storage-operator don't do this) so a reference to same is removed.

## Which issue(s) this PR fixes:
Fixes OCPBUGS-62172

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.
