### PR TITLE
feat: Support passing node selectors and tolerations to hypershift install cmd

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -504,6 +504,8 @@ type HyperShiftOperatorDeployment struct {
 	OIDCBucketRegion                        string
 	OIDCStorageProviderS3Secret             *corev1.Secret
 	OIDCStorageProviderS3SecretKey          string
+	OperatorTolerations                     []string
+	OperatorNodeSelectors                   map[string]string
 	MetricsSet                              metrics.MetricsSet
 	IncludeVersion                          bool
 	UWMTelemetry                            bool
@@ -536,6 +538,8 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 	var volumeMounts []corev1.VolumeMount
 	var initVolumeMounts []corev1.VolumeMount
 	var volumes []corev1.Volume
+	var tolerations []corev1.Toleration
+	var nodeSelectors map[string]string
 
 	o.addWebhookResources(&args, &volumeMounts, &volumes)
 	o.addOIDCResources(&args, &volumeMounts, &volumes)
@@ -548,6 +552,22 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 	image := o.resolveImage()
 	o.addImageTagEnvVars(&envVars)
 	o.addPrivatePlatformResources(&envVars, &volumeMounts, &volumes)
+
+	for _, tolerationStr := range o.OperatorTolerations {
+		toleration := cmdutil.ParseTolerationString(tolerationStr)
+		if toleration != nil {
+			tolerations = append(tolerations, *toleration)
+		}
+	}
+
+	for key, value := range o.OperatorNodeSelectors {
+		if key != "" {
+			if nodeSelectors == nil {
+				nodeSelectors = make(map[string]string)
+			}
+			nodeSelectors[key] = value
+		}
+	}
 
 	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -696,6 +716,14 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 	// federated tokens (AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_FEDERATED_TOKEN_FILE).
 	if o.AzurePLSManagedIdentityClientID != "" {
 		deployment.Spec.Template.Labels["azure.workload.identity/use"] = "true"
+	}
+
+	if len(tolerations) > 0 {
+		deployment.Spec.Template.Spec.Tolerations = tolerations
+	}
+
+	if len(nodeSelectors) > 0 {
+		deployment.Spec.Template.Spec.NodeSelector = nodeSelectors
 	}
 
 	if o.IncludeVersion {

--- a/cmd/install/assets/hypershift_operator_test.go
+++ b/cmd/install/assets/hypershift_operator_test.go
@@ -23,11 +23,13 @@ func TestHyperShiftOperatorDeployment_Build(t *testing.T) {
 	testNamespace := "hypershift"
 	testOperatorImage := "myimage"
 	tests := map[string]struct {
-		inputBuildParameters HyperShiftOperatorDeployment
-		expectedVolumeMounts []corev1.VolumeMount
-		expectedVolumes      []corev1.Volume
-		expectedArgs         []string
-		expectedEnvVars      []corev1.EnvVar
+		inputBuildParameters  HyperShiftOperatorDeployment
+		expectedVolumeMounts  []corev1.VolumeMount
+		expectedVolumes       []corev1.Volume
+		expectedArgs          []string
+		expectedEnvVars       []corev1.EnvVar
+		expectedTolerations   []corev1.Toleration
+		expectedNodeSelectors map[string]string
 	}{
 		"empty oidc parameters result in no volume mounts": {
 			inputBuildParameters: HyperShiftOperatorDeployment{
@@ -586,6 +588,52 @@ func TestHyperShiftOperatorDeployment_Build(t *testing.T) {
 				fmt.Sprintf("--private-platform=%s", string(hyperv1.NonePlatform)),
 			},
 		},
+		"When operator tolerations and nodeselectors are specified, it should apply them to the deployment": {
+			inputBuildParameters: HyperShiftOperatorDeployment{
+				Namespace: &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testNamespace,
+					},
+				},
+				OperatorImage: testOperatorImage,
+				ServiceAccount: &corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hypershift",
+					},
+				},
+				Replicas:                               3,
+				PrivatePlatform:                        string(hyperv1.NonePlatform),
+				EnableDedicatedRequestServingIsolation: false,
+				OperatorTolerations:                    []string{"infra=true:NoSchedule", "keyOnly:NoExecute"},
+				OperatorNodeSelectors:                  map[string]string{"aro-hcp.azure.com/role": "infra"},
+			},
+			expectedTolerations: []corev1.Toleration{
+				{
+					Key:      "infra",
+					Value:    "true",
+					Operator: corev1.TolerationOpEqual,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "keyOnly",
+					Effect:   corev1.TaintEffectNoExecute,
+					Operator: corev1.TolerationOpExists,
+				},
+			},
+			expectedNodeSelectors: map[string]string{
+				"aro-hcp.azure.com/role": "infra",
+			},
+			expectedArgs: []string{
+				"run",
+				"--namespace=$(MY_NAMESPACE)",
+				"--pod-name=$(MY_NAME)",
+				"--metrics-addr=:9000",
+				fmt.Sprintf("--enable-dedicated-request-serving-isolation=%t", false),
+				fmt.Sprintf("--enable-ocp-cluster-monitoring=%t", false),
+				fmt.Sprintf("--enable-ci-debug-output=%t", false),
+				fmt.Sprintf("--private-platform=%s", string(hyperv1.NonePlatform)),
+			},
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -595,6 +643,12 @@ func TestHyperShiftOperatorDeployment_Build(t *testing.T) {
 			g.Expect(deployment.Spec.Template.Spec.Volumes).To(BeEquivalentTo(test.expectedVolumes))
 			g.Expect(deployment.Spec.Template.Spec.Containers[0].VolumeMounts).To(BeEquivalentTo(test.expectedVolumeMounts))
 			g.Expect(deployment.Spec.Template.Spec.Containers[0].Env).To(ContainElements(test.expectedEnvVars))
+			if len(test.expectedTolerations) > 0 {
+				g.Expect(deployment.Spec.Template.Spec.Tolerations).To(BeEquivalentTo(test.expectedTolerations))
+			}
+			if len(test.expectedNodeSelectors) > 0 {
+				g.Expect(deployment.Spec.Template.Spec.NodeSelector).To(BeEquivalentTo(test.expectedNodeSelectors))
+			}
 		})
 	}
 }

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -49,6 +50,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/discovery"
@@ -158,6 +160,8 @@ type Options struct {
 	ScaleFromZeroCredentialsSecretKey         string
 	RenderSensitive                           bool
 	HCPEgressBlockCIDRs                       []string
+	OperatorTolerations                       []string
+	OperatorNodeSelectors                     map[string]string
 }
 
 func (o *Options) Validate() error {
@@ -359,7 +363,114 @@ func (o *Options) validateMiscConfig() []error {
 			errs = append(errs, fmt.Errorf("invalid --image-pull-policy: %s (want Always|Never|IfNotPresent)", o.ImagePullPolicy))
 		}
 	}
