### PR TITLE
OCPBUGS-69761: fix(ingress): clear LoadBalancerSourceRanges when AllowedCIDRBlocks is removed

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -76,7 +76,7 @@ func ReconcileRouterService(svc *corev1.Service, internal, crossZoneLoadBalancin
 	// Apply LoadBalancerSourceRanges for external router services to restrict CIDR access
 	// Only apply for external (non-internal) services and when not running on ARO HCP
 	allowedCIDRBlocks := util.AllowedCIDRBlocks(hcp)
-	if !internal && len(allowedCIDRBlocks) > 0 && !azureutil.IsAroHCP() {
+	if !internal && !azureutil.IsAroHCP() {
 		svc.Spec.LoadBalancerSourceRanges = allowedCIDRBlocks
 	}
 


### PR DESCRIPTION
## Summary
- Fixes a bug where removing `AllowedCIDRBlocks` from the HostedCluster spec would leave stale `LoadBalancerSourceRanges` on the router service
- The reconciliation now properly clears the field when the allowed CIDR blocks list becomes empty

## Test plan
- [ ] Deploy a HostedCluster with `AllowedCIDRBlocks` configured
- [ ] Verify `LoadBalancerSourceRanges` is set on the router service
- [ ] Remove `AllowedCIDRBlocks` from the HostedCluster spec
- [ ] Verify `LoadBalancerSourceRanges` is cleared from the router service

Fixes: https://issues.redhat.com/browse/OCPBUGS-69761

🤖 PR description generated with [Claude Code](https://claude.com/claude-code)