### PR TITLE
feat(cpo): use HO image for CPO on 4.20+ clusters

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -8,7 +8,9 @@ RUN make hypershift \
   && make hypershift-no-cgo \
   && make hypershift-operator \
   && make product-cli \
-  && make karpenter-operator
+  && make karpenter-operator \
+  && make control-plane-operator \
+  && make control-plane-pki-operator
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1760515502
 COPY --from=builder /hypershift/bin/hypershift \
@@ -16,7 +18,15 @@ COPY --from=builder /hypershift/bin/hypershift \
   /hypershift/bin/hcp \
   /hypershift/bin/hypershift-operator \
   /hypershift/bin/karpenter-operator \
+  /hypershift/bin/control-plane-operator \
+  /hypershift/bin/control-plane-pki-operator \
   /usr/bin/
+
+RUN cd /usr/bin && \
+    ln -s control-plane-operator ignition-server && \
+    ln -s control-plane-operator konnectivity-socks5-proxy && \
+    ln -s control-plane-operator availability-prober && \
+    ln -s control-plane-operator token-minter
 
 ENTRYPOINT ["/usr/bin/hypershift"]
 
@@ -41,4 +51,5 @@ LABEL io.openshift.hypershift.control-plane-operator-applies-management-kas-netw
 LABEL io.openshift.hypershift.restricted-psa=true
 LABEL io.openshift.hypershift.control-plane-pki-operator-signs-csrs=true
 LABEL io.openshift.hypershift.hosted-cluster-config-operator-reports-node-count=true
+LABEL io.openshift.hypershift.control-plane-operator-supports-kas-custom-kubeconfig=true
 LABEL io.openshift.hypershift.control-plane-operator.v2-isdefault=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ RUN make hypershift \
   && make hypershift-no-cgo \
   && make hypershift-operator \
   && make product-cli \
-  && make karpenter-operator
+  && make karpenter-operator \
+  && make control-plane-operator \
+  && make control-plane-pki-operator
 
 FROM registry.access.redhat.com/ubi9:latest
 COPY --from=builder /hypershift/bin/hypershift \
@@ -16,7 +18,15 @@ COPY --from=builder /hypershift/bin/hypershift \
                     /hypershift/bin/hcp \
                     /hypershift/bin/hypershift-operator \
                     /hypershift/bin/karpenter-operator \
+                    /hypershift/bin/control-plane-operator \
+                    /hypershift/bin/control-plane-pki-operator \
      /usr/bin/
+
+RUN cd /usr/bin && \
+    ln -s control-plane-operator ignition-server && \
+    ln -s control-plane-operator konnectivity-socks5-proxy && \
+    ln -s control-plane-operator availability-prober && \
+    ln -s control-plane-operator token-minter
 
 ENTRYPOINT ["/usr/bin/hypershift"]
 
@@ -32,4 +42,5 @@ LABEL io.openshift.hypershift.control-plane-operator-applies-management-kas-netw
 LABEL io.openshift.hypershift.restricted-psa=true
 LABEL io.openshift.hypershift.control-plane-pki-operator-signs-csrs=true
 LABEL io.openshift.hypershift.hosted-cluster-config-operator-reports-node-count=true
+LABEL io.openshift.hypershift.control-plane-operator-supports-kas-custom-kubeconfig=true
 LABEL io.openshift.hypershift.control-plane-operator.v2-isdefault=true

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -17,6 +17,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -627,17 +628,43 @@ func GetPullSecretBytes(ctx context.Context, c client.Client, hc *hyperv1.Hosted
 	return pullSecretBytes, nil
 }
 
+// cpoBinaryPath is the expected location of the control-plane-operator binary
+const cpoBinaryPath = "/usr/bin/control-plane-operator"
+
+var (
+	cpoBinaryExistsOnce   sync.Once
+	cpoBinaryExistsResult bool
+	// cpoBinaryExistsFunc is used for testing to override the binary existence check.
+	// When nil, the actual file system check is performed.
+	cpoBinaryExistsFunc func() bool
+)
+
+// cpoBinaryExistsInHOImage checks if the control-plane-operator binary exists in
+// the current container image. This is used to determine if the HO image can be
+// used as the CPO image for 4.20+ clusters. The result is cached after the first check.
+func cpoBinaryExistsInHOImage() bool {
+	if cpoBinaryExistsFunc != nil {
+		return cpoBinaryExistsFunc()
+	}
+	cpoBinaryExistsOnce.Do(func() {
+		_, err := os.Stat(cpoBinaryPath)
+		cpoBinaryExistsResult = err == nil
+	})
+	return cpoBinaryExistsResult
+}
+
 // GetControlPlaneOperatorImage resolves the appropriate control plane operator
 // image based on the following order of precedence (from most to least
 // preferred):
 //
 //  1. The image specified by the ControlPlaneOperatorImageAnnotation on the
 //     HostedCluster resource itself
