### PR TITLE
CNTRLPLANE-2203: add ControlPlaneConnectionAvailable condition

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -214,7 +214,18 @@ const (
 	// A failure here suggests potential issues such as: network policy restrictions,
 	// firewall rules, missing data plane nodes, or problems with infrastructure
 	// components like the konnectivity-agent workload.
+	// **Unknown** means the status cannot be determined (e.g., no worker nodes available or unable to inspect).
 	DataPlaneConnectionAvailable ConditionType = "DataPlaneConnectionAvailable"
+
+	// ControlPlaneConnectionAvailable indicates whether data plane workloads have a successful
+	// network connection to the control plane components. This condition is computed per-node using
+	// a DaemonSet that performs reachability checks from each worker node.
+	// **True** means all data plane nodes can successfully reach the control plane (per-node reachability check passes for every node).
+	// **False** means there are connectivity failures preventing some or all data plane nodes from reaching the control plane,
+	// or required infrastructure components (such as kube-apiserver-proxy pods or the connection checker DaemonSet) are missing or unavailable.
+	// **Unknown** means the status cannot be determined due to true inability to inspect (e.g., no worker nodes exist or inspection cannot be performed),
+	// not due to missing required components.
+	ControlPlaneConnectionAvailable ConditionType = "ControlPlaneConnectionAvailable"
 )
 
 // Reasons.
@@ -279,6 +290,12 @@ const (
 	DataPlaneConnectionLogsAccessFailedReason = "LogsAccessFailed"
 
 	DataPlaneConnectionNoWorkerNodesAvailableReason = "NoWorkerNodesAvailable"
+
+	ControlPlaneConnectionKASAccessFailedReason = "KASAccessFailed"
+
+	ControlPlaneConnectionDaemonSetNotFoundReason = "DaemonSetNotFound"
+
+	ControlPlaneConnectionNoWorkerNodesAvailableReason = "NoWorkerNodesAvailable"
 
 	ControlPlaneComponentsNotAvailable = "ComponentsNotAvailable"
 )

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/kasconnectionchecker.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/kasconnectionchecker.go
@@ -1,0 +1,23 @@
+package manifests
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// KASConnectionCheckerName is the name of the KAS connection checker DaemonSet
+	KASConnectionCheckerName = "kas-connection-checker"
+	// KASConnectionCheckerNamespace is the namespace where the DaemonSet is deployed
+	KASConnectionCheckerNamespace = "kube-system"
+)
+
+// KASConnectionCheckerDaemonSet returns an empty DaemonSet object for the KAS connection checker
+func KASConnectionCheckerDaemonSet() *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      KASConnectionCheckerName,
+			Namespace: KASConnectionCheckerNamespace,
+		},
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -67,6 +67,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -500,9 +501,26 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 		errs = append(errs, fmt.Errorf("failed to reconcile konnectivity agent: %w", err))
 	}
 
