### PR TITLE
OCM-19543 | support RHOBS monitoring with CVO

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -178,9 +178,9 @@ func (o *Options) Validate() error {
 		errs = append(errs, fmt.Errorf("cannot set --cert-rotation-scale longer than 24h, invalid value: %s", o.CertRotationScale.String()))
 	}
 
-	if o.RHOBSMonitoring && o.EnableCVOManagementClusterMetricsAccess {
-		errs = append(errs, fmt.Errorf("when invoking this command with the --rhobs-monitoring flag, the --enable-cvo-management-cluster-metrics-access flag is not supported "))
-	}
+	// if o.RHOBSMonitoring && o.EnableCVOManagementClusterMetricsAccess {
+	// 	errs = append(errs, fmt.Errorf("when invoking this command with the --rhobs-monitoring flag, the --enable-cvo-management-cluster-metrics-access flag is not supported "))
+	// }
 
 	if len(o.ManagedService) > 0 && o.ManagedService != hyperv1.AroHCP {
 		errs = append(errs, fmt.Errorf("not a valid managed service type: %s", o.ManagedService))


### PR DESCRIPTION
Enable RHOBS monitoring stack with CVO management cluster metrics access feature. When RHOBS_MONITORING=1 environment variable is set, CVO and network policies will use OBO Prometheus endpoint instead of the default Thanos Querier endpoint.

Changes:
- Remove validation that prevented using `--rhobs-monitoring` with `--enable-cvo-management-cluster-metrics-access`
- Update CVO deployment to conditionally configure metrics endpoint based on RHOBS_MONITORING env var
  - RHOBS: http://hypershift-monitoring-stack-prometheus.openshift-observability-operator.svc:9090
  - Default: https://thanos-querier.openshift-monitoring.svc:9092
- Update metrics server network policy to allow egress to appropriate monitoring stack


Commit-Message-Assisted-by: Claude (via Claude Code)

JIRA ticket: https://issues.redhat.com/browse/OCM-19543
