### PR TITLE
CNTRLPLANE-1673: feat(claude): add /test-tag-pipeline command

### DIFF
--- a/.claude/commands/test-tag-pipeline.md
+++ b/.claude/commands/test-tag-pipeline.md
@@ -1,0 +1,96 @@
+Create a manual PipelineRun to test tag pipeline changes before merging.
+
+**Usage**: `/test-tag-pipeline <tag-name> [branch-spec]`
+
+**Arguments**:
+- `tag-name` (required): The existing tag to rebuild (e.g., `v0.1.69`)
+- `branch-spec` (optional): The branch containing the updated pipeline (defaults to `main`)
+  - Format: `[fork:]branch-name`
+  - If no fork specified, defaults to `openshift`
+
+**What this does**:
+1. Verifies you are logged into the Konflux instance
+2. Gets the commit SHA that the tag points to
+3. Fetches the tag pipeline definition from the specified branch/fork
+4. Replaces template variables with actual values for the tag
+5. Creates a manual PipelineRun that uses the updated pipeline to build the tag's commit
+6. Outputs the PipelineRun name for monitoring
+
+**Examples**:
+```bash
+# Test main branch pipeline with v0.1.69 tag
+/test-tag-pipeline v0.1.69
+
+# Test PR branch pipeline with v0.1.69 tag
+/test-tag-pipeline v0.1.69 build-gomaxprocs-image
+
+# Test fork branch pipeline with v0.1.69 tag
+/test-tag-pipeline v0.1.69 celebdor:OCPBUGS-63194-part2
+```
+
+**Implementation**:
+
+IMPORTANT: Execute the commands exactly as shown with only the arguments provided by the user. If no branch argument is specified, the template `{{args.1:-main}}` will correctly default to `main`. Do NOT substitute the current git branch or any other inferred values.
+
+Step 1: Verify authentication to Konflux
+```bash
+oc whoami
+```
+
+If the authentication check fails, inform the user they need to log in first:
+```bash
+oc login --web https://api.stone-prd-rh01.pg1f.p1.openshiftapps.com:6443
+```
+
+Step 2: Create the PipelineRun
+```bash
+bash hack/tools/scripts/create-manual-tag-pipelinerun.sh {{args.0}} {{args.1:-main}}
+```
+
+After the PipelineRun is created, extract the name from the output and construct the web UI URL:
+- Base URL: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com
+- Pattern: /ns/crt-redhat-acm-tenant/applications/hypershift-operator/pipelineruns/{pipelinerun-name}
+
+Example: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/crt-redhat-acm-tenant/applications/hypershift-operator/pipelineruns/hypershift-operator-main-manual-v0.1.69-xxxxx
+
+Display the full URL to the user so they can monitor progress in the web UI.
+
+You can also monitor it from the CLI with:
+```bash
+# Watch the PipelineRun status
+oc get pipelinerun <name> -w
+```
+
+Step 3: After the PipelineRun completes successfully, create a Snapshot to trigger Enterprise Contract validation:
+```bash
+bash hack/tools/scripts/create-snapshot-from-pipelinerun.sh <pipelinerun-name>
+```
+
+After the Snapshot is created, extract the snapshot name from the output and get the EC PipelineRuns:
+```bash
+oc get pipelinerun -l appstudio.openshift.io/snapshot=<snapshot-name> -o name
+```
+
+For each EC PipelineRun, construct and display the web UI URL:
+- Base URL: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com
+- Pattern: /ns/crt-redhat-acm-tenant/applications/hypershift-operator/pipelineruns/{ec-pipelinerun-name}
+
+Example: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/crt-redhat-acm-tenant/applications/hypershift-operator/pipelineruns/hypershift-operator-enterprise-contract-xxxxx
+
+Display the full URLs to the user so they can monitor EC validation in the web UI.
+
+You can also monitor from the CLI with:
+```bash
+# Watch the snapshot status
+oc get snapshot <snapshot-name> -w
+
+# Check EC test results
+oc get pipelinerun -l appstudio.openshift.io/snapshot=<snapshot-name>
+```
+
+**Notes**:
+- This is useful for testing pipeline fixes before merging PRs
+- The PipelineRun uses the updated pipeline definition but builds the original tag's commit
+- The two-step process allows the PipelineRun to complete (20+ minutes) before creating the Snapshot
+- Requires `yq` and `oc` CLI tools to be installed
+- See `hack/tools/scripts/create-manual-tag-pipelinerun.sh` and `hack/tools/scripts/create-snapshot-from-pipelinerun.sh` for implementation details

