### PR TITLE
OCPBUGS-63130: fix: routes are not used in case of IBM Cloud

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1126,6 +1126,9 @@ func useHCPRouter(hostedControlPlane *hyperv1.HostedControlPlane) bool {
 	if sharedingress.UseSharedIngress() {
 		return false
 	}
+	if hostedControlPlane.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
+		return false
+	}
 	return util.IsPrivateHCP(hostedControlPlane) || util.IsPublicWithDNS(hostedControlPlane)
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	oapiv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/oapi"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/sharedingress"
 	component "github.com/openshift/hypershift/support/controlplane-component"
@@ -54,6 +55,9 @@ func NewComponent() component.ControlPlaneComponent {
 // Otherwise, the Routes use the management cluster Domain and resolve through the default ingress controller.
 func useHCPRouter(cpContext component.WorkloadContext) (bool, error) {
 	if sharedingress.UseSharedIngress() {
+		return false, nil
+	}
+	if cpContext.HCP.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
 		return false, nil
 	}
 	return util.IsPrivateHCP(cpContext.HCP) || util.IsPublicWithDNS(cpContext.HCP), nil


### PR DESCRIPTION
## What this PR does / why we need it:

In case of IBM Cloud, when HostedCluster is configued with "ServicePublishingStrategy: Route" configuration, control plane operator v2 creates an unnecessary router deployment in the HostedCluster namespace.

Related config:
```
  services:
  - service: APIServer
    servicePublishingStrategy:
      route:
        hostname: d3nm1ds40drqm3efpkig.api.prestage-us-south.containers.pretest.cloud.ibm.com
      type: Route
  - service: OAuthServer
    servicePublishingStrategy:
      route:
        hostname: d3nm1ds40drqm3efpkig.oauth.prestage-us-south.containers.pretest.cloud.ibm.com
      type: Route
  - service: Konnectivity
    servicePublishingStrategy:
      route:
        hostname: d3nm1ds40drqm3efpkig.tunnel.private.prestage-us-south.containers.pretest.cloud.ibm.com
      type: Route
  - service: Ignition
    servicePublishingStrategy:
      route:
        hostname: d3nm1ds40drqm3efpkig.ignition.private.prestage-us-south.containers.pretest.cloud.ibm.com
      type: Route
```

Unnecessary pods found in HostedCluster namespace on the control plane:
```
router-5788df8bd-2wbrq                                  1/1     Running     0          43h
router-5788df8bd-bbqdb                                  1/1     Running     0          43h
router-5788df8bd-h6xwb                                  1/1     Running     0          43h
```

This is unnecessary as in case of IBM Cloud, these router pods are not utilized.

Changes:

- change in [hostedcontrolplane_controller.go](https://github.com/openshift/hypershift/compare/main...mihivagyok:hypershift:ibmcloud-do-not-create-router#diff-3d4ffda0834e09a59a4d510523932e20b9234bcb9816e40258a0fb32a87a7006):
  - this change causes that admitHCPManagedRoutes is not called
  - unit test is added

- change in [component.go](https://github.com/openshift/hypershift/compare/main...mihivagyok:hypershift:ibmcloud-do-not-create-router#diff-95b2aedfb256ca8d31c905299ec6ae1885e1eb094bd63eb345318d23b9e16a77)
  - this change causes that router deployment (see above) in the HostedCluster namespace won't be created

When such changes are applied, the following can be observed:

- related HostedControlPlane status
```
status:
  conditions:
  - lastTransitionTime: "2025-10-15T08:58:04Z"
    message: Configuration passes validation
    observedGeneration: 1
    reason: AsExpected
    status: "True"
    type: ValidHostedControlPlaneConfiguration
  - lastTransitionTime: "2025-10-15T08:58:04Z"
    message: Etcd cluster is assumed to be running in unmanaged state
    observedGeneration: 1
    reason: EtcdRunning
    status: "True"
    type: EtcdAvailable
  - lastTransitionTime: "2025-10-15T08:59:22Z"
    message: Kube APIServer deployment is available
    observedGeneration: 1
    reason: AsExpected
    status: "True"
    type: KubeAPIServerAvailable
  - lastTransitionTime: "2025-10-15T09:23:04Z"
    message: ""
    observedGeneration: 1
    reason: AsExpected
    status: "False"
    type: Degraded
  - lastTransitionTime: "2025-10-15T08:58:05Z"
    message: All is well
    observedGeneration: 1
    reason: AsExpected
    status: "True"
    type: InfrastructureReady
  - lastTransitionTime: "2025-10-15T09:10:18Z"
    message: All is well
    observedGeneration: 1
    reason: AsExpected
    status: "True"
    type: ExternalDNSReachable
  - lastTransitionTime: "2025-10-15T08:59:22Z"
    message: ""
    observedGeneration: 1
    reason: AsExpected
    status: "True"
    type: Available
  - lastTransitionTime: "2025-10-15T08:58:04Z"
    message: Reconciliation active on resource
    observedGeneration: 1
    reason: AsExpected
    status: "True"
    type: ReconciliationActive
  - lastTransitionTime: "2025-10-15T08:58:04Z"
    message: Identity provider configuration is valid
    reason: IDPConfigurationValid
    status: "True"
    type: ValidIDPConfiguration
  - lastTransitionTime: "2025-10-15T08:58:05Z"
    message: All is well
    observedGeneration: 1
    reason: AsExpected
    status: "True"
    type: ValidReleaseInfo
  - lastTransitionTime: "2025-10-15T09:29:58Z"
    message: Cluster version is 4.20.0-rc.3
    observedGeneration: 1
    reason: FromClusterVersion
    status: "False"
    type: ClusterVersionProgressing
  - lastTransitionTime: "2025-10-15T09:29:58Z"
    message: Condition not found in the CVO.
    observedGeneration: 1
    reason: FromClusterVersion
    status: "True"
    type: ClusterVersionUpgradeable
  - lastTransitionTime: "2025-10-15T09:29:58Z"
    message: Done applying 4.20.0-rc.3
    observedGeneration: 1
    reason: FromClusterVersion
    status: "True"
    type: ClusterVersionAvailable
  - lastTransitionTime: "2025-10-15T09:29:58Z"
    message: ""
    observedGeneration: 1
    reason: FromClusterVersion
    status: "False"
    type: ClusterVersionFailing
  - lastTransitionTime: "2025-10-15T08:59:52Z"
    message: Payload loaded version="4.20.0-rc.3" image="us.icr.io/armada-master/ocp-release@sha256:67f4c08fae09d7aff55552bbe72865d422397e07a3df47c90201b5d09beab004"
      architecture="amd64"
    observedGeneration: 1
    reason: PayloadLoaded
    status: "True"
    type: ClusterVersionReleaseAccepted
  - lastTransitionTime: "2025-10-15T08:59:52Z"
    message: The update channel has not been configured.
    observedGeneration: 1
    reason: NoChannel
    status: "False"
    type: ClusterVersionRetrievedUpdates
  - lastTransitionTime: "2025-10-15T09:00:11Z"
    message: ""
    reason: AsExpected
    status: "False"
    type: network.operator.openshift.io/ManagementStateDegraded
  - lastTransitionTime: "2025-10-15T09:00:11Z"
    message: ""
    reason: AsExpected
    status: "False"
    type: network.operator.openshift.io/Degraded
  - lastTransitionTime: "2025-10-15T09:00:11Z"
    message: ""
    reason: AsExpected
    status: "True"
    type: network.operator.openshift.io/Upgradeable
  - lastTransitionTime: "2025-10-15T09:21:51Z"
    message: ""
    reason: AsExpected
    status: "False"
    type: network.operator.openshift.io/Progressing
  - lastTransitionTime: "2025-10-15T09:00:20Z"
    message: ""
    reason: AsExpected
    status: "True"
    type: network.operator.openshift.io/Available
  - lastTransitionTime: "2025-10-15T09:09:39Z"
    message: All is well
    observedGeneration: 1
    reason: AsExpected
    status: "True"
    type: IgnitionServerValidReleaseInfo
  controlPlaneEndpoint:
    host: d3nm1ds40drqm3efpkig.api.prestage-us-south.containers.pretest.cloud.ibm.com
    port: 443
  externalManagedControlPlane: true
  initialized: true
  kubeConfig:
    key: kubeconfig
    name: admin-kubeconfig
  oauthCallbackURLTemplate: https://<oauth-url>:443/oauth2callback/[identity-provider-name]
  ready: true
  releaseImage: registry/ocp-release@sha256:67f4c08fae09d7aff55552bbe72865d422397e07a3df47c90201b5d09beab004
  version: 4.20.0-rc.3
  versionStatus:
    availableUpdates: null
    desired:
      image: registry/ocp-release@sha256:67f4c08fae09d7aff55552bbe72865d422397e07a3df47c90201b5d09beab004
      url: https://access.redhat.com/errata/RHBA-2025:9562
      version: 4.20.0-rc.3
    history:
    - completionTime: "2025-10-15T09:29:58Z"
      image: registry/ocp-release@sha256:67f4c08fae09d7aff55552bbe72865d422397e07a3df47c90201b5d09beab004
      startedTime: "2025-10-15T08:59:43Z"
      state: Completed
      verified: false
      version: 4.20.0-rc.3
    observedGeneration: 1
```

- route's status is not populated, but it does not cause problem, e.g.:
```
apiVersion: route.openshift.io/v1
kind: Route
metadata:
  creationTimestamp: "2025-10-15T08:59:21Z"
  labels:
    hypershift.openshift.io/hosted-control-plane: master-d3nm1ds40drqm3efpkig
  name: ignition-server
  namespace: master-d3nm1ds40drqm3efpkig
  ownerReferences:
  - apiVersion: hypershift.openshift.io/v1beta1
    blockOwnerDeletion: true
    controller: true
    kind: HostedControlPlane
    name: d3nm1ds40drqm3efpkig
    uid: e8ec0509-23c1-44a4-81d3-05d475184635
  resourceVersion: "269914403"
  uid: 56c3e45b-eb0a-4cf1-b0b8-ff1a896a57e6
spec:
  host: <igniton-endpoint>
  tls:
    insecureEdgeTerminationPolicy: None
    termination: passthrough
  to:
    kind: Service
    name: ignition-server
    weight: 100
  wildcardPolicy: None
status: {}
```

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/OCPBUGS-63130

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.