### PR TITLE
GCP-120: feat(cli): add support for GCP cluster creation and destruction

### DIFF
--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openshift/hypershift/cmd/cluster/aws"
 	"github.com/openshift/hypershift/cmd/cluster/azure"
 	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/cmd/cluster/gcp"
 	"github.com/openshift/hypershift/cmd/cluster/kubevirt"
 	"github.com/openshift/hypershift/cmd/cluster/none"
 	"github.com/openshift/hypershift/cmd/cluster/openstack"
@@ -36,6 +37,7 @@ func NewCreateCommands() *cobra.Command {
 	cmd.AddCommand(azure.NewCreateCommand(opts))
 	cmd.AddCommand(powervs.NewCreateCommand(opts))
 	cmd.AddCommand(openstack.NewCreateCommand(opts))
+	cmd.AddCommand(gcp.NewCreateCommand(opts))
 
 	return cmd
 }
@@ -70,6 +72,7 @@ func NewDestroyCommands() *cobra.Command {
 	cmd.AddCommand(azure.NewDestroyCommand(opts))
 	cmd.AddCommand(powervs.NewDestroyCommand(opts))
 	cmd.AddCommand(openstack.NewDestroyCommand(opts))
+	cmd.AddCommand(gcp.NewDestroyCommand(opts))
 
 	return cmd
 }

--- a/cmd/cluster/gcp/create.go
+++ b/cmd/cluster/gcp/create.go
@@ -1,0 +1,140 @@
+package gcp
+
+import (
+	"context"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/cmd/util"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var _ core.Platform = (*CreateOptions)(nil)
+
+const (
+	flagProject = "project"
+	flagRegion  = "region"
+)
+
+// RawCreateOptions contains the raw command-line options for creating a GCP cluster
+type RawCreateOptions struct {
+	// Project is the GCP project ID where the HostedCluster will be created
+	Project string
+
+	// Region is the GCP region where the HostedCluster will be created
+	Region string
+}
+
+// BindOptions binds the GCP-specific flags to the provided flag set
+func BindOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
+	flags.StringVar(&opts.Project, flagProject, opts.Project, "GCP project ID where the HostedCluster will be created")
+	flags.StringVar(&opts.Region, flagRegion, opts.Region, "GCP region where the HostedCluster will be created")
+}
+
+// ValidatedCreateOptions represents validated options for creating a GCP cluster
+type ValidatedCreateOptions struct {
+	// Embed a private pointer that cannot be instantiated outside of this package.
+	*validatedCreateOptions
+}
+
+// validatedCreateOptions is a private wrapper that enforces a call of Validate() before Complete() can be invoked.
+type validatedCreateOptions struct {
+	*RawCreateOptions
+}
+
+// Validate validates the GCP create cluster command options
+func (o *RawCreateOptions) Validate(_ context.Context, _ *core.CreateOptions) (core.PlatformCompleter, error) {
+
+	if err := util.ValidateRequiredOption(flagProject, o.Project); err != nil {
+		return nil, err
+	}
+	if err := util.ValidateRequiredOption(flagRegion, o.Region); err != nil {
+		return nil, err
+	}
+	return &ValidatedCreateOptions{
+		validatedCreateOptions: &validatedCreateOptions{
+			RawCreateOptions: o,
+		},
+	}, nil
+}
+
+// completedCreateOptions is a private wrapper that enforces a call of Complete() before cluster creation can be invoked.
+type completedCreateOptions struct {
+	*ValidatedCreateOptions
+}
+
+// CreateOptions represents the completed and validated options for creating a GCP cluster
+type CreateOptions struct {
+	// Embed a private pointer that cannot be instantiated outside of this package.
+	*completedCreateOptions
+}
+
+// Complete completes the GCP create cluster command options
+func (o *ValidatedCreateOptions) Complete(ctx context.Context, opts *core.CreateOptions) (core.Platform, error) {
+	return &CreateOptions{
+		completedCreateOptions: &completedCreateOptions{
+			ValidatedCreateOptions: o,
+		},
+	}, nil
+}
+
+// DefaultOptions returns default options for GCP cluster creation
+func DefaultOptions() *RawCreateOptions {
+	return &RawCreateOptions{}
+}
+
+// NewCreateCommand creates a new cobra command for creating GCP clusters
+func NewCreateCommand(opts *core.RawCreateOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "gcp",
+		Short:        "Creates basic functional HostedCluster resources on GCP",
+		SilenceUsage: true,
+	}
+
+	gcpOpts := DefaultOptions()
+	BindOptions(gcpOpts, cmd.Flags())
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		if opts.Timeout > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
+			defer cancel()
+		}
+
+		if err := core.CreateCluster(ctx, opts, gcpOpts); err != nil {
+			opts.Log.Error(err, "Failed to create cluster")
+			return err
+		}
+		return nil
+	}
+
+	return cmd
+}
+
+// ApplyPlatformSpecifics applies GCP-specific configurations to the HostedCluster
+func (o *CreateOptions) ApplyPlatformSpecifics(hostedCluster *hyperv1.HostedCluster) error {
+	hostedCluster.Spec.Platform.Type = hyperv1.GCPPlatform
+	hostedCluster.Spec.Platform.GCP = &hyperv1.GCPPlatformSpec{
+		Project: o.Project,
+		Region:  o.Region,
+	}
+	// TODO: support for external DNS will be added later after details are defined
+	hostedCluster.Spec.Services = core.GetIngressServicePublishingStrategyMapping(hostedCluster.Spec.Networking.NetworkType, false)
+	return nil
+}
+
+// GenerateNodePools generates the NodePool resources for GCP
+func (o *CreateOptions) GenerateNodePools(constructor core.DefaultNodePoolConstructor) []*hyperv1.NodePool {
+	nodePool := constructor(hyperv1.GCPPlatform, "")
+	return []*hyperv1.NodePool{nodePool}
+}
+
+// GenerateResources generates additional resources for GCP
+func (o *CreateOptions) GenerateResources() ([]client.Object, error) {
+	return nil, nil
+}

