### PR TITLE
Add ARM64 build platform to control-plane-operator Tekton pipeline

### DIFF
--- a/.tekton/control-plane-operator-4-19-push.yaml
+++ b/.tekton/control-plane-operator-4-19-push.yaml
@@ -27,6 +27,7 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: Containerfile.control-plane
   - name: path-context


### PR DESCRIPTION
## Summary
- Add ARM64 (linux/arm64) build platform to the control-plane-operator Tekton pipeline for release-4.19

## Test plan
- [ ] Verify Tekton pipeline runs successfully with ARM64 builds
- [ ] Confirm both x86_64 and ARM64 binaries are produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)