### PR TITLE
NO-JIRA: docs(azure): add self-managed Azure setup without external DNS

### DIFF
--- a/docs/content/how-to/azure/self-managed-azure-index.md
+++ b/docs/content/how-to/azure/self-managed-azure-index.md
@@ -25,6 +25,24 @@ Unlike managed Azure HyperShift deployments, self-managed Azure:
 - Uses an OpenShift cluster as the management platform instead of AKS
 - Requires you to provision and manage the lifecycle of the management cluster
 
+## DNS Management Options
+
+Self-managed Azure HyperShift supports two DNS management approaches, and both are documented in the same guides:
+
+| Aspect | With External DNS | Without External DNS |
+|--------|------------------|---------------------|
+| **Best For** | Production, multi-cluster | Development, testing |
+| **API Server DNS** | Custom (e.g., `api-cluster.example.com`) | Azure LoadBalancer (e.g., `abc123.region.cloudapp.azure.com`) |
+| **Setup Complexity** | Higher (requires DNS zones, service principal) | Lower (minimal configuration) |
+| **Management** | Fully automatic | Manual or Azure-provided |
+
+!!! tip "Both Approaches in One Guide"
+
+    Our setup guides include instructions for both approaches. Simply follow the sections that match your choice:
+
+    - **With External DNS**: Follow all sections including DNS Zone Configuration and External DNS Service Principal Setup
+    - **Without External DNS**: Skip DNS sections and use the simplified operator installation command
+
 ## Deployment Workflow
 
 Setting up self-managed Azure HyperShift is a three-phase process that must be completed in order:
@@ -49,17 +67,17 @@ This phase creates the foundational security infrastructure required for your ho
 
 **Purpose**: Prepare your Azure OpenShift management cluster to host and manage HyperShift control planes.
 
-This phase configures the management cluster infrastructure:
+This phase installs the HyperShift operator with optional External DNS configuration:
 
-- **DNS Zone Configuration**: Creates Azure DNS zones and delegates DNS records for hosted cluster API endpoints and application routes
-- **External DNS**: Sets up a service principal and deploys ExternalDNS to automatically manage DNS records for hosted clusters
-- **HyperShift Operator**: Installs the HyperShift operator that will create and manage hosted control planes
+- **DNS Zone Configuration** (Optional): Creates Azure DNS zones for automatic DNS record management
+- **External DNS** (Optional): Sets up a service principal and deploys ExternalDNS operator
+- **HyperShift Operator**: Installs the HyperShift operator
 
-**Why This Matters**: The management cluster needs to automatically provision DNS records for each hosted cluster's API server and ingress endpoints. ExternalDNS watches for HostedCluster resources and creates the appropriate DNS records in Azure DNS. The HyperShift operator orchestrates the entire lifecycle of hosted control planes, from creation to upgrades to deletion.
+**Why This Matters**: The HyperShift operator orchestrates the entire lifecycle of hosted control planes. If you choose External DNS, it automatically provisions DNS records for each hosted cluster's endpoints.
 
 **When to Complete**: After Phase 1 is complete, but before creating any hosted clusters.
 
-👉 **Guide**: [Setup Azure Management Cluster for HyperShift](setup-management-cluster.md)
+👉 **Guide**: [Setup Azure Management Cluster for HyperShift](setup-management-cluster.md) - Includes both DNS approaches
 
 ### Phase 3: Create Hosted Clusters
 
@@ -75,7 +93,7 @@ This phase creates your actual hosted OpenShift clusters:
 
 **When to Complete**: After Phases 1 and 2 are fully configured and verified.
 
-👉 **Guide**: [Create a Self-Managed Azure HostedCluster](create-self-managed-azure-cluster.md)
+👉 **Guide**: [Create a Self-Managed Azure HostedCluster](create-self-managed-azure-cluster.md) - Includes both DNS approaches
 
 ## Prerequisites Summary
 
@@ -85,7 +103,7 @@ Before beginning the deployment process, ensure you have:
 
     - An existing Azure OpenShift management cluster
     - Azure subscription with appropriate permissions (Contributor + User Access Administrator)
-    - A parent DNS zone in Azure DNS for delegating cluster DNS records
+    - (Optional) A parent DNS zone in Azure DNS for delegating cluster DNS records (required only if using External DNS)
 
 - **Tools and Access**:
 
@@ -109,8 +127,8 @@ Self-managed Azure deployments use multiple resource groups with different lifec
 
     - Workload identities (managed identities)
     - OIDC issuer storage account
-    - Azure DNS zones
-    - External DNS service principal
+    - Azure DNS zones (if using External DNS)
+    - External DNS service principal (if using External DNS)
 
 - **Cluster-Specific Resource Groups**: Created and destroyed with each hosted cluster
 
@@ -140,9 +158,11 @@ Self-managed Azure HyperShift implements several security best practices:
 
 Begin your self-managed Azure HyperShift deployment by following the guides in order:
 
