### PR TITLE
NO-JIRA: fix(build): replace sysctl with getconf in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,7 +262,7 @@ delegating_client:
 .PHONY: test
 
 # Determine the number of CPU cores
-NUM_CORES := $(shell uname | grep -q 'Darwin' && sysctl -n hw.ncpu || nproc)
+NUM_CORES := $(shell getconf _NPROCESSORS_ONLN || echo 1)
 
 test: generate
 	echo "Running tests with $(NUM_CORES) parallel jobs..."


### PR DESCRIPTION
## What this PR does / why we need it:
The sysctl command requires permissions not available in the macOS Seatbelt sandbox, causing 'Operation not permitted' errors. Replace it with getconf _NPROCESSORS_ONLN which is POSIX-compliant and works on both macOS and Linux without requiring special permissions.