### PR TITLE
 CNTRLPLANE-1778: [hotfix-ocpbugs-63638] chore(ci): build cpo hotfix image for arm64 

### DIFF
--- a/.tekton/hypershift-cpo-hotfix-ocpbugs-63638-push.yaml
+++ b/.tekton/hypershift-cpo-hotfix-ocpbugs-63638-push.yaml
@@ -27,6 +27,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: Containerfile.control-plane
   - name: path-context


### PR DESCRIPTION
## What this PR does / why we need it:

Build CPO hotfix image for arm64 to the 4.18-based CPO-hotfix pipeline.

Related-to: OCPBUGS-63638

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.