### PR TITLE
KFLUXSPRT-5246: update base images from RHEL9 ELS to UBI9 minimal 9.4

### DIFF
--- a/.tekton/hypershift-operator-main-pull-request.yaml
+++ b/.tekton/hypershift-operator-main-pull-request.yaml
@@ -406,7 +406,7 @@ spec:
         - name: name
           value: sast-snyk-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:322c86ad5ee252c04440184d9f5046d276415148cb6bfaf571be1b102101786b
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:783f5de1b4def2fb3fad20b914f4b3afee46ffb8f652114946e321ef3fa86449
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/hypershift-operator-main-push.yaml
+++ b/.tekton/hypershift-operator-main-push.yaml
@@ -405,7 +405,7 @@ spec:
         - name: name
           value: sast-snyk-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:322c86ad5ee252c04440184d9f5046d276415148cb6bfaf571be1b102101786b
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:783f5de1b4def2fb3fad20b914f4b3afee46ffb8f652114946e321ef3fa86449
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/hypershift-operator-main-tag.yaml
+++ b/.tekton/hypershift-operator-main-tag.yaml
@@ -528,7 +528,7 @@ spec:
             - name: name
               value: sast-snyk-check
             - name: bundle
-              value: quay.io/redhat-appstudio-tekton-catalog/task-sast-snyk-check:0.4@sha256:4c049dc73f355f760e9dc756e4206d3b838ab6e45fa572383e7e4cddb9d265b2
+              value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:783f5de1b4def2fb3fad20b914f4b3afee46ffb8f652114946e321ef3fa86449
             - name: kind
               value: task
           resolver: bundles

--- a/Containerfile.control-plane
+++ b/Containerfile.control-plane
@@ -7,7 +7,7 @@ COPY --chown=default . .
 RUN make control-plane-operator \
   && make control-plane-pki-operator
 
-FROM registry.redhat.io/rhel9-2-els/rhel:9.2
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
 COPY --from=builder /hypershift/bin/control-plane-operator /usr/bin/control-plane-operator
 COPY --from=builder /hypershift/bin/control-plane-pki-operator /usr/bin/control-plane-pki-operator
 

--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -9,12 +9,12 @@ RUN make hypershift \
   && make product-cli \
   && make karpenter-operator
 
-FROM registry.redhat.io/rhel9-4-els/rhel:9.4
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
 COPY --from=builder /hypershift/bin/hypershift \
-                    /hypershift/bin/hcp \
-                    /hypershift/bin/hypershift-operator \
-                    /hypershift/bin/karpenter-operator \
-     /usr/bin/
+  /hypershift/bin/hcp \
+  /hypershift/bin/hypershift-operator \
+  /hypershift/bin/karpenter-operator \
+  /usr/bin/
 
 ENTRYPOINT ["/usr/bin/hypershift"]
 


### PR DESCRIPTION
## What this PR does / why we need it:

Update container base images in both Containerfile.control-plane and Containerfile.operator from registry.redhat.io RHEL9 ELS images to registry.access.redhat.com UBI9 minimal 9.4 for:

* Unauthenticated pulls
* Smaller sizes
* Fix Enterprise contract.

Also clean up COPY command formatting in Containerfile.operator for better readability.



## Which issue(s) this PR fixes:

Fixes: [KFLUXSPRT-5246](https://issues.redhat.com//browse/KFLUXSPRT-5246)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.