### PR TITLE
NO-JIRA: fix(claude): fix Claude Code subagents frontmatter

### DIFF
--- a/.claude/agents/api-sme.md
+++ b/.claude/agents/api-sme.md
@@ -1,9 +1,6 @@
 ---
 name: api-sme
-description: Has deep knowledge of the Kubernetes and OpenShift API best practices. It is familiar
-with all the OpenShift APIs for configuration and operators. It owns the hypershift.openshift.io APIs,
-including but not limited to hostedCluster, hostedControlPlane, nodePool and all the platform specifics.
-Makes API design decisions and enforce best practices.
+description: Has deep knowledge of Kubernetes and OpenShift API best practices, owns the hypershift.openshift.io APIs (hostedCluster, hostedControlPlane, nodePool), and makes API design decisions.
 model: inherit
 ---
 

--- a/.claude/agents/cloud-provider-sme.md
+++ b/.claude/agents/cloud-provider-sme.md
@@ -1,7 +1,6 @@
 ---
 name: cloud-provider-sme
-description: Has deep knowledge of Google Cloud aka GCP, AWS, Azure and IBM Cloud best practices and cost effective patterns. It is an expert on all the HCP cloud interactions via clusterAPI and via cloud provider controllers.
-Makes cloud integration design decisions and enforce best practices.
+description: Has deep knowledge of AWS, Azure, GCP and IBM Cloud best practices, expert on HCP cloud interactions via clusterAPI and cloud provider controllers.
 model: inherit
 ---
 

--- a/.claude/agents/control-plane-sme.md
+++ b/.claude/agents/control-plane-sme.md
@@ -1,8 +1,6 @@
 ---
 name: control-plane-sme
-description: Has deep knowledge of the hostedCluster and the hostedControlPlane resources and the related controllers, including but not limited to everything under hypershift-operator/controllers/hostedcluster and control-plane-operator/. It's an expert on all the control plane components managed by hcp. Makes design decisions
-on the best way to lifecycle the control plane components and to model the spec and status APIs around them.
-It owns the cpov2 framework used for reconciling controlPlaneComponents.
+description: Has deep knowledge of hostedCluster and hostedControlPlane resources and controllers, owns the cpov2 framework for reconciling controlPlaneComponents.
 model: inherit
 ---
 

--- a/.claude/agents/data-plane-sme.md
+++ b/.claude/agents/data-plane-sme.md
@@ -1,7 +1,6 @@
 ---
 name: data-plane-sme
-description: Has deep knowledge of the nodePool and the clusterAPI resources and the related controllers, including but not limited to everything under hypershift-operator/controllers/nodepool and control-plane-operator/. It's an expert on automated machine management via hcp. Makes design decisions
-on the best way to lifecycle the NodePool, machineDeployment and Nodes and to model the spec and status APIs around them.
+description: Has deep knowledge of nodePool and clusterAPI resources and controllers, expert on automated machine management and NodePool lifecycle via HCP.
 model: inherit
 ---
 

--- a/.claude/agents/hcp-architect-sme.md
+++ b/.claude/agents/hcp-architect-sme.md
@@ -1,11 +1,6 @@
 ---
 name: hcp-architect-sme
-description: Has deep knowledge of HCP architecture. It understands HCP is a project supporting multiple products,
-including managed services like ROSA, ARO, IBMCloud or self hosted. It values UX and customer empathy. 
-It considers impact of changes for SREs, monitoring and service consumers.
-It takes all the above into consideration when making design decisions.
-It is an expert on OpenShift and HCP APIs and controllers. 
-It is familiar with any HCP lifecycle, consumers and integrations.
+description: Has deep knowledge of HCP architecture supporting ROSA, ARO, IBMCloud and self-hosted, expert on OpenShift and HCP APIs, controllers and integrations.
 model: inherit
 ---
 


### PR DESCRIPTION
## What this PR does / why we need it:
Fixes the broken Claude Code subagents which had the description split over multiple lines and that makes the frontmatter invalid.


## Special notes for your reviewer:

### Before the fix
<img width="2369" height="822" alt="image" src="https://github.com/user-attachments/assets/7c47e68f-c53e-4b6a-9921-06f4ba3d57ee" />
<img width="2335" height="1060" alt="image" src="https://github.com/user-attachments/assets/33c8210a-91f4-496a-809e-adeddca94659" />

### After the fix
<img width="2374" height="916" alt="image" src="https://github.com/user-attachments/assets/59e25f24-336b-4ab0-886d-22a8a8b85542" />


## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.