### PR TITLE
DO NOT MERGE: get oauth deployment manifest from cluster-authentication-operator

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/oauth-openshift/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/oauth-openshift/deployment.yaml
@@ -1,152 +1,16 @@
+# The content below is a placeholder required by the asset loading framework
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: oauth-openshift
+  name: oauth-openshift2
 spec:
-  revisionHistoryLimit: 2
   selector:
     matchLabels:
-      app: oauth-openshift
-  strategy:
-    rollingUpdate:
-      maxSurge: 3
-      maxUnavailable: 1
-    type: RollingUpdate
+      app: oauth-openshift2
   template:
     metadata:
       labels:
-        app: oauth-openshift
+        app: oauth-openshift2
     spec:
-      containers:
-      - args:
-        - osinserver
-        - --config=/etc/kubernetes/config/config.yaml
-        - --audit-log-format=json
-        - --audit-log-maxbackup=1
-        - --audit-log-maxsize=10
-        - --audit-log-path=/var/run/kubernetes/audit.log
-        - --audit-policy-file=/etc/kubernetes/audit-config/policy.yaml
-        env:
-        - name: HTTP_PROXY
-          value: http://127.0.0.1:8092
-        - name: HTTPS_PROXY
-          value: http://127.0.0.1:8092
-        - name: ALL_PROXY
-          value: socks5://127.0.0.1:8090
-        - name: NO_PROXY
-          value: kube-apiserver,audit-webhook
-        image: oauth-server
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: healthz
-            port: 6443
-            scheme: HTTPS
-          initialDelaySeconds: 120
-          periodSeconds: 60
-          successThreshold: 1
-          timeoutSeconds: 10
-        name: oauth-openshift
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: healthz
-            port: 6443
-            scheme: HTTPS
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 5
-        resources:
-          requests:
-            cpu: 25m
-            memory: 40Mi
-        volumeMounts:
-        - mountPath: /etc/kubernetes/audit-config
-          name: audit-config
-        - mountPath: /etc/kubernetes/secrets/templates/error
-          name: error-template
-        - mountPath: /etc/kubernetes/secrets/svc-kubeconfig
-          name: kubeconfig
-        - mountPath: /etc/kubernetes/secrets/templates/login
-          name: login-template
-        - mountPath: /var/run/kubernetes
-          name: logs
-        - mountPath: /etc/kubernetes/certs/master-ca
-          name: master-ca-bundle
-        - mountPath: /etc/kubernetes/config
-          name: oauth-config
-        - mountPath: /etc/kubernetes/secrets/templates/providers
-          name: providers-template
-        - mountPath: /etc/kubernetes/certs/serving-cert
-          name: serving-cert
-        - mountPath: /etc/kubernetes/secrets/session
-          name: session-secret
-        workingDir: /var/run/kubernetes
-      - args:
-        - -c
-        - |          
-          set -o errexit
-          set -o nounset
-          set -o pipefail
-
-          function cleanup() {
-            pkill -P $$$
-            wait
-            exit
-          }
-          trap cleanup SIGTERM
-
-          /usr/bin/tail -c+1 -F /var/run/kubernetes/audit.log &
-          wait $!
-        command:
-        - /bin/bash
-        image: cli
-        imagePullPolicy: IfNotPresent
-        name: audit-logs
-        resources:
-          requests:
-            cpu: 5m
-            memory: 10Mi
-        volumeMounts:
-        - mountPath: /var/run/kubernetes
-          name: logs
-      volumes:
-      - configMap:
-          defaultMode: 420
-          name: oauth-openshift
-        name: oauth-config
-      - name: kubeconfig
-        secret:
-          defaultMode: 416
-          secretName: service-network-admin-kubeconfig
-      - name: serving-cert
-        secret:
-          defaultMode: 416
-          secretName: oauth-server-crt
-      - name: session-secret
-        secret:
-          defaultMode: 416
-          secretName: oauth-openshift-session
-      - name: error-template
-        secret:
-          defaultMode: 416
-          secretName: oauth-openshift-default-error-template
-      - name: login-template
-        secret:
-          defaultMode: 416
-          secretName: oauth-openshift-default-login-template
-      - name: providers-template
-        secret:
-          defaultMode: 416
-          secretName: oauth-openshift-default-provider-selection-template
-      - emptyDir: {}
-        name: logs
-      - configMap:
-          defaultMode: 420
-          name: oauth-master-ca-bundle
-        name: master-ca-bundle
-      - configMap:
-          defaultMode: 420
-          name: oauth-openshift-audit
-        name: audit-config
+      containers: []

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/manifest_generator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/manifest_generator.go
@@ -1,0 +1,136 @@
+package oauth
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/api"
+
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+const (
+	authOperatorBinaryPath = "/usr/local/bin/operators/authentication-operator"
+)
+
+type ManifestGenerator struct {
+	hcp *hyperv1.HostedControlPlane
+}
+
+func NewManifestGenerator(hcp *hyperv1.HostedControlPlane) *ManifestGenerator {
+	return &ManifestGenerator{
+		hcp: hcp,
+	}
+}
+
+func (m *ManifestGenerator) GenerateOAuthDeployment(ctx context.Context) (*appsv1.Deployment, error) {
+	hash := computeHash(m.hcp.Namespace, m.hcp.Name)
+	tmpDir := filepath.Join("/tmp", fmt.Sprintf("oauth-gen-%s", hash))
+	inputDir := filepath.Join(tmpDir, "input")
+	outputDir := filepath.Join(tmpDir, "output")
+
+	fmt.Printf("Generating OAuth deployment using authentication-operator %s/%s\n", m.hcp.Namespace, m.hcp.Name)
+	fmt.Printf("input-dir: %s, output-dir: %s\n", inputDir, outputDir)
+
+	if err := os.MkdirAll(inputDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create input directory: %w", err)
+	}
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create output directory: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	fmt.Printf("Executing authentication-operator at %s\n", authOperatorBinaryPath)
+	cmd := exec.CommandContext(ctx, authOperatorBinaryPath,
+		"apply-configuration",
+		"--input-dir", inputDir,
+		"--output-dir", outputDir,
+		"--controllers", "HyperShiftOAuthServerController",
+	)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute authentication-operator: %w\nOutput: %s", err, string(output))
+	}
+	fmt.Printf("Successfully executed authentication-operator: %d bytes\n", len(output))
+	if len(output) > 0 {
+		fmt.Printf("authentication-operator output:\n%s\n", string(output))
+	}
+
+	deploymentPath, err := findDeploymentManifest(outputDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find deployment manifest: %w", err)
+	}
+
+	deployment, err := parseDeploymentManifest(deploymentPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse deployment manifest: %w", err)
+	}
+
+	// todo: check if neede
+	// deployment.Namespace = ""
+
+	return deployment, nil
+}
+
+func findDeploymentManifest(outputDir string) (string, error) {
+	var foundManifests []string
+
+	err := filepath.Walk(outputDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		if strings.Contains(path, "openshift-authentication/apps/deployments") &&
+			strings.Contains(info.Name(), "body") &&
+			strings.HasSuffix(info.Name(), ".yaml") {
+			foundManifests = append(foundManifests, path)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return "", fmt.Errorf("error walking output directory: %w", err)
+	}
+
+	if len(foundManifests) == 0 {
+		return "", fmt.Errorf("no deployment manifest found in output directory")
+	}
+
+	if len(foundManifests) > 1 {
+		return "", fmt.Errorf("multiple deployment manifests found: %v", foundManifests)
+	}
+
+	return foundManifests[0], nil
+}
+
+func parseDeploymentManifest(manifestPath string) (*appsv1.Deployment, error) {
+	manifestBytes, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read manifest file: %w", err)
+	}
+
+	deployment := &appsv1.Deployment{}
+	if _, _, err := api.YamlSerializer.Decode(manifestBytes, nil, deployment); err != nil {
+		return nil, fmt.Errorf("failed to decode deployment manifest: %w", err)
+	}
+
+	return deployment, nil
+}
+
+func computeHash(namespace, name string) string {
+	h := sha256.New()
+	h.Write([]byte(namespace + "/" + name))
+	return fmt.Sprintf("%x", h.Sum(nil))[:8]
+}


### PR DESCRIPTION
This PR replaces the static OAuth server deployment manifest with dynamic generation from the authentication-operator binary.

CPO extracts the authentication-operator binary via an init container and executes it to generate the deployment manifest at runtime.

This ensures the OAuth deployment stays consistent with the canonical authentication-operator implementation while still allowing HCP-specific customizations like audit webhook configuration to be applied on top of the generated manifest.