### PR TITLE
NO-JIRA: fix(e2e): TestNodePoolAutoscalingScaleFromZero for 4.20 and later only

### DIFF
--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -388,6 +388,7 @@ func newWorkLoad(njobs int32, memoryRequest resource.Quantity, nodeSelector, ima
 }
 
 func TestNodePoolAutoscalingScaleFromZero(t *testing.T) {
+	e2eutil.AtLeast(t, e2eutil.Version420)
 	if globalOpts.Platform != hyperv1.AWSPlatform {
 		t.Skip("test only supported on platform AWS")
 	}


### PR DESCRIPTION
4.19 and earlier do not support this.

Urgent fix as all 4.19 and earlier periodic e2es are permafailing.

https://prow.ci.openshift.org/?job=periodic-ci-openshift-hypershift-release-*-periodics-e2e-aws-ovn

Triggered by https://github.com/openshift/release/pull/72805.  Before this PR, the test was being skipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restricts the scale-from-zero e2e to supported versions to avoid failures on older releases.
> 
> - Adds `e2eutil.AtLeast(t, e2eutil.Version420)` at the start of `TestNodePoolAutoscalingScaleFromZero` so the test runs only on 4.20+.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5547d92963d2606172643ee699a4098d17f730a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->