### PR TITLE
[release-4.19] OCPBUGS-62202: Enable VolumeAttributesClass runtime config

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/config.go
@@ -235,6 +235,9 @@ func generateConfig(p KubeAPIServerConfigParams) (*kcpv1.KubeAPIServerConfig, er
 		if gate == "DynamicResourceAllocation=true" {
 			runtimeConfig = append(runtimeConfig, "resource.k8s.io/v1beta1=true")
 		}
+		if gate == "VolumeAttributesClass=true" {
+			runtimeConfig = append(runtimeConfig, "storage.k8s.io/v1beta1=true")
+		}
 	}
 	args.Set("runtime-config", runtimeConfig...)
 	args.Set("service-account-issuer", p.ServiceAccountIssuerURL)


### PR DESCRIPTION
<!--
- Please ensure code changes are split into a series of logically independent commits.
- Every commit should have a subject/title (What) and a description/body (Why).
- Every PR must have a description.
- As an example you can use git commit -m"What" -m"Why" to achieve the requirements above. GitHub automatically recognises the commit description (-m"Why") in single commit PRs and adds it as the PR description.
- Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) in the subject line for every commit. E.g `Mark infraID as required` instead of `This patch marks infraID as required` (This follows Git’s own built-in conventions). See https://github.com/openshift/hypershift/pull/485 as an example.
- See https://hypershift-docs.netlify.app/contribute for more details.

Delete this text before submitting the PR.
-->

**What this PR does / why we need it**:
- Fixes # https://issues.redhat.com/browse/OCPBUGS-62202, manually cherry-pick https://github.com/openshift/hypershift/pull/6855 since in 4.19.z the default CPO is still v1.
- To complement https://github.com/openshift/cluster-kube-apiserver-operator/pull/1761, we need to enable the `storage.k8s.io/v1beta1` when the VolumeAttributesClass gate is enabled.

The VolumeAttributesClass is not enabled by default upstream yet but we are intending to enable it downstream for testing and development of tech preview features.

**Local test passed**:
- Manually replace the CPO image with the fix commit build.
```console
# On TechPreviewNoUpgrade hosted cluster replace the CPO image with the fix commit build

$ oc get --raw /apis/storage.k8s.io/v1beta1 | jq .resources

[
  {
    "name": "volumeattributesclasses",
    "singularName": "volumeattributesclass",
    "namespaced": false,
    "kind": "VolumeAttributesClass",
    "verbs": [
      "create",
      "delete",
      "deletecollection",
      "get",
      "list",
      "patch",
      "update",
      "watch"
    ],
    "shortNames": [
      "vac"
    ],
    "storageVersionHash": "Bl3MtjZ/n/s="
  }
]

$ oc get volumeattributesclass
No resources found
```
