### PR TITLE
refactor(api): deprecate Calico networkType enum value

### DIFF
--- a/api/hypershift/v1beta1/hosted_controlplane.go
+++ b/api/hypershift/v1beta1/hosted_controlplane.go
@@ -40,7 +40,7 @@ type HostedControlPlane struct {
 
 // HostedControlPlaneSpec defines the desired state of HostedControlPlane
 // +kubebuilder:validation:XValidation:rule="self.platform.type == 'IBMCloud' ? size(self.services) >= 3 : size(self.services) >= 4",message="spec.services in body should have at least 4 items or 3 for IBMCloud"
-// +kubebuilder:validation:XValidation:rule="!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator) || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork) || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork || self.networking.networkType == 'Other'",message="disableMultiNetwork can only be set to true when networkType is 'Other'"
+// +kubebuilder:validation:XValidation:rule="!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator) || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork) || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType in ['OpenShiftSDN','OVNKubernetes']))",message="disableMultiNetwork can only be true when networking.networkType is neither 'OpenShiftSDN' nor 'OVNKubernetes'"
 type HostedControlPlaneSpec struct {
 	// releaseImage is the release image applied to the hosted control plane.
 	// +required

--- a/api/hypershift/v1beta1/operator.go
+++ b/api/hypershift/v1beta1/operator.go
@@ -40,8 +40,8 @@ type ClusterNetworkOperatorSpec struct {
 	// guest cluster and the multus-admission-controller in the management cluster.
 	// Default is false (Multus is enabled).
 	// This field is immutable.
-	// This field can only be set to true when NetworkType is "Other". Setting it to true
-	// with any other NetworkType will result in a validation error during cluster creation.
+	// This field can only be set to true when NetworkType is third-party. Setting it to true
+	// with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
 	//
 	// +optional
 	// +kubebuilder:default:=false

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -2750,11 +2750,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -2839,8 +2836,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -5307,12 +5304,13 @@ spec:
                 && s.servicePublishingStrategy.loadBalancer.hostname != "" && has(self.configuration)
                 && has(self.configuration.apiServer) && self.configuration.apiServer.servingCerts.namedCertificates.exists(cert,
                 cert.names.exists(n, n == s.servicePublishingStrategy.loadBalancer.hostname)))'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
             - message: ovnKubernetesConfig is forbidden when networkType is not OVNKubernetes
               rule: self.networking.networkType == 'OVNKubernetes' || !has(self.operatorConfiguration)
                 || !has(self.operatorConfiguration.clusterNetworkOperator) || !has(self.operatorConfiguration.clusterNetworkOperator.ovnKubernetesConfig)

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -2788,11 +2788,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -2877,8 +2874,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -5337,12 +5334,13 @@ spec:
                 && s.servicePublishingStrategy.loadBalancer.hostname != "" && has(self.configuration)
                 && has(self.configuration.apiServer) && self.configuration.apiServer.servingCerts.namedCertificates.exists(cert,
                 cert.names.exists(n, n == s.servicePublishingStrategy.loadBalancer.hostname)))'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
             - message: ovnKubernetesConfig is forbidden when networkType is not OVNKubernetes
               rule: self.networking.networkType == 'OVNKubernetes' || !has(self.operatorConfiguration)
                 || !has(self.operatorConfiguration.clusterNetworkOperator) || !has(self.operatorConfiguration.clusterNetworkOperator.ovnKubernetesConfig)

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -2741,11 +2741,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -2830,8 +2827,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -5310,12 +5307,13 @@ spec:
                 && s.servicePublishingStrategy.loadBalancer.hostname != "" && has(self.configuration)
                 && has(self.configuration.apiServer) && self.configuration.apiServer.servingCerts.namedCertificates.exists(cert,
                 cert.names.exists(n, n == s.servicePublishingStrategy.loadBalancer.hostname)))'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
             - message: ovnKubernetesConfig is forbidden when networkType is not OVNKubernetes
               rule: self.networking.networkType == 'OVNKubernetes' || !has(self.operatorConfiguration)
                 || !has(self.operatorConfiguration.clusterNetworkOperator) || !has(self.operatorConfiguration.clusterNetworkOperator.ovnKubernetesConfig)

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -2762,11 +2762,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -2851,8 +2848,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -5311,12 +5308,13 @@ spec:
                 && s.servicePublishingStrategy.loadBalancer.hostname != "" && has(self.configuration)
                 && has(self.configuration.apiServer) && self.configuration.apiServer.servingCerts.namedCertificates.exists(cert,
                 cert.names.exists(n, n == s.servicePublishingStrategy.loadBalancer.hostname)))'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
             - message: ovnKubernetesConfig is forbidden when networkType is not OVNKubernetes
               rule: self.networking.networkType == 'OVNKubernetes' || !has(self.operatorConfiguration)
                 || !has(self.operatorConfiguration.clusterNetworkOperator) || !has(self.operatorConfiguration.clusterNetworkOperator.ovnKubernetesConfig)

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -3077,11 +3077,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -3166,8 +3163,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -5626,12 +5623,13 @@ spec:
                 && s.servicePublishingStrategy.loadBalancer.hostname != "" && has(self.configuration)
                 && has(self.configuration.apiServer) && self.configuration.apiServer.servingCerts.namedCertificates.exists(cert,
                 cert.names.exists(n, n == s.servicePublishingStrategy.loadBalancer.hostname)))'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
             - message: ovnKubernetesConfig is forbidden when networkType is not OVNKubernetes
               rule: self.networking.networkType == 'OVNKubernetes' || !has(self.operatorConfiguration)
                 || !has(self.operatorConfiguration.clusterNetworkOperator) || !has(self.operatorConfiguration.clusterNetworkOperator.ovnKubernetesConfig)

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -3231,11 +3231,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -3320,8 +3317,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -5780,12 +5777,13 @@ spec:
                 && s.servicePublishingStrategy.loadBalancer.hostname != "" && has(self.configuration)
                 && has(self.configuration.apiServer) && self.configuration.apiServer.servingCerts.namedCertificates.exists(cert,
                 cert.names.exists(n, n == s.servicePublishingStrategy.loadBalancer.hostname)))'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
             - message: ovnKubernetesConfig is forbidden when networkType is not OVNKubernetes
               rule: self.networking.networkType == 'OVNKubernetes' || !has(self.operatorConfiguration)
                 || !has(self.operatorConfiguration.clusterNetworkOperator) || !has(self.operatorConfiguration.clusterNetworkOperator.ovnKubernetesConfig)

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
@@ -2741,11 +2741,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -2830,8 +2827,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -5383,12 +5380,13 @@ spec:
                 && s.servicePublishingStrategy.loadBalancer.hostname != "" && has(self.configuration)
                 && has(self.configuration.apiServer) && self.configuration.apiServer.servingCerts.namedCertificates.exists(cert,
                 cert.names.exists(n, n == s.servicePublishingStrategy.loadBalancer.hostname)))'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
             - message: ovnKubernetesConfig is forbidden when networkType is not OVNKubernetes
               rule: self.networking.networkType == 'OVNKubernetes' || !has(self.operatorConfiguration)
                 || !has(self.operatorConfiguration.clusterNetworkOperator) || !has(self.operatorConfiguration.clusterNetworkOperator.ovnKubernetesConfig)

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -2759,11 +2759,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -2848,8 +2845,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -5308,12 +5305,13 @@ spec:
                 && s.servicePublishingStrategy.loadBalancer.hostname != "" && has(self.configuration)
                 && has(self.configuration.apiServer) && self.configuration.apiServer.servingCerts.namedCertificates.exists(cert,
                 cert.names.exists(n, n == s.servicePublishingStrategy.loadBalancer.hostname)))'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
             - message: ovnKubernetesConfig is forbidden when networkType is not OVNKubernetes
               rule: self.networking.networkType == 'OVNKubernetes' || !has(self.operatorConfiguration)
                 || !has(self.operatorConfiguration.clusterNetworkOperator) || !has(self.operatorConfiguration.clusterNetworkOperator.ovnKubernetesConfig)

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -2817,11 +2817,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -2906,8 +2903,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -5366,12 +5363,13 @@ spec:
                 && s.servicePublishingStrategy.loadBalancer.hostname != "" && has(self.configuration)
                 && has(self.configuration.apiServer) && self.configuration.apiServer.servingCerts.namedCertificates.exists(cert,
                 cert.names.exists(n, n == s.servicePublishingStrategy.loadBalancer.hostname)))'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
             - message: ovnKubernetesConfig is forbidden when networkType is not OVNKubernetes
               rule: self.networking.networkType == 'OVNKubernetes' || !has(self.operatorConfiguration)
                 || !has(self.operatorConfiguration.clusterNetworkOperator) || !has(self.operatorConfiguration.clusterNetworkOperator.ovnKubernetesConfig)

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -2893,11 +2893,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -2982,8 +2979,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -5442,12 +5439,13 @@ spec:
                 && s.servicePublishingStrategy.loadBalancer.hostname != "" && has(self.configuration)
                 && has(self.configuration.apiServer) && self.configuration.apiServer.servingCerts.namedCertificates.exists(cert,
                 cert.names.exists(n, n == s.servicePublishingStrategy.loadBalancer.hostname)))'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
             - message: ovnKubernetesConfig is forbidden when networkType is not OVNKubernetes
               rule: self.networking.networkType == 'OVNKubernetes' || !has(self.operatorConfiguration)
                 || !has(self.operatorConfiguration.clusterNetworkOperator) || !has(self.operatorConfiguration.clusterNetworkOperator.ovnKubernetesConfig)

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -2741,11 +2741,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -2830,8 +2827,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -5841,12 +5838,13 @@ spec:
                 && s.servicePublishingStrategy.loadBalancer.hostname != "" && has(self.configuration)
                 && has(self.configuration.apiServer) && self.configuration.apiServer.servingCerts.namedCertificates.exists(cert,
                 cert.names.exists(n, n == s.servicePublishingStrategy.loadBalancer.hostname)))'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
             - message: ovnKubernetesConfig is forbidden when networkType is not OVNKubernetes
               rule: self.networking.networkType == 'OVNKubernetes' || !has(self.operatorConfiguration)
                 || !has(self.operatorConfiguration.clusterNetworkOperator) || !has(self.operatorConfiguration.clusterNetworkOperator.ovnKubernetesConfig)

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -2658,11 +2658,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -2739,8 +2736,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -5136,12 +5133,13 @@ spec:
                 IBMCloud
               rule: 'self.platform.type == ''IBMCloud'' ? size(self.services) >= 3
                 : size(self.services) >= 4'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
           status:
             description: status is the status of the HostedControlPlane.
             properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -2696,11 +2696,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -2777,8 +2774,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -5166,12 +5163,13 @@ spec:
                 IBMCloud
               rule: 'self.platform.type == ''IBMCloud'' ? size(self.services) >= 3
                 : size(self.services) >= 4'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
           status:
             description: status is the status of the HostedControlPlane.
             properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -2649,11 +2649,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -2730,8 +2727,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -5139,12 +5136,13 @@ spec:
                 IBMCloud
               rule: 'self.platform.type == ''IBMCloud'' ? size(self.services) >= 3
                 : size(self.services) >= 4'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
           status:
             description: status is the status of the HostedControlPlane.
             properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/DynamicResourceAllocation.yaml
