### PR TITLE
CNTRLPLANE-2050: feat(azure): update default VM size to Standard_D4s_v5

### DIFF
--- a/cmd/cluster/azure/create.go
+++ b/cmd/cluster/azure/create.go
@@ -379,7 +379,7 @@ func (o *CreateOptions) GenerateNodePools(constructor core.DefaultNodePoolConstr
 		// Aligning with Azure IPI instance type defaults
 		switch azureNodePool.Spec.Arch {
 		case hyperv1.ArchitectureAMD64:
-			instanceType = "Standard_D4s_v3"
+			instanceType = "Standard_D4s_v5"
 		case hyperv1.ArchitectureARM64:
 			instanceType = "Standard_D4ps_v5"
 		}

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -166,7 +166,7 @@ spec:
         diskStorageAccountType: Premium_LRS
         sizeGiB: 120
       subnetID: fakeSubnetID
-      vmSize: Standard_D4s_v3
+      vmSize: Standard_D4s_v5
     type: Azure
   release:
     image: ""

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_KubeAPIServerDNSName.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_KubeAPIServerDNSName.yaml
@@ -167,7 +167,7 @@ spec:
         diskStorageAccountType: Premium_LRS
         sizeGiB: 120
       subnetID: fakeSubnetID
-      vmSize: Standard_D4s_v3
+      vmSize: Standard_D4s_v5
     type: Azure
   release:
     image: ""

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_ones.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_ones.yaml
@@ -165,7 +165,7 @@ spec:
         diskStorageAccountType: Premium_LRS
         sizeGiB: 120
       subnetID: fakeSubnetID
-      vmSize: Standard_D4s_v3
+      vmSize: Standard_D4s_v5
     type: Azure
   release:
     image: ""
@@ -197,7 +197,7 @@ spec:
         diskStorageAccountType: Premium_LRS
         sizeGiB: 120
       subnetID: fakeSubnetID
-      vmSize: Standard_D4s_v3
+      vmSize: Standard_D4s_v5
     type: Azure
   release:
     image: ""

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_zones.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_zones.yaml
@@ -167,7 +167,7 @@ spec:
         diskStorageAccountType: Premium_LRS
         sizeGiB: 120
       subnetID: fakeSubnetID
-      vmSize: Standard_D4s_v3
+      vmSize: Standard_D4s_v5
     type: Azure
   release:
     image: ""
@@ -199,7 +199,7 @@ spec:
         diskStorageAccountType: Premium_LRS
         sizeGiB: 120
       subnetID: fakeSubnetID
-      vmSize: Standard_D4s_v3
+      vmSize: Standard_D4s_v5
     type: Azure
   release:
     image: ""

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_zones_and_image_generation_Gen1.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_availability_zones_and_image_generation_Gen1.yaml
@@ -134,7 +134,7 @@ spec:
         diskStorageAccountType: Premium_LRS
         sizeGiB: 120
       subnetID: fakeSubnetID
-      vmSize: Standard_D4s_v3
+      vmSize: Standard_D4s_v5
     type: Azure
   release:
     image: ""
@@ -166,7 +166,7 @@ spec:
         diskStorageAccountType: Premium_LRS
         sizeGiB: 120
       subnetID: fakeSubnetID
-      vmSize: Standard_D4s_v3
+      vmSize: Standard_D4s_v5
     type: Azure
   release:
     image: ""
@@ -198,7 +198,7 @@ spec:
         diskStorageAccountType: Premium_LRS
         sizeGiB: 120
       subnetID: fakeSubnetID
-      vmSize: Standard_D4s_v3
+      vmSize: Standard_D4s_v5
     type: Azure
   release:
     image: ""

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_disabled_capabilities.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_disabled_capabilities.yaml
@@ -168,7 +168,7 @@ spec:
         diskStorageAccountType: Premium_LRS
         sizeGiB: 120
       subnetID: fakeSubnetID
-      vmSize: Standard_D4s_v3
+      vmSize: Standard_D4s_v5
     type: Azure
   release:
     image: ""

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_image_generation_Gen1.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_image_generation_Gen1.yaml
@@ -133,7 +133,7 @@ spec:
         diskStorageAccountType: Premium_LRS
         sizeGiB: 120
       subnetID: fakeSubnetID
-      vmSize: Standard_D4s_v3
+      vmSize: Standard_D4s_v5
     type: Azure
   release:
     image: ""

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_image_generation_Gen2.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_image_generation_Gen2.yaml
@@ -133,7 +133,7 @@ spec:
         diskStorageAccountType: Premium_LRS
         sizeGiB: 120
       subnetID: fakeSubnetID
-      vmSize: Standard_D4s_v3
+      vmSize: Standard_D4s_v5
     type: Azure
   release:
     image: ""

--- a/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_marketplace_flags_and_image_generation_Gen1.yaml
+++ b/cmd/cluster/azure/testdata/zz_fixture_TestCreateCluster_with_marketplace_flags_and_image_generation_Gen1.yaml
@@ -138,7 +138,7 @@ spec:
         diskStorageAccountType: Premium_LRS
         sizeGiB: 120
       subnetID: fakeSubnetID
-      vmSize: Standard_D4s_v3
+      vmSize: Standard_D4s_v5
     type: Azure
   release:
     image: ""

--- a/cmd/nodepool/azure/create.go
+++ b/cmd/nodepool/azure/create.go
@@ -218,7 +218,7 @@ func (o *CompletedAzurePlatformCreateOptions) NodePoolPlatform(nodePool *hyperv1
 		// Aligning with Azure IPI instance type defaults
 		switch nodePool.Spec.Arch {
 		case hyperv1.ArchitectureAMD64:
-			instanceType = "Standard_D4s_v3"
+			instanceType = "Standard_D4s_v5"
 		case hyperv1.ArchitectureARM64:
 			instanceType = "Standard_D4ps_v5"
 		}

--- a/cmd/nodepool/azure/create_test.go
+++ b/cmd/nodepool/azure/create_test.go
@@ -19,7 +19,7 @@ const (
 	testMarketplaceOffer     = "aro4"
 	testMarketplaceSKU       = "aro_414"
 	testMarketplaceVersion   = "414.1.20240101"
-	testInstanceType         = "Standard_D4s_v3"
+	testInstanceType         = "Standard_D4s_v5"
 	testDiskStorageType      = "Premium_LRS"
 )
 

--- a/hypershift-operator/controllers/nodepool/azure_test.go
+++ b/hypershift-operator/controllers/nodepool/azure_test.go
@@ -552,7 +552,7 @@ func TestAzureMachineTemplate(t *testing.T) {
 								ImageID: ptr.To("test-image-id"),
 							},
 							SubnetID: "/subscriptions/sub-123/resourceGroups/rg-test/providers/Microsoft.Network/virtualNetworks/vnet-test/subnets/subnet-worker",
-							VMSize:   "Standard_D4s_v3",
+							VMSize:   "Standard_D4s_v5",
 							OSDisk: hyperv1.AzureNodePoolOSDisk{
 								SizeGiB:                120,
 								DiskStorageAccountType: "Premium_LRS",
@@ -567,7 +567,7 @@ func TestAzureMachineTemplate(t *testing.T) {
 			expectedTemplateName:   "azure-machine-template-test",
 			expectedErr:            false,
 			validateTemplateSpec:   true,
-			expectedVMSize:         "Standard_D4s_v3",
+			expectedVMSize:         "Standard_D4s_v5",
 			expectedSubnetName:     "subnet-worker",
 			expectedImageID:        ptr.To("test-image-id"),
 			expectedDiskSizeGB:     ptr.To[int32](120),

--- a/test/e2e/azure_scheduler_test.go
+++ b/test/e2e/azure_scheduler_test.go
@@ -27,7 +27,7 @@ import (
 //   - the HypershiftOperator running with size tagging enabled.
 //   - the HostedCluster is running on Azure.
 //   - the HostedCluster has a NodePool with 2 replicas.
-//   - the NodePool is using Standard_D4s_v3 VMs.
+//   - the NodePool is using Standard_D4s_v5 VMs.
 func TestAzureScheduler(t *testing.T) {
 	t.Parallel()
 

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -2002,7 +2002,7 @@ func TestOnCreateAPIUX(t *testing.T) {
 						mutateInput: func(np *hyperv1.NodePool) {
 							np.Spec.Platform.Type = hyperv1.AzurePlatform
 							np.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
-								VMSize: "Standard_D4s_v3",
+								VMSize: "Standard_D4s_v5",
 								Image: hyperv1.AzureVMImage{
 									Type: hyperv1.AzureMarketplace,
 									AzureMarketplace: &hyperv1.AzureMarketplaceImage{
@@ -2026,7 +2026,7 @@ func TestOnCreateAPIUX(t *testing.T) {
 						mutateInput: func(np *hyperv1.NodePool) {
 							np.Spec.Platform.Type = hyperv1.AzurePlatform
 							np.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
-								VMSize: "Standard_D4s_v3",
+								VMSize: "Standard_D4s_v5",
 								Image: hyperv1.AzureVMImage{
 									Type: hyperv1.AzureMarketplace,
 									AzureMarketplace: &hyperv1.AzureMarketplaceImage{
@@ -2049,7 +2049,7 @@ func TestOnCreateAPIUX(t *testing.T) {
 						mutateInput: func(np *hyperv1.NodePool) {
 							np.Spec.Platform.Type = hyperv1.AzurePlatform
 							np.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
-								VMSize: "Standard_D4s_v3",
+								VMSize: "Standard_D4s_v5",
 								Image: hyperv1.AzureVMImage{
 									Type: hyperv1.AzureMarketplace,
 									AzureMarketplace: &hyperv1.AzureMarketplaceImage{
@@ -2069,7 +2069,7 @@ func TestOnCreateAPIUX(t *testing.T) {
 						mutateInput: func(np *hyperv1.NodePool) {
 							np.Spec.Platform.Type = hyperv1.AzurePlatform
 							np.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
-								VMSize: "Standard_D4s_v3",
+								VMSize: "Standard_D4s_v5",
 								Image: hyperv1.AzureVMImage{
 									Type: hyperv1.AzureMarketplace,
 									// AzureMarketplace can be nil or empty - will be defaulted by the controller
@@ -2088,7 +2088,7 @@ func TestOnCreateAPIUX(t *testing.T) {
 						mutateInput: func(np *hyperv1.NodePool) {
 							np.Spec.Platform.Type = hyperv1.AzurePlatform
 							np.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
-								VMSize: "Standard_D4s_v3",
+								VMSize: "Standard_D4s_v5",
 								Image: hyperv1.AzureVMImage{
 									Type: hyperv1.AzureMarketplace,
 									AzureMarketplace: &hyperv1.AzureMarketplaceImage{
@@ -2109,7 +2109,7 @@ func TestOnCreateAPIUX(t *testing.T) {
 						mutateInput: func(np *hyperv1.NodePool) {
 							np.Spec.Platform.Type = hyperv1.AzurePlatform
 							np.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
-								VMSize: "Standard_D4s_v3",
+								VMSize: "Standard_D4s_v5",
 								Image: hyperv1.AzureVMImage{
 									Type: hyperv1.AzureMarketplace,
 									AzureMarketplace: &hyperv1.AzureMarketplaceImage{
@@ -2129,7 +2129,7 @@ func TestOnCreateAPIUX(t *testing.T) {
 						mutateInput: func(np *hyperv1.NodePool) {
 							np.Spec.Platform.Type = hyperv1.AzurePlatform
 							np.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
-								VMSize: "Standard_D4s_v3",
+								VMSize: "Standard_D4s_v5",
 								Image: hyperv1.AzureVMImage{
 									Type: hyperv1.AzureMarketplace,
 									AzureMarketplace: &hyperv1.AzureMarketplaceImage{

--- a/test/e2e/nodepool_rolling_upgrade_test.go
+++ b/test/e2e/nodepool_rolling_upgrade_test.go
@@ -73,7 +73,7 @@ func (k *RollingUpgradeTest) Run(t *testing.T, nodePool hyperv1.NodePool, nodes 
 	case hyperv1.AWSPlatform:
 		instanceType = "m5.xlarge"
 	case hyperv1.AzurePlatform:
-		vmSize = "Standard_D4s_v3"
+		vmSize = "Standard_D4s_v5"
 	}
 	// change instance type to trigger a rolling upgrade
 	err := e2eutil.UpdateObject(t, k.ctx, k.mgmtClient, &nodePool, func(obj *hyperv1.NodePool) {

--- a/test/e2e/v2/tests/api_ux_validation_test.go
+++ b/test/e2e/v2/tests/api_ux_validation_test.go
@@ -1465,7 +1465,7 @@ var _ = Describe("API UX Validation", Label("API"), func() {
 				err := testNodePoolCreation(ctx, mgmtClient, "nodepool-base.yaml", func(np *hyperv1.NodePool) {
 					np.Spec.Platform.Type = hyperv1.AzurePlatform
 					np.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
-						VMSize: "Standard_D4s_v3",
+						VMSize: "Standard_D4s_v5",
 						Image: hyperv1.AzureVMImage{
 							Type: hyperv1.AzureMarketplace,
 							AzureMarketplace: &hyperv1.AzureMarketplaceImage{
@@ -1489,7 +1489,7 @@ var _ = Describe("API UX Validation", Label("API"), func() {
 				err := testNodePoolCreation(ctx, mgmtClient, "nodepool-base.yaml", func(np *hyperv1.NodePool) {
 					np.Spec.Platform.Type = hyperv1.AzurePlatform
 					np.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
-						VMSize: "Standard_D4s_v3",
+						VMSize: "Standard_D4s_v5",
 						Image: hyperv1.AzureVMImage{
 							Type: hyperv1.AzureMarketplace,
 							AzureMarketplace: &hyperv1.AzureMarketplaceImage{
@@ -1512,7 +1512,7 @@ var _ = Describe("API UX Validation", Label("API"), func() {
 				err := testNodePoolCreation(ctx, mgmtClient, "nodepool-base.yaml", func(np *hyperv1.NodePool) {
 					np.Spec.Platform.Type = hyperv1.AzurePlatform
 					np.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
-						VMSize: "Standard_D4s_v3",
+						VMSize: "Standard_D4s_v5",
 						Image: hyperv1.AzureVMImage{
 							Type: hyperv1.AzureMarketplace,
 							AzureMarketplace: &hyperv1.AzureMarketplaceImage{
@@ -1532,7 +1532,7 @@ var _ = Describe("API UX Validation", Label("API"), func() {
 				err := testNodePoolCreation(ctx, mgmtClient, "nodepool-base.yaml", func(np *hyperv1.NodePool) {
 					np.Spec.Platform.Type = hyperv1.AzurePlatform
 					np.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
-						VMSize: "Standard_D4s_v3",
+						VMSize: "Standard_D4s_v5",
 						Image: hyperv1.AzureVMImage{
 							Type:             hyperv1.AzureMarketplace,
 							AzureMarketplace: nil, // nil signals the controller to populate marketplace details from release payload
@@ -1550,7 +1550,7 @@ var _ = Describe("API UX Validation", Label("API"), func() {
 				err := testNodePoolCreation(ctx, mgmtClient, "nodepool-base.yaml", func(np *hyperv1.NodePool) {
 					np.Spec.Platform.Type = hyperv1.AzurePlatform
 					np.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
-						VMSize: "Standard_D4s_v3",
+						VMSize: "Standard_D4s_v5",
 						Image: hyperv1.AzureVMImage{
 							Type: hyperv1.AzureMarketplace,
 							AzureMarketplace: &hyperv1.AzureMarketplaceImage{
@@ -1572,7 +1572,7 @@ var _ = Describe("API UX Validation", Label("API"), func() {
 				err := testNodePoolCreation(ctx, mgmtClient, "nodepool-base.yaml", func(np *hyperv1.NodePool) {
 					np.Spec.Platform.Type = hyperv1.AzurePlatform
 					np.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
-						VMSize: "Standard_D4s_v3",
+						VMSize: "Standard_D4s_v5",
 						Image: hyperv1.AzureVMImage{
 							Type: hyperv1.AzureMarketplace,
 							AzureMarketplace: &hyperv1.AzureMarketplaceImage{
@@ -1593,7 +1593,7 @@ var _ = Describe("API UX Validation", Label("API"), func() {
 				err := testNodePoolCreation(ctx, mgmtClient, "nodepool-base.yaml", func(np *hyperv1.NodePool) {
 					np.Spec.Platform.Type = hyperv1.AzurePlatform
 					np.Spec.Platform.Azure = &hyperv1.AzureNodePoolPlatform{
-						VMSize: "Standard_D4s_v3",
+						VMSize: "Standard_D4s_v5",
 						Image: hyperv1.AzureVMImage{
 							Type: hyperv1.AzureMarketplace,
 							AzureMarketplace: &hyperv1.AzureMarketplaceImage{


### PR DESCRIPTION
## What this PR does / why we need it:

This PR updates the default Azure VM size for AMD64 architecture from `Standard_D4s_v3` to `Standard_D4s_v5`. The v5 series provides better performance and is the current generation of Azure VMs, aligning with modern Azure best practices.

The change affects:
- Default VM size for Azure cluster creation (`cmd/cluster/azure/create.go:382`)
- Default VM size for Azure nodepool creation (`cmd/nodepool/azure/create.go:221`)
- All related test fixtures and test cases

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-2050](https://issues.redhat.com//browse/CNTRLPLANE-2050)

## Special notes for your reviewer:

- This change updates test fixtures to reflect the new default VM size
- The v3 to v5 migration maintains the same vCPU/memory configuration (4 vCPUs, 16 GB RAM)
- ARM64 architecture already uses v5 series (`Standard_D4ps_v5`), so this aligns AMD64 with the same VM generation

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.