### PR TITLE
CNTRLPLANE-1778: [hotfix-ocpbugs-63639] chore(ci): build cpo hotfix image for arm64

### DIFF
--- a/.tekton/control-plane-operator-4-17-push.yaml
+++ b/.tekton/control-plane-operator-4-17-push.yaml
@@ -31,6 +31,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: /Containerfile.control-plane
   - name: hermetic


### PR DESCRIPTION
## What this PR does / why we need it:

Build CPO hotfix image for arm64 to the 4.17-based CPO-hotfix pipeline.

Related-to: OCPBUGS-63639

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.