### PR TITLE
CNTRLPLANE-1778: [hotfix-ocpbugs-63639] fix(ci): fix the correct cpo hotfix image pipeline

### DIFF
--- a/.tekton/control-plane-operator-4-17-push.yaml
+++ b/.tekton/control-plane-operator-4-17-push.yaml
@@ -31,7 +31,6 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
   - name: dockerfile
     value: /Containerfile.control-plane
   - name: hermetic

--- a/.tekton/hypershift-cpo-hotfix-ocpbugs-63639-push.yaml
+++ b/.tekton/hypershift-cpo-hotfix-ocpbugs-63639-push.yaml
@@ -27,6 +27,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: Containerfile.control-plane
   - name: path-context


### PR DESCRIPTION
## What this PR does / why we need it:

#7153 added the arm64 to the wrong pipeline file. 

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
This is part of the fix for OCPBUGS-63639


## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.