### PR TITLE
OCPBUGS-72258: use InfraStatus.APIPort for custom DNS kubeconfig

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kubeconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kubeconfig.go
@@ -120,8 +120,7 @@ func adapExternalAdminKubeconfigSecret(cpContext component.WorkloadContext, secr
 
 func adaptCustomAdminKubeconfigSecret(cpContext component.WorkloadContext, secret *corev1.Secret) error {
 	hcp := cpContext.HCP
-	apiServerPort := util.KASPodPort(hcp)
-	url := customExternalURL(hcp.Spec.KubeAPIServerDNSName, apiServerPort)
+	url := customExternalURL(hcp.Spec.KubeAPIServerDNSName, cpContext.InfraStatus.APIPort)
 
 	totalRootCA, err := combineRootCAWithServingCerts(cpContext)
 	if err != nil {


### PR DESCRIPTION
## What this PR does / why we need it:

This PR fixes custom kubeconfig generation to use the correct API server port when external-DNS is enabled. When using `--kas-dns-name` with external-DNS, the generated kubeconfig was incorrectly using port 6443 instead of port 443, causing connection failures.

**Key changes:**
- Modified `adaptCustomAdminKubeconfigSecret` function to use `cpContext.InfraStatus.APIPort` instead of `util.KASPodPort(hcp)`
- The `InfraStatus.APIPort` field already contains the correct port value (443 for external-DNS, 6443 for standard configurations)

**Solution rationale:** 
This minimal change leverages existing infrastructure status and follows the same pattern used by other kubeconfig generation functions in the codebase. Instead of complex parsing logic, we use the infrastructure field that already knows the correct port for the current configuration.

## Which issue(s) this PR fixes:

- Fixes [OCPBUGS-72258](https://issues.redhat.com/browse/OCPBUGS-72258)

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve OCPBUGS-72258 origin`