### PR TITLE
OCPBUGS-63698:  fix(azure): remove CSI secret ownership from hypershift-operator

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
@@ -288,6 +288,7 @@ func (a Azure) ReconcileCredentials(ctx context.Context, c client.Client, create
 		workloadIdentities := hcluster.Spec.Platform.Azure.AzureAuthenticationConfig.WorkloadIdentities
 
 		// Define credential configurations for the utility function
+		// NOTE: CSI driver credentials (disk/file) are managed by control-plane-operator, not here
 		credentialConfigs := []azureutil.AzureCredentialConfig{
 			// Ingress Operator credentials (only if capability enabled)
 			{
@@ -304,22 +305,6 @@ func (a Azure) ReconcileCredentials(ctx context.Context, c client.Client, create
 				ClientID:          string(workloadIdentities.ImageRegistry.ClientID),
 				CapabilityChecker: capabilities.IsImageRegistryCapabilityEnabled,
 				ErrorContext:      "image registry credentials",
-			},
-			// Azure Disk CSI credentials
-			{
-				Name:              "disk-csi",
-				ManifestFunc:      func() *corev1.Secret { return manifests.AzureDiskCSICredentials(controlPlaneNamespace) },
-				ClientID:          string(workloadIdentities.Disk.ClientID),
-				CapabilityChecker: nil, // Always enabled
-				ErrorContext:      "disk CSI credentials",
-			},
-			// Azure File CSI credentials
-			{
-				Name:              "file-csi",
-				ManifestFunc:      func() *corev1.Secret { return manifests.AzureFileCSICredentials(controlPlaneNamespace) },
-				ClientID:          string(workloadIdentities.File.ClientID),
-				CapabilityChecker: nil, // Always enabled
-				ErrorContext:      "file CSI credentials",
 			},
 		}
 


### PR DESCRIPTION
## Summary
This PR enables Azure Disk and File CSI drivers to work correctly on self-managed Azure HyperShift clusters by fixing the credential secret ownership and ensuring proper authentication configuration.

## Changes

### 1. Move CSI Secret Ownership to control-plane-operator
- Removed disk-csi and file-csi credential management from hypershift-operator's ReconcileCredentials function
- Control-plane-operator now has full ownership of CSI driver secrets (azure-disk-csi-config, azure-file-csi-config)
- Fixes ownership conflict where hypershift-operator was replacing the entire secret.Data map, wiping out the cloud.conf field

### 2. Authentication Flow
The proper authentication flow for self-managed Azure is:
- HyperShift → **control-plane-operator** → CSI driver
- control-plane-operator creates secrets with proper cloud.conf JSON configuration
- cloud.conf includes: `useFederatedWorkloadIdentityExtension: true`, `aadClientId`, `aadFederatedTokenFile`
- Token-minter sidecar (injected by csi-operator) creates the token file
- Azure SDK uses federated workload identity to authenticate

## Related PRs
- **csi-operator**: https://github.com/openshift/csi-operator/pull/461 (adds WithTokenMinter deployment hook)
- **cluster-storage-operator**: https://github.com/openshift/cluster-storage-operator/pull/643 (passes HYPERSHIFT_IMAGE env var for self-managed Azure)

## Testing
- [ ] Verify CSI driver pods start successfully on self-managed Azure clusters
- [ ] Verify azure-disk-csi-config and azure-file-csi-config secrets contain cloud.conf key
- [ ] Verify PVC creation and mounting works correctly
- [ ] Verify ARO HCP clusters still work (they use different auth mechanism)

Fixes: OCPBUGS-63698

Signed-off-by: Bryan Cox <brcox@redhat.com>