### PR TITLE
OCPBUGS-61829: resolve initContainer permission issue after node reboot

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/IBMCloud/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/IBMCloud/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
@@ -242,6 +242,11 @@ spec:
 
           set -euo pipefail
 
+          # Ensure the directory is empty, prevent restart from failing
+          rm -rf /run/ca-trust-generated/* || {
+            chmod -R u+w /run/ca-trust-generated/* 2>/dev/null || true
+            rm -rf /run/ca-trust-generated/* || true
+          }
           cp -f -r /etc/pki/ca-trust/extracted/pem/* /run/ca-trust-generated/
 
           if ! [[ -f /run/service-ca-signer/service-ca.crt ]]; then

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
@@ -242,6 +242,11 @@ spec:
 
           set -euo pipefail
 
+          # Ensure the directory is empty, prevent restart from failing
+          rm -rf /run/ca-trust-generated/* || {
+            chmod -R u+w /run/ca-trust-generated/* 2>/dev/null || true
+            rm -rf /run/ca-trust-generated/* || true
+          }
           cp -f -r /etc/pki/ca-trust/extracted/pem/* /run/ca-trust-generated/
 
           if ! [[ -f /run/service-ca-signer/service-ca.crt ]]; then

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
@@ -242,6 +242,11 @@ spec:
 
           set -euo pipefail
 
+          # Ensure the directory is empty, prevent restart from failing
+          rm -rf /run/ca-trust-generated/* || {
+            chmod -R u+w /run/ca-trust-generated/* 2>/dev/null || true
+            rm -rf /run/ca-trust-generated/* || true
+          }
           cp -f -r /etc/pki/ca-trust/extracted/pem/* /run/ca-trust-generated/
 
           if ! [[ -f /run/service-ca-signer/service-ca.crt ]]; then

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-apiserver/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/openshift-apiserver/deployment.yaml
@@ -139,6 +139,11 @@ spec:
 
           set -euo pipefail
 
+          # Ensure the directory is empty, prevent restart from failing
+          rm -rf /run/ca-trust-generated/* || {
+            chmod -R u+w /run/ca-trust-generated/* 2>/dev/null || true
+            rm -rf /run/ca-trust-generated/* || true
+          }
           cp -f -r /etc/pki/ca-trust/extracted/pem/* /run/ca-trust-generated/
 
           if ! [[ -f /run/service-ca-signer/service-ca.crt ]]; then


### PR DESCRIPTION
## What this PR does / why we need it:
Clear existing files in /run/ca-trust-generated before processing to prevent permission conflicts
## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes: [OCPBUGS-61829](https://issues.redhat.com/browse/OCPBUGS-61829)

## Special notes for your reviewer:
none

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.