### PR TITLE
OCPBUGS-63148: bump Konflux build images

### DIFF
--- a/Containerfile.control-plane
+++ b/Containerfile.control-plane
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1754467841 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1760420453 AS builder
 
 WORKDIR /hypershift
 
@@ -7,7 +7,7 @@ COPY --chown=default . .
 RUN make control-plane-operator \
   && make control-plane-pki-operator
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1760515502
 COPY --from=builder /hypershift/bin/control-plane-operator /usr/bin/control-plane-operator
 COPY --from=builder /hypershift/bin/control-plane-pki-operator /usr/bin/control-plane-pki-operator
 

--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1754467841 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1760420453 AS builder
 
 WORKDIR /hypershift
 
@@ -9,7 +9,7 @@ RUN make hypershift \
   && make product-cli \
   && make karpenter-operator
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1760515502
 COPY --from=builder /hypershift/bin/hypershift \
   /hypershift/bin/hcp \
   /hypershift/bin/hypershift-operator \


### PR DESCRIPTION
## What this PR does / why we need it:

This commit bumps HO and CPO to the latest release of both the builder and the base images. We need it to catch up with the builder and base image fixes that have happened since the last images were released.

## Which issue(s) this PR fixes:

Fixes: #OCPBUGS-63148 

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.