### PR TITLE
NO-JIRA: fix(ai): fix plugin marketplace name

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,6 @@
 {
   "extraKnownMarketplaces": {
-    "openshift-ai-helpers": {
+    "ai-helpers": {
       "source": {
         "source": "github",
         "repo": "openshift-eng/ai-helpers"


### PR DESCRIPTION
## What this PR does / why we need it:
Adding "openshift-ai-helpers" when the marketplace is actually called "ai-helpers" causes conflicts when loading the marketplace

ref: https://github.com/openshift-eng/ai-helpers/blob/98fa13ed200334066c014ea02f382b26285b4d7d/.claude-plugin/marketplace.json#L2

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.