### PR TITLE
OCPBUGS-62761: chore(e2e): remove KAS check from capi pod

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1204,13 +1204,6 @@ func EnsureNetworkPolicies(t *testing.T, ctx context.Context, c crclient.Client,
 					g.Expect(err).To(HaveOccurred())
 				}
 			}
-
-			// Validate cluster api is allowed to access management KAS.
-			stdOut, err := RunCommandInPod(ctx, c, "cluster-api", hcpNamespace, command, "manager", 0)
-			// Expect curl return a 403 from the KAS.
-			if !strings.Contains(stdOut, "HTTP/2 403") || err != nil {
-				t.Errorf("cluster api pod was unexpectedly not allowed to reach the management KAS. stdOut: %s. stdErr: %s", stdOut, err.Error())
-			}
 		})
 	})
 }


### PR DESCRIPTION
This method of testing KAS connectivity from the CAPI pod is not robust and results in test flakes.

Additionally, this connectivity is implicitly checked by the CAPI pod not crashing and nodes provisioning in the test cluster.

Remove this flaky assertion to improve e2e pass rates.

Recent flakes:
https://search.dptools.openshift.org/?search=cluster+api+pod+was+unexpectedly+not+allowed+to+reach+the+management+KAS&maxAge=336h&context=1&type=bug%2Bissue%2Bjunit&name=periodic-ci-openshift-hypershift.*&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes a flaky KAS connectivity assertion from the e2e network policies test to reduce flakes.
> 
> - Deletes the `cluster-api` pod curl check expecting `HTTP/2 403` in `EnsureNetworkPolicies/EnsureLimitedEgressTrafficToManagementKAS`
> - Retains existing checks for `cluster-version-operator` and conditional `private-router` access restrictions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ff1dc1942769ad022164286c0fe29faa1bc6086. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->