### PR TITLE
NO-JIRA: chore(ho): update lower bound version checks for OCP 5

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go
@@ -103,7 +103,7 @@ func (p AWS) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *hy
 	featureGates := []string{
 		"EKS=false",
 	}
-	if p.payloadVersion != nil && p.payloadVersion.Major == 4 && p.payloadVersion.Minor > 15 {
+	if p.payloadVersion != nil && (p.payloadVersion.Major >= 5 || (p.payloadVersion.Major == 4 && p.payloadVersion.Minor > 15)) {
 		featureGates = append(featureGates, "ROSA=false")
 	}
 

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/openstack/openstack.go
@@ -282,7 +282,7 @@ func (a OpenStack) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _
 
 	// Add the ORC manager container if the payload version is 4.19 or later
 	// ORC was decoupled from CAPO in 4.19 but was part of CAPO in 4.18.
-	if a.payloadVersion != nil && a.payloadVersion.Major == 4 && a.payloadVersion.Minor > 18 {
+	if a.payloadVersion != nil && (a.payloadVersion.Major >= 5 || (a.payloadVersion.Major == 4 && a.payloadVersion.Minor > 18)) {
 		deploymentSpec.Template.Spec.Containers = append(deploymentSpec.Template.Spec.Containers, corev1.Container{
 			Name:            "orc-manager",
 			Image:           orcImage,

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
@@ -160,7 +160,7 @@ func GetPlatform(ctx context.Context, hcluster *hyperv1.HostedCluster, releasePr
 			}
 			// Get the ORC image only if the payload version is 4.19 or later.
 			// ORC was decoupled from CAPO in 4.19 but was part of CAPO in 4.18.
-			if payloadVersion != nil && payloadVersion.Major == 4 && payloadVersion.Minor > 18 {
+			if payloadVersion != nil && (payloadVersion.Major >= 5 || (payloadVersion.Major == 4 && payloadVersion.Minor > 18)) {
 				orcImage, err = imgUtil.GetPayloadImage(ctx, releaseProvider, hcluster, OpenStackResourceController, pullSecretBytes)
 				if err != nil {
 					return nil, fmt.Errorf("failed to retrieve orc image: %w", err)


### PR DESCRIPTION
There are a few places in the HO where we ensure the OCP version is at least version 4.y or higher.  The checks currently ensure the major version is exactly 4.  When OCP 5 is released, these will no longer work.

This commit adjust these check to also work when the major version is 5 or higher.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures version-gated behavior continues to work with OCP 5.x.
> 
> - AWS: `ROSA=false` feature gate now enabled when payload version is >=5 or >4.15 in `aws.go`.
> - OpenStack: add `orc-manager` container only when payload version is >=5 or >4.18 in `openstack.go`.
> - Platform: fetch ORC image from payload only when version is >=5 or >4.18 in `platform.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7ea9363d2ed6422859d4341a88f8a9ba1d66644. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->