### PR TITLE
CNTRLPLANE-1867: Update base images to UBI9-minimal 9.7-1762180032

### DIFF
--- a/Containerfile.control-plane
+++ b/Containerfile.control-plane
@@ -7,7 +7,7 @@ COPY --chown=default . .
 RUN make control-plane-operator \
   && make control-plane-pki-operator
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1760515502
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1762180032
 COPY --from=builder /hypershift/bin/control-plane-operator /usr/bin/control-plane-operator
 COPY --from=builder /hypershift/bin/control-plane-pki-operator /usr/bin/control-plane-pki-operator
 

--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -10,7 +10,7 @@ RUN make hypershift \
   && make product-cli \
   && make karpenter-operator
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1760515502
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1762180032
 COPY --from=builder /hypershift/bin/hypershift \
   /hypershift/bin/hypershift-no-cgo \
   /hypershift/bin/hcp \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN make hypershift \
   && make product-cli \
   && make karpenter-operator
 
-FROM registry.access.redhat.com/ubi9:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1762180032
 COPY --from=builder /hypershift/bin/hypershift \
                     /hypershift/bin/hcp \
                     /hypershift/bin/hypershift-operator \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,7 +8,7 @@ COPY . .
 
 RUN make build
 
-FROM registry.access.redhat.com/ubi9:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1762180032
 COPY --from=builder /hypershift/bin/hypershift \
                     /hypershift/bin/hcp \
                     /hypershift/bin/hypershift-operator \

--- a/contrib/gomaxprocs-webhook/Dockerfile
+++ b/contrib/gomaxprocs-webhook/Dockerfile
@@ -11,7 +11,7 @@ COPY . ./
 
 RUN make build
 
-FROM registry.access.redhat.com/ubi9-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1762180032
 COPY --from=builder /workspace/bin/gomaxprocs-webhook /usr/bin/gomaxprocs-webhook
 USER 1001
 


### PR DESCRIPTION
## What this PR does / why we need it:

Updates all operator and operand runtime base images from UBI9 or UBI9-minimal 9.6 to UBI9-minimal 9.7-1762180032 (released November 11, 2025).

Now that UBI9-minimal 9.7 is available, version 9.6 will no longer receive updates. This change ensures our images continue to receive security patches and bug fixes.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-1867](https://issues.redhat.com//browse/CNTRLPLANE-1867)

## Special notes for your reviewer:

This is a straightforward base image version update with no functional code changes:
- Updated 2 files from UBI9-minimal 9.6 to 9.7 (Containerfile.operator, Containerfile.control-plane)
- Converted 3 files from `ubi9:latest` or `ubi9-minimal:latest` to the pinned version `ubi9/ubi-minimal:9.7-1762180032`

All affected Dockerfiles only copy pre-built binaries - they don't use `dnf` or install additional packages, so the minimal image is appropriate.

Builder images (go-toolset) and specialized images (nginx, python) remain unchanged.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. (N/A - infrastructure only)
- [x] This change includes unit tests. (N/A - infrastructure only)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve [CNTRLPLANE-1867](https://issues.redhat.com//browse/CNTRLPLANE-1867)`