### PR TITLE
OCPBUGS-67262: fix(e2e): Use NodePool replicas as authoritative source for expected node count instead of CountAvailableNodes

### DIFF
--- a/test/e2e/util/hypershift_framework.go
+++ b/test/e2e/util/hypershift_framework.go
@@ -159,7 +159,7 @@ func (h *hypershiftTest) before(hostedCluster *hyperv1.HostedCluster, opts *Plat
 					t.Fatal("AssetReader is required for Cilium installation. Call WithAssetReader() on the test instance.")
 				}
 				guestClient := WaitForGuestClient(t, context.Background(), h.client, hostedCluster)
-				InstallCilium(t, context.Background(), guestClient, hostedCluster, h.assetReader)
+				InstallCilium(t, context.Background(), guestClient, hostedCluster, h.assetReader, opts.NodePoolReplicas)
 				// wait hosted cluster ready
 				WaitForNReadyNodes(t, context.Background(), guestClient, opts.NodePoolReplicas, platform)
 				WaitForImageRollout(t, context.Background(), h.client, hostedCluster)


### PR DESCRIPTION
> [!WARNING]
>  This PR needs #7638 to go in first

## What this PR does / why we need it:

Use NodePool replicas as authoritative source for expected node count instead of CountAvailableNodes() which can return stale values when nodes are temporarily NotReady due to kubelet restarts.

This is needed to stabilize the e2e tests and make them more deterministic. 

Also wait for nodes to stabilize after pull secret update/deletion
operations that trigger kubelet restarts via global-pull-secret-syncer.


## Which issue(s) this PR fixes:

Fixes OCPBUGS-67262

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved DaemonSet readiness verification to use NodePool replica counts as the authoritative source instead of dynamically counting nodes.
  * Refactored test utilities with more granular per-DaemonSet readiness checks for improved validation accuracy and reliability.
  * Enhanced Cilium installation flow to receive explicit node pool replica information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->