### PR TITLE
OCPBUGS-63153: Revert "fix(capi-provider): wait for infrastructure resource before startup"

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/capi_provider/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/capi_provider/component.go
@@ -44,10 +44,7 @@ func NewComponent(deploymentSpec *appsv1.DeploymentSpec, platformPolicyRules []r
 	return component.NewDeploymentComponent(ComponentName, capi).
 		WithAdaptFunction(capi.adaptDeployment).
 		WithPredicate(predicate).
-		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{
-			KubeconfigVolumeName:          "svc-kubeconfig",
-			WaitForInfrastructureResource: true,
-		}).
+		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{}).
 		WithManifestAdapter(
 			"role.yaml",
 			component.WithAdaptFunction(capi.adaptRole),

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go
@@ -99,15 +99,6 @@ func (p Kubevirt) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ 
 							},
 						},
 					},
-					{
-						Name: "svc-kubeconfig",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{
-								DefaultMode: &defaultMode,
-								SecretName:  "service-network-admin-kubeconfig",
-							},
-						},
-					},
 				},
 				Containers: []corev1.Container{
 					{
@@ -125,10 +116,6 @@ func (p Kubevirt) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ 
 								Name:      "capi-webhooks-tls",
 								ReadOnly:  true,
 								MountPath: "/tmp/k8s-webhook-server/serving-certs",
-							},
-							{
-								Name:      "svc-kubeconfig",
-								MountPath: "/etc/kubernetes",
 							},
 						},
 						Env: []corev1.EnvVar{

--- a/hypershift-operator/controllers/hostedcluster/testdata/capi-provider/zz_fixture_TestReconcileComponents.yaml
+++ b/hypershift-operator/controllers/hostedcluster/testdata/capi-provider/zz_fixture_TestReconcileComponents.yaml
@@ -137,16 +137,11 @@ spec:
         - availability-prober
         - --target
         - https://kube-apiserver:6443/readyz
-        - --kubeconfig=/var/kubeconfig/kubeconfig
-        - --wait-for-infrastructure-resource
         image: availability-prober
         imagePullPolicy: IfNotPresent
         name: availability-prober
         resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts:
-        - mountPath: /var/kubeconfig
-          name: svc-kubeconfig
       priorityClassName: hypershift-control-plane
       serviceAccountName: capi-provider
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
## What this PR does / why we need it:
This reverts commit b1feaeff9e6d0fb9982f3f96a2b5ecaabde240f4.

The commit breaks the capi-provider for the agent platform. The PR should be reworked to only apply to the Azure platform.

## Which issue(s) this PR fixes:
Fixes [OCPBUGS-63153](https://issues.redhat.com/browse/OCPBUGS-63153)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.