### PR TITLE
Revert "CNTRLPLANE-2205: Auto-detect shared role use and enable for e2e"

### DIFF
--- a/cmd/cluster/aws/destroy.go
+++ b/cmd/cluster/aws/destroy.go
@@ -105,6 +105,7 @@ func destroyPlatformSpecifics(ctx context.Context, o *core.DestroyOptions) error
 			CredentialsSecretData:        secretData,
 			VPCOwnerCredentialsOpts:      o.AWSPlatform.VPCOwnerCredentials,
 			PrivateZonesInClusterAccount: o.AWSPlatform.PrivateZonesInClusterAccount,
+			SharedRole:                   o.AWSPlatform.SharedRole,
 		}
 		if err := destroyOpts.Run(ctx); err != nil {
 			return fmt.Errorf("failed to destroy IAM: %w", err)

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -2313,10 +2313,6 @@ func TestCreateCluster(t *testing.T) {
 	if !e2eutil.IsLessThan(e2eutil.Version418) {
 		clusterOpts.FeatureSet = string(configv1.TechPreviewNoUpgrade)
 	}
-	if globalOpts.Platform == hyperv1.AWSPlatform {
-		// Use this test cluster to validate per-component roles
-		clusterOpts.AWSPlatform.SharedRole = false
-	}
 
 	clusterOpts.PodsLabels = map[string]string{
 		"hypershift-e2e-test-label": "test",

--- a/test/e2e/util/options.go
+++ b/test/e2e/util/options.go
@@ -284,7 +284,6 @@ func (o *Options) DefaultAWSOptions() hypershiftaws.RawCreateOptions {
 		MultiArch:              o.ConfigurableClusterOptions.AWSMultiArch,
 		PublicOnly:             true,
 		UseROSAManagedPolicies: true,
-		SharedRole:             true,
 	}
 	if IsLessThan(semver.MustParse("4.16.0")) {
 		opts.PublicOnly = false


### PR DESCRIPTION
Reverts openshift/hypershift#7356

There is some transient issue with the ingress-operator cloud cred secret not being reconciled.

Per TRT SOP, reverting to get jobs reliable again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds CLI flags to delete either the shared IAM role or per-component roles, refactors role deletion API/flows (incl. shared VPC), and makes shared role creation use inline policies; updates e2e defaults accordingly.
> 
> - **AWS IAM/CLI**
>   - Add `--shared-role` flag to `cmd/cluster/aws destroy` and `cmd/infra/aws destroy-iam` to choose deleting the shared IAM role vs per-component roles.
>   - Pass `AWSPlatform.SharedRole` through to `DestroyIAMOptions`.
> - **IAM Destroy Refactor**
>   - Change `DestroyOIDCRole` signature to return `error` and accept `includeAssumePolicy` boolean; update all call sites (incl. shared VPC roles).
>   - Implement conditional deletion: `shared-role` when `SharedRole` is true; otherwise delete individual roles (e.g., `openshift-ingress`, `control-plane-operator`, etc.).
> - **IAM Create (Shared Role)**
>   - For `CreateSharedOIDCRole`, attach all permissions as inline policies (remove managed policy attachment path) and add optional assume policy inline.
> - **E2E**
>   - Stop forcing per-component roles in `TestCreateCluster` and remove default `SharedRole` setting from AWS test options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f08f5307d24b0422ef126065bfceaf37e83a5e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->