### PR TITLE
NO-JIRA: chore(ai): let jira-solve show the executed command in the PR desc

### DIFF
--- a/.claude/commands/jira-solve.md
+++ b/.claude/commands/jira-solve.md
@@ -62,6 +62,7 @@ Analyze a JIRA issue and create a pull request to solve it.
    - Create pull request with:
      - Clear title referencing JIRA issue as a prefix. For example: "OCPBUGS-12345: ..."
      - The PR description should satisfy the template within .github/PULL_REQUEST_TEMPLATE.md if the file exists
+     - The "🤖 Generated with Claude Code" sentence should include a reference to the slash command that triggered the execution, for example "via `/jira-solve OCPBUGS-12345 enxebre`"
      - Always create as draft PR
      - Always create the PR against https://github.com/openshift/hypershift
      - Use gh cli if you need to


### PR DESCRIPTION

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:
This lets reviewers see the /jira-solve claude command that triggered execution


## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.