### PR TITLE
NO-JIRA: test(e2e): extend timeouts for Azure and KubeVirt platforms 

### DIFF
--- a/test/e2e/nodepool_machineconfig_test.go
+++ b/test/e2e/nodepool_machineconfig_test.go
@@ -137,7 +137,7 @@ func (mc *NodePoolMachineconfigRolloutTest) Run(t *testing.T, nodePool hyperv1.N
 		t.Fatalf("failed to create %s DaemonSet in guestcluster: %v", ds.Name, err)
 	}
 
-	e2eutil.WaitForNodePoolConfigUpdateComplete(t, ctx, mc.mgmtClient, &nodePool)
+	e2eutil.WaitForNodePoolConfigUpdateCompleteWithPlatform(t, ctx, mc.mgmtClient, &nodePool, mc.hostedCluster.Spec.Platform.Type)
 	eventuallyDaemonSetRollsOut(t, ctx, mc.hostedClusterClient, len(nodes), np, ds)
 	e2eutil.WaitForReadyNodesByNodePool(t, ctx, mc.hostedClusterClient, &nodePool, mc.hostedCluster.Spec.Platform.Type)
 	e2eutil.EnsureNoCrashingPods(t, ctx, mc.mgmtClient, mc.hostedCluster)

--- a/test/e2e/nodepool_nto_machineconfig_test.go
+++ b/test/e2e/nodepool_nto_machineconfig_test.go
@@ -130,7 +130,7 @@ func (mc *NTOMachineConfigRolloutTest) Run(t *testing.T, nodePool hyperv1.NodePo
 		}
 	}
 
-	e2eutil.WaitForNodePoolConfigUpdateComplete(t, ctx, mc.mgmtClient, &nodePool)
+	e2eutil.WaitForNodePoolConfigUpdateCompleteWithPlatform(t, ctx, mc.mgmtClient, &nodePool, mc.hostedCluster.Spec.Platform.Type)
 	eventuallyDaemonSetRollsOut(t, ctx, mc.hostedClusterClient, len(nodes), np, ds)
 	e2eutil.WaitForReadyNodesByNodePool(t, ctx, mc.hostedClusterClient, &nodePool, mc.hostedCluster.Spec.Platform.Type)
 	e2eutil.EnsureNoCrashingPods(t, ctx, mc.mgmtClient, mc.hostedCluster)


### PR DESCRIPTION
Extend various E2E test timeouts from 20-30 minutes to 45 minutes for Azure and KubeVirt platforms
to account for slower VM provisioning and upgrade operations. Changes include:

- NodePool upgrade timeout: 20min -> 45min (Azure/KubeVirt)
- Rolling upgrade timeout: 30min -> 45min (Azure/KubeVirt)
- Config update timeout: 25min -> 45min (Azure/KubeVirt)
- Updated WaitForNodePoolConfigUpdateComplete to accept platform parameter

This addresses timeout issues observed during Azure E2E test runs where operations
were failing due to Azure's slower platform performance characteristics.

Signed-off-by: Cesar Wong <cewong@redhat.com>
Commit-Message-Assisted-by: Claude (via Claude Code)