### PR TITLE
CNV-76520: ci: allow restart of kubevirt-cloud-controller-manager

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -126,6 +126,8 @@ var (
 		"aws-ebs-csi-driver-controller": 1,
 		// Allow 1 restart for network-node-identity webhook startup timing
 		"network-node-identity": 1,
+		// temporary workaround for https://issues.redhat.com/browse/CNV-76520
+		"kubevirt-cloud-controller-manager": 2,
 	}
 )
 


### PR DESCRIPTION
## What this PR does / why we need it:
Workaround the kubevirt e2e failures, by allowing the restart of the kubevirt-cloud-controller-manager pod, as a temporary solution, to test urgent fixes in cluster-api-provider-kubevirt.

Currently, we can't progress with https://github.com/openshift/cluster-api-provider-kubevirt/pull/338, and need this workaround.