### PR TITLE
OCPBUGS-60472: fix kubevirt, use 100.66.0.0/16 for join subnet

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/network/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/network/reconcile.go
@@ -32,10 +32,9 @@ const kubevirtDefaultVXLANPort = uint32(9879)
 // 9880 is a currently unassigned IANA port in the user port range.
 const kubevirtDefaultGenevePort = uint32(9880)
 
-// The default OVN gateway router LRP CIDR is 100.64.0.0/16. We need to avoid
-// that for kubernetes which runs nested.
-// 100.65.0.0/16 is not used internally at OVN kubernetes.
-const kubevirtDefaultV4InternalSubnet = "100.65.0.0/16"
+// The default OVN gateway router LRP CIDR is 100.64.0.0/16 and the default UDNs
+// is 100.65.0.0/16. We need to avoid that for kubernetes which runs nested.
+const kubevirtDefaultV4InternalSubnet = "100.66.0.0/16"
 
 func ReconcileNetworkOperator(network *operatorv1.Network, networkType hyperv1.NetworkType, platformType hyperv1.PlatformType, disableMultiNetwork bool, ovnConfig *hyperv1.OVNKubernetesConfig) {
 	switch platformType {

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -3567,7 +3567,7 @@ func TestValidateSliceNetworkCIDRs(t *testing.T) {
 			networkType: hyperv1.OVNKubernetes,
 			ovnConfig: &hyperv1.OVNKubernetesConfig{
 				IPv4: &hyperv1.OVNIPv4Config{
-					InternalTransitSwitchSubnet: "100.65.0.0/16",
+					InternalTransitSwitchSubnet: "100.66.0.0/16",
 				},
 			},
 			wantErr: false,
@@ -3581,7 +3581,7 @@ func TestValidateSliceNetworkCIDRs(t *testing.T) {
 			ovnConfig: &hyperv1.OVNKubernetesConfig{
 				IPv4: &hyperv1.OVNIPv4Config{
 					InternalJoinSubnet:          "100.64.0.0/16",
-					InternalTransitSwitchSubnet: "100.65.0.0/16",
+					InternalTransitSwitchSubnet: "100.66.0.0/16",
 				},
 			},
 			wantErr: false,


### PR DESCRIPTION
## What this PR does / why we need it:
At openshift the default join subnet for use defined networks is 100.65.0.0/16, this change the hosted clusters at kubevirt from 100.65 to 100.66 so it do not collide with UDNs at guest clusters.

Since ovn-kubernetes allow changing the join subnet this is not an issue for running hosted clusters after hypershift operator is upgraded.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://issues.redhat.com//browse/OCPBUGS-60472

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.