### PR TITLE
OCPBUGS-72393: Fix Konflux EC voilation, nginx image deprecated

### DIFF
--- a/Containerfile.cli
+++ b/Containerfile.cli
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4-1754467841 AS builder
+FROM registry.redhat.io/rhel9/go-toolset:1.24.6-1763548439 AS builder
 
 WORKDIR /hypershift
 
@@ -16,7 +16,7 @@ RUN make product-cli-release && \
       done; \
     done
 
-FROM registry.redhat.io/ubi9/nginx-122:1-1743076774
+FROM registry.redhat.io/ubi9/nginx-124:1-1767745334
 
 COPY --from=builder /hypershift/bin/    /opt/app-root/src/
 RUN find /opt/app-root/src/ -type f ! -name "*.tar.gz" -delete


### PR DESCRIPTION

## What this PR does / why we need it:

This PR fixes Konflux EC violation. https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/crt-redhat-acm-tenant/applications/release-mce-29/pipelineruns/enterprise-contract-mce-29-c49x8/logs  The nginx base image is deprecated.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://issues.redhat.com/browse/OCPBUGS-72393

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.