### PR TITLE
NO-JIRA: fix(nodepool): prevent selector label accumulation in MachineSet and …

### DIFF
--- a/hypershift-operator/controllers/nodepool/capi.go
+++ b/hypershift-operator/controllers/nodepool/capi.go
@@ -391,12 +391,11 @@ func (c *CAPI) reconcileMachineDeployment(ctx context.Context, log logr.Logger,
 	machineDeployment.Spec.MinReadySeconds = ptr.To[int32](0)
 
 	machineDeployment.Spec.ClusterName = capiClusterName
-	if machineDeployment.Spec.Selector.MatchLabels == nil {
-		machineDeployment.Spec.Selector.MatchLabels = map[string]string{}
-	}
-	machineDeployment.Spec.Selector.MatchLabels[capiv1.ClusterNameLabel] = capiClusterName
 	resourcesName := generateName(capiClusterName, nodePool.Spec.ClusterName, nodePool.GetName())
-	machineDeployment.Spec.Selector.MatchLabels[resourcesName] = resourcesName
+	machineDeployment.Spec.Selector.MatchLabels = map[string]string{
+		capiv1.ClusterNameLabel: capiClusterName,
+		resourcesName:           resourcesName,
+	}
 
 	gvk, err := apiutil.GVKForObject(machineTemplateCR, api.Scheme)
 	if err != nil {
@@ -827,10 +826,10 @@ func (c *CAPI) reconcileMachineSet(ctx context.Context,
 
 	// Set selector and template
 	machineSet.Spec.ClusterName = capiClusterName
-	if machineSet.Spec.Selector.MatchLabels == nil {
-		machineSet.Spec.Selector.MatchLabels = map[string]string{}
+	machineSet.Spec.Selector.MatchLabels = map[string]string{
+		capiv1.ClusterNameLabel: capiClusterName,
+		resourcesName:           resourcesName,
 	}
-	machineSet.Spec.Selector.MatchLabels[resourcesName] = resourcesName
 	machineSet.Spec.Template = capiv1.MachineTemplateSpec{
 		ObjectMeta: capiv1.ObjectMeta{
 			Labels: map[string]string{


### PR DESCRIPTION
## What this PR does / why we need it:

  This PR fixes a critical bug in the MachineSet and MachineDeployment reconciliation logic that causes selector labels to accumulate instead of being properly synchronized with Machine template labels.

  **The Bug:**
  The `reconcileMachineSet()` and `reconcileMachineDeployment()` functions were appending labels to existing selector maps instead of recreating them from scratch:

  ```go
  // BROKEN: Appends to existing map
  if machineSet.Spec.Selector.MatchLabels == nil {
      machineSet.Spec.Selector.MatchLabels = map[string]string{}
  }
  machineSet.Spec.Selector.MatchLabels[resourcesName] = resourcesName  // Appends!

  Meanwhile, the template labels are always created fresh:
  // Template uses fresh map
  machineSet.Spec.Template.ObjectMeta.Labels = map[string]string{
      resourcesName:           resourcesName,
      capiv1.ClusterNameLabel: capiClusterName,
  }
```
  Why This Is Wrong:
  Any time resourcesName changes (due to infrastructure changes, upgrades, or other reconciliation logic), the selector accumulates the old label while the template only has the new label. This causes:
  1. Machines to not match their parent MachineSet/MachineDeployment selectors
  2. CAPI controllers to continuously create new Machines (thinking none match)
  3. Infinite machine creation loop

  **The Fix:**
  - Recreate the selector map from scratch instead of appending (makes it consistent with template behavior)
  - Add the missing cluster.x-k8s.io/cluster-name label to MachineSet selectors (was present in MachineDeployment but not MachineSet)
  ```go
  // FIXED: Creates fresh map
  machineSet.Spec.Selector.MatchLabels = map[string]string{
      capiv1.ClusterNameLabel: capiClusterName,
      resourcesName:           resourcesName,
  }
```
  This ensures selectors always stay in sync with template labels, preventing the mismatch regardless of what causes resourcesName to change.