### PR TITLE
Draft:  [RFE-8062] Add prometheus endpoint to HAProxy.

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/router/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/router/deployment.yaml
@@ -40,6 +40,9 @@ spec:
         - containerPort: 8443
           name: https
           protocol: TCP
+        - containerPort: 8405
+          name: metrics
+          protocol: TCP
         resources:
           requests:
             cpu: 50m

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/router_config.template
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/router_config.template
@@ -20,6 +20,12 @@ resolvers azure_dns
   nameserver azure 168.63.129.16:53
 {{- end }}
 
+frontend prometheus
+  bind :::8405 v4v6
+  mode http
+  http-request use-service prometheus-exporter if { path /metrics }
+  no log
+
 frontend main
   bind :::8443 v4v6
   tcp-request inspect-delay 5s


### PR DESCRIPTION
This enables administrators of Hypershift clusters to monitor HAProxy related
metrics (https://www.haproxy.com/documentation/haproxy-configuration-tutorials/alerts-and-monitoring/prometheus/#exported-metrics)

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/RFE-8062 - this allows adminstrators of Hypershift clusters to gain better insights into the router-default pods of hosted clusters.

Without the explicit frontend the metrics are not exposed.

## Special notes for your reviewer:

## Checklist:
- [X] Subject and description added to both, commit and PR.
- [X] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.