### PR TITLE
OCPBUGS-63369: Make the hypershift CLI binary FIPS-compliant

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -8,6 +8,7 @@ RUN make build
 
 FROM registry.redhat.io/rhel9-4-els/rhel:9.4
 COPY --from=builder /hypershift/bin/hypershift \
+                    /hypershift/bin/hypershift-no-cgo \
                     /hypershift/bin/hcp \
                     /hypershift/bin/hypershift-operator \
                     /hypershift/bin/control-plane-operator \
@@ -26,7 +27,7 @@ LABEL name="multicluster-engine/hypershift-operator"
 LABEL description="HyperShift Operator is an operator to manage the lifecycle of Hosted Clusters"
 LABEL summary="HyperShift Operator"
 LABEL url="https://catalog.redhat.com/software/containers/multicluster-engine/hypershift-rhel8-operator/"
-LABEL version=4.16
+LABEL version=4.18
 LABEL com.redhat.component="multicluster-engine-hypershift-operator"
 LABEL io.k8s.description="HyperShift Operator"
 LABEL io.k8s.display-name="hypershift-operator"

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ all: build e2e tests
 
 pre-commit: all verify test
 
-build: hypershift-operator control-plane-operator control-plane-pki-operator hypershift product-cli
+build: hypershift-operator control-plane-operator control-plane-pki-operator hypershift product-cli hypershift-no-cgo
 
 .PHONY: update
 update: workspace-sync api-deps api api-docs deps clients
@@ -94,7 +94,11 @@ control-plane-pki-operator:
 
 .PHONY: hypershift
 hypershift:
-	$(GO_CLI_RECIPE) -o $(OUT_DIR)/hypershift .
+	$(GO_BUILD_RECIPE) -o $(OUT_DIR)/hypershift .
+
+.PHONY: hypershift-no-cgo
+hypershift-no-cgo:
+	$(GO_CLI_RECIPE) -o $(OUT_DIR)/hypershift-no-cgo .
 
 .PHONY: product-cli
 product-cli:


### PR DESCRIPTION

## What this PR does / why we need it:

- Default FIPS compliance: Main binaries are now FIPS-compliant by default
- Backward compatibility: Non-FIPS option available via hypershift-no-cgo for any automation scripts that rely on non-FIPS binary.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://issues.redhat.com//browse/OCPBUGS-63369

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.