### PR TITLE
NO-JIRA: fix(e2e): extend ValidateHostedClusterConditions timeout

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -2703,7 +2703,13 @@ func ValidatePublicCluster(t *testing.T, ctx context.Context, client crclient.Cl
 		g.Expect(hostedCluster.Status.ControlPlaneEndpoint.Host).ToNot(ContainSubstring("hypershift.local"))
 	}
 
-	ValidateHostedClusterConditions(t, ctx, client, hostedCluster, numNodes > 0, 10*time.Minute)
+	// Extend the timeout to 20 minutes if there are no worker nodes as
+	// 10 minutes might not be enough if image pulls are slow.
+	timeout := 10 * time.Minute
+	if numNodes == 0 {
+		timeout = 20 * time.Minute
+	}
+	ValidateHostedClusterConditions(t, ctx, client, hostedCluster, numNodes > 0, timeout)
 
 	EnsureNodeCountMatchesNodePoolReplicas(t, ctx, client, guestClient, hostedCluster.Spec.Platform.Type, hostedCluster.Namespace)
 	EnsureNoCrashingPods(t, ctx, client, hostedCluster)
@@ -2746,7 +2752,13 @@ func ValidatePrivateCluster(t *testing.T, ctx context.Context, client crclient.C
 		g.Expect(hostedCluster.Status.ControlPlaneEndpoint.Host).ToNot(ContainSubstring("hypershift.local"))
 	}
 
-	ValidateHostedClusterConditions(t, ctx, client, hostedCluster, numNodes > 0, 10*time.Minute)
+	// Extend the timeout to 20 minutes if there are no worker nodes as
+	// 10 minutes might not be enough if image pulls are slow.
+	timeout := 10 * time.Minute
+	if numNodes == 0 {
+		timeout = 20 * time.Minute
+	}
+	ValidateHostedClusterConditions(t, ctx, client, hostedCluster, numNodes > 0, timeout)
 
 	EnsureNoCrashingPods(t, ctx, client, hostedCluster)
 	EnsureOAPIMountsTrustBundle(t, context.Background(), client, hostedCluster)


### PR DESCRIPTION
Extend ValidateHostedClusterConditions timeout when we initially have no nodes and don't delay on WaitForImageRollout.

Flake observed on this job with long image pull times for catalogs.

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/6674/pull-ci-openshift-hypershift-release-4.19-e2e-aks/1972715251858149376

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make ValidateHostedClusterConditions timeout dynamic: 10m by default, 20m when there are zero worker nodes to account for slow image pulls.
> 
> - **Tests (e2e)**:
>   - Increase `ValidateHostedClusterConditions` timeout dynamically in `test/e2e/util/util.go`:
>     - `ValidatePublicCluster` and `ValidatePrivateCluster`: use `timeout := 10m`, bump to `20m` when `numNodes == 0`.
>     - Adds clarifying comment about slow image pulls (catalogs) when no workers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b7f07bd6e109c218e89eea1bf5b8efdb5b76dd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->