### PR TITLE
CNTRLPLANE-1892: chore(e2ev2): fixup GCP API checks

### DIFF
--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -309,6 +309,19 @@ func TestOnCreateAPIUX(t *testing.T) {
 							hc.Spec.Platform.GCP = &hyperv1.GCPPlatformSpec{
 								Project: "My-Project",
 								Region:  "us-central1",
+								NetworkConfig: hyperv1.GCPNetworkConfig{
+									Network:                     hyperv1.GCPResourceReference{Name: "my-network"},
+									PrivateServiceConnectSubnet: hyperv1.GCPResourceReference{Name: "my-psc-subnet"},
+								},
+								WorkloadIdentity: hyperv1.GCPWorkloadIdentityConfig{
+									ProjectNumber: "123456789012",
+									PoolID:        "my-wif-pool",
+									ProviderID:    "my-wif-provider",
+									ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
+										NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
+										ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
+									},
+								},
 							}
 						},
 						expectedErrorSubstring: "project in body should match",
@@ -320,6 +333,19 @@ func TestOnCreateAPIUX(t *testing.T) {
 							hc.Spec.Platform.GCP = &hyperv1.GCPPlatformSpec{
 								Project: "my-project",
 								Region:  "us-central",
+								NetworkConfig: hyperv1.GCPNetworkConfig{
+									Network:                     hyperv1.GCPResourceReference{Name: "my-network"},
+									PrivateServiceConnectSubnet: hyperv1.GCPResourceReference{Name: "my-psc-subnet"},
+								},
+								WorkloadIdentity: hyperv1.GCPWorkloadIdentityConfig{
+									ProjectNumber: "123456789012",
+									PoolID:        "my-wif-pool",
+									ProviderID:    "my-wif-provider",
+									ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
+										NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
+										ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
+									},
+								},
 							}
 						},
 						expectedErrorSubstring: "region in body should match",
@@ -331,6 +357,19 @@ func TestOnCreateAPIUX(t *testing.T) {
 							hc.Spec.Platform.GCP = &hyperv1.GCPPlatformSpec{
 								Project: "my-project-123",
 								Region:  "europe-west2",
+								NetworkConfig: hyperv1.GCPNetworkConfig{
+									Network:                     hyperv1.GCPResourceReference{Name: "my-network"},
+									PrivateServiceConnectSubnet: hyperv1.GCPResourceReference{Name: "my-psc-subnet"},
+								},
+								WorkloadIdentity: hyperv1.GCPWorkloadIdentityConfig{
+									ProjectNumber: "123456789012",
+									PoolID:        "my-wif-pool",
+									ProviderID:    "my-wif-provider",
+									ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
+										NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
+										ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
+									},
+								},
 							}
 						},
 						expectedErrorSubstring: "",
@@ -360,6 +399,15 @@ func TestOnCreateAPIUX(t *testing.T) {
 										Name: "valid-subnet",
 									},
 								},
+								WorkloadIdentity: hyperv1.GCPWorkloadIdentityConfig{
+									ProjectNumber: "123456789012",
+									PoolID:        "my-wif-pool",
+									ProviderID:    "my-wif-provider",
+									ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
+										NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
+										ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
+									},
+								},
 							}
 						},
 						expectedErrorSubstring: "name in body should match",
@@ -379,6 +427,15 @@ func TestOnCreateAPIUX(t *testing.T) {
 										Name: "Invalid--Subnet",
 									},
 								},
+								WorkloadIdentity: hyperv1.GCPWorkloadIdentityConfig{
+									ProjectNumber: "123456789012",
+									PoolID:        "my-wif-pool",
+									ProviderID:    "my-wif-provider",
+									ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
+										NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
+										ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
+									},
+								},
 							}
 						},
 						expectedErrorSubstring: "name in body should match",
@@ -392,15 +449,24 @@ func TestOnCreateAPIUX(t *testing.T) {
 								Region:  "us-central1",
 								NetworkConfig: hyperv1.GCPNetworkConfig{
 									Network: hyperv1.GCPResourceReference{
-										Name: "this-network-name-is-way-too-long-and-exceeds-the-maximum-limit",
+										Name: "this-network-name-is-way-way-too-long-and-exceeds-the-maximum-limit",
 									},
 									PrivateServiceConnectSubnet: hyperv1.GCPResourceReference{
 										Name: "valid-subnet",
 									},
 								},
+								WorkloadIdentity: hyperv1.GCPWorkloadIdentityConfig{
+									ProjectNumber: "123456789012",
+									PoolID:        "my-wif-pool",
+									ProviderID:    "my-wif-provider",
+									ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
+										NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
+										ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
+									},
+								},
 							}
 						},
-						expectedErrorSubstring: "name in body should be at most 63 chars long",
+						expectedErrorSubstring: "may not be more than 63 bytes",
 					},
 					{
 						name: "when GCP network name is empty it should fail",
@@ -415,6 +481,15 @@ func TestOnCreateAPIUX(t *testing.T) {
 									},
 									PrivateServiceConnectSubnet: hyperv1.GCPResourceReference{
 										Name: "valid-subnet",
+									},
+								},
+								WorkloadIdentity: hyperv1.GCPWorkloadIdentityConfig{
+									ProjectNumber: "123456789012",
+									PoolID:        "my-wif-pool",
+									ProviderID:    "my-wif-provider",
+									ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
+										NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
+										ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
 									},
 								},
 							}
@@ -437,6 +512,15 @@ func TestOnCreateAPIUX(t *testing.T) {
 									},
 								},
 								EndpointAccess: "InvalidAccess",
