### PR TITLE
CNTRLPLANE-2152: chore: override capi images

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
@@ -105,6 +105,13 @@ func GetPlatform(ctx context.Context, hcluster *hyperv1.HostedCluster, releasePr
 				return nil, fmt.Errorf("failed to fetch payload version: %w", err)
 			}
 		}
+
+		// temporary override for 4.21 to unblock CAPI bump to 1.11 which introduces a new API version.
+		// used image from multiArch release payload 4.20.5 (quay.io/openshift-release-dev/ocp-release@sha256:1f2c28ac126453a3b9e83b349822b9f1fb7662973a212f936b90fdc40e06eb58)
+		// TODO(https://issues.redhat.com/browse/CNTRLPLANE-1200): Remove this override once Hypershift installs the CAPI v1beta2 API version
+		if payloadVersion != nil && payloadVersion.Major == 4 && payloadVersion.Minor == 21 {
+			capiImageProvider = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b8881eafb5fdb31bdaffe03d2cb74ee6729a4776ce879c550e0ea26c489e2cf6"
+		}
 		platform = aws.New(utilitiesImage, capiImageProvider, payloadVersion)
 	case hyperv1.IBMCloudPlatform:
 		platform = &ibmcloud.IBMCloud{}
@@ -124,6 +131,13 @@ func GetPlatform(ctx context.Context, hcluster *hyperv1.HostedCluster, releasePr
 			if err != nil {
 				return nil, fmt.Errorf("failed to fetch payload version: %w", err)
 			}
+		}
+
+		// temporary override for 4.21 to unblock CAPI bump to 1.11 which introduces a new API version.
+		// used image from multiArch release payload 4.20.5 (quay.io/openshift-release-dev/ocp-release@sha256:1f2c28ac126453a3b9e83b349822b9f1fb7662973a212f936b90fdc40e06eb58)
+		// TODO(https://issues.redhat.com/browse/CNTRLPLANE-1200): Remove this override once Hypershift installs the CAPI v1beta2 API version
+		if payloadVersion != nil && payloadVersion.Major == 4 && payloadVersion.Minor == 21 {
+			capiImageProvider = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:54c33e77c60da570e9f18dcae94c4c320145a77a78df9de615a9949fbebf6b40"
 		}
 		platform = azure.New(utilitiesImage, capiImageProvider, payloadVersion)
 	case hyperv1.PowerVSPlatform:


### PR DESCRIPTION
## What this PR does / why we need it:

This is needed to unblock capi rebass to v1.11 which introduces a new API version v1beta2. Without this, controller can't run as Hypershift doesn't install the new API version yet.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.