### PR TITLE
OCPBUGS-62832: fix(azure): correct DNS zone pagination loop in getBaseDomainID

### DIFF
--- a/cmd/infra/azure/networking.go
+++ b/cmd/infra/azure/networking.go
@@ -36,7 +36,7 @@ func (n *NetworkManager) GetBaseDomainID(ctx context.Context, baseDomain string)
 	}
 
 	pager := zonesClient.NewListPager(nil)
-	if pager.More() {
+	for pager.More() {
 		pagerResults, err := pager.NextPage(ctx)
 		if err != nil {
 			return "", fmt.Errorf("failed to retrieve list of DNS zones: %w", err)


### PR DESCRIPTION
## What this PR does / why we need it:

Change conditional statement from 'if' to 'for' loop to properly iterate through all pages of DNS zones instead of processing only the first page.