### PR TITLE
CNTRLPLANE-1617: add event-ttl to hypershift

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -355,6 +355,10 @@ const (
 	// KubeAPIServerGoAwayChance allows the --goaway-chance parameter of the kube-apiserver to be overridden from its default of 0
 	KubeAPIServerGoAwayChance = "hypershift.openshift.io/kube-apiserver-goaway-chance"
 
+	// KubeAPIServerEventTTLMinutes allows the --event-ttl parameter of the kube-apiserver to be overridden from its default of 3h (180 minutes)
+	// The value should be specified in minutes (e.g., "60", "180"). Valid range is 5-180 minutes.
+	KubeAPIServerEventTTLMinutes = "hypershift.openshift.io/event-ttl-minutes"
+
 	// AWSMachinePublicIPs, if set to "true", results in an AWS machine template that creates machines with public IPs
 	// WARNING: This option is for development and testing purposes only
 	AWSMachinePublicIPs = "hypershift.openshift.io/aws-machine-public-ips"

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/config.go
@@ -211,7 +211,7 @@ func generateConfig(p KubeAPIServerConfigParams) (*kcpv1.KubeAPIServerConfig, er
 	args.Set("etcd-keyfile", cpath(etcdClientCertVolumeName, pki.EtcdClientKeyKey))
 	args.Set("etcd-prefix", "kubernetes.io")
 	args.Set("etcd-servers", p.EtcdURL)
-	args.Set("event-ttl", "3h")
+	args.Set("event-ttl", p.EventTTL)
 	// TODO remove in 4.16 once we're able to have different featuregates for hypershift
 	featureGates := append([]string{}, p.FeatureGates...)
 	featureGates = enforceFeatureGates(featureGates, "ValidatingAdmissionPolicy=true", "StructuredAuthenticationConfiguration=true")

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/params.go
@@ -22,6 +22,7 @@ const (
 	defaultMaxRequestsInflight         = 3000
 	defaultMaxMutatingRequestsInflight = 1000
 	defaultGoAwayChance                = 0.001
+	defaultEventTTL                   = "3h"
 )
 
 type KubeAPIServerConfigParams struct {
@@ -50,6 +51,7 @@ type KubeAPIServerConfigParams struct {
 	MaxRequestsInflight          string
 	MaxMutatingRequestsInflight  string
 	GoAwayChance                 string
+	EventTTL                     string
 }
 
 func NewConfigParams(hcp *hyperv1.HostedControlPlane, featureGates []string) KubeAPIServerConfigParams {
@@ -120,6 +122,12 @@ func NewConfigParams(hcp *hyperv1.HostedControlPlane, featureGates []string) Kub
 	}
 	if goAwayChance := hcp.Annotations[hyperv1.KubeAPIServerGoAwayChance]; goAwayChance != "" {
 		kasConfig.GoAwayChance = hcp.Annotations[hyperv1.KubeAPIServerGoAwayChance]
+	}
+
+	kasConfig.EventTTL = defaultEventTTL
+	if eventTTLMinutes := hcp.Annotations[hyperv1.KubeAPIServerEventTTLMinutes]; eventTTLMinutes != "" {
+		// Convert minutes to duration format (e.g., "180" -> "180m", "60" -> "60m")
+		kasConfig.EventTTL = fmt.Sprintf("%sm", eventTTLMinutes)
 	}
 
 	if capabilities.IsImageRegistryCapabilityEnabled(hcp.Spec.Capabilities) {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/params_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/params_test.go
@@ -129,6 +129,7 @@ func defaultKubeAPIServerConfigParams() KubeAPIServerConfigParams {
 		MaxRequestsInflight:          fmt.Sprint(defaultMaxRequestsInflight),
 		MaxMutatingRequestsInflight:  fmt.Sprint(defaultMaxMutatingRequestsInflight),
 		GoAwayChance:                 fmt.Sprint(defaultGoAwayChance),
+		EventTTL:                     defaultEventTTL,
 		APIServerSTSDirectives:       "max-age=31536000,includeSubDomains,preload",
 	}
 }
@@ -271,6 +272,7 @@ func TestNewConfigParams(t *testing.T) {
 					hyperv1.KubeAPIServerMaximumRequestsInFlight:         "5000",
 					hyperv1.KubeAPIServerMaximumMutatingRequestsInFlight: "2000",
 					hyperv1.KubeAPIServerGoAwayChance:                    "0.002",
+					hyperv1.KubeAPIServerEventTTLMinutes:                 "60",
 					hyperv1.DisableProfilingAnnotation:                   manifests.KASDeployment("").Name,
 				}
 				return hcp
@@ -282,6 +284,23 @@ func TestNewConfigParams(t *testing.T) {
 				params.MaxRequestsInflight = "5000"
 				params.MaxMutatingRequestsInflight = "2000"
 				params.GoAwayChance = "0.002"
+				params.EventTTL = "60m"
+				return params
+			},
+		},
+		{
+			name: "with event-ttl annotation",
+			hcp: func() *hyperv1.HostedControlPlane {
+				hcp := createDefaultHostedControlPlane()
+				hcp.Annotations = map[string]string{
+					hyperv1.KubeAPIServerEventTTLMinutes: "180",
+				}
+				return hcp
+			}(),
+			expected: func(hcp *hyperv1.HostedControlPlane, featureGates []string) KubeAPIServerConfigParams {
+				params := defaultKubeAPIServerConfigParams()
+				params.FeatureGates = featureGates
+				params.EventTTL = "180m"
 				return params
 			},
 		},

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2229,6 +2229,7 @@ func reconcileHostedControlPlaneAnnotations(hcp *hyperv1.HostedControlPlane, hcl
 		hyperv1.AWSMachinePublicIPs,
 		hyperkarpenterv1.KarpenterProviderAWSImage,
 		hyperv1.KubeAPIServerGoAwayChance,
+		hyperv1.KubeAPIServerEventTTLMinutes,
 		hyperv1.HostedClusterRestoredFromBackupAnnotation,
 	}
 	for _, key := range mirroredAnnotations {

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -682,6 +682,7 @@ func TestReconcileHostedControlPlaneAnnotations(t *testing.T) {
 				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test1": "test1",
 				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test2": "test2",
 				hyperv1.KubeAPIServerGoAwayChance:                            "0.001",
+				hyperv1.KubeAPIServerEventTTLMinutes:                         "180",
 				"foo":                                                        "bar", // should not be copied
 			},
 			expectedAnnotations: map[string]string{
@@ -690,6 +691,7 @@ func TestReconcileHostedControlPlaneAnnotations(t *testing.T) {
 				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test1": "test1",
 				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test2": "test2",
 				hyperv1.KubeAPIServerGoAwayChance:                            "0.001",
+				hyperv1.KubeAPIServerEventTTLMinutes:                         "180",
 				hyperv1.RequestServingNodeAdditionalSelectorAnnotation:       "node-size=m5xl",
 				hyperutil.HostedClusterAnnotation:                            hcKey,
 				hyperv1.DisableClusterAutoscalerAnnotation:                   "true",

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -355,6 +355,10 @@ const (
 	// KubeAPIServerGoAwayChance allows the --goaway-chance parameter of the kube-apiserver to be overridden from its default of 0
 	KubeAPIServerGoAwayChance = "hypershift.openshift.io/kube-apiserver-goaway-chance"
 
+	// KubeAPIServerEventTTLMinutes allows the --event-ttl parameter of the kube-apiserver to be overridden from its default of 3h (180 minutes)
+	// The value should be specified in minutes (e.g., "60", "180").
+	KubeAPIServerEventTTLMinutes = "hypershift.openshift.io/event-ttl-minutes"
+
 	// AWSMachinePublicIPs, if set to "true", results in an AWS machine template that creates machines with public IPs
 	// WARNING: This option is for development and testing purposes only
 	AWSMachinePublicIPs = "hypershift.openshift.io/aws-machine-public-ips"


### PR DESCRIPTION
## What this PR does / why we need it:

This implements what was proposed in https://github.com/openshift/enhancements/pull/1857 - adding the event-ttl as a configurable value to the control plane.

This is done like #6019, as there is no KAS Operator in hypershift.

## Which issue(s) this PR fixes:

Fixes  https://issues.redhat.com/browse/CNTRLPLANE-1617

## Special notes for your reviewer:

This has been entirely coded by Cursor, given the above PR as an example input.

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.