### PR TITLE
OCPBUGS-63718: specify SCC annotation for pods in data plane

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm/catalogs.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/olm/catalogs.go
@@ -34,8 +34,11 @@ func reconcileCatalogSource(cs *operatorsv1alpha1.CatalogSource, address string,
 	cs.Spec = operatorsv1alpha1.CatalogSourceSpec{
 		SourceType:  operatorsv1alpha1.SourceTypeGrpc,
 		DisplayName: displayName,
-		Publisher:   "Red Hat",
-		Priority:    priority,
+		GrpcPodConfig: &operatorsv1alpha1.GrpcPodConfig{
+			SecurityContextConfig: operatorsv1alpha1.Restricted,
+		},
+		Publisher: "Red Hat",
+		Priority:  priority,
 		UpdateStrategy: &operatorsv1alpha1.UpdateStrategy{
 			RegistryPoll: &operatorsv1alpha1.RegistryPoll{
 				RawInterval: "10m",


### PR DESCRIPTION
Manual pick/squash of https://github.com/openshift/hypershift/pull/7091 and https://github.com/openshift/hypershift/pull/7130

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configures OLM CatalogSource pods to use the Restricted security context via GrpcPodConfig.
> 
> - **OLM**:
>   - **CatalogSource Spec**: Adds `GrpcPodConfig` with `SecurityContextConfig: Restricted` in `reconcileCatalogSource`, enforcing Restricted security context for CatalogSource pods.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 059ebf48e489799f8bfef6bc255e215f1bdc2f18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->