### PR TITLE
OCPBUGS-63194: fix(konflux): correct ADDITIONAL_BASE_IMAGES parameter typo in tag pipeline

### DIFF
--- a/.tekton/hypershift-operator-main-tag.yaml
+++ b/.tekton/hypershift-operator-main-tag.yaml
@@ -250,7 +250,7 @@ spec:
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
       - name: IMAGE_APPEND_PLATFORM
         value: "true"
-      - name: ADDITIONAL_BUILD_IMAGES
+      - name: ADDITIONAL_BASE_IMAGES
         value:
         - $(tasks.extract-tag.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
       runAfter:


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes a parameter name typo in the tag pipeline that was causing Enterprise Contract validation failures.

The EC fix in PR #7060 (commit deeec0b85) used the wrong parameter name `ADDITIONAL_BUILD_IMAGES` when it should have been `ADDITIONAL_BASE_IMAGES`. This caused the buildah task to silently ignore the parameter, resulting in the script runner image not being included in the SBOM, which triggered EC validation failures with:

> "Pre-Build-Script task runner image is not in the SBOM"

This PR corrects the parameter name to match the `buildah-remote-oci-ta` task definition.

## Which issue(s) this PR fixes:

Fixes #7060
Fixes OCPBUGS-63194

## Special notes for your reviewer:

The fix is a simple one-line change: renaming `ADDITIONAL_BUILD_IMAGES` to `ADDITIONAL_BASE_IMAGES` in the tag pipeline YAML.

This can be tested by creating a manual tag PipelineRun and verifying that the Enterprise Contract validation passes.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. (N/A - parameter name fix)
- [ ] This change includes unit tests. (N/A - pipeline configuration)