### PR TITLE
CNTRLPLANE-1484: Expose cluster autoscaler metrics in HCP

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_autoscaler_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_autoscaler_controlplanecomponent.yaml
@@ -20,6 +20,9 @@ status:
     status: "False"
     type: RolloutComplete
   resources:
+  - group: monitoring.coreos.com
+    kind: PodMonitor
+    name: cluster-autoscaler
   - group: rbac.authorization.k8s.io
     kind: Role
     name: cluster-autoscaler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_autoscaler_podmonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_autoscaler_podmonitor.yaml
@@ -1,0 +1,36 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  creationTimestamp: null
+  name: cluster-autoscaler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  namespaceSelector:
+    matchNames:
+    - hcp-namespace
+  podMetricsEndpoints:
+  - bearerTokenSecret:
+      key: ""
+    interval: 30s
+    metricRelabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    path: /metrics
+    port: metrics
+    relabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    scheme: http
+  selector:
+    matchLabels:
+      app: cluster-autoscaler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_autoscaler_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_autoscaler_controlplanecomponent.yaml
@@ -20,6 +20,9 @@ status:
     status: "False"
     type: RolloutComplete
   resources:
+  - group: monitoring.coreos.com
+    kind: PodMonitor
+    name: cluster-autoscaler
   - group: rbac.authorization.k8s.io
     kind: Role
     name: cluster-autoscaler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_autoscaler_podmonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_autoscaler_podmonitor.yaml
@@ -1,0 +1,36 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  creationTimestamp: null
+  name: cluster-autoscaler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  namespaceSelector:
+    matchNames:
+    - hcp-namespace
+  podMetricsEndpoints:
+  - bearerTokenSecret:
+      key: ""
+    interval: 30s
+    metricRelabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    path: /metrics
+    port: metrics
+    relabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    scheme: http
+  selector:
+    matchLabels:
+      app: cluster-autoscaler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/zz_fixture_TestControlPlaneComponents_cluster_autoscaler_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/zz_fixture_TestControlPlaneComponents_cluster_autoscaler_controlplanecomponent.yaml
@@ -20,6 +20,9 @@ status:
     status: "False"
     type: RolloutComplete
   resources:
+  - group: monitoring.coreos.com
+    kind: PodMonitor
+    name: cluster-autoscaler
   - group: rbac.authorization.k8s.io
     kind: Role
     name: cluster-autoscaler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/zz_fixture_TestControlPlaneComponents_cluster_autoscaler_podmonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/zz_fixture_TestControlPlaneComponents_cluster_autoscaler_podmonitor.yaml
@@ -1,0 +1,36 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  creationTimestamp: null
+  name: cluster-autoscaler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  namespaceSelector:
+    matchNames:
+    - hcp-namespace
+  podMetricsEndpoints:
+  - bearerTokenSecret:
+      key: ""
+    interval: 30s
+    metricRelabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    path: /metrics
+    port: metrics
+    relabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    scheme: http
+  selector:
+    matchLabels:
+      app: cluster-autoscaler

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-autoscaler/podmonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-autoscaler/podmonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: cluster-autoscaler
+  namespace: HCP_NAMESPACE
+spec:
+  namespaceSelector:
+    matchNames:
+      - HCP_NAMESPACE
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+  podMetricsEndpoints:
+  - port: metrics
+    path: /metrics
+    interval: 30s
+    scheme: http

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/autoscaler/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/autoscaler/component.go
@@ -40,6 +40,9 @@ func (a *Autoscaler) NeedsManagementKASAccess() bool {
 func NewComponent() component.ControlPlaneComponent {
 	return component.NewDeploymentComponent(ComponentName, &Autoscaler{}).
 		WithAdaptFunction(adaptDeployment).
+		WithManifestAdapter("podmonitor.yaml",
+			component.WithAdaptFunction(adaptPodMonitor),
+		).
 		WithPredicate(predicate).
 		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{}).
 		Build()

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/autoscaler/podmonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/autoscaler/podmonitor.go
@@ -1,0 +1,15 @@
+package autoscaler
+
+import (
+	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/util"
+
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+)
+
+func adaptPodMonitor(cpContext component.WorkloadContext, podMonitor *prometheusoperatorv1.PodMonitor) error {
+	podMonitor.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{MatchNames: []string{cpContext.HCP.Namespace}}
+	util.ApplyClusterIDLabelToPodMonitor(&podMonitor.Spec.PodMetricsEndpoints[0], cpContext.HCP.Spec.ClusterID)
+
+	return nil
+}


### PR DESCRIPTION
## What this PR does / why we need it:

This PR adds a PodMonitor to the cluster autoscaler component in control plane operator v2 to expose autoscaler metrics. The implementation follows the same pattern as the karpenter component by:

- Adding a `podmonitor.yaml` asset in the cluster-autoscaler assets directory
- Creating an `adaptPodMonitor` function that configures namespace selector and applies cluster ID labels
- Updating the component to include the manifest adapter for the PodMonitor
- Generating unit test fixtures for all platform configurations

## Which issue(s) this PR fixes:

Fixes CNTRLPLANE-1484

## Special notes for your reviewer:

- The PodMonitor targets pods with label `app: cluster-autoscaler` on port `metrics` (8085)
- Follows the exact same pattern as the karpenter component's PodMonitor implementation
- All existing unit tests pass and new test fixtures have been generated
- The PodMonitor includes proper cluster ID labels via `util.ApplyClusterIDLabelToPodMonitor`

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.ai/code) via `/jira-solve CNTRLPLANE-1484`