### PR TITLE
NO-JIRA: fix(build): suppress LC_DYSYMTAB warnings in macOS builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ GITLINT := $(TOOLS_BIN_DIR)/$(GITLINT_DIST_DIR)/$(GITLINT_BIN)-bin
 PROMTOOL=$(abspath $(TOOLS_BIN_DIR)/promtool)
 
 GO_GCFLAGS ?= -gcflags=all='-N -l'
-GO=GO111MODULE=on GOWORK=off GOFLAGS=-mod=vendor go
+GO=GO111MODULE=on GOWORK=off GOFLAGS=-mod=vendor CGO_LDFLAGS="-Wl,-w" go
 GOWS=GO111MODULE=on GOWORK=$(shell pwd)/hack/workspace/go.work GOFLAGS=-mod=vendor go
 GO_BUILD_RECIPE=CGO_ENABLED=1 $(GO) build $(GO_GCFLAGS)
 GO_CLI_RECIPE=CGO_ENABLED=0 $(GO) build $(GO_GCFLAGS) -ldflags '-extldflags "-static"'


### PR DESCRIPTION
## What this PR does / why we need it:
Add CGO_LDFLAGS=-Wl,-w to suppress aesthetically disruptive LC_DYSYMTAB linker warnings that appear during test runs on macOS. These warnings are cosmetic and don't affect functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set CGO_LDFLAGS="-Wl,-w" in the Makefile’s GO env to suppress macOS linker warnings.
> 
> - **Build system**:
>   - Update `Makefile`: set `CGO_LDFLAGS="-Wl,-w"` in `GO` env to silence macOS linker warnings during builds/tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9c5efc06b237b50ccacc965ff9a132014b9cfb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->