### PR TITLE
OCPBUGS-62177: Fix certificate revocation validation across all KAS pods

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/AROSwift/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/AROSwift/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_role.yaml
@@ -44,6 +44,8 @@ rules:
   - pods
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/GCP/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/GCP/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_role.yaml
@@ -44,6 +44,8 @@ rules:
   - pods
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_role.yaml
@@ -44,6 +44,8 @@ rules:
   - pods
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_role.yaml
@@ -44,6 +44,8 @@ rules:
   - pods
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/control-plane-pki-operator/zz_fixture_TestControlPlaneComponents_control_plane_pki_operator_role.yaml
@@ -44,6 +44,8 @@ rules:
   - pods
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/control-plane-pki-operator/role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/control-plane-pki-operator/role.yaml
@@ -35,6 +35,8 @@ rules:
   - pods
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/control-plane-pki-operator/certificaterevocationcontroller/certificaterevocationcontroller.go
+++ b/control-plane-pki-operator/certificaterevocationcontroller/certificaterevocationcontroller.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"net"
 	"sort"
 	"strconv"
 	"strings"
@@ -54,6 +55,7 @@ type CertificateRevocationController struct {
 	getSecret    func(namespace, name string) (*corev1.Secret, error)
 	listSecrets  func(namespace string) ([]*corev1.Secret, error)
 	getConfigMap func(namespace, name string) (*corev1.ConfigMap, error)
+	listPods     func(namespace string, selector labels.Selector) ([]*corev1.Pod, error)
 
 	// for unit testing only
 	skipKASConnections bool
@@ -85,11 +87,17 @@ func NewCertificateRevocationController(
 		getConfigMap: func(namespace, name string) (*corev1.ConfigMap, error) {
 			return kubeInformersForNamespaces.InformersFor(namespace).Core().V1().ConfigMaps().Lister().ConfigMaps(namespace).Get(name)
 		},
+		listPods: func(namespace string, selector labels.Selector) ([]*corev1.Pod, error) {
+			return kubeInformersForNamespaces.InformersFor(namespace).Core().V1().Pods().Lister().Pods(namespace).List(selector)
+		},
 	}
 
 	crrInformer := hypershiftInformers.Certificates().V1alpha1().CertificateRevocationRequests().Informer()
 	secretInformer := kubeInformersForNamespaces.InformersFor(hostedControlPlane.Namespace).Core().V1().Secrets().Informer()
 	configMapInformer := kubeInformersForNamespaces.InformersFor(hostedControlPlane.Namespace).Core().V1().ConfigMaps().Informer()
+	// Ensure the Pod informer is registered with the factory before Start() is called,
+	// so the cache is populated when listPods is invoked during certificate revocation.
+	kubeInformersForNamespaces.InformersFor(hostedControlPlane.Namespace).Core().V1().Pods().Informer()
 	listCRRs := func(namespace string) ([]*certificatesv1alpha1.CertificateRevocationRequest, error) {
 		return hypershiftInformers.Certificates().V1alpha1().CertificateRevocationRequests().Lister().CertificateRevocationRequests(hostedControlPlane.Namespace).List(labels.Everything())
 	}
@@ -535,6 +543,120 @@ func (c *CertificateRevocationController) generateNewSignerCertificate(ctx conte
 	return false, nil, false, nil
 }
 
+func isPodReady(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+// verifyCertificateAgainstAllKASPods verifies a certificate against all kube-apiserver pods
+// and returns true if the verification passes for all pods, false otherwise.
+// The verifyFunc should return true if the verification passes, false if it should requeue.
+func (c *CertificateRevocationController) verifyCertificateAgainstAllKASPods(
+	ctx context.Context,
+	namespace string,
+	certPEM, keyPEM []byte,
+	testFunc func(client kubernetes.Interface) (bool, error),
+) (bool, error) {
+	if c.skipKASConnections {
+		return true, nil
+	}
+
+	// Get the base kubeconfig for the guest cluster service network
+	kubeconfig := hcpmanifests.KASServiceKubeconfigSecret(namespace)
+	kubeconfigSecret, err := c.getSecret(kubeconfig.Namespace, kubeconfig.Name)
+	if err != nil {
+		return false, fmt.Errorf("couldn't fetch guest cluster service network kubeconfig: %w", err)
+	}
+	adminClientCfg, err := clientcmd.NewClientConfigFromBytes(kubeconfigSecret.Data["kubeconfig"])
+	if err != nil {
+		return false, fmt.Errorf("couldn't load guest cluster service network kubeconfig: %w", err)
+	}
+	baseCfg, err := adminClientCfg.ClientConfig()
+	if err != nil {
+		return false, fmt.Errorf("couldn't load guest cluster service network kubeconfig: %w", err)
+	}
+
+	// List all kube-apiserver pods
+	pods, err := c.listPods(namespace, labels.SelectorFromSet(labels.Set{"app": "kube-apiserver"}))
+	if err != nil {
+		return false, fmt.Errorf("couldn't list kube-apiserver pods: %w", err)
+	}
+	if len(pods) == 0 {
+		// No pods found, requeue
+		klog.Warningf("No kube-apiserver pods found")
+		return false, nil
+	}
+
+	// Extract the port from the base config
+	_, port, err := net.SplitHostPort(strings.TrimPrefix(baseCfg.Host, "https://"))
+	if err != nil {
+		klog.Warningf("couldn't extract kube api-server port from base config: %v. Trying with 6443", err)
+		port = "6443" // fall-back to 6443 in case something went wrong
+	}
+
+	tested := false
+	// Test the certificate against each kube-apiserver pod
+	for _, pod := range pods {
+		// Skip pods that are being terminated (e.g. during a rolling update)
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+		// Skip pods without an IP assigned yet or that are not ready
+		if !isPodReady(pod) || pod.Status.PodIP == "" {
+			// Pod not ready, requeue
+			return false, nil
+		}
+
+		// Create a client config that connects directly to this pod's IP
+		podCfg := rest.CopyConfig(baseCfg)
+		// Use the pod IP with the port from the base config
+		podCfg.Host = "https://" + net.JoinHostPort(pod.Status.PodIP, port)
+		// Pod IPs are not in the KAS serving certificate SANs, so we must set
+		// ServerName to the KAS service name to pass TLS verification.
+		podCfg.TLSClientConfig.ServerName = hcpmanifests.KubeAPIServerServiceName
+		// To prevent the entire revocation process from hanging if a pod is unresponsive.
+		// Set timeout to 5 seconds if not already configured.
+		if podCfg.Timeout == 0 {
+			podCfg.Timeout = 5 * time.Second
+		}
+
+		certCfg := rest.AnonymousClientConfig(podCfg)
+		certCfg.TLSClientConfig.CertData = certPEM
+		certCfg.TLSClientConfig.KeyData = keyPEM
+
+		testClient, err := kubernetes.NewForConfig(certCfg)
+		if err != nil {
+			return false, fmt.Errorf("couldn't create guest cluster client for pod %s/%s: %w", pod.Namespace, pod.Name, err)
+		}
+
+		tested = true
+		// Run the test function
+		passed, err := testFunc(testClient)
+		if err != nil {
+			return false, err
+		}
+		if !passed {
+			// Test failed for this pod, requeue
+			return false, nil
+		}
+	}
+
+	if !tested {
+		klog.Warningf("No non-terminating kube-apiserver pods ready for verification")
+		return false, nil
+	}
+	// All pods passed the test
+	return true, nil
+}
+
 func (c *CertificateRevocationController) ensureNewSignerCertificatePropagated(ctx context.Context, namespace string, name string, now func() time.Time, crr *certificatesv1alpha1.CertificateRevocationRequest) (bool, *actions, bool, error) {
 	signer, ok := secretForSignerClass(namespace, certificates.SignerClass(crr.Spec.SignerClass))
 	if !ok {
@@ -578,38 +700,26 @@ func (c *CertificateRevocationController) ensureNewSignerCertificatePropagated(c
 	}
 
 	// if the updated trust bundle has propagated as far as we can tell, let's go ahead and ask
-	// KAS to detect when it trusts the new signer
-	if !c.skipKASConnections {
-		kubeconfig := hcpmanifests.KASServiceKubeconfigSecret(namespace)
-		kubeconfigSecret, err := c.getSecret(kubeconfig.Namespace, kubeconfig.Name)
-		if err != nil {
-			return true, nil, false, fmt.Errorf("couldn't fetch guest cluster service network kubeconfig: %w", err)
-		}
-		adminClientCfg, err := clientcmd.NewClientConfigFromBytes(kubeconfigSecret.Data["kubeconfig"])
-		if err != nil {
-			return true, nil, false, fmt.Errorf("couldn't load guest cluster service network kubeconfig: %w", err)
-		}
-		adminCfg, err := adminClientCfg.ClientConfig()
-		if err != nil {
-			return true, nil, false, fmt.Errorf("couldn't load guest cluster service network kubeconfig: %w", err)
-		}
-		certCfg := rest.AnonymousClientConfig(adminCfg)
-		certCfg.TLSClientConfig.CertData = currentCertPEM
-		certCfg.TLSClientConfig.KeyData = currentKeyPEM
-
-		testClient, err := kubernetes.NewForConfig(certCfg)
-		if err != nil {
-			return true, nil, false, fmt.Errorf("couldn't create guest cluster client using old certificate: %w", err)
-		}
-
-		_, err = testClient.AuthenticationV1().SelfSubjectReviews().Create(ctx, &authenticationv1.SelfSubjectReview{}, metav1.CreateOptions{})
+	// each KAS pod to detect when it trusts the new signer
+	allPodsTrust, err := c.verifyCertificateAgainstAllKASPods(ctx, namespace, currentCertPEM, currentKeyPEM, func(testClient kubernetes.Interface) (bool, error) {
+		_, err := testClient.AuthenticationV1().SelfSubjectReviews().Create(ctx, &authenticationv1.SelfSubjectReview{}, metav1.CreateOptions{})
 		if apierrors.IsUnauthorized(err) {
-			// this is OK, things are just propagating still
-			return true, nil, true, nil // we need to synthetically re-queue since nothing about KAS loading will trigger us
+			// this pod hasn't loaded the new trust bundle yet, requeue
+			return false, nil
 		}
 		if err != nil {
-			return true, nil, false, fmt.Errorf("couldn't send SSR to guest cluster: %w", err)
+			return false, fmt.Errorf("couldn't send SSR to guest cluster: %w", err)
 		}
+		// this pod trusts the new certificate
+		return true, nil
+	})
+	if err != nil {
+		return true, nil, false, err
+	}
+	if !allPodsTrust {
+		// not all pods trust the new certificate yet, requeue
+		// we need to synthetically re-queue since nothing about KAS loading will trigger us
+		return true, nil, true, nil
 	}
 
 	var recorded bool
@@ -850,38 +960,26 @@ func (c *CertificateRevocationController) ensureOldSignerCertificateRevoked(ctx 
 	}
 
 	// if the updated trust bundle has propagated as far as we can tell, let's go ahead and ask
-	// KAS to ensure it no longer trusts the old signer
-	if !c.skipKASConnections {
-		kubeconfig := hcpmanifests.KASServiceKubeconfigSecret(namespace)
-		kubeconfigSecret, err := c.getSecret(kubeconfig.Namespace, kubeconfig.Name)
-		if err != nil {
-			return true, nil, false, fmt.Errorf("couldn't fetch guest cluster service network kubeconfig: %w", err)
-		}
-		adminClientCfg, err := clientcmd.NewClientConfigFromBytes(kubeconfigSecret.Data["kubeconfig"])
-		if err != nil {
-			return true, nil, false, fmt.Errorf("couldn't load guest cluster service network kubeconfig: %w", err)
-		}
-		adminCfg, err := adminClientCfg.ClientConfig()
-		if err != nil {
-			return true, nil, false, fmt.Errorf("couldn't load guest cluster service network kubeconfig: %w", err)
-		}
-		certCfg := rest.AnonymousClientConfig(adminCfg)
-		certCfg.TLSClientConfig.CertData = oldCertPEM
-		certCfg.TLSClientConfig.KeyData = oldKeyPEM
-
-		testClient, err := kubernetes.NewForConfig(certCfg)
-		if err != nil {
-			return true, nil, false, fmt.Errorf("couldn't create guest cluster client using old certificate: %w", err)
-		}
-
-		_, err = testClient.AuthenticationV1().SelfSubjectReviews().Create(ctx, &authenticationv1.SelfSubjectReview{}, metav1.CreateOptions{})
+	// each KAS pod to ensure it no longer trusts the old signer
+	allPodsRevoke, err := c.verifyCertificateAgainstAllKASPods(ctx, namespace, oldCertPEM, oldKeyPEM, func(testClient kubernetes.Interface) (bool, error) {
+		_, err := testClient.AuthenticationV1().SelfSubjectReviews().Create(ctx, &authenticationv1.SelfSubjectReview{}, metav1.CreateOptions{})
 		if err == nil {
-			// this is OK, things are just propagating still
-			return true, nil, true, nil // we need to synthetically re-queue since nothing about KAS loading will trigger us
+			// this pod still trusts the old certificate, requeue
+			return false, nil
 		}
 		if !apierrors.IsUnauthorized(err) {
-			return true, nil, false, fmt.Errorf("couldn't send SSR to guest cluster: %w", err)
+			return false, fmt.Errorf("couldn't send SSR to guest cluster: %w", err)
 		}
+		// this pod has revoked the old certificate (returns Unauthorized)
+		return true, nil
+	})
+	if err != nil {
+		return true, nil, false, err
+	}
+	if !allPodsRevoke {
+		// not all pods have revoked the old certificate yet, requeue
+		// we need to synthetically re-queue since nothing about KAS loading will trigger us
+		return true, nil, true, nil
 	}
 
 	var recorded bool

--- a/control-plane-pki-operator/certificaterevocationcontroller/certificaterevocationcontroller_test.go
+++ b/control-plane-pki-operator/certificaterevocationcontroller/certificaterevocationcontroller_test.go
@@ -21,8 +21,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	corev1applyconfigurations "k8s.io/client-go/applyconfigurations/core/v1"
 	metav1applyconfigurations "k8s.io/client-go/applyconfigurations/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/cert"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
@@ -1047,6 +1049,9 @@ func TestCertificateRevocationController_processCertificateRevocationRequest(t *
 					}
 					return nil, apierrors.NewNotFound(corev1.SchemeGroupVersion.WithResource("configmaps").GroupResource(), name)
 				},
+				listPods: func(namespace string, selector labels.Selector) ([]*corev1.Pod, error) {
+					return nil, nil
+				},
 				skipKASConnections: true,
 			}
 			a, requeue, err := c.processCertificateRevocationRequest(t.Context(), testCase.crrNamespace, testCase.crrName, testCase.now)
@@ -1060,6 +1065,222 @@ func TestCertificateRevocationController_processCertificateRevocationRequest(t *
 			}
 			if diff := cmp.Diff(a, testCase.expected, compareActions()...); diff != "" {
 				t.Errorf("invalid actions: %v", diff)
+			}
+		})
+	}
+}
+
+func TestIsPodReady(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		expected bool
+	}{
+		{
+			name:     "When pod is nil it should return false",
+			pod:      nil,
+			expected: false,
+		},
+		{
+			name: "When pod has Ready=True condition it should return true",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "When pod has Ready=False condition it should return false",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "When pod has no Ready condition it should return false",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodScheduled, Status: corev1.ConditionTrue},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isPodReady(tc.pod); got != tc.expected {
+				t.Errorf("isPodReady() = %v, expected %v", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestTestCertificateAgainstAllKASPods_SkipsTerminatingPods(t *testing.T) {
+	now := metav1.Now()
+	fakeKubeconfig := []byte(`apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://kube-apiserver:6443
+    insecure-skip-tls-verify: true
+  name: guest
+contexts:
+- context:
+    cluster: guest
+    user: admin
+  name: guest
+current-context: guest
+users:
+- name: admin
+  user: {}
+`)
+
+	tests := []struct {
+		name              string
+		pods              []*corev1.Pod
+		expected          bool
+		testFuncCalled    bool
+		expectedCallCount int
+	}{
+		{
+			name: "When all pods are terminating it should requeue without testing any",
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "kube-apiserver-old-abc123",
+						DeletionTimestamp: &now,
+					},
+					Status: corev1.PodStatus{
+						PodIP: "10.0.0.1",
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+			},
+			expected:       false,
+			testFuncCalled: false,
+		},
+		{
+			name:           "When no pods exist it should requeue",
+			pods:           []*corev1.Pod{},
+			expected:       false,
+			testFuncCalled: false,
+		},
+		{
+			name: "When a non-terminating pod is not ready it should requeue",
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-new-xyz789"},
+					Status: corev1.PodStatus{
+						PodIP: "10.0.0.2",
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+						},
+					},
+				},
+			},
+			expected:       false,
+			testFuncCalled: false,
+		},
+		{
+			name: "When a terminating pod is mixed with a not-ready pod it should skip the terminating pod and requeue for the not-ready one",
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "kube-apiserver-old-abc123",
+						DeletionTimestamp: &now,
+					},
+					Status: corev1.PodStatus{
+						PodIP: "10.0.0.1",
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-new-xyz789"},
+					Status: corev1.PodStatus{
+						PodIP: "10.0.0.2",
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+						},
+					},
+				},
+			},
+			expected:       false,
+			testFuncCalled: false,
+		},
+		{
+			name: "When ready non-terminating pods exist it should call testFunc for each",
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-abc123"},
+					Status: corev1.PodStatus{
+						PodIP: "10.0.0.1",
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-def456"},
+					Status: corev1.PodStatus{
+						PodIP: "10.0.0.2",
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+			},
+			expected:          true,
+			testFuncCalled:    true,
+			expectedCallCount: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			callCount := 0
+			c := &CertificateRevocationController{
+				getSecret: func(namespace, name string) (*corev1.Secret, error) {
+					return &corev1.Secret{
+						Data: map[string][]byte{
+							"kubeconfig": fakeKubeconfig,
+						},
+					}, nil
+				},
+				listPods: func(namespace string, selector labels.Selector) ([]*corev1.Pod, error) {
+					return tc.pods, nil
+				},
+			}
+
+			result, err := c.verifyCertificateAgainstAllKASPods(t.Context(), "test-ns", nil, nil, func(client kubernetes.Interface) (bool, error) {
+				callCount++
+				return true, nil
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result != tc.expected {
+				t.Errorf("verifyCertificateAgainstAllKASPods() = %v, expected %v", result, tc.expected)
+			}
+			called := callCount > 0
+			if called != tc.testFuncCalled {
+				t.Errorf("testFunc called = %v, expected %v", called, tc.testFuncCalled)
+			}
+			if tc.expectedCallCount > 0 && callCount != tc.expectedCallCount {
+				t.Errorf("testFunc call count = %d, expected %d", callCount, tc.expectedCallCount)
 			}
 		})
 	}

--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -2804,6 +2804,28 @@ func TestCreateClusterRequestServingIsolation(t *testing.T) {
 		e2eutil.EnsureAllReqServingPodsLandOnReqServingNodes(t, ctx, guestClient)
 		e2eutil.EnsureOnlyRequestServingPodsOnRequestServingNodes(t, ctx, guestClient)
 		e2eutil.EnsureNoHCPPodsLandOnDefaultNode(t, ctx, guestClient, hostedCluster)
+
+		// Test certificate revocation with HA control plane
+		t.Logf("fetching mgmt kubeconfig")
+		mgmtCfg, err := e2eutil.GetConfig()
+		g.Expect(err).NotTo(HaveOccurred(), "couldn't get mgmt kubeconfig")
+		mgmtCfg.QPS = -1
+		mgmtCfg.Burst = -1
+
+		mgmtClients, err := integrationframework.NewClients(mgmtCfg)
+		g.Expect(err).NotTo(HaveOccurred(), "couldn't create mgmt clients")
+
+		guestKubeConfigSecretData := e2eutil.WaitForGuestKubeConfig(t, ctx, mgtClient, hostedCluster)
+
+		guestConfig, err := clientcmd.RESTConfigFromKubeConfig(guestKubeConfigSecretData)
+		g.Expect(err).NotTo(HaveOccurred(), "couldn't load guest kubeconfig")
+		guestConfig.QPS = -1
+		guestConfig.Burst = -1
+
+		guestClients, err := integrationframework.NewClients(guestConfig)
+		g.Expect(err).NotTo(HaveOccurred(), "couldn't create guest clients")
+
+		integration.RunTestControlPlanePKIOperatorBreakGlassCredentials(t, testContext, hostedCluster, mgmtClients, guestClients)
 	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, "request-serving-isolation", globalOpts.ServiceAccountSigningKey)
 }
 


