### PR TITLE
OCPBUGS-64596: fix(tooling): Hypershift deployment tool erroneosly skip sectors

### DIFF
--- a/hack/tools/deployment/deployment-update.go
+++ b/hack/tools/deployment/deployment-update.go
@@ -63,11 +63,7 @@ var (
 			"osd-fleet-manager-production-me-central-1",
 			"osd-fleet-manager-production-ap-southeast-5",
 		},
-		// These envs belongs to Fedramp and HCM are not managing the upgrades
-		// xref: https://redhat-internal.slack.com/archives/C081W589GRG/p1750926263072849?thread_ts=1750681329.961589&cid=C081W589GRG
 		"no-update": {
-			"osd-fleet-manager-production-ca-west-1",
-			"osd-fleet-manager-production-il-central-1",
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Salvatore Dario Minonne <sminonne@redhat.com>

update-deployment tool is erroneously skipping sectors.

Fixes OCPUBUGS-64596

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.