### PR TITLE
OCPBUGS-61175: Let cluster-storage-operator to grant NetworkPolicies

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_role.yaml
@@ -73,3 +73,15 @@ rules:
   - watch
   - list
   - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - watch
+  - list
+  - get
+  - create
+  - delete
+  - patch
+  - update

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_role.yaml
@@ -73,3 +73,15 @@ rules:
   - watch
   - list
   - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - watch
+  - list
+  - get
+  - create
+  - delete
+  - patch
+  - update

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-storage-operator/zz_fixture_TestControlPlaneComponents_cluster_storage_operator_role.yaml
@@ -73,3 +73,15 @@ rules:
   - watch
   - list
   - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - watch
+  - list
+  - get
+  - create
+  - delete
+  - patch
+  - update

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-storage-operator/role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-storage-operator/role.yaml
@@ -64,3 +64,15 @@ rules:
       - watch
       - list
       - get
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - watch
+      - list
+      - get
+      - create
+      - delete
+      - patch
+      - update


### PR DESCRIPTION
## What this PR does / why we need it:

Manila csi driver controller pods reside in a custome namespace (`openshift-manila-csi-driver`). Hence, Manila csi driver operator must create NetworkPolicy for them expicitly. It is cluster-storage-operator who is legit to grant permissions for that to Manila csi driver operator. But to do it, cluster-storage-operator itself must have proper permissions.
