### PR TITLE
NO-JIRA: Add karpenter approvers and reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -115,4 +115,9 @@ filters:
   "^token-minter/.*":
     labels:
     - area/control-plane-operator
+  "^karpenter-operator/.*":
+    labels:
+    - area/karpenter-operator
+    reviewers:
+    - karpenter-reviewers
 component: hypershift

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -19,6 +19,20 @@ aliases:
     - bryan-cox
     - jparrill
     - devguyio
+  karpenter-approvers:
+    - elmiko
+    - enxebre
+    - jkyros
+    - joelsmith
+    - maxcao13
+    - muraee
+  karpenter-reviewers:
+    - elmiko
+    - enxebre
+    - jkyros
+    - joelsmith
+    - maxcao13
+    - muraee
   konflux-approvers:
     - celebdor
   kubevirt-approvers:


### PR DESCRIPTION
Add owners aliases and add a new section for reviewers for karpenter-operator.