--- a/hack/tools/scripts/create-manual-tag-pipelinerun.sh
+++ b/hack/tools/scripts/create-manual-tag-pipelinerun.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Create a manual PipelineRun to test tag pipeline changes before merging
+# Usage: create-manual-tag-pipelinerun.sh <tag-name> [branch-name]
+
+set -euo pipefail
+
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+  echo "Usage: $0 <tag-name> [branch-spec]"
+  echo ""
+  echo "Arguments:"
+  echo "  tag-name     - The existing tag to rebuild (e.g., v0.1.69)"
+  echo "  branch-spec  - Branch containing the updated pipeline (defaults to main)"
+  echo "                 Format: [fork:]branch-name"
+  echo "                 If no fork specified, defaults to 'openshift'"
+  echo ""
+  echo "Examples:"
+  echo "  $0 v0.1.69"
+  echo "  $0 v0.1.69 build-gomaxprocs-image"
+  echo "  $0 v0.1.69 celebdor:OCPBUGS-63194-part2"
+  exit 1
+fi
+
+TAG_NAME="$1"
+BRANCH_SPEC="${2:-main}"
+
+# Parse fork:branch format
+if [[ "${BRANCH_SPEC}" == *":"* ]]; then
+  FORK="${BRANCH_SPEC%%:*}"
+  BRANCH_NAME="${BRANCH_SPEC#*:}"
+else
+  FORK="openshift"
+  BRANCH_NAME="${BRANCH_SPEC}"
+fi
+
+echo "==> Fetching commit SHA for tag ${TAG_NAME}..."
+COMMIT_SHA=$(git rev-parse "${TAG_NAME}")
+echo "    Commit: ${COMMIT_SHA}"
+
+echo "==> Fetching pipeline from ${FORK}/${BRANCH_NAME}..."
+curl -sSf "https://raw.githubusercontent.com/${FORK}/hypershift/${BRANCH_NAME}/.tekton/hypershift-operator-main-tag.yaml" \
+  -o /tmp/pipeline.yaml
+
+echo "==> Replacing template variables..."
+sed -e "s/{{source_url}}/https:\\/\\/github.com\\/openshift\\/hypershift/g" \
+    -e "s/{{revision}}/${COMMIT_SHA}/g" \
+    -e "s/{{target_branch}}/refs\\/tags\\/${TAG_NAME}/g" \
+    -e "s/name: hypershift-operator-main-on-tag/generateName: hypershift-operator-main-manual-${TAG_NAME}-/g" \
+    /tmp/pipeline.yaml > /tmp/manual-pr.yaml
+
+echo "==> Cleaning up for manual execution..."
+# Remove PipelinesAsCode annotations (these are for automatic triggers)
+yq eval -i 'del(.metadata.annotations."pipelinesascode.tekton.dev/on-cel-expression")' /tmp/manual-pr.yaml
+yq eval -i 'del(.metadata.annotations."pipelinesascode.tekton.dev/max-keep-runs")' /tmp/manual-pr.yaml
+yq eval -i 'del(.metadata.annotations."pipelinesascode.tekton.dev/cancel-in-progress")' /tmp/manual-pr.yaml
+yq eval -i 'del(.metadata.creationTimestamp)' /tmp/manual-pr.yaml
+yq eval -i 'del(.status)' /tmp/manual-pr.yaml
+
+# Remove workspace bindings (workspaces are optional in the pipelineSpec)
+yq eval -i 'del(.spec.workspaces)' /tmp/manual-pr.yaml
+
+# Keep taskRunTemplate but set the service account explicitly
+yq eval -i '.spec.taskRunTemplate.serviceAccountName = "build-pipeline-hypershift-operator-main"' /tmp/manual-pr.yaml
+
+# Add labels to identify manual runs
+yq eval -i '.metadata.labels."test.manual-trigger" = "true"' /tmp/manual-pr.yaml
+yq eval -i ".metadata.labels.\"test.branch-source\" = \"${FORK}_${BRANCH_NAME}\"" /tmp/manual-pr.yaml
+
+echo "==> Creating PipelineRun..."
+PIPELINERUN_NAME=$(oc create -f /tmp/manual-pr.yaml -o jsonpath='{.metadata.name}')
+
+echo ""
+echo "✓ PipelineRun created: ${PIPELINERUN_NAME}"
+echo ""
+echo "Monitor with:"
+echo "  oc get pipelinerun ${PIPELINERUN_NAME} -w"
+echo "  tkn pr logs ${PIPELINERUN_NAME} -f"
+echo ""
+echo "After the PipelineRun completes successfully, create a Snapshot to trigger EC validation:"
+echo "  bash hack/tools/scripts/create-snapshot-from-pipelinerun.sh ${PIPELINERUN_NAME}"
+echo ""
+echo "Clean up temp files:"
+echo "  rm /tmp/pipeline.yaml /tmp/manual-pr.yaml"

