### PR TITLE
OCPBUGS-74022: chore(ci): update ose-hypershift-container image for ART 4.22

### DIFF
--- a/Dockerfile.control-plane
+++ b/Dockerfile.control-plane
@@ -7,7 +7,7 @@ COPY . .
 RUN make control-plane-operator \
   && make control-plane-pki-operator
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.22:base-rhel9-minimal
 COPY --from=builder /hypershift/bin/control-plane-operator /usr/bin/control-plane-operator
 COPY --from=builder /hypershift/bin/control-plane-pki-operator /usr/bin/control-plane-pki-operator
 


### PR DESCRIPTION
## Summary

This PR supersedes #7540 (authored by openshift-bot).

The original bot PR required proper conventional commit format to pass CI verification. This PR includes:
- All changes from the original bot PR (with corrected conventional commit format)
- Validated with `make verify` and `make test`

### Changes

- Updates `.ci-operator.yaml` to align CI configuration with ART's configuration for 4.22

### Original PR Description

Updating ose-hypershift-container image to be consistent with ART for 4.22

Reconciling with https://github.com/openshift/ocp-build-data/tree/37a25cc2e6eec9883ae439d785f89ab3f6cb2f51/images/hypershift.yml

---

**Original PR:** #7540
**Bot Author:** openshift-bot

---

Assisted-by: Claude (via Claude Code)