### PR TITLE
NO-JIRA: build: downgrade Go version to 1.24.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/hypershift
 
-go 1.24.4
+go 1.24.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.2


### PR DESCRIPTION
## What this PR does / why we need it:

Downgrades the Go version from 1.24.4 to 1.24.0 in go.mod to maintain compatibility with the project's build environment and CI infrastructure.

## Which issue(s) this PR fixes:

N/A

## Special notes for your reviewer:

This is a straightforward Go version change. No functional code changes are included.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.