### PR TITLE
OCPBUGS-61291: fix(e2e): get TestHAEtcdChaos to a functioning state

### DIFF
--- a/test/e2e/chaos_test.go
+++ b/test/e2e/chaos_test.go
@@ -43,26 +43,13 @@ func TestHAEtcdChaos(t *testing.T) {
 	clusterOpts.NodePoolReplicas = 0
 
 	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
-		t.Run("SingleMemberRecovery", func(t *testing.T) {
-			t.Parallel()
-			testSingleMemberRecovery(ctx, mgtClient, hostedCluster)
-		})
-		t.Run("KillRandomMembers", func(t *testing.T) {
-			t.Parallel()
-			testKillRandomMembers(ctx, mgtClient, hostedCluster)
-		})
-		t.Run("KillAllMembers", func(t *testing.T) {
-			t.Parallel()
-			testKillAllMembers(ctx, mgtClient, hostedCluster)
-		})
-		t.Run("SingleMemberRecoveryWithCorruption", func(t *testing.T) {
-			testEtcdMemberCorruption(ctx, mgtClient, hostedCluster)
-		})
-		t.Run("SingleMissingMemberRecovery", func(t *testing.T) {
-			testEtcdMemberMissing(ctx, mgtClient, hostedCluster)
-		})
+		t.Run("SingleMemberRecovery", testSingleMemberRecovery(ctx, mgtClient, hostedCluster))
+		t.Run("KillRandomMembers", testKillRandomMembers(ctx, mgtClient, hostedCluster))
+		t.Run("KillAllMembers", testKillAllMembers(ctx, mgtClient, hostedCluster))
+		t.Run("SingleMemberRecoveryWithCorruption", testEtcdMemberCorruption(ctx, mgtClient, hostedCluster))
+		t.Run("SingleMissingMemberRecovery", testEtcdMemberMissing(ctx, mgtClient, hostedCluster))
 
-	}).Execute(&clusterOpts, hyperv1.NonePlatform, globalOpts.ArtifactDir, "ha-etcd-chaos", globalOpts.ServiceAccountSigningKey)
+	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, "ha-etcd-chaos", globalOpts.ServiceAccountSigningKey)
 }
 
 // testKillRandomMembers ensures that data is preserved following a period where


### PR DESCRIPTION
> [!NOTE]
> This PR also incorporates #6761

## What this PR does / why we need it:

Change TestHAEtcdChaos from hardcoded Platform=None to globalOpts.Platform, allowing the test to run on AWS, Azure, and other supported platforms.

**Problem**:
Yes the TestHAEtcdChaos was running, but it was giving a false positive signal, the validation were actually never running and the test was succeeding due to how the validation were wired within the sub-tests. 

Here's an example validation, `testSingleMemberRecovery()` actually returns a `func(*testing.T)` that never get executed.

```go
t.Run("SingleMemberRecovery", func(t *testing.T) {
    t.Parallel()
    testSingleMemberRecovery(ctx, mgtClient, hostedCluster)
})
```

And a control-plane was never deployed due to the platform being set to None. 

- [this e2e-aws job](
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_hypershift/6924/pull-ci-openshift-hypershift-main-e2e-aws/1975925453898125312/artifacts/e2e-aws/hypershift-aws-run-e2e-external/artifacts/TestHAEtcdChaos/namespaces/e2e-clusters-dv84n-ha-etcd-chaos-htw5g/core/pods/)  shows that there's only a CPO pod in the HCP namespace in . 
- [this e2e-aks job](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_hypershift/6957/pull-ci-openshift-hypershift-main-e2e-aks/1975973525063733248/artifacts/e2e-aks/hypershift-azure-run-e2e/artifacts/TestHAEtcdChaos/namespaces/e2e-clusters-vmttl-ha-etcd-chaos-j5gwf/core/pods/) , shows that only CPO & CAPI pods exist in the HCP namespace.  

So the test was running and not doing anything. Any validation of the actual HostedCluster availability in the `before()` would actually uncover this situation. 

## Which issue(s) this PR fixes:
Fixes OCPBUGS-61291

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified internal test execution structure and improved test platform configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->