### PR TITLE
CNTRLPLANE-2123: Fix buildah-remote-oci-ta task enterprise contract violation

### DIFF
--- a/.tekton/pipelines/common-operator-build.yaml
+++ b/.tekton/pipelines/common-operator-build.yaml
@@ -183,7 +183,7 @@ spec:
       - name: name
         value: buildah-remote-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.7@sha256:b24359805297760c87cbce7b4c378267bc83aa1b9a3ac8431829f80bc26ed5d7
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.7@sha256:ef1c062b10c9fb17951350de76bce6bb54a4ea75fca4f37ea136d626c444bf78
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
## Summary
- Updates buildah-remote-oci-ta task digest to resolve enterprise contract violation
- Task was marked as unsupported as of 2025-12-11T00:00:00Z
- Updated from outdated digest to latest available digest for version 0.7

## Changes Made
- Updated `.tekton/pipelines/common-operator-build.yaml` 
- Changed buildah-remote-oci-ta task digest from `sha256:b24359805297760c87cbce7b4c378267bc83aa1b9a3ac8431829f80bc26ed5d7` to `sha256:ef1c062b10c9fb17951350de76bce6bb54a4ea75fca4f37ea136d626c444bf78`

## Analysis Results
- Analyzed 10 outdated tasks from enterprise contract verification log
- 9 tasks were already current with latest digests 
- Only buildah-remote-oci-ta required updating due to expiration

## Fixes
- [CNTRLPLANE-2123](https://issues.redhat.com/browse/CNTRLPLANE-2123)

## Test Plan
- [x] Verified task digest exists in konflux registry
- [x] Confirmed version compatibility (0.7 -> 0.7, digest update only)
- [x] No migration notes required (same version, different digest)
- [ ] CI pipeline validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)