### PR TITLE
OCPBUGS-65701: test: fix ovnKubernetesConfig forbidden when networkType is not OVNKubernetes

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -3873,6 +3873,11 @@ func EnsureCNOOperatorConfiguration(t *testing.T, ctx context.Context, mgmtClien
 	t.Run("EnsureCNOOperatorConfiguration", func(t *testing.T) {
 		AtLeast(t, Version420)
 		g := NewWithT(t)
+		// Skip test if network type is not OVNKubernetes
+		if hostedCluster.Spec.Networking.NetworkType != hyperv1.OVNKubernetes {
+			t.Skipf("Skipping EnsureCNOOperatorConfiguration test because network type is %s, not OVNKubernetes", hostedCluster.Spec.Networking.NetworkType)
+		}
+
 		const newJoinSubnet = "100.99.0.0/16"
 		const newTransitSwitchSubnet = "100.100.0.0/16"
 		// Update the HostedCluster to configure CNO settings


### PR DESCRIPTION
## What this PR does / why we need it:
This PR update  EnsureCNOOperatorConfiguration function when the cluster's network type is not actually OVNKubernetes

## Which issue(s) this PR fixes:
Fixes Invalid value: "object": ovnKubernetesConfig is forbidden when networkType is not OVNKubernetes  issues in TestCreateClusterCustomConfig/Main/EnsureCNOOperatorConfiguration in [e2e job](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/71182/rehearse-71182-periodic-ci-openshift-hypershift-release-4.21-periodics-e2e-aks/1989239426324107264 ) when the cluster networkType is Other

## Special notes for your reviewer:
nothing

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.