### PR TITLE
OCPBUGS-44436: fix(HostedClusterReconciler): check service nodeport address to avoid a panic

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3992,7 +3992,10 @@ func checkAdvertiseAddressOverlapping(hc *hyperv1.HostedCluster) field.ErrorList
 func validateNodePortVsServiceNetwork(hc *hyperv1.HostedCluster) field.ErrorList {
 	var errs field.ErrorList
 
-	ip := getNodePortIP(hc)
+	ip, err := getNodePortIP(hc)
+	if err != nil {
+		errs = append(errs, err)
+	}
 	if ip != nil {
 		// Validate that the nodeport IP is not within the ServiceNetwork CIDR.
 		for _, cidr := range hc.Spec.Networking.ServiceNetwork {
@@ -4758,13 +4761,16 @@ func (r *HostedClusterReconciler) reconcileSREMetricsConfig(ctx context.Context,
 	return nil
 }
 
-func getNodePortIP(hcluster *hyperv1.HostedCluster) net.IP {
-	for _, svc := range hcluster.Spec.Services {
+func getNodePortIP(hcluster *hyperv1.HostedCluster) (net.IP, *field.Error) {
+	for idx, svc := range hcluster.Spec.Services {
 		if svc.Service == hyperv1.APIServer && svc.Type == hyperv1.NodePort {
-			return net.ParseIP(svc.NodePort.Address)
+			if svc.NodePort == nil {
+				return nil, field.Required(field.NewPath(fmt.Sprintf("spec.Services[%v].NodePort", idx)), "Nodeport can not be empty")
+			}
+			return net.ParseIP(svc.NodePort.Address), nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 func ensureReferencedResourceAnnotation(ctx context.Context, client client.Client, hcName string, obj client.Object) error {


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:
getNodePortIP does not check whether .nodeport is set. If not set accessing Address field produces a panic.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [-] Relevant issues have been referenced.
- [-] This change includes docs. 
- [x] This change includes unit tests.