### PR TITLE
NO-JIRA: fix(test): shorten scale-from-zero test name to avoid IAM role length limit

### DIFF
--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -388,7 +388,6 @@ func newWorkLoad(njobs int32, memoryRequest resource.Quantity, nodeSelector, ima
 }
 
 func TestNodePoolAutoscalingScaleFromZero(t *testing.T) {
-	e2eutil.AtLeast(t, e2eutil.Version420)
 	if globalOpts.Platform != hyperv1.AWSPlatform {
 		t.Skip("test only supported on platform AWS")
 	}
@@ -423,7 +422,7 @@ func TestNodePoolAutoscalingScaleFromZero(t *testing.T) {
 
 	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 		t.Run("TestScaleFromZero", testScaleFromZero(ctx, mgtClient, hostedCluster))
-	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, "autoscaling-scale-from-zero", globalOpts.ServiceAccountSigningKey)
+	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, "scale-from-zero", globalOpts.ServiceAccountSigningKey)
 }
 
 func testScaleFromZero(ctx context.Context, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) func(t *testing.T) {


### PR DESCRIPTION
The test name 'autoscaling-scale-from-zero' generates IAM role names that exceed AWS's 64 character limit when combined with the component name 'cloud-network-config-controller' (65 chars total).

Shortened to 'scale-from-zero' to fix the issue (53 chars total).

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.