### PR TITLE
CNTRLPLANE-1687: feat(e2e): add support for azure-workload-identities-file flag

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -130,6 +130,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.ConfigurableClusterOptions.AzureIssuerURL, "e2e.oidc-issuer-url", "", "The OIDC provider issuer URL")
 	flag.StringVar(&globalOpts.ConfigurableClusterOptions.AzureServiceAccountTokenIssuerKeyPath, "e2e.sa-token-issuer-private-key-path", "", "The file to the private key for the service account token issuer")
 	flag.StringVar(&globalOpts.ConfigurableClusterOptions.AzureDataPlaneIdentities, "e2e.azure-data-plane-identities-file", "", "Path to a file containing the client IDs of the managed identities associated with the data plane")
+	flag.StringVar(&globalOpts.ConfigurableClusterOptions.AzureWorkloadIdentitiesFile, "e2e.azure-workload-identities-file", "", "Path to an Azure workload identities file")
 	flag.StringVar(&globalOpts.ConfigurableClusterOptions.AzureEncryptionKeyID, "e2e.azure-encryption-key-id", "", "etcd encryption key identifier in the form of https://<vaultName>.vault.azure.net/keys/<keyName>/<keyVersion>")
 	flag.StringVar(&globalOpts.ConfigurableClusterOptions.AzureKMSUserAssignedCredsSecretName, "e2e.azure-kms-credentials-secret-name", "", "The name of a secret, in Azure KeyVault, containing the JSON UserAssignedIdentityCredentials used in KMS to authenticate to Azure.")
 

--- a/test/e2e/util/options.go
+++ b/test/e2e/util/options.go
@@ -116,6 +116,7 @@ type ConfigurableClusterOptions struct {
 	AzureMultiArch                        bool
 	AzureServiceAccountTokenIssuerKeyPath string
 	AzureDataPlaneIdentities              string
+	AzureWorkloadIdentitiesFile           string
 	AzureEncryptionKeyID                  string
 	AzureKMSUserAssignedCredsSecretName   string
 	OpenStackCredentialsFile              string
@@ -346,6 +347,10 @@ func (o *Options) DefaultAzureOptions() azure.RawCreateOptions {
 
 	if o.ConfigurableClusterOptions.AzureManagedIdentitiesFile != "" {
 		opts.ManagedIdentitiesFile = o.ConfigurableClusterOptions.AzureManagedIdentitiesFile
+	}
+
+	if o.ConfigurableClusterOptions.AzureWorkloadIdentitiesFile != "" {
+		opts.WorkloadIdentitiesFile = o.ConfigurableClusterOptions.AzureWorkloadIdentitiesFile
 	}
 
 	if opts.ManagedIdentitiesFile != "" {


### PR DESCRIPTION
## What this PR does / why we need it:

This PR adds support for the `--e2e.azure-workload-identities-file` flag to Azure e2e tests. This enables the self-managed Azure e2e workflow to specify workload identities configuration via a file, supporting workload identity authentication in Azure hosted clusters.

The change adds:
- A new `AzureWorkloadIdentitiesFile` field to `ConfigurableClusterOptions` 
- The corresponding flag `--e2e.azure-workload-identities-file` in the e2e test main
- Wiring in `DefaultAzureOptions()` to pass the file path to the Azure options

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-1687](https://issues.redhat.com//browse/CNTRLPLANE-1687)

## Special notes for your reviewer:

This is a small, focused change to support passing workload identities to Azure e2e tests. The implementation follows the same pattern as other Azure configuration flags like `AzureManagedIdentitiesFile`.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. (N/A - test infrastructure flag)
- [ ] This change includes unit tests. (N/A - adding e2e test flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>