### PR TITLE
CNTRLPLANE-2205: feat(aws): enable shared role in e2e

### DIFF
--- a/test/e2e/control_plane_upgrade_test.go
+++ b/test/e2e/control_plane_upgrade_test.go
@@ -28,6 +28,11 @@ func TestUpgradeControlPlane(t *testing.T) {
 	clusterOpts.ReleaseImage = globalOpts.PreviousReleaseImage
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.HighlyAvailable)
 
+	if globalOpts.Platform == hyperv1.AWSPlatform {
+		// Use this test to verify that individual roles work as expected
+		clusterOpts.AWSPlatform.SharedRole = false
+	}
+
 	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 		// Sanity check the cluster by waiting for the nodes to report ready
 		guestClient := e2eutil.WaitForGuestClient(t, ctx, mgtClient, hostedCluster)

--- a/test/e2e/util/options.go
+++ b/test/e2e/util/options.go
@@ -284,9 +284,17 @@ func (o *Options) DefaultAWSOptions() hypershiftaws.RawCreateOptions {
 		MultiArch:              o.ConfigurableClusterOptions.AWSMultiArch,
 		PublicOnly:             true,
 		UseROSAManagedPolicies: true,
+		SharedRole:             true,
 	}
+
 	if IsLessThan(semver.MustParse("4.16.0")) {
 		opts.PublicOnly = false
+	}
+
+	// HCCO requires this fix https://github.com/openshift/hypershift/pull/7383
+	// in order for shared roles to work properly.
+	if IsLessThan(semver.MustParse("4.20.0")) {
+		opts.SharedRole = false
 	}
 
 	// Set an expiration date tag if it's not already set


### PR DESCRIPTION
This commit enables the use of a shared role on AWS for all test clusters 4.20 and newer, except TestUpgradeControlPlane, which continues to verify the use individual roles.  This test cluster was also chosen to avoid having to do complex filtering for z-stream releases that do not contain the required HCCO fix.

https://github.com/openshift/hypershift/pull/7383

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable AWS shared IAM role for e2e clusters by default (gated to 4.20+), while the control plane upgrade test continues to use individual roles.
> 
> - **E2E AWS defaults (`test/e2e/util/options.go`)**:
>   - Enable `SharedRole: true` by default; auto-disable for versions `< 4.20.0` due to HCCO fix requirement.
>   - Preserve existing `PublicOnly` behavior toggle for versions `< 4.16.0`.
> - **Control plane upgrade test (`test/e2e/control_plane_upgrade_test.go`)**:
>   - For AWS, explicitly set `clusterOpts.AWSPlatform.SharedRole = false` to validate individual roles during upgrade.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99bef3022ac007468497fad6f606f6f34c8e81a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->