### PR TITLE
OCPBUGS-69447: feat(updates): enable CVO metrics access with RHOBS monitoring flag

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -432,6 +432,7 @@ type HyperShiftOperatorDeployment struct {
 	IncludeVersion                          bool
 	UWMTelemetry                            bool
 	RHOBSMonitoring                         bool
+	CVOPrometheusURL                        string
 	MonitoringDashboards                    bool
 	CertRotationScale                       time.Duration
 	EnableCVOManagementClusterMetricsAccess bool
@@ -719,6 +720,13 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  rhobsmonitoring.EnvironmentVariable,
 			Value: "1",
+		})
+	}
+
+	if o.CVOPrometheusURL != "" {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  config.CVOPrometheusURLEnvVar,
+			Value: o.CVOPrometheusURL,
 		})
 	}
 
@@ -1093,6 +1101,7 @@ func (o HyperShiftOperatorServiceAccount) Build() *corev1.ServiceAccount {
 
 type HyperShiftOperatorClusterRole struct {
 	EnableCVOManagementClusterMetricsAccess bool
+	RHOBSMonitoring                         bool
 	ManagedService                          string
 	EnableAuditLogPersistence               bool
 }
@@ -1380,7 +1389,7 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 			},
 		},
 	}
-	if o.EnableCVOManagementClusterMetricsAccess {
+	if o.EnableCVOManagementClusterMetricsAccess || o.RHOBSMonitoring {
 		role.Rules = append(role.Rules,
 			rbacv1.PolicyRule{
 				APIGroups: []string{"metrics.k8s.io"},

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -116,6 +116,7 @@ type Options struct {
 	WaitUntilAvailable                        bool
 	WaitUntilEstablished                      bool
 	RHOBSMonitoring                           bool
+	CVOPrometheusURL                          string
 	SLOsAlerts                                bool
 	MonitoringDashboards                      bool
 	CertRotationScale                         time.Duration
@@ -225,6 +226,10 @@ func (o *Options) Validate() error {
 		errs = append(errs, fmt.Errorf("when invoking this command with the --rhobs-monitoring flag, the --enable-cvo-management-cluster-metrics-access flag is not supported "))
 	}
 
+	if len(o.CVOPrometheusURL) > 0 && !o.RHOBSMonitoring && !o.EnableCVOManagementClusterMetricsAccess {
+		errs = append(errs, fmt.Errorf("--cvo-prometheus-url requires either --rhobs-monitoring or --enable-cvo-management-cluster-metrics-access to be enabled"))
+	}
+
 	if len(o.ManagedService) > 0 && o.ManagedService != hyperv1.AroHCP {
 		errs = append(errs, fmt.Errorf("not a valid managed service type: %s", o.ManagedService))
 	}
@@ -305,7 +310,8 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&opts.EnableCVOManagementClusterMetricsAccess, "enable-cvo-management-cluster-metrics-access", opts.EnableCVOManagementClusterMetricsAccess, "If true, the hosted CVO will have access to the management cluster metrics server to evaluate conditional updates (supported for OpenShift management clusters)")
 	cmd.Flags().BoolVar(&opts.WaitUntilAvailable, "wait-until-available", opts.WaitUntilAvailable, "If true, pauses installation until hypershift operator has been rolled out and its webhook service is available (if installing the webhook)")
 	cmd.Flags().BoolVar(&opts.WaitUntilEstablished, "wait-until-crds-established", opts.WaitUntilEstablished, "If true, pauses installation until all custom resource definitions are established before applying other manifests.")
-	cmd.PersistentFlags().BoolVar(&opts.RHOBSMonitoring, "rhobs-monitoring", opts.RHOBSMonitoring, "If true, HyperShift will generate and use the RHOBS version of monitoring resources (ServiceMonitors, PodMonitors, etc)")
+	cmd.PersistentFlags().BoolVar(&opts.RHOBSMonitoring, "rhobs-monitoring", opts.RHOBSMonitoring, "If true, HyperShift will generate and use the RHOBS version of monitoring resources (ServiceMonitors, PodMonitors, etc). For ROSA HCP, this also enables the Cluster Version Operator to query the RHOBS Prometheus for conditional update evaluation. Use --cvo-prometheus-url to override the default Prometheus endpoint.")
+	cmd.PersistentFlags().StringVar(&opts.CVOPrometheusURL, "cvo-prometheus-url", opts.CVOPrometheusURL, "Prometheus URL for the Cluster Version Operator to query metrics for conditional update risk evaluation. Only effective when --rhobs-monitoring or --enable-cvo-management-cluster-metrics-access is enabled. If not specified, defaults to the RHOBS monitoring stack for ROSA HCP, or the Thanos querier for self-managed HyperShift.")
 	cmd.PersistentFlags().BoolVar(&opts.SLOsAlerts, "slos-alerts", opts.SLOsAlerts, "If true, HyperShift will generate and use the prometheus alerts for monitoring HostedCluster and NodePools")
 	cmd.PersistentFlags().BoolVar(&opts.MonitoringDashboards, "monitoring-dashboards", opts.MonitoringDashboards, "If true, HyperShift will generate a monitoring dashboard for every HostedCluster that it creates")
 	cmd.PersistentFlags().DurationVar(&opts.CertRotationScale, "cert-rotation-scale", opts.CertRotationScale, "The scaling factor for certificate rotation. It is not supported to set this to anything other than 24h.")
@@ -899,6 +905,7 @@ func setupOperatorResources(opts Options, userCABundleCM *corev1.ConfigMap, trus
 		IncludeVersion:                          !opts.Template,
 		UWMTelemetry:                            opts.EnableUWMTelemetryRemoteWrite,
 		RHOBSMonitoring:                         opts.RHOBSMonitoring,
+		CVOPrometheusURL:                        opts.CVOPrometheusURL,
 		MonitoringDashboards:                    opts.MonitoringDashboards,
 		CertRotationScale:                       opts.CertRotationScale,
 		EnableCVOManagementClusterMetricsAccess: opts.EnableCVOManagementClusterMetricsAccess,
@@ -1066,6 +1073,7 @@ func setupRBAC(opts Options, operatorNamespace *corev1.Namespace) (*corev1.Servi
 
 	operatorClusterRole := assets.HyperShiftOperatorClusterRole{
 		EnableCVOManagementClusterMetricsAccess: opts.EnableCVOManagementClusterMetricsAccess,
+		RHOBSMonitoring:                         opts.RHOBSMonitoring,
 		ManagedService:                          opts.ManagedService,
 		EnableAuditLogPersistence:               opts.EnableAuditLogPersistence,
 	}.Build()

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/controlplaneoperator/role.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/controlplaneoperator/role.go
@@ -3,9 +3,11 @@ package controlplaneoperator
 import (
 	"os"
 
+	"github.com/openshift/hypershift/support/awsutil"
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/rhobsmonitoring"
 	"github.com/openshift/hypershift/support/util"
 
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -13,6 +15,14 @@ import (
 
 func adaptRole(cpContext component.WorkloadContext, role *rbacv1.Role) error {
 	if os.Getenv(config.EnableCVOManagementClusterMetricsAccessEnvVar) == "1" {
+		role.Rules = append(role.Rules, rbacv1.PolicyRule{
+			APIGroups: []string{"metrics.k8s.io"},
+			Resources: []string{"pods"},
+			Verbs:     []string{"get"},
+		})
+	}
+
+	if os.Getenv(rhobsmonitoring.EnvironmentVariable) == "1" && awsutil.IsROSAHCP(cpContext.HCP) {
 		role.Rules = append(role.Rules, rbacv1.PolicyRule{
 			APIGroups: []string{"metrics.k8s.io"},
 			Resources: []string{"pods"},

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/component.go
@@ -1,9 +1,13 @@
 package cvo
 
 import (
+	"os"
+
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	oapiv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/oapi"
+	"github.com/openshift/hypershift/support/awsutil"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/rhobsmonitoring"
 	"github.com/openshift/hypershift/support/util"
 )
 
@@ -67,6 +71,13 @@ func NewComponent(enableCVOManagementClusterMetricsAccess bool) component.Contro
 		Build()
 }
 
+// isManagementClusterMetricsAccessEnabled determines if CVO needs access to a metrics
+// endpoint on the Management Cluster. This covers two scenarios:
+//   - Self-managed HyperShift: Thanos Querier in openshift-monitoring namespace
+//     (controlled by enableCVOManagementClusterMetricsAccess flag)
+//   - ROSA HCP: RHOBS Prometheus in openshift-observability-operator namespace
+//     (enabled when RHOBS monitoring is active on ROSA HCP clusters)
 func (cvo *clusterVersionOperator) isManagementClusterMetricsAccessEnabled(cpContext component.WorkloadContext) bool {
-	return cvo.enableCVOManagementClusterMetricsAccess
+	return cvo.enableCVOManagementClusterMetricsAccess ||
+		(os.Getenv(rhobsmonitoring.EnvironmentVariable) == "1" && awsutil.IsROSAHCP(cpContext.HCP))
 }

--- a/hypershift-operator/controllers/hostedcluster/network_policies.go
+++ b/hypershift-operator/controllers/hostedcluster/network_policies.go
@@ -5,13 +5,16 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"os"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/networkpolicy"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/sharedingress"
+	"github.com/openshift/hypershift/support/awsutil"
 	"github.com/openshift/hypershift/support/capabilities"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/rhobsmonitoring"
 	"github.com/openshift/hypershift/support/upsert"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -84,10 +87,12 @@ func (r *HostedClusterReconciler) reconcileNetworkPolicies(ctx context.Context, 
 		}
 
 		// Allow egress communication to the HCP metrics server for pods that have a known annotation.
-		if r.EnableCVOManagementClusterMetricsAccess {
+		// Enable if either RHOBS monitoring is enabled for ROSA HCP or the explicit flag is set.
+		enableMetricsAccess := r.EnableCVOManagementClusterMetricsAccess || (os.Getenv(rhobsmonitoring.EnvironmentVariable) == "1" && awsutil.IsROSAHCP(hcp))
+		if enableMetricsAccess {
 			policy = networkpolicy.MetricsServerNetworkPolicy(controlPlaneNamespaceName)
 			if _, err := createOrUpdate(ctx, r.Client, policy, func() error {
-				return reconcileMetricsServerNetworkPolicy(policy)
+				return reconcileMetricsServerNetworkPolicy(policy, hcp)
 			}); err != nil {
 				return fmt.Errorf("failed to reconcile metrics server network policy: %w", err)
 			}
@@ -831,35 +836,71 @@ func kasEndpointsToCIDRs(kubernetesEndpoint *corev1.Endpoints) []string {
 }
 
 // reconcileMetricsServerNetworkPolicy selects pods having NeedMetricsServerAccessLabel.
-// It allows egress traffic to the HCP metrics server that is available for self-managed
-// HyperShift running on an OpenShift management cluster.
-func reconcileMetricsServerNetworkPolicy(policy *networkingv1.NetworkPolicy) error {
+// It allows egress traffic to the HCP metrics server that is available for self-managed HyperShift and ROSA HCP.
+// Depending on the monitoring stack:
+// - RHOBS (ROSA HCP only): targets OBO Prometheus at port 9090 in openshift-observability-operator namespace
+// - CoreOS (self-managed HyperShift): targets Thanos Querier at port 9092 in openshift-monitoring namespace
+func reconcileMetricsServerNetworkPolicy(policy *networkingv1.NetworkPolicy, hcp *hyperv1.HostedControlPlane) error {
 	protocol := corev1.ProtocolTCP
-	port := intstr.FromInt(9092)
-	policy.Spec.Egress = []networkingv1.NetworkPolicyEgressRule{
-		{
-			To: []networkingv1.NetworkPolicyPeer{
-				{
-					PodSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"app.kubernetes.io/instance": "thanos-querier",
-							"app.kubernetes.io/name":     "thanos-query",
-						}},
-					NamespaceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"network.openshift.io/policy-group": "monitoring",
+	var egressRules []networkingv1.NetworkPolicyEgressRule
+
+	if os.Getenv(rhobsmonitoring.EnvironmentVariable) == "1" && awsutil.IsROSAHCP(hcp) {
+		// RHOBS Prometheus configuration (ROSA HCP specific)
+		port := intstr.FromInt(9090)
+		egressRules = []networkingv1.NetworkPolicyEgressRule{
+			{
+				To: []networkingv1.NetworkPolicyPeer{
+					{
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"app.kubernetes.io/instance": "hypershift-monitoring-stack",
+								"app.kubernetes.io/name":     "prometheus",
+							}},
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"network.openshift.io/policy-group": "monitoring",
+							},
 						},
 					},
 				},
-			},
-			Ports: []networkingv1.NetworkPolicyPort{
-				{
-					Protocol: &protocol,
-					Port:     &port,
+				Ports: []networkingv1.NetworkPolicyPort{
+					{
+						Protocol: &protocol,
+						Port:     &port,
+					},
 				},
 			},
-		},
+		}
+	} else {
+		// CoreOS Thanos configuration
+		port := intstr.FromInt(9092)
+		egressRules = []networkingv1.NetworkPolicyEgressRule{
+			{
+				To: []networkingv1.NetworkPolicyPeer{
+					{
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"app.kubernetes.io/instance": "thanos-querier",
+								"app.kubernetes.io/name":     "thanos-query",
+							}},
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"network.openshift.io/policy-group": "monitoring",
+							},
+						},
+					},
+				},
+				Ports: []networkingv1.NetworkPolicyPort{
+					{
+						Protocol: &protocol,
+						Port:     &port,
+					},
+				},
+			},
+		}
 	}
+
+	policy.Spec.Egress = egressRules
 
 	policy.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeEgress}
 	policy.Spec.PodSelector = metav1.LabelSelector{

--- a/support/awsutil/platform.go
+++ b/support/awsutil/platform.go
@@ -1,0 +1,19 @@
+package awsutil
+
+import (
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+)
+
+// IsROSAHCP returns true if the hosted control plane is a ROSA HCP cluster.
+func IsROSAHCP(hcp *hyperv1.HostedControlPlane) bool {
+	if hcp.Spec.Platform.AWS == nil {
+		return false
+	}
+
+	for _, tag := range hcp.Spec.Platform.AWS.ResourceTags {
+		if tag.Key == "red-hat-managed" && tag.Value == "true" {
+			return true
+		}
+	}
+	return false
+}

--- a/support/awsutil/platform_test.go
+++ b/support/awsutil/platform_test.go
@@ -1,0 +1,146 @@
+package awsutil
+
+import (
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+)
+
+func TestIsROSAHCP(t *testing.T) {
+	tests := []struct {
+		name string
+		hcp  *hyperv1.HostedControlPlane
+		want bool
+	}{
+		{
+			name: "When HCP has red-hat-managed=true tag, it should return true",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							ResourceTags: []hyperv1.AWSResourceTag{
+								{
+									Key:   "red-hat-managed",
+									Value: "true",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "When HCP has red-hat-managed=true tag among other tags, it should return true",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							ResourceTags: []hyperv1.AWSResourceTag{
+								{
+									Key:   "environment",
+									Value: "production",
+								},
+								{
+									Key:   "red-hat-managed",
+									Value: "true",
+								},
+								{
+									Key:   "team",
+									Value: "platform",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "When HCP has red-hat-managed=false tag, it should return false",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							ResourceTags: []hyperv1.AWSResourceTag{
+								{
+									Key:   "red-hat-managed",
+									Value: "false",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "When HCP has no red-hat-managed tag, it should return false",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							ResourceTags: []hyperv1.AWSResourceTag{
+								{
+									Key:   "environment",
+									Value: "dev",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "When HCP has no resource tags, it should return false",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							ResourceTags: []hyperv1.AWSResourceTag{},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "When HCP is not on AWS platform, it should return false",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type:  hyperv1.AzurePlatform,
+						Azure: &hyperv1.AzurePlatformSpec{},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "When HCP has nil AWS spec, it should return false",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS:  nil,
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsROSAHCP(tt.hcp); got != tt.want {
+				t.Errorf("IsROSAHCP() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/support/config/constants.go
+++ b/support/config/constants.go
@@ -45,6 +45,7 @@ const (
 
 	DefaultIngressDomainEnvVar                    = "DEFAULT_INGRESS_DOMAIN"
 	EnableCVOManagementClusterMetricsAccessEnvVar = "ENABLE_CVO_MANAGEMENT_CLUSTER_METRICS_ACCESS"
+	CVOPrometheusURLEnvVar                        = "CVO_PROMETHEUS_URL"
 
 	EnableEtcdRecoveryEnvVar = "ENABLE_ETCD_RECOVERY"
 


### PR DESCRIPTION
## What this PR does:
When `--rhobs-monitoring=true` is set (for ROSA HCP), enable CVO access to OBO Prometheus for conditional update risk evaluation. 

Aldo add `--cvo-prometheus-url` flag to allow overriding the default Prometheus endpoint. This provides flexibility for future changes (e.g., if ROSA changes the service name) or for platforms with different monitoring architectures (e.g., ARO HCP's self-managed Prometheus). When not specified, platform-appropriate defaults are used.

The CVO deployment logic routes to different metrics endpoints based on the monitoring stack:
- RHOBS stack (ROSA HCP): `http://hypershift-monitoring-stack-prometheus.openshift-observability-operator.svc:9090`
- CoreOS stack (Self-managed HyperShift on OpenShift or ARP HCP): `https://thanos-querier.openshift-monitoring.svc:9092`
- Custom URL: Configurable via `--cvo-prometheus-url` parameter

Key changes:
- CVO deployment enables metrics access when either `--rhobs-monitoring` (for ROSA HCP) or `--enable-cvo-management-cluster-metrics-access` (for self-managed HyperShift on OpenShift or ARO HCP) is set
- Network policies updated to allow egress to the appropriate monitoring endpoint based on stack configuration
- Add `--cvo-prometheus-url` flag to configure CVO Prometheus endpoint

## Which issue(s) this PR fixes:
fixes https://issues.redhat.com//browse/OCM-10395
fixes https://issues.redhat.com//browse/OCM-20970

## Special notes for your reviewer:
### Backport Requirements
This change should be backported to 4.17.z, 4.18.z, 4.19.z, 4.20.z and 4.21.z to benefit customers on that version.
