### PR TITLE
OCPBUGS-62324: Fix test-e2e `annotations` flag parsing

### DIFF
--- a/test/e2e/util/options.go
+++ b/test/e2e/util/options.go
@@ -502,7 +502,7 @@ func (s *stringMapVar) String() string {
 }
 
 func (s *stringMapVar) Set(value string) error {
-	split := strings.Split(value, "=")
+	split := strings.SplitN(value, "=", 2)
 	if len(split) != 2 {
 		return fmt.Errorf("invalid argument: %s", value)
 	}


### PR DESCRIPTION
## What this PR does / why we need it:
Annotation parsing on the `test-e2e` command fails when annotations have more than one `=` character on the value (e.g. `-e2e.annotations="hypershift.openshift.io/image-overrides=my-component=my-image"`)

## Which issue(s) this PR fixes:
Fixes [OCPBUGS-62324](https://issues.redhat.com/browse/OCPBUGS-62324)

## Special notes for your reviewer:
- One liner fix for flag parsing.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.