@@ -2670,11 +2670,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -2751,8 +2748,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -5140,12 +5137,13 @@ spec:
                 IBMCloud
               rule: 'self.platform.type == ''IBMCloud'' ? size(self.services) >= 3
                 : size(self.services) >= 4'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
           status:
             description: status is the status of the HostedControlPlane.
             properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -2985,11 +2985,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -3066,8 +3063,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -5455,12 +5452,13 @@ spec:
                 IBMCloud
               rule: 'self.platform.type == ''IBMCloud'' ? size(self.services) >= 3
                 : size(self.services) >= 4'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
           status:
             description: status is the status of the HostedControlPlane.
             properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -3139,11 +3139,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -3220,8 +3217,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -5609,12 +5606,13 @@ spec:
                 IBMCloud
               rule: 'self.platform.type == ''IBMCloud'' ? size(self.services) >= 3
                 : size(self.services) >= 4'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
           status:
             description: status is the status of the HostedControlPlane.
             properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
@@ -2649,11 +2649,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -2730,8 +2727,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -5212,12 +5209,13 @@ spec:
                 IBMCloud
               rule: 'self.platform.type == ''IBMCloud'' ? size(self.services) >= 3
                 : size(self.services) >= 4'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
           status:
             description: status is the status of the HostedControlPlane.
             properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -2667,11 +2667,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -2748,8 +2745,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -5137,12 +5134,13 @@ spec:
                 IBMCloud
               rule: 'self.platform.type == ''IBMCloud'' ? size(self.services) >= 3
                 : size(self.services) >= 4'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
           status:
             description: status is the status of the HostedControlPlane.
             properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -2725,11 +2725,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -2806,8 +2803,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -5195,12 +5192,13 @@ spec:
                 IBMCloud
               rule: 'self.platform.type == ''IBMCloud'' ? size(self.services) >= 3
                 : size(self.services) >= 4'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
           status:
             description: status is the status of the HostedControlPlane.
             properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -2801,11 +2801,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -2882,8 +2879,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -5271,12 +5268,13 @@ spec:
                 IBMCloud
               rule: 'self.platform.type == ''IBMCloud'' ? size(self.services) >= 3
                 : size(self.services) >= 4'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
           status:
             description: status is the status of the HostedControlPlane.
             properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -2649,11 +2649,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -2730,8 +2727,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -5670,12 +5667,13 @@ spec:
                 IBMCloud
               rule: 'self.platform.type == ''IBMCloud'' ? size(self.services) >= 3
                 : size(self.services) >= 4'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
           status:
             description: status is the status of the HostedControlPlane.
             properties:

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -70,7 +70,7 @@ func bindCoreOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
 	flags.StringVar(&opts.BaseDomain, "base-domain", opts.BaseDomain, "The ingress base domain for the cluster")
 	flags.StringVar(&opts.BaseDomainPrefix, "base-domain-prefix", opts.BaseDomainPrefix, "The ingress base domain prefix for the cluster, defaults to cluster name. Use 'none' for an empty prefix")
 	flags.StringVar(&opts.ExternalDNSDomain, "external-dns-domain", opts.ExternalDNSDomain, "Sets hostname to opinionated values in the specified domain for services with publishing type LoadBalancer or Route.")
