### PR TITLE
CNTRLPLANE-1643: implement multi-branch strategy with security-focused release management

### DIFF
--- a/docs/content/contribute/branch-process.md
+++ b/docs/content/contribute/branch-process.md
@@ -3,6 +3,7 @@ These are a set of tasks we need to perform on every OCP branching. We need to:
 
 1. Update the HyperShift Repository to add the latest supported OCP version - [Update Supported Version](#update-supported-version)
 1. Update the base images in our Dockerfiles (if they are available at branching) - [Update Dockerfiles](#update-dockerfiles)
+1. Update the Renovate configuration to include the new release branch - [Update Renovate](#update-renovate-configuration)
 1. Update the OpenShift Release repository to fix the step registry configuration files - [OpenShift/Release](#openshiftrelease-repository)
 1. Update TestGrid to include the new OCP version tests - [TestGrid](#update-testgrid)
 
@@ -27,6 +28,47 @@ We need to add the latest supported version in the `hypershift` repository. We n
 We also need to bump the base images in our Dockerfiles.
 
 [Example Base Image Bump PR](https://github.com/openshift/hypershift/pull/5195/files)
+
+#### Update Renovate Configuration
+We need to add the new release branch to the Renovate configuration so that security updates are automatically applied to the release branch.
+
+Update `renovate.json` to include the new release branch in two places:
+
+1. Add the new branch to the `baseBranches` array at the top of the file
+2. Add the new branch to the `matchBaseBranches` array in the security-only Go updates package rule
+
+!!! note
+    If any release branch has reached End of Life and is no longer supported, remove it from both locations in `renovate.json` to stop automated updates on that branch.
+
+Example change for release-4.21:
+```json
+{
+  "baseBranches": [
+    "main",
+    "release-4.16",
+    "release-4.17",
+    "release-4.18",
+    "release-4.19",
+    "release-4.20",
+    "release-4.21"
+  ],
+  "packageRules": [
+    {
+      "description": "Enable security-only Go updates on release branches",
+      "matchManagers": ["gomod"],
+      "matchBaseBranches": [
+        "release-4.16",
+        "release-4.17",
+        "release-4.18",
+        "release-4.19",
+        "release-4.20",
+        "release-4.21"
+      ],
+      "matchUpdateTypes": ["patch"]
+    }
+  ]
+}
+```
 
 ---
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,42 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "tekton": {
-        "branchConcurrentLimit": 10,
-        "extends": [
-            "github>konflux-ci/mintmaker-presets:update-fedora-to-stable"
-        ]
-    }
+      "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+      "baseBranches": [
+          "main",
+          "release-4.16",
+          "release-4.17",
+          "release-4.18",
+          "release-4.19",
+          "release-4.20"
+      ],
+      "tekton": {
+          "branchConcurrentLimit": 10,
+          "extends": [
+              "github>konflux-ci/mintmaker-presets:update-fedora-to-stable"
+          ]
+      },
+      "packageRules": [
+          {
+              "description": "Disable Go dependency updates on all branches by default",
+              "matchManagers": ["gomod"],
+              "enabled": false
+          },
+          {
+              "description": "Enable all Go dependency updates on main branch",
+              "matchManagers": ["gomod"],
+              "matchBaseBranches": ["main"],
+              "enabled": true
+          },
+          {
+              "description": "Enable security-only Go updates on release branches",
+              "matchManagers": ["gomod"],
+              "matchBaseBranches": [
+                  "release-4.16",
+                  "release-4.17",
+                  "release-4.18",
+                  "release-4.19",
+                  "release-4.20"
+              ],
+              "matchUpdateTypes": ["patch"]
+          }
+      ]
   }


### PR DESCRIPTION
## What this PR does / why we need it:

  This PR enhances the Renovate configuration to support automated dependency management across main and all active release branches (4.16-4.20) with branch-specific update policies.

  The implementation introduces a layered approach to Go dependency updates:
  - **Main branch**: Receives all Go dependency updates to maintain currency and support innovation
  - **Release branches**: Only receive security vulnerability updates (CVEs) to ensure stability while maintaining security posture
  - **All branches**: Continue to receive Tekton task updates via existing Konflux Mintmaker presets

Seeks to address the created maintenance overhead. Validated with:

```
    npx --yes --package renovate -- renovate-config-validator
```

  Key benefits:
  - Automated CVE patching on 6 release branches without manual intervention
  - Reduced maintenance burden tracking golang bumps  across multiple branches
  - Risk mitigation by preventing non-vulnerability updates from destabilizing stable releases
  - Improved dependency currency on main branch
  - Scalable pattern for future release branches

  ## Which issue(s) this PR fixes:

  Fixes: #[CNTRLPLANE-1643](https://issues.redhat.com//browse/CNTRLPLANE-1643)

  ## Special notes for your reviewer:

  The configuration uses a 3-tier `packageRules` structure:
  1. Global baseline disables all gomod updates
  2. Main branch override enables all updates
  3. Release branch override enables only `vulnerabilityAlerts`

  This layered approach ensures correct precedence and makes the intent clear for each branch type.

  ## Checklist:
  - [x] Subject and description added to both, commit and PR.
  - [x] Relevant issues have been referenced.
  - [ ] This change includes docs. (N/A - configuration change only)
  - [ ] This change includes unit tests. (N/A - Renovate configuration, validated against schema)