### PR TITLE
NO-JIRA: fix(rbac): add missing CAPI manager ClusterRole permissions for v1.10

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -1218,7 +1218,7 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 			{
 				APIGroups: []string{"ipam.cluster.x-k8s.io"},
 				Resources: []string{"ipaddresses", "ipaddresses/status"},
-				Verbs:     []string{"create", "delete", "get", "list", "update", "watch"},
+				Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
 			},
 			// This allows hypershift operator to grant RBAC permissions for ORC to the capi-provider.
 			{

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2841,7 +2841,17 @@ func reconcileCAPIManagerClusterRole(role *rbacv1.ClusterRole) error {
 		{
 			APIGroups: []string{"apiextensions.k8s.io"},
 			Resources: []string{"customresourcedefinitions"},
-			Verbs:     []string{"get", "list", "watch"},
+			Verbs:     []string{"get", "list", "watch", "patch", "update"},
+		},
+		{
+			APIGroups: []string{"ipam.cluster.x-k8s.io"},
+			Resources: []string{"ipaddresses", "ipaddressclaims"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+		},
+		{
+			APIGroups: []string{"cluster.x-k8s.io"},
+			Resources: []string{"*"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 		},
 	}
 	return nil


### PR DESCRIPTION
## What this PR does / why we need it:

The cluster-api manager ClusterRole was missing required permissions for the crdmigrator controller introduced in CAPI v1.10.0. This caused permission errors when the controller attempted to patch CRDs and manage IPAM resources.

The crdmigrator controller replaces the deprecated clusterctl upgrade CRD storage version migration and requires additional RBAC permissions:
- patch and update verbs for CRDs (previously only get/list/watch)
- full CRUD permissions for ipam.cluster.x-k8s.io resources
- cluster-scoped permissions for cluster.x-k8s.io resources

This is a pre-existing bug that became visible after upgrading from CAPI v1.9.4 to v1.10.4 in commit 82af36570. The original ClusterRole implementation dates back to March 2021 (commit ed606fb50d) and affects all platforms (AWS, Azure, GCP, etc.), not just GCP.

Errors fixed:
- failed to patch CustomResourceDefinition: "cluster-api" cannot patch resource "customresourcedefinitions"
- failed to list IPAddress/IPAddressClaim: "cluster-api" cannot list resource "ipaddresses/ipaddressclaims" in API group "ipam.cluster.x-k8s.io"

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.