### PR TITLE
OCPBUGS-65576: add hypershift-no-cgo to the latest operator conta…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,14 @@ WORKDIR /hypershift
 COPY . .
 
 RUN make hypershift \
+  && make hypershift-no-cgo \
   && make hypershift-operator \
   && make product-cli \
   && make karpenter-operator
 
 FROM registry.access.redhat.com/ubi9:latest
 COPY --from=builder /hypershift/bin/hypershift \
+                    /hypershift/bin/hypershift-no-cgo \
                     /hypershift/bin/hcp \
                     /hypershift/bin/hypershift-operator \
                     /hypershift/bin/karpenter-operator \


### PR DESCRIPTION

## What this PR does / why we need it:

Non-FIPS compliant hypershift CLI (hypershift-no-cgo) needs to be in the operator container image so that QE test pipelines can extract this binary to run test cases outside the container.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes  https://issues.redhat.com/browse/OCPBUGS-65576

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.