### PR TITLE
OCPBUGS-63345: AWS credential metric to distinguish unknown from invalid status

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3131,7 +3131,7 @@ func deleteAWSEndpointServices(ctx context.Context, c client.Client, hc *hyperv1
 	}
 	for _, ep := range awsEndpointServiceList.Items {
 		if ep.DeletionTimestamp != nil {
-			if platformaws.ValidCredentials(hc) && time.Since(ep.DeletionTimestamp.Time) < awsEndpointDeletionGracePeriod {
+			if platformaws.GetCredentialStatus(hc) == platformaws.CredentialStatusValid && time.Since(ep.DeletionTimestamp.Time) < awsEndpointDeletionGracePeriod {
 				continue
 			}
 

--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
@@ -78,7 +78,7 @@ const (
 	proxyCAExpiryTimestampMetricHelp = "Shows the earliest timestamp when a certificate in the configured CA will expire."
 
 	InvalidAwsCredsMetricName = "hypershift_cluster_invalid_aws_creds"
-	invalidAwsCredsMetricHelp = "Indicates if the given HostedCluster has valid AWS credentials or not"
+	invalidAwsCredsMetricHelp = "AWS credential status for the HostedCluster: 0=valid, 1=invalid, 2=unknown"
 
 	DeletingDurationMetricName = "hypershift_cluster_deleting_duration_seconds"
 	deletingDurationMetricHelp = "Time in seconds it is taking to delete the HostedCluster since the beginning of the delete. " +
@@ -563,10 +563,9 @@ func (c *hostedClustersMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 
 			// invalidAwsCredsMetric
 			{
-				invalidAwsCredsValue := 0.0
-				if !platformaws.ValidCredentials(hcluster) {
-					invalidAwsCredsValue = 1.0
-				}
+				// Use detailed credential status: 0=valid, 1=invalid, 2=unknown
+				credStatus := platformaws.GetCredentialStatus(hcluster)
+				invalidAwsCredsValue := float64(credStatus)
 
 				ch <- prometheus.MustNewConstMetric(
 					invalidAwsCredsMetricDesc,

--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
@@ -564,22 +564,46 @@ func TestReportInvalidAwsCreds(t *testing.T) {
 		expected                                *dto.MetricFamily
 	}{
 		{
-			name:                                    "When ValidOIDCConfigurationCondition status is false, metric is reported with a value set to 1",
+			name:                                    "When both conditions are true, metric is reported with a value set to 0 (valid)",
+			ValidOIDCConfigurationConditionStatus:   metav1.ConditionTrue,
+			ValidAWSIdentityProviderConditionStatus: metav1.ConditionTrue,
+			expected:                                wrapExpectedValueAsMetric(0),
+		},
+		{
+			name:                                    "When ValidOIDCConfigurationCondition status is false, metric is reported with a value set to 1 (invalid)",
 			ValidOIDCConfigurationConditionStatus:   metav1.ConditionFalse,
 			ValidAWSIdentityProviderConditionStatus: metav1.ConditionTrue,
 			expected:                                wrapExpectedValueAsMetric(1),
 		},
 		{
-			name:                                    "When ValidAWSIdentityProviderCondition status is false, metric is reported with a value set to 1",
+			name:                                    "When ValidAWSIdentityProviderCondition status is false, metric is reported with a value set to 1 (invalid)",
 			ValidOIDCConfigurationConditionStatus:   metav1.ConditionTrue,
 			ValidAWSIdentityProviderConditionStatus: metav1.ConditionFalse,
 			expected:                                wrapExpectedValueAsMetric(1),
 		},
 		{
-			name:                                    "When both ValidAWSIdentityProviderCondition and ValidOIDCConfigurationCondition statuses is true, metric is reported with a value set to 0",
-			ValidOIDCConfigurationConditionStatus:   metav1.ConditionTrue,
+			name:                                    "When both conditions are false, metric is reported with a value set to 1 (invalid)",
+			ValidOIDCConfigurationConditionStatus:   metav1.ConditionFalse,
+			ValidAWSIdentityProviderConditionStatus: metav1.ConditionFalse,
+			expected:                                wrapExpectedValueAsMetric(1),
+		},
+		{
+			name:                                    "When ValidOIDCConfigurationCondition status is unknown, metric is reported with a value set to 2 (unknown)",
+			ValidOIDCConfigurationConditionStatus:   metav1.ConditionUnknown,
 			ValidAWSIdentityProviderConditionStatus: metav1.ConditionTrue,
-			expected:                                wrapExpectedValueAsMetric(0),
+			expected:                                wrapExpectedValueAsMetric(2),
+		},
+		{
+			name:                                    "When ValidAWSIdentityProviderCondition status is unknown, metric is reported with a value set to 2 (unknown)",
+			ValidOIDCConfigurationConditionStatus:   metav1.ConditionTrue,
+			ValidAWSIdentityProviderConditionStatus: metav1.ConditionUnknown,
+			expected:                                wrapExpectedValueAsMetric(2),
+		},
+		{
+			name:                                    "When both conditions are unknown, metric is reported with a value set to 2 (unknown)",
+			ValidOIDCConfigurationConditionStatus:   metav1.ConditionUnknown,
+			ValidAWSIdentityProviderConditionStatus: metav1.ConditionUnknown,
+			expected:                                wrapExpectedValueAsMetric(2),
 		},
 	}
 


### PR DESCRIPTION
Fixes [OCPBUGS-63345](https://issues.redhat.com/browse/OCPBUGS-63345) 

## Problem

During the recent AWS us-east-1 outage, AWS API calls resulted in 5xx errors causing credential status conditions to become `Unknown`. However, the `hypershift_cluster_invalid_aws_creds` metric incorrectly treated `Unknown` status as invalid credentials (value 1).

### Current Issue
- **OIDC condition Unknown** → incorrectly treated as **valid** 
- **AWS Identity Provider condition Unknown** → incorrectly treated as **invalid**
- **Both conditions Unknown** → treated as **invalid** 

This asymmetric handling meant that during AWS service disruptions (most recently the us-east-1 outage), the metric couldn't distinguish between actual credential problems and transient AWS service issues.

### Impact on Downstream Consumers
**Context for upstream:** SRE teams use this metric for automated customer notifications about AWS credential issues. The current behavior triggered false notifications during the AWS outage, incorrectly telling customers their credentials were invalid when it was actually a transient AWS service problem.

## Solution

Changed the metric from binary (0/1) to three-state (0/1/2) values:
- **0** = Valid credentials (both conditions are True)
- **1** = Invalid credentials (either condition is False) 
- **2** = Unknown status (either condition is Unknown/missing)

### Changes Made
- Added `CredentialStatus` enum with proper constants
- Replaced `ValidCredentials()` with `GetCredentialStatus()` for detailed status  
- Updated metric emission logic to use 0/1/2 values
- Fixed asymmetric Unknown handling for consistent behavior
- Updated metric help text to document the new values
- Added comprehensive tests covering all condition combinations

## Backward Compatibility

✅ **Maintains compatibility** - existing automation checking `!= 0` will still work correctly  
✅ **Both invalid (1) and unknown (2) are non-zero** - existing alerts remain functional  
✅ **Downstream consumers can now distinguish** between actual credential issues vs. transient AWS problems

## Testing

- All existing tests updated and passing
- New comprehensive test coverage for edge cases
- Tests verify proper three-state logic and missing condition handling

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)