### PR TITLE
Revert "OCPBUGS-63175: remove NTO Service and ServiceMonitor"

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-node-tuning-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_node_tuning_operator_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-node-tuning-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_node_tuning_operator_controlplanecomponent.yaml
@@ -27,5 +27,11 @@ status:
     kind: RoleBinding
     name: cluster-node-tuning-operator
   - group: ""
+    kind: Service
+    name: node-tuning-operator
+  - group: ""
     kind: ServiceAccount
     name: cluster-node-tuning-operator
+  - group: monitoring.coreos.com
+    kind: ServiceMonitor
+    name: node-tuning-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-node-tuning-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_node_tuning_operator_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-node-tuning-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_node_tuning_operator_controlplanecomponent.yaml
@@ -27,5 +27,11 @@ status:
     kind: RoleBinding
     name: cluster-node-tuning-operator
   - group: ""
+    kind: Service
+    name: node-tuning-operator
+  - group: ""
     kind: ServiceAccount
     name: cluster-node-tuning-operator
+  - group: monitoring.coreos.com
+    kind: ServiceMonitor
+    name: node-tuning-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-node-tuning-operator/zz_fixture_TestControlPlaneComponents_cluster_node_tuning_operator_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-node-tuning-operator/zz_fixture_TestControlPlaneComponents_cluster_node_tuning_operator_controlplanecomponent.yaml
@@ -27,5 +27,11 @@ status:
     kind: RoleBinding
     name: cluster-node-tuning-operator
   - group: ""
+    kind: Service
+    name: node-tuning-operator
+  - group: ""
     kind: ServiceAccount
     name: cluster-node-tuning-operator
+  - group: monitoring.coreos.com
+    kind: ServiceMonitor
+    name: node-tuning-operator

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/nto/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/nto/component.go
@@ -35,20 +35,8 @@ func NewComponent() component.ControlPlaneComponent {
 		WithAdaptFunction(adaptDeployment).
 		WithPredicate(isNodeTuningCapabilityEnabled).
 		WithManifestAdapter(
-			"service.yaml",
-			component.WithPredicate(func(cpContext component.WorkloadContext) bool {
-				// Remove this resource until we support authn NTO metrics
-				// https://issues.redhat.com/browse/OCPBUGS-55399
-				return false
-			}),
-		).
-		WithManifestAdapter(
 			"servicemonitor.yaml",
-			component.WithPredicate(func(cpContext component.WorkloadContext) bool {
-				// Remove this resource until we support authn NTO metrics
-				// https://issues.redhat.com/browse/OCPBUGS-55399
-				return false
-			}),
+			component.WithAdaptFunction(adaptServiceMonitor),
 		).
 		WithDependencies(oapiv2.ComponentName).
 		Build()

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/nto/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/nto/servicemonitor.go
@@ -1,0 +1,27 @@
+package nto
+
+import (
+	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/metrics"
+	"github.com/openshift/hypershift/support/util"
+
+	"k8s.io/utils/ptr"
+
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+)
+
+const (
+	metricsServiceName = "node-tuning-operator"
+)
+
+func adaptServiceMonitor(cpContext component.WorkloadContext, sm *prometheusoperatorv1.ServiceMonitor) error {
+	sm.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{
+		MatchNames: []string{sm.Namespace},
+	}
+
+	sm.Spec.Endpoints[0].TLSConfig.ServerName = ptr.To(metricsServiceName + "." + sm.Namespace + ".svc")
+	sm.Spec.Endpoints[0].MetricRelabelConfigs = metrics.NTORelabelConfigs(cpContext.MetricsSet)
+	util.ApplyClusterIDLabel(&sm.Spec.Endpoints[0], cpContext.HCP.Spec.ClusterID)
+
+	return nil
+}


### PR DESCRIPTION
Reverts openshift/hypershift#7086 as it is fixed by https://github.com/openshift/cluster-node-tuning-operator/pull/1438 and fix shipped in the latest nightlies.

