### PR TITLE
NO-JIRA: Update expected digest for busybox:latest in TestGetDigest

### DIFF
--- a/support/util/imagemetadata_test.go
+++ b/support/util/imagemetadata_test.go
@@ -236,7 +236,7 @@ func TestGetDigest(t *testing.T) {
 			pullSecret:     pullSecret,
 			expectedErr:    false,
 			validateCache:  true,
-			expectedDigest: "sha256:dfa54ef35e438b9e71ac5549159074576b6382f95ce1a434088e05fd6b730bc4",
+			expectedDigest: "sha256:fe9080e7b47dd0751812e64eb2510b0444b3706fbbe426c4e9372dd8a77141ee",
 		},
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it:

This PR fixes a flaky test failure in `TestGetDigest` caused by an outdated expected digest for `quay.io/prometheus/busybox:latest`.

The test was using a hardcoded digest that became stale when the `:latest` image was updated. Since `:latest` is a mutable tag, the underlying image can change at any time, causing the digest to change.

**This is a quick fix. See PR #7323 for a more robust alternative.**

**Changes:**
- Updated the expected digest in the test case "Image not present in overridden registry, falling back to original imageRef"
- Changed from: `sha256:dfa54ef35e438b9e71ac5549159074576b6382f95ce1a434088e05fd6b730bc4`
- Changed to: `sha256:fe9080e7b47dd0751812e64eb2510b0444b3706fbbe426c4e9372dd8a77141ee`

**Trade-offs:**
- ✅ Minimal change - only updates one digest value
- ❌ Will break again when upstream updates the `:latest` image
- ❌ Requires periodic maintenance

**Comparison with PR #7323:**
- **This PR**: Quick fix, updates hardcoded digest (will need updates in the future)
- **PR #7323**: Uses digest reference instead of `:latest` tag (permanent fix)

## Which issue(s) this PR fixes:

Fixes flaky unit test in `support/util/imagemetadata_test.go`

**Note**: Only ONE of this PR or PR #7323 should be merged, not both.

## Special notes for your reviewer:

- This is a minimal change - only updates the hardcoded digest to match current upstream image
- The new digest was verified by running `skopeo inspect docker://quay.io/prometheus/busybox:latest`
- Test passes locally after this change
- Choose this PR if you prefer a quick minimal fix, or choose PR #7323 for a permanent solution

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.