### PR TITLE
CNTRLPLANE-208: Document needed Azure infrastructure

### DIFF
--- a/docs/content/how-to/azure/index.md
+++ b/docs/content/how-to/azure/index.md
@@ -1,0 +1,55 @@
+# Azure
+
+This section provides guides for deploying HyperShift hosted clusters on Microsoft Azure. There are two deployment models available, each with different management cluster platforms and authentication mechanisms.
+
+## Deployment Models
+
+### ARO HCP (Managed Azure)
+
+ARO HCP (Azure Red Hat OpenShift Hosted Control Planes) uses an AKS (Azure Kubernetes Service) cluster as the management platform. This model uses Azure Managed Identities with certificate-based authentication, with credentials stored in Azure Key Vault.
+
+**Guides:**
+
+- [Create an Azure Hosted Cluster on AKS](create-azure-cluster-on-aks.md) - Step-by-step setup guide
+- [Azure Hosted Cluster with Options](create-azure-cluster-with-options.md) - Advanced configuration options
+
+### Self-Managed Azure
+
+Self-managed Azure uses an OpenShift cluster (running on any platform - AWS, Azure, bare metal, etc.) as the management platform. This model uses Azure Workload Identity with OIDC federation for tokenless authentication.
+
+!!! note "Developer Preview in OCP 4.21"
+
+    Self-managed Azure HostedClusters are available as a Developer Preview feature in OpenShift Container Platform 4.21.
+
+**Guides:**
+
+- [Self-Managed Azure Overview](self-managed-azure-index.md) - Architecture and deployment workflow
+- [Azure Workload Identity Setup](azure-workload-identity-setup.md) - Set up managed identities and OIDC federation
+- [Setup Azure Management Cluster](setup-management-cluster.md) - Install HyperShift operator
+- [Create a Self-Managed Azure HostedCluster](create-self-managed-azure-cluster.md) - Deploy your first hosted cluster
+
+## Comparison
+
+| Aspect | ARO HCP | Self-Managed Azure |
+|--------|---------|-------------------|
+| **Management Cluster** | AKS | OpenShift (any platform) |
+| **Control Plane Auth** | Certificate-based (Key Vault) | Workload Identity (OIDC) |
+| **Data Plane Auth** | Federated Identity (OIDC) | Workload Identity (OIDC) |
+| **Credential Storage** | Azure Key Vault | None (tokenless via OIDC) |
+| **Identity Configuration** | Managed identities file + data plane identities file | Workload identities file |
+| **Secrets Access** | Secrets Store CSI Driver | Projected ServiceAccount tokens |
+| **Setup Complexity** | Higher (Key Vault, service principals, CSI driver) | Moderate (OIDC federation only) |
+| **Automation Scripts** | Available in `contrib/managed-azure/` | Available in `contrib/self-managed-azure/` |
+
+## Infrastructure Reference
+
+For detailed information about the Azure infrastructure resources required for each deployment model, see:
+
+- [ARO HCP Infrastructure](../../reference/infrastructure/azure-aro-hcp.md)
+- [Self-Managed Azure Infrastructure](../../reference/infrastructure/azure-self-managed.md)
+
+## Additional Resources
+
+- [Azure Workload Identity Documentation](https://azure.github.io/azure-workload-identity/docs/)
+- [Azure Managed Identities Documentation](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview)
+- [Secrets Store CSI Driver](https://secrets-store-csi-driver.sigs.k8s.io/)

--- a/docs/content/reference/infrastructure/azure-self-managed.md
+++ b/docs/content/reference/infrastructure/azure-self-managed.md
@@ -38,7 +38,7 @@ The following infrastructure must exist before creating a self-managed Azure Hos
 | Azure Subscription | Active subscription with sufficient quota |
 | Azure CLI | `az` CLI installed and configured |
 | `jq` | Command-line JSON processor |
-| CCO Tool | Cloud Credential Operator tool for OIDC setup |
+| CCO Tool | [Cloud Credential Operator CLI](https://github.com/openshift/cloud-credential-operator/blob/master/docs/ccoctl.md#azure) for OIDC setup |
 
 #### Required Azure Permissions
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -117,6 +117,7 @@ nav:
         - how-to/aws/troubleshooting/debug-nodes.md
         - how-to/aws/troubleshooting/troubleshooting-disaster-recovery.md
   - 'Azure':
+    - how-to/azure/index.md
     - 'Managed Azure':
       - how-to/azure/create-azure-cluster-on-aks.md
       - how-to/azure/create-azure-cluster-with-options.md


### PR DESCRIPTION
## What this PR does / why we need it:

Adds comprehensive Azure documentation to the upstream docs:

1. **Azure Overview Page** (`docs/content/how-to/azure/index.md`) - A new landing page for Azure that provides:
   - Overview of both deployment models (ARO HCP and self-managed Azure)
   - Comparison table highlighting key differences (authentication, credential storage, setup complexity)
   - Links to relevant guides for each deployment model

2. **Infrastructure Reference Documentation** (`docs/content/reference/infrastructure/`):
   - **`azure-self-managed.md`** - For self-managed Azure HyperShift deployments using an OpenShift management cluster (can run on any platform - AWS, Azure, bare metal, etc.) with workload identity federation
   - **`azure-aro-hcp.md`** - For ARO HCP (managed Azure) deployments using an AKS management cluster with managed identities and Azure Key Vault

Both infrastructure documents describe:
- Pre-required infrastructure and Azure permissions
- Infrastructure created by HyperShift CLI (Resource Groups, VNet, Subnet, NSG, DNS, Load Balancer)
- Infrastructure managed by Kubernetes controllers
- Authentication models (Workload Identities vs Managed Identities)
- Resource group strategies (persistent vs cluster-specific)

This follows the same pattern as the existing AWS and Agent infrastructure reference pages.

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/CNTRLPLANE-208

## Special notes for your reviewer:

- Documentation-only change, no code changes
- The self-managed Azure document clarifies that the management cluster can run on any platform (AWS, Azure, bare metal, etc.), not just Azure
- The new Azure index page helps users understand the differences between ARO HCP and self-managed Azure before diving into specific guides
- Links to existing how-to guides are included for further details

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.
- [ ] This change includes unit tests. (N/A - documentation only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)