### PR TITLE
OCPBUGS-63194: fix(konflux): fix tag pipeline EC failures

### DIFF
--- a/.tekton/hypershift-operator-main-tag.yaml
+++ b/.tekton/hypershift-operator-main-tag.yaml
@@ -178,7 +178,7 @@ spec:
         - name: name
           value: git-clone-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:1144353cf608f0a44a6416a70db6408727733ff40070d382158d6f6984096d8e
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:3a920a83fc0135aaae2730fe9d446eb2da2ffc9d63a34bceea04afd24653bdee
         - name: kind
           value: task
         resolver: bundles
@@ -207,7 +207,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:dc82a7270aace9b1c26f7e96f8ccab2752e53d32980c41a45e1733baad76cde6
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:970285e3b0495961199523b566e0dd92ec2e29bedbcf61d8fc67106b06d0f923
         - name: kind
           value: task
         resolver: bundles
@@ -250,14 +250,18 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: IMAGE_APPEND_PLATFORM
         value: "true"
+      - name: ADDITIONAL_BUILD_IMAGES
+        value:
+        - $(tasks.extract-tag.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
       runAfter:
       - prefetch-dependencies
+      - extract-tag
       taskRef:
         params:
         - name: name
           value: buildah-remote-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.5@sha256:5e59c05455619580f4383010726f7db8440ecf6959882e9053ac697dd6d277fd
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.5@sha256:4f348fa6e0b5d7f976ae6cbb75f4e93bc0be1188f074e39bcae3b5fd71796a3f
         - name: kind
           value: task
         resolver: bundles
@@ -385,7 +389,7 @@ spec:
         - name: name
           value: ecosystem-cert-preflight-checks
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:dae8e28761cee4ab0baf04ab9f8f1a4b3cee3c7decf461fda2bacc5c01652a60
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:9568c51a5158d534248908b9b561cf67d2826ed4ea164ffd95628bb42380e6ec
         - name: kind
           value: task
         resolver: bundles
@@ -638,7 +642,7 @@ spec:
         - name: name
           value: push-dockerfile-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:2bc5b3afc5de56da0f06eac60b65e86f6b861b16a63f48579fc0bac7d657e14c
+          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:14fba04580b236e4206a904b86ee2fd8eeaa4163f7619a9c2602d361e4f74c51
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
## What this PR does / why we need it:

This PR fixes enterprise contract (EC) validation failures in the Konflux tag pipeline for HyperShift. The tag pipeline was failing because the script runner image used by the `extract-tag` task was not being included in the SBOM (Software Bill of Materials).

The fix includes two key changes:

1. **SBOM Fix**: Pass the `SCRIPT_RUNNER_IMAGE_REFERENCE` result from the `extract-tag` task to the `build-images` task via the `ADDITIONAL_BUILD_IMAGES` parameter. This ensures the UBI10 script runner image is properly included in the SBOM.

2. **Task Version Updates**: Update several Konflux task bundles to match the versions used in the push pipeline:
   - git-clone-oci-ta: 0.1 (newer SHA)
   - prefetch-dependencies-oci-ta: 0.2 (newer SHA)
   - buildah-remote-oci-ta: 0.5 (newer SHA)
   - ecosystem-cert-preflight-checks: 0.2 (newer SHA)
   - push-dockerfile-oci-ta: 0.1 (newer SHA)

## Which issue(s) this PR fixes:

Fixes OCPBUGS-63194

## Special notes for your reviewer:

- This only affects the **tag pipeline** (`.tekton/hypershift-operator-main-tag.yaml`). The push pipeline already works correctly.
- The main fix is adding the `ADDITIONAL_BUILD_IMAGES` parameter and updating the `runAfter` dependency to ensure `extract-tag` completes before `build-images` runs.
- The task version updates align the tag pipeline with the push pipeline, which has been working without EC issues.
- After this PR is merged, creating a new tag will trigger the updated pipeline and should pass EC validation.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. (N/A - pipeline configuration change)
- [ ] This change includes unit tests. (N/A - pipeline configuration change)