### PR TITLE
feat: new arg to forward env variables set during hypershift install cmd to the hypershift operator deployment

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -402,6 +402,7 @@ type HyperShiftOperatorDeployment struct {
 	RegistryOverrides                       string
 	PlatformsInstalled                      string
 	ImagePullPolicy                         string
+	AdditionalEnvironmentVariables          map[string]string
 }
 
 func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
@@ -444,6 +445,14 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 			Name:  "CERT_ROTATION_SCALE",
 			Value: o.CertRotationScale.String(),
 		},
+	}
+
+	// Propagate specified environment variables from the installer's environment to the operator deployment
+	for name, value := range o.AdditionalEnvironmentVariables {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  name,
+			Value: value,
+		})
 	}
 
 	// Add the new HYPERSHIFT_FEATURESET env var if TPNU is set.


### PR DESCRIPTION
## What this PR does / why we need it:
This PR adds a new arg to the install cmd which allows forwarding the env variables specified to the hypershift operator deployment.

## Which issue(s) this PR fixes:
Fixes https://issues.redhat.com/browse/AROSLSRE-218

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.