### PR TITLE
OCPBUGS-62407: chore(build): update container images to 4.21

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.24-openshift-4.20
+  tag: rhel-9-release-golang-1.24-openshift-4.21

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.20 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.21 AS builder
 
 WORKDIR /hypershift
 

--- a/Dockerfile.control-plane
+++ b/Dockerfile.control-plane
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.21 AS builder
 
 WORKDIR /hypershift
 
@@ -7,7 +7,7 @@ COPY . .
 RUN make control-plane-operator \
   && make control-plane-pki-operator
 
-FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
 COPY --from=builder /hypershift/bin/control-plane-operator /usr/bin/control-plane-operator
 COPY --from=builder /hypershift/bin/control-plane-pki-operator /usr/bin/control-plane-pki-operator
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,7 @@
 # Disclaimer: The purpose of this Dockerfile is to simplify development tasks by building a container image with all-in-one binaries.
 # The control-plane-operator should not be included in the Hypershift operator image because it is already part of the OpenShift payload.
 
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.20 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.21 AS builder
 WORKDIR /hypershift
 
 COPY . .

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.20 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.21 AS builder
 
 WORKDIR /hypershift
 
@@ -8,7 +8,7 @@ RUN make e2e
 
 # Reuse the same image as builder because we need go command in ci-test-e2e.sh
 # Multi-stage build lets us drop the source code and build cache from the final image
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.20
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.21
 
 WORKDIR /hypershift
 


### PR DESCRIPTION
## What this PR does / why we need it:

This PR updates all HyperShift container base images to version 4.21 to align with the upcoming OpenShift release cycle. Specifically:

- Updates development and e2e builder images (Dockerfile, Dockerfile.dev, Dockerfile.e2e) to use 4.21 base images
- Updates the ose-hypershift-container image reference in Dockerfile.control-plane to be consistent with ART (Automated Release Tooling) for 4.21
- Updates CI operator configuration (.ci-operator.yaml) to reference the correct 4.21 image streams

These changes ensure that HyperShift development, testing, and production images are built on the latest OpenShift 4.21 base images with the most recent security updates and platform features.

## Which issue(s) this PR fixes:

Fixes OCPBUGS-62407

## Special notes for your reviewer:

- All changes are version bumps in container image references
- No functional code changes - only base image updates
- These changes should be tested in CI to ensure all images build successfully with the new base images

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.