### PR TITLE
NO-JIRA: update OCP documentation links to latest versions

### DIFF
--- a/docs/content/how-to/kubevirt/ingress-and-dns.md
+++ b/docs/content/how-to/kubevirt/ingress-and-dns.md
@@ -175,7 +175,7 @@ example         4.14.0    example-admin-kubeconfig         Completed   True     
 ## Optional MetalLB Configuration Steps
 
 LoadBalancer type services are required. If MetalLB is in use, here are some example steps
-outlining how to configure MetalLB after [installing MetalLB using CLI](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/networking_operators/metallb-operator#nw-metallb-installing-operator-cli_metallb-operator-install).
+outlining how to configure MetalLB after [installing MetalLB using CLI](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/networking_operators/metallb-operator#nw-metallb-installing-operator-cli_metallb-operator-install).
 
 1. Create a MetalLB instance:
 

--- a/docs/content/how-to/openstack/performance-tuning.md
+++ b/docs/content/how-to/openstack/performance-tuning.md
@@ -137,5 +137,5 @@ For every node that was deployed by the Nodepool, label it with the following co
 oc label node "${WORKER_NODE}" feature.node.kubernetes.io/network-sriov.capable="true"
 ```
 
-The operator can now be installed in the guest cluster by following the [SR-IOV Network Operator documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/networking/index#installing-sr-iov-operator_installing-sriov-operator).
+The operator can now be installed in the guest cluster by following the [SR-IOV Network Operator documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/networking_operators/sr-iov-operator).
 The rest of the operations in order to get the workload running with high performances are the same as on a Standalone OCP cluster.


### PR DESCRIPTION
This PR updates OpenShift Container Platform documentation URLs to point to the latest available versions.

## Changes
- Automatically updated OCP documentation links using [ocp-doc-checker](https://github.com/sebrandon1/ocp-doc-checker)
- All documentation URLs now point to current versions

## Tool Information
This PR was created automatically by scanning the repository with `ocp-doc-checker`, which identifies and updates outdated OpenShift documentation links.

Repository: https://github.com/sebrandon1/ocp-doc-checker

---

**Tracking Issue:** https://github.com/sebrandon1/ocp-doc-checker/issues/18