### PR TITLE
GCP-152:feat:(gcp)Add basic GCP platform recognition support

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
@@ -1,0 +1,109 @@
+// Package gcp provides Google Cloud Platform support for HyperShift.
+//
+// This package implements the Platform interface to enable HyperShift
+// to create and manage OpenShift control planes on Google Cloud Platform.
+//
+// The package currently provides enough functionality to allow HostedCluster
+// resources with platform.type: GCP to be accepted and reconciled by the
+// HyperShift operator without errors. All methods return nil or no-op values
+// to indicate that no platform-specific operations should be performed at this time.
+//
+// For more information about HyperShift platform implementations, see:
+// https://github.com/openshift/hypershift/blob/main/docs/content/how-to/platforms.md
+package gcp
+
+import (
+	"context"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/upsert"
+
+	appsv1 "k8s.io/api/apps/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GCP implements the Platform interface for Google Cloud Platform.
+//
+// This is a minimal implementation that enables HostedCluster reconciliation
+// for GCP platform. The struct provides no-op implementations for all Platform
+// interface methods, which allows HyperShift to accept and process HostedCluster
+// resources with platform.type: GCP without attempting actual cloud resource
+// management.
+type GCP struct{}
+
+// New creates a new GCP platform instance.
+//
+// This function returns a new instance of the GCP platform implementation
+// that can be used with the HyperShift platform factory. The returned
+// platform provides minimal no-op implementations for all required
+// Platform interface methods.
+//
+// The platform instance is stateless and can be safely reused across
+// multiple HostedCluster reconciliation operations.
+//
+// Returns:
+//   - *GCP: A new GCP platform instance ready for use with HyperShift controllers
+//
+// Example usage:
+//
+//	platform := gcp.New()
+//	// platform can now be used with HyperShift platform factory
+func New() *GCP {
+	return &GCP{}
+}
+
+// ReconcileCAPIInfraCR is a no-op
+// TODO: Implement CAPI/CAPG integration for NodePool support.
+func (p GCP) ReconcileCAPIInfraCR(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
+	hcluster *hyperv1.HostedCluster,
+	controlPlaneNamespace string, apiEndpoint hyperv1.APIEndpoint) (client.Object, error) {
+
+	// TODO: Implement CAPI GCP infrastructure reconciliation in future phase
+	// for NodePool support (CAPG integration)
+	return nil, nil
+}
+
+// CAPIProviderDeploymentSpec is a no-op
+// TODO: Implement CAPI/CAPG deployment for NodePool support.
+func (p GCP) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error) {
+	// TODO: Implement CAPI GCP provider deployment
+	// for NodePool support (CAPG integration)
+	return nil, nil
+}
+
+// ReconcileCredentials is a no-op
+// TODO: Implement GCP workload identity credential reconciliation.
+func (p GCP) ReconcileCredentials(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
+	hcluster *hyperv1.HostedCluster,
+	controlPlaneNamespace string) error {
+
+	// TODO: Implement GCP workload identity credential reconciliation
+	return nil
+}
+
+// ReconcileSecretEncryption is a no-op
+// TODO: Implement GCP KMS secret encryption integration.
+func (p GCP) ReconcileSecretEncryption(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
+	hcluster *hyperv1.HostedCluster,
+	controlPlaneNamespace string) error {
+
+	// TODO: Implement GCP KMS secret encryption
+	return nil
+}
+
+// CAPIProviderPolicyRules is a no-op
+// TODO: Implement CAPI/CAPG RBAC policy rules for NodePool support.
+func (p GCP) CAPIProviderPolicyRules() []rbacv1.PolicyRule {
+	// TODO: Implement CAPI GCP provider policy rules
+	// for NodePool support (CAPG integration)
+	return nil
+}
+
+// DeleteCredentials is a no-op
+// TODO: Implement GCP workload identity credential cleanup.
+func (p GCP) DeleteCredentials(ctx context.Context, c client.Client, hcluster *hyperv1.HostedCluster, controlPlaneNamespace string) error {
+	// TODO: Implement GCP credential cleanup
+	return nil
+}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp_test.go
@@ -1,0 +1,190 @@
+package gcp
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGCPPlatformInterface(t *testing.T) {
+	g := NewWithT(t)
+
+	// Test that GCP implements the Platform interface
+	platform := New()
+	g.Expect(platform).ToNot(BeNil())
+}
+
+func TestReconcileCAPIInfraCR(t *testing.T) {
+	g := NewWithT(t)
+
+	platform := New()
+	fakeClient := fake.NewClientBuilder().Build()
+
+	// Test minimal implementation returns nil (no CAPI infrastructure)
+	obj, err := platform.ReconcileCAPIInfraCR(
+		context.Background(),
+		fakeClient,
+		nil, // createOrUpdate function
+		&hyperv1.HostedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: "test-namespace",
+			},
+			Spec: hyperv1.HostedClusterSpec{
+				Platform: hyperv1.PlatformSpec{
+					Type: hyperv1.GCPPlatform,
+					GCP: &hyperv1.GCPPlatformSpec{
+						Project: "test-project",
+						Region:  "us-central1",
+					},
+				},
+			},
+		},
+		"test-control-plane-namespace",
+		hyperv1.APIEndpoint{Host: "example.com", Port: 443},
+	)
+
+	g.Expect(err).To(BeNil())
+	g.Expect(obj).To(BeNil()) // Minimal implementation returns nil
+}
+
+func TestCAPIProviderDeploymentSpec(t *testing.T) {
+	g := NewWithT(t)
+
+	platform := New()
+
+	// Test minimal implementation returns nil (no CAPI provider)
+	spec, err := platform.CAPIProviderDeploymentSpec(
+		&hyperv1.HostedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: "test-namespace",
+			},
+			Spec: hyperv1.HostedClusterSpec{
+				Platform: hyperv1.PlatformSpec{
+					Type: hyperv1.GCPPlatform,
+					GCP: &hyperv1.GCPPlatformSpec{
+						Project: "test-project",
+						Region:  "us-central1",
+					},
+				},
+			},
+		},
+		nil, // HostedControlPlane
+	)
+
+	g.Expect(err).To(BeNil())
+	g.Expect(spec).To(BeNil()) // Minimal implementation returns nil
+}
+
+func TestReconcileCredentials(t *testing.T) {
+	g := NewWithT(t)
+
+	platform := New()
+	fakeClient := fake.NewClientBuilder().Build()
+
+	// Test minimal implementation returns no error
+	err := platform.ReconcileCredentials(
+		context.Background(),
+		fakeClient,
+		nil, // createOrUpdate function
+		&hyperv1.HostedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: "test-namespace",
+			},
+			Spec: hyperv1.HostedClusterSpec{
+				Platform: hyperv1.PlatformSpec{
+					Type: hyperv1.GCPPlatform,
+					GCP: &hyperv1.GCPPlatformSpec{
+						Project: "test-project",
+						Region:  "us-central1",
+					},
+				},
+			},
+		},
+		"test-control-plane-namespace",
+	)
+
+	g.Expect(err).To(BeNil()) // Minimal implementation returns nil
+}
+
+func TestReconcileSecretEncryption(t *testing.T) {
+	g := NewWithT(t)
+
+	platform := New()
+	fakeClient := fake.NewClientBuilder().Build()
+
+	// Test minimal implementation returns no error
+	err := platform.ReconcileSecretEncryption(
+		context.Background(),
+		fakeClient,
+		nil, // createOrUpdate function
+		&hyperv1.HostedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: "test-namespace",
+			},
+			Spec: hyperv1.HostedClusterSpec{
+				Platform: hyperv1.PlatformSpec{
+					Type: hyperv1.GCPPlatform,
+					GCP: &hyperv1.GCPPlatformSpec{
+						Project: "test-project",
+						Region:  "us-central1",
+					},
+				},
+			},
+		},
+		"test-control-plane-namespace",
+	)
+
+	g.Expect(err).To(BeNil()) // Minimal implementation returns nil
+}
+
+func TestCAPIProviderPolicyRules(t *testing.T) {
+	g := NewWithT(t)
+
+	platform := New()
+
+	// Test minimal implementation returns nil
+	rules := platform.CAPIProviderPolicyRules()
+	g.Expect(rules).To(BeNil()) // Minimal implementation returns nil
+}
+
+func TestDeleteCredentials(t *testing.T) {
+	g := NewWithT(t)
+
+	platform := New()
+	fakeClient := fake.NewClientBuilder().Build()
+
+	// Test minimal implementation returns no error
+	err := platform.DeleteCredentials(
+		context.Background(),
+		fakeClient,
+		&hyperv1.HostedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: "test-namespace",
+			},
+			Spec: hyperv1.HostedClusterSpec{
+				Platform: hyperv1.PlatformSpec{
+					Type: hyperv1.GCPPlatform,
+					GCP: &hyperv1.GCPPlatformSpec{
+						Project: "test-project",
+						Region:  "us-central1",
+					},
+				},
+			},
+		},
+		"test-control-plane-namespace",
+	)
+
+	g.Expect(err).To(BeNil()) // Minimal implementation returns nil
+}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/agent"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/aws"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/azure"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/gcp"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/ibmcloud"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/none"
@@ -39,6 +40,7 @@ var _ Platform = ibmcloud.IBMCloud{}
 var _ Platform = none.None{}
 var _ Platform = agent.Agent{}
 var _ Platform = kubevirt.Kubevirt{}
+var _ Platform = gcp.GCP{}
 
 type Platform interface {
 	// ReconcileCAPIInfraCR is called during HostedCluster reconciliation prior to reconciling the CAPI Cluster CR.
@@ -152,6 +154,8 @@ func GetPlatform(ctx context.Context, hcluster *hyperv1.HostedCluster, releasePr
 			}
 		}
 		platform = openstack.New(capiImageProvider, orcImage, payloadVersion)
+	case hyperv1.GCPPlatform:
+		platform = gcp.New()
 	default:
 		return nil, fmt.Errorf("unsupported platform: %s", hcluster.Spec.Platform.Type)
 	}


### PR DESCRIPTION
## What this PR does / why we need it:

This enables HostedCluster creation with GCP platform type.
- Add GCPPlatformSpec with project and region fields
- Implement minimal GCP platform interface (no-op)
- Add platform registration and basic tests
- Update API documentation for GCP support

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/GCP-152

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.