### PR TITLE
OCPBUGS-64576:fix(dump): Fix dump command failure when EC2NodeClass resource is not registered

### DIFF
--- a/support/api/scheme.go
+++ b/support/api/scheme.go
@@ -28,6 +28,9 @@ import (
 	securityv1 "github.com/openshift/api/security/v1"
 	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1beta1"
 
+	awskarpenterapis "github.com/aws/karpenter-provider-aws/pkg/apis"
+	awskarpenterv1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+
 	batchv1 "k8s.io/api/batch/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -154,6 +157,14 @@ func init() {
 			&karpenterv1.NodePool{},
 			&karpenterv1.NodePoolList{},
 		)
+
+		awsKarpenterGroupVersion := schema.GroupVersion{Group: awskarpenterapis.Group, Version: "v1"}
+		metav1.AddToGroupVersion(scheme, awsKarpenterGroupVersion)
+		scheme.AddKnownTypes(awsKarpenterGroupVersion,
+			&awskarpenterv1.EC2NodeClass{},
+			&awskarpenterv1.EC2NodeClassList{},
+		)
+
 		_ = hyperkarpenterv1.AddToScheme(scheme)
 	}
 }


### PR DESCRIPTION
## What this PR does / why we need it:
Fix `hypershift dump` failure in the prow CI jobs by adding `EC2NodeClass` into the schema

## Which issue(s) this PR fixes:
OCPBUGS-64576 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.