### PR TITLE
CNTRLPLANE-2205: feat(aws): add shared-role support for IAM operations

### DIFF
--- a/cmd/cluster/aws/create.go
+++ b/cmd/cluster/aws/create.go
@@ -60,6 +60,7 @@ type RawCreateOptions struct {
 	PublicOnly                       bool
 	AutoNode                         bool
 	UseROSAManagedPolicies           bool
+	SharedRole                       bool
 }
 
 // validatedCreateOptions is a private wrapper that enforces a call of Validate() before Complete() can be invoked.
@@ -502,6 +503,7 @@ func bindCoreOptions(opts *RawCreateOptions, flags *flag.FlagSet) {
 	flags.BoolVar(&opts.PrivateZonesInClusterAccount, "private-zones-in-cluster-account", opts.PrivateZonesInClusterAccount, "In shared VPC infrastructure, create private hosted zones in cluster account")
 	flags.BoolVar(&opts.PublicOnly, "public-only", opts.PublicOnly, "If true, creates a cluster that does not have private subnets or NAT gateway and assigns public IPs to all instances.")
 	flags.BoolVar(&opts.UseROSAManagedPolicies, "use-rosa-managed-policies", opts.UseROSAManagedPolicies, "Use ROSA managed policies for the operator roles and worker instance profile")
+	flags.BoolVar(&opts.SharedRole, "shared-role", opts.SharedRole, "Create a single shared role with all role policies instead of individual component roles")
 
 	_ = flags.MarkDeprecated("multi-arch", "Multi-arch validation is now performed automatically based on the release image and signaled in the HostedCluster.Status.PayloadArch.")
 }
@@ -581,6 +583,7 @@ func CreateIAMOptions(awsOpts *ValidatedCreateOptions, infra *awsinfra.CreateInf
 		PrivateZonesInClusterAccount: awsOpts.PrivateZonesInClusterAccount,
 		CreateKarpenterRoleARN:       awsOpts.AutoNode,
 		UseROSAManagedPolicies:       awsOpts.UseROSAManagedPolicies,
+		SharedRole:                   awsOpts.SharedRole,
 	}
 }
 

--- a/cmd/cluster/aws/destroy.go
+++ b/cmd/cluster/aws/destroy.go
@@ -34,6 +34,7 @@ func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.CredentialSecretName, "secret-creds", opts.CredentialSecretName, "A Kubernetes secret with a platform credential, pull-secret and base-domain. The secret must exist in the supplied \"--namespace\"")
 	cmd.Flags().DurationVar(&opts.AWSPlatform.AwsInfraGracePeriod, "aws-infra-grace-period", opts.AWSPlatform.AwsInfraGracePeriod, "Timeout for destroying infrastructure in minutes")
 	cmd.Flags().BoolVar(&opts.AWSPlatform.PrivateZonesInClusterAccount, "private-zones-in-cluster-account", opts.AWSPlatform.PrivateZonesInClusterAccount, "In shared VPC infrastructure, delete private hosted zones in cluster account")
+	cmd.Flags().BoolVar(&opts.AWSPlatform.SharedRole, "shared-role", opts.AWSPlatform.SharedRole, "Delete the shared role instead of individual component roles")
 
 	opts.AWSPlatform.Credentials.BindFlags(cmd.Flags())
 	opts.AWSPlatform.VPCOwnerCredentials.BindVPCOwnerFlags(cmd.Flags())
@@ -104,6 +105,7 @@ func destroyPlatformSpecifics(ctx context.Context, o *core.DestroyOptions) error
 			CredentialsSecretData:        secretData,
 			VPCOwnerCredentialsOpts:      o.AWSPlatform.VPCOwnerCredentials,
 			PrivateZonesInClusterAccount: o.AWSPlatform.PrivateZonesInClusterAccount,
