### PR TITLE
CNTRLPLANE-1756: fix(ai-skill): prevent security warning in git-commit-format skill

### DIFF
--- a/.claude/skills/git-commit-format/SKILL.md
+++ b/.claude/skills/git-commit-format/SKILL.md
@@ -123,7 +123,7 @@ When creating commits:
 - [ ] Include `Signed-off-by` footer
 - [ ] Include `Commit-Message-Assisted-by: Claude (via Claude Code)` footer
 - [ ] Validate with `make run-gitlint`
-- [ ] Use `!` or `BREAKING CHANGE` for breaking changes
+- [ ] Use "!" or `BREAKING CHANGE` for breaking changes
 
 ## Reference
 


### PR DESCRIPTION
## Summary
- Fix backtick formatting in git-commit-format skill documentation that triggers false-positive security warnings

## Details
The checklist used backticks around the "!" character, which Claude Code's security checks misinterpret as command execution. This triggered permission prompts for "!" which cannot be granted, blocking normal use of the skill documentation.

Changed to double quotes to prevent the false-positive security warning while maintaining proper formatting.

## Test plan
- [x] Documentation change only
- [x] Verified formatting renders correctly
- [x] No security warnings triggered

Jira: [CNTRLPLANE-1756](https://issues.redhat.com//browse/CNTRLPLANE-1756)

🤖 Generated with [Claude Code](https://claude.com/claude-code)