### PR TITLE
OCPBUGS-65702: test: Fix control plane components rollout failure when NetworkType is not OVNKubernetes

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cno/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cno/component.go
@@ -110,23 +110,30 @@ type operand struct {
 }
 
 func checkOperandsRolloutStatus(cpContext component.WorkloadContext) (bool, error) {
-	operandsDeploymentsList := []operand{
-		{
-			DeploymentName:  "ovnkube-control-plane",
-			ContainerName:   "ovnkube-control-plane",
-			ReleaseImageKey: "ovn-kubernetes",
-		},
-		{
-			DeploymentName:  "network-node-identity",
-			ContainerName:   "approver",
-			ReleaseImageKey: "ovn-kubernetes",
-		},
-		{
-			DeploymentName:  "cloud-network-config-controller",
-			ContainerName:   "controller",
-			ReleaseImageKey: "cloud-network-config-controller",
-		},
+	var operandsDeploymentsList []operand
+
+	// OVN-specific operands are only checked when NetworkType is OVNKubernetes
+	if cpContext.HCP.Spec.Networking.NetworkType == hyperv1.OVNKubernetes {
+		operandsDeploymentsList = []operand{
+			{
+				DeploymentName:  "ovnkube-control-plane",
+				ContainerName:   "ovnkube-control-plane",
+				ReleaseImageKey: "ovn-kubernetes",
+			},
+			{
+				DeploymentName:  "network-node-identity",
+				ContainerName:   "approver",
+				ReleaseImageKey: "ovn-kubernetes",
+			},
+			{
+				DeploymentName:  "cloud-network-config-controller",
+				ContainerName:   "controller",
+				ReleaseImageKey: "cloud-network-config-controller",
+			},
+		}
 	}
+
+	// multus-admission-controller is needed for all network types when multi-network is enabled
 	if !util.IsDisableMultiNetwork(cpContext.HCP) {
 		operandsDeploymentsList = append(operandsDeploymentsList, operand{
 			DeploymentName:  "multus-admission-controller",


### PR DESCRIPTION

## What this PR does / why we need it:
The pr ingores checkOperandsRolloutStatus when NetworkType is Other, no need to check cno

## Which issue(s) this PR fixes:
Fix issues about failing to wait for control plane components to complete rollout in [TestUpgradeControlPlane/Main/Wait_for_control_plane_components_to_complete_rollout ](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/71182/rehearse-71182-periodic-ci-openshift-hypershift-release-4.21-periodics-e2e-aks/1989239426324107264), when Network type is Other.

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.