### PR TITLE
OCPBUGS-63367: FIPS compliant hypershift binary

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -5,12 +5,14 @@ WORKDIR /hypershift
 COPY --chown=default . .
 
 RUN make hypershift \
+  && make hypershift-no-cgo \
   && make hypershift-operator \
   && make product-cli \
   && make karpenter-operator
 
 FROM registry.redhat.io/rhel9-4-els/rhel:9.4
 COPY --from=builder /hypershift/bin/hypershift \
+                    /hypershift/bin/hypershift-no-cgo \
                     /hypershift/bin/hcp \
                     /hypershift/bin/hypershift-operator \
                     /hypershift/bin/karpenter-operator \

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,11 @@ control-plane-pki-operator:
 
 .PHONY: hypershift
 hypershift:
-	$(GO_CLI_RECIPE) -o $(OUT_DIR)/hypershift .
+	$(GO_BUILD_RECIPE) -o $(OUT_DIR)/hypershift .
+
+.PHONY: hypershift-no-cgo
+hypershift-no-cgo:
+	$(GO_CLI_RECIPE) -o $(OUT_DIR)/hypershift-no-cgo .
 
 .PHONY: product-cli
 product-cli:


### PR DESCRIPTION

## What this PR does / why we need it:

- Default FIPS compliance: Main binaries are now FIPS-compliant by default
- Backward compatibility: Non-FIPS option available via hypershift-no-cgo for any automation scripts that rely on non-FIPS binary.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://issues.redhat.com/browse/OCPBUGS-63367

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.