### PR TITLE
OCPBUGS-63452: Add finalizer protection to control plane workloads

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -144,8 +144,11 @@ const (
 	referencedResourceAnnotationPrefix    = "referenced-resource.hypershift.openshift.io/"
 )
 
-// NoopReconcile is just a default mutation function that does nothing.
-var NoopReconcile controllerutil.MutateFn = func() error { return nil }
+var (
+	// NoopReconcile is just a default mutation function that does nothing.
+	NoopReconcile  controllerutil.MutateFn = func() error { return nil }
+	CAPIComponents                         = []string{capimanagerv2.ComponentName, capiproviderv2.ComponentName}
+)
 
 // HostedClusterReconciler reconciles a HostedCluster object
 type HostedClusterReconciler struct {
@@ -4885,10 +4888,9 @@ func (r *HostedClusterReconciler) reconcileCAPIFinalizers(ctx context.Context, h
 		return nil
 	}
 
-	capiComponents := []string{capimanagerv2.ComponentName, capiproviderv2.ComponentName}
 	namespace := manifests.HostedControlPlaneNamespace(hc.Namespace, hc.Name)
 
-	for _, name := range capiComponents {
+	for _, name := range CAPIComponents {
 		deployment := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -2348,6 +2348,7 @@ func TestCreateCluster(t *testing.T) {
 		e2eutil.EnsureCustomTolerations(t, ctx, mgtClient, hostedCluster)
 		e2eutil.EnsureAppLabel(t, ctx, mgtClient, hostedCluster)
 		e2eutil.EnsureFeatureGateStatus(t, ctx, guestClient)
+		e2eutil.EnsureCAPIFinalizers(t, ctx, mgtClient, hostedCluster)
 
 		// ensure KAS DNS name is configured with a KAS Serving cert
 		e2eutil.EnsureKubeAPIDNSNameCustomCert(t, ctx, mgtClient, hostedCluster)

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -24,6 +24,7 @@ import (
 	cpomanifests "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	hccokasvap "github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas"
 	hccomanifests "github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
+	hcc "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster"
 	hcmetrics "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/metrics"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	controlplaneoperatoroverrides "github.com/openshift/hypershift/hypershift-operator/controlplaneoperator-overrides"
@@ -2136,7 +2137,6 @@ func waitForDaemonSetsReady(t *testing.T, ctx context.Context, guestClient crcli
 				return true, nil
 			}
 		})
-
 		if err != nil {
 			return fmt.Errorf("failed to wait for DaemonSet %s to be ready: %w", dsName, err)
 		}


### PR DESCRIPTION
## What this PR does / why we need it:

This PR adds finalizer protection for critical control plane deployments to prevent orphaned cloud resources when workloads are accidentally deleted.

**Problem**: Control plane deployments (capi-provider, cluster-api, cloud-controller-manager-*) lack finalizers. If these deployments are accidentally deleted before HostedCluster deletion, the controller pods stop running before they can process finalizers on their managed CAPI resources (MachineDeployment, Machine, platform-specific machines). This leads to orphaned cloud resources (EC2 instances, VMs, disks, NICs, load balancers) that continue running and generating costs.

**Solution**: Add a finalizer to all control plane workloads that require it. The finalizer ensures:
1. Deployments aren't deleted immediately when deletion is requested, leaving orphaned resources.
2. CAPI resources can be marked for deletion and their finalizers processed by still-running controllers
3. Only after the underlying infrastructure is deleted are the finalizers removed, allowing safe removal of the HC namespace.

**Affected components**:
- cluster-api
- capi-provider
- cloud-controller-manager (for each provider)
- karpenter-operator
- cluster-autoscaler

## Which issue(s) this PR fixes:

Fixes OCPBUGS-63452

## Special notes for your reviewer:

- **Implementation approach**: Framework-level (support/controlplane-component) rather than per-component to ensure consistent protection across all workloads
- **Test fixture updates**: Test fixtures for affected components have been updated to reflect the new finalizer being added to deployments.
- **Deletion flow**: Finalizers are removed from the deployments after the underlying infrastructure is deleted.

**What reviewers should verify**:
- Code changes in `support/controlplane-component/controlplane-component.go` and `hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go`.
- Test fixtures for affected components components include the finalizer in metadata.finalizers.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.