### PR TITLE
OCPBUGS-65617: fix(conformance): set priorityClass on global-pull-secret-syncer DaemonSet

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps.go
@@ -25,9 +25,10 @@ import (
 )
 
 const (
-	ControllerName     = "globalps"
-	configSeedLabelKey = "hypershift.openshift.io/globalps-config-hash"
-	globalPSLabelKey   = "hypershift.openshift.io/nodepool-globalps-enabled"
+	ControllerName                     = "globalps"
+	configSeedLabelKey                 = "hypershift.openshift.io/globalps-config-hash"
+	globalPSLabelKey                   = "hypershift.openshift.io/nodepool-globalps-enabled"
+	openshiftUserCriticalPriorityClass = "openshift-user-critical"
 )
 
 // GlobalPullSecretPodConfig encapsulates the configuration for GlobalPullSecret DaemonSet pods
@@ -286,6 +287,7 @@ func reconcileDaemonSet(ctx context.Context, daemonSet *appsv1.DaemonSet, global
 					AutomountServiceAccountToken: ptr.To(false),
 					SecurityContext:              &corev1.PodSecurityContext{},
 					DNSPolicy:                    corev1.DNSDefault,
+					PriorityClassName:            openshiftUserCriticalPriorityClass,
 					Tolerations:                  []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
 					// Use nodeSelector to only include nodes that are explicitly enabled for GlobalPullSecret
 					NodeSelector: map[string]string{


### PR DESCRIPTION
## What this PR does / why we need it:
Configure openshift-user-critical priorityClass on the `global-pull-secret-syncer` DaemonSet to ensure conformance tests pass. This resolves the priority class validation failure where pods were found with empty priority class values.

## Which issue(s) this PR fixes:
- [OCPBUGS-65617](https://issues.redhat.com/browse/OCPBUGS-65617)