### PR TITLE
OCPSTRAT-2472: Add latest tag to MCE 2.10 build pipeline

### DIFF
--- a/.tekton/hypershift-release-mce-210-push.yaml
+++ b/.tekton/hypershift-release-mce-210-push.yaml
@@ -37,6 +37,9 @@ spec:
     value: "true"
   - name: hermetic
     value: "true"
+  - name: additional-tags
+    value:
+    - "latest"
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary
Add latest tag to MCE 2.10 HyperShift Operator build pipeline for predictable build locations.

## Problem
[OCPSTRAT-2472](https://issues.redhat.com//browse/OCPSTRAT-2472) requests predictable latest MCE HO build locations so QE can easily find the latest build of the HyperShift Operator for self-managed hosted control planes.

## Solution
- Add `additional-tags: ["latest"]` parameter to the MCE 2.10 pipeline configuration
- Leverages the enhancement from stolostron/konflux-build-catalog#293 that added support for additional tags
- Every build will now be tagged with both the commit SHA and `latest` for easy discovery

## Files Changed
- `.tekton/hypershift-release-mce-210-push.yaml`: Added additional-tags parameter

## Testing
This change will take effect on the next push to release-4.20 branch and will apply the `latest` tag to all subsequent MCE 2.10 builds.

🤖 Generated with [Claude Code](https://claude.ai/code)