### PR TITLE
fix(skills): update link Code Review Comments

### DIFF
--- a/.claude/skills/effective-go/SKILL.md
+++ b/.claude/skills/effective-go/SKILL.md
@@ -28,5 +28,5 @@ Follow the conventions and patterns documented at https://go.dev/doc/effective_g
 ## References
 
 - Official Guide: https://go.dev/doc/effective_go
-- Code Review Comments: https://github.com/golang/go/wiki/CodeReviewComments
+- Code Review Comments: https://go.dev/wiki/CodeReviewComments
 - Standard Library: Use as reference for idiomatic patterns


### PR DESCRIPTION
This pull request makes a minor update to the references in the `.claude/skills/effective-go/SKILL.md` documentation. The change updates the link for "Code Review Comments" to use the official Go website instead of the old GitHub wiki.


## What this PR does / why we need it:

Broken link.

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.