### PR TITLE
OCPBUGS-64609:fix:(hcp-aws-create): remove the default imagestram 

### DIFF
--- a/product-cli/cmd/cluster/aws/create.go
+++ b/product-cli/cmd/cluster/aws/create.go
@@ -5,7 +5,6 @@ import (
 
 	hypershiftaws "github.com/openshift/hypershift/cmd/cluster/aws"
 	"github.com/openshift/hypershift/cmd/cluster/core"
-	"github.com/openshift/hypershift/support/config"
 
 	"github.com/spf13/cobra"
 )
@@ -16,8 +15,6 @@ func NewCreateCommand(opts *core.RawCreateOptions) *cobra.Command {
 		Short:        "Creates basic functional HostedCluster resources on AWS",
 		SilenceUsage: true,
 	}
-
-	opts.ReleaseStream = config.DefaultReleaseStream
 
 	awsOpts := hypershiftaws.DefaultOptions()
 


### PR DESCRIPTION
Issue:
When using the hcp client, if `--release-image` is not specified, it always uses the latest image (for example, 4.20.2-multi), even in a 4.19 HO environment.

Fix:
Removed the default imagestream set in hcp aws create to ensure that when `spec.release.image` is unset, the system uses the latest supported stable release image instead of the absolute latest.

Note:  
- When neither an imagestream nor `--release-image` is provided, the hostedcluster `spec.release.image` field in the rendered create file is left empty.
- The webhook subsequently injects the default latest supported stable release image into the HostedCluster resource after `oc apply`