### PR TITLE
OCPBUGS-61678: fix(kas): Disable PSA enforcement in 4.21

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/config.go
@@ -117,7 +117,7 @@ func generateConfig(p KubeAPIServerConfigParams) (*kcpv1.KubeAPIServerConfig, er
 									Kind:       "PodSecurityConfiguration",
 								},
 								Defaults: podsecurityadmissionv1.PodSecurityDefaults{
-									Enforce:        "restricted",
+									Enforce:        "privileged",
 									EnforceVersion: "latest",
 									Audit:          "restricted",
 									AuditVersion:   "latest",


### PR DESCRIPTION
Disable PSA enforcement in 4.21

Related to https://github.com/openshift/api/pull/2623

See https://github.com/openshift/hypershift/pull/6830 for reference