### PR TITLE
OCPBUGS-60457: test(e2e): Revert "Workaround for external oidc tests to bypass the teardown"

### DIFF
--- a/test/e2e/util/dump/dump.go
+++ b/test/e2e/util/dump/dump.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -40,10 +39,7 @@ func DumpHostedCluster(ctx context.Context, t *testing.T, hc *hyperv1.HostedClus
 
 	var allErrors []error
 	findKubeObjectUpdateLoops := func(filename string, content []byte) {
-		// TODO: currently we need the "strings.Contains" workaround to let the ExternalOIDCWithUIDAndExtraClaimMappings jobs not fail,
-		// to promote the 4.20 featuregate ExternalOIDCWithUIDAndExtraClaimMappings to GA.
-		// Once https://issues.redhat.com/browse/OCPBUGS-60457 is fixed, remove the "strings.Contains" condition
-		if bytes.Contains(content, []byte(upsert.LoopDetectorWarningMessage)) && !strings.Contains(t.Name(), "TestExternalOIDC") {
+		if bytes.Contains(content, []byte(upsert.LoopDetectorWarningMessage)) {
 			allErrors = append(allErrors, fmt.Errorf("found %s messages in file %s", upsert.LoopDetectorWarningMessage, filename))
 		}
 	}


### PR DESCRIPTION
Reverts openshift/hypershift#6684

Depends on https://github.com/openshift/api/pull/2523

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restore unconditional loop-detection failure in e2e dump by removing the ExternalOIDC test bypass.
> 
> - **Tests (e2e)**:
>   - Loop detector in `test/e2e/util/dump/dump.go` now errors on any `upsert.LoopDetectorWarningMessage` occurrence, removing the ExternalOIDC-specific bypass.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80de5dc4a184ae5800fb334b1d474b5a0851c839. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->