### PR TITLE
GCP-232: refactor(rbac): apply extension-apiserver-authentication rolebinding unconditionally

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -989,14 +989,11 @@ func setupRBAC(opts Options, operatorNamespace *corev1.Namespace) (*corev1.Servi
 	}.Build()
 	objects = append(objects, operatorRoleBinding)
 
-	// In OpenShift management clusters, this RoleBinding is brought in through openshift/cluster-kube-apiserver-operator.
-	// In ARO HCP, Hosted Clusters are running on AKS management clusters, so we need to provide this through the HO.
-	if opts.ManagedService == hyperv1.AroHCP {
-		roleBinding := assets.KubeSystemRoleBinding{
-			Namespace: "kube-system",
-		}.Build()
-		objects = append(objects, roleBinding)
-	}
+	// HyperShift components that serve metrics need access to the client CA bundle
+	// for request authentication. This RoleBinding grants service accounts read access
+	// to the extension-apiserver-authentication-reader Role in kube-system namespace.
+	roleBinding := assets.HyperShiftExtensionAPIServerAuthenticationReaderRoleBinding{}.Build()
+	objects = append(objects, roleBinding)
 
 	if opts.EnableAdminRBACGeneration {
 		clientObjs := setupAdminRBAC(operatorNamespace)


### PR DESCRIPTION
## Summary

This PR simplifies the creation of the `extension-apiserver-authentication-reader` RoleBinding by applying it unconditionally to all clusters at installation time, removing platform-specific conditional logic. Previously this RoleBinding was only created for ARO HCP clusters.

## Changes

- **Renamed Type**: `KubeSystemRoleBinding` → `HyperShiftExtensionAPIServerAuthenticationReaderRoleBinding` (follows HyperShift naming conventions)
- **Removed Conditional Logic**: Applied to all clusters instead of only ARO HCP (`opts.ManagedService == hyperv1.AroHCP`)
- **Updated RoleBinding Name**: `authentication-reader-for-authenticated-users` → `hypershift:extension-apiserver-authentication-reader`
- **Changed Subject**: `system:authenticated` → `system:serviceaccounts` (more secure, least privilege)
- **Use Kubernetes Constant**: `metav1.NamespaceSystem` instead of hardcoded `"kube-system"`
- **Removed Namespace Field**: Always kube-system, no configuration needed
- **Added Comprehensive Documentation**: Explains why this RoleBinding is needed and why it's safe

## Motivation

The `extension-apiserver-authentication-reader` Role provides read access to the client CA bundle used to verify client certificates for authentication. HyperShift components that serve metrics endpoints need this information to properly authenticate requests.

### Why Unconditional Application is Safe

1. **Read-only access**: The Role only grants read access to authentication configuration metadata, not write permissions
2. **Standard practice**: OpenShift clusters include this RoleBinding out of the box via `cluster-kube-apiserver-operator`
3. **Required for metrics**: HyperShift instantiates multiple metrics-serving operators dynamically across many namespaces as hosted clusters are created
4. **No harm to OpenShift**: Clusters that already have this RoleBinding are unaffected by creating another one
5. **Fixes gaps**: Non-OpenShift platforms (vanilla K8s, AKS, GKE) need this for metrics to work correctly

### Why This is Better Than Conditional Logic

The previous approach only created this for ARO HCP. This unconditional approach:
- **Simpler**: No platform detection or conditionals needed
- **More maintainable**: Less code, clearer intent
- **Future-proof**: Any new platform automatically gets necessary permissions
- **Consistent**: All clusters have the same RBAC configuration

## Testing

- [x] Build succeeds (`make hypershift`)
- [x] Verified RoleBinding structure and naming
- [x] Confirmed subject uses `system:serviceaccounts`
- [x] Verified namespace uses `metav1.NamespaceSystem` constant