### PR TITLE
OCPBUGS-64792: fix(api): Check imageType exists before accessing in CEL validation

### DIFF
--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -101,7 +101,7 @@ type NodePool struct {
 // +kubebuilder:validation:XValidation:rule="self.arch != 'arm64' || has(self.platform.aws) || has(self.platform.azure) || has(self.platform.agent) || self.platform.type == 'None'", message="Setting Arch to arm64 is only supported for AWS, Azure, Agent and None"
 // +kubebuilder:validation:XValidation:rule="!has(self.replicas) || !has(self.autoScaling)", message="Both replicas or autoScaling should not be set"
 // +kubebuilder:validation:XValidation:rule="self.arch != 's390x' || has(self.platform.kubevirt)", message="s390x is only supported on KubeVirt platform"
-// +kubebuilder:validation:XValidation:rule="!has(self.platform.aws) || self.platform.aws.imageType != 'Windows' || self.arch == 'amd64'", message="ImageType 'Windows' requires arch 'amd64' (AWS only)"
+// +kubebuilder:validation:XValidation:rule="(has(self.platform.aws) && has(self.platform.aws.imageType) && self.platform.aws.imageType == 'Windows') ? self.arch == 'amd64' : true", message="ImageType 'Windows' requires arch 'amd64' (AWS only)"
 type NodePoolSpec struct {
 	// clusterName is the name of the HostedCluster this NodePool belongs to.
 	// If a HostedCluster with this name doesn't exist, the controller will no-op until it exists.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
@@ -1462,8 +1462,9 @@ spec:
             - message: s390x is only supported on KubeVirt platform
               rule: self.arch != 's390x' || has(self.platform.kubevirt)
             - message: ImageType 'Windows' requires arch 'amd64' (AWS only)
-              rule: '!has(self.platform.aws) || self.platform.aws.imageType != ''Windows''
-                || self.arch == ''amd64'''
+              rule: '(has(self.platform.aws) && has(self.platform.aws.imageType) &&
+                self.platform.aws.imageType == ''Windows'') ? self.arch == ''amd64''
+                : true'
           status:
             description: status is the latest observed status of the NodePool.
             properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
@@ -1648,8 +1648,9 @@ spec:
             - message: s390x is only supported on KubeVirt platform
               rule: self.arch != 's390x' || has(self.platform.kubevirt)
             - message: ImageType 'Windows' requires arch 'amd64' (AWS only)
-              rule: '!has(self.platform.aws) || self.platform.aws.imageType != ''Windows''
-                || self.arch == ''amd64'''
+              rule: '(has(self.platform.aws) && has(self.platform.aws.imageType) &&
+                self.platform.aws.imageType == ''Windows'') ? self.arch == ''amd64''
+                : true'
           status:
             description: status is the latest observed status of the NodePool.
             properties:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -1651,8 +1651,9 @@ spec:
             - message: s390x is only supported on KubeVirt platform
               rule: self.arch != 's390x' || has(self.platform.kubevirt)
             - message: ImageType 'Windows' requires arch 'amd64' (AWS only)
-              rule: '!has(self.platform.aws) || self.platform.aws.imageType != ''Windows''
-                || self.arch == ''amd64'''
+              rule: '(has(self.platform.aws) && has(self.platform.aws.imageType) &&
+                self.platform.aws.imageType == ''Windows'') ? self.arch == ''amd64''
+                : true'
           status:
             description: status is the latest observed status of the NodePool.
             properties:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -1465,8 +1465,9 @@ spec:
             - message: s390x is only supported on KubeVirt platform
               rule: self.arch != 's390x' || has(self.platform.kubevirt)
             - message: ImageType 'Windows' requires arch 'amd64' (AWS only)
-              rule: '!has(self.platform.aws) || self.platform.aws.imageType != ''Windows''
-                || self.arch == ''amd64'''
+              rule: '(has(self.platform.aws) && has(self.platform.aws.imageType) &&
+                self.platform.aws.imageType == ''Windows'') ? self.arch == ''amd64''
+                : true'
           status:
             description: status is the latest observed status of the NodePool.
             properties:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -1651,8 +1651,9 @@ spec:
             - message: s390x is only supported on KubeVirt platform
               rule: self.arch != 's390x' || has(self.platform.kubevirt)
             - message: ImageType 'Windows' requires arch 'amd64' (AWS only)