-	flags.StringVar(&opts.NetworkType, "network-type", opts.NetworkType, "Enum specifying the cluster SDN provider. Supports either Calico, OVNKubernetes, OpenShiftSDN or Other.")
+	flags.StringVar(&opts.NetworkType, "network-type", opts.NetworkType, "Sets the cluster SDN provider. OVNKubernetes and OpenShiftSDN have special handling; any other value (e.g., Cilium, Calico) is treated as third-party. Values are case-sensitive.")
 	flags.StringVar(&opts.ReleaseImage, "release-image", opts.ReleaseImage, "The OCP release image for the cluster")
 	flags.StringVar(&opts.PullSecretFile, "pull-secret", opts.PullSecretFile, "File path to a pull secret.")
 	flags.StringVar(&opts.ControlPlaneAvailabilityPolicy, "control-plane-availability-policy", opts.ControlPlaneAvailabilityPolicy, "Availability policy for hosted cluster components. Supported options: SingleReplica, HighlyAvailable")
@@ -768,8 +768,8 @@ func (opts *RawCreateOptions) Validate(ctx context.Context) (*ValidatedCreateOpt
 		}
 	}
 
-	if opts.DisableMultiNetwork && opts.NetworkType != "Other" {
-		return nil, fmt.Errorf("disableMultiNetwork is only allowed when networkType is 'Other' (got '%s')", opts.NetworkType)
+	if opts.DisableMultiNetwork && (opts.NetworkType == string(hyperv1.OVNKubernetes) || opts.NetworkType == string(hyperv1.OpenShiftSDN)) {
+		return nil, fmt.Errorf("disableMultiNetwork is only allowed when networkType is third-party (got '%s')", opts.NetworkType)
 	}
 
 	return &ValidatedCreateOptions{

--- a/cmd/cluster/core/create_test.go
+++ b/cmd/cluster/core/create_test.go
@@ -359,14 +359,14 @@ func TestValidate(t *testing.T) {
 			expectedErr: "ingress capability can only be disabled if Console capability is also disabled",
 		},
 		{
-			name: "passes when disable-multi-network is used with network-type=Other",
+			name: "passes when disable-multi-network is used with third-party CNI",
 			rawOpts: &RawCreateOptions{
 				Name:                "test-hc",
 				Namespace:           "test-hc",
 				PullSecretFile:      pullSecretFile,
 				Arch:                "amd64",
 				DisableMultiNetwork: true,
-				NetworkType:         "Other",
+				NetworkType:         "Cilium", //choose arbitrary value for third-party network provider
 			},
 			expectedErr: "",
 		},
@@ -378,7 +378,7 @@ func TestValidate(t *testing.T) {
 				PullSecretFile:      pullSecretFile,
 				Arch:                "amd64",
 				DisableMultiNetwork: false,
-				NetworkType:         "OVNKubernetes",
+				NetworkType:         string(hyperv1.OVNKubernetes),
 			},
 			expectedErr: "",
 		},
@@ -390,9 +390,9 @@ func TestValidate(t *testing.T) {
 				PullSecretFile:      pullSecretFile,
 				Arch:                "amd64",
 				DisableMultiNetwork: true,
-				NetworkType:         "OVNKubernetes",
+				NetworkType:         string(hyperv1.OVNKubernetes),
 			},
-			expectedErr: "disableMultiNetwork is only allowed when networkType is 'Other' (got 'OVNKubernetes')",
+			expectedErr: "disableMultiNetwork is only allowed when networkType is third-party (got 'OVNKubernetes')",
 		},
 		{
 			name: "fails when disable-multi-network is true with network-type=OpenShiftSDN",
@@ -402,21 +402,9 @@ func TestValidate(t *testing.T) {
 				PullSecretFile:      pullSecretFile,
 				Arch:                "amd64",
 				DisableMultiNetwork: true,
-				NetworkType:         "OpenShiftSDN",
+				NetworkType:         string(hyperv1.OpenShiftSDN),
 			},
-			expectedErr: "disableMultiNetwork is only allowed when networkType is 'Other' (got 'OpenShiftSDN')",
-		},
-		{
-			name: "fails when disable-multi-network is true with network-type=Calico",
-			rawOpts: &RawCreateOptions{
-				Name:                "test-hc",
-				Namespace:           "test-hc",
-				PullSecretFile:      pullSecretFile,
-				Arch:                "amd64",
-				DisableMultiNetwork: true,
-				NetworkType:         "Calico",
-			},
-			expectedErr: "disableMultiNetwork is only allowed when networkType is 'Other' (got 'Calico')",
+			expectedErr: "disableMultiNetwork is only allowed when networkType is third-party (got 'OpenShiftSDN')",
 		},
 	}
 	for _, test := range tests {

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-CustomNoUpgrade.crd.yaml
@@ -3548,11 +3548,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -3637,8 +3634,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -6751,12 +6748,13 @@ spec:
                 && s.servicePublishingStrategy.loadBalancer.hostname != "" && has(self.configuration)
                 && has(self.configuration.apiServer) && self.configuration.apiServer.servingCerts.namedCertificates.exists(cert,
                 cert.names.exists(n, n == s.servicePublishingStrategy.loadBalancer.hostname)))'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
             - message: ovnKubernetesConfig is forbidden when networkType is not OVNKubernetes
               rule: self.networking.networkType == 'OVNKubernetes' || !has(self.operatorConfiguration)
                 || !has(self.operatorConfiguration.clusterNetworkOperator) || !has(self.operatorConfiguration.clusterNetworkOperator.ovnKubernetesConfig)

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Default.crd.yaml
@@ -3412,11 +3412,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -3501,8 +3498,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -5969,12 +5966,13 @@ spec:
                 && s.servicePublishingStrategy.loadBalancer.hostname != "" && has(self.configuration)
                 && has(self.configuration.apiServer) && self.configuration.apiServer.servingCerts.namedCertificates.exists(cert,
                 cert.names.exists(n, n == s.servicePublishingStrategy.loadBalancer.hostname)))'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
             - message: ovnKubernetesConfig is forbidden when networkType is not OVNKubernetes
               rule: self.networking.networkType == 'OVNKubernetes' || !has(self.operatorConfiguration)
                 || !has(self.operatorConfiguration.clusterNetworkOperator) || !has(self.operatorConfiguration.clusterNetworkOperator.ovnKubernetesConfig)

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-TechPreviewNoUpgrade.crd.yaml
@@ -3459,11 +3459,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -3548,8 +3545,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -6662,12 +6659,13 @@ spec:
                 && s.servicePublishingStrategy.loadBalancer.hostname != "" && has(self.configuration)
                 && has(self.configuration.apiServer) && self.configuration.apiServer.servingCerts.namedCertificates.exists(cert,
                 cert.names.exists(n, n == s.servicePublishingStrategy.loadBalancer.hostname)))'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
             - message: ovnKubernetesConfig is forbidden when networkType is not OVNKubernetes
               rule: self.networking.networkType == 'OVNKubernetes' || !has(self.operatorConfiguration)
                 || !has(self.operatorConfiguration.clusterNetworkOperator) || !has(self.operatorConfiguration.clusterNetworkOperator.ovnKubernetesConfig)

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-CustomNoUpgrade.crd.yaml
@@ -3456,11 +3456,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -3537,8 +3534,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -6580,12 +6577,13 @@ spec:
                 IBMCloud
               rule: 'self.platform.type == ''IBMCloud'' ? size(self.services) >= 3
                 : size(self.services) >= 4'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
           status:
             description: status is the status of the HostedControlPlane.
             properties:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Default.crd.yaml
