### PR TITLE
fix(e2e): extend NodePool upgrade timeout to 30m

### DIFF
--- a/test/e2e/nodepool_additionalTrustBundlePropagation_test.go
+++ b/test/e2e/nodepool_additionalTrustBundlePropagation_test.go
@@ -107,7 +107,7 @@ func (k *AdditionalTrustBundlePropagationTest) Run(t *testing.T, nodePool hyperv
 					Status: metav1.ConditionTrue,
 				}),
 			},
-			e2eutil.WithInterval(10*time.Second), e2eutil.WithTimeout(20*time.Minute),
+			e2eutil.WithInterval(10*time.Second), e2eutil.WithTimeout(30*time.Minute),
 		)
 
 		t.Logf("Updating hosted cluster by removing additional trust bundle.")
@@ -174,7 +174,7 @@ func (k *AdditionalTrustBundlePropagationTest) Run(t *testing.T, nodePool hyperv
 					Status: metav1.ConditionTrue,
 				}),
 			},
-			e2eutil.WithInterval(10*time.Second), e2eutil.WithTimeout(20*time.Minute),
+			e2eutil.WithInterval(10*time.Second), e2eutil.WithTimeout(30*time.Minute),
 		)
 	})
 }

--- a/test/e2e/nodepool_upgrade_test.go
+++ b/test/e2e/nodepool_upgrade_test.go
@@ -213,7 +213,7 @@ func (ru *NodePoolUpgradeTest) Run(t *testing.T, nodePool hyperv1.NodePool, node
 				Status: metav1.ConditionFalse,
 			}),
 		},
-		e2eutil.WithTimeout(20*time.Minute),
+		e2eutil.WithTimeout(30*time.Minute),
 	)
 	newNodes := e2eutil.WaitForReadyNodesByNodePool(t, ctx, ru.hostedClusterClient, &nodePool, ru.hostedCluster.Spec.Platform.Type)
 	e2eutil.EnsureNodesRuntime(t, newNodes)


### PR DESCRIPTION
## Summary

Azure/AKS node provisioning during NodePool upgrade operations takes longer than the current 20-minute timeout, causing e2e-aks test failures. This PR increases the timeout to 30 minutes to align with similar operations and accommodate Azure's slower provisioning times.

## Problem

The `e2e-aks` CI job has been experiencing a 100% failure rate across all recent PRs, with the `TestNodePoolReplaceUpgrade` test consistently timing out after 20 minutes while waiting for NodePool version upgrades to complete. Analysis shows that Azure CAPI machines remain stuck in "NodeProvisioning" state beyond the timeout period.

Failing test: `TestNodePool/HostedCluster0/Main/TestNodePoolReplaceUpgrade`
Error: `Failed to wait for NodePool to have version X in 20m0s: context deadline exceeded`

## Solution

Extend the timeout from 20 to 30 minutes for the following tests:
- `TestNodePoolReplaceUpgrade` (nodepool_upgrade_test.go:216)
- `TestAdditionalTrustBundlePropagation` (nodepool_additionalTrustBundlePropagation_test.go:110, 177)

This aligns with the timeout used by other similar operations:
- `TestNodePoolRollingUpgrade` already uses 30 minutes
- Control plane component rollouts use similar extended timeouts

## Tests Affected

✅ `TestNodePoolReplaceUpgrade` - NodePool upgrade with replace strategy
✅ `TestAdditionalTrustBundlePropagation` - NodePool config updates with additional trust bundle

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>