### PR TITLE
CNTRLPLANE-1332: docs(readme): correct spelling mistake

### DIFF
--- a/docs/content/how-to/azure/azure-workload-identity-setup.md
+++ b/docs/content/how-to/azure/azure-workload-identity-setup.md
@@ -10,7 +10,7 @@ This document describes how to set up Azure Workload Identities and OIDC issuer 
     
     When setting up workload identities and OIDC issuer for the first time, create them in a **persistent resource group** that will not be deleted when individual clusters are destroyed. This allows you to reuse the same workload identities and OIDC issuer across multiple HostedClusters, reducing setup time and avoiding unnecessary resource recreation.
     
-    - Use a persistant resource group like `os4-common`.
+    - Use a persistent resource group like `os4-common`.
     - This resource group should be separate from the cluster-specific resource groups that get created and deleted with each HostedCluster.
     - The OIDC issuer storage account should also be created in this persistent resource group.
 


### PR DESCRIPTION
## What this PR does / why we need it:
This PR corrects a spelling mistake in the documentation to improve clarity and professionalism.

## Which issue(s) this PR fixes:
A part of [CNTRLPLANE-1332](https://issues.redhat.com//browse/CNTRLPLANE-1332)

## Special notes for your reviewer:

This is a simple documentation fix with no functional changes.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.