@@ -3320,11 +3320,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -3401,8 +3398,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -5798,12 +5795,13 @@ spec:
                 IBMCloud
               rule: 'self.platform.type == ''IBMCloud'' ? size(self.services) >= 3
                 : size(self.services) >= 4'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
           status:
             description: status is the status of the HostedControlPlane.
             properties:

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-TechPreviewNoUpgrade.crd.yaml
@@ -3367,11 +3367,8 @@ spec:
                       Defaults to OVNKubernetes.
                       This field is required and immutable.
                       kubebuilder:validation:XValidation:rule="self == oldSelf", message="networkType is immutable"
-                    enum:
-                    - OpenShiftSDN
-                    - Calico
-                    - OVNKubernetes
-                    - Other
+                    maxLength: 255
+                    minLength: 1
                     type: string
                   serviceNetwork:
                     default:
@@ -3448,8 +3445,8 @@ spec:
                           guest cluster and the multus-admission-controller in the management cluster.
                           Default is false (Multus is enabled).
                           This field is immutable.
-                          This field can only be set to true when NetworkType is "Other". Setting it to true
-                          with any other NetworkType will result in a validation error during cluster creation.
+                          This field can only be set to true when NetworkType is third-party. Setting it to true
+                          with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
                         type: boolean
                         x-kubernetes-validations:
                         - message: disableMultiNetwork is immutable
