### PR TITLE
test: update external-oidc e2e tests to dynamically determine tests to run

### DIFF
--- a/test/e2e/external_oidc_test.go
+++ b/test/e2e/external_oidc_test.go
@@ -20,13 +20,12 @@ import (
 	kauthnv1typedclient "k8s.io/client-go/kubernetes/typed/authentication/v1"
 
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/hypershift/control-plane-operator/featuregates"
 )
 
 func TestExternalOIDC(t *testing.T) {
 	e2eutil.AtLeast(t, e2eutil.Version419)
-	if os.Getenv("TECH_PREVIEW_NO_UPGRADE") != "true" {
-		t.Skipf("Only tested when CI sets TECH_PREVIEW_NO_UPGRADE=true and the Hypershift Operator is installed with --tech-preview-no-upgrade")
-	}
 
 	if globalOpts.ExternalOIDCProvider == "" {
 		t.Skipf("skip external OIDC test if e2e.external-oidc-provider is not provided")
@@ -38,42 +37,16 @@ func TestExternalOIDC(t *testing.T) {
 	defer cancel()
 
 	clusterOpts := globalOpts.DefaultClusterOptions(t)
-
-	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
-		t.Run("[OCPFeatureGate:ExternalOIDC] test keycloak external OIDC", func(t *testing.T) {
-			g := NewWithT(t)
-			t.Logf("begin to test external OIDC %s", globalOpts.ExternalOIDCProvider)
-			g.Expect(hostedCluster.Spec.Configuration).NotTo(BeNil())
-			g.Expect(hostedCluster.Spec.Configuration.Authentication).NotTo(BeNil())
-			g.Expect(hostedCluster.Spec.Configuration.Authentication.OIDCProviders).NotTo(BeEmpty())
-			clientCfg := e2eutil.WaitForGuestRestConfig(t, ctx, mgtClient, hostedCluster)
-			e2eutil.ChangeClientForKeycloakExtOIDC(t, ctx, clientCfg, clusterOpts.ExtOIDCConfig)
-			t.Logf("successfully get oidc user client")
-		})
-	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, "external-oidc", globalOpts.ServiceAccountSigningKey)
-}
-
-func TestExternalOIDCTechPreview(t *testing.T) {
-	e2eutil.AtLeast(t, e2eutil.Version419)
-	if os.Getenv("TECH_PREVIEW_NO_UPGRADE") != "true" {
-		t.Skipf("Only tested when CI sets TECH_PREVIEW_NO_UPGRADE=true and the Hypershift Operator is installed with --tech-preview-no-upgrade")
-	}
-
-	if globalOpts.ExternalOIDCProvider == "" {
-		t.Skipf("skip external OIDC test if e2e.external-oidc-provider is not provided")
-	}
-
-	t.Parallel()
-
-	ctx, cancel := context.WithCancel(testContext)
-	defer cancel()
-
-	clusterOpts := globalOpts.DefaultClusterOptions(t)
-	clusterOpts.FeatureSet = string(configv1.TechPreviewNoUpgrade)
 	clusterOpts.NodePoolReplicas = 1
+	clusterOpts.FeatureSet = string(configv1.Default)
+
+	if os.Getenv("TECH_PREVIEW_NO_UPGRADE") == "true" {
+		clusterOpts.FeatureSet = string(configv1.TechPreviewNoUpgrade)
+	}
+
+	featuregates.ConfigureFeatureSet(clusterOpts.FeatureSet)
 
 	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
-		t.Logf("begin to test external OIDC with TechPreviewNoUpgrade enabled %s", globalOpts.ExternalOIDCProvider)
 		g.Expect(hostedCluster.Spec.Configuration).NotTo(BeNil())
 		g.Expect(hostedCluster.Spec.Configuration.Authentication).NotTo(BeNil())
 		g.Expect(hostedCluster.Spec.Configuration.Authentication.OIDCProviders).NotTo(BeEmpty())
@@ -85,43 +58,57 @@ func TestExternalOIDCTechPreview(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 		t.Logf("selfSubjectReview %+v", selfSubjectReview)
 
-		t.Run("[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] Test external OIDC userInfo username", func(t *testing.T) {
+		t.Run("[OCPFeatureGate:ExternalOIDC] test keycloak external OIDC", func(t *testing.T) {
+			// No gates exist for ExternalOIDC as it has already been enabled by default.
 			g := NewWithT(t)
-			t.Logf("begin to test external OIDC with external OIDC userInfo username")
-			g.Expect(selfSubjectReview.Status.UserInfo.Username).NotTo(BeEmpty())
-			g.Expect(selfSubjectReview.Status.UserInfo.Username).Should(ContainSubstring(clusterOpts.ExtOIDCConfig.UserPrefix))
+			t.Logf("begin to test external OIDC %s", globalOpts.ExternalOIDCProvider)
+			g.Expect(hostedCluster.Spec.Configuration).NotTo(BeNil())
+			g.Expect(hostedCluster.Spec.Configuration.Authentication).NotTo(BeNil())
+			g.Expect(hostedCluster.Spec.Configuration.Authentication.OIDCProviders).NotTo(BeEmpty())
+			clientCfg := e2eutil.WaitForGuestRestConfig(t, ctx, mgtClient, hostedCluster)
+			e2eutil.ChangeClientForKeycloakExtOIDC(t, ctx, clientCfg, clusterOpts.ExtOIDCConfig)
+			t.Logf("successfully get oidc user client")
 		})
 
-		t.Run("[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] Test external OIDC userInfo Groups", func(t *testing.T) {
-			g := NewWithT(t)
-			t.Logf("begin to test external OIDC userInfo Groups")
-			g.Expect(selfSubjectReview.Status.UserInfo.Groups).NotTo(BeEmpty())
-			g.Expect(selfSubjectReview.Status.UserInfo.Groups).Should(ContainElements(ContainSubstring(clusterOpts.ExtOIDCConfig.GroupPrefix)))
-		})
+		if featuregates.Gate().Enabled(featuregates.ExternalOIDCWithUIDAndExtraClaimMappings) {
+			t.Run("[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] Test external OIDC userInfo username", func(t *testing.T) {
+				g := NewWithT(t)
+				t.Logf("begin to test external OIDC with external OIDC userInfo username")
+				g.Expect(selfSubjectReview.Status.UserInfo.Username).NotTo(BeEmpty())
+				g.Expect(selfSubjectReview.Status.UserInfo.Username).Should(ContainSubstring(clusterOpts.ExtOIDCConfig.UserPrefix))
+			})
 
-		t.Run("[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] Test external OIDC userInfo UID", func(t *testing.T) {
-			g := NewWithT(t)
-			t.Logf("begin to test external OIDC userInfo UID")
-			g.Expect(selfSubjectReview.Status.UserInfo.UID).NotTo(BeEmpty())
-			g.Expect(selfSubjectReview.Status.UserInfo.UID).Should(ContainSubstring(e2eutil.ExternalOIDCUIDExpressionPrefix))
-			g.Expect(selfSubjectReview.Status.UserInfo.UID).Should(ContainSubstring(e2eutil.ExternalOIDCUIDExpressionSubfix))
-		})
+			t.Run("[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] Test external OIDC userInfo Groups", func(t *testing.T) {
+				g := NewWithT(t)
+				t.Logf("begin to test external OIDC userInfo Groups")
+				g.Expect(selfSubjectReview.Status.UserInfo.Groups).NotTo(BeEmpty())
+				g.Expect(selfSubjectReview.Status.UserInfo.Groups).Should(ContainElements(ContainSubstring(clusterOpts.ExtOIDCConfig.GroupPrefix)))
+			})
 
-		t.Run("[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] Test external OIDC userInfo Extra", func(t *testing.T) {
-			g := NewWithT(t)
-			t.Logf("begin to test external OIDC userInfo Extra")
-			g.Expect(selfSubjectReview.Status.UserInfo.Extra).NotTo(BeEmpty())
-			g.Expect(selfSubjectReview.Status.UserInfo.Extra).Should(HaveKey(e2eutil.ExternalOIDCExtraKeyBar))
-			g.Expect(selfSubjectReview.Status.UserInfo.Extra).Should(HaveKey(e2eutil.ExternalOIDCExtraKeyFoo))
-		})
+			t.Run("[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] Test external OIDC userInfo UID", func(t *testing.T) {
+				g := NewWithT(t)
+				t.Logf("begin to test external OIDC userInfo UID")
+				g.Expect(selfSubjectReview.Status.UserInfo.UID).NotTo(BeEmpty())
+				g.Expect(selfSubjectReview.Status.UserInfo.UID).Should(ContainSubstring(e2eutil.ExternalOIDCUIDExpressionPrefix))
+				g.Expect(selfSubjectReview.Status.UserInfo.UID).Should(ContainSubstring(e2eutil.ExternalOIDCUIDExpressionSubfix))
+			})
 
-		t.Run("[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] Test external OIDC: check co status using oauth client", func(t *testing.T) {
-			g := NewWithT(t)
-			t.Logf("begin to test for checking co status")
-			client, err := configv1client.NewForConfig(authKubeConfig)
-			g.Expect(err).NotTo(HaveOccurred())
-			_, err = client.ConfigV1().ClusterOperators().Get(ctx, "image-registry", metav1.GetOptions{})
-			g.Expect(err).To(HaveOccurred())
-		})
+			t.Run("[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] Test external OIDC userInfo Extra", func(t *testing.T) {
+				g := NewWithT(t)
+				t.Logf("begin to test external OIDC userInfo Extra")
+				g.Expect(selfSubjectReview.Status.UserInfo.Extra).NotTo(BeEmpty())
+				g.Expect(selfSubjectReview.Status.UserInfo.Extra).Should(HaveKey(e2eutil.ExternalOIDCExtraKeyBar))
+				g.Expect(selfSubjectReview.Status.UserInfo.Extra).Should(HaveKey(e2eutil.ExternalOIDCExtraKeyFoo))
+			})
+
+			t.Run("[OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] Test external OIDC: check co status using oauth client", func(t *testing.T) {
+				g := NewWithT(t)
+				t.Logf("begin to test for checking co status")
+				client, err := configv1client.NewForConfig(authKubeConfig)
+				g.Expect(err).NotTo(HaveOccurred())
+				_, err = client.ConfigV1().ClusterOperators().Get(ctx, "image-registry", metav1.GetOptions{})
+				g.Expect(err).To(HaveOccurred())
+			})
+		}
 	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, "external-oidc", globalOpts.ServiceAccountSigningKey)
 }


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

This PR updates the external OIDC tests so that they dynamically run based on the testing environment in which they are run.

This more closely simulates the behavior of the standalone openshift tests where tests can be skipped or included based on feature gate enablement.

This makes it easier to have both a techpreview and default Prow job that will run these tests and makes it easier for future techpreview work on this feature to be tested without having the extra step of adding back a techpreview job while ensuring that we also capture any regressions from change introduced in TPNU before they are promoted to the Default feature set.

## Which issue(s) this PR fixes:

N/A

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.