### PR TITLE
OCPBUGS-74106: Fix CVE-2025-58183

### DIFF
--- a/Containerfile.cli
+++ b/Containerfile.cli
@@ -1,8 +1,8 @@
-FROM registry.redhat.io/rhel9/go-toolset:1.24.6-1763548439 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.24 AS builder
 
 WORKDIR /hypershift
 
-COPY --chown=default . .
+COPY . .
 
 RUN make product-cli-release && \
     # Create tar.gz files for Linux architectures \
@@ -14,16 +14,18 @@ RUN make product-cli-release && \
       for ARCH in amd64 arm64; do \
         tar -czvf ./bin/${OS}/${ARCH}/hcp.tar.gz -C ./bin/${OS}/${ARCH} ./hcp || exit 1; \
       done; \
-    done
+    done && \
+    # Remove raw binaries, keep only tar.gz files \
+    find ./bin -type f ! -name "*.tar.gz" -delete
 
 FROM registry.redhat.io/ubi9/nginx-124:1-1767745334
 
-COPY --from=builder /hypershift/bin/    /opt/app-root/src/
-RUN find /opt/app-root/src/ -type f ! -name "*.tar.gz" -delete
+COPY --from=builder /hypershift/bin/ /opt/app-root/src/
 
 CMD ["nginx", "-g", "daemon off;"]
 
 LABEL name="multicluster-engine/hypershift-cli-rhel9" \
+      cpe="cpe:/a:redhat:multicluster_engine:2.9::el9" \
       description="HyperShift HCP CLI for managing the lifecycle of Hosted Clusters via the command line." \
       summary="HyperShift HCP CLI" \
       url="https://catalog.redhat.com/software/containers/multicluster-engine/hypershift-cli-rhel9/" \

--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -21,6 +21,7 @@ COPY --from=builder /hypershift/bin/hypershift \
 ENTRYPOINT ["/usr/bin/hypershift"]
 
 LABEL name="multicluster-engine/hypershift-operator"
+LABEL cpe="cpe:/a:redhat:multicluster_engine:2.9::el9"
 LABEL description="HyperShift Operator is an operator to manage the lifecycle of Hosted Clusters"
 LABEL summary="HyperShift Operator"
 LABEL url="https://catalog.redhat.com/software/containers/multicluster-engine/hypershift-rhel9-operator/"


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

Upgrade the base image which contains the fix for https://github.com/advisories/GHSA-9gcr-gp5f-jw27

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://issues.redhat.com/browse/OCPBUGS-74106

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.