### PR TITLE
GCP-262: feat(gcp): add destroy IAM infrastructure command

### DIFF
--- a/cmd/infra/destroy_iam.go
+++ b/cmd/infra/destroy_iam.go
@@ -2,6 +2,7 @@ package infra
 
 import (
 	"github.com/openshift/hypershift/cmd/infra/aws"
+	"github.com/openshift/hypershift/cmd/infra/gcp"
 
 	"github.com/spf13/cobra"
 )
@@ -14,6 +15,7 @@ func NewDestroyIAMCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(aws.NewDestroyIAMCommand())
+	cmd.AddCommand(gcp.NewDestroyIAMCommand())
 
 	return cmd
 }

--- a/cmd/infra/gcp/destroy_iam.go
+++ b/cmd/infra/gcp/destroy_iam.go
@@ -1,0 +1,90 @@
+package gcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/hypershift/cmd/log"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+)
+
+type DestroyIAMOptions struct {
+	ProjectID string
+	InfraID   string
+}
+
+func NewDestroyIAMCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "gcp",
+		Short:        "Destroys GCP IAM infrastructure for HyperShift cluster",
+		SilenceUsage: true,
+	}
+
+	opts := &DestroyIAMOptions{}
+
+	cmd.Flags().StringVar(&opts.InfraID, infraIDFlag, opts.InfraID, "Infrastructure ID used for GCP resources.")
+	cmd.Flags().StringVar(&opts.ProjectID, projectIDFlag, opts.ProjectID, "GCP Project ID where resources were created")
+
+	_ = cmd.MarkFlagRequired(infraIDFlag)
+	_ = cmd.MarkFlagRequired(projectIDFlag)
+
+	logger := log.Log
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		return opts.ValidateInputs()
+	}
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := opts.Run(cmd.Context(), logger); err != nil {
+			logger.Error(err, "Failed to destroy GCP IAM infrastructure")
+			return err
+		}
+		logger.Info("Successfully destroyed GCP IAM infrastructure")
+		return nil
+	}
+
+	return cmd
+}
+
+func (o *DestroyIAMOptions) ValidateInputs() error {
+	if o.InfraID == "" {
+		return fmt.Errorf("infra-id is required")
+	}
+	if o.ProjectID == "" {
+		return fmt.Errorf("project-id is required")
+	}
+	return nil
+}
+
+func (o *DestroyIAMOptions) Run(ctx context.Context, logger logr.Logger) error {
+	return o.DestroyIAM(ctx, logger)
+}
+
+func (o *DestroyIAMOptions) DestroyIAM(ctx context.Context, logger logr.Logger) error {
+	// Use IAMManager for all GCP API interactions
+	iamManager, err := NewIAMManager(ctx, o.ProjectID, o.InfraID, "", logger)
+	if err != nil {
+		return fmt.Errorf("failed to initialize GCP clients: %w", err)
+	}
+
+	// Delete service accounts first (they reference the WIF pool)
+	logger.Info("Deleting service accounts...")
+	if err := iamManager.DeleteServiceAccounts(ctx); err != nil {
+		return fmt.Errorf("failed to delete service accounts: %w", err)
+	}
+
+	// Delete OIDC provider (it references the WIF pool)
+	logger.Info("Deleting OIDC provider...")
+	if err := iamManager.DeleteOIDCProvider(ctx); err != nil {
+		return fmt.Errorf("failed to delete OIDC provider: %w", err)
+	}
+
+	// Delete workload identity pool last
+	logger.Info("Deleting workload identity pool...")
+	if err := iamManager.DeleteWorkloadIdentityPool(ctx); err != nil {
+		return fmt.Errorf("failed to delete workload identity pool: %w", err)
+	}
+
+	logger.Info("Destroyed GCP IAM infrastructure", "infraID", o.InfraID, "projectID", o.ProjectID)
+	return nil
+}

