### PR TITLE
OCPBUGS-66067: fix(kas): apply LoadBalancerSourceRanges only for LoadBalancer service type

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -626,7 +626,6 @@ func TestReconcileAPIServerService(t *testing.T) {
 						TargetPort: intstr.FromString(kasPort),
 					},
 				},
-				LoadBalancerSourceRanges: allowCIDRString,
 				Selector: map[string]string{
 					"app": "kube-apiserver",
 					"hypershift.openshift.io/control-plane-component": "kube-apiserver",
@@ -646,12 +645,13 @@ func TestReconcileAPIServerService(t *testing.T) {
 			s.Annotations["service.beta.kubernetes.io/aws-load-balancer-internal"] = "true"
 
 			s.Labels = nil
-
-			s.Spec.LoadBalancerSourceRanges = nil
 		})...)
 	}
 	withCrossZoneAnnotation := func(svc *corev1.Service) {
 		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"] = "true"
+	}
+	withLoadBalancerSourceRanges := func(svc *corev1.Service) {
+		svc.Spec.LoadBalancerSourceRanges = allowCIDRString
 	}
 	kasExternalPublicRoute := routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
@@ -738,7 +738,7 @@ func TestReconcileAPIServerService(t *testing.T) {
 			},
 
 			expectedServices: []corev1.Service{
-				kasPublicService(),
+				kasPublicService(withLoadBalancerSourceRanges),
 			},
 		},
 		{
@@ -752,7 +752,7 @@ func TestReconcileAPIServerService(t *testing.T) {
 			},
 
 			expectedServices: []corev1.Service{
-				kasPublicService(withCrossZoneAnnotation),
+				kasPublicService(withCrossZoneAnnotation, withLoadBalancerSourceRanges),
 				kasPrivateService(withCrossZoneAnnotation),
 			},
 		},

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -71,6 +71,10 @@ func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingSt
 			if strategy.LoadBalancer != nil && strategy.LoadBalancer.Hostname != "" {
 				svc.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = strategy.LoadBalancer.Hostname
 			}
+			if !azureutil.IsAroHCP() {
+				svc.Spec.LoadBalancerSourceRanges = apiAllowedCIDRBlocks
+			}
+
 			if isPrivate {
 				// AWS Private link requires endpoint and service endpoints to exist in the same underlying zone.
 				// To ensure that requirement is satisfied in Regions with more than 3 zones, managed services create subnets in all of them.
@@ -95,9 +99,6 @@ func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingSt
 	}
 	svc.Spec.Ports[0] = portSpec
 
-	if !azureutil.IsAroHCP() {
-		svc.Spec.LoadBalancerSourceRanges = apiAllowedCIDRBlocks
-	}
 	return nil
 }
 


### PR DESCRIPTION
## What this PR does / why we need it:

when `hc.spec.allowedCIDRBlocks` is set, only set `LoadBalancerSourceRanges` filed on KAS service  when service is of type LoadBalancer.

## Which issue(s) this PR fixes:

Fixes: https://issues.redhat.com/browse/OCPBUGS-66067

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.