### PR TITLE
NO-JIRA: chore(ai): configure all agents to inherit model configuration

### DIFF
--- a/.claude/agents/api-sme.md
+++ b/.claude/agents/api-sme.md
@@ -4,7 +4,7 @@ description: Has deep knowledge of the Kubernetes and OpenShift API best practic
 with all the OpenShift APIs for configuration and operators. It owns the hypershift.openshift.io APIs,
 including but not limited to hostedCluster, hostedControlPlane, nodePool and all the platform specifics.
 Makes API design decisions and enforce best practices.
-model: opus
+model: inherit
 ---
 
 You are an API subject matter expert system architect specializing in HCP.

--- a/.claude/agents/cloud-provider-sme.md
+++ b/.claude/agents/cloud-provider-sme.md
@@ -2,7 +2,7 @@
 name: cloud-provider-sme
 description: Has deep knowledge of Google Cloud aka GCP, AWS, Azure and IBM Cloud best practices and cost effective patterns. It is an expert on all the HCP cloud interactions via clusterAPI and via cloud provider controllers.
 Makes cloud integration design decisions and enforce best practices.
-model: opus
+model: inherit
 ---
 
 You are a Cloud provider (AWS, Azure, GCP, IBM) subject matter expert system architect specializing in HCP.

--- a/.claude/agents/control-plane-sme.md
+++ b/.claude/agents/control-plane-sme.md
@@ -3,7 +3,7 @@ name: control-plane-sme
 description: Has deep knowledge of the hostedCluster and the hostedControlPlane resources and the related controllers, including but not limited to everything under hypershift-operator/controllers/hostedcluster and control-plane-operator/. It's an expert on all the control plane components managed by hcp. Makes design decisions
 on the best way to lifecycle the control plane components and to model the spec and status APIs around them.
 It owns the cpov2 framework used for reconciling controlPlaneComponents.
-model: opus
+model: inherit
 ---
 
 You are a control plane subject matter expert system architect specializing in HCP.

--- a/.claude/agents/data-plane-sme.md
+++ b/.claude/agents/data-plane-sme.md
@@ -2,7 +2,7 @@
 name: data-plane-sme
 description: Has deep knowledge of the nodePool and the clusterAPI resources and the related controllers, including but not limited to everything under hypershift-operator/controllers/nodepool and control-plane-operator/. It's an expert on automated machine management via hcp. Makes design decisions
 on the best way to lifecycle the NodePool, machineDeployment and Nodes and to model the spec and status APIs around them.
-model: opus
+model: inherit
 ---
 
 You are a data plane subject matter expert system architect specializing in HCP.

--- a/.claude/agents/hcp-architect-sme.md
+++ b/.claude/agents/hcp-architect-sme.md
@@ -6,7 +6,7 @@ It considers impact of changes for SREs, monitoring and service consumers.
 It takes all the above into consideration when making design decisions.
 It is an expert on OpenShift and HCP APIs and controllers. 
 It is familiar with any HCP lifecycle, consumers and integrations.
-model: opus
+model: inherit
 ---
 
 You are an architect subject matter expert specializing in HCP.


### PR DESCRIPTION
## What this PR does / why we need it:

Update all Claude Code agents in .claude/agents/ to use 'model: inherit'
instead of hardcoded 'model: opus', allowing them to inherit the model
configuration from parent/default settings.


## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.