### PR TITLE
CNTRLPLANE-2082: feat(ci): add Azure AKS credential rotation Taskfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ __pycache__/
 .venv/
 venv/
 *.egg
+
+# Azure credential rotation temp files that get generated under hack/ci/e2e-aks/
+creds-tmp/
+managed-identities.json

--- a/hack/ci/e2e-aks/README.md
+++ b/hack/ci/e2e-aks/README.md
@@ -1,0 +1,182 @@
+# Azure AKS E2E Credential Rotation
+
+This directory contains a Taskfile for rotating Azure managed identity credentials used in AKS E2E testing.
+
+## Prerequisites
+
+- [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) (`az`) - authenticated with appropriate permissions
+- [Task](https://taskfile.dev/installation/) - task runner
+- `jq` - JSON processor
+- `openssl` - for certificate conversion
+
+## Azure Authentication
+
+If you have an Azure credentials file (`credentials.json`):
+
+```json
+{
+  "subscriptionId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "tenantId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "clientId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "clientSecret": "<SECRET>"
+}
+```
+
+Sign in using:
+
+```bash
+az login --service-principal \
+  -u $(jq -r .clientId credentials.json) \
+  -p $(jq -r .clientSecret credentials.json) \
+  --tenant $(jq -r .tenantId credentials.json)
+```
+
+## Configuration
+
+Create a `managed-identities.json` file with your managed identity configuration:
+
+```json
+{
+  "managedIdentitiesKeyVault": {
+    "name": "your-keyvault-name"
+  },
+  "firstComponentName": {
+    "clientID": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "credentialsSecretName": "secret-name-in-vault",
+    "certificateName": "certificate-display-name"
+  },
+  "secondComponentName": {
+    "clientID": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "credentialsSecretName": "secret-name-in-vault",
+    "certificateName": "certificate-display-name"
+  },
+  ...
+}
+```
+
+Each component (other than `managedIdentitiesKeyVault`) represents a managed identity whose credentials will be rotated.
+
+### Field Relationships
+
+For each component, the fields map to Azure resources as follows:
+
+| Field | Description | Azure CLI Command |
+|-------|-------------|-------------------|
+| `clientID` | App Registration ID | `az ad app credential list --id <clientID> --cert` |
+| `credentialsSecretName` | Key Vault secret name | `az keyvault secret show --vault-name <vault> --name <credentialsSecretName>` |
+| `certificateName` | Display name for the certificate | Shown in `displayName` field of credential list |
+
+**Example:** For a component with:
+```json
+{
+  "clientID": "cabb490b-b6cc-4d6c-ae25-4205f0b1c6af",
+  "credentialsSecretName": "ciro-miv3-aks-e2e",
+  "certificateName": "ciro-aks-e2e"
+}
+```
+
+View the app's registered certificates:
+```bash
+az ad app credential list --id cabb490b-b6cc-4d6c-ae25-4205f0b1c6af --cert
+```
+
+Output shows the certificate with `displayName: "ciro-aks-e2e"`:
+```json
+[
+  {
+    "displayName": "ciro-aks-e2e",
+    "endDateTime": "2026-11-28T17:47:08Z",
+    "startDateTime": "2025-11-28T17:47:08Z",
+    "type": "AsymmetricX509Cert"
+  }
+]
+```
+
+View the corresponding vault secret:
+```bash
+az keyvault secret show --vault-name aks-e2e --name ciro-miv3-aks-e2e --query "value" -o table
+```
+
+The vault secret contains the JSON credentials (with `client_secret` being the base64-encoded PKCS12 certificate) that applications use to authenticate as this managed identity.
+
+## Usage
+
+### Workflow
+
+The typical credential rotation workflow is:
+
+1. **Generate credentials locally** (does NOT modify vault):
+   ```bash
+   task rotate-all
+   ```
+   This creates new certificates for all components and saves them to `./creds-tmp/`.
+
+2. **Store credentials to vault**:
+   ```bash
+   task store-all
+   ```
+   Uploads the generated credentials to Azure Key Vault.
+
+3. **Verify credentials**:
+   ```bash
+   task verify-all
+   ```
+   Confirms that vault contents match local files.
+
+4. **Cleanup local files**:
+   ```bash
+   task cleanup-creds
+   ```
+   Removes the temporary credential files from `./creds-tmp/`.
+
+### Available Tasks
+
+| Task | Description |
+|------|-------------|
+| `rotate-all` | Generate all credentials locally (does NOT store to vault) |
+| `store-all` | Store all local credentials to vault |
+| `verify-all` | Verify all vault credentials match local files |
+| `cleanup-creds` | Remove all local credential files |
+
+Run `task --list` to see all available tasks.
+
+## Output Format
+
+Generated credentials are stored in JSON format compatible with Azure SDK:
+
+```json
+{
+  "authentication_endpoint": "https://login.microsoftonline.com/",
+  "client_id": "...",
+  "client_secret": "<base64-encoded-pkcs12>",
+  "tenant_id": "...",
+  "not_before": "2025-01-01T00:00:00Z",
+  "not_after": "2026-01-01T00:00:00Z"
+}
+```
+
+## Troubleshooting
+
+### PKCS12 Compatibility Error
+
+If the operator fails with:
+```
+pkcs12: unknown digest algorithm: 2.16.840.1.101.3.4.2.1
+```
+
+This means the PKCS12 certificate was created with modern algorithms (SHA-256) that Go's `crypto/pkcs12` library doesn't support. The Taskfile uses `-legacy` flag to generate compatible certificates, but if that doesn't work on your system, edit the `convert-pem-to-json` task to use explicit legacy algorithms:
+
+```bash
+# Replace this:
+openssl pkcs12 -export -legacy -in "$PEM_FILE" ...
+
+# With this:
+openssl pkcs12 -export -certpbe PBE-SHA1-3DES -keypbe PBE-SHA1-3DES -macalg sha1 -in "$PEM_FILE" ...
+```
+
+## Security Notes
+
+- Credentials are temporarily stored in `./creds-tmp/` during rotation
+- The `creds-tmp/` directory is in `.gitignore` to prevent accidental commits
+- Always run `task cleanup-creds` after successful rotation
+- Ensure you have appropriate Azure RBAC permissions before rotating credentials

--- a/hack/ci/e2e-aks/Taskfile.yml
+++ b/hack/ci/e2e-aks/Taskfile.yml
@@ -1,0 +1,260 @@
+version: "3"
+
+vars:
+  # The hardcoded JSON configuration
+  SECRETS_JSON:
+    sh: cat managed-identities.json
+  # Global extraction of the Vault Name (used by all tasks)
+  GLOBAL_KV_NAME:
+    sh: echo '{{.SECRETS_JSON}}' | jq -r '.managedIdentitiesKeyVault.name'
+
+tasks:
+  # ============================================
+  # Orchestrator Tasks
+  # ============================================
+
+  default:
+    desc: "Show available tasks"
+    cmds:
+      - task --list
+
+  rotate-all:
+    desc: "Generate all credentials locally (does NOT store to vault)"
+    vars:
+      COMPONENT_KEYS:
+        sh: echo '{{.SECRETS_JSON}}' | jq -r 'del(.managedIdentitiesKeyVault) | keys[]'
+    cmds:
+      - echo "Target Vault {{.GLOBAL_KV_NAME}}"
+      - echo "Generating credentials for all components..."
+      - for:
+          var: COMPONENT_KEYS
+        task: extract-and-generate
+        vars:
+          COMPONENT: "{{.ITEM}}"
+      - echo ""
+      - echo "All credentials generated. Files saved in ./creds-tmp/"
+      - echo "Next step  Run 'task store-all' to store to vault"
+
+  store-all:
+    desc: "Store all local credentials to vault"
+    vars:
+      COMPONENT_KEYS:
+        sh: echo '{{.SECRETS_JSON}}' | jq -r 'del(.managedIdentitiesKeyVault) | keys[]'
+    cmds:
+      - echo "Target Vault  {{.GLOBAL_KV_NAME}}"
+      - echo "Storing all credentials to vault..."
+      - for:
+          var: COMPONENT_KEYS
+        task: extract-and-store
+        vars:
+          COMPONENT: "{{.ITEM}}"
+          KV_NAME: "{{.GLOBAL_KV_NAME}}"
+      - echo ""
+      - echo "All credentials stored in vault."
+      - echo "Next step  Run 'task verify-all' to verify, then 'task cleanup-creds' to remove local files"
+
+  verify-all:
+    desc: "Verify all vault credentials match local files"
+    silent: true
+    vars:
+      COMPONENT_KEYS:
+        sh: echo '{{.SECRETS_JSON}}' | jq -r 'del(.managedIdentitiesKeyVault) | keys[]'
+    cmds:
+      - echo "Target Vault  {{.GLOBAL_KV_NAME}}"
+      - echo "Verifying all credentials..."
+      - for:
+          var: COMPONENT_KEYS
+        task: extract-and-verify
+        vars:
+          COMPONENT: "{{.ITEM}}"
+          KV_NAME: "{{.GLOBAL_KV_NAME}}"
+      - echo ""
+      - echo "All credentials verified successfully."
+      - echo "You can now safely run 'task cleanup-creds' to remove local files"
+
+  # ============================================
+  # Middle-Layer Tasks (variable extraction)
+  # ============================================
+
+  extract-and-generate:
+    desc: "Middle-layer: Extract variables and generate credentials"
+    internal: true
+    requires:
+      vars: [COMPONENT]
+    vars:
+      CLIENT_ID:
+        sh: echo '{{.SECRETS_JSON}}' | jq -r '.{{.COMPONENT}}.clientID'
+      SECRET_NAME:
+        sh: echo '{{.SECRETS_JSON}}' | jq -r '.{{.COMPONENT}}.credentialsSecretName'
+      CERT_NAME:
+        sh: echo '{{.SECRETS_JSON}}' | jq -r '.{{.COMPONENT}}.certificateName'
+    cmds:
+      - task: generate-creds
+        vars:
+          APP_ID: "{{.CLIENT_ID}}"
+          SECRET_NAME: "{{.SECRET_NAME}}"
+          CERT_NAME: "{{.CERT_NAME}}"
+
+  extract-and-store:
+    desc: "Middle-layer: Extract variables and store to vault"
+    internal: true
+    requires:
+      vars: [COMPONENT, KV_NAME]
+    vars:
+      SECRET_NAME:
+        sh: echo '{{.SECRETS_JSON}}' | jq -r '.{{.COMPONENT}}.credentialsSecretName'
+    cmds:
+      - task: store-to-vault
+        vars:
+          SECRET_NAME: "{{.SECRET_NAME}}"
+          KV_NAME: "{{.KV_NAME}}"
+
+  extract-and-verify:
+    desc: "Middle-layer: Extract variables and verify credentials"
+    internal: true
+    silent: true
+    requires:
+      vars: [COMPONENT, KV_NAME]
+    vars:
+      SECRET_NAME:
+        sh: echo '{{.SECRETS_JSON}}' | jq -r '.{{.COMPONENT}}.credentialsSecretName'
+    cmds:
+      - task: verify-creds
+        vars:
+          SECRET_NAME: "{{.SECRET_NAME}}"
+          KV_NAME: "{{.KV_NAME}}"
+
+  # ============================================
+  # Worker Tasks (actual Azure CLI operations)
+  # ============================================
+
+  reset-app-credential:
+    desc: "Reset app credential and save raw output"
+    requires:
+      vars: [APP_ID, SECRET_NAME, CERT_NAME]
+    cmds:
+      - mkdir -p ./creds-tmp
+      - echo "Resetting credential for {{.SECRET_NAME}} (App {{.APP_ID}})..."
+      - |
+        az ad app credential reset \
+          --id {{.APP_ID}} \
+          --create-cert \
+          --display-name "{{.CERT_NAME}}" \
+          -o json > ./creds-tmp/{{.SECRET_NAME}}.reset-output.json
+      - echo "Reset output saved to ./creds-tmp/{{.SECRET_NAME}}.reset-output.json"
+
+  convert-pem-to-json:
+    desc: "Convert PEM to JSON credentials format"
+    requires:
+      vars: [SECRET_NAME]
+    preconditions:
+      - sh: test -f ./creds-tmp/{{.SECRET_NAME}}.reset-output.json
+        msg: "Reset output not found. Run reset-app-credential first."
+    cmds:
+      - echo "Converting PEM to JSON for {{.SECRET_NAME}}..."
+      - |
+        # Extract values from reset output
+        PEM_FILE=$(jq -r '.fileWithCertAndPrivateKey' ./creds-tmp/{{.SECRET_NAME}}.reset-output.json)
+        TENANT_ID=$(jq -r '.tenant' ./creds-tmp/{{.SECRET_NAME}}.reset-output.json)
+        CLIENT_ID=$(jq -r '.appId' ./creds-tmp/{{.SECRET_NAME}}.reset-output.json)
+
+        # Convert PEM to PKCS12/PFX (with private key) and base64 encode
+        # Use -legacy because Go's crypto/pkcs12 only supports legacy algorithms (SHA1+3DES).
+        # OpenSSL 3.x defaults to modern algorithms (SHA256+AES) which cause:
+        #   "pkcs12: unknown digest algorithm: 2.16.840.1.101.3.4.2.1"
+        # If -legacy fails, use explicit flags instead:
+        #   openssl pkcs12 -export -certpbe PBE-SHA1-3DES -keypbe PBE-SHA1-3DES -macalg sha1 ...
+        CLIENT_SECRET=$(openssl pkcs12 -export -legacy -in "$PEM_FILE" -out /dev/stdout -passout pass: 2>/dev/null | base64 -w 0)
+
+        # Get certificate validity dates from the PEM
+        NOT_BEFORE=$(openssl x509 -in "$PEM_FILE" -noout -startdate | cut -d= -f2)
+        NOT_AFTER=$(openssl x509 -in "$PEM_FILE" -noout -enddate | cut -d= -f2)
+
+        # Convert dates to ISO 8601 UTC format (with Z suffix to match Key Vault format)
+        NOT_BEFORE_ISO=$(date -u -d "$NOT_BEFORE" +"%Y-%m-%dT%H:%M:%SZ")
+        NOT_AFTER_ISO=$(date -u -d "$NOT_AFTER" +"%Y-%m-%dT%H:%M:%SZ")
+
+        # Build the JSON credentials file
+        jq -n \
+          --arg auth_endpoint "https://login.microsoftonline.com/" \
+          --arg client_id "$CLIENT_ID" \
+          --arg client_secret "$CLIENT_SECRET" \
+          --arg tenant_id "$TENANT_ID" \
+          --arg not_before "$NOT_BEFORE_ISO" \
+          --arg not_after "$NOT_AFTER_ISO" \
+          '{
+            authentication_endpoint: $auth_endpoint,
+            client_id: $client_id,
+            client_secret: $client_secret,
+            tenant_id: $tenant_id,
+            not_before: $not_before,
+            not_after: $not_after
+          }' > ./creds-tmp/{{.SECRET_NAME}}.json
+      - echo "JSON saved to ./creds-tmp/{{.SECRET_NAME}}.json"
+
+  generate-creds:
+    desc: "Generate credentials (reset + convert)"
+    requires:
+      vars: [APP_ID, SECRET_NAME, CERT_NAME]
+    cmds:
+      - task: reset-app-credential
+        vars:
+          APP_ID: "{{.APP_ID}}"
+          SECRET_NAME: "{{.SECRET_NAME}}"
+          CERT_NAME: "{{.CERT_NAME}}"
+      - task: convert-pem-to-json
+        vars:
+          SECRET_NAME: "{{.SECRET_NAME}}"
+
+  store-to-vault:
+    desc: "Store local credentials to vault"
+    requires:
+      vars: [SECRET_NAME, KV_NAME]
+    preconditions:
+      - sh: test -f ./creds-tmp/{{.SECRET_NAME}}.json
+        msg: "Credentials file not found: ./creds-tmp/{{.SECRET_NAME}}.json. Run generate-creds first."
+    cmds:
+      - echo "Storing {{.SECRET_NAME}} to vault {{.KV_NAME}}..."
+      - |
+        az keyvault secret set \
+          --vault-name {{.KV_NAME}} \
+          --name {{.SECRET_NAME}} \
+          --file ./creds-tmp/{{.SECRET_NAME}}.json > /dev/null
+      - echo "{{.SECRET_NAME}} stored in vault {{.KV_NAME}}"
+
+  verify-creds:
+    desc: "Verify vault contents match local file"
+    silent: true
+    requires:
+      vars: [SECRET_NAME, KV_NAME]
+    preconditions:
+      - sh: test -f ./creds-tmp/{{.SECRET_NAME}}.json
+        msg: "Local credentials file not found: ./creds-tmp/{{.SECRET_NAME}}.json"
+    cmds:
+      - echo "Verifying {{.SECRET_NAME}}..."
+      - |
+        vault_value=$(az keyvault secret show \
+          --vault-name {{.KV_NAME}} \
+          --name {{.SECRET_NAME}} \
+          --query value -o tsv)
+        local_value=$(cat ./creds-tmp/{{.SECRET_NAME}}.json)
+        if [ "$vault_value" = "$local_value" ]; then
+          echo "✅ PASS  {{.SECRET_NAME}} matches"
+        else
+          echo "❌ FAIL  {{.SECRET_NAME}} mismatch!"
+          exit 1
+        fi
+
+  cleanup-creds:
+    desc: "Remove all local credential files"
+    cmds:
+      - rm -rf ./creds-tmp
+      - echo "Local credentials cleaned up"
+
+  cleanup-component-creds:
+    desc: "Remove specific component's credential file"
+    requires:
+      vars: [SECRET_NAME]
+    cmds:
+      - rm -f ./creds-tmp/{{.SECRET_NAME}}.json
+      - echo "Removed ./creds-tmp/{{.SECRET_NAME}}.json"


### PR DESCRIPTION
## What this PR does / why we need it:
Add Taskfile and documentation for rotating Azure managed identity credentials used in AKS E2E testing. Credentials are generated locally, stored to Key Vault, and verified before cleanup.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-2082](https://issues.redhat.com//browse/CNTRLPLANE-2082)

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.