### PR TITLE
CNTRLPLANE-1893: Create an ARO HCP override test

### DIFF
--- a/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
+++ b/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
@@ -9,6 +9,14 @@ platforms:
         cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-19@sha256:88c55ea554f7e62a64e34ff8d3be45ef85ef6b80fe4e9b0240b9a1aa226f9d98
       - version: 4.19.10
         cpoImage: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-19@sha256:88c55ea554f7e62a64e34ff8d3be45ef85ef6b80fe4e9b0240b9a1aa226f9d98
+    testing:
+      # Update the image refs below to indicate which images should be used for CPO override
+      # testing. Currently, we only test one latest/previous combination. In the future, we
+      # may be able to test multiple combinations at a time. To test more than one, update
+      # the referenced images before each e2e test run.
+      latest: quay.io/openshift-release-dev/ocp-release:4.19.10-x86_64
+      previous: quay.io/openshift-release-dev/ocp-release:4.19.9-x86_64
+      runTests: true
   aws:
     overrides:
     # Beginning of OCPBUGS-48519 overrides 4.15 section
@@ -223,8 +231,9 @@ platforms:
     # End of OCPBUGS-58837 overrides
     testing:
     # Update the image refs below to indicate which images should be used for CPO override
-    # testing. Currently, we only test one latest/previous combination. In the future, we 
+    # testing. Currently, we only test one latest/previous combination. In the future, we
     # may be able to test multiple combinations at a time. To test more than one, update
     # the referenced images before each e2e test run.
       latest: quay.io/openshift-release-dev/ocp-release:4.15.53-x86_64
       previous: quay.io/openshift-release-dev/ocp-release:4.15.52-x86_64
+      runTests: false

--- a/hypershift-operator/controlplaneoperator-overrides/overrides.go
+++ b/hypershift-operator/controlplaneoperator-overrides/overrides.go
@@ -35,6 +35,7 @@ type CPOOverride struct {
 type CPOOverrideTestReleases struct {
 	Latest   string `yaml:"latest"`
 	Previous string `yaml:"previous"`
+	RunTests bool   `yaml:"runTests"`
 }
 
 //go:embed assets/overrides.yaml
@@ -73,6 +74,10 @@ func LatestOverrideTestReleases(platform string) (string, string) {
 	return overrideTestReleases(platform, overrides)
 }
 
+func ShouldRunOverrideTests(platform string) bool {
+	return shouldRunOverrideTests(platform, overrides)
+}
+
 func overrideTestReleases(platform string, o *CPOOverrides) (string, string) {
 	switch strings.ToLower(platform) {
 	case "aws":
@@ -85,6 +90,20 @@ func overrideTestReleases(platform string, o *CPOOverrides) (string, string) {
 		}
 	}
 	return "", ""
+}
+
+func shouldRunOverrideTests(platform string, o *CPOOverrides) bool {
+	switch strings.ToLower(platform) {
+	case "aws":
+		if o.Platforms.AWS != nil && o.Platforms.AWS.Testing != nil {
+			return o.Platforms.AWS.Testing.RunTests
+		}
+	case "azure":
+		if o.Platforms.Azure != nil && o.Platforms.Azure.Testing != nil {
+			return o.Platforms.Azure.Testing.RunTests
+		}
+	}
+	return false
 }
 
 func mustLoadOverrides() *CPOOverrides {

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -18,6 +18,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/api/util/ipnet"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	"github.com/openshift/hypershift/support/assets"
 	"github.com/openshift/hypershift/support/azureutil"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
@@ -2355,6 +2356,13 @@ func TestCreateCluster(t *testing.T) {
 
 		if globalOpts.Platform == hyperv1.AzurePlatform {
 			e2eutil.EnsureKubeAPIServerAllowedCIDRs(t, ctx, mgtClient, guestConfig, hostedCluster)
+		}
+		e2eutil.EnsureGlobalPullSecret(t, ctx, mgtClient, hostedCluster)
+
+		// Verify CPO override image if TEST_CPO_OVERRIDE=1 is set
+		if os.Getenv("TEST_CPO_OVERRIDE") == "1" {
+			controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
+			e2eutil.VerifyCPOOverrideImage(t, ctx, mgtClient, controlPlaneNamespace, clusterOpts.ReleaseImage, string(globalOpts.Platform))
 		}
 	}).
 		Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, "create-cluster", globalOpts.ServiceAccountSigningKey)


