### PR TITLE
GCP-251: feat(install): Add GCP provider support for external-dns with Workload Identity

### DIFF
--- a/cmd/install/install_helm.go
+++ b/cmd/install/install_helm.go
@@ -28,6 +28,7 @@ var helmTemplateParams = TemplateParams{
 	ExternalDNSDomainFilter:     ".Values.externaldns.domainFilter",
 	ExternalDNSTxtOwnerID:       ".Values.externaldns.txtOwnerId",
 	ExternalDNSImage:            ".Values.externaldns.image",
+	ExternalDNSGoogleProject:    ".Values.externaldns.googleProject",
 	RegistryOverrides:           ".Values.registryOverrides",
 	AROHCPKeyVaultUsersClientID: ".Values.azure.keyVault.clientId",
 	TemplateNamespace:           false,
@@ -114,6 +115,13 @@ func WriteValuesFile(dir string) error {
 				"credsSecret":    "",
 				"credsSecretKey": "",
 			},
+		},
+		"externaldns": map[string]interface{}{
+			"credsSecret":   "",
+			"domainFilter":  "",
+			"txtOwnerId":    "",
+			"image":         "",
+			"googleProject": "",
 		},
 	}
 	return writeYamlFile(fmt.Sprintf("%s/values.yaml", dir), data)

--- a/cmd/install/install_test.go
+++ b/cmd/install/install_test.go
@@ -83,6 +83,33 @@ func TestOptions_Validate(t *testing.T) {
 			},
 			expectError: true,
 		},
