### PR TITLE
feat(tekton): add 4.20 pipelines using common pipeline template

### DIFF
--- a/.tekton/control-plane-operator-4-20-pull-request.yaml
+++ b/.tekton/control-plane-operator-4-20-pull-request.yaml
@@ -1,0 +1,61 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/hypershift?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "release-4.20"
+      && ( "control-plane-operator/***".pathChanged() ||
+           "support/***".pathChanged() ||
+           ".tekton/control-plane-operator*".pathChanged() ||
+           "/Containerfile.control-plane-operator".pathChanged() )
+  creationTimestamp:
+  labels:
+    appstudio.openshift.io/application: control-plane-operator
+    appstudio.openshift.io/component: control-plane-operator-4-20
+    pipelines.appstudio.openshift.io/type: build
+  name: control-plane-operator-4-20-on-pull-request
+  namespace: crt-redhat-acm-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
+  - name: build-platforms
+    value:
+    - linux/x86_64
+  - name: dockerfile
+    value: /Containerfile.control-plane
+  - name: path-context
+    value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/openshift/hypershift.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: .tekton/pipelines/common-operator-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-control-plane-operator-4-20
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}

--- a/.tekton/control-plane-operator-4-20-push.yaml
+++ b/.tekton/control-plane-operator-4-20-push.yaml
@@ -1,0 +1,58 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/hypershift?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && target_branch == "release-4.20"
+      && ( "control-plane-operator/***".pathChanged() ||
+           "support/***".pathChanged() ||
+           ".tekton/control-plane-operator*".pathChanged() ||
+           "/Containerfile.control-plane-operator".pathChanged() )
+  creationTimestamp:
+  labels:
+    appstudio.openshift.io/application: control-plane-operator
+    appstudio.openshift.io/component: control-plane-operator-4-20
+    pipelines.appstudio.openshift.io/type: build
+  name: control-plane-operator-4-20-on-push
+  namespace: crt-redhat-acm-tenant
+spec:
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-20:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/arm64
+  - name: dockerfile
+    value: /Containerfile.control-plane
+  - name: path-context
+    value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/openshift/hypershift.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: .tekton/pipelines/common-operator-build.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-control-plane-operator-4-20
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
## Summary

Migrate control-plane-operator pipelines for release-4.20 to use the common pipeline from main branch instead of inline specifications.

This PR creates new pipeline files that reference the shared pipeline template via `pipelineRef` with git resolver, reducing maintenance overhead and ensuring consistency across releases.

## Changes

- **Add `.tekton/control-plane-operator-4-20-pull-request.yaml`**
  - Single platform (linux/x86_64) for PR builds
  - 5-day image expiration
  - Triggers on pull_request events to release-4.20

- **Add `.tekton/control-plane-operator-4-20-push.yaml`**
  - Multi-platform (linux/x86_64, linux/arm64) for release builds
  - No image expiration
  - Triggers on push events to release-4.20

Both pipelines reference the common pipeline template at:
```
https://github.com/openshift/hypershift.git
main/.tekton/pipelines/common-operator-build.yaml
```

## Benefits

1. **Reduced Maintenance**: Single common pipeline definition instead of duplicated specs
2. **Consistency**: All release branches use the same pipeline structure
3. **Automatic Updates**: Pipeline improvements on main are automatically inherited
4. **Reduced File Size**: ~60 lines vs 600+ lines per pipeline file
5. **Easier Review**: Changes to metadata and parameters are clearer without inline pipeline specs

## Test Plan

- [x] Create the pipeline files locally
- [x] Validate YAML syntax with make pre-commit (passed for YAML files)
- [ ] Push to release-4.20 branch
- [ ] Create a test PR to verify pull-request pipeline triggers correctly
- [ ] Merge test PR to verify push pipeline triggers correctly
- [ ] Validate that builds complete successfully in Konflux

## Related Issues

Resolves: [CNTRLPLANE-1905](https://issues.redhat.com//browse/CNTRLPLANE-1905)

🤖 Generated with [Claude Code](https://claude.com/claude-code)