### PR TITLE
test: add AWS ImageType and arch validation tests

### DIFF
--- a/test/e2e/v2/tests/api_ux_validation_test.go
+++ b/test/e2e/v2/tests/api_ux_validation_test.go
@@ -1460,6 +1460,100 @@ var _ = Describe("API UX Validation", Label("API"), func() {
 			})
 		})
 
+		Context("AWS ImageType and arch validation", Label("AWS", "ImageType", "Arch"), func() {
+			It("should accept when imageType is not set with arm64 architecture", func() {
+				err := testNodePoolCreation(ctx, mgmtClient, "nodepool-base.yaml", func(np *hyperv1.NodePool) {
+					np.Spec.Arch = hyperv1.ArchitectureARM64
+					np.Spec.Platform.Type = hyperv1.AWSPlatform
+					if np.Spec.Platform.AWS == nil {
+						np.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{}
+					}
+					np.Spec.Platform.AWS.InstanceType = "m6g.large"
+					// ImageType intentionally not set
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should accept when imageType is not set with amd64 architecture", func() {
+				err := testNodePoolCreation(ctx, mgmtClient, "nodepool-base.yaml", func(np *hyperv1.NodePool) {
+					np.Spec.Arch = hyperv1.ArchitectureAMD64
+					np.Spec.Platform.Type = hyperv1.AWSPlatform
+					if np.Spec.Platform.AWS == nil {
+						np.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{}
+					}
+					np.Spec.Platform.AWS.InstanceType = "m6i.large"
+					// ImageType intentionally not set
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should reject when imageType is Windows with arm64 architecture", func() {
+				err := testNodePoolCreation(ctx, mgmtClient, "nodepool-base.yaml", func(np *hyperv1.NodePool) {
+					np.Spec.Arch = hyperv1.ArchitectureARM64
+					np.Spec.Platform.Type = hyperv1.AWSPlatform
+					if np.Spec.Platform.AWS == nil {
+						np.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{}
+					}
+					np.Spec.Platform.AWS.InstanceType = "m6g.large"
+					np.Spec.Platform.AWS.ImageType = hyperv1.ImageTypeWindows
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("ImageType 'Windows' requires arch 'amd64' (AWS only)"))
+			})
+
+			It("should accept when imageType is Windows with amd64 architecture", func() {
+				err := testNodePoolCreation(ctx, mgmtClient, "nodepool-base.yaml", func(np *hyperv1.NodePool) {
+					np.Spec.Arch = hyperv1.ArchitectureAMD64
+					np.Spec.Platform.Type = hyperv1.AWSPlatform
+					if np.Spec.Platform.AWS == nil {
+						np.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{}
+					}
+					np.Spec.Platform.AWS.InstanceType = "m6i.large"
+					np.Spec.Platform.AWS.ImageType = hyperv1.ImageTypeWindows
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should accept when imageType is Windows without arch (defaults to amd64)", func() {
+				err := testNodePoolCreation(ctx, mgmtClient, "nodepool-base.yaml", func(np *hyperv1.NodePool) {
+					// Don't set arch - it will default to amd64
+					np.Spec.Platform.Type = hyperv1.AWSPlatform
+					if np.Spec.Platform.AWS == nil {
+						np.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{}
+					}
+					np.Spec.Platform.AWS.InstanceType = "m6i.large"
+					np.Spec.Platform.AWS.ImageType = hyperv1.ImageTypeWindows
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should accept when imageType is Linux with arm64 architecture", func() {
+				err := testNodePoolCreation(ctx, mgmtClient, "nodepool-base.yaml", func(np *hyperv1.NodePool) {
+					np.Spec.Arch = hyperv1.ArchitectureARM64
+					np.Spec.Platform.Type = hyperv1.AWSPlatform
+					if np.Spec.Platform.AWS == nil {
+						np.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{}
+					}
+					np.Spec.Platform.AWS.InstanceType = "m6g.large"
+					np.Spec.Platform.AWS.ImageType = hyperv1.ImageTypeLinux
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should accept when imageType is Linux with amd64 architecture", func() {
+				err := testNodePoolCreation(ctx, mgmtClient, "nodepool-base.yaml", func(np *hyperv1.NodePool) {
+					np.Spec.Arch = hyperv1.ArchitectureAMD64
+					np.Spec.Platform.Type = hyperv1.AWSPlatform
+					if np.Spec.Platform.AWS == nil {
+						np.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{}
+					}
+					np.Spec.Platform.AWS.InstanceType = "m6i.large"
+					np.Spec.Platform.AWS.ImageType = hyperv1.ImageTypeLinux
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
 		Context("Azure VM image configuration validation", Label("Azure", "VMImage"), func() {
 			It("should accept when marketplace is fully populated with imageGeneration set", func() {
 				err := testNodePoolCreation(ctx, mgmtClient, "nodepool-base.yaml", func(np *hyperv1.NodePool) {


### PR DESCRIPTION
## Summary

Add NodePool validation tests for AWS ImageType and architecture combinations to `test/e2e/v2/tests/api_ux_validation_test.go`.

These tests validate that:
- ImageType can be unset for both arm64 and amd64 architectures
- Windows ImageType requires amd64 architecture
- Windows ImageType works with amd64 or when arch defaults to amd64
- Linux ImageType works with both arm64 and amd64 architectures

## Related Issues

- JIRA: [OCPBUGS-64792](https://issues.redhat.com/browse/OCPBUGS-64792)
- Related PR: #7205 (CRD validation fix)

## Context

These tests complement the CRD validation added in PR #7205, which fixed NodePool CRD validation failing with 'no such key: imageType' when creating AWS ARM64 clusters.

As requested by @devel, these API validation tests are easier to run on any management cluster and don't require a hosted cluster to exist.

## Test plan

- [x] Added 7 new test cases covering all imageType and arch combinations
- [x] Tests follow existing patterns using `testNodePoolCreation` helper
- [x] `make lint-fix` passes
- [x] `make verify` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds e2e NodePool validation tests ensuring AWS `imageType` and architecture combinations are validated (Windows requires `amd64`; Linux supports `amd64` and `arm64`; `imageType` may be unset).
> 
> - **Tests (e2e)**:
>   - Add `NodePool` AWS validation for `imageType` vs. arch in `test/e2e/v2/tests/api_ux_validation_test.go`.
>     - Accept: `imageType` unset for `arm64`/`amd64`.
>     - Reject: `imageType` `Windows` with `arm64` (requires `amd64`).
>     - Accept: `imageType` `Windows` with `amd64` or default arch.
>     - Accept: `imageType` `Linux` with `amd64` and `arm64`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 371a979eb49d4901a4499db0b32346812e8570af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->