### PR TITLE
OCPBUGS-63717: Fix flaky EnsureGlobalPullSecret test race condition

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -2065,7 +2065,7 @@ func waitForDaemonSetsReady(t *testing.T, ctx context.Context, guestClient crcli
 		allowPartialNodes := dsManifest.AllowPartialNodes
 
 		if allowPartialNodes {
-			t.Logf("Waiting for %s DaemonSet to be ready with ≤%d available nodes", dsName, nodeCount)
+			t.Logf("Waiting for %s DaemonSet to be ready (using DesiredNumberScheduled)", dsName)
 		} else {
 			t.Logf("Waiting for %s DaemonSet to be ready with %d nodes", dsName, nodeCount)
 		}
@@ -2086,19 +2086,21 @@ func waitForDaemonSetsReady(t *testing.T, ctx context.Context, guestClient crcli
 			actualReady := daemonSet.Status.NumberReady
 
 			if allowPartialNodes {
-				// Check UpdatedNumberScheduled for partial nodes mode
-				if daemonSet.Status.UpdatedNumberScheduled > nodeCount {
-					t.Logf("DaemonSet %s update in flight: %d/%d pods updated (based on available nodes)", dsName, daemonSet.Status.UpdatedNumberScheduled, nodeCount)
+				// Use the DaemonSet's own DesiredNumberScheduled which reflects current cluster state.
+				// This avoids race conditions where nodeCount was captured before additional nodes became available,
+				// which would cause the check to fail indefinitely with "X/Y pods ready" where X > Y.
+				desiredCount := daemonSet.Status.DesiredNumberScheduled
+
+				// For partial nodes mode, we wait for the rollout to complete but don't require
+				// all pods to be ready. This allows for nodes that may be temporarily unavailable.
+				if daemonSet.Status.UpdatedNumberScheduled != desiredCount {
+					t.Logf("DaemonSet %s update in flight: %d/%d pods updated",
+						dsName, daemonSet.Status.UpdatedNumberScheduled, desiredCount)
 					return false, nil
 				}
 
-				// Allow NumberReady to be <= nodeCount
-				if actualReady > nodeCount {
-					t.Logf("DaemonSet %s not ready: %d/%d pods ready (based on available nodes)", dsName, actualReady, nodeCount)
-					return false, nil
-				}
-
-				t.Logf("DaemonSet %s ready: %d/%d pods (based on available nodes)", dsName, actualReady, nodeCount)
+				// Rollout complete - consider ready (partial readiness is acceptable)
+				t.Logf("DaemonSet %s ready: %d/%d pods ready, rollout complete", dsName, actualReady, desiredCount)
 				return true, nil
 			} else {
 				// Exact match for normal mode


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes a race condition in the `EnsureGlobalPullSecret` E2E test that caused flaky failures.

The `waitForDaemonSetsReady` function in `AllowPartialNodes` mode was comparing against a stale `nodeCount` value captured before node availability changed. When additional nodes became available during test execution, the DaemonSet would have more pods (e.g., 2) than expected (e.g., 1), causing the polling loop to fail indefinitely with messages like:
```
DaemonSet global-pull-secret-syncer not ready: 2/1 pods ready (based on available nodes)
```

This timeout would eventually trigger a Gomega assertion failure, and since the Gomega instance was created with the parent test's `*testing.T` rather than the subtest's, it caused a panic:
```
testing.go:1679: test executed panic(nil) or runtime.Goexit: subtest may have called FailNow on a parent test
```

The fix uses the DaemonSet's own `DesiredNumberScheduled` field which always reflects the current cluster state, eliminating the race condition entirely.

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/OCPBUGS-63717

## Special notes for your reviewer:

The change is minimal and focused - only modifying the `AllowPartialNodes` mode in `waitForDaemonSetsReady` to use `DesiredNumberScheduled` instead of a potentially stale `nodeCount`.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve OCPBUGS-63717`