### PR TITLE
OCPBUGS-72397: Fix Konflux EC voilation, update deprecated base …

### DIFF
--- a/Containerfile.cli
+++ b/Containerfile.cli
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.3-1765311584 AS builder
+FROM registry.redhat.io/rhel9/go-toolset:1.24.6-1763548439 AS builder
 
 WORKDIR /hypershift
 
@@ -16,7 +16,7 @@ RUN make product-cli-release && \
       done; \
     done
 
-FROM registry.redhat.io/ubi9/nginx-122:1-1743076774
+FROM registry.redhat.io/ubi9/nginx-124:1-1767745334
 
 COPY --from=builder /hypershift/bin/    /opt/app-root/src/
 RUN find /opt/app-root/src/ -type f ! -name "*.tar.gz" -delete


### PR DESCRIPTION


## What this PR does / why we need it:

Base images are deprecated causing Konflux image validations and EC violations. 

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://issues.redhat.com/browse/OCPBUGS-72397

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.