### PR TITLE
NO-JIRA: fix(ingress-operator): include metrics port in deployment

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
@@ -94,6 +94,10 @@ spec:
         image: cluster-ingress-operator
         imagePullPolicy: IfNotPresent
         name: ingress-operator
+        ports:
+        - containerPort: 60000
+          name: metrics
+          protocol: TCP
         resources:
           requests:
             cpu: 10m

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
@@ -94,6 +94,10 @@ spec:
         image: cluster-ingress-operator
         imagePullPolicy: IfNotPresent
         name: ingress-operator
+        ports:
+        - containerPort: 60000
+          name: metrics
+          protocol: TCP
         resources:
           requests:
             cpu: 10m

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
@@ -94,6 +94,10 @@ spec:
         image: cluster-ingress-operator
         imagePullPolicy: IfNotPresent
         name: ingress-operator
+        ports:
+        - containerPort: 60000
+          name: metrics
+          protocol: TCP
         resources:
           requests:
             cpu: 10m

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/ingress-operator/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/ingress-operator/deployment.yaml
@@ -50,6 +50,10 @@ spec:
         image: cluster-ingress-operator
         imagePullPolicy: IfNotPresent
         name: ingress-operator
+        ports:
+        - containerPort: 60000
+          name: metrics
+          protocol: TCP
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
The ingress-operator has a pod monitor that references a currently non-existent "metrics" port on pod.

Add the metrics port to the deployment definition so that the pod monitor works.

Thanks to @wking for finding this :bowing_man: 

Relates to https://issues.redhat.com//browse/OCPBUGS-62851

Supersedes https://github.com/openshift/hypershift/pull/7052