### PR TITLE
NO-JIRA: test(autoscaling): make GPU annotation optional in scale-from-zero test

### DIFF
--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -487,9 +487,7 @@ func testScaleFromZero(ctx context.Context, mgtClient crclient.Client, hostedClu
 					if _, ok := md.Annotations["machine.openshift.io/memoryMb"]; !ok {
 						return false, "missing memoryMb annotation", nil
 					}
-					if _, ok := md.Annotations["machine.openshift.io/GPU"]; !ok {
-						return false, "missing GPU annotation", nil
-					}
+					// GPU annotation is optional - only set when instance type has GPUs
 					labels, ok := md.Annotations["capacity.cluster-autoscaler.kubernetes.io/labels"]
 					if !ok {
 						return false, "missing capacity labels annotation", nil
@@ -502,10 +500,14 @@ func testScaleFromZero(ctx context.Context, mgtClient crclient.Client, hostedClu
 			},
 			e2eutil.WithTimeout(5*time.Minute),
 		)
+		gpuValue := md.Annotations["machine.openshift.io/GPU"]
+		if gpuValue == "" {
+			gpuValue = "none (non-GPU instance)"
+		}
 		t.Logf("MachineDeployment has capacity annotations: vCPU=%s, memoryMb=%s, GPU=%s, labels=%s",
 			md.Annotations["machine.openshift.io/vCPU"],
 			md.Annotations["machine.openshift.io/memoryMb"],
-			md.Annotations["machine.openshift.io/GPU"],
+			gpuValue,
 			md.Annotations["capacity.cluster-autoscaler.kubernetes.io/labels"])
 
 		// Verify NodePool autoscaling is enabled


### PR DESCRIPTION
## What this PR does / why we need it:

This PR fixes a test failure in `TestNodePoolAutoscalingScaleFromZero` that was failing when testing with non-GPU instance types.

The test unconditionally expected the `machine.openshift.io/GPU` annotation to be present on the MachineDeployment. However, the scale-from-zero controller only sets this annotation when the instance type has GPUs (see `hypershift-operator/controllers/nodepool/scale_from_zero.go:126-132`). When testing with non-GPU instances (like m5.large), the GPU annotation is intentionally not set, causing the test to fail.

**Changes:**
1. Removed mandatory GPU annotation check - The test now only requires vCPU, memoryMb, and labels annotations (which are always set)
2. Updated logging to gracefully handle missing GPU annotation in log output

## Which issue(s) this PR fixes:

Fixes test failures seen in https://github.com/openshift/release/pull/72805 which enables scale-from-zero testing in CI.

## Special notes for your reviewer:

- The controller behavior is correct - verified from CI artifacts that vCPU, memoryMb, and labels annotations are properly set
- GPU annotation is correctly omitted for non-GPU instances per the implementation in `scale_from_zero.go`
- `make staticcheck` passes

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. (N/A - test-only change)
- [ ] This change includes unit tests. (N/A - fixes existing e2e test)