### PR TITLE
NO-JIRA: chore(ai): ensure jira-solve run make pre-commit

### DIFF
--- a/.claude/commands/jira-solve.md
+++ b/.claude/commands/jira-solve.md
@@ -51,9 +51,10 @@ Analyze a JIRA issue and create a pull request to solve it.
    - Follow existing code patterns and conventions
    - Add or update tests as needed
    - Update documentation if needed within the docs/ folder
-   - Ensure code builds and passes existing tests:
-      - Use `make pre-commit` if needed, or `make build` and `make test` if you need to be more specific
    - If the problem is too complex consider delegating to one of the SME agents.
+   - Always ensure code builds and passes existing tests:
+   - Run `make pre-commit`, or `make verify`, `make build` and `make test` if you need to be more specific
+   - Do not go to the "PR Creation" step until `make pre-commit` passes
 
 4. **PR Creation**: 
    - Create feature branch using the jira-key $1 as the branch name. For example: "git checkout -b fix-{jira-key}"


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:
This change the spec to be more prescriptive on running make pre-commit before creating a PR

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.