-	log.Info("reconciling control-Plane to data-Plane status conditions")
-	if err := r.reconcileControlPlaneDataPlaneConnectivityConditions(ctx, hcp, log); err != nil {
+	log.Info("reconciling KAS connection checker daemonset")
+	// The "pod" component is a standard component in OpenShift release payloads
+	// that provides this lightweight pause container from the release itself.
+	pauseImage, ok := releaseImage.ComponentImages()["pod"]
+	if !ok {
+		errs = append(errs, fmt.Errorf("failed to find pod image in release"))
+	} else {
+		if err := r.reconcileKASConnectionCheckerDaemonSet(ctx, hcp, pauseImage); err != nil {
+			errs = append(errs, fmt.Errorf("failed to reconcile KAS connection checker daemonset: %w", err))
+		}
+	}
+
+	log.Info("reconciling data plane connection available condition")
+	if err := r.reconcileDataPlaneConnectionAvailable(ctx, hcp, log); err != nil {
 		errs = append(errs, fmt.Errorf("failed to update ControlPlaneToDataPlaneConnectivity condition: %w", err))
+	}
+
+	log.Info("reconciling control plane connection available condition")
+	if err := r.reconcileControlPlaneConnectionAvailable(ctx, hcp); err != nil {
+		errs = append(errs, fmt.Errorf("failed to update ControlPlaneConnectionAvailable condition: %w", err))
 	}
 
 	log.Info("reconciling openshift apiserver apiservices")
@@ -1355,19 +1373,7 @@ func (r *reconciler) reconcileClusterVersion(ctx context.Context, hcp *hyperv1.H
 	return nil
 }
 
-func (r *reconciler) reconcileControlPlaneDataPlaneConnectivityConditions(ctx context.Context, hcp *hyperv1.HostedControlPlane, log logr.Logger) error {
-	patchHCPWithCondition := func(hcp *hyperv1.HostedControlPlane, condition *metav1.Condition) error {
-		originalHCP := hcp.DeepCopy()
-		if !meta.SetStatusCondition(&hcp.Status.Conditions, *condition) {
-			return nil // No status change; avoid unnecessary API call.
-		}
-		if err := r.cpClient.Status().Patch(ctx, hcp, client.MergeFrom(originalHCP)); err != nil {
-			return fmt.Errorf("failed to update HostedControlPlane status with %s condition: %w", condition.Type, err)
-		}
-		log.Info(string(hyperv1.DataPlaneConnectionAvailable) + " updated")
-		return nil
-	}
-
+func (r *reconciler) reconcileDataPlaneConnectionAvailable(ctx context.Context, hcp *hyperv1.HostedControlPlane, log logr.Logger) error {
 	condition := &metav1.Condition{
 		Type:   string(hyperv1.DataPlaneConnectionAvailable),
 		Status: metav1.ConditionFalse, // False by default
@@ -1377,20 +1383,20 @@ func (r *reconciler) reconcileControlPlaneDataPlaneConnectivityConditions(ctx co
 		condition.Status = metav1.ConditionUnknown
 		condition.Reason = hyperv1.ReconcileErrorReason
 		condition.Message = "Unable to count worker nodes: " + err.Error()
-		return patchHCPWithCondition(hcp, condition)
+		return r.patchHCPStatusCondition(ctx, hcp, condition)
 	}
 	if totalNodes == 0 {
 		condition.Status = metav1.ConditionUnknown
 		condition.Reason = hyperv1.DataPlaneConnectionNoWorkerNodesAvailableReason
 		condition.Message = "No worker nodes available"
-		return patchHCPWithCondition(hcp, condition)
+		return r.patchHCPStatusCondition(ctx, hcp, condition)
 	}
 	var podList corev1.PodList
 	if err := r.uncachedClient.List(ctx, &podList,
 		client.MatchingLabels{"app": "konnectivity-agent"}, client.InNamespace("kube-system")); err != nil {
 		condition.Reason = hyperv1.ReconciliationErrorReason
 		condition.Message = "Couldn't list konnectivity-agent PODs in kube-system namespace: " + err.Error()
-		return patchHCPWithCondition(hcp, condition)
+		return r.patchHCPStatusCondition(ctx, hcp, condition)
 	}
 
 	logsFound := false
@@ -1425,7 +1431,132 @@ func (r *reconciler) reconcileControlPlaneDataPlaneConnectivityConditions(ctx co
 		}
 	}
 
-	return patchHCPWithCondition(hcp, condition)
+	return r.patchHCPStatusCondition(ctx, hcp, condition)
+}
+
+// getKASHealthCheckEndpoint returns the appropriate KAS health check endpoint based on the platform type.
+// IBM Cloud uses a different liveness endpoint that excludes etcd and log checks.
+func getKASHealthCheckEndpoint(platformType hyperv1.PlatformType) string {
+	if platformType == hyperv1.IBMCloudPlatform {
+		return "/livez?exclude=etcd&exclude=log"
+	}
+	return "/version"
+}
+
+// patchHCPStatusCondition patches the HostedControlPlane status with the provided condition.
+// It only performs the API call if the condition actually changed.
+func (r *reconciler) patchHCPStatusCondition(ctx context.Context, hcp *hyperv1.HostedControlPlane, condition *metav1.Condition) error {
+	log := ctrl.LoggerFrom(ctx)
+	originalHCP := hcp.DeepCopy()
+	if !meta.SetStatusCondition(&hcp.Status.Conditions, *condition) {
+		return nil // No status change; avoid unnecessary API call.
+	}
+	if err := r.cpClient.Status().Patch(ctx, hcp, client.MergeFrom(originalHCP)); err != nil {
+		return fmt.Errorf("failed to update HostedControlPlane status with %s condition: %w", condition.Type, err)
+	}
+	log.Info(string(condition.Type) + " condition updated")
+	return nil
+}
+
+func (r *reconciler) reconcileKASConnectionCheckerDaemonSet(ctx context.Context, hcp *hyperv1.HostedControlPlane, pauseImage string) error {
+	kasAdvertiseAddress := util.GetAdvertiseAddress(hcp, config.DefaultAdvertiseIPv4Address, config.DefaultAdvertiseIPv6Address)
+	kasPort := util.KASPodPort(hcp)
+	endpoint := getKASHealthCheckEndpoint(hcp.Spec.Platform.Type)
+
+	daemonSet := manifests.KASConnectionCheckerDaemonSet()
+	if _, err := r.CreateOrUpdate(ctx, r.client, daemonSet, func() error {
+		// Configure the DaemonSet spec
+		daemonSet.Spec.Selector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app": manifests.KASConnectionCheckerName,
+			},
+		}
+
+		daemonSet.Spec.Template.ObjectMeta.Labels = map[string]string{
+			"app": manifests.KASConnectionCheckerName,
+		}
+
+		// Use a lightweight pause container from the release payload
+		daemonSet.Spec.Template.Spec.Containers = []corev1.Container{
+			{
+				Name:  "connection-checker",
+				Image: pauseImage,
+				ReadinessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path:   endpoint,
+							Port:   intstr.FromInt(int(kasPort)),
+							Scheme: corev1.URISchemeHTTPS,
+							Host:   kasAdvertiseAddress,
+						},
+					},
+					InitialDelaySeconds: 5,
+					PeriodSeconds:       10,
+					TimeoutSeconds:      5,
+					SuccessThreshold:    1,
+					FailureThreshold:    3,
+				},
+			},
+		}
+
+		// Tolerate all taints so it runs on all nodes
+		daemonSet.Spec.Template.Spec.Tolerations = []corev1.Toleration{
+			{
+				Operator: corev1.TolerationOpExists,
+			},
+		}
+
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile kas-connection-checker daemonset: %w", err)
+	}
+
+	return nil
+}
+
+func (r *reconciler) reconcileControlPlaneConnectionAvailable(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
+	condition := &metav1.Condition{
+		Type:   string(hyperv1.ControlPlaneConnectionAvailable),
+		Status: metav1.ConditionUnknown,
+		Reason: hyperv1.StatusUnknownReason,
+	}
+
+	// Get the KAS connection checker DaemonSet
+	daemonSet := manifests.KASConnectionCheckerDaemonSet()
+
+	if err := r.client.Get(ctx, client.ObjectKeyFromObject(daemonSet), daemonSet); err != nil {
+		if apierrors.IsNotFound(err) {
+			condition.Reason = hyperv1.ControlPlaneConnectionDaemonSetNotFoundReason
+			condition.Message = fmt.Sprintf("KAS connection checker DaemonSet %s/%s not found; the hosted cluster config operator may not have reconciled it yet",
+				manifests.KASConnectionCheckerNamespace, manifests.KASConnectionCheckerName)
+			return r.patchHCPStatusCondition(ctx, hcp, condition)
+		}
+		condition.Reason = hyperv1.ReconcileErrorReason
+		condition.Message = fmt.Sprintf("Failed to get KAS connection checker DaemonSet %s/%s: %v",
+			manifests.KASConnectionCheckerNamespace, manifests.KASConnectionCheckerName, err)
+		return r.patchHCPStatusCondition(ctx, hcp, condition)
+	}
+
+	// Check if there are any nodes to schedule pods on
+	if daemonSet.Status.DesiredNumberScheduled == 0 {
+		condition.Reason = hyperv1.ControlPlaneConnectionNoWorkerNodesAvailableReason
+		condition.Message = "KAS connection checker DaemonSet has 0 desired pods scheduled; no worker nodes are available to verify control plane connectivity"
+		return r.patchHCPStatusCondition(ctx, hcp, condition)
+	}
+
+	// Check if all desired pods are ready
+	if daemonSet.Status.NumberReady == daemonSet.Status.DesiredNumberScheduled {
+		condition.Status = metav1.ConditionTrue
+		condition.Reason = hyperv1.AsExpectedReason
+		condition.Message = hyperv1.AllIsWellMessage
+	} else {
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = hyperv1.ControlPlaneConnectionKASAccessFailedReason
+		condition.Message = fmt.Sprintf("Data plane to control plane connection is not available: %d/%d pods ready",
+			daemonSet.Status.NumberReady, daemonSet.Status.DesiredNumberScheduled)
+	}
+
+	return r.patchHCPStatusCondition(ctx, hcp, condition)
 }
 
 func (r *reconciler) reconcileOpenshiftAPIServerAPIServices(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/nodepool"
 	"github.com/openshift/hypershift/support/azureutil"
+	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/globalconfig"
 	fakereleaseprovider "github.com/openshift/hypershift/support/releaseinfo/fake"
 	supportutil "github.com/openshift/hypershift/support/util"
@@ -91,6 +92,7 @@ var initialObjects = []client.Object{
 	manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", kas.AdmissionPolicyNameInfra)),
 
 	fakeOperatorHub(),
+	manifests.KASConnectionCheckerDaemonSet(),
 }
 
 func shouldNotError(key client.ObjectKey) bool {
@@ -165,8 +167,12 @@ func TestReconcileErrorHandling(t *testing.T) {
 			cpClient:               fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(cpObjects...).WithStatusSubresource(&hyperv1.HostedControlPlane{}).Build(),
 			hcpName:                "foo",
 			hcpNamespace:           "bar",
-			releaseProvider:        &fakereleaseprovider.FakeReleaseProvider{},
-			ImageMetaDataProvider:  &imageMetaDataProvider,
+			releaseProvider: &fakereleaseprovider.FakeReleaseProvider{
+				Components: map[string]string{
+					"pod": "registry.k8s.io/pause:3.9",
+				},
+			},
+			ImageMetaDataProvider: &imageMetaDataProvider,
 		}
 		_, err := r.Reconcile(ctx, controllerruntime.Request{})
 		if err != nil {
@@ -195,8 +201,12 @@ func TestReconcileErrorHandling(t *testing.T) {
 			cpClient:               fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(cpObjects...).Build(),
 			hcpName:                "foo",
 			hcpNamespace:           "bar",
-			releaseProvider:        &fakereleaseprovider.FakeReleaseProvider{},
-			ImageMetaDataProvider:  &imageMetaDataProvider,
+			releaseProvider: &fakereleaseprovider.FakeReleaseProvider{
+				Components: map[string]string{
+					"pod": "registry.k8s.io/pause:3.9",
+				},
+			},
+			ImageMetaDataProvider: &imageMetaDataProvider,
 		}
 		_, err := r.Reconcile(ctx, controllerruntime.Request{})
 		if err != nil {
@@ -2286,7 +2296,7 @@ func newCondition(conditionType string, status metav1.ConditionStatus, reason, m
 	}
 }
 
-func Test_reconciler_reconcileControlPlaneDataPlaneConnectivityConditions(t *testing.T) {
+func Test_reconciler_reconcileDataPlaneConnectionAvailable(t *testing.T) {
 	newKonnectivityAgentPod := func(name string, phase corev1.PodPhase) corev1.Pod {
 		return corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2453,15 +2463,15 @@ func Test_reconciler_reconcileControlPlaneDataPlaneConnectivityConditions(t *tes
 			r.cpClient = fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(tt.hcp).WithStatusSubresource(&hyperv1.HostedControlPlane{}).Build()
 			r.GetPodLogs = tt.mockedGetPodLogs
 
-			gotErr := r.reconcileControlPlaneDataPlaneConnectivityConditions(ctx, tt.hcp, log)
+			gotErr := r.reconcileDataPlaneConnectionAvailable(ctx, tt.hcp, log)
 			if gotErr != nil {
 				if !tt.wantErr {
-					t.Errorf("reconcileControlPlaneDataPlaneConnectivityConditions() failed: %v", gotErr)
+					t.Errorf("reconcileDataPlaneConnectionAvailable() failed: %v", gotErr)
 				}
 				return
 			}
 			if tt.wantErr {
-				t.Fatal("reconcileControlPlaneDataPlaneConnectivityConditions() succeeded unexpectedly")
+				t.Fatal("reconcileDataPlaneConnectionAvailable() succeeded unexpectedly")
 			}
 			if tt.expectedCondition != nil {
 				found := false
@@ -2476,6 +2486,365 @@ func Test_reconciler_reconcileControlPlaneDataPlaneConnectivityConditions(t *tes
 				if !found {
 					t.Fatal("couldn't find expected condition")
 				}
+			}
+		})
+	}
+}
+
+func Test_reconciler_reconcileControlPlaneConnectionAvailable(t *testing.T) {
+	newKASConnectionCheckerDaemonSet := func(desiredScheduled, numberReady int32) *appsv1.DaemonSet {
+		return &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      manifests.KASConnectionCheckerName,
+				Namespace: manifests.KASConnectionCheckerNamespace,
+			},
+			Status: appsv1.DaemonSetStatus{
+				DesiredNumberScheduled: desiredScheduled,
+				NumberReady:            numberReady,
+			},
+		}
+	}
+
+	tests := []struct {
+		name              string
+		hcp               *hyperv1.HostedControlPlane
+		wantErr           bool
+		expectedCondition *metav1.Condition
+		daemonSet         *appsv1.DaemonSet
+	}{
+		{
+			name:    "When DaemonSet does not exist it should set condition to Unknown with DaemonSetNotFound reason",
+			hcp:     fakeHCP(),
+			wantErr: false,
+			expectedCondition: newCondition(
+				string(hyperv1.ControlPlaneConnectionAvailable),
+				metav1.ConditionUnknown,
+				hyperv1.ControlPlaneConnectionDaemonSetNotFoundReason,
+				fmt.Sprintf("KAS connection checker DaemonSet %s/%s not found; the hosted cluster config operator may not have reconciled it yet",
+					manifests.KASConnectionCheckerNamespace, manifests.KASConnectionCheckerName),
+			),
+			daemonSet: nil, // No DaemonSet
+		},
+		{
+			name:    "When DesiredNumberScheduled is 0 it should set condition to Unknown with NoWorkerNodesAvailable reason",
+			hcp:     fakeHCP(),
+			wantErr: false,
+			expectedCondition: newCondition(
+				string(hyperv1.ControlPlaneConnectionAvailable),
+				metav1.ConditionUnknown,
+				hyperv1.ControlPlaneConnectionNoWorkerNodesAvailableReason,
+				"KAS connection checker DaemonSet has 0 desired pods scheduled; no worker nodes are available to verify control plane connectivity",
+			),
+			daemonSet: newKASConnectionCheckerDaemonSet(0, 0),
+		},
+		{
+			name:    "When all pods are ready it should set condition to True",
+			hcp:     fakeHCP(),
+			wantErr: false,
+			expectedCondition: newCondition(
+				string(hyperv1.ControlPlaneConnectionAvailable),
+				metav1.ConditionTrue,
+				hyperv1.AsExpectedReason,
+				hyperv1.AllIsWellMessage,
+			),
+			daemonSet: newKASConnectionCheckerDaemonSet(3, 3),
+		},
+		{
+			name:    "When some pods are not ready it should set condition to False",
+			hcp:     fakeHCP(),
+			wantErr: false,
+			expectedCondition: newCondition(
+				string(hyperv1.ControlPlaneConnectionAvailable),
+				metav1.ConditionFalse,
+				hyperv1.ControlPlaneConnectionKASAccessFailedReason,
+				"Data plane to control plane connection is not available: 1/3 pods ready",
+			),
+			daemonSet: newKASConnectionCheckerDaemonSet(3, 1),
+		},
+		{
+			name:    "When no pods are ready it should set condition to False",
+			hcp:     fakeHCP(),
+			wantErr: false,
+			expectedCondition: newCondition(
+				string(hyperv1.ControlPlaneConnectionAvailable),
+				metav1.ConditionFalse,
+				hyperv1.ControlPlaneConnectionKASAccessFailedReason,
+				"Data plane to control plane connection is not available: 0/5 pods ready",
+			),
+			daemonSet: newKASConnectionCheckerDaemonSet(5, 0),
+		},
+		{
+			name:    "When only one pod is ready out of one it should set condition to True",
+			hcp:     fakeHCP(),
+			wantErr: false,
+			expectedCondition: newCondition(
+				string(hyperv1.ControlPlaneConnectionAvailable),
+				metav1.ConditionTrue,
+				hyperv1.AsExpectedReason,
+				hyperv1.AllIsWellMessage,
+			),
+			daemonSet: newKASConnectionCheckerDaemonSet(1, 1),
+		},
+	}
+
+	log := zapr.NewLogger(zaptest.NewLogger(t))
+	ctx := logr.NewContext(context.Background(), log)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var r reconciler
+
+			// Build client with DaemonSet if provided
+			var objects []client.Object
+			if tt.daemonSet != nil {
+				objects = append(objects, tt.daemonSet)
+			}
+
+			r.client = fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(objects...).Build()
+			r.cpClient = fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(tt.hcp).WithStatusSubresource(&hyperv1.HostedControlPlane{}).Build()
+
+			gotErr := r.reconcileControlPlaneConnectionAvailable(ctx, tt.hcp)
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("reconcileControlPlaneConnectionAvailable() failed: %v", gotErr)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Fatal("reconcileControlPlaneConnectionAvailable() succeeded unexpectedly")
+			}
+			if tt.expectedCondition != nil {
+				found := false
+				for _, c := range tt.hcp.Status.Conditions {
+					if tt.expectedCondition.Type == c.Type &&
+						tt.expectedCondition.Message == c.Message &&
+						tt.expectedCondition.Status == c.Status &&
+						tt.expectedCondition.Reason == c.Reason {
+						found = true
+					}
+				}
+				if !found {
+					t.Fatalf("couldn't find expected condition. Expected: %+v, Got: %+v", tt.expectedCondition, tt.hcp.Status.Conditions)
+				}
+			}
+		})
+	}
+}
+
+func Test_reconciler_reconcileKASConnectionCheckerDaemonSet(t *testing.T) {
+	tests := []struct {
+		name              string
+		hcp               *hyperv1.HostedControlPlane
+		existingDaemonSet *appsv1.DaemonSet
+		wantErr           bool
+		validate          func(t *testing.T, ds *appsv1.DaemonSet)
+	}{
+		{
+			name:              "When DaemonSet does not exist it should create it with correct spec",
+			hcp:               fakeHCP(),
+			existingDaemonSet: nil,
+			wantErr:           false,
+			validate: func(t *testing.T, ds *appsv1.DaemonSet) {
+				if ds == nil {
+					t.Fatal("DaemonSet should be created")
+				}
+				if ds.Name != manifests.KASConnectionCheckerName {
+					t.Errorf("Expected name %s, got %s", manifests.KASConnectionCheckerName, ds.Name)
+				}
+				if ds.Namespace != manifests.KASConnectionCheckerNamespace {
+					t.Errorf("Expected namespace %s, got %s", manifests.KASConnectionCheckerNamespace, ds.Namespace)
+				}
+
+				// Validate labels and selectors
+				if ds.Spec.Selector == nil || ds.Spec.Selector.MatchLabels["app"] != manifests.KASConnectionCheckerName {
+					t.Error("Selector labels not set correctly")
+				}
+				if ds.Spec.Template.ObjectMeta.Labels["app"] != manifests.KASConnectionCheckerName {
+					t.Error("Pod template labels not set correctly")
+				}
+
+				// Validate container spec
+				if len(ds.Spec.Template.Spec.Containers) != 1 {
+					t.Fatalf("Expected 1 container, got %d", len(ds.Spec.Template.Spec.Containers))
+				}
+				container := ds.Spec.Template.Spec.Containers[0]
+				if container.Name != "connection-checker" {
+					t.Errorf("Expected container name 'connection-checker', got %s", container.Name)
+				}
+				if container.Image != "registry.k8s.io/pause:3.9" {
+					t.Errorf("Expected pause image, got %s", container.Image)
+				}
+
+				// Validate readiness probe
+				if container.ReadinessProbe == nil {
+					t.Fatal("ReadinessProbe should be set")
+				}
+				probe := container.ReadinessProbe
+				if probe.HTTPGet == nil {
+					t.Fatal("HTTPGet probe should be set")
+				}
+				if probe.HTTPGet.Scheme != corev1.URISchemeHTTPS {
+					t.Errorf("Expected HTTPS scheme, got %s", probe.HTTPGet.Scheme)
+				}
+				if probe.HTTPGet.Host != config.DefaultAdvertiseIPv4Address {
+					t.Errorf("Expected host %s (KAS advertise address), got %s", config.DefaultAdvertiseIPv4Address, probe.HTTPGet.Host)
+				}
+				if probe.HTTPGet.Port.IntValue() != 6443 {
+					t.Errorf("Expected port 6443, got %d", probe.HTTPGet.Port.IntValue())
+				}
+				if probe.HTTPGet.Path != "/version" {
+					t.Errorf("Expected path /version, got %s", probe.HTTPGet.Path)
+				}
+
+				// Validate probe timing
+				if probe.InitialDelaySeconds != 5 {
+					t.Errorf("Expected InitialDelaySeconds 5, got %d", probe.InitialDelaySeconds)
+				}
+				if probe.PeriodSeconds != 10 {
+					t.Errorf("Expected PeriodSeconds 10, got %d", probe.PeriodSeconds)
+				}
+				if probe.TimeoutSeconds != 5 {
+					t.Errorf("Expected TimeoutSeconds 5, got %d", probe.TimeoutSeconds)
+				}
+				if probe.SuccessThreshold != 1 {
+					t.Errorf("Expected SuccessThreshold 1, got %d", probe.SuccessThreshold)
+				}
+				if probe.FailureThreshold != 3 {
+					t.Errorf("Expected FailureThreshold 3, got %d", probe.FailureThreshold)
+				}
+
+				// Validate that host network is NOT used
+				if ds.Spec.Template.Spec.HostNetwork {
+					t.Error("HostNetwork should be false (not set)")
+				}
+
+				// Validate tolerations
+				if len(ds.Spec.Template.Spec.Tolerations) != 1 {
+					t.Fatalf("Expected 1 toleration, got %d", len(ds.Spec.Template.Spec.Tolerations))
+				}
+				if ds.Spec.Template.Spec.Tolerations[0].Operator != corev1.TolerationOpExists {
+					t.Error("Expected toleration operator Exists")
+				}
+			},
+		},
+		{
+			name: "When platform is IBM Cloud it should use IBM Cloud specific endpoint",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: "test-namespace",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.IBMCloudPlatform,
+					},
+				},
+			},
+			existingDaemonSet: nil,
+			wantErr:           false,
+			validate: func(t *testing.T, ds *appsv1.DaemonSet) {
+				if ds == nil {
+					t.Fatal("DaemonSet should be created")
+				}
+				container := ds.Spec.Template.Spec.Containers[0]
+				if container.ReadinessProbe.HTTPGet.Path != "/livez?exclude=etcd&exclude=log" {
+					t.Errorf("Expected IBM Cloud endpoint, got %s", container.ReadinessProbe.HTTPGet.Path)
+				}
+			},
+		},
+		{
+			name: "When DaemonSet already exists it should update it",
+			hcp:  fakeHCP(),
+			existingDaemonSet: &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      manifests.KASConnectionCheckerName,
+					Namespace: manifests.KASConnectionCheckerNamespace,
+				},
+				Spec: appsv1.DaemonSetSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "old-label",
+						},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app": "old-label",
+							},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "old-container",
+									Image: "old-image",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			validate: func(t *testing.T, ds *appsv1.DaemonSet) {
+				if ds == nil {
+					t.Fatal("DaemonSet should exist")
+				}
+				// Verify it was updated with new spec
+				if ds.Spec.Selector.MatchLabels["app"] != manifests.KASConnectionCheckerName {
+					t.Error("DaemonSet should be updated with correct selector")
+				}
+				if len(ds.Spec.Template.Spec.Containers) != 1 {
+					t.Fatalf("Expected 1 container after update, got %d", len(ds.Spec.Template.Spec.Containers))
+				}
+				container := ds.Spec.Template.Spec.Containers[0]
+				if container.Name != "connection-checker" {
+					t.Error("Container should be updated to connection-checker")
+				}
+				if container.Image != "registry.k8s.io/pause:3.9" {
+					t.Error("Image should be updated to pause:3.9")
+				}
+				if container.ReadinessProbe == nil {
+					t.Error("ReadinessProbe should be added during update")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var r reconciler
+
+			// Setup fake client with existing DaemonSet if provided
+			objects := []client.Object{}
+			if tt.existingDaemonSet != nil {
+				objects = append(objects, tt.existingDaemonSet)
+			}
+			r.client = fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(objects...).Build()
+			r.CreateOrUpdateProvider = &simpleCreateOrUpdater{}
+
+			ctx := context.Background()
+			pauseImage := "registry.k8s.io/pause:3.9"
+			err := r.reconcileKASConnectionCheckerDaemonSet(ctx, tt.hcp, pauseImage)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("reconcileKASConnectionCheckerDaemonSet() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			// Retrieve the DaemonSet and validate
+			daemonSet := &appsv1.DaemonSet{}
+			key := client.ObjectKey{
+				Name:      manifests.KASConnectionCheckerName,
+				Namespace: manifests.KASConnectionCheckerNamespace,
+			}
+			if err := r.client.Get(ctx, key, daemonSet); err != nil {
+				if !apierrors.IsNotFound(err) {
+					t.Errorf("Failed to get DaemonSet: %v", err)
+				}
+				daemonSet = nil
+			}
+
+			if tt.validate != nil {
+				tt.validate(t, daemonSet)
 			}
 		})
 	}

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -32711,6 +32711,16 @@ underlying cluster&rsquo;s ClusterVersion.</p>
 </tr><tr><td><p>&#34;RolloutComplete&#34;</p></td>
 <td><p>ControlPlaneComponentRolloutComplete indicates whether the ControlPlaneComponent has completed its rollout.</p>
 </td>
