### PR TITLE
API-1835: Scaffold OpenShiftManager controller

### DIFF
--- a/control-plane-operator/controllers/openshiftmanager/OWNERS
+++ b/control-plane-operator/controllers/openshiftmanager/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+- csrwng
+- bertinatto
+- p0lyn0mial
+- benluddy
+
+reviewers:
+- csrwng
+- bertinatto
+- p0lyn0mial
+- benluddy

--- a/control-plane-operator/controllers/openshiftmanager/openshiftmanager_controller.go
+++ b/control-plane-operator/controllers/openshiftmanager/openshiftmanager_controller.go
@@ -1,0 +1,19 @@
+package openshiftmanager
+
+import (
+	"fmt"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// Reconciler is responsible for integration with OpenShiftManager.
+// This controller is experimental and will be disabled by default.
+//
+// For more information on OpenShiftManager, see
+// https://github.com/openshift/enhancements/blob/master/dev-guide/multi-operator-manager.md.
+type Reconciler struct {
+}
+
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return fmt.Errorf("not implemented")
+}


### PR DESCRIPTION
Scaffolds a Reconciler which will be responsible for integration with OpenShiftManager.
This controller is experimental and will be **disabled** by default.

For more information on OpenShiftManager, see
https://github.com/openshift/enhancements/blob/master/dev-guide/multi-operator-manager.md.