### PR TITLE
CNTRLPLANE-2204: add a Failed condition to NodePool

### DIFF
--- a/api/hypershift/v1beta1/nodepool_conditions.go
+++ b/api/hypershift/v1beta1/nodepool_conditions.go
@@ -84,6 +84,10 @@ const (
 	// KubeVirtNodesLiveMigratable indicates if all (VirtualMachines) nodes of the kubevirt
 	// hosted cluster can be live migrated without experiencing a node restart
 	NodePoolKubeVirtLiveMigratableType = "KubeVirtNodesLiveMigratable"
+
+	// NodePoolFailedConditionType signals if a node pool is in an error terminal state
+	// A failed node pool won't be reconciled
+	NodePoolFailedConditionType = "Failed"
 )
 
 // PerformanceProfile Conditions

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_conditions.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_conditions.go
@@ -84,6 +84,10 @@ const (
 	// KubeVirtNodesLiveMigratable indicates if all (VirtualMachines) nodes of the kubevirt
 	// hosted cluster can be live migrated without experiencing a node restart
 	NodePoolKubeVirtLiveMigratableType = "KubeVirtNodesLiveMigratable"
+
+	// NodePoolFailedConditionType signals if a node pool is in an error terminal state
+	// A failed node pool won't be reconciled
+	NodePoolFailedConditionType = "Failed"
 )
 
 // PerformanceProfile Conditions


### PR DESCRIPTION
It adds the NodePoolDegradedConditionType to nodepool conditions API

## What this PR does / why we need it:
It adds a degraded condition for NodePool for terminal error like for example
https://github.com/openshift/hypershift/blob/main/hypershift-operator/controllers/nodepool/nodepool_controller.go#L308-L314
Or for situation where the capi machine keep producing errors.
See https://issues.redhat.com/browse/CNTRLPLANE-399

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/CNTRLPLANE-2204

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.