+			SharedRole:                   o.AWSPlatform.SharedRole,
 		}
 		if err := destroyOpts.Run(ctx); err != nil {
 			return fmt.Errorf("failed to destroy IAM: %w", err)

--- a/cmd/cluster/core/destroy.go
+++ b/cmd/cluster/core/destroy.go
@@ -56,6 +56,7 @@ type AWSPlatformDestroyOptions struct {
 	AwsInfraGracePeriod          time.Duration
 	VPCOwnerCredentials          awsutil.AWSCredentialsOptions
 	PrivateZonesInClusterAccount bool
+	SharedRole                   bool
 }
 
 type AzurePlatformDestroyOptions struct {

--- a/cmd/infra/aws/create_iam.go
+++ b/cmd/infra/aws/create_iam.go
@@ -47,6 +47,7 @@ type CreateIAMOptions struct {
 	additionalIAMTags      []*iam.Tag
 	CreateKarpenterRoleARN bool
 	UseROSAManagedPolicies bool
+	SharedRole             bool
 }
 
 type CreateIAMOutput struct {
@@ -90,6 +91,7 @@ func NewCreateIAMCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.PrivateZonesInClusterAccount, "private-zones-in-cluster-account", opts.PrivateZonesInClusterAccount, "In shared VPC infrastructure, create private hosted zones in cluster account")
 	cmd.Flags().BoolVar(&opts.UseROSAManagedPolicies, "use-rosa-managed-policies", opts.UseROSAManagedPolicies, "Use ROSA managed policies for the operator roles and worker instance profile")
 	cmd.Flags().StringVar(&opts.BaseDomain, "base-domain", opts.BaseDomain, "The ingress base domain for the cluster")
+	cmd.Flags().BoolVar(&opts.SharedRole, "shared-role", opts.SharedRole, "Create a single shared role with all role policies instead of individual component roles")
 
 	opts.AWSCredentialsOpts.BindFlags(cmd.Flags())
 	opts.VPCOwnerCredentialsOpts.BindVPCOwnerFlags(cmd.Flags())


### PR DESCRIPTION
Add `shared-role` flag to create/destroy IAM commands to support creating a single shared IAM role with all component policies instead of individual roles for each component. This reduces the number of IAM roles from 7+ to 1, reducing AWS API load and Roles quota issues.

Changes:
- Add SharedRole field to CreateIAMOptions and DestroyIAMOptions
- Add --shared-role flag to "hypershift create iam aws" command
- Add --shared-role flag to "hypershift destroy iam aws" command
- Implement CreateSharedOIDCRole to create single role with multiple inline policies
- Refactor DestroyOIDCRole to dynamically list and delete all inline policies, supporting both shared and individual roles
- Fix credential secret creation bug: change from map to slice to support multiple secrets with same ARN when using shared roles

The shared role includes all service accounts in its trust policy and contains separate inline policies for each component (ingress, image-registry, ebs-csi, cloud-controller, node-pool, control-plane-operator, network, karpenter, kms-provider).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a --shared-role option to create/destroy IAM paths to use a single aggregated IAM role, updates deletion logic accordingly, and fixes credential secret syncing for shared ARNs.
> 
> - **IAM**:
>   - **Shared role support**: Implement `CreateSharedOIDCRole` in `cmd/infra/aws/iam.go` to create one role (`<infra-id>-shared-role`) with combined trust policy and multiple inline policies; sets all role ARNs to the shared ARN.
>   - **Destroy logic**: In `cmd/infra/aws/destroy_iam.go`, add `SharedRole` handling to delete the shared role or individual roles; refactor `DestroyOIDCRole` to list/delete all inline policies dynamically and detach managed policies.
> - **CLI/Options**:
>   - Add `SharedRole` field and `--shared-role` flag across create/destroy commands and option structs: `cmd/infra/aws/create_iam.go`, `cmd/infra/aws/destroy_iam.go`, `cmd/cluster/aws/create.go`, `cmd/cluster/aws/destroy.go`, `cmd/cluster/core/destroy.go`.
>   - Plumb `SharedRole` through to IAM create/destroy options.
> - **Operator**:
>   - Update credential secret sync in `hypershift-operator/.../platform/aws/aws.go` to use a slice instead of a map, allowing multiple secrets to reference the same ARN when using a shared role.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28895f2ffb58f39a1777fa1c71774785ae338cda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->