### PR TITLE
CNTRLPLANE-2049: chore(lint): remove unused exclusion rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,14 +47,6 @@ linters:
         source: 'Konnectivity'
       - linters:
           - staticcheck
-        text: 'ST1019'
-        path: 'test/e2e/util/(util|kubevirt)\.go$'
-      - linters:
-          - staticcheck
-        text: 'ST1019'
-        path: 'support/util/util_test\.go$'
-      - linters:
-          - staticcheck
         text: 'QF1008'
       - linters:
           - staticcheck

--- a/api/.golangci.yml
+++ b/api/.golangci.yml
@@ -1333,10 +1333,6 @@ linters:
       - linters:
           - kubeapilinter
         path: hypershift/v1beta1/gcpprivateserviceconnect_types.go
-        text: 'requiredfields: field ForwardingRuleName should have the omitempty tag'
-      - linters:
-          - kubeapilinter
-        path: hypershift/v1beta1/gcpprivateserviceconnect_types.go
         text: 'requiredfields: field LoadBalancerIP has a valid zero value'
       - linters:
           - kubeapilinter


### PR DESCRIPTION
## Summary
Removed unused golangci-lint exclusion rules from both root and API configuration files that were not matching any issues, as identified by running `make lint` with `warn-unused: true` enabled.

## Changes
- **`.golangci.yml`**: Removed 2 unused ST1019 exclusion rules
- **`api/.golangci.yml`**: Removed 1 unused ForwardingRuleName exclusion rule
- **Preserved**: Path exclusions for `third_party$`, `builtin$`, and `examples$`

## Motivation
- Clean up linting configuration by removing rules that don't serve a purpose
- Reduce noise in the configuration files
- Make the linting setup more maintainable

## Testing
- Ran `make lint` to identify unused rules (showed "Skipped 0 issues" warnings)
- Removed the unused rules
- Re-ran `make lint` to verify:
  - 0 linting issues
  - No unused rule warnings (except for path patterns)
  - No new errors introduced

## Additional Notes
This is a pure cleanup change with no functional impact on linting behavior. Path exclusions were intentionally preserved as defensive patterns.