--- a/hack/tools/scripts/create-snapshot-from-pipelinerun.sh
+++ b/hack/tools/scripts/create-snapshot-from-pipelinerun.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+# Create a Snapshot from a completed PipelineRun to trigger Enterprise Contract validation
+# Usage: create-snapshot-from-pipelinerun.sh <pipelinerun-name>
+#        create-snapshot-from-pipelinerun.sh --image-url <url> --image-digest <digest> [--commit <sha>] [--target-branch <branch>] [--branch-source <source>]
+
+set -euo pipefail
+
+# Default values for optional parameters
+IMAGE_URL=""
+IMAGE_DIGEST=""
+COMMIT_SHA=""
+TARGET_BRANCH=""
+BRANCH_SOURCE=""
+PIPELINERUN_NAME=""
+
+# Parse command-line arguments
+if [ $# -eq 1 ]; then
+  # Original mode: single argument is the PipelineRun name
+  PIPELINERUN_NAME="$1"
+elif [ $# -ge 4 ]; then
+  # New mode: parse named arguments
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --image-url)
+        IMAGE_URL="$2"
+        shift 2
+        ;;
+      --image-digest)
+        IMAGE_DIGEST="$2"
+        shift 2
+        ;;
+      --commit)
+        COMMIT_SHA="$2"
+        shift 2
+        ;;
+      --target-branch)
+        TARGET_BRANCH="$2"
+        shift 2
+        ;;
+      --branch-source)
+        BRANCH_SOURCE="$2"
+        shift 2
+        ;;
+      --pipelinerun)
+        PIPELINERUN_NAME="$2"
+        shift 2
+        ;;
+      *)
+        echo "Unknown argument: $1"
+        exit 1
+        ;;
+    esac
+  done
+else
+  echo "Usage: $0 <pipelinerun-name>"
+  echo "   or: $0 --image-url <url> --image-digest <digest> --pipelinerun <name> [--commit <sha>] [--target-branch <branch>] [--branch-source <source>]"
+  echo ""
+  echo "Mode 1 - From PipelineRun:"
+  echo "  pipelinerun-name - The name of the completed PipelineRun"
+  echo ""
+  echo "Mode 2 - Direct image parameters (useful when PipelineRun is cleaned up):"
+  echo "  --image-url       - The full image URL (required)"
+  echo "  --image-digest    - The image digest (required)"
+  echo "  --pipelinerun     - The source PipelineRun name (required)"
+  echo "  --commit          - The git commit SHA (optional, defaults to HEAD)"
+  echo "  --target-branch   - The target branch or tag ref (optional, defaults to refs/heads/main)"
+  echo "  --branch-source   - The branch source label (optional, defaults to main)"
+  echo ""
+  echo "Examples:"
+  echo "  # From PipelineRun"
+  echo "  $0 hypershift-operator-main-manual-v0.1.69-xxxxx"
+  echo ""
+  echo "  # Direct image parameters"
+  echo "  $0 --image-url quay.io/repo/hypershift-operator-main:v0.1.69 \\"
+  echo "     --image-digest sha256:abc123... \\"
+  echo "     --pipelinerun hypershift-operator-main-manual-v0.1.69-gb49w \\"
+  echo "     --commit 6e6ecadc61361e4fe359af34dcdee17df06c664e \\"
+  echo "     --target-branch refs/tags/v0.1.69"
+  exit 1
+fi
+
+NAMESPACE=$(oc project -q)
+
+# Determine which mode we're in based on whether IMAGE_URL was provided
+if [ -z "${IMAGE_URL}" ]; then
+  # Mode 1: Extract details from PipelineRun
+  echo "==> Checking PipelineRun status..."
+  STATUS=$(oc get pipelinerun "${PIPELINERUN_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].status}' 2>/dev/null || echo "")
+  REASON=$(oc get pipelinerun "${PIPELINERUN_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].reason}' 2>/dev/null || echo "")
+
+  if [ "$STATUS" != "True" ]; then
+    echo "✗ PipelineRun has not completed successfully (Status: ${STATUS}, Reason: ${REASON})"
+    echo ""
+    echo "Check status with:"
+    echo "  oc get pipelinerun ${PIPELINERUN_NAME} -n ${NAMESPACE}"
+    exit 1
+  fi
+
+  echo "✓ PipelineRun completed successfully"
+  echo ""
+
+  echo "==> Extracting image details..."
+  IMAGE_URL=$(oc get pipelinerun "${PIPELINERUN_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.results[?(@.name=="IMAGE_URL")].value}')
+  IMAGE_DIGEST=$(oc get pipelinerun "${PIPELINERUN_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.results[?(@.name=="IMAGE_DIGEST")].value}')
+  COMMIT_SHA=$(oc get pipelinerun "${PIPELINERUN_NAME}" -n "${NAMESPACE}" -o jsonpath='{.metadata.annotations.build\.appstudio\.redhat\.com/commit_sha}')
+  TARGET_BRANCH=$(oc get pipelinerun "${PIPELINERUN_NAME}" -n "${NAMESPACE}" -o jsonpath='{.metadata.annotations.build\.appstudio\.redhat\.com/target_branch}')
+  BRANCH_SOURCE=$(oc get pipelinerun "${PIPELINERUN_NAME}" -n "${NAMESPACE}" -o jsonpath='{.metadata.labels.test\.branch-source}')
+
+  if [ -z "${IMAGE_URL}" ] || [ -z "${IMAGE_DIGEST}" ]; then
+    echo "✗ Failed to extract image details from PipelineRun"
+    exit 1
+  fi
+else
+  # Mode 2: Use provided image parameters and set defaults for missing values
+  echo "==> Using provided image details..."
+
+  # Validate required parameters
+  if [ -z "${IMAGE_DIGEST}" ] || [ -z "${PIPELINERUN_NAME}" ]; then
+    echo "✗ --image-url, --image-digest, and --pipelinerun are required in direct mode"
+    exit 1
+  fi
+
+  # Set defaults for optional parameters
+  if [ -z "${COMMIT_SHA}" ]; then
+    COMMIT_SHA=$(git rev-parse HEAD)
+    echo "    Using HEAD commit: ${COMMIT_SHA}"
+  fi
+
+  if [ -z "${TARGET_BRANCH}" ]; then
+    TARGET_BRANCH="refs/heads/main"
+    echo "    Using default target branch: ${TARGET_BRANCH}"
+  fi
+
+  if [ -z "${BRANCH_SOURCE}" ]; then
+    BRANCH_SOURCE="main"
+    echo "    Using default branch source: ${BRANCH_SOURCE}"
+  fi
+fi
+
+echo "    IMAGE_URL: ${IMAGE_URL}"
+echo "    IMAGE_DIGEST: ${IMAGE_DIGEST}"
+echo "    COMMIT_SHA: ${COMMIT_SHA}"
+echo "    TARGET_BRANCH: ${TARGET_BRANCH}"
+echo ""
+
+# Strip tag from IMAGE_URL to get just the repository
+# (Remove everything from : or @ to the end)
+IMAGE_REPO="${IMAGE_URL%%:*}"
+IMAGE_REPO="${IMAGE_REPO%%@*}"
+
+echo "==> Creating Snapshot to trigger Enterprise Contract validation..."
+
+cat > /tmp/snapshot.yaml <<EOF
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Snapshot
+metadata:
+  generateName: hypershift-operator-manual-
+  namespace: ${NAMESPACE}
+  labels:
+    appstudio.openshift.io/application: hypershift-operator
+    appstudio.openshift.io/component: hypershift-operator-main
+    test.appstudio.openshift.io/type: component
+    test.manual-trigger: "true"
+    test.branch-source: "${BRANCH_SOURCE:-main}"
+    test.source-pipelinerun: "${PIPELINERUN_NAME}"
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/hypershift?rev=${COMMIT_SHA}
+    build.appstudio.redhat.com/commit_sha: ${COMMIT_SHA}
+    build.appstudio.redhat.com/target_branch: ${TARGET_BRANCH}
+    test.appstudio.openshift.io/source-repo-url: https://github.com/openshift/hypershift
+spec:
+  application: hypershift-operator
+  artifacts: {}
+  components:
+  - name: hypershift-operator-main
+    containerImage: ${IMAGE_REPO}@${IMAGE_DIGEST}
+    source:
+      git:
+        url: https://github.com/openshift/hypershift
+        revision: ${COMMIT_SHA}
+EOF
+
+SNAPSHOT_NAME=$(oc create -f /tmp/snapshot.yaml -o jsonpath='{.metadata.name}')
+
+echo ""
+echo "✓ Snapshot created: ${SNAPSHOT_NAME}"
+echo ""
+echo "Monitor integration tests with:"
+echo "  oc get snapshot ${SNAPSHOT_NAME} -n ${NAMESPACE} -w"
+echo ""
+echo "Check Enterprise Contract results:"
+echo "  oc get pipelinerun -n ${NAMESPACE} -l appstudio.openshift.io/snapshot=${SNAPSHOT_NAME}"
+echo ""
+echo "View EC logs:"
+echo "  oc logs -n ${NAMESPACE} -l appstudio.openshift.io/snapshot=${SNAPSHOT_NAME} --all-containers | grep -A10 'Violation'"
+echo ""
+echo "Clean up temp files:"
+echo "  rm /tmp/snapshot.yaml"


### PR DESCRIPTION
## What this PR does / why we need it:

This PR adds a new Claude Code slash command `/test-tag-pipeline` to help test tag pipeline changes before merging PRs.

The command allows developers to rebuild existing tags with an updated pipeline definition from any branch (PR branch or main), without needing to delete and recreate tags or wait for merge.

**Example usage**:
```bash
# Test main branch pipeline with existing tag
/test-tag-pipeline v0.1.69

# Test PR branch pipeline with existing tag  
/test-tag-pipeline v0.1.69 my-fix-branch
```

The command automates the process of:
1. Getting the commit SHA that a tag points to
2. Fetching the updated pipeline definition from the specified branch
3. Replacing template variables with actual tag values
4. Creating a manual PipelineRun in Konflux
5. Providing monitoring commands

This is particularly useful for validating pipeline fixes (like enterprise contract violations) before merging, as demonstrated in OCPBUGS-63194 where we needed to test tag pipeline changes.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-1673](https://issues.redhat.com//browse/CNTRLPLANE-1673)

## Special notes for your reviewer:

- This is a developer tooling improvement - adds a Claude Code command to `.claude/commands/`
- No production code changes, only a documentation/tooling file
- The command was already tested successfully when fixing OCPBUGS-63194 (created manual PipelineRun `hypershift-operator-main-manual-v0.1.69-qf9hb`)
- Requires `yq` to be installed for YAML manipulation

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. (N/A - Claude Code command documentation is self-contained)
- [ ] This change includes unit tests. (N/A - tooling/documentation change)