### PR TITLE
OCPBUGS-62172: Add OpenStack node drivers to allowed non-read-only root filesystem containers

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1630,20 +1630,22 @@ func EnsureReadOnlyRootFilesystem(t *testing.T, ctx context.Context, hostClient 
 		// auditedAppContainersNoRORFS[labelSelector{label: "app", value: "value"}][pod.Spec.Containers[*]] indicates that particular container is allowed to be false.
 		// if a labelSelector is given with an empty map, allow all containers to be false
 		auditedAppContainersNoRORFS := map[labelSelector]map[string]struct{}{
-			{label: "app", value: "azure-disk-csi-driver-controller"}:     {},
-			{label: "app", value: "azure-disk-csi-driver-operator"}:       {},
-			{label: "app", value: "azure-file-csi-driver-controller"}:     {},
-			{label: "app", value: "azure-file-csi-driver-operator"}:       {},
-			{label: "app", value: "aws-ebs-csi-driver-controller"}:        {},
-			{label: "app", value: "aws-ebs-csi-driver-operator"}:          {},
-			{label: "app", value: "openstack-cinder-csi-driver-operator"}: {},
-			{label: "app", value: "manila-csi-driver-operator"}:           {},
-			{label: "app", value: "multus-admission-controller"}:          {},
-			{label: "app", value: "network-node-identity"}:                {},
-			{label: "app", value: "ovnkube-control-plane"}:                {},
-			{label: "app", value: "cloud-network-config-controller"}:      {},
-			{label: "app", value: "vmi-console-debug"}:                    {},
-			{label: "kubevirt.io", value: "virt-launcher"}:                {}, // virt-launcher pods have no app label
+			{label: "app", value: "azure-disk-csi-driver-controller"}:       {},
+			{label: "app", value: "azure-disk-csi-driver-operator"}:         {},
+			{label: "app", value: "azure-file-csi-driver-controller"}:       {},
+			{label: "app", value: "azure-file-csi-driver-operator"}:         {},
+			{label: "app", value: "aws-ebs-csi-driver-controller"}:          {},
+			{label: "app", value: "aws-ebs-csi-driver-operator"}:            {},
+			{label: "app", value: "openstack-cinder-csi-driver-operator"}:   {},
+			{label: "app", value: "openstack-cinder-csi-driver-controller"}: {},
+			{label: "app", value: "manila-csi-driver-operator"}:             {},
+			{label: "app", value: "openstack-manila-csi"}:                   {},
+			{label: "app", value: "multus-admission-controller"}:            {},
+			{label: "app", value: "network-node-identity"}:                  {},
+			{label: "app", value: "ovnkube-control-plane"}:                  {},
+			{label: "app", value: "cloud-network-config-controller"}:        {},
+			{label: "app", value: "vmi-console-debug"}:                      {},
+			{label: "kubevirt.io", value: "virt-launcher"}:                  {}, // virt-launcher pods have no app label
 		}
 
 		for _, pod := range hcpPods.Items {
@@ -1695,7 +1697,7 @@ func EnsureReadOnlyRootFilesystem(t *testing.T, ctx context.Context, hostClient 
 			{label: "app", value: "aws-ebs-csi-driver-controller"}:          {},
 			{label: "app", value: "aws-ebs-csi-driver-operator"}:            {},
 			{label: "app", value: "openstack-cinder-csi-driver-controller"}: {},
-			{label: "app", value: "openstack-manila-csi-controllerplugin"}:  {},
+			{label: "app", value: "openstack-manila-csi"}:                   {},
 			{label: "app", value: "multus-admission-controller"}:            {},
 			{label: "app", value: "network-node-identity"}:                  {},
 			{label: "app", value: "ovnkube-control-plane"}:                  {},


### PR DESCRIPTION
## What this PR does / why we need it:

This is a follow-up to https://github.com/openshift/hypershift/pull/6885. An undefined `readOnlyRootFilesystem` value means an implicit `false`, not `true`. Add the apps corresponding to the Cinder and Manila CSI node driver services to the list of apps allowed non-read-only root filesystems.

We also fix a typo for the test that checks for `/tmp` mounts (which aren't necessary when `readOnlyRootFilesystem` is `false`): the *name* of the Manila CSI node driver deployment is `openstack-manila-csi-controllerplugin`, but the `app` label - which is what we care about - is `openstack-manila-csi`.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes OCPBUGS-62172

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.
