### PR TITLE
NO-JIRA: fix(install): skip IPAM CRDs if they already exist

### DIFF
--- a/cmd/install/install_helm.go
+++ b/cmd/install/install_helm.go
@@ -49,7 +49,8 @@ func NewHelmRenderCommand(opts *Options) *cobra.Command {
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		opts.ApplyDefaults()
 
-		crds, manifests, err := hyperShiftOperatorTemplateManifest(opts, helmTemplateParams)
+		// Helm rendering doesn't need to check for existing CRDs, so pass nil for client
+		crds, manifests, err := hyperShiftOperatorTemplateManifest(cmd.Context(), nil, opts, helmTemplateParams)
 		if err != nil {
 			return err
 		}

--- a/cmd/install/install_test.go
+++ b/cmd/install/install_test.go
@@ -193,7 +193,8 @@ func TestSetupCRDs(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
-			crds := setupCRDs(tc.inputOptions, &corev1.Namespace{}, nil)
+			crds, err := setupCRDs(t.Context(), nil, tc.inputOptions, &corev1.Namespace{}, nil)
+			g.Expect(err).ToNot(HaveOccurred())
 			nodePoolCRDS := make([]crclient.Object, 0)
 			var machineDeploymentCRD crclient.Object
 			var awsEndpointServicesCRD crclient.Object

--- a/cmd/install/render.go
+++ b/cmd/install/render.go
@@ -1,6 +1,7 @@
 package install
 
 import (
+	"context"
 	"fmt"
 
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,7 +30,7 @@ type TemplateParams struct {
 	TemplateParamWrapper        func(string) string
 }
 
-func hyperShiftOperatorTemplateManifest(opts *Options, templateParamConfig TemplateParams) ([]crclient.Object, []crclient.Object, error) {
+func hyperShiftOperatorTemplateManifest(ctx context.Context, client crclient.Client, opts *Options, templateParamConfig TemplateParams) ([]crclient.Object, []crclient.Object, error) {
 	// validate options
 	if err := opts.ValidateRender(); err != nil {
 		return nil, nil, err
@@ -78,7 +79,7 @@ func hyperShiftOperatorTemplateManifest(opts *Options, templateParamConfig Templ
 
 	// create manifests
 	opts.RenderNamespace = templateParamConfig.TemplateNamespace
-	crds, objects, err := hyperShiftOperatorManifests(*opts)
+	crds, objects, err := hyperShiftOperatorManifests(ctx, client, *opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/test/e2e/util/install.go
+++ b/test/e2e/util/install.go
@@ -21,7 +21,7 @@ func InstallHyperShiftOperator(ctx context.Context, opts HyperShiftOperatorInsta
 		installOpts.OutputFile = opts.DryRunDir + "/install-hypershift-operator.yaml"
 		installOpts.Format = install.RenderFormatYaml
 		installOpts.OutputTypes = string(install.OutputAll)
-		return install.RenderHyperShiftOperator(os.Stdout, &installOpts)
+		return install.RenderHyperShiftOperator(ctx, os.Stdout, &installOpts)
 	}
 
 	return install.InstallHyperShiftOperator(ctx, os.Stdout, installOpts)


### PR DESCRIPTION
## Summary

- Skip installing cluster-api IPAM CRDs (ipaddressclaims, ipaddresses) if they already exist in the cluster
- These CRDs may already be installed by other components (e.g., by CVO) and overwriting them can cause conflicts
- The render command also skips existing IPAM CRDs when a kubeconfig is available

## Test plan

- [ ] Run `hypershift install` on a cluster with existing IPAM CRDs and verify they are skipped
- [ ] Run `hypershift install` on a cluster without IPAM CRDs and verify they are installed
- [ ] Run `hypershift install render` and verify IPAM CRDs are included when no kubeconfig is available
- [ ] Run existing unit tests: `go test ./cmd/install/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)