@@ -6491,12 +6488,13 @@ spec:
                 IBMCloud
               rule: 'self.platform.type == ''IBMCloud'' ? size(self.services) >= 3
                 : size(self.services) >= 4'
-            - message: disableMultiNetwork can only be set to true when networkType
-                is 'Other'
+            - message: disableMultiNetwork can only be true when networking.networkType
+                is neither 'OpenShiftSDN' nor 'OVNKubernetes'
               rule: '!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator)
                 || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork)
                 || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork
-                || self.networking.networkType == ''Other'''
+                || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType
+                in [''OpenShiftSDN'',''OVNKubernetes'']))'
           status:
             description: status is the status of the HostedControlPlane.
             properties:

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/network/reconcile_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/network/reconcile_test.go
@@ -202,7 +202,7 @@ func TestReconcileDefaultIngressController(t *testing.T) {
 		{
 			name:                "DisableMultiNetwork sets disableMultiNetwork to true",
 			inputNetwork:        NetworkOperator(),
-			inputNetworkType:    hyperv1.Other,
+			inputNetworkType:    "Other",
 			inputPlatformType:   hyperv1.AWSPlatform,
 			disableMultiNetwork: true,
 			expectedNetwork: &operatorv1.Network{
@@ -218,7 +218,7 @@ func TestReconcileDefaultIngressController(t *testing.T) {
 		{
 			name:                "DisableMultiNetwork false does not set disableMultiNetwork",
 			inputNetwork:        NetworkOperator(),
-			inputNetworkType:    hyperv1.Other,
+			inputNetworkType:    "Other",
 			inputPlatformType:   hyperv1.AWSPlatform,
 			disableMultiNetwork: false,
 			expectedNetwork: &operatorv1.Network{

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -4512,8 +4512,8 @@ in the hosted cluster. This prevents the installation of multus daemon sets in t
 guest cluster and the multus-admission-controller in the management cluster.
 Default is false (Multus is enabled).
 This field is immutable.
-This field can only be set to true when NetworkType is &ldquo;Other&rdquo;. Setting it to true
-with any other NetworkType will result in a validation error during cluster creation.</p>
+This field can only be set to true when NetworkType is third-party. Setting it to true
+with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.</p>
 </td>
 </tr>
 <tr>
@@ -9651,7 +9651,9 @@ NetworkFilter
 <a href="#hypershift.openshift.io/v1beta1.ClusterNetworking">ClusterNetworking</a>)
 </p>
 <p>
-<p>NetworkType specifies the SDN provider used for cluster networking.</p>
+<p>NetworkType specifies the SDN provider used for cluster networking.
+Any string value is accepted to support third-party network providers.
+The values OpenShiftSDN and OVNKubernetes receive special handling by HyperShift.</p>
 </p>
 <table>
 <thead>
@@ -9660,17 +9662,11 @@ NetworkFilter
 <th>Description</th>
 </tr>
 </thead>
-<tbody><tr><td><p>&#34;Calico&#34;</p></td>
-<td><p>Calico specifies Calico as the SDN provider</p>
-</td>
-</tr><tr><td><p>&#34;OVNKubernetes&#34;</p></td>
+<tbody><tr><td><p>&#34;OVNKubernetes&#34;</p></td>
 <td><p>OVNKubernetes specifies OVN as the SDN provider</p>
 </td>
 </tr><tr><td><p>&#34;OpenShiftSDN&#34;</p></td>
 <td><p>OpenShiftSDN specifies OpenShiftSDN as the SDN provider</p>
-</td>
-</tr><tr><td><p>&#34;Other&#34;</p></td>
-<td><p>Other specifies an undefined SDN provider</p>
 </td>
 </tr></tbody>
 </table>

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -576,7 +576,7 @@ func TestReconcileHostedControlPlaneConfiguration(t *testing.T) {
 					Domain: "test.domain.com",
 				},
 				Network: &configv1.NetworkSpec{
-					NetworkType: "OpenShiftSDN",
+					NetworkType: string(hyperv1.OpenShiftSDN),
 				},
 			},
 		},
@@ -1617,7 +1617,7 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 				Name: "cluster",
 			},
 			Spec: configv1.NetworkSpec{
-				NetworkType: "OVNKubernetes",
+				NetworkType: string(hyperv1.OVNKubernetes),
 			},
 		},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "agent-namespace"}},

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -678,15 +678,6 @@ func TestOnCreateAPIUX(t *testing.T) {
 					expectedErrorSubstring string
 				}{
 					{
-						name: "when networkType is not one of OpenShiftSDN;Calico;OVNKubernetes;Other it should fail",
-						mutateInput: func(hc *hyperv1.HostedCluster) {
-							hc.Spec.Networking = hyperv1.ClusterNetworking{
-								NetworkType: "foo",
-							}
-						},
-						expectedErrorSubstring: "Unsupported value: \"foo\": supported values: \"OpenShiftSDN\", \"Calico\", \"OVNKubernetes\", \"Other\"",
-					},
-					{
 						name: "when the cidr is not valid it should fail",
 						mutateInput: func(hc *hyperv1.HostedCluster) {
 							hc.Spec.Networking = hyperv1.ClusterNetworking{
@@ -1560,10 +1551,10 @@ func TestOnCreateAPIUX(t *testing.T) {
 						expectedErrorSubstring: "",
 					},
 					{
-						name: "when disableMultiNetwork is true and networkType is Other it should pass",
+						name: "when disableMultiNetwork is true and networkType is third-party it should pass",
 						mutateInput: func(hc *hyperv1.HostedCluster) {
 							hc.Spec.Networking = hyperv1.ClusterNetworking{
-								NetworkType: hyperv1.Other,
+								NetworkType: "Calico",
 							}
 							hc.Spec.OperatorConfiguration = &hyperv1.OperatorConfiguration{
 								ClusterNetworkOperator: &hyperv1.ClusterNetworkOperatorSpec{
@@ -1648,6 +1639,15 @@ func TestOnCreateAPIUX(t *testing.T) {
 								ClusterNetworkOperator: &hyperv1.ClusterNetworkOperatorSpec{
 									DisableMultiNetwork: ptr.To(false),
 								},
+							}
+						},
+						expectedErrorSubstring: "",
+					},
+					{
+						name: "when networkType is a custom third-party value it should pass",
+						mutateInput: func(hc *hyperv1.HostedCluster) {
+							hc.Spec.Networking = hyperv1.ClusterNetworking{
+								NetworkType: "Cilium",
 							}
 						},
 						expectedErrorSubstring: "",

--- a/test/e2e/v2/tests/api_ux_validation_test.go
+++ b/test/e2e/v2/tests/api_ux_validation_test.go
@@ -1,3 +1,4 @@
+//go:build e2ev2
 // +build e2ev2
 
 /*
@@ -417,16 +418,6 @@ var _ = Describe("API UX Validation", Label("API"), func() {
 		})
 
 		Context("Networking validation", Label("Networking"), func() {
-			It("should reject when networkType is not one of OpenShiftSDN;Calico;OVNKubernetes;Other", func() {
-				err := testHostedClusterCreation(ctx, mgmtClient, "hostedcluster-base.yaml", func(hc *hyperv1.HostedCluster) {
-					hc.Spec.Networking = hyperv1.ClusterNetworking{
-						NetworkType: "foo",
-					}
-				})
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("Unsupported value: \"foo\": supported values: \"OpenShiftSDN\", \"Calico\", \"OVNKubernetes\", \"Other\""))
-			})
-
 			It("should reject when the cidr is not valid", func() {
 				err := testHostedClusterCreation(ctx, mgmtClient, "hostedcluster-base.yaml", func(hc *hyperv1.HostedCluster) {
 					hc.Spec.Networking = hyperv1.ClusterNetworking{
@@ -1095,10 +1086,10 @@ var _ = Describe("API UX Validation", Label("API"), func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			It("should accept when disableMultiNetwork is true and networkType is Other", func() {
+			It("should accept when disableMultiNetwork is true and networkType is third-party CNI", func() {
 				err := testHostedClusterCreation(ctx, mgmtClient, "hostedcluster-base.yaml", func(hc *hyperv1.HostedCluster) {
 					hc.Spec.Networking = hyperv1.ClusterNetworking{
-						NetworkType: hyperv1.Other,
+						NetworkType: "Cilium", //choose arbitrary value for third-party network provider
 					}
 					hc.Spec.OperatorConfiguration = &hyperv1.OperatorConfiguration{
 						ClusterNetworkOperator: &hyperv1.ClusterNetworkOperatorSpec{
@@ -1109,7 +1100,7 @@ var _ = Describe("API UX Validation", Label("API"), func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			It("should reject when disableMultiNetwork is true and networkType is not Other", func() {
+			It("should reject when disableMultiNetwork is true and networkType is OVNKubernetes", func() {
 				err := testHostedClusterCreation(ctx, mgmtClient, "hostedcluster-base.yaml", func(hc *hyperv1.HostedCluster) {
 					hc.Spec.Networking = hyperv1.ClusterNetworking{
 						NetworkType: hyperv1.OVNKubernetes,

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hosted_controlplane.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hosted_controlplane.go
@@ -40,7 +40,7 @@ type HostedControlPlane struct {
 
 // HostedControlPlaneSpec defines the desired state of HostedControlPlane
 // +kubebuilder:validation:XValidation:rule="self.platform.type == 'IBMCloud' ? size(self.services) >= 3 : size(self.services) >= 4",message="spec.services in body should have at least 4 items or 3 for IBMCloud"
-// +kubebuilder:validation:XValidation:rule="!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator) || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork) || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork || self.networking.networkType == 'Other'",message="disableMultiNetwork can only be set to true when networkType is 'Other'"
+// +kubebuilder:validation:XValidation:rule="!has(self.operatorConfiguration) || !has(self.operatorConfiguration.clusterNetworkOperator) || !has(self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork) || !self.operatorConfiguration.clusterNetworkOperator.disableMultiNetwork || (has(self.networking) && has(self.networking.networkType) && !(self.networking.networkType in ['OpenShiftSDN','OVNKubernetes']))",message="disableMultiNetwork can only be true when networking.networkType is neither 'OpenShiftSDN' nor 'OVNKubernetes'"
 type HostedControlPlaneSpec struct {
 	// releaseImage is the release image applied to the hosted control plane.
 	// +required

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/operator.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/operator.go
@@ -40,8 +40,8 @@ type ClusterNetworkOperatorSpec struct {
 	// guest cluster and the multus-admission-controller in the management cluster.
 	// Default is false (Multus is enabled).
 	// This field is immutable.
-	// This field can only be set to true when NetworkType is "Other". Setting it to true
-	// with any other NetworkType will result in a validation error during cluster creation.
+	// This field can only be set to true when NetworkType is third-party. Setting it to true
+	// with NetworkType OpenShiftSDN or OVNKubernetes will result in a validation error during cluster creation.
 	//
 	// +optional
 	// +kubebuilder:default:=false


### PR DESCRIPTION
## What this PR does / why we need it:

Remove the Calico enum value from NetworkType while maintaining support for third-party network providers by accepting any string value.

Changes:
  - Remove Calico from NetworkType enum in hostedcluster_types.go
  - Change NetworkType from constrained enum to open string type
  - Update CEL validation to check against OpenShiftSDN and OVNKubernetes
    instead of requiring networkType == 'Other'
  - Update disableMultiNetwork validation messages to reference "third-party" instead of "Other"
  - Regenerate all CRD manifests and API documentation
  - Update tests to reflect new validation logic
  - Add a new test that accepts custom value (Cilium)

The NetworkType field now accepts any string value to support third-party network providers, while OpenShiftSDN and OVNKubernetes continue to receive special handling by HyperShift.
This is closer to how ClusterNetworkOperator handles the values. It accepts any value and handles OVNKubernetes and OpenShiftSDN specifically.
This also allows passing a specific value such as "Cilium" or "Calico" and use this value in tests to install the specific stack.

This is a backward-compatible change as existing "Other" values remain valid, and the validation logic is now more flexible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.