### PR TITLE
CNTRLPLANE-451: Document HyperShift API certificate rotation workflow

### DIFF
--- a/docs/content/how-to/pki/break-glass-credentials.md
+++ b/docs/content/how-to/pki/break-glass-credentials.md
@@ -1,0 +1,279 @@
+# Break-Glass Credentials
+
+This document describes break-glass credential management in HyperShift, including automatic rotation and revocation using the CertificateRevocationRequest API.
+
+## Overview
+
+The `control-plane-pki-operator` runs in each hosted control plane namespace and manages the lifecycle of **break-glass credentials**. These credentials provide emergency access to the hosted cluster's API server for both customers and Site Reliability Engineers (SREs).
+
+Break-glass credentials are separate from [internal control plane certificates](control-plane-certificates.md), which are managed by the control-plane-operator (CPO).
+
+The control-plane-pki-operator handles:
+
+- **Automatic certificate rotation** - Continuous rotation of break-glass signing CAs and client certificates
+- **Certificate signing request (CSR) approval** - Processing requests for new break-glass credentials
+- **Certificate revocation** - Revoking compromised break-glass certificates through a safe, multi-step workflow
+
+## Architecture
+
+### Control Plane PKI Operator Components
+
+The control-plane-pki-operator consists of several controllers:
+
+| Controller | Purpose |
+|------------|---------|
+| Certificate Rotation Controller | Automatically rotates signing CAs and client certificates |
+| Certificate Loading Controller | Loads signing CA certificates for use by the signing controllers |
+| CSR Approval Controller | Approves CertificateSigningRequests when a matching CertificateSigningRequestApproval exists |
+| Certificate Signing Controller | Signs approved CSRs to generate client certificates |
+| Certificate Revocation Controller | Processes CertificateRevocationRequests to revoke certificates |
+
+### Signer Classes
+
+HyperShift defines two signer classes for break-glass credentials:
+
+| Signer Class | Purpose |
+|--------------|---------|
+| `customer-break-glass` | Emergency access credentials for customers |
+| `sre-break-glass` | Emergency access credentials for SREs |
+
+Each signer class has its own:
+
+- Signing CA secret
+- CA trust bundle ConfigMap
+- Client certificate secret
+
+### Certificate Resources
+
+For each signer class, the following resources are created in the hosted control plane namespace:
+
+**Customer Break-Glass:**
+
+| Resource | Type | Description |
+|----------|------|-------------|
+| `customer-system-admin-signer` | Secret | Root signing CA for customer credentials |
+| `customer-system-admin-signer-ca` | ConfigMap | Trust bundle containing the CA certificate |
+| `customer-system-admin-client-cert-key` | Secret | Client certificate for customer break-glass access |
+
+**SRE Break-Glass:**
+
+| Resource | Type | Description |
+|----------|------|-------------|
+| `sre-system-admin-signer` | Secret | Root signing CA for SRE credentials |
+| `sre-system-admin-signer-ca` | ConfigMap | Trust bundle containing the CA certificate |
+| `sre-system-admin-client-cert-key` | Secret | Client certificate for SRE break-glass access |
+
+**Combined Trust Bundle:**
+
+The individual CA bundles from both signer classes are combined into a `total-client-ca` ConfigMap. This combined trust bundle is used by the hosted cluster's kube-apiserver for client certificate authentication.
+
+## Automatic Certificate Rotation
+
+The control-plane-pki-operator automatically rotates break-glass signing CAs and client certificates based on configurable timing parameters.
+
+### Default Rotation Schedule
+
+The rotation timing for break-glass certificates is based on multiples of the rotation scale (default: 24 hours):
+
+| Certificate Type | Validity Period | Refresh Interval |
+|------------------|-----------------|------------------|
+| Signing CA | 7 × scale (7 days) | 2 × scale (every 2 days) |
+| Client Certificate | 1.5 × scale (36 hours) | 0.25 × scale (every 6 hours) |
+
+### How It Works
+
+1. The Certificate Rotation Controller monitors the validity of signing CAs and client certificates
+2. When a certificate approaches its refresh interval, the controller generates a new certificate
+3. New certificates are signed by the current CA and placed in the appropriate secrets
+4. The CA trust bundle is updated to include both old and new CAs during the transition period
+5. Old certificates are eventually removed from the trust bundle after all clients have transitioned
+
+### Configuration
+
+The rotation timing can be scaled using the `CERT_ROTATION_SCALE` environment variable on the control-plane-pki-operator. The default scale is 24 hours.
+
+!!! warning
+
+    Modifying `CERT_ROTATION_SCALE` is unsupported and should only be used for testing purposes.
+
+## Requesting Break-Glass Credentials
+
+Break-glass credentials provide emergency access to a hosted cluster when normal authentication methods are unavailable.
+
+To request new break-glass credentials, create a `CertificateSigningRequest` with the appropriate signer name:
+
+```yaml
+apiVersion: certificates.k8s.io/v1
+kind: CertificateSigningRequest
+metadata:
+  name: my-break-glass-request
+spec:
+  request: <base64-encoded-csr>
+  signerName: hypershift.openshift.io/<hcp-namespace>.customer-break-glass
+  usages:
+  - client auth
+```
+
+The signer name format is: `hypershift.openshift.io/<hosted-control-plane-namespace>.<signer-class>`
+
+### Approving Requests
+
+CSRs are not automatically approved. To approve a CSR, create a matching `CertificateSigningRequestApproval` resource:
+
+```yaml
+apiVersion: certificates.hypershift.openshift.io/v1alpha1
+kind: CertificateSigningRequestApproval
+metadata:
+  name: my-break-glass-request
+  namespace: <hosted-control-plane-namespace>
+spec: {}
+```
+
+!!! note
+
+    The CertificateSigningRequestApproval must have the same name as the CertificateSigningRequest.
+
+Once the approval resource exists, the CSR Approval Controller will approve the CSR, and the Certificate Signing Controller will sign it.
+
+### Viewing CSR Status
+
+Check the status of a CertificateSigningRequest:
+
+```bash
+oc get csr my-break-glass-request -o yaml
+```
+
+The signed certificate will be available in the `.status.certificate` field once approved and signed.
+
+## Certificate Revocation
+
+When certificates are compromised or need to be invalidated, use the `CertificateRevocationRequest` API to trigger a safe revocation workflow.
+
+### Creating a Revocation Request
+
+To revoke all certificates for a signer class:
+
+```yaml
+apiVersion: certificates.hypershift.openshift.io/v1alpha1
+kind: CertificateRevocationRequest
+metadata:
+  name: revoke-customer-certs
+  namespace: <hosted-control-plane-namespace>
+spec:
+  signerClass: customer-break-glass
+```
+
+Apply the revocation request:
+
+```bash
+oc apply -f revocation-request.yaml
+```
+
+### Revocation Workflow
+
+The Certificate Revocation Controller processes revocation requests through the following steps:
+
+1. **Commit Revocation Timestamp** - Records the point in time after which certificates must be regenerated
+2. **Generate New Signer Certificate** - Creates a new signing CA valid only after the revocation timestamp
+3. **Ensure New Signer Propagated** - Verifies the new CA is trusted by the hosted cluster's API server
+4. **Regenerate Leaf Certificates** - Re-signs all client certificates with the new CA
+5. **Prune Previous Signer** - Removes the old CA from the trust bundle
+6. **Ensure Old Signer Revoked** - Verifies that certificates signed by the old CA are rejected
+
+### Monitoring Revocation Progress
+
+Check the status of a CertificateRevocationRequest:
+
+```bash
+oc get certificaterevocationrequest -n <hosted-control-plane-namespace> revoke-customer-certs -o yaml
+```
+
+The status includes conditions that indicate progress through each step:
+
+| Condition Type | Description |
+|----------------|-------------|
+| `SignerClassValid` | The specified signer class is recognized |
+| `RootCertificatesRegenerated` | New signing CA has been generated |
+| `NewCertificatesTrusted` | New CA is trusted by the API server |
+| `LeafCertificatesRegenerated` | All client certificates have been re-signed |
+| `PreviousCertificatesRevoked` | Old certificates are no longer accepted |
+
+Example output:
+
+```yaml
+status:
+  revocationTimestamp: "2024-01-15T10:30:00Z"
+  previousSigner:
+    name: abc123def456
+  conditions:
+  - type: SignerClassValid
+    status: "True"
+    reason: AsExpected
+    message: Signer class "customer-break-glass" known.
+  - type: RootCertificatesRegenerated
+    status: "True"
+    reason: AsExpected
+    message: Signer certificate clusters-example/customer-system-admin-signer regenerated.
+  - type: NewCertificatesTrusted
+    status: "True"
+    reason: AsExpected
+    message: New signer certificate clusters-example/customer-system-admin-signer trusted.
+  - type: LeafCertificatesRegenerated
+    status: "True"
+    reason: AsExpected
+    message: All leaf certificates are re-generated.
+  - type: PreviousCertificatesRevoked
+    status: "True"
+    reason: AsExpected
+    message: Previous signer certificate revoked.
+```
+
+### Revocation Events
+
+The controller emits Kubernetes events during revocation. View them with:
+
+```bash
+oc get events -n <hosted-control-plane-namespace> --field-selector reason=CertificateRevocationProgressing
+```
+
+## Troubleshooting
+
+### Checking Certificate Status
+
+View the signing CA secret:
+
+```bash
+oc get secret customer-system-admin-signer -n <hosted-control-plane-namespace> -o yaml
+```
+
+View the CA trust bundle:
+
+```bash
+oc get configmap customer-system-admin-signer-ca -n <hosted-control-plane-namespace> -o yaml
+```
+
+### Viewing Operator Logs
+
+Check the control-plane-pki-operator logs for certificate rotation activity:
+
+```bash
+oc logs -n <hosted-control-plane-namespace> deployment/control-plane-pki-operator
+```
+
+### Common Issues
+
+**CSR not being approved:**
+
+- Verify a CertificateSigningRequestApproval with the same name exists in the hosted control plane namespace
+- Check that the signer name in the CSR matches the expected format
+
+**Revocation stuck:**
+
+- Check the conditions on the CertificateRevocationRequest for the current step
+- Review operator logs for errors
+- Ensure the hosted cluster's API server is accessible
+
+**Certificate validation errors:**
+
+- Verify the CA trust bundle ConfigMap contains the expected certificates
+- Check that the client certificate was signed by a CA in the trust bundle