### PR DESCRIPTION
## What this PR does / why we need it:

The control-plane-pki-operator's `CertificateRevocationController` incorrectly reports certificate revocation conditions because it does not verify each individual kube-apiserver pod has reloaded its CA bundles. This means a certificate may still be usable for a short period after the PKI operator reports it revoked, depending on which KAS pod handles the request.

This PR introduces per-pod KAS verification during certificate revocation by:

1. **Enumerating all kube-apiserver pods** via label selector (`app=kube-apiserver`)
2. **Connecting directly to each pod's IP** to verify certificate trust/revocation status
3. **Only advancing the CRR condition** (`NewCertificatesTrusted` / `PreviousCertificatesRevoked`) once **all** KAS pods confirm the expected state

### Fixes applied on top of initial implementation

The initial per-pod verification had two bugs causing e2e test failures:

- **TLS ServerName mismatch**: Connecting directly to pod IPs caused TLS verification failures because pod IPs are not in the KAS serving certificate SANs. Fixed by explicitly setting `TLSClientConfig.ServerName = "kube-apiserver"` so Go's TLS library verifies against the service DNS name instead of the pod IP.

- **Terminating pods not filtered**: During KAS rolling updates, old pods with `DeletionTimestamp` set still report `Ready=True` during their graceful termination period. The controller would attempt to connect to these unresponsive pods and get stuck. Fixed by skipping pods where `DeletionTimestamp != nil`.

Based on @enxebre https://github.com/openshift/hypershift/pull/6926, addressing reviewer feedback.

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/OCPBUGS-62177

## Special notes for your reviewer:

- The `testCertificateAgainstAllKASPods` helper is used in both `ensureNewSignerCertificatePropagated` (checks new cert is trusted) and `ensureOldSignerCertificateRevoked` (checks old cert is rejected)
- Unit tests added for `isPodReady` and `testCertificateAgainstAllKASPods` pod filtering behavior
- The 5-second per-pod timeout prevents the revocation process from hanging if a pod is unresponsive

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve OCPBUGS-62177`