-1. [Azure Workload Identity Setup](azure-workload-identity-setup.md) - Set up managed identities and OIDC federation
-2. [Setup Azure Management Cluster for HyperShift](setup-management-cluster.md) - Configure DNS and install HyperShift operator
-3. [Create a Self-Managed Azure HostedCluster](create-self-managed-azure-cluster.md) - Deploy your first hosted cluster
+1. **[Azure Workload Identity Setup](azure-workload-identity-setup.md)** - Set up managed identities and OIDC federation
+2. **[Setup Azure Management Cluster for HyperShift](setup-management-cluster.md)** - Install HyperShift operator (with or without External DNS)
+3. **[Create a Self-Managed Azure HostedCluster](create-self-managed-azure-cluster.md)** - Deploy your first hosted cluster
+
+Each guide includes sections for both DNS approaches - simply follow the sections that match your choice.
 
 ## Additional Resources
 

--- a/docs/content/how-to/azure/setup-management-cluster.md
+++ b/docs/content/how-to/azure/setup-management-cluster.md
@@ -1,21 +1,45 @@
 # Setup Azure Management Cluster for HyperShift
 
 !!! note "Developer Preview in OCP 4.21"
-    
+
     Self-managed Azure HostedClusters are available as a Developer Preview feature in OpenShift Container Platform 4.21.
 
-This document describes how to set up DNS and install the HyperShift operator on your Azure management cluster.
+This document describes how to install the HyperShift operator on your Azure management cluster with optional External DNS configuration.
+
+## DNS Management Options
+
+You can set up your management cluster with or without External DNS:
+
+!!! tip "Choose Your Approach"
+
+    **With External DNS (Recommended for Production)**
+
+    - Automatic DNS record management
+    - Custom domain names (e.g., `api-cluster.example.com`)
+    - Requires: DNS zones, service principal, External DNS operator
+    - **Follow sections**: DNS Zone Configuration → External DNS Service Principal Setup → HyperShift Operator Installation (With External DNS)
+
+    **Without External DNS (Simpler for Dev/Test)**
+
+    - Manual or Azure-provided DNS
+    - API server uses Azure LoadBalancer DNS (e.g., `abc123.region.cloudapp.azure.com`)
+    - No DNS zones or service principals needed
+    - **Skip to**: HyperShift Operator Installation (Without External DNS)
 
 ## Prerequisites
 
 - Azure CLI (`az`) installed and configured
 - OpenShift CLI (`oc`) or Kubernetes CLI (`kubectl`)
-- `jq` command-line JSON processor
 - An Azure OpenShift management cluster
+- **For External DNS only**: `jq` command-line JSON processor
 
-## DNS Zone Configuration
+## DNS Zone Configuration (External DNS Only)
 
