### PR TITLE
OCPBUGS-65957: test(e2e): fix TestNodePool test failure when installing cilium as external cni

### DIFF
--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -210,6 +210,12 @@ func executeNodePoolTests(t *testing.T, nodePoolTestCasesPerHostedCluster []Host
 				clusterOpts.NodePoolReplicas = 1
 			}
 
+			// On ARO HCP with Cilium, we need at least one worker node to install cilium-olm operator
+			// before individual tests run. The cilium-olm deployment requires worker nodes to schedule its pods.
+			if globalOpts.Platform == hyperv1.AzurePlatform && clusterOpts.ExternalCNIProvider == "cilium" {
+				clusterOpts.NodePoolReplicas = 1
+			}
+
 			ctx, cancel := context.WithCancel(testContext)
 			defer cancel()
 			e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {


### PR DESCRIPTION
## What this PR does / why we need it:
The pr update NodePoolReplicas is 1 for NodePoolTests, because On ARO HCP with Cilium, we need at least one worker node to install cilium-olm operator before individual tests run
## Which issue(s) this PR fixes:
Fixes:
```
 TestNodePool/HostedCluster0/ValidateHostedCluster/InstallCilium/InstallCilium expand_less 	10m1s
{Failed  === RUN   TestNodePool/HostedCluster0/ValidateHostedCluster/InstallCilium/InstallCilium
    util.go:1296: Installing Cilium operator version 1.15.1
    util.go:1315: Applying manifest from https://raw.githubusercontent.com/isovalent/olm-for-cilium/main/manifests/cilium.v1.15.1/cluster-network-03-cilium-ciliumconfigs-crd.yaml
    util.go:1315: Applying manifest from https://raw.githubusercontent.com/isovalent/olm-for-cilium/main/manifests/cilium.v1.15.1/cluster-network-06-cilium-00000-cilium-namespace.yaml
    util.go:1315: Applying manifest from https://raw.githubusercontent.com/isovalent/olm-for-cilium/main/manifests/cilium.v1.15.1/cluster-network-06-cilium-00001-cilium-olm-serviceaccount.yaml
    util.go:1315: Applying manifest from https://raw.githubusercontent.com/isovalent/olm-for-cilium/main/manifests/cilium.v1.15.1/cluster-network-06-cilium-00002-cilium-olm-deployment.yaml
    util.go:1321: Verifying Cilium resources creation
    util.go:1329: Waiting for cilium-olm deployment to be ready
    util.go:1338: 
        Timed out after 600.001s.
        cilium-olm deployment should be ready
        Expected
            <bool>: false
        to be true
                --- FAIL: TestNodePool/HostedCluster0/ValidateHostedCluster/InstallCilium/InstallCilium (600.59s)
```

## Special notes for your reviewer:
The pr is depend on :https://github.com/openshift/hypershift/pull/7077, because ExternalCNIProvider is defined in pr7077

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test behavior for Azure (ARO HCP) environments using Cilium: tests now ensure at least one worker node is present so the Cilium operator can deploy successfully, preventing false failures in those platform-specific scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->