### PR TITLE
CNTRLPLANE-2123: feat: add release-4.21 branch to renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,8 @@
         "release-4.17",
         "release-4.18",
         "release-4.19",
-        "release-4.20"
+        "release-4.20",
+        "release-4.21"
     ],
     "tekton": {
         "branchConcurrentLimit": 10,
@@ -42,7 +43,8 @@
                 "release-4.17",
                 "release-4.18",
                 "release-4.19",
-                "release-4.20"
+                "release-4.20",
+                "release-4.21"
             ],
             "matchUpdateTypes": [
                 "patch"


### PR DESCRIPTION
## Summary
Add release-4.21 branch to Renovate configuration to enable security-only Go dependency updates.

## Changes
- Add `release-4.21` to `baseBranchPatterns` 
- Add `release-4.21` to `matchBaseBranches` in packageRules

## Fixes
- [CNTRLPLANE-2123](https://issues.redhat.com/browse/CNTRLPLANE-2123)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `release-4.21` to Renovate base branch patterns and to release branches for security-only Go (patch) updates.
> 
> - **Renovate configuration (`renovate.json`)**:
>   - Add `release-4.21` to `baseBranchPatterns`.
>   - Add `release-4.21` to `packageRules.matchBaseBranches` for Go `patch` updates only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ada943bd091d41a0394aceb24a7d4eed1c8a8cb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->