### PR TITLE
OCPBUGS-34027: Fix cleanup of orphaned OIDC resources in guest cluster

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -2571,7 +2571,7 @@ func TestCleanupOrphanedOIDCResources(t *testing.T) {
 			for _, name := range test.expectDeletedConfigMaps {
 				cm := &corev1.ConfigMap{}
 				err := hcClient.Get(ctx, client.ObjectKey{Name: name, Namespace: ConfigNamespace}, cm)
-				g.Expect(errors.IsNotFound(err)).To(BeTrue(), "ConfigMap %s should have been deleted", name)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "ConfigMap %s should have been deleted", name)
 			}
 
 			// Verify remaining ConfigMaps
@@ -2585,7 +2585,7 @@ func TestCleanupOrphanedOIDCResources(t *testing.T) {
 			for _, name := range test.expectDeletedSecrets {
 				secret := &corev1.Secret{}
 				err := hcClient.Get(ctx, client.ObjectKey{Name: name, Namespace: ConfigNamespace}, secret)
-				g.Expect(errors.IsNotFound(err)).To(BeTrue(), "Secret %s should have been deleted", name)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "Secret %s should have been deleted", name)
 			}
 
 			// Verify remaining Secrets
@@ -2729,12 +2729,12 @@ func TestCleanupOrphanedOIDCResourcesWithAuthenticationStatus(t *testing.T) {
 				for _, name := range test.expectRemainingConfigMaps {
 					cm := &corev1.ConfigMap{}
 					err := hcClient.Get(ctx, client.ObjectKey{Name: name, Namespace: ConfigNamespace}, cm)
-					g.Expect(errors.IsNotFound(err)).To(BeTrue(), "ConfigMap %s should have been deleted", name)
+					g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "ConfigMap %s should have been deleted", name)
 				}
 				for _, name := range test.expectRemainingSecrets {
 					secret := &corev1.Secret{}
 					err := hcClient.Get(ctx, client.ObjectKey{Name: name, Namespace: ConfigNamespace}, secret)
-					g.Expect(errors.IsNotFound(err)).To(BeTrue(), "Secret %s should have been deleted", name)
+					g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "Secret %s should have been deleted", name)
 				}
 			} else {
 				// Resources should still exist

--- a/support/globalconfig/authentication.go
+++ b/support/globalconfig/authentication.go
@@ -19,6 +19,11 @@ func AuthenticationConfiguration() *configv1.Authentication {
 func ReconcileAuthenticationConfiguration(authentication *configv1.Authentication, config *hyperv1.ClusterConfiguration, issuerURL string) error {
 	if config != nil && config.Authentication != nil {
 		authentication.Spec = *config.Authentication
+	} else {
+		// When configuration or authentication is removed, explicitly clear the spec
+		// to ensure the Authentication resource is reset to default state.
+		// Only preserve the ServiceAccountIssuer which is set below.
+		authentication.Spec = configv1.AuthenticationSpec{}
 	}
 	authentication.Spec.ServiceAccountIssuer = issuerURL
 	return nil

--- a/support/globalconfig/authentication.go
+++ b/support/globalconfig/authentication.go
@@ -20,10 +20,12 @@ func ReconcileAuthenticationConfiguration(authentication *configv1.Authenticatio
 	if config != nil && config.Authentication != nil {
 		authentication.Spec = *config.Authentication
 	} else {
-		// When configuration or authentication is removed, explicitly clear the spec
-		// to ensure the Authentication resource is reset to default state.
-		// Only preserve the ServiceAccountIssuer which is set below.
-		authentication.Spec = configv1.AuthenticationSpec{}
+		// When configuration or authentication is removed, explicitly reset the spec
+		// to default state (IntegratedOAuth). This ensures the authentication-operator
+		// properly clears OIDC configuration and falls back to OAuth.
+		authentication.Spec = configv1.AuthenticationSpec{
+			Type: configv1.AuthenticationTypeIntegratedOAuth,
+		}
 	}
 	authentication.Spec.ServiceAccountIssuer = issuerURL
 	return nil

--- a/support/globalconfig/authentication_test.go
+++ b/support/globalconfig/authentication_test.go
@@ -1,0 +1,107 @@
+package globalconfig
+
+import (
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReconcileAuthenticationConfiguration(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		existingAuth          *configv1.Authentication
+		config                *hyperv1.ClusterConfiguration
+		issuerURL             string
+		expectedType          configv1.AuthenticationType
+		expectedOIDCProviders int
+		expectedServiceIssuer string
+	}{
+		{
+			name:                  "When OIDC config is removed, it should explicitly set IntegratedOAuth type (not empty string)",
+			existingAuth:          AuthenticationConfiguration(),
+			config:                nil,
+			issuerURL:             "https://test-issuer.com",
+			expectedType:          configv1.AuthenticationTypeIntegratedOAuth,
+			expectedOIDCProviders: 0,
+			expectedServiceIssuer: "https://test-issuer.com",
+		},
+		{
+			name: "When transitioning from OIDC to no OIDC, Type must be explicitly IntegratedOAuth",
+			existingAuth: &configv1.Authentication{
+				Spec: configv1.AuthenticationSpec{
+					Type: configv1.AuthenticationTypeOIDC,
+					OIDCProviders: []configv1.OIDCProvider{
+						{Name: "old-provider"},
+					},
+				},
+			},
+			config:                nil,
+			issuerURL:             "https://test-issuer.com",
+			expectedType:          configv1.AuthenticationTypeIntegratedOAuth,
+			expectedOIDCProviders: 0,
+			expectedServiceIssuer: "https://test-issuer.com",
+		},
+		{
+			name:         "When OIDC config is provided, it should use the provided spec",
+			existingAuth: AuthenticationConfiguration(),
+			config: &hyperv1.ClusterConfiguration{
+				Authentication: &configv1.AuthenticationSpec{
+					Type: configv1.AuthenticationTypeOIDC,
+					OIDCProviders: []configv1.OIDCProvider{
+						{
+							Name: "test-provider",
+							Issuer: configv1.TokenIssuer{
+								URL: "https://oidc-provider.com",
+							},
+						},
+					},
+				},
+			},
+			issuerURL:             "https://test-issuer.com",
+			expectedType:          configv1.AuthenticationTypeOIDC,
+			expectedOIDCProviders: 1,
+			expectedServiceIssuer: "https://test-issuer.com",
+		},
+		{
+			name:         "When config exists but Authentication is nil, it should set IntegratedOAuth",
+			existingAuth: AuthenticationConfiguration(),
+			config: &hyperv1.ClusterConfiguration{
+				Authentication: nil,
+			},
+			issuerURL:             "https://test-issuer.com",
+			expectedType:          configv1.AuthenticationTypeIntegratedOAuth,
+			expectedOIDCProviders: 0,
+			expectedServiceIssuer: "https://test-issuer.com",
+		},
+		{
+			name:         "ServiceAccountIssuer should be preserved when switching to IntegratedOAuth",
+			existingAuth: AuthenticationConfiguration(),
+			config:       nil,
+			issuerURL:    "https://different-issuer.com",
+			expectedType: configv1.AuthenticationTypeIntegratedOAuth,
+			// The key fix: Type should NOT be empty string, it should be IntegratedOAuth
+			expectedOIDCProviders: 0,
+			expectedServiceIssuer: "https://different-issuer.com",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ReconcileAuthenticationConfiguration(tc.existingAuth, tc.config, tc.issuerURL)
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedType, tc.existingAuth.Spec.Type,
+				"Authentication Type should be set correctly (not empty string)")
+			require.NotEmpty(t, tc.existingAuth.Spec.Type,
+				"Type field must not be empty - authentication-operator needs explicit type")
+			require.Equal(t, tc.expectedServiceIssuer, tc.existingAuth.Spec.ServiceAccountIssuer,
+				"ServiceAccountIssuer should always be set")
+			require.Len(t, tc.existingAuth.Spec.OIDCProviders, tc.expectedOIDCProviders,
+				"OIDCProviders count should match expected")
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it:

This PR fixes an issue where ConfigMaps and Secrets created for external authentication (OIDC providers) in the guest cluster's `openshift-config` namespace were not being deleted when the OIDC configuration was removed from the HostedControlPlane spec.

**UPDATE after testing:** The initial implementation caused a race condition where resources were deleted before the guest cluster's Authentication status was updated, causing components to report errors. This has been fixed with an additional safety check.

The fix:
1. Tracks expected ConfigMaps and Secrets based on current HCP configuration
2. Adds managed labels to OIDC resources for identification
3. **Waits for Authentication status to clear before deleting resources** (prevents race condition)
4. Deletes orphaned resources when safe to do so

Cleanup handles these scenarios:
- Complete removal of OIDC provider configuration
- Removal of CA certificate reference from the provider
- Removal of individual OIDCClients from a provider

## Which issue(s) this PR fixes:

Fixes OCPBUGS-34027

## Special notes for your reviewer:

### Race Condition Fix (Critical)

The initial implementation deleted resources immediately when OIDC config was removed, but the Authentication operator hadn't finished updating the guest cluster's Authentication status yet. This caused:
- Console/CLI components still expecting OIDC resources
- Errors: `secret 'authid-console-openshift-console' not found`
- Errors: `configmap 'keycloak-oidc-ca' not found`

**Solution:** Added safety check that prevents deletion until `Authentication.status.oidcClients` is empty. Resources are cleaned up on the next reconciliation loop after the Authentication operator finishes processing the change.

### Other Considerations

1. **Backwards Compatibility**: Resources created before this change won't have the managed label but can still be cleaned up
2. **ARO HCP Day-2 Secrets**: Secrets with `hypershift.openshift.io/hosted-cluster-sourced: "true"` are preserved
3. **Test Coverage**: Comprehensive unit tests covering all scenarios including the race condition

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. (No docs needed - internal implementation detail)
- [x] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve OCPBUGS-34027 origin`