### PR TITLE
GCP-232: feat(gcp): Add GCP-HCP managed service with system:serviceaccounts RBAC

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -297,6 +297,9 @@ const (
 	// AroHCP represents the ARO HCP managed service offering
 	AroHCP = "ARO-HCP"
 
+	// GcpHCP represents the GCP HCP managed service offering
+	GcpHCP = "GCP-HCP"
+
 	// HostedClusterSizeLabel is a label on HostedClusters indicating a size based on the number of nodes.
 	HostedClusterSizeLabel = "hypershift.openshift.io/hosted-cluster-size"
 

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -1980,7 +1980,8 @@ func (o HyperShiftPullSecret) Build() *corev1.Secret {
 }
 
 type KubeSystemRoleBinding struct {
-	Namespace string
+	Namespace    string
+	SubjectGroup string
 }
 
 func (o KubeSystemRoleBinding) Build() *rbacv1.RoleBinding {
@@ -2002,7 +2003,7 @@ func (o KubeSystemRoleBinding) Build() *rbacv1.RoleBinding {
 			{
 				Kind:     "Group",
 				APIGroup: "rbac.authorization.k8s.io",
-				Name:     "system:authenticated",
+				Name:     o.SubjectGroup,
 			},
 		},
 	}

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -297,6 +297,9 @@ const (
 	// AroHCP represents the ARO HCP managed service offering
 	AroHCP = "ARO-HCP"
 
+	// GcpHCP represents the GCP HCP managed service offering
+	GcpHCP = "GCP-HCP"
+
 	// HostedClusterSizeLabel is a label on HostedClusters indicating a size based on the number of nodes.
 	HostedClusterSizeLabel = "hypershift.openshift.io/hosted-cluster-size"
 


### PR DESCRIPTION
## Summary

Add GCP-HCP as a valid managed service type and create kube-system RoleBinding with appropriate subject groups for GKE management clusters.

Resolves: [GCP-232](https://issues.redhat.com//browse/GCP-232)

## Problem

On GKE Autopilot management clusters, control plane operators crash with `CrashLoopBackOff` due to missing RBAC permissions to read the `extension-apiserver-authentication` ConfigMap in the management cluster's `kube-system` namespace:

- `control-plane-pki-operator`
- `cluster-storage-operator`
- `csi-snapshot-controller-operator`

These operators need this ConfigMap to initialize delegating authentication.

### GKE Autopilot Constraint

GKE Autopilot's Warden security policy explicitly blocks RoleBindings to `system:authenticated`:

```
error: admission webhook "warden-validating.common-webhooks.networking.gke.io" denied the request:
GKE Warden rejected the request because it violates one or more constraints.
Violations details: {"[denied by rbac-binding-limitation]":["Binding any Role or ClusterRole to Group \"system:authenticated\" is forbidden."]}
```

## Solution

Create platform-specific RoleBindings:
- **ARO-HCP (AKS)**: Uses `system:authenticated` group (all authenticated users + service accounts)
- **GCP-HCP (GKE)**: Uses `system:serviceaccounts` group (only service accounts - more secure and GKE Autopilot compatible)

## Changes

1. **Add GcpHCP constant** to `api/hypershift/v1beta1/hostedcluster_types.go`
2. **Update ManagedService validation** to accept `GCP-HCP`
3. **Refactor `KubeSystemRoleBinding` asset** to accept configurable `SubjectGroup` parameter
4. **Use switch statement** to configure appropriate subject group per managed service

## Testing

- ✅ Verified on GKE Autopilot cluster with ArgoCD
- ✅ All 3 control plane operators running successfully
- ✅ No GKE Warden policy violations
- ✅ `make verify` passes (gitlint error is from old upstream commit)
- ✅ `make lint-fix` passes

## Test Plan

- [x] Deploy HyperShift operator on GKE Autopilot with `--managed-service=GCP-HCP`
- [x] Create a HostedCluster
- [x] Verify RoleBinding is created in `kube-system` with `system:serviceaccounts` subject
- [x] Verify control plane operators can read the ConfigMap and start successfully
- [x] Verify ARO HCP still works with `system:authenticated` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)