### PR TITLE
OCPBUGS-62816: set default goaway-chance to 0.001

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params.go
@@ -88,7 +88,7 @@ const (
 
 	defaultMaxRequestsInflight         = 3000
 	defaultMaxMutatingRequestsInflight = 1000
-	defaultGoAwayChance                = 0
+	defaultGoAwayChance                = 0.001
 )
 
 func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider imageprovider.ReleaseImageProvider, externalAPIAddress string, externalAPIPort int32, externalOAuthAddress string, externalOAuthPort int32, setDefaultSecurityContext bool) *KubeAPIServerParams {
@@ -134,6 +134,10 @@ func NewKubeAPIServerParams(ctx context.Context, hcp *hyperv1.HostedControlPlane
 	}
 	if mutatingReqInflight := hcp.Annotations[hyperv1.KubeAPIServerMaximumMutatingRequestsInFlight]; mutatingReqInflight != "" {
 		params.MaxMutatingRequestsInflight = mutatingReqInflight
+	}
+	if hcp.Spec.ControllerAvailabilityPolicy == hyperv1.SingleReplica {
+		// There is no point in rebalancing connections if there is only one KAS
+		params.GoAwayChance = "0"
 	}
 	if goAwayChance := hcp.Annotations[hyperv1.KubeAPIServerGoAwayChance]; goAwayChance != "" {
 		params.GoAwayChance = goAwayChance

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/params_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/params_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/openshift/hypershift/api/util/ipnet"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/support/config"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // TODO (cewong): Add tests for other params
@@ -73,6 +75,70 @@ func TestNewAPIServerParamsAPIAdvertiseAddressAndPort(t *testing.T) {
 				g.Expect(test.advertiseAddress).To(Equal(test.expectedAddress))
 			}
 			g.Expect(p.KASPodPort).To(Equal(test.expectedPort))
+		})
+	}
+}
+
+func TestNewAPIServerParamsGoAwayChance(t *testing.T) {
+	tests := []struct {
+		name                 string
+		hcp                  *hyperv1.HostedControlPlane
+		expectedGoAwayChance string
+	}{
+		{
+			name: "highly-available",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					ControllerAvailabilityPolicy: hyperv1.HighlyAvailable,
+				},
+			},
+			expectedGoAwayChance: "0.001",
+		},
+		{
+			name: "single-replica",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					ControllerAvailabilityPolicy: hyperv1.SingleReplica,
+				},
+			},
+			expectedGoAwayChance: "0",
+		},
+		{
+			name: "highly-available with annotation",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						hyperv1.KubeAPIServerGoAwayChance: "0.002",
+					},
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					ControllerAvailabilityPolicy: hyperv1.HighlyAvailable,
+				},
+			},
+			expectedGoAwayChance: "0.002",
+		},
+		{
+			name: "single-replica with annotation",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						hyperv1.KubeAPIServerGoAwayChance: "0.002",
+					},
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					ControllerAvailabilityPolicy: hyperv1.SingleReplica,
+				},
+			},
+			expectedGoAwayChance: "0.002",
+		},
+	}
+
+	imageProvider := imageprovider.NewFromImages(map[string]string{})
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			p := NewKubeAPIServerParams(context.Background(), test.hcp, imageProvider, "", 0, "", 0, false)
+			g.Expect(p.GoAwayChance).To(Equal(test.expectedGoAwayChance))
 		})
 	}
 }


### PR DESCRIPTION
Manual backport of https://github.com/openshift/hypershift/pull/6712

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets default `GoAwayChance` to 0.001, forces 0 for single-replica, and adds tests covering policy and annotation overrides.
> 
> - **KAS params (`controllers/hostedcontrolplane/kas/params.go`)**:
>   - Set default `GoAwayChance` to `0.001` (from `0`).
>   - For `SingleReplica` availability, set `GoAwayChance` to `"0"`.
>   - Respect `hyperv1.KubeAPIServerGoAwayChance` annotation to override.
> - **Tests (`controllers/hostedcontrolplane/kas/params_test.go`)**:
>   - Add `TestNewAPIServerParamsGoAwayChance` validating defaults, single-replica override, and annotation override.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1381234389d3a7b826fbc4fc7e7f8b16c4fae716. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->