-Before creating HostedClusters, you need to set up DNS zones and delegate DNS records for your clusters.
+!!! warning "External DNS Only"
+
+    This section is only required if you want automatic DNS management with External DNS. If you prefer a simpler setup, skip to [HyperShift Operator Installation (Without External DNS)](#hypershift-operator-installation-without-external-dns).
+
+Before creating HostedClusters with External DNS, you need to set up DNS zones and delegate DNS records for your clusters.
 
 !!! note "About PERSISTENT_RG_NAME"
     In Red Hat environments, a periodic Azure resource "reaper" deletes resources that are not properly tagged or not located in an approved resource group. We frequently use the `os4-common` resource group for shared, long-lived assets (for example, public DNS zones) to avoid accidental cleanup. If you are not in Red Hat infrastructure, set `PERSISTENT_RG_NAME` to any long-lived resource group in your subscription that will not be automatically reaped, or ensure your organization’s required tags/policies are applied. The name does not have to be `os4-common`—use whatever persistent resource group fits your environment.
@@ -65,7 +89,11 @@ for ns in "${ns_array[@]}"; do
 done
 ```
 
-## External DNS Service Principal Setup
+## External DNS Service Principal Setup (External DNS Only)
+
+!!! warning "External DNS Only"
+
+    This section is only required if you're using External DNS. Skip to [HyperShift Operator Installation (Without External DNS)](#hypershift-operator-installation-without-external-dns) if not.
 
 Create a dedicated service principal for External DNS:
 
@@ -118,39 +146,96 @@ kubectl create secret generic azure-config-file \
 
 ## HyperShift Operator Installation
 
-Install the HyperShift operator with External DNS configuration on your Azure management cluster:
+Choose the installation method that matches your DNS approach:
+
+### With External DNS
+
+Install the HyperShift operator with External DNS configuration:
 
 ```bash
 # Set installation variables
-TAG="self-managed-2025-09-04-1"  # Use appropriate tag
 PULL_SECRET="/path/to/pull-secret.json"
 HYPERSHIFT_BINARY_PATH="/path/to/hypershift/bin"
 
-# Install HyperShift operator
+# Install HyperShift operator with External DNS
 ${HYPERSHIFT_BINARY_PATH}/hypershift install \
     --external-dns-provider=azure \
     --external-dns-credentials ${SERVICE_PRINCIPAL_FILEPATH} \
     --pull-secret ${PULL_SECRET} \
     --external-dns-domain-filter ${DNS_ZONE_NAME} \
-    --limit-crd-install Azure \
-    --hypershift-image quay.io/hypershift/hypershift:${TAG}
+    --limit-crd-install Azure
 ```
 
-!!! important "HyperShift Image"
-    
-    Replace the `--hypershift-image` value with the appropriate image for your environment. Or remove this flag completely if not using a custom HyperShift Operator image.
+!!! tip "Custom HyperShift Image"
 
-## Verification
+    Add `--hypershift-image quay.io/hypershift/hypershift:TAG` if using a custom operator image.
 
-After installation, verify that the HyperShift operator and External DNS are running:
+After installation, verify both the HyperShift operator and External DNS are running:
 
 ```bash
 # Check HyperShift operator and ExternalDNS pods
 oc get pods -n hypershift
 ```
 
+You should see both `operator-*` and `external-dns-*` pods running.
+
+### Without External DNS
+
+Install the HyperShift operator without External DNS:
+
+```bash
+# Set installation variables
+PULL_SECRET="/path/to/pull-secret.json"
+HYPERSHIFT_BINARY_PATH="/path/to/hypershift/bin"
+
+# Install HyperShift operator (no External DNS)
+${HYPERSHIFT_BINARY_PATH}/hypershift install \
+    --pull-secret ${PULL_SECRET} \
+    --limit-crd-install Azure
+```
+
+!!! tip "Custom HyperShift Image"
+
+    Add `--hypershift-image quay.io/hypershift/hypershift:TAG` if using a custom operator image.
+
+After installation, verify the HyperShift operator is running:
+
+```bash
+# Check HyperShift operator pods
+oc get pods -n hypershift
+```
+
+You should see the `operator-*` pod running (no `external-dns` pod).
+
+## Verification
+
+Verify your installation:
+
+=== "With External DNS"
+
+    ```bash
+    # Check for both operator and external-dns
+    oc get pods -n hypershift
+
+    # Expected output:
+    # NAME                           READY   STATUS    RESTARTS   AGE
+    # external-dns-xxxxx-xxxxx       1/1     Running   0          1m
+    # operator-xxxxx-xxxxx           1/1     Running   0          1m
+    ```
+
+=== "Without External DNS"
+
+    ```bash
+    # Check for operator only
+    oc get pods -n hypershift
+
+    # Expected output:
+    # NAME                     READY   STATUS    RESTARTS   AGE
+    # operator-xxxxx-xxxxx     1/1     Running   0          1m
+    ```
+
 ## Next Steps
 
-Once the management cluster is set up, you can proceed to:
+Once the management cluster is set up, create hosted clusters:
 
-- [Create a Self-Managed Azure HostedCluster](create-self-managed-azure-cluster.md)
+- [Create a Self-Managed Azure HostedCluster](create-self-managed-azure-cluster.md) - Includes guidance for both DNS approaches


### PR DESCRIPTION
## Description

This PR updates the existing self-managed Azure HyperShift documentation to include both "with External DNS" and "without External DNS" approaches in the same guides, eliminating duplication.

## What Changed

Instead of creating separate documentation files, the existing guides now include sections for both DNS approaches:

### Updated Files

1. **`setup-management-cluster.md`**
   - Added "DNS Management Options" section explaining both approaches
   - Shows both operator installation commands (with/without external-dns flags)
   - Uses tabs/sections to separate the two approaches
   - Marked DNS Zone and Service Principal sections as "External DNS Only"

2. **`create-self-managed-azure-cluster.md`**
   - Updated prerequisites to note External DNS is optional
   - Shows both cluster creation commands (with/without --external-dns-domain flag)
   - Uses tabs to separate the two approaches
   - Explains DNS behavior for each approach

3. **`self-managed-azure-index.md`**
   - Added DNS Management Options comparison table
   - Simplified Phase descriptions to avoid duplication
   - Single path through the guides with clear section markers

4. **`mkdocs.yml`**
   - Updated navigation (no duplicate pages)

## Key Benefits

- **No Duplication**: Both approaches in one place
- **Easier Maintenance**: Single source of truth
- **Clear Choices**: Users see both options and can choose
- **Less Complexity**: 4 files updated vs. creating 2 new duplicate files

## How DNS Options Work

### With External DNS
- Add flags: `--external-dns-provider=azure`, `--external-dns-credentials`, `--external-dns-domain-filter` 
- Add flag to cluster creation: `--external-dns-domain`
- Result: Custom DNS names like `api-cluster.example.com`

### Without External DNS
- Omit external-dns flags from operator installation
- Omit `--external-dns-domain` from cluster creation
- Result: Azure LoadBalancer DNS like `abc123.eastus.cloudapp.azure.com`

The difference is literally just a few command-line flags - no need for entirely separate guides.

## Testing

- [x] Documentation builds without errors
- [x] All links work correctly  
- [x] Both approaches clearly documented
- [x] Manual review of rendered docs

## Related Issues

Addresses the need for simpler self-managed Azure setup documentation without requiring External DNS configuration, while avoiding documentation duplication.