### PR TITLE
CNTRLPLANE-1543: fix(aws): use clean image for placeholder nodes

### DIFF
--- a/hypershift-operator/controllers/scheduler/aws/dedicated_request_serving_nodes.go
+++ b/hypershift-operator/controllers/scheduler/aws/dedicated_request_serving_nodes.go
@@ -908,7 +908,7 @@ func (r *DedicatedServingComponentSchedulerAndSizer) ensurePlaceholderDeployment
 				Containers: []corev1.Container{
 					{
 						Name:  "placeholder",
-						Image: "quay.io/openshift/origin-hello-openshift:latest",
+						Image: defaultPlaceholderImage,
 					},
 				},
 			},

--- a/hypershift-operator/controllers/scheduler/aws/placeholders.go
+++ b/hypershift-operator/controllers/scheduler/aws/placeholders.go
@@ -33,8 +33,11 @@ import (
 
 type PlaceholderScheduler struct{}
 
-const placeholderNamespace = "hypershift-request-serving-node-placeholders"
-const placeholderControllerName = "PlaceholderScheduler"
+const (
+	placeholderNamespace      = "hypershift-request-serving-node-placeholders"
+	placeholderControllerName = "PlaceholderScheduler"
+	defaultPlaceholderImage   = "registry.access.redhat.com/ubi8/pause:latest"
+)
 
 func (r *PlaceholderScheduler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	kubernetesClient, err := kubernetes.NewForConfig(mgr.GetConfig())
@@ -464,7 +467,7 @@ func newDeployment(namespace, sizeClass string, placeholderIndex int, pairedNode
 					).
 					WithContainers(corev1applyconfigurations.Container().
 						WithName("placeholder").
-						WithImage("quay.io/openshift/origin-hello-openshift:latest"),
+						WithImage(defaultPlaceholderImage),
 					),
 				),
 			),


### PR DESCRIPTION
use a continuously remediated and updated image to run on request- serving placeholder pods, as hello-openshift has not been updated in 2 years.

## What this PR does / why we need it:

The [origin-hello-openshift](https://quay.io/repository/openshift/origin-hello-openshift?tab=tags&tag=latest) image is no longer continuously updated, and as such has accumulated several high CVEs that make it risky to deploy in certain environments. In order to account for this, we should move the placeholder pods to make use of a more continuously maintained and secure container image: in this MR I chose to use the ubi8 pause image from registry.redhat.io

## Which issue(s) this PR fixes:

Fixes CNTRLPLANE-1543

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.