### PR TITLE
OCPBUGS-63172: control-plane-operator/.../ingress-operator/deployment: Declare a metrics port

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
@@ -94,6 +94,10 @@ spec:
         image: cluster-ingress-operator
         imagePullPolicy: IfNotPresent
         name: ingress-operator
+        ports:
+        - containerPort: 60000
+          name: metrics
+          protocol: TCP
         resources:
           requests:
             cpu: 10m

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
@@ -94,6 +94,10 @@ spec:
         image: cluster-ingress-operator
         imagePullPolicy: IfNotPresent
         name: ingress-operator
+        ports:
+        - containerPort: 60000
+          name: metrics
+          protocol: TCP
         resources:
           requests:
             cpu: 10m

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
@@ -94,6 +94,10 @@ spec:
         image: cluster-ingress-operator
         imagePullPolicy: IfNotPresent
         name: ingress-operator
+        ports:
+        - containerPort: 60000
+          name: metrics
+          protocol: TCP
         resources:
           requests:
             cpu: 10m

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/ingress-operator/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/ingress-operator/deployment.yaml
@@ -50,6 +50,10 @@ spec:
         image: cluster-ingress-operator
         imagePullPolicy: IfNotPresent
         name: ingress-operator
+        ports:
+        - containerPort: 60000
+          name: metrics
+          protocol: TCP
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
## What this PR does / why we need it:

We need the `metrics` declaration so the PodMonitor knows where to scrape:

```console
$ grep port: control-plane-operator/controllers/hostedcontrolplane/v2/assets/ingress-operator/podmonitor.yaml
    port: metrics
```

The port number is set to match the:

```
  - --metrics-listen-addr
  - 0.0.0.0:60000
```

arguments from earlier in the container spec.

I'm not sure why 60000 was chosen, and I have not gone digging in history to find out.  I'd have expected the port choice to be something that just had to be unique within the Pod, and for something more common like 8000 to have been chosen.  But if folks want to adjust there, that can happen in follow-up work.

## Which issue(s) this PR fixes:

~I haven't filed an OCPBUGS around this, but I can if you think it's worth backporting.~ Fixes [OCPBUGS-63172](https://issues.redhat.com/browse/OCPBUGS-63172).

## Special notes for your reviewer:

No unit tests here, but #6965 is bringing in test coverage.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.