### PR TITLE
CNTRLPLANE-2559: feat(contrib): add request serving setup utility

### DIFF
--- a/contrib/reqserving-setup/Makefile
+++ b/contrib/reqserving-setup/Makefile
@@ -1,0 +1,14 @@
+GO_GCFLAGS ?= -gcflags=all='-N -l'
+GO=GO111MODULE=on GOWORK=off GOFLAGS=-mod=vendor go
+GO_BUILD_RECIPE=CGO_ENABLED=1 $(GO) build $(GO_GCFLAGS)
+
+.PHONY: all
+all: build
+
+.PHONY: build
+build:
+	$(GO_BUILD_RECIPE) -o reqserving-setup .
+
+.PHONY: clean
+clean:
+	rm -f reqserving-setup

--- a/contrib/reqserving-setup/README.md
+++ b/contrib/reqserving-setup/README.md
@@ -1,0 +1,55 @@
+# Request Serving Setup Utility
+
+This utility configures an OpenShift management cluster for HyperShift's dedicated request serving isolation. It is based on the setup logic used in the HyperShift e2e test suite.
+
+## Building
+
+To build the utility, run `make` from this directory:
+
+```bash
+make
+```
+
+This will produce a `reqserving-setup` binary.
+
+## Running
+
+The utility requires a configured `KUBECONFIG` with cluster-admin permissions on the management cluster.
+
+### Apply Configuration
+
+To apply the configuration directly to the cluster:
+
+```bash
+./reqserving-setup
+```
+
+### Dry Run
+
+To see what resources would be created without applying them, use the `--dry-run-dir` flag:
+
+```bash
+./reqserving-setup --dry-run-dir ./manifests
+```
+
+## What This Utility Does
+
+The utility performs the following configuration steps:
+
+1.  **Cluster Autoscaler**: Configures the `default` `ClusterAutoscaler` resource to enable `balanceSimilarNodeGroups` and scale-down.
+2.  **Machine Health Check**: Creates a `MachineHealthCheck` named `request-serving-mhc` in the `openshift-machine-api` namespace. It monitors nodes labeled with `hypershift.openshift.io/control-plane=true`.
+3.  **Common MachineSets**: Creates "common" `MachineSet` resources in 3 availability zones for non-request-serving control plane workloads.
+    *   **Taints**: `hypershift.openshift.io/control-plane=true:NoSchedule`
+    *   **Autoscaling**: Creates a `MachineAutoscaler` for each, scaling from 0 to 20.
+4.  **Request Serving MachineSets**: Creates a comprehensive set of `MachineSet` resources across 2 availability zones for 3 different node sizes (`small`, `medium`, `large`).
+    *   **Isolation**: 20 pairs of MachineSets are created for each size and zone.
+    *   **Labels**: Nodes are labeled with `hypershift.openshift.io/request-serving-component=true` and `hypershift.openshift.io/node-size=<size>`.
+    *   **Taints**: Nodes are tainted with:
+        *   `hypershift.openshift.io/control-plane=true:NoSchedule`
+        *   `hypershift.openshift.io/control-plane-serving-component=true:NoSchedule`
+    *   **Autoscaling**: Creates a `MachineAutoscaler` for each, scaling from 0 to 1.
+
+## Prerequisites
+
+*   The management cluster must be a standalone Highly Available (HA) cluster.
+*   Currently, this utility is specific to AWS-based management clusters as it relies on AWS `MachineSet` provider specifications.

--- a/contrib/reqserving-setup/main.go
+++ b/contrib/reqserving-setup/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/openshift/hypershift/test/e2e/util/reqserving"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	crzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"go.uber.org/zap/zapcore"
+)
+
+func main() {
+	var dryRunDir string
+	flag.StringVar(&dryRunDir, "dry-run-dir", "", "If specified, only output YAMLs to this directory")
+	flag.Parse()
+
+	log := crzap.New(crzap.UseDevMode(true), crzap.JSONEncoder(func(o *zapcore.EncoderConfig) {
+		o.EncodeTime = zapcore.RFC3339TimeEncoder
+	}))
+	ctrl.SetLogger(log)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigs
+		log.Info("received shutdown signal and will be canceled")
+		cancel()
+	}()
+
+	var dryRunOpts *reqserving.DryRunOptions
+	if dryRunDir != "" {
+		dryRunOpts = &reqserving.DryRunOptions{
+			Dir: dryRunDir,
+		}
+		if err := os.MkdirAll(dryRunOpts.Dir, 0o755); err != nil {
+			log.Error(err, "failed to create dry run directory")
+			os.Exit(1)
+		}
+	}
+
+	log.Info("configuring management cluster for request serving")
+	if err := reqserving.ConfigureManagementCluster(ctx, dryRunOpts); err != nil {
+		log.Error(err, "failed to configure management cluster")
+		os.Exit(1)
+	}
+
+	log.Info("management cluster configured successfully")
+}


### PR DESCRIPTION
## What this PR does / why we need it:
Add a standalone utility under contrib/reqserving-setup to configure a management cluster for HyperShift's dedicated request serving isolation. This includes a Makefile and README documentation.

Assisted-by: gemini-3-flash-preview (via Cursor)

## Which issue(s) this PR fixes:
Fixes [CNTRLPLANE-2559](https://issues.redhat.com/browse/CNTRLPLANE-2559)

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 