### PR TITLE
OCPBUGS-62863: feat(cmd): collect ServiceMonitor and PodMonitor resources in dump

### DIFF
--- a/cmd/cluster/core/dump.go
+++ b/cmd/cluster/core/dump.go
@@ -63,6 +63,7 @@ import (
 	"github.com/go-logr/logr"
 	orcv1alpha1 "github.com/k-orc/openstack-resource-controller/api/v1alpha1"
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/spf13/cobra"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
@@ -106,6 +107,11 @@ var (
 		&karpenterv1.NodePool{},
 		&awskarpenterv1.EC2NodeClass{},
 		&hyperkarpenterv1.OpenshiftEC2NodeClass{},
+	}
+
+	monitoringResources = []client.Object{
+		&prometheusoperatorv1.ServiceMonitor{},
+		&prometheusoperatorv1.PodMonitor{},
 	}
 )
 
@@ -391,6 +397,7 @@ func DumpCluster(ctx context.Context, opts *DumpOptions) error {
 	kubeClient := kubeclient.NewForConfigOrDie(cfg)
 	kubeDiscoveryClient := kubeClient.Discovery()
 	optionalResources := append(featureGatedResources, ocpResources...)
+	optionalResources = append(optionalResources, monitoringResources...)
 	for _, resource := range optionalResources {
 		gvk, err := c.GroupVersionKindFor(resource)
 		if err != nil {


### PR DESCRIPTION
Add monitoring.coreos.com resources (ServiceMonitor and PodMonitor) to the dump collection. These resources are created by the control-plane operator and are essential for debugging monitoring issues in hosted control planes.

The resources are added as optional resources and will only be collected if the monitoring.coreos.com API group is registered in the management cluster.

Fixes: [OCPBUGS-62863](https://issues.redhat.com/browse/OCPBUGS-62863)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Collects `monitoring.coreos.com` `ServiceMonitor` and `PodMonitor` resources during dumps when the API group is registered.
> 
> - **Dump enhancements**:
>   - Add optional collection of `monitoring.coreos.com` resources: `ServiceMonitor` and `PodMonitor`.
>   - Gate collection on API registration via discovery to avoid errors on clusters without the CRDs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 635095ae97d28545b54d43354bfa78cb81588300. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->