### PR TITLE
[release-4.20] OCPBUGS-62434: Add Manila, Cinder to list of pods allowed readOnlyRootFileSystem=false

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1561,18 +1561,20 @@ func EnsureReadOnlyRootFilesystem(t *testing.T, ctx context.Context, hostClient 
 		// auditedAppContainersNoRORFS[labelSelector{label: "app", value: "value"}][pod.Spec.Containers[*]] indicates that particular container is allowed to be false.
 		// if a labelSelector is given with an empty map, allow all containers to be false
 		auditedAppContainersNoRORFS := map[labelSelector]map[string]struct{}{
-			{label: "app", value: "azure-disk-csi-driver-controller"}: {},
-			{label: "app", value: "azure-disk-csi-driver-operator"}:   {},
-			{label: "app", value: "azure-file-csi-driver-controller"}: {},
-			{label: "app", value: "azure-file-csi-driver-operator"}:   {},
-			{label: "app", value: "aws-ebs-csi-driver-controller"}:    {},
-			{label: "app", value: "aws-ebs-csi-driver-operator"}:      {},
-			{label: "app", value: "multus-admission-controller"}:      {},
-			{label: "app", value: "network-node-identity"}:            {},
-			{label: "app", value: "ovnkube-control-plane"}:            {},
-			{label: "app", value: "cloud-network-config-controller"}:  {},
-			{label: "app", value: "vmi-console-debug"}:                {},
-			{label: "kubevirt.io", value: "virt-launcher"}:            {}, // virt-launcher pods have no app label
+			{label: "app", value: "azure-disk-csi-driver-controller"}:     {},
+			{label: "app", value: "azure-disk-csi-driver-operator"}:       {},
+			{label: "app", value: "azure-file-csi-driver-controller"}:     {},
+			{label: "app", value: "azure-file-csi-driver-operator"}:       {},
+			{label: "app", value: "aws-ebs-csi-driver-controller"}:        {},
+			{label: "app", value: "aws-ebs-csi-driver-operator"}:          {},
+			{label: "app", value: "openstack-cinder-csi-driver-operator"}: {},
+			{label: "app", value: "manila-csi-driver-operator"}:           {},
+			{label: "app", value: "multus-admission-controller"}:          {},
+			{label: "app", value: "network-node-identity"}:                {},
+			{label: "app", value: "ovnkube-control-plane"}:                {},
+			{label: "app", value: "cloud-network-config-controller"}:      {},
+			{label: "app", value: "vmi-console-debug"}:                    {},
+			{label: "kubevirt.io", value: "virt-launcher"}:                {}, // virt-launcher pods have no app label
 		}
 
 		for _, pod := range hcpPods.Items {
@@ -1601,7 +1603,7 @@ func EnsureReadOnlyRootFilesystem(t *testing.T, ctx context.Context, hostClient 
 		}
 	})
 
-	// By default, we add an emptyDir pod volume named "tmp-dir" and mount it into every container in the pod at /tmp.
+	// By default, we add an emptyDir pod volume and mount it into every container in the pod at /tmp.
 	// This test checks to make sure that every container has this mount, unless manually specified in auditedAppContainerNoTmpDir.
 	t.Run("EnsureReadOnlyRootFilesystemTmpDirMount", func(t *testing.T) {
 		g := NewWithT(t)
@@ -1617,20 +1619,22 @@ func EnsureReadOnlyRootFilesystem(t *testing.T, ctx context.Context, hostClient 
 		// auditedAppContainerNoTmpDir[labelSelector{label: "app", value: "value"}][pod.Spec.Containers[*]] indicates that particular container is allowed to not have the mount
 		// if a labelSelector is given with an empty map, allow all containers to not have it
 		auditedAppContainerNoTmpDir := map[labelSelector]map[string]struct{}{
-			{label: "app", value: "azure-disk-csi-driver-controller"}: {},
-			{label: "app", value: "azure-disk-csi-driver-operator"}:   {},
-			{label: "app", value: "azure-file-csi-driver-controller"}: {},
-			{label: "app", value: "azure-file-csi-driver-operator"}:   {},
-			{label: "app", value: "aws-ebs-csi-driver-controller"}:    {},
-			{label: "app", value: "aws-ebs-csi-driver-operator"}:      {},
-			{label: "app", value: "multus-admission-controller"}:      {},
-			{label: "app", value: "network-node-identity"}:            {},
-			{label: "app", value: "ovnkube-control-plane"}:            {},
-			{label: "app", value: "cloud-network-config-controller"}:  {},
-			{label: "app", value: "vmi-console-debug"}:                {},
-			{label: "kubevirt.io", value: "virt-launcher"}:            {}, // virt-launcher pods have no app label
-			{label: "app", value: "csi-snapshot-controller"}:          {},
-			{label: "app", value: "csi-snapshot-webhook"}:             {},
+			{label: "app", value: "azure-disk-csi-driver-controller"}:       {},
+			{label: "app", value: "azure-disk-csi-driver-operator"}:         {},
+			{label: "app", value: "azure-file-csi-driver-controller"}:       {},
+			{label: "app", value: "azure-file-csi-driver-operator"}:         {},
+			{label: "app", value: "aws-ebs-csi-driver-controller"}:          {},
+			{label: "app", value: "aws-ebs-csi-driver-operator"}:            {},
+			{label: "app", value: "openstack-cinder-csi-driver-controller"}: {},
+			{label: "app", value: "openstack-manila-csi-controllerplugin"}:  {},
+			{label: "app", value: "multus-admission-controller"}:            {},
+			{label: "app", value: "network-node-identity"}:                  {},
+			{label: "app", value: "ovnkube-control-plane"}:                  {},
+			{label: "app", value: "cloud-network-config-controller"}:        {},
+			{label: "app", value: "vmi-console-debug"}:                      {},
+			{label: "kubevirt.io", value: "virt-launcher"}:                  {}, // virt-launcher pods have no app label
+			{label: "app", value: "csi-snapshot-controller"}:                {},
+			{label: "app", value: "csi-snapshot-webhook"}:                   {},
 			{label: "app", value: "packageserver"}: {
 				"packageserver": {}, // the package server was able to enabled readOnlyRootFilesystem without needing to mount /tmp
 			},


### PR DESCRIPTION
This is a manual backport of #6885, that also includes manual backports of #6770 and #6842 which address the same issue but for kubevirt and are necessary to avoid merge conflicts.