### PR TITLE
test: add AWS ImageType and arch validation tests

### DIFF
--- a/test/e2e/v2/tests/api_ux_validation_test.go
+++ b/test/e2e/v2/tests/api_ux_validation_test.go
@@ -1460,6 +1460,76 @@ var _ = Describe("API UX Validation", Label("API"), func() {
 			})
 		})
 
+	Context("AWS ImageType and arch validation", Label("AWS", "ImageType", "Arch"), func() {
+		// Helper function to reduce boilerplate for AWS platform setup
+		setupAWSNodePool := func(np *hyperv1.NodePool, arch string, instanceType string) {
+			np.Spec.Arch = arch
+			np.Spec.Platform.Type = hyperv1.AWSPlatform
+			if np.Spec.Platform.AWS == nil {
+				np.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{}
+			}
+			np.Spec.Platform.AWS.InstanceType = instanceType
+		}
+
+		It("should accept when imageType is not set with arm64 architecture", func() {
+			err := testNodePoolCreation(ctx, mgmtClient, "nodepool-base.yaml", func(np *hyperv1.NodePool) {
+				setupAWSNodePool(np, hyperv1.ArchitectureARM64, "m6g.large")
+				// ImageType intentionally not set
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should accept when imageType is not set with amd64 architecture", func() {
+			err := testNodePoolCreation(ctx, mgmtClient, "nodepool-base.yaml", func(np *hyperv1.NodePool) {
+				setupAWSNodePool(np, hyperv1.ArchitectureAMD64, "m6i.large")
+				// ImageType intentionally not set
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should reject when imageType is Windows with arm64 architecture", func() {
+			err := testNodePoolCreation(ctx, mgmtClient, "nodepool-base.yaml", func(np *hyperv1.NodePool) {
+				setupAWSNodePool(np, hyperv1.ArchitectureARM64, "m6g.large")
+				np.Spec.Platform.AWS.ImageType = hyperv1.ImageTypeWindows
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("ImageType 'Windows' requires arch 'amd64' (AWS only)"))
+		})
+
+		It("should accept when imageType is Windows with amd64 architecture", func() {
+			err := testNodePoolCreation(ctx, mgmtClient, "nodepool-base.yaml", func(np *hyperv1.NodePool) {
+				setupAWSNodePool(np, hyperv1.ArchitectureAMD64, "m6i.large")
+				np.Spec.Platform.AWS.ImageType = hyperv1.ImageTypeWindows
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should accept when imageType is Windows without arch (defaults to amd64)", func() {
+			err := testNodePoolCreation(ctx, mgmtClient, "nodepool-base.yaml", func(np *hyperv1.NodePool) {
+				// Explicitly unset arch to test default behavior (defaults to amd64)
+				setupAWSNodePool(np, "", "m6i.large")
+				np.Spec.Platform.AWS.ImageType = hyperv1.ImageTypeWindows
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should accept when imageType is Linux with arm64 architecture", func() {
+			err := testNodePoolCreation(ctx, mgmtClient, "nodepool-base.yaml", func(np *hyperv1.NodePool) {
+				setupAWSNodePool(np, hyperv1.ArchitectureARM64, "m6g.large")
+				np.Spec.Platform.AWS.ImageType = hyperv1.ImageTypeLinux
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should accept when imageType is Linux with amd64 architecture", func() {
+			err := testNodePoolCreation(ctx, mgmtClient, "nodepool-base.yaml", func(np *hyperv1.NodePool) {
+				setupAWSNodePool(np, hyperv1.ArchitectureAMD64, "m6i.large")
+				np.Spec.Platform.AWS.ImageType = hyperv1.ImageTypeLinux
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
 		Context("Azure VM image configuration validation", Label("Azure", "VMImage"), func() {
 			It("should accept when marketplace is fully populated with imageGeneration set", func() {
 				err := testNodePoolCreation(ctx, mgmtClient, "nodepool-base.yaml", func(np *hyperv1.NodePool) {


### PR DESCRIPTION
## What this PR does / why we need it:

Add NodePool validation tests for AWS ImageType and architecture combinations to test/e2e/v2/tests/api_ux_validation_test.go.

These tests validate that:
- ImageType can be unset for both arm64 and amd64 architectures
- Windows ImageType requires amd64 architecture
- Windows ImageType works with amd64 or when arch defaults to amd64
- Linux ImageType works with both arm64 and amd64 architectures

## Which issue(s) this PR fixes:

These tests complement the CRD validation added in PR #7205, which fixed NodePool CRD validation failing with 'no such key: imageType' when creating AWS ARM64 clusters.

As requested, these API validation tests are easier to run on any management cluster and don't require a hosted cluster to exist.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds E2E NodePool validation tests for AWS `imageType` vs architecture (Windows requires `amd64`, Linux allowed on `amd64`/`arm64`, and defaults handled).
> 
> - **Tests (E2E)**:
>   - **AWS NodePool `imageType`/arch validation** in `test/e2e/v2/tests/api_ux_validation_test.go`:
>     - Accepts unset `imageType` for `arm64` and `amd64`.
>     - Rejects `imageType` `Windows` with `arm64`; accepts with `amd64` or when arch unset (defaults to `amd64`).
>     - Accepts `imageType` `Linux` with both `arm64` and `amd64`.
>   - Adds helper `setupAWSNodePool` to streamline AWS platform setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2319e8234577607e53e6293db3c22fa43e3e42fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->