### PR TITLE
NO-JIRA: feat(e2e-v2): new binary and add to makefile and e2e image

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -14,7 +14,8 @@ WORKDIR /hypershift
 
 RUN mkdir -p /hypershift/bin /hypershift/hack
 COPY --from=builder /hypershift/bin/test-e2e /hypershift/bin/test-e2e
-COPY --from=builder /hypershift/bin/test-setup /hypershift//bin/test-setup
+COPY --from=builder /hypershift/bin/test-setup /hypershift/bin/test-setup
+COPY --from=builder /hypershift/bin/test-e2e-v2 /hypershift/bin/test-e2e-v2
 COPY --from=builder /hypershift/hack/ci-test-e2e.sh /hypershift/hack/ci-test-e2e.sh
 
 RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc && \

--- a/Makefile
+++ b/Makefile
@@ -270,6 +270,7 @@ test: generate
 e2e:
 	$(GO_E2E_RECIPE) -o bin/test-e2e ./test/e2e
 	$(GO_BUILD_RECIPE) -o bin/test-setup ./test/setup
+	$(GO_BUILD_RECIPE) -o bin/test-e2e-v2 ./test/e2e/v2
 	cd $(TOOLS_DIR); GO111MODULE=on GOFLAGS=-mod=vendor GOWORK=off go build -tags=tools -o ../../bin/gotestsum gotest.tools/gotestsum
 
 # Run go fmt against code

--- a/test/e2e/v2/main.go
+++ b/test/e2e/v2/main.go
@@ -1,0 +1,64 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	cmd := &cobra.Command{
+		Use:              "test-e2e-v2",
+		SilenceUsage:     true,
+		TraverseChildren: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			_ = cmd.Help()
+			os.Exit(1)
+		},
+	}
+
+	cmd.AddCommand(newCreateCommand())
+	cmd.AddCommand(newTestCommand())
+
+	if err := cmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func newCreateCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:          "create",
+		Short:        "Create command",
+		SilenceUsage: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			os.Exit(0)
+		},
+	}
+}
+
+func newTestCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:          "test",
+		Short:        "Test command",
+		SilenceUsage: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			os.Exit(0)
+		},
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new Cobra-based `test-e2e-v2` CLI and includes it in the Makefile build and the e2e Docker image.
> 
> - **E2E**:
>   - **New CLI**: Introduces `test/e2e/v2` with Cobra-based `test-e2e-v2` providing `create` and `test` subcommands (stubs that exit 0).
>   - **Build/CI**:
>     - Makefile: builds `bin/test-e2e-v2` in the `e2e` target.
>     - `Dockerfile.e2e`: copies `test-e2e-v2` into the final image alongside existing e2e binaries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b23e477162b7e7bd3812909a2f049eb1d1efee8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->