### PR TITLE
 CNTRLPLANE-1778: fix(cpo-overrides): add CPO overrides for 4.17.20 - 4.17.43

### DIFF
--- a/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
+++ b/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
@@ -221,10 +221,62 @@ platforms:
       cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-cert-hotfix-416-multi:2d2e6071841bb12ff1f41c457889bb44b6fb1cf7
     # End of OCPBUGS-58837 overrides 4.15 section
     # End of OCPBUGS-58837 overrides
+    # Beginning of OCPBUGS-61296 overrides
+    # Beginning of OCPBUGS-61296 overrides 4.17 section
+    - version: 4.17.20
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+    - version: 4.17.21
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+    - version: 4.17.22
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+    - version: 4.17.23
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+    - version: 4.17.24
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+    - version: 4.17.25
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+    - version: 4.17.26
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+    - version: 4.17.27
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+    - version: 4.17.28
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+    - version: 4.17.29
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+    - version: 4.17.30
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+    - version: 4.17.31
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+    - version: 4.17.32
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+    - version: 4.17.33
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+    - version: 4.17.34
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+    - version: 4.17.35
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+    - version: 4.17.36
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+    - version: 4.17.37
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+    - version: 4.17.38
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+    - version: 4.17.39
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+    - version: 4.17.40
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+    - version: 4.17.41
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+    - version: 4.17.42
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+    - version: 4.17.43
+      cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+    # End of OCPBUGS-61296 overrides 4.17 section
+    # End of OCPBUGS-61296 overrides
     testing:
     # Update the image refs below to indicate which images should be used for CPO override
     # testing. Currently, we only test one latest/previous combination. In the future, we 
     # may be able to test multiple combinations at a time. To test more than one, update
     # the referenced images before each e2e test run.
-      latest: quay.io/openshift-release-dev/ocp-release:4.15.53-x86_64
-      previous: quay.io/openshift-release-dev/ocp-release:4.15.52-x86_64
+      latest: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-hotfix-ocpbugs-63639:765731018bc98e0a8ad89a636cfa2fe9fce9aab2
+      previous: quay.io/openshift-release-dev/ocp-release:4.17.43-x86_64


### PR DESCRIPTION
## What this PR does / why we need it:
Add CPO overrides for 4.17.20 - 4.17.43

## Which issue(s) this PR fixes:

- OCPBUGS-61296 : Tracks the bug on main
- OCPBUGS-63639: Backport for release-4.17
- Hotfix branch [hotfix-ocpbugs-63639](https://github.com/openshift/hypershift/tree/hotfix-ocpbugs-63639)

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.