### PR TITLE
 OCPBUGS-51136: revert scc annotation for components in kube-system

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps.go
@@ -134,9 +134,6 @@ func reconcileDaemonSet(ctx context.Context, daemonSet *appsv1.DaemonSet, global
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"openshift.io/required-scc": "restricted-v2",
-					},
 					Labels: map[string]string{
 						"name": manifests.GlobalPullSecretDSName,
 					},

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/reconcile.go
@@ -43,12 +43,6 @@ func ReconcileAgentDaemonSet(daemonset *appsv1.DaemonSet, params *KonnectivityPa
 		}
 	}
 
-	annotations := make(map[string]string, len(params.AdditionalAnnotations)+1)
-	for k, v := range params.AdditionalAnnotations {
-		annotations[k] = v
-	}
-	annotations["openshift.io/required-scc"] = "restricted-v2"
-
 	daemonset.Spec = appsv1.DaemonSetSpec{
 		Selector: &metav1.LabelSelector{
 			MatchLabels: labels,
@@ -56,7 +50,7 @@ func ReconcileAgentDaemonSet(daemonset *appsv1.DaemonSet, params *KonnectivityPa
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels:      labels,
-				Annotations: annotations,
+				Annotations: params.AdditionalAnnotations,
 			},
 			Spec: corev1.PodSpec{
 				// Default is not the default, it means that the kubelets will reuse the hosts DNS resolver


### PR DESCRIPTION
The SCC annotation has no effect for pods in the kube-system namespace.

Remove setting the annotation that has no effect.

Partial revert of https://github.com/openshift/hypershift/pull/7091

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Drops the "openshift.io/required-scc" annotation from the Global Pull Secret and Konnectivity Agent DaemonSets, using only provided annotations.
> 
> - **DaemonSets in `kube-system`**:
>   - **Global Pull Secret** (`controllers/globalps/globalps.go`): remove Pod template annotation `openshift.io/required-scc: restricted-v2`.
>   - **Konnectivity Agent** (`controllers/resources/konnectivity/reconcile.go`): stop injecting `openshift.io/required-scc: restricted-v2`; use `params.AdditionalAnnotations` as-is.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57805ff51481f75d87700960ad8fea38134edd73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->