+		"when external-dns GCP provider is set without credentials it succeeds (Workload Identity)": {
+			inputOptions: Options{
+				PrivatePlatform:          string(hyperv1.GCPPlatform),
+				ExternalDNSProvider:      "google",
+				ExternalDNSDomainFilter:  "test.com",
+				ExternalDNSGoogleProject: "my-project",
+			},
+			expectError: false,
+		},
+		"when external-dns GCP provider is set with credentials it succeeds": {
+			inputOptions: Options{
+				PrivatePlatform:          string(hyperv1.GCPPlatform),
+				ExternalDNSProvider:      "google",
+				ExternalDNSDomainFilter:  "test.com",
+				ExternalDNSGoogleProject: "my-project",
+				ExternalDNSCredentials:   "/path/to/credentials",
+			},
+			expectError: false,
+		},
+		"when external-dns GCP provider is set without google-project it succeeds": {
+			inputOptions: Options{
+				PrivatePlatform:         string(hyperv1.GCPPlatform),
+				ExternalDNSProvider:     "google",
+				ExternalDNSDomainFilter: "test.com",
+			},
+			expectError: false,
+		},
 		"when all data specified there is no error": {
 			inputOptions: Options{
 				PrivatePlatform:                           string(hyperv1.NonePlatform),

--- a/cmd/install/render.go
+++ b/cmd/install/render.go
@@ -22,6 +22,7 @@ type TemplateParams struct {
 	ExternalDNSDomainFilter     string
 	ExternalDNSTxtOwnerID       string
 	ExternalDNSImage            string
+	ExternalDNSGoogleProject    string
 	RegistryOverrides           string
 	AROHCPKeyVaultUsersClientID string
 	TemplateNamespace           bool
@@ -58,8 +59,15 @@ func hyperShiftOperatorTemplateManifest(opts *Options, templateParamConfig Templ
 	if opts.ExternalDNSProvider != "" {
 		opts.ExternalDNSImage = templateParamConfig.TemplateParamWrapper(templateParamConfig.ExternalDNSImage)
 		opts.ExternalDNSDomainFilter = templateParamConfig.TemplateParamWrapper(templateParamConfig.ExternalDNSDomainFilter)
-		opts.ExternalDNSCredentialsSecret = templateParamConfig.TemplateParamWrapper(templateParamConfig.ExternalDNSCredsSecret)
-		opts.ExternalDNSTxtOwnerId = templateParamConfig.TemplateParamWrapper(templateParamConfig.ExternalDNSTxtOwnerID)
+		if opts.ExternalDNSCredentialsSecret != "" {
+			opts.ExternalDNSCredentialsSecret = templateParamConfig.TemplateParamWrapper(templateParamConfig.ExternalDNSCredsSecret)
+		}
+		if opts.ExternalDNSTxtOwnerId != "" {
+			opts.ExternalDNSTxtOwnerId = templateParamConfig.TemplateParamWrapper(templateParamConfig.ExternalDNSTxtOwnerID)
+		}
+		if opts.ExternalDNSGoogleProject != "" {
+			opts.ExternalDNSGoogleProject = templateParamConfig.TemplateParamWrapper(templateParamConfig.ExternalDNSGoogleProject)
+		}
 	}
 
 	// registry overrides

--- a/cmd/install/testdata/zz_fixture_TestHelmCommand_values.yaml
+++ b/cmd/install/testdata/zz_fixture_TestHelmCommand_values.yaml
@@ -6,6 +6,12 @@ aws:
 azure:
   keyVault:
     clientId: ""
+externaldns:
+  credsSecret: ""
+  domainFilter: ""
+  googleProject: ""
+  image: ""
+  txtOwnerId: ""
 image: ""
 imagetag: ""
 oidc:


### PR DESCRIPTION
## Summary

Adds Google Cloud Platform provider support to Hypershift's external-dns integration using principal-based Workload Identity Federation.

Complements gcp-hcp-infra changes in https://github.com/openshift-online/gcp-hcp-infra/pull/209

## Changes

### GCP Provider Support

- Added `GCPExternalDNSProvider` constant ("google")
- Added `GoogleProject` field to `ExternalDNSDeployment` struct
- Added GCP case in provider switch with `--google-project` arg
- Added `--external-dns-google-project` CLI flag

### Optional Credentials for GCP (Workload Identity)

- Made credentials optional when `--external-dns-provider=google`
- Validation: Credentials required for AWS/Azure, optional for GCP
- Conditional volume/volumeMount: Only added when `CredentialsSecret != nil`

### Optional google-project Parameter

- `--external-dns-google-project` is optional
- When omitted: external-dns falls back to `EXTERNAL_DNS_GOOGLE_PROJECT` env var → metadata server auto-detection
- When provided: Added as `--google-project` arg to external-dns deployment
- Supports ArgoCD env var injection pattern

### Template/Helm Rendering Support

- Added `ExternalDNSGoogleProject` to `TemplateParams` struct
- OpenShift Template: Conditional `${EXTERNAL_DNS_GOOGLE_PROJECT}` parameter
- Helm: Added `.Values.externaldns.googleProject` support
- Conditional field wrapping: Only creates template vars for provided fields

### Test Coverage

Added 3 test cases:
- GCP provider without credentials (Workload Identity)
- GCP provider with credentials (optional)
- GCP provider without google-project (uses env var fallback)

## Authentication Flow

**Principal-Based Workload Identity (no annotations):**

```bash
# IAM binding grants permissions directly to Kubernetes SA principal
gcloud projects add-iam-policy-binding DNS_PROJECT_ID \
  --role=roles/dns.admin \
  --member=principal://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/PROJECT_ID.svc.id.goog/subject/ns/hypershift/sa/external-dns
```

**Installation:**
```bash
hypershift install \
  --external-dns-provider=google \
  --external-dns-domain-filter=example.com
  # --external-dns-google-project is optional (uses env var or auto-detect)
```

## Fallback Chain

When `--google-project` arg is omitted:
1. Checks `EXTERNAL_DNS_GOOGLE_PROJECT` environment variable
2. Falls back to GCP metadata server (auto-detects cluster project)
3. Fails if neither available

## Backward Compatibility

- AWS/Azure behavior unchanged (credentials still required)
- Existing external-dns deployments continue to work
- GCP users can provide credentials if needed (both auth methods supported)

## Testing

- [x] Unit tests pass (16/16)
- [x] Build successful
- [x] Validated all install modes: `install`, `install render`, `install render --template`, `install helm`
- [ ] Integration testing with GKE cluster + Workload Identity

Jira: https://issues.redhat.com/browse/GCP-251