### PR TITLE
OSDOCS-14984: docs: update hostedcluster examples for disconnected environments

### DIFF
--- a/docs/content/labs/Dual/hostedcluster/hostedcluster.md
+++ b/docs/content/labs/Dual/hostedcluster/hostedcluster.md
@@ -111,16 +111,22 @@ metadata:
   name: hosted-dual
   namespace: clusters
 spec:
+  configuration:
+    operatorhub:
+      disableAllDefaultSources: true
   additionalTrustBundle:
     name: "user-ca-bundle"
   olmCatalogPlacement: guest
   imageContentSources:
   - source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
     mirrors:
-    - registry.hypershiftbm.lab:5000/openshift/release
+    - registry.<dns.base.domain.name>:5000/openshift/release
   - source: quay.io/openshift-release-dev/ocp-release
     mirrors:
-    - registry.hypershiftbm.lab:5000/openshift/release-images
+    - registry.<dns.base.domain.name>:5000/openshift/release-images
+  - source: registry.redhat.io/multicluster-engine
+    mirrors:
+    - registry.<dns.base.domain.name>:5000/openshift/multicluster-engine
   - mirrors:
   ...
   ...
@@ -195,6 +201,17 @@ status:
 !!! note
 
     The `imageContentSources` section within the `spec` field contains mirror references for user workloads within the HostedCluster.
+
+!!! note
+
+    If your Hosted Cluster is intended for a disconnected environment, consider disabling the default OLM sources to define custom ones according to your requirements:
+    ```
+    spec:
+      configuration:
+        operatorhub:
+          disableAllDefaultSources: true
+    ```
+
 
 As you can see, all the objects created before are referenced here. You can also refer to the [documentation](https://hypershift-docs.netlify.app/reference/api/#hypershift.openshift.io%2fv1beta1) where all the fields are described.
 

--- a/docs/content/labs/IPv4/hostedcluster/hostedcluster.md
+++ b/docs/content/labs/IPv4/hostedcluster/hostedcluster.md
@@ -116,10 +116,13 @@ spec:
   imageContentSources:
   - source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
     mirrors:
-    - registry.hypershiftbm.lab:5000/openshift/release
+    - registry.<dns.base.domain.name>:5000/openshift/release
   - source: quay.io/openshift-release-dev/ocp-release
     mirrors:
-    - registry.hypershiftbm.lab:5000/openshift/release-images
+    - registry.<dns.base.domain.name>:5000/openshift/release-images
+  - source: registry.redhat.io/multicluster-engine
+    mirrors:
+    - registry.<dns.base.domain.name>:5000/openshift/multicluster-engine
   - mirrors:
   ...
   ...
@@ -192,6 +195,16 @@ status:
 !!! note
 
     The `imageContentSources` section within the `spec` field contains mirror references for user workloads within the HostedCluster.
+
+!!! note
+
+    If your Hosted Cluster is intended for a disconnected environment, consider disabling the default OLM sources to define custom ones according to your requirements:
+    ```
+    spec:
+      configuration:
+        operatorhub:
+          disableAllDefaultSources: true
+    ```
 
 As you can see, all the objects created before are referenced here. You can also refer to the [documentation](https://hypershift-docs.netlify.app/reference/api/#hypershift.openshift.io%2fv1beta1) where all the fields are described.
 

--- a/docs/content/labs/IPv6/hostedcluster/hostedcluster.md
+++ b/docs/content/labs/IPv6/hostedcluster/hostedcluster.md
@@ -110,19 +110,23 @@ kind: HostedCluster
 metadata:
   name: hosted-ipv6
   namespace: clusters
-  annotations:
-    hypershift.openshift.io/control-plane-operator-image: registry.ocp-edge-cluster-0.qe.lab.redhat.com:5005/openshift/release@sha256:31149e3e5f8c5e5b5b100ff2d89975cf5f7a73801b2c06c639bf6648766117f8
 spec:
+  configuration:
+    operatorhub:
+      disableAllDefaultSources: true
   additionalTrustBundle:
     name: "user-ca-bundle"
   olmCatalogPlacement: guest
   imageContentSources:
   - source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
     mirrors:
-    - registry.hypershiftbm.lab:5000/openshift/release
+    - registry.<dns.base.domain.name>:5000/openshift/release
   - source: quay.io/openshift-release-dev/ocp-release
     mirrors:
-    - registry.hypershiftbm.lab:5000/openshift/release-images
+    - registry.<dns.base.domain.name>:5000/openshift/release-images
+  - source: registry.redhat.io/multicluster-engine
+    mirrors:
+    - registry.<dns.base.domain.name>:5000/openshift/multicluster-engine
   - mirrors:
   ...
   ...


### PR DESCRIPTION
## What this PR does / why we need it:
- Standardize registry URLs to use template format <dns.base.domain.name>
- Add multicluster-engine image source mirror configuration
- Add operatorhub configuration to disable default sources for disconnected setups
- Add documentation note explaining OLM configuration for disconnected environments
- Remove hardcoded control-plane-operator-image annotation from IPv6 example

This improves the documentation for users setting up HyperShift in disconnected/air-gapped environments across IPv4, IPv6, and dual-stack configurations.

## Which issue(s) this PR fixes:
- [OSDOCS-15001](https://issues.redhat.com/browse/OSDOCS-15001)
- [OSDOCS-14984](https://issues.redhat.com/browse/OSDOCS-14984)