--- a/docs/content/how-to/pki/control-plane-certificates.md
+++ b/docs/content/how-to/pki/control-plane-certificates.md
@@ -1,0 +1,45 @@
+# Internal Control Plane Certificates
+
+This document describes how internal control plane certificates are managed in HyperShift hosted control planes.
+
+## Overview
+
+The control-plane-operator (CPO) manages all internal PKI for the hosted control plane. These certificates secure communication between control plane components and are separate from [break-glass credentials](break-glass-credentials.md), which are managed by the control-plane-pki-operator.
+
+## Certificates Managed
+
+The CPO manages certificates for:
+
+- Kube API server serving certificates (internal and external)
+- Client certificates for kubelet, scheduler, controller-manager
+- etcd peer and client certificates
+- Aggregator proxy certificates
+- Service account signing keys
+
+## CA Certificate Lifecycle
+
+Root CA certificates managed by the CPO have a **10-year validity period** and are generated once. They are not automatically rotated unless the certificate or key data is missing from the secret.
+
+## Leaf Certificate Rotation
+
+Leaf certificates (server and client certificates signed by a CA) are automatically rotated by the CPO:
+
+| Setting | Default Value | Description |
+|---------|---------------|-------------|
+| Validity Period | 1 year | How long the certificate is valid |
+| Renewal Threshold | 30 days | Certificate is renewed when less than this time remains |
+
+Rotation is **reconciliation-driven**: during each reconciliation loop, the CPO validates existing certificates and regenerates them if they are approaching expiration or if their configuration has changed.
+
+## Test Configuration Options
+
+Certificate validity and renewal can be customized using environment variables on the CPO:
+
+| Environment Variable | Description |
+|---------------------|-------------|
+| `CERTIFICATE_VALIDITY` | Custom certificate validity duration (e.g., `8760h` for 1 year) |
+| `CERTIFICATE_RENEWAL_PERCENTAGE` | Fraction of validity period at which to renew (e.g., `0.30` renews when 30% of validity remains) |
+
+!!! warning
+
+    Modifying certificate validity settings is advanced configuration. Incorrect values may cause control plane instability or security issues.

