### PR TITLE
NO-JIRA: docs(ai): add reference to AGENTS.md for AI agent guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
 # HyperShift Claude Code Configuration
 
-This repository includes Claude Code configuration for enhanced development assistance.
+This repository includes Claude Code specific configuration for enhanced development assistance.
+
+Please also refer to @AGENTS.md for guidance to all AI agents when working with code in this repository.
 
 ## Documentation
 


### PR DESCRIPTION
## What this PR does / why we need it:
In #7074, the symlink from CLAUDE.md to AGENTS.md was removed and some specific content added to CLAUDE.md. This PR adds a directive to CLAUDE.md to instruct it to look and injest the information from AGENTS.md as well.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.