+
+	if len(o.OperatorTolerations) > 0 {
+		for _, tolerationStr := range o.OperatorTolerations {
+			if err := validateTolerationString(tolerationStr); err != nil {
+				errs = append(errs, fmt.Errorf("invalid operator toleration '%s': %w", tolerationStr, err))
+			}
+		}
+	}
+
+	if len(o.OperatorNodeSelectors) > 0 {
+		for nodeSelectorKey, nodeSelectorValue := range o.OperatorNodeSelectors {
+			if err := validateNodeSelectorKey(nodeSelectorKey); err != nil {
+				errs = append(errs, fmt.Errorf("invalid operator node selector key '%s': %w", nodeSelectorKey, err))
+			}
+			if err := validateNodeSelectorValue(nodeSelectorValue); err != nil {
+				errs = append(errs, fmt.Errorf("invalid operator node selector value '%s': %w", nodeSelectorValue, err))
+			}
+		}
+	}
 	return errs
+}
+
+func validateNodeSelectorKey(key string) error {
+	if errs := validation.IsQualifiedName(key); len(errs) > 0 {
+		return fmt.Errorf("invalid key '%s': %s", key, strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+func validateNodeSelectorValue(value string) error {
+	if value != "" {
+		if errs := validation.IsValidLabelValue(value); len(errs) > 0 {
+			return fmt.Errorf("invalid value '%s': %s", value, strings.Join(errs, "; "))
+		}
+	}
+	return nil
+}
+
+func validateTolerationString(s string) error {
+	if s == "" {
+		return fmt.Errorf("toleration string cannot be empty")
+	}
+
+	parts := strings.Split(s, ":")
+
+	// Check number of parts
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid format: expected key=value:effect or key:effect")
+	}
+
+	// Validate key[=value] part
+	if err := validateTolerationKeyValuePart(parts[0]); err != nil {
+		return err
+	}
+
+	// Validate effect part
+	if err := validateTolerationEffectPart(parts[1]); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Validates the key[=value] portion of the toleration string.
+func validateTolerationKeyValuePart(part string) error {
+	if part == "" {
+		return fmt.Errorf("toleration key:value cannot be empty")
+	}
+
+	keyValue := strings.SplitN(part, "=", 2)
+
+	key := keyValue[0]
+	if key == "" {
+		return fmt.Errorf("toleration key cannot be empty")
+	}
+
+	if errs := validation.IsQualifiedName(key); len(errs) > 0 {
+		return fmt.Errorf("invalid key '%s': %s", key, strings.Join(errs, "; "))
+	}
+
+	// If value is present.
+	if len(keyValue) == 2 {
+		value := keyValue[1]
+		if value != "" {
+			if errs := validation.IsValidLabelValue(value); len(errs) > 0 {
+				return fmt.Errorf("invalid value '%s': %s", value, strings.Join(errs, "; "))
+			}
+		}
+	}
+
+	return nil
+}
+
+// Validates the effect part of the toleration string.
+func validateTolerationEffectPart(effect string) error {
+	if effect == "" {
+		return fmt.Errorf("toleration effect can't be empty")
+	}
+
+	validEffects := []string{
+		string(corev1.TaintEffectNoSchedule),
+		string(corev1.TaintEffectPreferNoSchedule),
+		string(corev1.TaintEffectNoExecute),
+	}
+	if !slices.Contains(validEffects, effect) {
+		return fmt.Errorf("invalid effect '%s': must be NoSchedule, PreferNoSchedule, or NoExecute", effect)
+	}
+	return nil
 }
 
 func (o *Options) ApplyDefaults() {
@@ -453,6 +564,8 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.ScaleFromZeroCredentialsSecret, "scale-from-zero-secret", opts.ScaleFromZeroCredentialsSecret, "Name of existing secret containing scale-from-zero credentials (alternative to --scale-from-zero-creds)")
 	cmd.PersistentFlags().StringVar(&opts.ScaleFromZeroCredentialsSecretKey, "scale-from-zero-secret-key", opts.ScaleFromZeroCredentialsSecretKey, "Key within the scale-from-zero credentials secret (default: credentials)")
 	cmd.PersistentFlags().StringArrayVar(&opts.HCPEgressBlockCIDRs, "hcp-egress-block-cidrs", nil, "Static CIDRs to block in HCP namespace egress NetworkPolicies instead of dynamically-discovered hosting cluster KAS endpoint IPs. When specified, eliminates NetworkPolicy churn during hosting cluster KAS rolling restarts and avoids OVN port-group reconciliation races that can drop traffic to HCP routers. May be specified multiple times.")
+	cmd.PersistentFlags().StringSliceVar(&opts.OperatorTolerations, "operator-tolerations", opts.OperatorTolerations, "A list of tolerations to apply to the HyperShift Operator deployment in the format 'key=value:effect' or 'key:effect'.")
+	cmd.PersistentFlags().StringToStringVar(&opts.OperatorNodeSelectors, "operator-node-selectors", opts.OperatorNodeSelectors, "Set of node selectors to apply to the HyperShift Operator deployment in the format 'key1=value1,key2=value2'.")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		return InstallHyperShiftOperator(cmd.Context(), cmd.OutOrStdout(), opts)
@@ -563,6 +676,8 @@ func NewInstallOptionsWithDefaults() Options {
 	opts.PrivatePlatform = string(hyperv1.NonePlatform)
 	opts.ImagePullPolicy = "IfNotPresent"
 	opts.AdditionalOperatorEnvVars = map[string]string{}
+	opts.OperatorTolerations = []string{}
+	opts.OperatorNodeSelectors = map[string]string{}
 
 	return opts
 }
@@ -1299,6 +1414,8 @@ func setupOperatorResources(opts Options, userCABundleCM *corev1.ConfigMap, trus
 		EnableEtcdRecovery:                      opts.EnableEtcdRecovery,
 		EnableCPOOverrides:                      opts.EnableCPOOverrides,
 		AdditionalOperatorEnvVars:               opts.AdditionalOperatorEnvVars,
+		OperatorTolerations:                     opts.OperatorTolerations,
+		OperatorNodeSelectors:                   opts.OperatorNodeSelectors,
 		AROHCPKeyVaultUsersClientID:             opts.AroHCPKeyVaultUsersClientID,
 		TechPreviewNoUpgrade:                    opts.TechPreviewNoUpgrade,
 		RegistryOverrides:                       opts.RegistryOverrides,

--- a/cmd/install/install_test.go
+++ b/cmd/install/install_test.go
@@ -360,6 +360,56 @@ func TestOptions_Validate(t *testing.T) {
 			},
 			expectError: false,
 		},
+		"when valid operator tolerations are set there is no error": {
+			inputOptions: Options{
+				PrivatePlatform:     string(hyperv1.NonePlatform),
+				OperatorTolerations: []string{"key1=value1:NoSchedule", "key2:PreferNoSchedule", "key3=value3:NoExecute"},
+			},
+			expectError: false,
+		},
+		"when invalid operator tolerations are set it errors": {
+			inputOptions: Options{
+				PrivatePlatform:     string(hyperv1.NonePlatform),
+				OperatorTolerations: []string{"invalidtolerationstring", "key2=value2"},
+			},
+			expectError: true,
+		},
+		"when toleration has too many colons it errors": {
+			inputOptions: Options{
+				PrivatePlatform:     string(hyperv1.NonePlatform),
+				OperatorTolerations: []string{"key1=value1:NoSchedule:3600"},
+			},
+			expectError: true,
+		},
+		"when mixed valid and invalid operator tolerations are set it errors": {
+			inputOptions: Options{
+				PrivatePlatform:     string(hyperv1.NonePlatform),
+				OperatorTolerations: []string{"key1=value1:NoSchedule", "invalidtolerationstring"},
+			},
+			expectError: true,
+		},
+		"when invalid node selector is set it errors": {
+			inputOptions: Options{
+				PrivatePlatform:       string(hyperv1.NonePlatform),
+				OperatorNodeSelectors: map[string]string{"&&invalidkey": "value"},
+			},
+			expectError: true,
+		},
+		"when valid node selector is set there is no error": {
+			inputOptions: Options{
+				PrivatePlatform:       string(hyperv1.NonePlatform),
+				OperatorNodeSelectors: map[string]string{"validkey": "value"},
+			},
+			expectError: false,
+		},
+		"when both valid operator tolerations and node selectors are set there is no error": {
+			inputOptions: Options{
+				PrivatePlatform:       string(hyperv1.NonePlatform),
+				OperatorTolerations:   []string{"key1=value1:NoSchedule", "key2:PreferNoSchedule"},
+				OperatorNodeSelectors: map[string]string{"validkey": "value", "anotherkey": ""},
+			},
+			expectError: false,
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,4 +40,29 @@ func ConfigMapResource(namespace, name string) *corev1.ConfigMap {
 			Namespace: namespace,
 		},
 	}
+}
+
+// ParseTolerationString parses a toleration string in the format "key=value:effect" or "key:effect"
+// and returns a corev1.Toleration object. Returns nil if the format is invalid.
+func ParseTolerationString(s string) *corev1.Toleration {
+	parts := strings.Split(s, ":")
+	if len(parts) != 2 {
+		return nil
+	}
+
+	toleration := corev1.Toleration{
+		Effect: corev1.TaintEffect(parts[1]),
+	}
+
+	if strings.Contains(parts[0], "=") {
+		kv := strings.SplitN(parts[0], "=", 2)
+		toleration.Key = kv[0]
+		toleration.Value = kv[1]
+		toleration.Operator = corev1.TolerationOpEqual
+	} else {
+		toleration.Key = parts[0]
+		toleration.Operator = corev1.TolerationOpExists
+	}
+
+	return &toleration
 }


### PR DESCRIPTION
## What this PR does / why we need it:
Allow passing node selectors and tolerations to hypershift install cmd so that we can influence the placement of the HO pods.


Fixes 

https://issues.redhat.com/browse/ARO-23223

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.