### PR TITLE
CNTRLPLANE-2123: feat: update latest supported version from 4.21 to 4.22

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -1652,7 +1652,7 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 				},
 			},
 			Data: map[string]string{
-				"supported-versions": "{\"versions\":[\"4.20\",\"4.19\",\"4.18\",\"4.17\",\"4.16\",\"4.15\",\"4.14\"]}",
+				"supported-versions": "{\"versions\":[\"4.21\",\"4.20\",\"4.19\",\"4.18\",\"4.17\",\"4.16\",\"4.15\",\"4.14\"]}",
 				"server-version":     "some-fake-server-version",
 			},
 		},

--- a/support/supportedversion/version.go
+++ b/support/supportedversion/version.go
@@ -33,7 +33,7 @@ const (
 // NOTE: The .0 (z release) should be ignored. It's only here to support
 // semver parsing.
 var (
-	LatestSupportedVersion      = semver.MustParse("4.21.0")
+	LatestSupportedVersion      = semver.MustParse("4.22.0")
 	MinSupportedVersion         = semver.MustParse("4.14.0")
 	IBMCloudMinSupportedVersion = semver.MustParse("4.14.0")
 )
@@ -48,6 +48,7 @@ var ocpVersionToKubeVersion = map[string]semver.Version{
 	"4.18.0": semver.MustParse("1.31.0"),
 	"4.19.0": semver.MustParse("1.32.0"),
 	"4.20.0": semver.MustParse("1.33.0"),
+	"4.21.0": semver.MustParse("1.34.0"),
 }
 
 func GetKubeVersionForSupportedVersion(supportedVersion semver.Version) (*semver.Version, error) {

--- a/support/supportedversion/version_test.go
+++ b/support/supportedversion/version_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestSupportedVersions(t *testing.T) {
 	g := NewGomegaWithT(t)
-	g.Expect(Supported()).To(Equal([]string{"4.21", "4.20", "4.19", "4.18", "4.17", "4.16", "4.15", "4.14"}))
+	g.Expect(Supported()).To(Equal([]string{"4.22", "4.21", "4.20", "4.19", "4.18", "4.17", "4.16", "4.15", "4.14"}))
 }
 
 func TestIsValidReleaseVersion(t *testing.T) {
@@ -59,7 +59,7 @@ func TestIsValidReleaseVersion(t *testing.T) {
 				Major: LatestSupportedVersion.Major,
 				Minor: LatestSupportedVersion.Minor + 1,
 			},
-			latestVersionSupported: v("4.20.0"),
+			latestVersionSupported: v("4.21.0"),
 			minVersionSupported:    v("4.14.0"),
 			expectError:            true,
 			platform:               hyperv1.NonePlatform,
@@ -266,7 +266,7 @@ func TestGetSupportedOCPVersions(t *testing.T) {
 	// struct is ever refactored, this test will fail to compile, providing an early signal that
 	// the test is out of date. It also allows for a clean, type-safe assertion.
 	validVersions := SupportedVersions{
-		Versions: []string{"4.20", "4.19", "4.18", "4.17", "4.16", "4.15", "4.14"},
+		Versions: []string{"4.21", "4.20", "4.19", "4.18", "4.17", "4.16", "4.15", "4.14"},
 	}
 	validVersionsJSON, err := json.Marshal(validVersions)
 	if err != nil {

--- a/test/e2e/util/version.go
+++ b/test/e2e/util/version.go
@@ -15,6 +15,7 @@ import (
 
 var (
 	// y-stream versions supported by e2e in main
+	Version422 = semver.MustParse("4.22.0")
 	Version421 = semver.MustParse("4.21.0")
 	Version420 = semver.MustParse("4.20.0")
 	Version419 = semver.MustParse("4.19.0")
@@ -31,6 +32,7 @@ func init() {
 	// Ensure that the version constants are valid semver versions
 	// This is a compile-time check to ensure that the versions are valid
 	// semver versions.
+	_ = Version422
 	_ = Version421
 	_ = Version420
 	_ = Version419


### PR DESCRIPTION
## Summary
- Update LatestSupportedVersion from 4.21.0 to 4.22.0
- Add Kubernetes 1.34.0 mapping for OCP 4.21.0

## Changes
- **Version constants**: Updated supported version range to 4.14-4.22
- **Kubernetes mappings**: Added 4.21.0 → 1.34.0 mapping
- **Test updates**: Updated all tests to reflect new version constraints
- **NodePool tests**: Fixed version skew test with compatible versions

## Fixes
- [CNTRLPLANE-2123](https://issues.redhat.com/browse/CNTRLPLANE-2123)

## Test plan
- [x] Unit tests pass with updated version ranges
- [x] `hypershift version` command shows 4.22.0 as latest supported
- [x] Version skew validation works correctly with new minimum versions
- [x] All existing functionality preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)