--- a/cmd/infra/gcp/destroy_iam_test.go
+++ b/cmd/infra/gcp/destroy_iam_test.go
@@ -1,0 +1,89 @@
+package gcp
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDestroyIAMOptionsValidateInputs(t *testing.T) {
+	tests := []struct {
+		name          string
+		opts          *DestroyIAMOptions
+		expectedError string
+	}{
+		{
+			name: "When all required fields are provided it should pass validation",
+			opts: &DestroyIAMOptions{
+				InfraID:   "test-infra-id",
+				ProjectID: "test-project-id",
+			},
+		},
+		{
+			name: "When infra-id is missing it should return error",
+			opts: &DestroyIAMOptions{
+				InfraID:   "",
+				ProjectID: "test-project-id",
+			},
+			expectedError: "infra-id is required",
+		},
+		{
+			name: "When project-id is missing it should return error",
+			opts: &DestroyIAMOptions{
+				InfraID:   "test-infra-id",
+				ProjectID: "",
+			},
+			expectedError: "project-id is required",
+		},
+		{
+			name: "When both infra-id and project-id are missing it should return infra-id error first",
+			opts: &DestroyIAMOptions{
+				InfraID:   "",
+				ProjectID: "",
+			},
+			expectedError: "infra-id is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.opts.ValidateInputs()
+
+			if tt.expectedError != "" {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.expectedError)
+					return
+				}
+				if !strings.Contains(err.Error(), tt.expectedError) {
+					t.Errorf("expected error containing %q, got %q", tt.expectedError, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestDestroyIAMNewDestroyIAMCommand(t *testing.T) {
+	cmd := NewDestroyIAMCommand()
+
+	if cmd == nil {
+		t.Fatal("expected command to be non-nil")
+	}
+
+	if cmd.Use != "gcp" {
+		t.Errorf("expected Use to be %q, got %q", "gcp", cmd.Use)
+	}
+
+	// Verify required flags are defined
+	infraIDFlag := cmd.Flag("infra-id")
+	if infraIDFlag == nil {
+		t.Error("expected infra-id flag to be defined")
+	}
+
+	projectIDFlag := cmd.Flag("project-id")
+	if projectIDFlag == nil {
+		t.Error("expected project-id flag to be defined")
+	}
+}

--- a/cmd/infra/gcp/iam_test.go
+++ b/cmd/infra/gcp/iam_test.go
@@ -1,0 +1,407 @@
+package gcp
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"google.golang.org/api/cloudresourcemanager/v1"
+	"google.golang.org/api/iam/v1"
+)
+
+func TestIAMManagerFormatServiceAccountMethods(t *testing.T) {
+	manager := &IAMManager{
+		projectID: "test-project",
+		infraID:   "test-infra",
+		logger:    logr.Discard(),
+	}
+
+	tests := []struct {
+		name     string
+		method   func(string) string
+		arg      string
+		expected string
+	}{
+		{
+			name:     "When formatServiceAccountID is called it should return correct ID",
+			method:   manager.formatServiceAccountID,
+			arg:      "nodepool-mgmt",
+			expected: "test-infra-nodepool-mgmt",
+		},
+		{
+			name:     "When formatServiceAccountEmail is called it should return correct email",
+			method:   manager.formatServiceAccountEmail,
+			arg:      "nodepool-mgmt",
+			expected: "test-infra-nodepool-mgmt@test-project.iam.gserviceaccount.com",
+		},
+		{
+			name:     "When formatServiceAccountResource is called it should return correct resource path",
+			method:   manager.formatServiceAccountResource,
+			arg:      "test-infra-nodepool-mgmt@test-project.iam.gserviceaccount.com",
+			expected: "projects/test-project/serviceAccounts/test-infra-nodepool-mgmt@test-project.iam.gserviceaccount.com",
+		},
+		{
+			name:     "When formatServiceAccountMember is called it should return correct member format",
+			method:   manager.formatServiceAccountMember,
+			arg:      "test-infra-nodepool-mgmt@test-project.iam.gserviceaccount.com",
+			expected: "serviceAccount:test-infra-nodepool-mgmt@test-project.iam.gserviceaccount.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.method(tt.arg)
+			if got != tt.expected {
+				t.Errorf("got %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIAMManagerFormatWIFPrincipal(t *testing.T) {
+	manager := &IAMManager{
+		projectNumber: "123456789",
+		infraID:       "test-infra",
+		logger:        logr.Discard(),
+	}
+
+	tests := []struct {
+		name      string
+		namespace string
+		saName    string
+		expected  string
+	}{
+		{
+			name:      "When formatWIFPrincipal is called with kube-system namespace it should return correct principal",
+			namespace: "kube-system",
+			saName:    "control-plane-operator",
+			expected:  "principal://iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/test-infra-wi-pool/subject/system:serviceaccount:kube-system:control-plane-operator",
+		},
+		{
+			name:      "When formatWIFPrincipal is called with custom namespace it should return correct principal",
+			namespace: "openshift-cloud-controller-manager",
+			saName:    "cloud-controller-manager",
+			expected:  "principal://iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/test-infra-wi-pool/subject/system:serviceaccount:openshift-cloud-controller-manager:cloud-controller-manager",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := manager.formatWIFPrincipal(tt.namespace, tt.saName)
+			if got != tt.expected {
+				t.Errorf("got %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIAMManagerFormatIssuerUri(t *testing.T) {
+	tests := []struct {
+		name          string
+		oidcIssuerURL string
+		infraID       string
+		expected      string
+	}{
+		{
+			name:          "When custom OIDC issuer URL is set it should return the custom URL",
+			oidcIssuerURL: "https://custom-oidc.example.com",
+			infraID:       "test-infra",
+			expected:      "https://custom-oidc.example.com",
+		},
+		{
+			name:          "When no custom OIDC issuer URL is set it should derive from infraID",
+			oidcIssuerURL: "",
+			infraID:       "test-infra",
+			expected:      "https://hypershift-test-infra-oidc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := &IAMManager{
+				oidcIssuerURL: tt.oidcIssuerURL,
+				infraID:       tt.infraID,
+				logger:        logr.Discard(),
+			}
+
+			got := manager.formatIssuerUri()
+			if got != tt.expected {
+				t.Errorf("got %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAddMemberToRoleBinding(t *testing.T) {
+	manager := &IAMManager{
+		logger: logr.Discard(),
+	}
+
+	tests := []struct {
+		name           string
+		policy         *cloudresourcemanager.Policy
+		role           string
+		member         string
+		expectedResult bool
+		expectedCount  int
+	}{
+		{
+			name: "When member does not exist in role it should add member and return true",
+			policy: &cloudresourcemanager.Policy{
+				Bindings: []*cloudresourcemanager.Binding{
+					{
+						Role:    "roles/compute.admin",
+						Members: []string{"serviceAccount:existing@project.iam.gserviceaccount.com"},
+					},
+				},
+			},
+			role:           "roles/compute.admin",
+			member:         "serviceAccount:new@project.iam.gserviceaccount.com",
+			expectedResult: true,
+			expectedCount:  2,
+		},
+		{
+			name: "When member already exists in role it should return false",
+			policy: &cloudresourcemanager.Policy{
+				Bindings: []*cloudresourcemanager.Binding{
+					{
+						Role:    "roles/compute.admin",
+						Members: []string{"serviceAccount:existing@project.iam.gserviceaccount.com"},
+					},
+				},
+			},
+			role:           "roles/compute.admin",
+			member:         "serviceAccount:existing@project.iam.gserviceaccount.com",
+			expectedResult: false,
+			expectedCount:  1,
+		},
+		{
+			name: "When role does not exist it should create new binding and return true",
+			policy: &cloudresourcemanager.Policy{
+				Bindings: []*cloudresourcemanager.Binding{},
+			},
+			role:           "roles/compute.admin",
+			member:         "serviceAccount:new@project.iam.gserviceaccount.com",
+			expectedResult: true,
+			expectedCount:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := manager.addMemberToRoleBinding(tt.policy, tt.role, tt.member)
+			if got != tt.expectedResult {
+				t.Errorf("expected result %v, got %v", tt.expectedResult, got)
+			}
+
+			// Verify member count in the role binding
+			for _, binding := range tt.policy.Bindings {
+				if binding.Role == tt.role {
+					if len(binding.Members) != tt.expectedCount {
+						t.Errorf("expected %d members, got %d", tt.expectedCount, len(binding.Members))
+					}
+					break
+				}
+			}
+		})
+	}
+}
+
+func TestRemoveMemberFromRoleBinding(t *testing.T) {
+	manager := &IAMManager{
+		logger: logr.Discard(),
+	}
+
+	tests := []struct {
+		name           string
+		policy         *cloudresourcemanager.Policy
+		role           string
+		member         string
+		expectedResult bool
+		expectedCount  int
+	}{
+		{
+			name: "When member exists in role it should remove member and return true",
+			policy: &cloudresourcemanager.Policy{
+				Bindings: []*cloudresourcemanager.Binding{
+					{
+						Role: "roles/compute.admin",
+						Members: []string{
+							"serviceAccount:keep@project.iam.gserviceaccount.com",
+							"serviceAccount:remove@project.iam.gserviceaccount.com",
+						},
+					},
+				},
+			},
+			role:           "roles/compute.admin",
+			member:         "serviceAccount:remove@project.iam.gserviceaccount.com",
+			expectedResult: true,
+			expectedCount:  1,
+		},
+		{
+			name: "When member does not exist in role it should return false",
+			policy: &cloudresourcemanager.Policy{
+				Bindings: []*cloudresourcemanager.Binding{
+					{
+						Role:    "roles/compute.admin",
+						Members: []string{"serviceAccount:existing@project.iam.gserviceaccount.com"},
+					},
+				},
+			},
+			role:           "roles/compute.admin",
+			member:         "serviceAccount:nonexistent@project.iam.gserviceaccount.com",
+			expectedResult: false,
+			expectedCount:  1,
+		},
+		{
+			name: "When role does not exist it should return false",
+			policy: &cloudresourcemanager.Policy{
+				Bindings: []*cloudresourcemanager.Binding{},
+			},
+			role:           "roles/compute.admin",
+			member:         "serviceAccount:any@project.iam.gserviceaccount.com",
+			expectedResult: false,
+			expectedCount:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := manager.removeMemberFromRoleBinding(tt.policy, tt.role, tt.member)
+			if got != tt.expectedResult {
+				t.Errorf("expected result %v, got %v", tt.expectedResult, got)
+			}
+
+			// Verify member count in the role binding
+			for _, binding := range tt.policy.Bindings {
+				if binding.Role == tt.role {
+					if len(binding.Members) != tt.expectedCount {
+						t.Errorf("expected %d members, got %d", tt.expectedCount, len(binding.Members))
+					}
+					break
+				}
+			}
+		})
+	}
+}
+
+func TestAddMemberToServiceAccountRoleBinding(t *testing.T) {
+	manager := &IAMManager{
+		logger: logr.Discard(),
+	}
+
+	tests := []struct {
+		name           string
+		policy         *iam.Policy
+		role           string
+		member         string
+		expectedResult bool
+		expectedCount  int
+	}{
+		{
+			name: "When member does not exist in role it should add member and return true",
+			policy: &iam.Policy{
+				Bindings: []*iam.Binding{
+					{
+						Role:    "roles/iam.workloadIdentityUser",
+						Members: []string{"principal://existing"},
+					},
+				},
+			},
+			role:           "roles/iam.workloadIdentityUser",
+			member:         "principal://new",
+			expectedResult: true,
+			expectedCount:  2,
+		},
+		{
+			name: "When member already exists in role it should return false",
+			policy: &iam.Policy{
+				Bindings: []*iam.Binding{
+					{
+						Role:    "roles/iam.workloadIdentityUser",
+						Members: []string{"principal://existing"},
+					},
+				},
+			},
+			role:           "roles/iam.workloadIdentityUser",
+			member:         "principal://existing",
+			expectedResult: false,
+			expectedCount:  1,
+		},
+		{
+			name: "When role does not exist it should create new binding and return true",
+			policy: &iam.Policy{
+				Bindings: []*iam.Binding{},
+			},
+			role:           "roles/iam.workloadIdentityUser",
+			member:         "principal://new",
+			expectedResult: true,
+			expectedCount:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := manager.addMemberToServiceAccountRoleBinding(tt.policy, tt.role, tt.member)
+			if got != tt.expectedResult {
+				t.Errorf("expected result %v, got %v", tt.expectedResult, got)
+			}
+
+			// Verify member count in the role binding
+			for _, binding := range tt.policy.Bindings {
+				if binding.Role == tt.role {
+					if len(binding.Members) != tt.expectedCount {
+						t.Errorf("expected %d members, got %d", tt.expectedCount, len(binding.Members))
+					}
+					break
+				}
+			}
+		})
+	}
+}
+
+func TestLoadServiceAccountDefinitions(t *testing.T) {
+	// Test loading the embedded default configuration
+	t.Run("When loading embedded default configuration it should return valid definitions", func(t *testing.T) {
+		definitions, err := loadServiceAccountDefinitions("")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if len(definitions) == 0 {
+			t.Error("expected at least one service account definition")
+		}
+
+		// Verify each definition has required fields
+		for _, def := range definitions {
+			if def.Name == "" {
+				t.Error("expected Name to be non-empty")
+			}
+			if def.DisplayName == "" {
+				t.Errorf("expected DisplayName to be non-empty for %s", def.Name)
+			}
+		}
+	})
+}
+
+func TestIsAlreadyExistsError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "When error is nil it should return false",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAlreadyExistsError(tt.err)
+			if got != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

Add the ability to destroy GCP IAM infrastructure created for HyperShift clusters. This includes:

- New 'hypershift destroy iam gcp' CLI command
- IAMManager destroy methods:
  - DeleteWorkloadIdentityPool
  - DeleteOIDCProvider
  - DeleteServiceAccounts (with role binding cleanup)
- Format helper methods for resource paths
- Unit tests for validation and IAMManager methods

The destroy command cleans up:
- Google Service Accounts and their project IAM role bindings
- OIDC Provider in the Workload Identity Pool
- Workload Identity Pool

Ref: [GCP-262](https://issues.redhat.com//browse/GCP-262)

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
(https://issues.redhat.com/browse/GCP-262)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.