-              rule: '!has(self.platform.aws) || self.platform.aws.imageType != ''Windows''
-                || self.arch == ''amd64'''
+              rule: '(has(self.platform.aws) && has(self.platform.aws.imageType) &&
+                self.platform.aws.imageType == ''Windows'') ? self.arch == ''amd64''
+                : true'
           status:
             description: status is the latest observed status of the NodePool.
             properties:

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -2170,6 +2170,107 @@ func TestOnCreateAPIUX(t *testing.T) {
 					},
 				},
 			},
+			{
+				name: "when AWS imageType and arch combinations are validated",
+				file: "nodepool-base.yaml",
+				validations: []struct {
+					name                   string
+					mutateInput            func(*hyperv1.NodePool)
+					expectedErrorSubstring string
+				}{
+					{
+						name: "should pass when imageType is not specified for arm64",
+						mutateInput: func(np *hyperv1.NodePool) {
+							np.Spec.Arch = hyperv1.ArchitectureARM64
+							np.Spec.Platform.Type = hyperv1.AWSPlatform
+							if np.Spec.Platform.AWS == nil {
+								np.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{}
+							}
+							np.Spec.Platform.AWS.InstanceType = "m6g.large"
+							// ImageType intentionally not set
+						},
+						expectedErrorSubstring: "",
+					},
+					{
+						name: "should pass when imageType is not specified for amd64",
+						mutateInput: func(np *hyperv1.NodePool) {
+							np.Spec.Arch = hyperv1.ArchitectureAMD64
+							np.Spec.Platform.Type = hyperv1.AWSPlatform
+							if np.Spec.Platform.AWS == nil {
+								np.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{}
+							}
+							np.Spec.Platform.AWS.InstanceType = "m6i.large"
+							// ImageType intentionally not set
+						},
+						expectedErrorSubstring: "",
+					},
+					{
+						name: "should fail when imageType is Windows with arm64 architecture",
+						mutateInput: func(np *hyperv1.NodePool) {
+							np.Spec.Arch = hyperv1.ArchitectureARM64
+							np.Spec.Platform.Type = hyperv1.AWSPlatform
+							if np.Spec.Platform.AWS == nil {
+								np.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{}
+							}
+							np.Spec.Platform.AWS.InstanceType = "m6g.large"
+							np.Spec.Platform.AWS.ImageType = hyperv1.ImageTypeWindows
+						},
+						expectedErrorSubstring: "ImageType 'Windows' requires arch 'amd64' (AWS only)",
+					},
+					{
+						name: "should pass when imageType is Windows with amd64 architecture",
+						mutateInput: func(np *hyperv1.NodePool) {
+							np.Spec.Arch = hyperv1.ArchitectureAMD64
+							np.Spec.Platform.Type = hyperv1.AWSPlatform
+							if np.Spec.Platform.AWS == nil {
+								np.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{}
+							}
+							np.Spec.Platform.AWS.InstanceType = "m6i.large"
+							np.Spec.Platform.AWS.ImageType = hyperv1.ImageTypeWindows
+						},
+						expectedErrorSubstring: "",
+					},
+					{
+						name: "should pass when imageType is Windows without arch (defaults to amd64)",
+						mutateInput: func(np *hyperv1.NodePool) {
+							// Don't set arch - it will default to amd64
+							np.Spec.Platform.Type = hyperv1.AWSPlatform
+							if np.Spec.Platform.AWS == nil {
+								np.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{}
+							}
+							np.Spec.Platform.AWS.InstanceType = "m6i.large"
+							np.Spec.Platform.AWS.ImageType = hyperv1.ImageTypeWindows
+						},
+						expectedErrorSubstring: "",
+					},
+					{
+						name: "should pass when imageType is Linux with arm64 architecture",
+						mutateInput: func(np *hyperv1.NodePool) {
+							np.Spec.Arch = hyperv1.ArchitectureARM64
+							np.Spec.Platform.Type = hyperv1.AWSPlatform
+							if np.Spec.Platform.AWS == nil {
+								np.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{}
+							}
+							np.Spec.Platform.AWS.InstanceType = "m6g.large"
+							np.Spec.Platform.AWS.ImageType = hyperv1.ImageTypeLinux
+						},
+						expectedErrorSubstring: "",
+					},
+					{
+						name: "should pass when imageType is Linux with amd64 architecture",
+						mutateInput: func(np *hyperv1.NodePool) {
+							np.Spec.Arch = hyperv1.ArchitectureAMD64
+							np.Spec.Platform.Type = hyperv1.AWSPlatform
+							if np.Spec.Platform.AWS == nil {
+								np.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{}
+							}
+							np.Spec.Platform.AWS.InstanceType = "m6i.large"
+							np.Spec.Platform.AWS.ImageType = hyperv1.ImageTypeLinux
+						},
+						expectedErrorSubstring: "",
+					},
+				},
+			},
 		}
 
 		for _, tc := range testCases {

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -101,7 +101,7 @@ type NodePool struct {
 // +kubebuilder:validation:XValidation:rule="self.arch != 'arm64' || has(self.platform.aws) || has(self.platform.azure) || has(self.platform.agent) || self.platform.type == 'None'", message="Setting Arch to arm64 is only supported for AWS, Azure, Agent and None"
 // +kubebuilder:validation:XValidation:rule="!has(self.replicas) || !has(self.autoScaling)", message="Both replicas or autoScaling should not be set"
 // +kubebuilder:validation:XValidation:rule="self.arch != 's390x' || has(self.platform.kubevirt)", message="s390x is only supported on KubeVirt platform"
-// +kubebuilder:validation:XValidation:rule="!has(self.platform.aws) || self.platform.aws.imageType != 'Windows' || self.arch == 'amd64'", message="ImageType 'Windows' requires arch 'amd64' (AWS only)"
+// +kubebuilder:validation:XValidation:rule="(has(self.platform.aws) && has(self.platform.aws.imageType) && self.platform.aws.imageType == 'Windows') ? self.arch == 'amd64' : true", message="ImageType 'Windows' requires arch 'amd64' (AWS only)"
 type NodePoolSpec struct {
 	// clusterName is the name of the HostedCluster this NodePool belongs to.
 	// If a HostedCluster with this name doesn't exist, the controller will no-op until it exists.


### PR DESCRIPTION
## What this PR does / why we need it:

The CEL validation rule for NodePool was accessing the optional imageType field without checking if it exists, causing "no such key: imageType" errors when creating AWS ARM64 clusters.

This PR adds a `!has(self.platform.aws.imageType)` check to fix the validation, allowing NodePool creation to succeed when imageType is not specified while still enforcing that Windows imageType requires amd64 architecture when the field is present.

## Which issue(s) this PR fixes:

Fixes OCPBUGS-64792

## Special notes for reviewer:

The fix is a simple addition of a `has()` check in the CEL validation expression. The validation now has three conditions that allow the validation to pass:
1. Platform is not AWS (`!has(self.platform.aws)`)
2. ImageType field is not set (`!has(self.platform.aws.imageType)`) - **NEW**
3. ImageType is not Windows OR arch is amd64 (`self.platform.aws.imageType != 'Windows' || self.arch == 'amd64'`)
API UX tests in TestOnCreateAPIUX to validate the CEL logic

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via /jira:solve OCPBUGS-64792


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates NodePool CEL to only enforce Windows→amd64 on AWS when imageType is set, regenerates CRDs, and adds e2e tests for imageType/arch combos.
> 
> - **API / Validation**:
>   - Update `NodePoolSpec` CEL rule to conditionally require `arch == 'amd64'` only when `self.platform.aws.imageType == 'Windows'` and the field exists (`has(...)`).
>   - Mirror change in vendored `nodepool_types.go` and regenerate CRDs: `api/hypershift/v1beta1/zz_generated.*` and `cmd/install/assets/...nodepools-*.crd.yaml`.
> - **Tests**:
>   - Extend `test/e2e/create_cluster_test.go` with cases validating AWS `imageType` and `arch` combinations (unspecified `imageType`, Windows/amd64 pass, Windows/arm64 fail, Linux any-arch pass).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e06cfad4ac91d9216810030b813a9172fab1836. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->