### PR TITLE
OCPBUGS-34078: Prevent duplicate AWS resource tag keys in HostedCluster and NodePool

### DIFF
--- a/api/hypershift/v1beta1/aws.go
+++ b/api/hypershift/v1beta1/aws.go
@@ -61,6 +61,8 @@ type AWSNodePoolPlatform struct {
 	// for the user.
 	//
 	// +kubebuilder:validation:MaxItems=25
+	// +listType=map
+	// +listMapKey=key
 	// +optional
 	ResourceTags []AWSResourceTag `json:"resourceTags,omitempty"`
 
@@ -314,6 +316,8 @@ type AWSPlatformSpec struct {
 	// These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
 	//
 	// +kubebuilder:validation:MaxItems=25
+	// +listType=map
+	// +listMapKey=key
 	// +optional
 	ResourceTags []AWSResourceTag `json:"resourceTags,omitempty"`
 

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -3800,6 +3800,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -3838,6 +3838,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -3811,6 +3811,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -4148,6 +4148,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -4302,6 +4302,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
@@ -3791,6 +3791,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -3813,6 +3813,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -3809,6 +3809,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -3867,6 +3867,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -3943,6 +3943,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -3791,6 +3791,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -3692,6 +3692,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -3730,6 +3730,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -3703,6 +3703,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -4040,6 +4040,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -4194,6 +4194,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
@@ -3683,6 +3683,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -3705,6 +3705,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -3701,6 +3701,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -3759,6 +3759,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -3835,6 +3835,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -3683,6 +3683,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
@@ -561,6 +561,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rootVolume:
                         description: rootVolume specifies configuration for the root
                           volume of node instances.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
@@ -561,6 +561,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rootVolume:
                         description: rootVolume specifies configuration for the root
                           volume of node instances.

--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -118,7 +118,7 @@ func (o *ValidatedCreateOptions) Complete(ctx context.Context, opts *core.Create
 	}
 
 	if o.UseROSAManagedPolicies {
-		o.AdditionalTags = append(o.AdditionalTags, "red-hat-managed=true")
+		o.AdditionalTags = util.AddUniqueTag(o.AdditionalTags, "red-hat-managed=true")
 	}
 
 	if opts.EtcdStorageClass == "" {

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
@@ -4639,6 +4639,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
@@ -4483,6 +4483,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -4550,6 +4550,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
@@ -4531,6 +4531,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
@@ -4375,6 +4375,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -4442,6 +4442,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rolesRef:
                         description: |-
                           rolesRef contains references to various AWS IAM roles required to enable

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -564,6 +564,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rootVolume:
                         description: rootVolume specifies configuration for the root
                           volume of node instances.

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -564,6 +564,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rootVolume:
                         description: rootVolume specifies configuration for the root
                           volume of node instances.

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -564,6 +564,9 @@ spec:
                           type: object
                         maxItems: 25
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
                       rootVolume:
                         description: rootVolume specifies configuration for the root
                           volume of node instances.

--- a/cmd/util/client.go
+++ b/cmd/util/client.go
@@ -67,7 +67,8 @@ func GetImpersonatedClient(userName string) (crclient.Client, error) {
 	return client, nil
 }
 
-// ParseAWSTags does exactly that
+// ParseAWSTags parses a slice of "key=value" strings into a map.
+// Returns an error if any tag is malformed or if duplicate keys are found.
 func ParseAWSTags(tags []string) (map[string]string, error) {
 	tagMap := make(map[string]string, len(tags))
 	for _, tagStr := range tags {
@@ -75,7 +76,11 @@ func ParseAWSTags(tags []string) (map[string]string, error) {
 		if len(parts) != 2 {
 			return nil, fmt.Errorf("invalid tag specification: %q (expecting \"key=value\")", tagStr)
 		}
-		tagMap[parts[0]] = parts[1]
+		key := parts[0]
+		if _, exists := tagMap[key]; exists {
+			return nil, fmt.Errorf("duplicate tag key: %q", key)
+		}
+		tagMap[key] = parts[1]
 	}
 	return tagMap, nil
 }

--- a/cmd/util/client.go
+++ b/cmd/util/client.go
@@ -84,3 +84,15 @@ func ParseAWSTags(tags []string) (map[string]string, error) {
 	}
 	return tagMap, nil
 }
+
+// AddUniqueTag appends a tag to the slice only if a tag with the same key doesn't already exist.
+// The tag should be in "key=value" format.
+func AddUniqueTag(tags []string, newTag string) []string {
+	key := strings.SplitN(newTag, "=", 2)[0]
+	for _, tag := range tags {
+		if strings.HasPrefix(tag, key+"=") {
+			return tags
+		}
+	}
+	return append(tags, newTag)
+}

--- a/cmd/util/client_test.go
+++ b/cmd/util/client_test.go
@@ -87,3 +87,60 @@ func containsHelper(s, substr string) bool {
 	}
 	return false
 }
+
+func TestAddUniqueTag(t *testing.T) {
+	tests := []struct {
+		name     string
+		tags     []string
+		newTag   string
+		expected []string
+	}{
+		{
+			name:     "When adding to empty slice, it should append the tag",
+			tags:     []string{},
+			newTag:   "key=value",
+			expected: []string{"key=value"},
+		},
+		{
+			name:     "When adding unique tag, it should append the tag",
+			tags:     []string{"existing=value"},
+			newTag:   "new=value",
+			expected: []string{"existing=value", "new=value"},
+		},
+		{
+			name:     "When tag key already exists, it should not add duplicate",
+			tags:     []string{"key=value1"},
+			newTag:   "key=value2",
+			expected: []string{"key=value1"},
+		},
+		{
+			name:     "When multiple tags exist, it should check all keys",
+			tags:     []string{"first=1", "second=2", "third=3"},
+			newTag:   "second=new",
+			expected: []string{"first=1", "second=2", "third=3"},
+		},
+		{
+			name:     "When tag value contains equals sign, it should still match by key",
+			tags:     []string{"config=a=b"},
+			newTag:   "config=c=d",
+			expected: []string{"config=a=b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := AddUniqueTag(tt.tags, tt.newTag)
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("expected %d tags, got %d", len(tt.expected), len(result))
+				return
+			}
+
+			for i, expected := range tt.expected {
+				if result[i] != expected {
+					t.Errorf("at index %d: expected %q, got %q", i, expected, result[i])
+				}
+			}
+		})
+	}
+}

--- a/cmd/util/client_test.go
+++ b/cmd/util/client_test.go
@@ -1,0 +1,89 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestParseAWSTags(t *testing.T) {
+	tests := []struct {
+		name        string
+		tags        []string
+		expected    map[string]string
+		expectError bool
+		errorSubstr string
+	}{
+		{
+			name:     "When valid unique tags are provided, it should parse successfully",
+			tags:     []string{"env=production", "team=platform"},
+			expected: map[string]string{"env": "production", "team": "platform"},
+		},
+		{
+			name:     "When empty slice is provided, it should return empty map",
+			tags:     []string{},
+			expected: map[string]string{},
+		},
+		{
+			name:     "When tag value contains equals sign, it should preserve the value",
+			tags:     []string{"config=key=value"},
+			expected: map[string]string{"config": "key=value"},
+		},
+		{
+			name:        "When duplicate tag keys are provided, it should return error",
+			tags:        []string{"env=production", "env=staging"},
+			expectError: true,
+			errorSubstr: "duplicate tag key",
+		},
+		{
+			name:        "When malformed tag is provided, it should return error",
+			tags:        []string{"invalid-tag"},
+			expectError: true,
+			errorSubstr: "invalid tag specification",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParseAWSTags(tt.tags)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.errorSubstr)
+					return
+				}
+				if tt.errorSubstr != "" && !contains(err.Error(), tt.errorSubstr) {
+					t.Errorf("expected error containing %q, got %q", tt.errorSubstr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("expected %d tags, got %d", len(tt.expected), len(result))
+				return
+			}
+
+			for k, v := range tt.expected {
+				if result[k] != v {
+					t.Errorf("expected tag %q=%q, got %q=%q", k, v, k, result[k])
+				}
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -1688,6 +1688,81 @@ func TestOnCreateAPIUX(t *testing.T) {
 					},
 				},
 			},
+			{
+				name: "when AWS HostedCluster resource tags have duplicate keys, it should fail",
+				file: "hostedcluster-base.yaml",
+				validations: []struct {
+					name                   string
+					mutateInput            func(*hyperv1.HostedCluster)
+					expectedErrorSubstring string
+				}{
+					{
+						name: "when duplicate tag keys are provided, it should reject with appropriate error",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.Platform = hyperv1.PlatformSpec{
+								Type: hyperv1.AWSPlatform,
+								AWS: &hyperv1.AWSPlatformSpec{
+									Region: "us-east-1",
+									CloudProviderConfig: &hyperv1.AWSCloudProviderConfig{
+										VPC: "vpc-12345",
+										Subnet: &hyperv1.AWSResourceReference{
+											ID: ptr.To("subnet-12345"),
+										},
+										Zone: "us-east-1a",
+									},
+									RolesRef: hyperv1.AWSRolesRef{
+										IngressARN:              "arn:aws:iam::123456789012:role/ingress",
+										ImageRegistryARN:        "arn:aws:iam::123456789012:role/registry",
+										StorageARN:              "arn:aws:iam::123456789012:role/storage",
+										NetworkARN:              "arn:aws:iam::123456789012:role/network",
+										KubeCloudControllerARN:  "arn:aws:iam::123456789012:role/cloud-controller",
+										NodePoolManagementARN:   "arn:aws:iam::123456789012:role/nodepool",
+										ControlPlaneOperatorARN: "arn:aws:iam::123456789012:role/cpo",
+									},
+									ResourceTags: []hyperv1.AWSResourceTag{
+										{Key: "environment", Value: "production"},
+										{Key: "environment", Value: "staging"},
+									},
+								},
+							}
+						},
+						expectedErrorSubstring: "Duplicate value",
+					},
+					{
+						name: "when valid unique tags are provided, it should succeed",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.Platform = hyperv1.PlatformSpec{
+								Type: hyperv1.AWSPlatform,
+								AWS: &hyperv1.AWSPlatformSpec{
+									Region: "us-east-1",
+									CloudProviderConfig: &hyperv1.AWSCloudProviderConfig{
+										VPC: "vpc-12345",
+										Subnet: &hyperv1.AWSResourceReference{
+											ID: ptr.To("subnet-12345"),
+										},
+										Zone: "us-east-1a",
+									},
+									RolesRef: hyperv1.AWSRolesRef{
+										IngressARN:              "arn:aws:iam::123456789012:role/ingress",
+										ImageRegistryARN:        "arn:aws:iam::123456789012:role/registry",
+										StorageARN:              "arn:aws:iam::123456789012:role/storage",
+										NetworkARN:              "arn:aws:iam::123456789012:role/network",
+										KubeCloudControllerARN:  "arn:aws:iam::123456789012:role/cloud-controller",
+										NodePoolManagementARN:   "arn:aws:iam::123456789012:role/nodepool",
+										ControlPlaneOperatorARN: "arn:aws:iam::123456789012:role/cpo",
+									},
+									ResourceTags: []hyperv1.AWSResourceTag{
+										{Key: "environment", Value: "production"},
+										{Key: "team", Value: "platform"},
+										{Key: "cost-center", Value: "engineering"},
+									},
+								},
+							}
+						},
+						expectedErrorSubstring: "",
+					},
+				},
+			},
 		}
 
 		for _, tc := range testCases {
@@ -2448,6 +2523,51 @@ func TestOnCreateAPIUX(t *testing.T) {
 						mutateInput: func(np *hyperv1.NodePool) {
 							np.Spec.AutoScaling = nil
 							np.Spec.Replicas = ptr.To[int32](1)
+						},
+						expectedErrorSubstring: "",
+					},
+				},
+			},
+			{
+				name: "when AWS resource tags have duplicate keys, it should fail",
+				file: "nodepool-base.yaml",
+				validations: []struct {
+					name                   string
+					mutateInput            func(*hyperv1.NodePool)
+					expectedErrorSubstring string
+				}{
+					{
+						name: "when duplicate tag keys are provided, it should reject with appropriate error",
+						mutateInput: func(np *hyperv1.NodePool) {
+							np.Spec.Platform.Type = hyperv1.AWSPlatform
+							np.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{
+								InstanceType: "m5.large",
+								Subnet: hyperv1.AWSResourceReference{
+									ID: ptr.To("subnet-12345"),
+								},
+								ResourceTags: []hyperv1.AWSResourceTag{
+									{Key: "environment", Value: "production"},
+									{Key: "environment", Value: "staging"},
+								},
+							}
+						},
+						expectedErrorSubstring: "Duplicate value",
+					},
+					{
+						name: "when valid unique tags are provided, it should succeed",
+						mutateInput: func(np *hyperv1.NodePool) {
+							np.Spec.Platform.Type = hyperv1.AWSPlatform
+							np.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{
+								InstanceType: "m5.large",
+								Subnet: hyperv1.AWSResourceReference{
+									ID: ptr.To("subnet-12345"),
+								},
+								ResourceTags: []hyperv1.AWSResourceTag{
+									{Key: "environment", Value: "production"},
+									{Key: "team", Value: "platform"},
+									{Key: "cost-center", Value: "engineering"},
+								},
+							}
 						},
 						expectedErrorSubstring: "",
 					},

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/aws.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/aws.go
@@ -61,6 +61,8 @@ type AWSNodePoolPlatform struct {
 	// for the user.
 	//
 	// +kubebuilder:validation:MaxItems=25
+	// +listType=map
+	// +listMapKey=key
 	// +optional
 	ResourceTags []AWSResourceTag `json:"resourceTags,omitempty"`
 
@@ -314,6 +316,8 @@ type AWSPlatformSpec struct {
 	// These take precedence over tags defined out of band (i.e., tags added manually or by other tools outside of HyperShift) in AWS in case of conflicts.
 	//
 	// +kubebuilder:validation:MaxItems=25
+	// +listType=map
+	// +listMapKey=key
 	// +optional
 	ResourceTags []AWSResourceTag `json:"resourceTags,omitempty"`
 


### PR DESCRIPTION
## What this PR does / why we need it:

Prevents duplicate AWS resource tag keys in HostedCluster and NodePool resources. Previously, users could specify the same tag key multiple times without receiving an error, leading to undefined behavior.

## Which issue(s) this PR fixes:

Fixes OCPBUGS-34078

## How the fix works:

**Three levels of validation:**

1. **CRD Schema Validation** (`api/hypershift/v1beta1/aws.go`): Uses `+listType=map` with `+listMapKey=key` on both:
   - `HostedCluster.Spec.Platform.AWS.ResourceTags`
   - `NodePool.Spec.Platform.AWS.ResourceTags`

   This ensures users receive clear "Duplicate value" errors when applying YAML with duplicate tag keys.

2. **CLI Validation** (`cmd/util/client.go`): The `ParseAWSTags` function now returns an error when duplicate keys are detected: `duplicate tag key: "foo"`

3. **Idempotent Tag Addition** (`cmd/util/client.go`): Added `AddUniqueTag()` helper to safely add tags without creating duplicates. This fixes e2e test failures where `Complete()` was called multiple times on the same options object.

## Testing:

- Unit tests added for `ParseAWSTags` duplicate key detection
- Unit tests added for `AddUniqueTag` helper function
- E2E tests added for both HostedCluster and NodePool validation

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.