### PR DESCRIPTION
## Summary

Implements per-platform CPO override testing with granular control via the `runTests` field. Allows testing AWS or Azure overrides independently while skipping tests for unmodified platforms, saving CI resources.

## Changes

### Core Implementation
- **Add `runTests` field** to `overrides.yaml` for platform-specific test control
- **Implement `ShouldRunOverrideTests()`** function to check `runTests` field
- **Add TestMain early skip logic**: If `TEST_CPO_OVERRIDE=1` but `runTests: false`, skip entire test suite (complete no-op)
- **Add override image verification** to `TestCreateCluster` when `TEST_CPO_OVERRIDE=1`

### Supporting Changes
- Add Azure testing release configuration to `overrides.yaml`
- Add `VerifyCPOOverrideImage` and `ExtractVersionFromReleaseImage` utilities
- Update CPO overrides documentation with `runTests` usage

## How It Works

### Two-Layer Control System

**Layer 1: TEST_CPO_OVERRIDE environment variable**
- Not set → Regular tests with default releases, no override verification
- Set to "1" → Override tests with override releases, verification enabled

**Layer 2: runTests field in overrides.yaml**
```yaml
platforms:
  aws:
    testing:
      runTests: false  # AWS override tests disabled
  azure:
    testing:
      runTests: true   # Azure override tests enabled
```

### Complete Flow

When overrides.yaml is modified:
1. **Both CI jobs trigger**: `e2e-aws-override` and `e2e-aks-override` (both have `run_if_changed: (/overrides\.yaml$)`)
2. **Both set TEST_CPO_OVERRIDE=1**
3. **TestMain checks runTests field**:
   - If `runTests: false` → TestMain returns 0 (skips ALL tests, complete no-op)
   - If `runTests: true` → TestMain proceeds to run tests
4. **TestCreateCluster runs** (if platform has `runTests: true`):
   - Creates cluster with override test releases
   - Verifies CPO pod has expected override image

## Example Scenario

**Updating only Azure overrides:**
```yaml
platforms:
  aws:
    testing:
      runTests: false   # ← Set to false
  azure:
    overrides:
      - version: 4.19.10
        cpoImage: quay.io/...  # ← Updated Azure override
    testing:
      runTests: true    # ← Set to true
```

**Result:**
- `e2e-aws-override` triggers but TestMain skips all tests (no-op, saves CI resources)
- `e2e-aks-override` triggers and runs full test suite with Azure override verification
- Only the modified platform is tested

## Benefits

- **Per-platform override testing**: Test only the platform you modified
- **CI resource savings**: Skip tests for unmodified platforms (complete no-op)
- **Granular control**: Independent control of AWS and Azure override tests
- **Platform-agnostic**: Works for any platform with overrides
- **No impact on regular PRs**: Only applies when `TEST_CPO_OVERRIDE=1` (set by override CI jobs)

## Test Plan

- [x] Code compiles without errors
- [x] TestMain skips tests when `runTests: false`
- [x] TestMain proceeds when `runTests: true`
- [x] Verification works in TestCreateCluster
- [x] Pushed to branch
- [ ] E2E test passes in CI

## Related PRs

- **openshift/release #71204**: Adds `e2e-aks-override` CI job (companion PR)

## Related Issues

Fixes: [CNTRLPLANE-1893](https://issues.redhat.com//browse/CNTRLPLANE-1893)