### PR TITLE
OCPBUGS-69866: skip HCP router LB when routes use apps domain

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -24,6 +24,7 @@ import (
 	ignitionproxyv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy"
 	kasv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/kas"
 	oapiv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/oapi"
+	routerv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/router"
 	"github.com/openshift/hypershift/support/api"
 	autoscalercommon "github.com/openshift/hypershift/support/autoscaler"
 	fakecapabilities "github.com/openshift/hypershift/support/capabilities/fake"
@@ -1577,7 +1578,7 @@ func TestReconcileRouter(t *testing.T) {
 			}
 
 			releaseInfo := &releaseinfo.ReleaseImage{ImageStream: &imagev1.ImageStream{}}
-			if useHCPRouter(hcp) {
+			if routerv2.UseHCPRouter(hcp, "") {
 				if err := r.reconcileRouter(ctx, hcp, imageprovider.New(releaseInfo), controllerutil.CreateOrUpdate); err != nil {
 					t.Fatalf("reconcileRouter failed: %v", err)
 				}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	oapiv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/oapi"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/sharedingress"
 	component "github.com/openshift/hypershift/support/controlplane-component"
@@ -33,7 +34,9 @@ func (k *router) NeedsManagementKASAccess() bool {
 
 func NewComponent() component.ControlPlaneComponent {
 	return component.NewDeploymentComponent(ComponentName, &router{}).
-		WithPredicate(useHCPRouter).
+		WithPredicate(func(cpContext component.WorkloadContext) (bool, error) {
+			return UseHCPRouter(cpContext.HCP, cpContext.DefaultIngressDomain), nil
+		}).
 		WithManifestAdapter(
 			"config.yaml",
 			component.WithAdaptFunction(adaptConfig),
@@ -46,15 +49,19 @@ func NewComponent() component.ControlPlaneComponent {
 		Build()
 }
 
-// useHCPRouter returns true if a dedicated common router is created for a HCP to handle ingress for the managed endpoints.
-// This is true when the API input specifies intent for the following:
-// 1 - AWS endpointAccess is private somehow (i.e. publicAndPrivate or private) or is public and configured with external DNS.
-// 2 - When 1 is true, we recommend (and automate via CLI) ServicePublishingStrategy to be "Route" for all endpoints but the KAS
-// which needs a dedicated Service type LB external to be exposed if no external DNS is supported.
-// Otherwise, the Routes use the management cluster Domain and resolve through the default ingress controller.
-func useHCPRouter(cpContext component.WorkloadContext) (bool, error) {
+// UseHCPRouter returns true if a dedicated HCP router is needed to handle ingress for managed endpoints.
+// This is true when:
+// 1 - Shared ingress is not enabled, AND
+// 2 - AWS endpointAccess is private (i.e. publicAndPrivate or private), OR
+// 3 - The HCP is public and has services configured with Route hostnames external to the
+//
+//	management cluster's default ingress domain.
+//
+// When hostnames are subdomains of the apps domain, they are served by the management cluster's
+// default router via wildcard DNS, so no dedicated HCP router is needed.
+func UseHCPRouter(hcp *hyperv1.HostedControlPlane, defaultIngressDomain string) bool {
 	if sharedingress.UseSharedIngress() {
-		return false, nil
+		return false
 	}
-	return util.IsPrivateHCP(cpContext.HCP) || util.IsPublicWithDNS(cpContext.HCP), nil
+	return util.IsPrivateHCP(hcp) || util.IsPublicWithExternalDNS(hcp, defaultIngressDomain)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/component_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/component_test.go
@@ -1,0 +1,202 @@
+package router
+
+import (
+	"os"
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+)
+
+func TestUseHCPRouter(t *testing.T) {
+	// Ensure shared ingress is not enabled for these tests
+	os.Unsetenv("MANAGED_SERVICE")
+
+	// Test platforms that should behave the same for public HCPs
+	publicPlatforms := []hyperv1.PlatformType{
+		hyperv1.NonePlatform,
+		hyperv1.AgentPlatform,
+		hyperv1.KubevirtPlatform,
+	}
+
+	tests := []struct {
+		name                 string
+		hcp                  *hyperv1.HostedControlPlane
+		defaultIngressDomain string
+		want                 bool
+	}{
+		{
+			name: "AWS private - needs router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: hyperv1.Private,
+						},
+					},
+				},
+			},
+			defaultIngressDomain: "apps.example.com",
+			want:                 true,
+		},
+		{
+			name: "AWS publicAndPrivate - needs router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: hyperv1.PublicAndPrivate,
+						},
+					},
+				},
+			},
+			defaultIngressDomain: "apps.example.com",
+			want:                 true,
+		},
+		{
+			name: "AWS public with apps domain hostname - no router needed",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: hyperv1.Public,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.OAuthServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "oauth.apps.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			defaultIngressDomain: "apps.example.com",
+			want:                 false,
+		},
+		{
+			name: "AWS public with external DNS - needs router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: hyperv1.Public,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.OAuthServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "oauth.external.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			defaultIngressDomain: "apps.example.com",
+			want:                 true,
+		},
+	}
+
+	// Add platform-specific tests for public platforms with external DNS and apps domain hostnames
+	for _, platform := range publicPlatforms {
+		tests = append(tests,
+			struct {
+				name                 string
+				hcp                  *hyperv1.HostedControlPlane
+				defaultIngressDomain string
+				want                 bool
+			}{
+				name: string(platform) + " with external DNS - needs router",
+				hcp: &hyperv1.HostedControlPlane{
+					Spec: hyperv1.HostedControlPlaneSpec{
+						Platform: hyperv1.PlatformSpec{
+							Type: platform,
+						},
+						Services: []hyperv1.ServicePublishingStrategyMapping{
+							{
+								Service: hyperv1.OAuthServer,
+								ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+									Type: hyperv1.Route,
+									Route: &hyperv1.RoutePublishingStrategy{
+										Hostname: "oauth.external.com",
+									},
+								},
+							},
+						},
+					},
+				},
+				defaultIngressDomain: "apps.example.com",
+				want:                 true,
+			},
+			struct {
+				name                 string
+				hcp                  *hyperv1.HostedControlPlane
+				defaultIngressDomain string
+				want                 bool
+			}{
+				name: string(platform) + " with apps domain hostname - no router needed",
+				hcp: &hyperv1.HostedControlPlane{
+					Spec: hyperv1.HostedControlPlaneSpec{
+						Platform: hyperv1.PlatformSpec{
+							Type: platform,
+						},
+						Services: []hyperv1.ServicePublishingStrategyMapping{
+							{
+								Service: hyperv1.OAuthServer,
+								ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+									Type: hyperv1.Route,
+									Route: &hyperv1.RoutePublishingStrategy{
+										Hostname: "oauth.apps.example.com",
+									},
+								},
+							},
+						},
+					},
+				},
+				defaultIngressDomain: "apps.example.com",
+				want:                 false,
+			},
+		)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := UseHCPRouter(tt.hcp, tt.defaultIngressDomain); got != tt.want {
+				t.Errorf("UseHCPRouter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUseHCPRouterWithSharedIngress(t *testing.T) {
+	// Set up shared ingress mode
+	os.Setenv("MANAGED_SERVICE", string(hyperv1.AroHCP))
+	defer os.Unsetenv("MANAGED_SERVICE")
+
+	hcp := &hyperv1.HostedControlPlane{
+		Spec: hyperv1.HostedControlPlaneSpec{
+			Platform: hyperv1.PlatformSpec{
+				Type: hyperv1.AWSPlatform,
+				AWS: &hyperv1.AWSPlatformSpec{
+					EndpointAccess: hyperv1.Private,
+				},
+			},
+		},
+	}
+
+	// When shared ingress is enabled, UseHCPRouter should always return false
+	if got := UseHCPRouter(hcp, "apps.example.com"); got != false {
+		t.Errorf("UseHCPRouter() with shared ingress = %v, want false", got)
+	}
+}

--- a/support/controlplane-component/controlplane-component.go
+++ b/support/controlplane-component/controlplane-component.go
@@ -55,6 +55,8 @@ type ControlPlaneContext struct {
 	EnableCIDebugOutput bool
 	// MetricsSet specifies which metrics to use in the service/pod-monitors.
 	MetricsSet metrics.MetricsSet
+	// DefaultIngressDomain is the default ingress domain for the management cluster.
+	DefaultIngressDomain string
 
 	// This is needed for the generic unit test, so we can always generate a fixture for the components deployment/statefulset.
 	SkipPredicate bool
@@ -77,6 +79,8 @@ type WorkloadContext struct {
 	SetDefaultSecurityContext bool
 	EnableCIDebugOutput       bool
 	MetricsSet                metrics.MetricsSet
+	// DefaultIngressDomain is the default ingress domain for the management cluster.
+	DefaultIngressDomain string
 
 	// skip generation of certificates for unit tests
 	SkipCertificateSigning bool
@@ -94,6 +98,7 @@ func (cp *ControlPlaneContext) workloadContext() WorkloadContext {
 		EnableCIDebugOutput:       cp.EnableCIDebugOutput,
 		MetricsSet:                cp.MetricsSet,
 		ImageMetadataProvider:     cp.ImageMetadataProvider,
+		DefaultIngressDomain:      cp.DefaultIngressDomain,
 		SkipCertificateSigning:    cp.SkipCertificateSigning,
 	}
 }

--- a/support/util/expose_test.go
+++ b/support/util/expose_test.go
@@ -6,6 +6,208 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 )
 
+func TestIsSubdomain(t *testing.T) {
+	tests := []struct {
+		name     string
+		hostname string
+		domain   string
+		want     bool
+	}{
+		{
+			name:     "proper subdomain",
+			hostname: "oauth.apps.example.com",
+			domain:   "apps.example.com",
+			want:     true,
+		},
+		{
+			name:     "multi-level subdomain",
+			hostname: "foo.bar.apps.example.com",
+			domain:   "apps.example.com",
+			want:     true,
+		},
+		{
+			name:     "exact match is not a subdomain",
+			hostname: "apps.example.com",
+			domain:   "apps.example.com",
+			want:     false,
+		},
+		{
+			name:     "different domain",
+			hostname: "oauth.external.com",
+			domain:   "apps.example.com",
+			want:     false,
+		},
+		{
+			name:     "partial label match is not a subdomain",
+			hostname: "foobar.apps.example.com",
+			domain:   "bar.apps.example.com",
+			want:     false,
+		},
+		{
+			name:     "suffix match but not label boundary",
+			hostname: "evilapps.example.com",
+			domain:   "apps.example.com",
+			want:     false,
+		},
+		{
+			name:     "empty hostname",
+			hostname: "",
+			domain:   "apps.example.com",
+			want:     false,
+		},
+		{
+			name:     "empty domain",
+			hostname: "oauth.apps.example.com",
+			domain:   "",
+			want:     false,
+		},
+		{
+			name:     "case insensitive matching",
+			hostname: "OAuth.Apps.Example.Com",
+			domain:   "apps.example.com",
+			want:     true,
+		},
+		{
+			name:     "hostname shorter than domain",
+			hostname: "example.com",
+			domain:   "apps.example.com",
+			want:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsSubdomain(tt.hostname, tt.domain); got != tt.want {
+				t.Errorf("IsSubdomain(%q, %q) = %v, want %v", tt.hostname, tt.domain, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUseDedicatedDNSWithExternalDomain(t *testing.T) {
+	tests := []struct {
+		name                 string
+		hcp                  *hyperv1.HostedControlPlane
+		svcType              hyperv1.ServiceType
+		defaultIngressDomain string
+		want                 bool
+	}{
+		{
+			name: "route with hostname under apps domain",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.OAuthServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "oauth.apps.mgmt-cluster.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			svcType:              hyperv1.OAuthServer,
+			defaultIngressDomain: "apps.mgmt-cluster.example.com",
+			want:                 false,
+		},
+		{
+			name: "route with hostname external to apps domain",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.OAuthServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "oauth.external-domain.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			svcType:              hyperv1.OAuthServer,
+			defaultIngressDomain: "apps.mgmt-cluster.example.com",
+			want:                 true,
+		},
+		{
+			name: "route with no hostname",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.OAuthServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type:  hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{},
+							},
+						},
+					},
+				},
+			},
+			svcType:              hyperv1.OAuthServer,
+			defaultIngressDomain: "apps.mgmt-cluster.example.com",
+			want:                 false,
+		},
+		{
+			name: "LoadBalancer service type",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			svcType:              hyperv1.APIServer,
+			defaultIngressDomain: "apps.mgmt-cluster.example.com",
+			want:                 false,
+		},
+		{
+			name: "empty default ingress domain",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.OAuthServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "oauth.apps.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			svcType:              hyperv1.OAuthServer,
+			defaultIngressDomain: "",
+			want:                 true,
+		},
+		{
+			name:                 "service not found",
+			hcp:                  &hyperv1.HostedControlPlane{},
+			svcType:              hyperv1.OAuthServer,
+			defaultIngressDomain: "apps.mgmt-cluster.example.com",
+			want:                 false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := UseDedicatedDNSWithExternalDomain(tt.hcp, tt.svcType, tt.defaultIngressDomain); got != tt.want {
+				t.Errorf("UseDedicatedDNSWithExternalDomain() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsLBKASByHC(t *testing.T) {
 	tests := []struct {
 		description string

--- a/support/util/visibility.go
+++ b/support/util/visibility.go
@@ -44,6 +44,17 @@ func IsPublicWithDNS(hcp *hyperv1.HostedControlPlane) bool {
 		UseDedicatedDNS(hcp, hyperv1.Ignition))
 }
 
+// IsPublicWithExternalDNS checks if any service uses a Route with a hostname that is external to
+// the management cluster's default ingress domain. This is used to determine if a dedicated HCP
+// router LoadBalancer service is needed. Hostnames that are subdomains of the apps domain are
+// served by the management cluster's default router via wildcard DNS.
+func IsPublicWithExternalDNS(hcp *hyperv1.HostedControlPlane, defaultIngressDomain string) bool {
+	return IsPublicHCP(hcp) && (UseDedicatedDNSWithExternalDomain(hcp, hyperv1.APIServer, defaultIngressDomain) ||
+		UseDedicatedDNSWithExternalDomain(hcp, hyperv1.OAuthServer, defaultIngressDomain) ||
+		UseDedicatedDNSWithExternalDomain(hcp, hyperv1.Konnectivity, defaultIngressDomain) ||
+		UseDedicatedDNSWithExternalDomain(hcp, hyperv1.Ignition, defaultIngressDomain))
+}
+
 func IsPublicWithDNSByHC(hc *hyperv1.HostedCluster) bool {
 	return IsPublicHC(hc) && (UseDedicatedDNSByHC(hc, hyperv1.APIServer) ||
 		UseDedicatedDNSByHC(hc, hyperv1.OAuthServer) ||

--- a/support/util/visibility_test.go
+++ b/support/util/visibility_test.go
@@ -86,6 +86,157 @@ func TestIsPrivateHCP(t *testing.T) {
 	}
 }
 
+func TestIsPublicWithExternalDNS(t *testing.T) {
+	tests := []struct {
+		name                 string
+		hcp                  *hyperv1.HostedControlPlane
+		defaultIngressDomain string
+		want                 bool
+	}{
+		{
+			name: "public HCP with external DNS hostname",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.NonePlatform,
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.OAuthServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "oauth.external-domain.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			defaultIngressDomain: "apps.mgmt-cluster.example.com",
+			want:                 true,
+		},
+		{
+			name: "public HCP with hostname under apps domain",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.NonePlatform,
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.OAuthServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "oauth.apps.mgmt-cluster.example.com",
+								},
+							},
+						},
+						{
+							Service: hyperv1.Konnectivity,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "konnectivity.apps.mgmt-cluster.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			defaultIngressDomain: "apps.mgmt-cluster.example.com",
+			want:                 false,
+		},
+		{
+			name: "public HCP with mixed hostnames - one external",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.NonePlatform,
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.OAuthServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "oauth.apps.mgmt-cluster.example.com",
+								},
+							},
+						},
+						{
+							Service: hyperv1.Konnectivity,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "konnectivity.external.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			defaultIngressDomain: "apps.mgmt-cluster.example.com",
+			want:                 true,
+		},
+		{
+			name: "private AWS HCP - not public",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: hyperv1.Private,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.OAuthServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "oauth.external-domain.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			defaultIngressDomain: "apps.mgmt-cluster.example.com",
+			want:                 false,
+		},
+		{
+			name: "public HCP with no hostname set",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.NonePlatform,
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.OAuthServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type:  hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{},
+							},
+						},
+					},
+				},
+			},
+			defaultIngressDomain: "apps.mgmt-cluster.example.com",
+			want:                 false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsPublicWithExternalDNS(tt.hcp, tt.defaultIngressDomain); got != tt.want {
+				t.Errorf("IsPublicWithExternalDNS() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsPublicHCP(t *testing.T) {
 	type args struct {
 		hcp *hyperv1.HostedControlPlane


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix regression in 4.19 where HCP router LoadBalancer service was created unexpectedly for configurations using Route hostnames under the management cluster's apps domain.

After upgrading HCP clusters from 4.18 to 4.19, a `router` service of type LoadBalancer is created unexpectedly. On platforms with limited LoadBalancer IPs (e.g., BareMetal with exhausted MetalLB IPAddressPool), the service stays in `<pending>` state and blocks the upgrade.

The fix for OCPBUGS-56914 (PR #6780) changed the condition for creating the public router service from checking only if KAS uses Route to checking if ANY service uses Route with hostname. This caused the router service to be created for configurations that previously didn't need it.

This PR adds `IsPublicWithExternalDNS()` function that checks if any service uses a Route with a hostname that is **external to** the management cluster's default ingress domain. When hostnames are subdomains of the apps domain (e.g., `oauth.apps.mgmt-cluster.example.com`), the management cluster's default router can serve them via wildcard DNS, so no dedicated HCP router LoadBalancer service is needed.

This preserves the OCPBUGS-56914 fix for external DNS users while preventing unnecessary router service creation for apps-domain routes.

**Which issue(s) this PR fixes**:
Fixes OCPBUGS-69866

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)