### PR TITLE
NO-JIRA: chore(azure): bump AKS Kubernetes version to 1.33.0

### DIFF
--- a/contrib/managed-azure/setup_aks_cluster.sh
+++ b/contrib/managed-azure/setup_aks_cluster.sh
@@ -33,7 +33,7 @@ az aks create \
 --os-sku AzureLinux \
 --node-vm-size Standard_D4s_v4 \
 --enable-fips-image \
---kubernetes-version 1.31.1 \
+--kubernetes-version 1.33.0 \
 --enable-addons azure-keyvault-secrets-provider \
 --enable-secret-rotation \
 --rotation-poll-interval 1m \


### PR DESCRIPTION
## What this PR does / why we need it:

Updates the AKS cluster setup script to use Kubernetes version 1.33.0, upgrading from 1.31.1.

## Which issue(s) this PR fixes:

N/A - version maintenance

## Special notes for your reviewer:

Simple version bump for the managed Azure AKS cluster setup script.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.