### PR TITLE
CNTRLPLANE-1956: add logic to check control-plane to data-plane connectivity 

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -195,6 +195,15 @@ const (
 	// This condition is used to track the status of the recovery process and to determine if the HostedCluster
 	// is ready to be used after restoration.
 	HostedClusterRestoredFromBackup ConditionType = "HostedClusterRestoredFromBackup"
+
+	// DataPlaneConnectionAvailable indicates whether the control plane has a successful
+	// network connection to the data plane components.
+	// **True** means the control plane can successfully reach the data plane nodes.
+	// **False** means there are network connection issues preventing the control plane from reaching the data plane.
+	// A failure here suggests potential issues such as: network policy restrictions,
+	// firewall rules, missing data plane nodes, or problems with infrastructure
+	// components like the konnectivity-agent workload.
+	DataPlaneConnectionAvailable ConditionType = "DataPlaneConnectionAvailable"
 )
 
 // Reasons.
@@ -250,7 +259,15 @@ const (
 
 	RecoveryFinishedReason = "RecoveryFinished"
 
+	ReconcileErrorReason = "ReconcileError"
+
 	CloudResourcesCleanupSkippedReason = "CloudResourcesCleanupSkipped"
+
+	DataPlaneConnectionNoKonnectivityAgentPodsNotFoundReason = "KonnectivityAgentPodsNotFound"
+
+	DataPlaneConnectionLogsAccessFailedReason = "LogsAccessFailed"
+
+	DataPlaneConnectionNoWorkerNodesAvailableReason = "NoWorkerNodesAvailable"
 )
 
 // Messages.

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -4901,6 +4901,15 @@ underlying cluster&rsquo;s ClusterVersion.</p>
 </tr><tr><td><p>&#34;RolloutComplete&#34;</p></td>
 <td><p>ControlPlaneComponentRolloutComplete indicates whether the ControlPlaneComponent has completed its rollout.</p>
 </td>
+</tr><tr><td><p>&#34;DataPlaneConnectionAvailable&#34;</p></td>
+<td><p>DataPlaneConnectionAvailable indicates whether the control plane has a successful
+network connection to the data plane components.
+<strong>True</strong> means the control plane can successfully reach the data plane nodes.
+<strong>False</strong> means there are network connection issues preventing the control plane from reaching the data plane.
+A failure here suggests potential issues such as: network policy restrictions,
+firewall rules, missing data plane nodes, or problems with infrastructure
+components like the konnectivity-agent workload.</p>
+</td>
 </tr><tr><td><p>&#34;EtcdAvailable&#34;</p></td>
 <td><p>EtcdAvailable bubbles up the same condition from HCP. It signals if etcd is available.
 A failure here often means a software bug or a non-stable cluster.</p>

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -825,6 +825,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 			hyperv1.ValidReleaseInfo,
 			hyperv1.ValidIDPConfiguration,
 			hyperv1.HostedClusterRestoredFromBackup,
+			hyperv1.DataPlaneConnectionAvailable,
 		}
 
 		for _, conditionType := range hcpConditions {

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -195,6 +195,15 @@ const (
 	// This condition is used to track the status of the recovery process and to determine if the HostedCluster
 	// is ready to be used after restoration.
 	HostedClusterRestoredFromBackup ConditionType = "HostedClusterRestoredFromBackup"
+
+	// DataPlaneConnectionAvailable indicates whether the control plane has a successful
+	// network connection to the data plane components.
+	// **True** means the control plane can successfully reach the data plane nodes.
+	// **False** means there are network connection issues preventing the control plane from reaching the data plane.
+	// A failure here suggests potential issues such as: network policy restrictions,
+	// firewall rules, missing data plane nodes, or problems with infrastructure
+	// components like the konnectivity-agent workload.
+	DataPlaneConnectionAvailable ConditionType = "DataPlaneConnectionAvailable"
 )
 
 // Reasons.
@@ -250,7 +259,15 @@ const (
 
 	RecoveryFinishedReason = "RecoveryFinished"
 
+	ReconcileErrorReason = "ReconcileError"
+
 	CloudResourcesCleanupSkippedReason = "CloudResourcesCleanupSkipped"
+
+	DataPlaneConnectionNoKonnectivityAgentPodsNotFoundReason = "KonnectivityAgentPodsNotFound"
+
+	DataPlaneConnectionLogsAccessFailedReason = "LogsAccessFailed"
+
+	DataPlaneConnectionNoWorkerNodesAvailableReason = "NoWorkerNodesAvailable"
 )
 
 // Messages.


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:
We need this PR to create and update a status.condition in hosted-control-plane CR to show the status of connection between control-plane and data-plane. 
It lists the konnecivity-agent PODs and it get the logs.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes [CNTRLPLANE-1956](https://issues.redhat.com//browse/CNTRLPLANE-1956)

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.