### PR TITLE
OCPBUGS-66205: [kubevirt] Make L3 migration labeling conditional

### DIFF
--- a/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go
@@ -25,18 +25,16 @@ import (
 	"kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 
-var (
-	LocalStorageVolumes = []string{
-		"private",
-		"public",
-		"sockets",
-		"virt-bin-share-dir",
-		"libvirt-runtime",
-		"ephemeral-disks",
-		"container-disks",
-		"hotplug-disks",
-	}
-)
+var LocalStorageVolumes = []string{
+	"private",
+	"public",
+	"sockets",
+	"virt-bin-share-dir",
+	"libvirt-runtime",
+	"ephemeral-disks",
+	"container-disks",
+	"hotplug-disks",
+}
 
 func defaultImage(nodePoolArch string, releaseImage *releaseinfo.ReleaseImage) (string, string, error) {
 	var archName string
@@ -169,11 +167,6 @@ func virtualMachineTemplateBase(nodePool *hyperv1.NodePool, bootImage BootImage)
 		Spec: kubevirtv1.VirtualMachineSpec{
 			RunStrategy: ptr.To(kubevirtv1.RunStrategyAlways),
 			Template: &kubevirtv1.VirtualMachineInstanceTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"kubevirt.io/allow-pod-bridge-network-live-migration": "",
-					},
-				},
 				Spec: kubevirtv1.VirtualMachineInstanceSpec{
 					Domain: kubevirtv1.DomainSpec{
 						Devices: kubevirtv1.Devices{
@@ -184,6 +177,12 @@ func virtualMachineTemplateBase(nodePool *hyperv1.NodePool, bootImage BootImage)
 				},
 			},
 		},
+	}
+
+	if shouldAttachDefaultNetwork(kvPlatform) {
+		template.Spec.Template.ObjectMeta.Annotations = map[string]string{
+			"kubevirt.io/allow-pod-bridge-network-live-migration": "",
+		}
 	}
 
 	if guaranteedResources {
@@ -289,7 +288,6 @@ func virtualMachineTemplateBase(nodePool *hyperv1.NodePool, bootImage BootImage)
 				hostDevices = append(hostDevices, kvHostDevice)
 				deviceCounter++
 			}
-
 		}
 		template.Spec.Template.Spec.Domain.Devices.HostDevices = hostDevices
 	}
@@ -344,6 +342,7 @@ func virtualMachineNetworks(kvPlatform *hyperv1.KubevirtNodePoolPlatform) []kube
 	}
 	return networks
 }
+
 func shouldAttachDefaultNetwork(kvPlatform *hyperv1.KubevirtNodePoolPlatform) bool {
 	return kvPlatform.AttachDefaultNetwork == nil || *kvPlatform.AttachDefaultNetwork
 }

--- a/hypershift-operator/controllers/nodepool/kubevirt/kubevirt_test.go
+++ b/hypershift-operator/controllers/nodepool/kubevirt/kubevirt_test.go
@@ -394,6 +394,10 @@ func TestKubevirtMachineTemplate(t *testing.T) {
 							memoryTmpltOpt("5Gi"),
 							cpuTmpltOpt(4),
 							storageTmpltOpt("32Gi"),
+							annotationsTmpltOpt(map[string]string{
+								// Skip the kubevirt.io/allow-pod-bridge-network-live-migration annotation
+								suppconfig.PodSafeToEvictLocalVolumesKey: strings.Join(LocalStorageVolumes, ","),
+							}),
 							interfacesTmpltOpt([]kubevirtv1.Interface{
 								{
 									Name: "iface1_ns1-nad1",
@@ -1344,6 +1348,7 @@ func interfacesTmpltOpt(interfaces []kubevirtv1.Interface) nodeTemplateOption {
 		template.Spec.Template.Spec.Domain.Devices.Interfaces = interfaces
 	}
 }
+
 func networksTmpltOpt(networks []kubevirtv1.Network) nodeTemplateOption {
 	return func(template *capikubevirt.VirtualMachineTemplateSpec) {
 		template.Spec.Template.Spec.Networks = networks
@@ -1426,7 +1431,6 @@ func generateNodeTemplate(options ...nodeTemplateOption) *capikubevirt.VirtualMa
 					},
 				},
 				Spec: kubevirtv1.VirtualMachineInstanceSpec{
-
 					Affinity: &corev1.Affinity{
 						PodAntiAffinity: &corev1.PodAntiAffinity{
 							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{


### PR DESCRIPTION
## What this PR does / why we need it:
When a kubevirt hosted cluster is created, then inconditionally the VMs get annotates with kubevirt.io/allow-pod-bridge-network-live-migration, this activates ovn-kubernetes capabilities to be able to live migration L3 topoogoies, do not configure ip address at virt-launcher pod and activatre DHCP, all this should not be activated if --attach-default-network is false.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://issues.redhat.com/browse/CNTRLPLANE-2117

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.