### PR TITLE
OCPBUGS-62760: Pre-pull images to avoid startup delays and flaky e2e

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/GCP/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/GCP/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
@@ -366,21 +366,6 @@ spec:
             - ALL
           runAsNonRoot: true
         terminationMessagePolicy: FallbackToLogsOnError
-      - command:
-        - /bin/sh
-        - -c
-        - 'echo ''Image pre-pulled: cli''; exit 0'
-        image: cli
-        imagePullPolicy: IfNotPresent
-        name: pre-pull-image-cli
-        resources: {}
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          runAsNonRoot: true
-        terminationMessagePolicy: FallbackToLogsOnError
       - args:
         - -c
         - |

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
@@ -328,15 +328,6 @@ spec:
         name: pre-pull-image-apiserver-network-proxy
         resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
-      - command:
-        - /bin/sh
-        - -c
-        - 'echo ''Image pre-pulled: cli''; exit 0'
-        image: cli
-        imagePullPolicy: IfNotPresent
-        name: pre-pull-image-cli
-        resources: {}
-        terminationMessagePolicy: FallbackToLogsOnError
       - args:
         - -c
         - |

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
@@ -359,15 +359,6 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - 'echo ''Image pre-pulled: cli''; exit 0'
-        image: cli
-        imagePullPolicy: IfNotPresent
-        name: pre-pull-image-cli
-        resources: {}
-        terminationMessagePolicy: FallbackToLogsOnError
-      - command:
-        - /bin/sh
-        - -c
         - 'echo ''Image pre-pulled: aws-pod-identity-webhook''; exit 0'
         image: aws-pod-identity-webhook
         imagePullPolicy: IfNotPresent

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-apiserver/zz_fixture_TestControlPlaneComponents_kube_apiserver_deployment.yaml
@@ -359,15 +359,6 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - 'echo ''Image pre-pulled: cli''; exit 0'
-        image: cli
-        imagePullPolicy: IfNotPresent
-        name: pre-pull-image-cli
-        resources: {}
-        terminationMessagePolicy: FallbackToLogsOnError
-      - command:
-        - /bin/sh
-        - -c
         - 'echo ''Image pre-pulled: aws-pod-identity-webhook''; exit 0'
         image: aws-pod-identity-webhook
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## What this PR does / why we need it:
This PR pre-pulls images via `InitContainers` to avoid delayed startup of KAS and bootstrap containers, which would cause flakiness in the e2e tests.

## Which issue(s) this PR fixes:
[OCPBUGS-62760](https://issues.redhat.com/browse/OCPBUGS-62760)

## Special notes for your reviewer:
- Added one init container per regular container.
- Pre-pull init containers are prepended to other init containers to make sure they run at the very start.
- Added an e2e test to verify the above.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.