### PR TITLE
CNTRLPLANE-1934: Add devguyio to core-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -10,6 +10,7 @@ aliases:
     - muraee
     - bryan-cox
     - jparrill
+    - devguyio
   core-reviewers:
     - enxebre
     - csrwng


### PR DESCRIPTION
## What this PR does / why we need it:

Adds Ahmed Abdalla Abdelrehim (GitHub: devguyio) to the core-approvers list in OWNERS_ALIASES to enable them to approve pull requests.

Ahmed is currently a core-reviewer and this change promotes them to core-approver status.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-1934](https://issues.redhat.com//browse/CNTRLPLANE-1934)

## Special notes for your reviewer:

This is a straightforward OWNERS file change with no code impact. Ahmed has been contributing to the HyperShift project and is already listed as a core-reviewer.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. (N/A - OWNERS files are self-documenting)
- [x] This change includes unit tests. (N/A - configuration change only)

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve [CNTRLPLANE-1934](https://issues.redhat.com//browse/CNTRLPLANE-1934)`