+</tr><tr><td><p>&#34;ControlPlaneConnectionAvailable&#34;</p></td>
+<td><p>ControlPlaneConnectionAvailable indicates whether data plane workloads have a successful
+network connection to the control plane components. This condition is computed per-node using
+a DaemonSet that performs reachability checks from each worker node.
+<strong>True</strong> means all data plane nodes can successfully reach the control plane (per-node reachability check passes for every node).
+<strong>False</strong> means there are connectivity failures preventing some or all data plane nodes from reaching the control plane,
+or required infrastructure components (such as kube-apiserver-proxy pods or the connection checker DaemonSet) are missing or unavailable.
+<strong>Unknown</strong> means the status cannot be determined due to true inability to inspect (e.g., no worker nodes exist or inspection cannot be performed),
+not due to missing required components.</p>
+</td>
 </tr><tr><td><p>&#34;DataPlaneConnectionAvailable&#34;</p></td>
 <td><p>DataPlaneConnectionAvailable indicates whether the control plane has a successful
 network connection to the data plane components.
@@ -32718,7 +32728,8 @@ network connection to the data plane components.
 <strong>False</strong> means there are network connection issues preventing the control plane from reaching the data plane.
 A failure here suggests potential issues such as: network policy restrictions,
 firewall rules, missing data plane nodes, or problems with infrastructure
