### PR TITLE
OCPBUGS-65687: fix(cpov2): prevent azure component access on non-Azure platforms

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/assets.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/assets.go
@@ -85,7 +85,7 @@ func LoadManifestInto(componentName string, fileName string, into client.Object)
 	return obj.(client.Object), gvk, err
 }
 
-func ForEachManifest(componentName string, action func(manifestName string) error) error {
+func ForEachManifest(componentName string, manifestFilter func(manifestName string) bool, action func(manifestName string) error) error {
 	return fs.WalkDir(manifestsAssets, componentName, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -95,6 +95,12 @@ func ForEachManifest(componentName string, action func(manifestName string) erro
 		}
 		manifestName := d.Name()
 		if manifestName == deploymentManifest || manifestName == statefulSetManifest || manifestName == cronJobManifest || manifestName == jobManifest {
+			return nil
+		}
+
+		// Apply filter if provided - skip manifest if filter returns false
+		// This prevents LoadManifest from being called, avoiding informer creation
+		if manifestFilter != nil && !manifestFilter(manifestName) {
 			return nil
 		}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/component.go
@@ -37,7 +37,7 @@ func (c *azureOptions) NeedsManagementKASAccess() bool {
 func NewComponent() component.ControlPlaneComponent {
 	return component.NewDeploymentComponent(ComponentName, &azureOptions{}).
 		WithAdaptFunction(adaptDeployment).
-		WithPredicate(predicate).
+		WithPlatformPredicate(predicate).
 		WithManifestAdapter(
 			"serviceaccount.yaml",
 			component.WithAdaptFunction(adaptServiceAccount),
@@ -54,7 +54,7 @@ func NewComponent() component.ControlPlaneComponent {
 		WithManifestAdapter(
 			"config-secretprovider.yaml",
 			component.WithAdaptFunction(adaptSecretProvider),
-			component.WithPredicate(isAroHCP),
+			component.WithPlatformPredicate(isAroHCP),
 		).
 		InjectTokenMinterContainer(component.TokenMinterContainerOptions{
 			TokenType:               component.CloudToken,

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cno/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cno/component.go
@@ -53,7 +53,7 @@ func NewComponent() component.ControlPlaneComponent {
 		WithManifestAdapter(
 			"azure-secretprovider.yaml",
 			component.WithAdaptFunction(adaptAzureSecretProvider),
-			component.WithPredicate(isAroHCP),
+			component.WithPlatformPredicate(isAroHCP),
 		).
 		WithDependencies(oapiv2.ComponentName).
 		InjectKonnectivityContainer(component.KonnectivityContainerOptions{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ingressoperator/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ingressoperator/component.go
@@ -49,7 +49,7 @@ func NewComponent() component.ControlPlaneComponent {
 		WithManifestAdapter(
 			"azure-secretprovider.yaml",
 			component.WithAdaptFunction(adaptAzureSecretProvider),
-			component.WithPredicate(isAroHCP),
+			component.WithPlatformPredicate(isAroHCP),
 		).
 		WithDependencies(oapiv2.ComponentName).
 		InjectKonnectivityContainer(component.KonnectivityContainerOptions{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/component.go
@@ -113,7 +113,7 @@ func NewComponent() component.ControlPlaneComponent {
 		WithManifestAdapter(
 			"azure-kms-secretprovider.yaml",
 			component.WithAdaptFunction(kms.AdaptAzureSecretProvider),
-			component.WithPredicate(enableAzureKMSSecretProvider),
+			component.WithPlatformPredicate(enableAzureKMSSecretProvider),
 		).
 		Build()
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/registryoperator/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/registryoperator/component.go
@@ -42,7 +42,7 @@ func NewComponent() component.ControlPlaneComponent {
 		WithManifestAdapter(
 			"azure-secretprovider.yaml",
 			component.WithAdaptFunction(adaptAzureSecretProvider),
-			component.WithPredicate(isAroHCP),
+			component.WithPlatformPredicate(isAroHCP),
 		).
 		WithDependencies(oapiv2.ComponentName).
 		InjectTokenMinterContainer(component.TokenMinterContainerOptions{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/storage/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/storage/component.go
@@ -52,7 +52,7 @@ func NewComponent() component.ControlPlaneComponent {
 		WithManifestAdapter(
 			"azure-disk-csi-secretprovider.yaml",
 			component.WithAdaptFunction(adaptAzureCSIDiskSecretProvider),
-			component.WithPredicate(isAroHCP),
+			component.WithPlatformPredicate(isAroHCP),
 		).
 		WithManifestAdapter(
 			"azure-file-csi-config.yaml",
@@ -62,7 +62,7 @@ func NewComponent() component.ControlPlaneComponent {
 		WithManifestAdapter(
 			"azure-file-csi-secretprovider.yaml",
 			component.WithAdaptFunction(adaptAzureCSIFileSecretProvider),
-			component.WithPredicate(isAroHCP),
+			component.WithPlatformPredicate(isAroHCP),
 		).
 		WithDependencies(oapiv2.ComponentName).
 		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{

--- a/support/controlplane-component/builder.go
+++ b/support/controlplane-component/builder.go
@@ -63,6 +63,15 @@ func (b *controlPlaneWorkloadBuilder[T]) WithPredicate(predicate func(cpContext 
 	return b
 }
 
+// WithPlatformPredicate sets a predicate that determines if this component is applicable to the current platform.
+// If the predicate returns false, the component is completely skipped (no API calls, no informer creation, no deletion).
+// Use this for platform-specific components (e.g., Azure CCM on AWS).
+// For configuration-based enabling/disabling (where cleanup is needed), use WithPredicate instead.
+func (b *controlPlaneWorkloadBuilder[T]) WithPlatformPredicate(predicate func(cpContext WorkloadContext) (bool, error)) *controlPlaneWorkloadBuilder[T] {
+	b.workload.platformPredicate = predicate
+	return b
+}
+
 func (b *controlPlaneWorkloadBuilder[T]) WithManifestAdapter(manifestName string, opts ...option) *controlPlaneWorkloadBuilder[T] {
 	adapter := &genericAdapter{}
 	for _, opt := range opts {

--- a/support/controlplane-component/common.go
+++ b/support/controlplane-component/common.go
@@ -55,8 +55,9 @@ func DisableIfAnnotationExist(annotation string) option {
 }
 
 // EnableForPlatform is a helper predicate for the common use case of only enabling a resource for a specific platform.
+// This uses WithPlatformPredicate to ensure the resource is completely skipped (no API calls) on other platforms.
 func EnableForPlatform(platform hyperv1.PlatformType) option {
-	return WithPredicate(func(cpContext WorkloadContext) bool {
+	return WithPlatformPredicate(func(cpContext WorkloadContext) bool {
 		return cpContext.HCP.Spec.Platform.Type == platform
 	})
 }


### PR DESCRIPTION
## What this PR does / why we need it:

Prevents control-plane-operator from attempting to access Azure-specific resources on non-Azure platforms.

**The Problem:**
The azure-cloud-controller-manager component was attempting to access SecretProviderClass resources on ALL platforms (AWS, KubeVirt, OpenStack, etc.), not just Azure. This caused the controller to create informers for resources that should never exist on those platforms, resulting in continuous RBAC forbidden errors that blocked control plane reconciliation.

**Root Cause:**
The azure-cloud-controller-manager component only used `.WithPredicate()` which triggers cleanup mode on non-Azure platforms. In cleanup mode, the framework calls `Client.Get()` to check for existing resources before deletion. When called with platform-specific resource types like SecretProviderClass, controller-runtime automatically creates informers that continuously attempt to LIST/WATCH those resources, even though they will never exist on non-Azure platforms.

**The Fix:**
Add `.WithPlatformPredicate()` to azure-cloud-controller-manager, which causes the component to skip entirely on non-Azure platforms without any API calls or cleanup attempts.

Both predicates are now present:
- `WithPlatformPredicate` (platform filtering) - checked first, exits early on wrong platform
- `WithPredicate` (configuration-based) - checked second, for disabling on correct platform

The generic-adapter implementation enforces this evaluation order automatically.

**Impact:**
- Control-plane-operator no longer attempts to access Azure resources on non-Azure platforms
- No unnecessary informer creation for platform-specific resource types
- Control plane reconciliation proceeds normally on all platforms

## Which issue(s) this PR fixes:

Fixes OCPBUGS-65687