+								WorkloadIdentity: hyperv1.GCPWorkloadIdentityConfig{
+									ProjectNumber: "123456789012",
+									PoolID:        "my-wif-pool",
+									ProviderID:    "my-wif-provider",
+									ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
+										NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
+										ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
+									},
+								},
 							}
 						},
 						expectedErrorSubstring: "Unsupported value: \"InvalidAccess\": supported values: \"PublicAndPrivate\", \"Private\"",
@@ -457,6 +541,15 @@ func TestOnCreateAPIUX(t *testing.T) {
 									},
 								},
 								EndpointAccess: hyperv1.GCPEndpointAccessPrivate,
+								WorkloadIdentity: hyperv1.GCPWorkloadIdentityConfig{
+									ProjectNumber: "123456789012",
+									PoolID:        "my-wif-pool",
+									ProviderID:    "my-wif-provider",
+									ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
+										NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
+										ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
+									},
+								},
 							}
 						},
 						expectedErrorSubstring: "",
@@ -477,6 +570,15 @@ func TestOnCreateAPIUX(t *testing.T) {
 									},
 								},
 								EndpointAccess: hyperv1.GCPEndpointAccessPublicAndPrivate,
+								WorkloadIdentity: hyperv1.GCPWorkloadIdentityConfig{
+									ProjectNumber: "123456789012",
+									PoolID:        "my-wif-pool",
+									ProviderID:    "my-wif-provider",
+									ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
+										NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
+										ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
+									},
+								},
 							}
 						},
 						expectedErrorSubstring: "",
@@ -497,6 +599,15 @@ func TestOnCreateAPIUX(t *testing.T) {
 									},
 								},
 								EndpointAccess: hyperv1.GCPEndpointAccessPrivate,
+								WorkloadIdentity: hyperv1.GCPWorkloadIdentityConfig{
+									ProjectNumber: "123456789012",
+									PoolID:        "my-wif-pool",
+									ProviderID:    "my-wif-provider",
+									ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
+										NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
+										ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
+									},
+								},
 							}
 						},
 						expectedErrorSubstring: "",
@@ -517,6 +628,15 @@ func TestOnCreateAPIUX(t *testing.T) {
 									},
 								},
 								EndpointAccess: hyperv1.GCPEndpointAccessPrivate,
+								WorkloadIdentity: hyperv1.GCPWorkloadIdentityConfig{
+									ProjectNumber: "123456789012",
+									PoolID:        "my-wif-pool",
+									ProviderID:    "my-wif-provider",
+									ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
+										NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
+										ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
+									},
+								},
 							}
 						},
 						expectedErrorSubstring: "",

--- a/test/e2e/v2/tests/api_ux_validation_test.go
+++ b/test/e2e/v2/tests/api_ux_validation_test.go
@@ -1,3 +1,4 @@
+//go:build e2ev2
 // +build e2ev2
 
 /*
@@ -334,6 +335,19 @@ var _ = Describe("API UX Validation", Label("API"), func() {
 					hc.Spec.Platform.GCP = &hyperv1.GCPPlatformSpec{
 						Project: "my-project-123",
 						Region:  "europe-west2",
+						NetworkConfig: hyperv1.GCPNetworkConfig{
+							Network:                     hyperv1.GCPResourceReference{Name: "my-network"},
+							PrivateServiceConnectSubnet: hyperv1.GCPResourceReference{Name: "my-psc-subnet"},
+						},
+						WorkloadIdentity: hyperv1.GCPWorkloadIdentityConfig{
+							ProjectNumber: "123456789012",
+							PoolID:        "my-wif-pool",
+							ProviderID:    "my-wif-provider",
+							ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
+								NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
+								ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
+							},
+						},
 					}
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -499,7 +513,7 @@ var _ = Describe("API UX Validation", Label("API"), func() {
 					}
 				})
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("nodePool in body should match"))
+				Expect(err.Error()).To(ContainSubstring("nodePool in body"))
 			})
 
 			It("should reject when ControlPlane service account has invalid email format", func() {
@@ -524,7 +538,7 @@ var _ = Describe("API UX Validation", Label("API"), func() {
 					}
 				})
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("controlPlane in body should match"))
+				Expect(err.Error()).To(ContainSubstring("controlPlane in body"))
 			})
 
 			It("should accept when GCP resource labels have valid values", func() {


### PR DESCRIPTION
There has been some API drift on GCP since e2e-v2 was originally committed.

These fields now have a 1 char minimum
`spec.platform.gcp.networkConfig.network.name`
`spec.platform.gcp.networkConfig.privateServiceConnectSubnet.name`

And `spec.platform.gcp.workloadIdentity` is now required

The email validation test cases now fail on the length requirement, not invalid format.  Reducing the match string catches both.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates tests to match current API and expand validation coverage.
> 
> - Update GCP HostedCluster validations to include required `spec.platform.gcp.workloadIdentity` and `spec.platform.gcp.networkConfig` fields; adjust expected error substrings (e.g., name length to "may not be more than 63 bytes", project/region patterns, endpointAccess values)
> - Add/expand e2e-v2 `api_ux_validation_test.go` with comprehensive HostedCluster and NodePool validation scenarios (GCP WIF, resource labels, networking, services, issuerURL, autoscaling, Azure auth, AWS placement, Azure VM images)
> - Relax WIF service account email assertion substrings to match new validation messages
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d218172928584d2378d37e44ae7a38a61dfe8fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->