### PR TITLE
OCPBUGS-63049: Make the hypershift CLI binary FIPS-compliant

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -5,12 +5,14 @@ WORKDIR /hypershift
 COPY --chown=default . .
 
 RUN make hypershift \
+  && make hypershift-no-cgo \
   && make hypershift-operator \
   && make product-cli \
   && make karpenter-operator
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
 COPY --from=builder /hypershift/bin/hypershift \
+  /hypershift/bin/hypershift-no-cgo \
   /hypershift/bin/hcp \
   /hypershift/bin/hypershift-operator \
   /hypershift/bin/karpenter-operator \

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,11 @@ control-plane-pki-operator:
 
 .PHONY: hypershift
 hypershift:
-	$(GO_CLI_RECIPE) -o $(OUT_DIR)/hypershift .
+	$(GO_BUILD_RECIPE) -o $(OUT_DIR)/hypershift .
+
+.PHONY: hypershift-no-cgo
+hypershift-no-cgo:
+	$(GO_CLI_RECIPE) -o $(OUT_DIR)/hypershift-no-cgo .
 
 .PHONY: product-cli
 product-cli:


### PR DESCRIPTION
## What this PR does / why we need it:

- Default FIPS compliance: Main binaries are now FIPS-compliant by default
- Backward compatibility: Non-FIPS option available via hypershift-no-cgo for any automation scripts that rely on non-FIPS binary.

## Which issue(s) this PR fixes:
Fixes  https://issues.redhat.com/browse/OCPBUGS-63049

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.