### PR TITLE
OCPBUGS-61296: Override CPO for 4.17.20-4.17.43 with 4.17.44 image

### DIFF
--- a/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
+++ b/hypershift-operator/controlplaneoperator-overrides/assets/overrides.yaml
@@ -217,6 +217,59 @@ platforms:
       cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1ac8880940e256abb01cf8d8276beeb53db37572ab7369a752de5af244bc24e4
     # End of OCPBUGS-48519 overrides 4.17 section
     # End of OCPBUGS-48519 overrides
+    # Beginning of OCPBUGS-61296 overrides
+    # Beginning of OCPBUGS-61296 overrides 4.17 section
+    # Using CPO from ocp-release:4.17.44-multi which contains the fix for konnectivity DNS resolution
+    - version: 4.17.20
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e
+    - version: 4.17.21
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e
+    - version: 4.17.22
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e
+    - version: 4.17.23
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e
+    - version: 4.17.24
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e
+    - version: 4.17.25
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e
+    - version: 4.17.26
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e
+    - version: 4.17.27
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e
+    - version: 4.17.28
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e
+    - version: 4.17.29
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e
+    - version: 4.17.30
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e
+    - version: 4.17.31
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e
+    - version: 4.17.32
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e
+    - version: 4.17.33
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e
+    - version: 4.17.34
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e
+    - version: 4.17.35
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e
+    - version: 4.17.36
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e
+    - version: 4.17.37
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e
+    - version: 4.17.38
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e
+    - version: 4.17.39
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e
+    - version: 4.17.40
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e
+    - version: 4.17.41
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e
+    - version: 4.17.42
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e
+    - version: 4.17.43
+      cpoImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e
+    # End of OCPBUGS-61296 overrides 4.17 section
+    # End of OCPBUGS-61296 overrides
     # Beginning of OCPBUGS-58837 overrides
     # Beginning of OCPBUGS-58837 overrides 4.15 section
     - version: 4.15.53
@@ -234,6 +287,6 @@ platforms:
     # testing. Currently, we only test one latest/previous combination. In the future, we
     # may be able to test multiple combinations at a time. To test more than one, update
     # the referenced images before each e2e test run.
-      latest: quay.io/openshift-release-dev/ocp-release:4.15.53-x86_64
-      previous: quay.io/openshift-release-dev/ocp-release:4.15.52-x86_64
-      runTests: false
+      latest: quay.io/openshift-release-dev/ocp-release:4.17.43-x86_64
+      previous: quay.io/openshift-release-dev/ocp-release:4.17.20-x86_64
+      runTests: true


### PR DESCRIPTION
## What this PR does / why we need it:

Overrides the control-plane-operator image for versions 4.17.20 through 4.17.43 with the CPO from 4.17.44-multi which contains the fix for the konnectivity DNS resolution issue.

This addresses the LDAP authentication failures where customers are unable to perform `oc login` to HCP clusters using on-prem LDAP servers. The root cause was a circular dependency causing DNS timeouts and excessive retries in the konnectivity socks5-proxy container.

The fix was delivered in 4.17.44 via [PR #7112](https://github.com/openshift/hypershift/pull/7112).

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/OCPBUGS-61296

## Special notes for your reviewer:

- This uses the official 4.17.44-multi CPO image (`quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:75f141026e4c4efb68ba1691942ac2d2abae906b402bdce85ed5f967712d1e7e`)
- Versions 4.17.0-4.17.14 already have overrides from OCPBUGS-48519
- Versions 4.17.15-4.17.19 do not have overrides (they may not be affected or were not in scope)
- This override applies to versions 4.17.20-4.17.43 which are affected
- Version 4.17.44+ includes the fix natively

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve OCPBUGS-61296`