-components like the konnectivity-agent workload.</p>
+components like the konnectivity-agent workload.
+<strong>Unknown</strong> means the status cannot be determined (e.g., no worker nodes available or unable to inspect).</p>
 </td>
 </tr><tr><td><p>&#34;EtcdAvailable&#34;</p></td>
 <td><p>EtcdAvailable bubbles up the same condition from HCP. It signals if etcd is available.

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -4961,6 +4961,16 @@ underlying cluster&rsquo;s ClusterVersion.</p>
 </tr><tr><td><p>&#34;RolloutComplete&#34;</p></td>
 <td><p>ControlPlaneComponentRolloutComplete indicates whether the ControlPlaneComponent has completed its rollout.</p>
 </td>
+</tr><tr><td><p>&#34;ControlPlaneConnectionAvailable&#34;</p></td>
+<td><p>ControlPlaneConnectionAvailable indicates whether data plane workloads have a successful
+network connection to the control plane components. This condition is computed per-node using
+a DaemonSet that performs reachability checks from each worker node.
+<strong>True</strong> means all data plane nodes can successfully reach the control plane (per-node reachability check passes for every node).
+<strong>False</strong> means there are connectivity failures preventing some or all data plane nodes from reaching the control plane,
+or required infrastructure components (such as kube-apiserver-proxy pods or the connection checker DaemonSet) are missing or unavailable.
+<strong>Unknown</strong> means the status cannot be determined due to true inability to inspect (e.g., no worker nodes exist or inspection cannot be performed),
+not due to missing required components.</p>
+</td>
 </tr><tr><td><p>&#34;DataPlaneConnectionAvailable&#34;</p></td>
 <td><p>DataPlaneConnectionAvailable indicates whether the control plane has a successful
 network connection to the data plane components.
