### PR TITLE
OCPBUGS-62851: feat(e2e): add check for Service and Pod Monitors

### DIFF
--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -2553,6 +2553,7 @@ func TestCreateCluster(t *testing.T) {
 		e2eutil.EnsureAppLabel(t, ctx, mgtClient, hostedCluster)
 		e2eutil.EnsureFeatureGateStatus(t, ctx, guestClient)
 		e2eutil.EnsureCAPIFinalizers(t, ctx, mgtClient, hostedCluster)
+		e2eutil.EnsureNoMetricsTargetsAreDown(t, ctx, mgtClient, hostedCluster)
 
 		// ensure KAS DNS name is configured with a KAS Serving cert
 		e2eutil.EnsureKubeAPIDNSNameCustomCert(t, ctx, mgtClient, hostedCluster)

--- a/test/e2e/util/scheme.go
+++ b/test/e2e/util/scheme.go
@@ -16,6 +16,7 @@ import (
 
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 )
 
 var (
@@ -30,6 +31,7 @@ func init() {
 	_ = operatorsv1.AddToScheme(scheme)
 	_ = operatorsv1alpha1.AddToScheme(scheme)
 	_ = capikubevirt.AddToScheme(scheme)
+	_ = monitoringv1.AddToScheme(scheme)
 
 	awsKarpanterGroupVersion := schema.GroupVersion{Group: awskarpenterapis.Group, Version: "v1"}
 	metav1.AddToGroupVersion(scheme, awsKarpanterGroupVersion)


### PR DESCRIPTION
We need to catch when Service and Pod Monitor targets are down

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a health check to catch down metrics targets during cluster creation.
> 
> - Adds `EnsureNoMetricsTargetsAreDown` in `test/e2e/util/util.go` to list `ServiceMonitors`/`PodMonitors`, derive jobs, and query Prometheus `up{namespace="<hcp>"}` with retries; skips autoscaler PodMonitor when no pods match
> - Registers Prometheus Operator `monitoring.v1` types in `test/e2e/util/scheme.go`
> - Invokes the new check in `TestCreateCluster` after existing validations
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3affe3825d89ac1016b97f44b85efc7b62e08243. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->