### PR TITLE
OCPBUGS-62172: Identify OpenStack CSI apps via their correct app labels

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1630,20 +1630,20 @@ func EnsureReadOnlyRootFilesystem(t *testing.T, ctx context.Context, hostClient 
 		// auditedAppContainersNoRORFS[labelSelector{label: "app", value: "value"}][pod.Spec.Containers[*]] indicates that particular container is allowed to be false.
 		// if a labelSelector is given with an empty map, allow all containers to be false
 		auditedAppContainersNoRORFS := map[labelSelector]map[string]struct{}{
-			{label: "app", value: "azure-disk-csi-driver-controller"}:     {},
-			{label: "app", value: "azure-disk-csi-driver-operator"}:       {},
-			{label: "app", value: "azure-file-csi-driver-controller"}:     {},
-			{label: "app", value: "azure-file-csi-driver-operator"}:       {},
-			{label: "app", value: "aws-ebs-csi-driver-controller"}:        {},
-			{label: "app", value: "aws-ebs-csi-driver-operator"}:          {},
-			{label: "app", value: "openstack-cinder-csi-driver-operator"}: {},
-			{label: "app", value: "manila-csi-driver-operator"}:           {},
-			{label: "app", value: "multus-admission-controller"}:          {},
-			{label: "app", value: "network-node-identity"}:                {},
-			{label: "app", value: "ovnkube-control-plane"}:                {},
-			{label: "app", value: "cloud-network-config-controller"}:      {},
-			{label: "app", value: "vmi-console-debug"}:                    {},
-			{label: "kubevirt.io", value: "virt-launcher"}:                {}, // virt-launcher pods have no app label
+			{label: "app", value: "azure-disk-csi-driver-controller"}:       {},
+			{label: "app", value: "azure-disk-csi-driver-operator"}:         {},
+			{label: "app", value: "azure-file-csi-driver-controller"}:       {},
+			{label: "app", value: "azure-file-csi-driver-operator"}:         {},
+			{label: "app", value: "aws-ebs-csi-driver-controller"}:          {},
+			{label: "app", value: "aws-ebs-csi-driver-operator"}:            {},
+			{label: "app", value: "openstack-cinder-csi-driver-controller"}: {},
+			{label: "app", value: "openstack-manila-csi"}:                   {},
+			{label: "app", value: "multus-admission-controller"}:            {},
+			{label: "app", value: "network-node-identity"}:                  {},
+			{label: "app", value: "ovnkube-control-plane"}:                  {},
+			{label: "app", value: "cloud-network-config-controller"}:        {},
+			{label: "app", value: "vmi-console-debug"}:                      {},
+			{label: "kubevirt.io", value: "virt-launcher"}:                  {}, // virt-launcher pods have no app label
 		}
 
 		for _, pod := range hcpPods.Items {
@@ -1695,7 +1695,7 @@ func EnsureReadOnlyRootFilesystem(t *testing.T, ctx context.Context, hostClient 
 			{label: "app", value: "aws-ebs-csi-driver-controller"}:          {},
 			{label: "app", value: "aws-ebs-csi-driver-operator"}:            {},
 			{label: "app", value: "openstack-cinder-csi-driver-controller"}: {},
-			{label: "app", value: "openstack-manila-csi-controllerplugin"}:  {},
+			{label: "app", value: "openstack-manila-csi"}:                   {},
 			{label: "app", value: "multus-admission-controller"}:            {},
 			{label: "app", value: "network-node-identity"}:                  {},
 			{label: "app", value: "ovnkube-control-plane"}:                  {},


### PR DESCRIPTION
According to the configs in csi-operator [1] and [2], the correct app labels should be `openstack-manila-csi` and
`openstack-cinder-csi-driver-controller`.

[1] https://github.com/openshift/csi-operator/blob/12ef6e82b4cdf0cb45b43056a81dfdf9fbd833ff/assets/overlays/openstack-manila/generated/hypershift/controller.yaml#L52
[2] https://github.com/openshift/csi-operator/blob/12ef6e82b4cdf0cb45b43056a81dfdf9fbd833ff/assets/overlays/openstack-cinder/generated/hypershift/controller.yaml#L53

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes OCPBUGS-62172

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.