### PR TITLE
OCPBUGS-60707: Fix user-ca-bundle cleanup when additionalTrustBundle is removed

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1589,17 +1589,26 @@ func (r *reconciler) reconcileOAuthServingCertCABundle(ctx context.Context, hcp 
 }
 
 func (r *reconciler) reconcileUserCertCABundle(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
+	log := ctrl.LoggerFrom(ctx)
+	userCAConfigMap := manifests.UserCABundle()
+
 	if hcp.Spec.AdditionalTrustBundle != nil {
 		cpUserCAConfigMap := cpomanifests.UserCAConfigMap(hcp.Namespace)
 		if err := r.cpClient.Get(ctx, client.ObjectKeyFromObject(cpUserCAConfigMap), cpUserCAConfigMap); err != nil {
 			return fmt.Errorf("cannot get AdditionalTrustBundle ConfigMap: %w", err)
 		}
-		userCAConfigMap := manifests.UserCABundle()
 		if _, err := r.CreateOrUpdate(ctx, r.client, userCAConfigMap, func() error {
 			userCAConfigMap.Data = cpUserCAConfigMap.Data
 			return nil
 		}); err != nil {
 			return fmt.Errorf("failed to reconcile the %s ConfigMap: %w", client.ObjectKeyFromObject(userCAConfigMap), err)
+		}
+	} else {
+		// If the HostedControlPlane has no additional trust bundle, delete the user-ca-bundle ConfigMap if it exists
+		if deleted, err := util.DeleteIfNeeded(ctx, r.client, userCAConfigMap); err != nil {
+			return fmt.Errorf("failed to delete unused user-ca-bundle ConfigMap: %w", err)
+		} else if deleted {
+			log.Info("deleted unused user-ca-bundle ConfigMap", "name", userCAConfigMap.Name, "namespace", userCAConfigMap.Namespace)
 		}
 	}
 	return nil

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -165,7 +165,7 @@ func TestNodePool(t *testing.T) {
 			build: func(ctx context.Context, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster, hostedClusterClient crclient.Client, clusterOpts e2eutil.PlatformAgnosticOptions) []NodePoolTestCase {
 				return []NodePoolTestCase{{
 					name: "TestAdditionalTrustBundlePropagation",
-					test: NewAdditionalTrustBundlePropagation(ctx, mgtClient, hostedCluster),
+					test: NewAdditionalTrustBundlePropagation(ctx, mgtClient, hostedCluster, hostedClusterClient),
 				}}
 			},
 		},


### PR DESCRIPTION
## Summary
- Fixes the issue where the `user-ca-bundle` ConfigMap in the guest cluster was not being deleted when `additionalTrustBundle` was removed from the HostedCluster spec
- Adds proper cleanup logic in `reconcileUserCertCABundle` function 
- Ensures complete reconciliation when additionalTrustBundle configuration is removed

## Changes Made
- **Fixed core reconciliation logic**: Added proper deletion of `user-ca-bundle` ConfigMap when `additionalTrustBundle` is nil
- **Enhanced unit tests**: Added test case "AdditionalTrustBundle removed - should delete existing user-ca-bundle" 
- **Improved e2e tests**: Added verification that the ConfigMap is properly deleted from guest cluster
- **Added utility function**: Created `EventuallyNotFound` helper for e2e testing

## Test Plan
- [x] Unit tests pass (`TestReconcileUserCertCABundle`)
- [x] Code builds successfully (`make build`)
- [x] Linting passes (`make lint`) 
- [x] E2e test framework validates user-ca-bundle deletion
- [x] Follows existing patterns and conventions

## Verification Steps
1. Create a HostedCluster with additionalTrustBundle
2. Verify user-ca-bundle ConfigMap exists in guest cluster
3. Remove additionalTrustBundle from HostedCluster spec
4. Verify user-ca-bundle ConfigMap is deleted from guest cluster

🤖 Generated with [Claude Code](https://claude.ai/code) via `/jira-solve OCPBUGS-60707 enxebre`