### PR TITLE
CORENET-6484: Restart ovnkube-control-plane pods when restart-date annotation is set

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2344,6 +2344,12 @@ func (r *HostedControlPlaneReconciler) cleanupClusterNetworkOperatorResources(ct
 		if err := cnov2.SetRestartAnnotationAndPatch(ctx, r.Client, networkNodeIdentityDeployment, restartAnnotation); err != nil {
 			return fmt.Errorf("failed to restart network node identity: %w", err)
 		}
+
+		// CNO manages overall ovnkube-control-plane deployment. CPO manages restarts.  Note that cnov2.SetRestartAnnotationAndPatch just returns err == nil if the deployment isn't found (so if OVN isn't being used)
+		ovnKubeControlPlaneDeployment := manifests.OVNKubeControlPlaneDeployment(hcp.Namespace)
+		if err := cnov2.SetRestartAnnotationAndPatch(ctx, r.Client, ovnKubeControlPlaneDeployment, restartAnnotation); err != nil {
+			return fmt.Errorf("failed to restart ovnkube-control-plane: %w", err)
+		}
 	}
 
 	// Clean up ovnkube-sbdb Route if exists

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/cno.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/cno.go
@@ -12,6 +12,7 @@ import (
 const clusterNetworkOperator = "cluster-network-operator"
 const multusAdmissionController = "multus-admission-controller"
 const networkNodeIdentity = "network-node-identity"
+const ovnKubeControlPlane = "ovnkube-control-plane"
 
 func ClusterNetworkOperatorDeployment(ns string) *appsv1.Deployment {
 	return &appsv1.Deployment{
@@ -63,6 +64,15 @@ func NetworkNodeIdentityDeployment(namespace string) *appsv1.Deployment {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      networkNodeIdentity,
+		},
+	}
+}
+
+func OVNKubeControlPlaneDeployment(namespace string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      ovnKubeControlPlane,
 		},
 	}
 }


### PR DESCRIPTION
Ensure the ovnkube-control-plane pods match the behavior specified in docs/content/how-to/restart-control-plane-components.md, which is to restart when the hypershift.openshift.io/restart-date annotation is set/changed on the hostedcluster

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:
This PR ensures the ovnkube-control-plane pods match the behavior specified in docs/content/how-to/restart-control-plane-components.md, which is to restart when the hypershift.openshift.io/restart-date annotation is set/changed on the hostedcluster

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes # https://issues.redhat.com/browse/CORENET-6484

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.