### PR TITLE
OCPBUGS-51136: specify SCC annotation for pods in data plane

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps.go
@@ -134,6 +134,9 @@ func reconcileDaemonSet(ctx context.Context, daemonSet *appsv1.DaemonSet, global
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"openshift.io/required-scc": "restricted-v2",
+					},
 					Labels: map[string]string{
 						"name": manifests.GlobalPullSecretDSName,
 					},

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/reconcile.go
@@ -43,6 +43,12 @@ func ReconcileAgentDaemonSet(daemonset *appsv1.DaemonSet, params *KonnectivityPa
 		}
 	}
 
+	annotations := make(map[string]string, len(params.AdditionalAnnotations)+1)
+	for k, v := range params.AdditionalAnnotations {
+		annotations[k] = v
+	}
+	annotations["openshift.io/required-scc"] = "restricted-v2"
+
 	daemonset.Spec = appsv1.DaemonSetSpec{
 		Selector: &metav1.LabelSelector{
 			MatchLabels: labels,
@@ -50,7 +56,7 @@ func ReconcileAgentDaemonSet(daemonset *appsv1.DaemonSet, params *KonnectivityPa
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels:      labels,
-				Annotations: params.AdditionalAnnotations,
+				Annotations: annotations,
 			},
 			Spec: corev1.PodSpec{
 				// Default is not the default, it means that the kubelets will reuse the hosts DNS resolver

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm/catalogs.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm/catalogs.go
@@ -34,8 +34,11 @@ func reconcileCatalogSource(cs *operatorsv1alpha1.CatalogSource, address string,
 	cs.Spec = operatorsv1alpha1.CatalogSourceSpec{
 		SourceType:  operatorsv1alpha1.SourceTypeGrpc,
 		DisplayName: displayName,
-		Publisher:   "Red Hat",
-		Priority:    priority,
+		GrpcPodConfig: &operatorsv1alpha1.GrpcPodConfig{
+			SecurityContextConfig: operatorsv1alpha1.Restricted,
+		},
+		Publisher: "Red Hat",
+		Priority:  priority,
 		UpdateStrategy: &operatorsv1alpha1.UpdateStrategy{
 			RegistryPoll: &operatorsv1alpha1.RegistryPoll{
 				RawInterval: "10m",


### PR DESCRIPTION
For the pods we create within the hosted cluster, SCC configuration within the hosted cluster can prevent those pods from starting if the cluster admin has configured an SCC with priority higher than the system default.

This adds an annotation that manually specifies the SCC to be used to the CatalogSources (the OLM mechanism for
setting SCC annotation on the underlying catalog pods) and the konnectivity-agent DaemonSet pods we create in the hosted cluster.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds required SCC annotation (restricted-v2) to Global Pull Secret and Konnectivity Agent DaemonSets and configures OLM CatalogSource pods with Restricted security context.
> 
> - **Security/Pod constraints**:
>   - `controllers/globalps/globalps.go`:
>     - Add `openshift.io/required-scc: restricted-v2` annotation to Global Pull Secret DaemonSet pod template.
>   - `controllers/resources/konnectivity/reconcile.go`:
>     - Merge `params.AdditionalAnnotations` with `openshift.io/required-scc: restricted-v2` for Konnectivity Agent DaemonSet pod template.
>   - `controllers/resources/olm/catalogs.go`:
>     - Set `GrpcPodConfig.SecurityContextConfig` to `Restricted` for `CatalogSource` pods.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1563b544dc154bec76be80d3438dd98798327406. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->