--- a/cmd/cluster/gcp/create_test.go
+++ b/cmd/cluster/gcp/create_test.go
@@ -1,0 +1,145 @@
+package gcp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/support/certs"
+	"github.com/openshift/hypershift/support/testutil"
+	"github.com/openshift/hypershift/test/integration/framework"
+
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/spf13/pflag"
+)
+
+func TestCreateOptionsApplyPlatformSpecifics(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	opts := &CreateOptions{
+		completedCreateOptions: &completedCreateOptions{
+			ValidatedCreateOptions: &ValidatedCreateOptions{
+				validatedCreateOptions: &validatedCreateOptions{
+					RawCreateOptions: &RawCreateOptions{
+						Project: "test-project-123",
+						Region:  "us-central1",
+					},
+				},
+			},
+		},
+	}
+
+	hostedCluster := &hyperv1.HostedCluster{}
+
+	err := opts.ApplyPlatformSpecifics(hostedCluster)
+	g.Expect(err).To(BeNil())
+	g.Expect(hostedCluster.Spec.Platform.Type).To(Equal(hyperv1.GCPPlatform))
+	g.Expect(hostedCluster.Spec.Platform.GCP).ToNot(BeNil())
+	g.Expect(hostedCluster.Spec.Platform.GCP.Project).To(Equal("test-project-123"))
+	g.Expect(hostedCluster.Spec.Platform.GCP.Region).To(Equal("us-central1"))
+}
+
+func TestValidateGCPOptions(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	tests := map[string]struct {
+		project      string
+		region       string
+		expectErr    bool
+		expectSubstr string
+	}{
+		"missing project": {
+			project:      "",
+			region:       "us-central1",
+			expectErr:    true,
+			expectSubstr: "required flag(s) \"project\" not set",
+		},
+		"missing region": {
+			project:      "test-project-123",
+			region:       "",
+			expectErr:    true,
+			expectSubstr: "required flag(s) \"region\" not set",
+		},
+		"both provided": {
+			project:   "test-project-123",
+			region:    "us-central1",
+			expectErr: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			raw := &RawCreateOptions{Project: tc.project, Region: tc.region}
+			_, err := raw.Validate(context.Background(), &core.CreateOptions{})
+			if tc.expectErr {
+				g.Expect(err).To(HaveOccurred())
+				if tc.expectSubstr != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tc.expectSubstr))
+				}
+			} else {
+				g.Expect(err).To(BeNil())
+			}
+		})
+	}
+}
+
+func TestCreateCluster(t *testing.T) {
+	utilrand.Seed(1234567890)
+	certs.UnsafeSeed(1234567890)
+	ctx := framework.InterruptableContext(t.Context())
+	tempDir := t.TempDir()
+	t.Setenv("FAKE_CLIENT", "true")
+
+	pullSecretFile := filepath.Join(tempDir, "pull-secret.json")
+	if err := os.WriteFile(pullSecretFile, []byte(`fake`), 0600); err != nil {
+		t.Fatalf("failed to write pullSecret: %v", err)
+	}
+
+	for _, testCase := range []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "minimal flags necessary to render",
+			args: []string{
+				"--project=test-project-123",
+				"--region=us-central1",
+				"--node-pool-replicas=-1",
+				"--name=example",
+				"--pull-secret=" + pullSecretFile,
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			flags := pflag.NewFlagSet(testCase.name, pflag.ContinueOnError)
+			coreOpts := core.DefaultOptions()
+			core.BindDeveloperOptions(coreOpts, flags)
+			gcpOpts := DefaultOptions()
+			BindOptions(gcpOpts, flags)
+			if err := flags.Parse(testCase.args); err != nil {
+				t.Fatalf("failed to parse flags: %v", err)
+			}
+
+			tempDir := t.TempDir()
+			manifestsFile := filepath.Join(tempDir, "manifests.yaml")
+			coreOpts.Render = true
+			coreOpts.RenderInto = manifestsFile
+
+			if err := core.CreateCluster(ctx, coreOpts, gcpOpts); err != nil {
+				t.Fatalf("failed to create cluster: %v", err)
+			}
+
+			manifests, err := os.ReadFile(manifestsFile)
+			if err != nil {
+				t.Fatalf("failed to read manifests file: %v", err)
+			}
+			testutil.CompareWithFixture(t, manifests)
+		})
+	}
+}

