### PR TITLE
CNTRLPLANE-1850: test(e2e): add N-3 and N-4 release image flags

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -71,6 +71,8 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&globalOpts.ConfigurableClusterOptions.SSHKeyFile, "e2e.ssh-key-file", "", "Path to a ssh public key")
 	flag.StringVar(&globalOpts.N1MinorReleaseImage, "e2e.n1-minor-release-image", "", "The n-1 minor OCP release image relative to the latest")
 	flag.StringVar(&globalOpts.N2MinorReleaseImage, "e2e.n2-minor-release-image", "", "The n-2 minor OCP release image relative to the latest")
+	flag.StringVar(&globalOpts.N3MinorReleaseImage, "e2e.n3-minor-release-image", "", "The n-3 minor OCP release image relative to the latest")
+	flag.StringVar(&globalOpts.N4MinorReleaseImage, "e2e.n4-minor-release-image", "", "The n-4 minor OCP release image relative to the latest")
 	flag.StringVar(&globalOpts.PlatformRaw, "e2e.platform", string(hyperv1.AWSPlatform), "The platform to use for the tests")
 	flag.Var(&globalOpts.ConfigurableClusterOptions.Annotations, "e2e.annotations", "Annotations to apply to the HostedCluster (key=value). Can be specified multiple times")
 	flag.Var(&globalOpts.ConfigurableClusterOptions.ClusterCIDR, "e2e.cluster-cidr", "The CIDR of the cluster network. Can be specified multiple times.")

--- a/test/e2e/util/options.go
+++ b/test/e2e/util/options.go
@@ -40,6 +40,8 @@ const (
 type Options struct {
 	LatestReleaseImage   string
 	PreviousReleaseImage string
+	N4MinorReleaseImage  string
+	N3MinorReleaseImage  string
 	N2MinorReleaseImage  string
 	N1MinorReleaseImage  string
 	IsRunningInCI        bool


### PR DESCRIPTION
## What this PR does / why we need it:
Add e2e.n3-minor-release-image and e2e.n4-minor-release-image flags to support extended version testing scenarios.

## Which issue(s) this PR fixes:
[CNTRLPLANE-1850](https://issues.redhat.com//browse/CNTRLPLANE-1850)

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.