--- a/docs/content/how-to/pki/index.md
+++ b/docs/content/how-to/pki/index.md
@@ -1,0 +1,13 @@
+# PKI and Certificate Management
+
+This section covers Public Key Infrastructure (PKI) and certificate management in HyperShift hosted control planes.
+
+HyperShift manages two distinct categories of certificates:
+
+- **Internal Control Plane Certificates** - Managed by the control-plane-operator (CPO), these certificates secure communication between control plane components
+- **Break-Glass Credentials** - Managed by the control-plane-pki-operator, these certificates provide emergency access to the hosted cluster's API server
+
+## Topics
+
+- [Internal Control Plane Certificates](control-plane-certificates.md) - How the CPO manages certificates for control plane components
+- [Break-Glass Credentials](break-glass-credentials.md) - Managing emergency access credentials, including rotation and revocation

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -80,6 +80,10 @@ nav:
     - how-to/ci/checking-ci.md
   - 'HyperShift Operator Install':
     - how-to/install/index.md
+  - 'PKI and Certificates':
+    - how-to/pki/index.md
+    - how-to/pki/control-plane-certificates.md
+    - how-to/pki/break-glass-credentials.md
   - 'Disaster Recovery':
     - how-to/disaster-recovery/index.md
     - how-to/disaster-recovery/dr-cli.md