--- a/cmd/cluster/gcp/destroy.go
+++ b/cmd/cluster/gcp/destroy.go
@@ -1,0 +1,47 @@
+package gcp
+
+import (
+	"context"
+
+	"github.com/openshift/hypershift/cmd/cluster/core"
+	"github.com/openshift/hypershift/cmd/log"
+
+	"github.com/spf13/cobra"
+)
+
+// NewDestroyCommand creates a new cobra command for destroying GCP clusters
+func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "gcp",
+		Short:        "Destroys a GCP HostedCluster",
+		SilenceUsage: true,
+	}
+
+	logger := log.Log
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := DestroyCluster(cmd.Context(), opts); err != nil {
+			logger.Error(err, "Failed to destroy cluster")
+			return err
+		}
+		return nil
+	}
+
+	return cmd
+}
+
+// DestroyCluster destroys a GCP HostedCluster and its associated infrastructure
+func DestroyCluster(ctx context.Context, destroyOptions *core.DestroyOptions) error {
+	hostedCluster, err := core.GetCluster(ctx, destroyOptions)
+	if err != nil {
+		return err
+	}
+	if hostedCluster != nil && hostedCluster.Spec.Platform.GCP != nil {
+		destroyOptions.InfraID = hostedCluster.Spec.InfraID
+		// Set GCP-specific options from the HostedCluster if available
+		// Currently, there are no GCP-specific destroy options, but this is where they would be set
+	}
+
+	// For now, GCP cluster destruction only removes the HostedCluster resource
+	// Additional GCP infrastructure cleanup logic can be added here in the future
+	return core.DestroyCluster(ctx, hostedCluster, destroyOptions, nil)
+}

--- a/cmd/cluster/gcp/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/gcp/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: clusters
+spec: {}
+status: {}
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  creationTimestamp: null
+  name: example
+  namespace: clusters
+spec:
+  autoscaling: {}
+  capabilities: {}
+  configuration: {}
+  controllerAvailabilityPolicy: SingleReplica
+  dns:
+    baseDomain: ""
+  etcd:
+    managed:
+      storage:
+        persistentVolume:
+          size: 8Gi
+        type: PersistentVolume
+    managementType: Managed
+  fips: false
+  infraID: example-sffhb
+  networking:
+    clusterNetwork:
+    - cidr: 10.132.0.0/14
+    networkType: OVNKubernetes
+    serviceNetwork:
+    - cidr: 172.31.0.0/16
+  olmCatalogPlacement: management
+  platform:
+    gcp:
+      project: test-project-123
+      region: us-central1
+    type: GCP
+  pullSecret:
+    name: example-pull-secret
+  release:
+    image: ""
+  secretEncryption:
+    aescbc:
+      activeKey:
+        name: example-etcd-encryption-key
+    type: aescbc
+  services:
+  - service: APIServer
+    servicePublishingStrategy:
+      type: LoadBalancer
+  - service: Ignition
+    servicePublishingStrategy:
+      type: Route
+  - service: Konnectivity
+    servicePublishingStrategy:
+      type: Route
+  - service: OAuthServer
+    servicePublishingStrategy:
+      type: Route
+  sshKey: {}
+status:
+  controlPlaneEndpoint:
+    host: ""
+    port: 0
+---


### PR DESCRIPTION

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

  Adds basic GCP platform support to the hypershift CLI, enabling creation and
  destruction of HostedClusters on GCP. This implementation provides the
  foundational CLI interface and integrates with the existing cluster command
  structure.

  Changes:
  - Add cmd/cluster/gcp/ package with create and destroy commands
  - Integrate GCP commands into main cluster command structure
  - Support for required GCP project and region parameters
  - Basic HostedCluster configuration for GCP platform type
  - Test coverage for GCP cluster creation command


## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Ref: https://issues.redhat.com/browse/GCP-120

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.