-//  2. The hypershift image specified in the release payload indicated by the
+//  2. If CPO overrides are enabled, the override image for the platform and version
+//  3. For release versions 4.20+, the hypershift-operator's own image (if it
+//     contains the control-plane-operator binary)
+//  4. The hypershift image specified in the release payload indicated by the
 //     HostedCluster's release field
-//  3. The hypershift-operator's own image for release versions 4.9 and 4.10
-//  4. The registry.ci.openshift.org/hypershift/hypershift:4.8 image for release
-//     version 4.8
+//  5. The hypershift-operator's own image for release versions 4.9+
 //
 // If no image can be found according to these rules, an error is returned.
 func GetControlPlaneOperatorImage(ctx context.Context, hc *hyperv1.HostedCluster, releaseProvider releaseinfo.Provider, hypershiftOperatorImage string, pullSecret []byte) (string, error) {
@@ -657,6 +684,17 @@ func GetControlPlaneOperatorImage(ctx context.Context, hc *hyperv1.HostedCluster
 		if overrideImage != "" {
 			return overrideImage, nil
 		}
+	}
+
+	// For 4.20+, use the hypershift-operator image directly if it contains the
+	// control-plane-operator binary. This enables faster feature delivery and
+	// simplified hotfix processes, as the CPO is delivered with the HO rather
+	// than being tied to the OCP release payload.
+	minVersionForHOImage := semver.Version{Major: 4, Minor: 20, Patch: 0}
+	// Compare only Major.Minor.Patch, ignoring pre-release info (e.g., 4.20.0-rc.1 should match >= 4.20.0)
+	versionWithoutPrerelease := semver.Version{Major: version.Major, Minor: version.Minor, Patch: version.Patch}
+	if versionWithoutPrerelease.GTE(minVersionForHOImage) && cpoBinaryExistsInHOImage() {
+		return hypershiftOperatorImage, nil
 	}
 
 	if hypershiftImage, exists := releaseInfo.ComponentImages()["hypershift"]; exists {


### PR DESCRIPTION
## Summary

For cluster versions 4.20 and above, use the HyperShift Operator image directly for the Control Plane Operator instead of extracting it from the OCP release payload.

### Benefits
- **Faster feature delivery**: CPO ships with HO releases instead of being tied to OCP payload
- **Simplified hotfix process**: Single HO image bump fixes all 4.20+ clusters (no per-cluster annotation overrides needed)
- **Consistent deployment model**: Same approach for both managed services and self-managed

### Changes
1. **`support/util/util.go`**: Modified `GetControlPlaneOperatorImage()` to use HO image for 4.20+ if the CPO binary exists
2. **`support/util/util_test.go`**: Added comprehensive unit tests for the new behavior
3. **`Dockerfile` & `Containerfile.operator`**: 
   - Build and include `control-plane-operator` and `control-plane-pki-operator` binaries
   - Add symlinks for `ignition-server`, `konnectivity-socks5-proxy`, `availability-prober`, `token-minter`
   - Add missing label `io.openshift.hypershift.control-plane-operator-supports-kas-custom-kubeconfig=true`

### Safety Mechanism
The code includes a safety check that verifies `/usr/bin/control-plane-operator` exists in the HO image before using it. This ensures:
- Older HO images (without the CPO binary) continue to use the release payload CPO
- Self-managed users running pre-change HO versions are not affected
- Graceful fallback to payload CPO if binary check fails

### Behavior Matrix

| Cluster Version | HO Has CPO Binary | Result |
|-----------------|-------------------|--------|
| 4.20+ | Yes | Uses HO image |
| 4.20+ | No | Uses payload CPO (graceful fallback) |
| < 4.20 | Any | Uses payload CPO |

## Test plan
- [x] Unit tests pass for `GetControlPlaneOperatorImage`
- [ ] E2E test with 4.20+ cluster to verify CPO uses HO image
- [ ] E2E test with pre-change HO image to verify fallback to payload CPO
- [ ] Verify CPO starts correctly with the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)