### PR TITLE
NO-JIRA: test(e2e): extend Azure node ready timeout to 45 minutes

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -527,6 +527,11 @@ func WaitForNReadyNodesWithOptions(t *testing.T, ctx context.Context, client crc
 	// waitTimeout for nodes to become Ready
 	waitTimeout := 30 * time.Minute
 	switch platform {
+	case hyperv1.AzurePlatform:
+		// Azure VMs are experiencing slow provisioning (30+ minutes instead of 10-15 minutes).
+		// Azure platform has a hardcoded 20-minute timeout that marks VMs as failed,
+		// but VMs often succeed eventually. Give them 45 minutes to complete.
+		waitTimeout = 45 * time.Minute
 	case hyperv1.KubevirtPlatform:
 		waitTimeout = 45 * time.Minute
 	case hyperv1.PowerVSPlatform:


### PR DESCRIPTION
## What this PR does / why we need it:

This PR extends the node ready wait timeout for Azure platform from the default 30 minutes to 45 minutes in E2E tests.

Azure VMs are experiencing slow provisioning times (30+ minutes instead of the typical 10-15 minutes). The Azure platform has a hardcoded 20-minute timeout that marks VMs as failed, but these VMs often succeed eventually if given more time. By extending the E2E test timeout to 45 minutes, we allow Azure nodes sufficient time to complete provisioning and become ready, reducing false test failures.

This change aligns the Azure timeout with the existing KubevirtPlatform timeout (45 minutes) and is less than PowerVSPlatform (60 minutes).

## Which issue(s) this PR fixes:

Fixes 

## Special notes for your reviewer:

- This only affects E2E test timeouts, not production behavior
- The change is Azure-specific and doesn't impact other platforms
- Similar timeout extensions already exist for KubeVirt (45m) and PowerVS (60m) platforms

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)