### PR DESCRIPTION
## What this PR does / why we need it:

Adds documentation explaining certificate management in HyperShift hosted control planes. The documentation is split into two separate pages to clearly distinguish the different certificate management systems:

**Internal Control Plane Certificates** (`control-plane-certificates.md`):
- Managed by the control-plane-operator (CPO)
- Covers certificates for kube-apiserver, etcd, controller-manager, scheduler, etc.
- Documents CA lifecycle (10-year validity, generated once)
- Documents leaf certificate rotation (1-year validity, 30-day renewal threshold)
- Explains configuration options (`CERTIFICATE_VALIDITY`, `CERTIFICATE_RENEWAL_PERCENTAGE`)

**Break-Glass Credentials** (`break-glass-credentials.md`):
- Managed by the control-plane-pki-operator
- Emergency access credentials for customers and SREs
- Automatic rotation of signing CAs and client certificates
- Certificate signing request and approval workflow (CSR/CSRA)
- Certificate revocation using CertificateRevocationRequest API
- Troubleshooting guidance

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-451](https://issues.redhat.com//browse/CNTRLPLANE-451)

## Special notes for your reviewer:

- Documentation is split into two pages under `docs/content/how-to/pki/` to avoid confusion between CPO-managed internal certs and control-plane-pki-operator-managed break-glass credentials
- Each page cross-references the other for clarity
- Uses `oc` commands per project conventions
- Resource names verified against `control-plane-pki-operator/manifests/pki.go`

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.
- [ ] This change includes unit tests. (N/A - documentation only)

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve [CNTRLPLANE-451](https://issues.redhat.com//browse/CNTRLPLANE-451)`