@@ -4968,7 +4978,8 @@ network connection to the data plane components.
 <strong>False</strong> means there are network connection issues preventing the control plane from reaching the data plane.
 A failure here suggests potential issues such as: network policy restrictions,
 firewall rules, missing data plane nodes, or problems with infrastructure
-components like the konnectivity-agent workload.</p>
+components like the konnectivity-agent workload.
+<strong>Unknown</strong> means the status cannot be determined (e.g., no worker nodes available or unable to inspect).</p>
 </td>
 </tr><tr><td><p>&#34;EtcdAvailable&#34;</p></td>
 <td><p>EtcdAvailable bubbles up the same condition from HCP. It signals if etcd is available.

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -828,6 +828,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 			hyperv1.ValidIDPConfiguration,
 			hyperv1.HostedClusterRestoredFromBackup,
 			hyperv1.DataPlaneConnectionAvailable,
+			hyperv1.ControlPlaneConnectionAvailable,
 		}
 
 		for _, conditionType := range hcpConditions {

--- a/support/conditions/conditions.go
+++ b/support/conditions/conditions.go
@@ -28,6 +28,7 @@ func ExpectedHCConditions(hostedCluster *hyperv1.HostedCluster) map[hyperv1.Cond
 		hyperv1.ValidReleaseImage:                    metav1.ConditionTrue,
 		hyperv1.PlatformCredentialsFound:             metav1.ConditionTrue,
 		hyperv1.DataPlaneConnectionAvailable:         metav1.ConditionTrue,
+		hyperv1.ControlPlaneConnectionAvailable:      metav1.ConditionTrue,
 
 		hyperv1.HostedClusterProgressing:  metav1.ConditionFalse,
 		hyperv1.HostedClusterDegraded:     metav1.ConditionFalse,

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -2937,6 +2937,7 @@ func ValidateHostedClusterConditions(t *testing.T, ctx context.Context, client c
 		expectedConditions[hyperv1.ClusterVersionProgressing] = metav1.ConditionTrue
 		delete(expectedConditions, hyperv1.ValidKubeVirtInfraNetworkMTU)
 		expectedConditions[hyperv1.DataPlaneConnectionAvailable] = metav1.ConditionUnknown
+		expectedConditions[hyperv1.ControlPlaneConnectionAvailable] = metav1.ConditionUnknown
 	}
 	if IsLessThan(Version415) {
 		// ValidKubeVirtInfraNetworkMTU condition is not present in versions < 4.15
@@ -2945,6 +2946,17 @@ func ValidateHostedClusterConditions(t *testing.T, ctx context.Context, client c
 
 	if IsLessThan(Version421) {
 		delete(expectedConditions, hyperv1.DataPlaneConnectionAvailable)
+	}
+
+	if IsLessThan(Version422) {
+		delete(expectedConditions, hyperv1.ControlPlaneConnectionAvailable)
+	}
+
+	// TODO: TEMPORARY - Remove this once ControlPlaneConnectionAvailable condition is merged and stable.
+	// Exclude ControlPlaneConnectionAvailable during upgrade tests as the condition
+	// may not be present in all builds during the upgrade window.
+	if strings.Contains(t.Name(), "Upgrade") {
+		delete(expectedConditions, hyperv1.ControlPlaneConnectionAvailable)
 	}
 
 	var predicates []Predicate[*hyperv1.HostedCluster]

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -214,7 +214,18 @@ const (
 	// A failure here suggests potential issues such as: network policy restrictions,
 	// firewall rules, missing data plane nodes, or problems with infrastructure
 	// components like the konnectivity-agent workload.
+	// **Unknown** means the status cannot be determined (e.g., no worker nodes available or unable to inspect).
 	DataPlaneConnectionAvailable ConditionType = "DataPlaneConnectionAvailable"
+
+	// ControlPlaneConnectionAvailable indicates whether data plane workloads have a successful
+	// network connection to the control plane components. This condition is computed per-node using
+	// a DaemonSet that performs reachability checks from each worker node.
+	// **True** means all data plane nodes can successfully reach the control plane (per-node reachability check passes for every node).
+	// **False** means there are connectivity failures preventing some or all data plane nodes from reaching the control plane,
+	// or required infrastructure components (such as kube-apiserver-proxy pods or the connection checker DaemonSet) are missing or unavailable.
+	// **Unknown** means the status cannot be determined due to true inability to inspect (e.g., no worker nodes exist or inspection cannot be performed),
+	// not due to missing required components.
+	ControlPlaneConnectionAvailable ConditionType = "ControlPlaneConnectionAvailable"
 )
 
 // Reasons.
@@ -279,6 +290,12 @@ const (
 	DataPlaneConnectionLogsAccessFailedReason = "LogsAccessFailed"
 
 	DataPlaneConnectionNoWorkerNodesAvailableReason = "NoWorkerNodesAvailable"
+
+	ControlPlaneConnectionKASAccessFailedReason = "KASAccessFailed"
+
+	ControlPlaneConnectionDaemonSetNotFoundReason = "DaemonSetNotFound"
+
+	ControlPlaneConnectionNoWorkerNodesAvailableReason = "NoWorkerNodesAvailable"
 
 	ControlPlaneComponentsNotAvailable = "ComponentsNotAvailable"
 )


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

It introduces ControlPlaneConnectionAvailable condition. It detect connection problem executing a curl command. The curl is a simple GET to ` https://kubernetes.default.svc/api`

## Which issue(s) this PR fixes:
Fixes https://issues.redhat.com/browse/CNTRLPLANE-2203

## Special notes for your reviewer:

This change includes e2e. Upgrade e2e is temporary modified since we're upgrading from 4.22+newCondition -> 4.22 and lack os condition is problematic. 
See https://github.com/openshift/hypershift/pull/7489/changes#diff-cebde6b83b4b372162b2c6a22710a4ab0b1838576120535593a66a3a9bdfc170R2944

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [x] This change includes unit tests.
