### PR TITLE
OCPBUGS-66145: fix(e2e): Ensure release rollout in NodePool tests

### DIFF
--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -236,6 +236,12 @@ func executeNodePoolTests(t *testing.T, nodePoolTestCasesPerHostedCluster []Host
 						executeNodePoolTest(t, ctx, mgtClient, hostedCluster, hostedClusterClient, *defaultNodepool, testCase.test, testCase.manifestBuilder)
 					})
 				}
+				// Wait for HostedCluster to stabilize if test potentially triggered rollouts.
+				// Some tests modify NodePools' configuration in Run() (e.g., removing kubeletconfig),
+				// which triggers rollouts that might affect cluster operators and CVO conditions.
+				//
+				// We're assuming this test will not end up with a 0 workers cluster.
+				e2eutil.WaitForHealthyHostedCluster(t, ctx, mgtClient, hostedCluster, true)
 			}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, "node-pool", globalOpts.ServiceAccountSigningKey)
 		})
 	}


### PR DESCRIPTION
## What this PR does / why we need it:

Some node pool e2e tests modify a NodePool's configuration in Run() , which triggers rollouts that might affect CVO conditions.

This might cause failures in the after() validations of the e2e framework which expect that a HostedCluster is not progressing such as [this failure](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/7218/pull-ci-openshift-hypershift-main-e2e-aks/1988710603581034496)

This PR introduces a change to wait for the HostedCluster to stabilize after running each NodePool test

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.