### PR TITLE
CNTRLPLANE-2600: docs: cli flags doc generater

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ pre-commit: all verify test
 build: hypershift-operator control-plane-operator control-plane-pki-operator karpenter-operator hypershift product-cli
 
 .PHONY: update
-update: api-deps workspace-sync deps api api-docs clients docs-aggregate
+update: api-deps workspace-sync deps api api-docs clients docs-aggregate cli-docs
 
 GOLANGCI_LINT := $(abspath $(TOOLS_BIN_DIR)/golangci-lint)
 $(GOLANGCI_LINT): $(TOOLS_DIR)/go.mod # Build golangci-lint from tools folder.
@@ -247,6 +247,10 @@ cluster-api-provider-openstack: $(CONTROLLER_GEN)
 .PHONY: api-docs
 api-docs: $(GENAPIDOCS)
 	hack/gen-api-docs.sh $(GENAPIDOCS) $(DIR)
+
+.PHONY: cli-docs
+cli-docs: hypershift
+	$(OUT_DIR)/hypershift docs generate --platform aws --output docs/content/reference/cli-flags
 
 .PHONY: clients
 clients: delegating_client

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -27,6 +27,9 @@ func NewCreateCommands() *cobra.Command {
 
 	core.BindDeveloperOptions(opts, cmd.PersistentFlags())
 
+	_ = cmd.MarkPersistentFlagRequired("name")
+	_ = cmd.MarkPersistentFlagRequired("pull-secret")
+
 	cmd.MarkFlagsMutuallyExclusive("service-cidr", "default-dual")
 	cmd.MarkFlagsMutuallyExclusive("cluster-cidr", "default-dual")
 

--- a/cmd/docs/categories.go
+++ b/cmd/docs/categories.go
@@ -1,0 +1,136 @@
+package docs
+
+// CategoryOrder defines the display order of categories
+var CategoryOrder = []string{
+	"Required",
+	"Cluster Identity",
+	"Release Configuration",
+	"AWS Infrastructure",
+	"Networking",
+	"Proxy Configuration",
+	"Node Pool Configuration",
+	"Security & Encryption",
+	"AWS Credentials & IAM",
+	"Control Plane Configuration",
+	"OLM Configuration",
+	"Output & Execution",
+	"Developer-Only",
+	"Deprecated",
+}
+
+// FlagCategories maps flag names to their categories.
+// Note: Required flags are auto-detected via cobra annotations (MarkFlagRequired),
+// so they don't need to be listed here.
+var FlagCategories = map[string]string{
+	// Cluster Identity
+	"namespace":          "Cluster Identity",
+	"base-domain":        "Cluster Identity",
+	"base-domain-prefix": "Cluster Identity",
+	"infra-id":           "Cluster Identity",
+	"annotations":        "Cluster Identity",
+	"labels":             "Cluster Identity",
+
+	// Release Configuration
+	"release-image":                "Release Configuration",
+	"release-stream":               "Release Configuration",
+	"arch":                         "Release Configuration",
+	"feature-set":                  "Release Configuration",
+	"disable-cluster-capabilities": "Release Configuration",
+	"enable-cluster-capabilities":  "Release Configuration",
+
+	// AWS Infrastructure
+	"region":                           "AWS Infrastructure",
+	"zones":                            "AWS Infrastructure",
+	"vpc-cidr":                         "AWS Infrastructure",
+	"additional-tags":                  "AWS Infrastructure",
+	"public-only":                      "AWS Infrastructure",
+	"private-zones-in-cluster-account": "AWS Infrastructure",
+
+	// Networking
+	"network-type":          "Networking",
+	"service-cidr":          "Networking",
+	"cluster-cidr":          "Networking",
+	"machine-cidr":          "Networking",
+	"default-dual":          "Networking",
+	"endpoint-access":       "Networking",
+	"external-dns-domain":   "Networking",
+	"kas-dns-name":          "Networking",
+	"disable-multi-network": "Networking",
+	"allocate-node-cidrs":   "Networking",
+
+	// Proxy Configuration
+	"enable-proxy":                    "Proxy Configuration",
+	"enable-secure-proxy":             "Proxy Configuration",
+	"proxy-vpc-endpoint-service-name": "Proxy Configuration",
+
+	// Node Pool Configuration
+	"node-pool-replicas":         "Node Pool Configuration",
+	"instance-type":              "Node Pool Configuration",
+	"root-volume-type":           "Node Pool Configuration",
+	"root-volume-size":           "Node Pool Configuration",
+	"root-volume-iops":           "Node Pool Configuration",
+	"root-volume-kms-key":        "Node Pool Configuration",
+	"auto-repair":                "Node Pool Configuration",
+	"auto-node":                  "Node Pool Configuration",
+	"node-upgrade-type":          "Node Pool Configuration",
+	"node-drain-timeout":         "Node Pool Configuration",
+	"node-volume-detach-timeout": "Node Pool Configuration",
+
+	// Security & Encryption
+	"fips":                             "Security & Encryption",
+	"ssh-key":                          "Security & Encryption",
+	"generate-ssh":                     "Security & Encryption",
+	"kms-key-arn":                      "Security & Encryption",
+	"additional-trust-bundle":          "Security & Encryption",
+	"image-content-sources":            "Security & Encryption",
+	"oidc-issuer-url":                  "Security & Encryption",
+	"sa-token-issuer-private-key-path": "Security & Encryption",
+
+	// AWS Credentials & IAM
+	"role-arn":                  "AWS Credentials & IAM",
+	"sts-creds":                 "AWS Credentials & IAM",
+	"secret-creds":              "AWS Credentials & IAM",
+	"use-rosa-managed-policies": "AWS Credentials & IAM",
+	"shared-role":               "AWS Credentials & IAM",
+
+	// Control Plane Configuration
+	"control-plane-availability-policy": "Control Plane Configuration",
+	"infra-availability-policy":         "Control Plane Configuration",
+	"node-selector":                     "Control Plane Configuration",
+	"pods-labels":                       "Control Plane Configuration",
+	"toleration":                        "Control Plane Configuration",
+	"etcd-storage-class":                "Control Plane Configuration",
+	"etcd-storage-size":                 "Control Plane Configuration",
+
+	// OLM Configuration
+	"olm-catalog-placement":       "OLM Configuration",
+	"olm-disable-default-sources": "OLM Configuration",
+
+	// Output & Execution
+	"render":           "Output & Execution",
+	"render-into":      "Output & Execution",
+	"render-sensitive": "Output & Execution",
+	"wait":             "Output & Execution",
+	"timeout":          "Output & Execution",
+	"pausedUntil":      "Output & Execution",
+	"version-check":    "Output & Execution",
+
+	// Developer-Only
+	"control-plane-operator-image": "Developer-Only",
+	"infra-json":                   "Developer-Only",
+	"iam-json":                     "Developer-Only",
+	"single-nat-gateway":           "Developer-Only",
+	"aws-creds":                    "Developer-Only",
+	"vpc-owner-aws-creds":          "Developer-Only",
+
+	// Deprecated
+	"multi-arch": "Deprecated",
+}
+
+// GetCategory returns the category for a flag, defaulting to "Other" if not found
+func GetCategory(flagName string) string {
+	if cat, ok := FlagCategories[flagName]; ok {
+		return cat
+	}
+	return "Other"
+}

--- a/cmd/docs/docs.go
+++ b/cmd/docs/docs.go
@@ -1,0 +1,19 @@
+package docs
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewCommand creates the docs command
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "docs",
+		Short:        "Generate CLI documentation",
+		Long:         "Commands for generating CLI flag documentation in various formats.",
+		SilenceUsage: true,
+	}
+
+	cmd.AddCommand(NewGenerateCommand())
+
+	return cmd
+}

--- a/cmd/docs/generate.go
+++ b/cmd/docs/generate.go
@@ -1,0 +1,315 @@
+package docs
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"text/template"
+
+	clustercmd "github.com/openshift/hypershift/cmd/cluster"
+	productclustercmd "github.com/openshift/hypershift/product-cli/cmd/cluster"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+//go:embed templates/*.tmpl
+var templateFS embed.FS
+
+// GenerateOptions contains options for the generate command
+type GenerateOptions struct {
+	OutputDir    string
+	Platform     string
+	Command      string
+	TemplatePath string
+}
+
+// NewGenerateCommand creates the docs generate command
+func NewGenerateCommand() *cobra.Command {
+	opts := &GenerateOptions{
+		OutputDir: "docs/content/reference/cli-flags",
+		Platform:  "aws",
+		Command:   "create-cluster",
+	}
+
+	cmd := &cobra.Command{
+		Use:          "generate",
+		Short:        "Generate CLI flag documentation",
+		Long:         "Generate markdown documentation for CLI flags, comparing hcp and hypershift CLIs.",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGenerate(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.OutputDir, "output", "o", opts.OutputDir, "Output directory for generated docs")
+	cmd.Flags().StringVar(&opts.Platform, "platform", opts.Platform, "Platform to generate docs for (aws)")
+	cmd.Flags().StringVar(&opts.Command, "command", opts.Command, "Command to generate docs for (create-cluster)")
+	cmd.Flags().StringVar(&opts.TemplatePath, "template", "", "Path to custom template file (uses embedded default if not set)")
+
+	return cmd
+}
+
+func runGenerate(opts *GenerateOptions) error {
+	if opts.Platform != "aws" {
+		return fmt.Errorf("platform %q not yet supported, only 'aws' is available", opts.Platform)
+	}
+
+	if opts.Command != "create-cluster" {
+		return fmt.Errorf("command %q not yet supported, only 'create-cluster' is available", opts.Command)
+	}
+
+	// Extract flags from both CLIs
+	data, err := extractAWSCreateClusterFlags()
+	if err != nil {
+		return fmt.Errorf("failed to extract flags: %w", err)
+	}
+
+	// Load and render template
+	content, err := renderTemplate(opts, data)
+	if err != nil {
+		return fmt.Errorf("failed to render template: %w", err)
+	}
+
+	// Write output file
+	outputPath := filepath.Join(opts.OutputDir, opts.Platform+".md")
+	if err := os.MkdirAll(opts.OutputDir, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	if err := os.WriteFile(outputPath, []byte(content), 0644); err != nil {
+		return fmt.Errorf("failed to write output file: %w", err)
+	}
+
+	fmt.Printf("Generated %s\n", outputPath)
+	return nil
+}
+
+func extractAWSCreateClusterFlags() (*TemplateData, error) {
+	// Use the actual command construction to get proper flag annotations
+	// This ensures the doc generator uses the same source of truth as the CLIs
+
+	// hcp CLI (product) - use actual NewCreateCommands()
+	hcpClusterCmd := productclustercmd.NewCreateCommands()
+	hcpAWSCmd := findSubcommand(hcpClusterCmd, "aws")
+	if hcpAWSCmd == nil {
+		return nil, fmt.Errorf("aws subcommand not found in hcp CLI")
+	}
+
+	// hypershift CLI (developer) - use actual NewCreateCommands()
+	hypershiftClusterCmd := clustercmd.NewCreateCommands()
+	hypershiftAWSCmd := findSubcommand(hypershiftClusterCmd, "aws")
+	if hypershiftAWSCmd == nil {
+		return nil, fmt.Errorf("aws subcommand not found in hypershift CLI")
+	}
+
+	// Extract flag info from both commands (persistent + local flags)
+	hcpFlagMap := extractFlagMapFromCommand(hcpAWSCmd)
+	hypershiftFlagMap := extractFlagMapFromCommand(hypershiftAWSCmd)
+
+	// Merge flags
+	allFlags := mergeFlags(hcpFlagMap, hypershiftFlagMap)
+
+	// Group by category
+	categories := groupByCategory(allFlags)
+
+	// Calculate counts
+	sharedCount := 0
+	devOnlyCount := 0
+	for _, flag := range allFlags {
+		if flag.InHcp && flag.InHypershift {
+			sharedCount++
+		} else if flag.InHypershift && !flag.InHcp {
+			devOnlyCount++
+		}
+	}
+
+	return &TemplateData{
+		Platform:        "aws",
+		Command:         "create-cluster",
+		Categories:      categories,
+		SharedCount:     sharedCount,
+		DevOnlyCount:    devOnlyCount,
+		HcpTotal:        sharedCount,
+		HypershiftTotal: sharedCount + devOnlyCount,
+	}, nil
+}
+
+// findSubcommand finds a subcommand by name
+func findSubcommand(parent *cobra.Command, name string) *cobra.Command {
+	for _, cmd := range parent.Commands() {
+		if cmd.Use == name || cmd.Name() == name {
+			return cmd
+		}
+	}
+	return nil
+}
+
+// BashCompOneRequiredFlag is the annotation key used by cobra for required flags
+const BashCompOneRequiredFlag = "cobra_annotation_bash_completion_one_required_flag"
+
+// extractFlagMapFromCommand extracts flags from a cobra command by walking the command tree.
+// This ensures we access the original flag objects where annotations are stored,
+// rather than relying on cobra's merged views which may contain copies.
+func extractFlagMapFromCommand(cmd *cobra.Command) map[string]*FlagInfo {
+	result := make(map[string]*FlagInfo)
+
+	// 1. This command's local flags (non-persistent)
+	cmd.LocalFlags().VisitAll(func(f *pflag.Flag) {
+		addFlagToMap(result, f)
+	})
+
+	// 2. This command's persistent flags
+	cmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+		if _, exists := result[f.Name]; !exists {
+			addFlagToMap(result, f)
+		}
+	})
+
+	// 3. Walk up parent chain for inherited persistent flags
+	// This accesses the original flag objects where MarkPersistentFlagRequired sets annotations
+	for p := cmd.Parent(); p != nil; p = p.Parent() {
+		p.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+			if _, exists := result[f.Name]; !exists {
+				addFlagToMap(result, f)
+			}
+		})
+	}
+
+	return result
+}
+
+func addFlagToMap(result map[string]*FlagInfo, f *pflag.Flag) {
+	// Check if flag is marked as required via MarkFlagRequired
+	isRequired := false
+	if annotations, ok := f.Annotations[BashCompOneRequiredFlag]; ok {
+		isRequired = len(annotations) > 0 && annotations[0] == "true"
+	}
+
+	// Store required status separately - category will be determined during merge
+	result[f.Name] = &FlagInfo{
+		Name:                 f.Name,
+		Type:                 f.Value.Type(),
+		Default:              cleanDefault(f.DefValue),
+		Description:          f.Usage,
+		Category:             GetCategory(f.Name), // Use normal category, Required handled during merge
+		RequiredInHcp:        isRequired,          // Will be used as source for hcp flags
+		RequiredInHypershift: isRequired,          // Will be used as source for hypershift flags
+	}
+}
+
+// cleanDefault removes noisy default values like empty arrays/maps
+func cleanDefault(defValue string) string {
+	switch defValue {
+	case "[]", "map[]", "0s":
+		return ""
+	}
+	return defValue
+}
+
+func mergeFlags(hcpFlags, hypershiftFlags map[string]*FlagInfo) []FlagInfo {
+	merged := make(map[string]*FlagInfo)
+
+	// Add hcp flags - track RequiredInHcp from hcp's required status
+	for name, flag := range hcpFlags {
+		f := *flag
+		f.InHcp = true
+		// RequiredInHcp was set by addFlagToMap based on hcp CLI annotations
+		// Clear RequiredInHypershift - will be set from hypershift flags
+		f.RequiredInHypershift = false
+		merged[name] = &f
+	}
+
+	// Add/merge hypershift flags - track RequiredInHypershift from hypershift's required status
+	for name, flag := range hypershiftFlags {
+		if existing, ok := merged[name]; ok {
+			existing.InHypershift = true
+			// RequiredInHypershift comes from hypershift CLI's annotation
+			existing.RequiredInHypershift = flag.RequiredInHcp // addFlagToMap sets both fields the same
+		} else {
+			f := *flag
+			f.InHypershift = true
+			// This flag is only in hypershift, so RequiredInHcp should be false
+			f.RequiredInHypershift = f.RequiredInHcp // Move to correct field
+			f.RequiredInHcp = false
+			merged[name] = &f
+		}
+	}
+
+	// Convert to slice and set category to "Required" if required in either CLI
+	result := make([]FlagInfo, 0, len(merged))
+	for _, flag := range merged {
+		// If required in either CLI, put in Required category
+		if flag.RequiredInHcp || flag.RequiredInHypershift {
+			flag.Category = "Required"
+		}
+		result = append(result, *flag)
+	}
+
+	// Sort by name for consistent output
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+
+	return result
+}
+
+func groupByCategory(flags []FlagInfo) []CategoryInfo {
+	// Group flags by category
+	categoryMap := make(map[string][]FlagInfo)
+	for _, flag := range flags {
+		categoryMap[flag.Category] = append(categoryMap[flag.Category], flag)
+	}
+
+	// Create ordered categories
+	var categories []CategoryInfo
+	for _, catName := range CategoryOrder {
+		if flags, ok := categoryMap[catName]; ok {
+			// Sort flags within category by name
+			sort.Slice(flags, func(i, j int) bool {
+				return flags[i].Name < flags[j].Name
+			})
+			categories = append(categories, CategoryInfo{
+				Name:  catName,
+				Flags: flags,
+			})
+		}
+	}
+
+	// Add any uncategorized flags as "Other"
+	if flags, ok := categoryMap["Other"]; ok && len(flags) > 0 {
+		sort.Slice(flags, func(i, j int) bool {
+			return flags[i].Name < flags[j].Name
+		})
+		categories = append(categories, CategoryInfo{
+			Name:  "Other",
+			Flags: flags,
+		})
+	}
+
+	return categories
+}
+
+func loadTemplate(customPath, defaultName string) (*template.Template, error) {
+	if customPath != "" {
+		return template.ParseFiles(customPath)
+	}
+	return template.ParseFS(templateFS, "templates/"+defaultName)
+}
+
+func renderTemplate(opts *GenerateOptions, data *TemplateData) (string, error) {
+	tmpl, err := loadTemplate(opts.TemplatePath, opts.Platform+".md.tmpl")
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}

--- a/cmd/docs/generate_test.go
+++ b/cmd/docs/generate_test.go
@@ -1,0 +1,568 @@
+package docs
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func TestExtractFlagMapFromCommand_LocalFlags(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupCmd      func() *cobra.Command
+		expectedFlags map[string]bool
+		expectedReq   map[string]bool
+	}{
+		{
+			name: "When command has local flags it should extract them",
+			setupCmd: func() *cobra.Command {
+				cmd := &cobra.Command{Use: "test"}
+				cmd.Flags().String("local-flag", "default", "A local flag")
+				return cmd
+			},
+			expectedFlags: map[string]bool{"local-flag": true},
+			expectedReq:   map[string]bool{},
+		},
+		{
+			name: "When local flag is marked required it should detect annotation",
+			setupCmd: func() *cobra.Command {
+				cmd := &cobra.Command{Use: "test"}
+				cmd.Flags().String("required-flag", "", "A required flag")
+				_ = cmd.MarkFlagRequired("required-flag")
+				return cmd
+			},
+			expectedFlags: map[string]bool{"required-flag": true},
+			expectedReq:   map[string]bool{"required-flag": true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := tt.setupCmd()
+			flags := extractFlagMapFromCommand(cmd)
+
+			for flagName := range tt.expectedFlags {
+				if _, ok := flags[flagName]; !ok {
+					t.Errorf("expected flag %q to be extracted", flagName)
+				}
+			}
+
+			for flagName, shouldBeReq := range tt.expectedReq {
+				flag, ok := flags[flagName]
+				if !ok {
+					t.Errorf("expected flag %q to exist", flagName)
+					continue
+				}
+				// Check RequiredInHcp since addFlagToMap sets both fields the same
+				isRequired := flag.RequiredInHcp
+				if isRequired != shouldBeReq {
+					t.Errorf("flag %q: expected required=%v, got required=%v", flagName, shouldBeReq, isRequired)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractFlagMapFromCommand_PersistentFlags(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupCmd      func() *cobra.Command
+		expectedFlags map[string]bool
+		expectedReq   map[string]bool
+	}{
+		{
+			name: "When command has persistent flags it should extract them",
+			setupCmd: func() *cobra.Command {
+				cmd := &cobra.Command{Use: "test"}
+				cmd.PersistentFlags().String("persistent-flag", "default", "A persistent flag")
+				return cmd
+			},
+			expectedFlags: map[string]bool{"persistent-flag": true},
+			expectedReq:   map[string]bool{},
+		},
+		{
+			name: "When persistent flag is marked required it should detect annotation",
+			setupCmd: func() *cobra.Command {
+				cmd := &cobra.Command{Use: "test"}
+				cmd.PersistentFlags().String("name", "", "A required persistent flag")
+				_ = cmd.MarkPersistentFlagRequired("name")
+				return cmd
+			},
+			expectedFlags: map[string]bool{"name": true},
+			expectedReq:   map[string]bool{"name": true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := tt.setupCmd()
+			flags := extractFlagMapFromCommand(cmd)
+
+			for flagName := range tt.expectedFlags {
+				if _, ok := flags[flagName]; !ok {
+					t.Errorf("expected flag %q to be extracted", flagName)
+				}
+			}
+
+			for flagName, shouldBeReq := range tt.expectedReq {
+				flag, ok := flags[flagName]
+				if !ok {
+					t.Errorf("expected flag %q to exist", flagName)
+					continue
+				}
+				// Check RequiredInHcp since addFlagToMap sets both fields the same
+				isRequired := flag.RequiredInHcp
+				if isRequired != shouldBeReq {
+					t.Errorf("flag %q: expected required=%v, got required=%v", flagName, shouldBeReq, isRequired)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractFlagMapFromCommand_InheritedPersistentFlags(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupCmd      func() *cobra.Command
+		expectedFlags map[string]bool
+		expectedReq   map[string]bool
+	}{
+		{
+			name: "When parent has persistent flags it should extract them from child",
+			setupCmd: func() *cobra.Command {
+				parent := &cobra.Command{Use: "parent"}
+				parent.PersistentFlags().String("parent-flag", "default", "A parent flag")
+
+				child := &cobra.Command{Use: "child"}
+				parent.AddCommand(child)
+				return child
+			},
+			expectedFlags: map[string]bool{"parent-flag": true},
+			expectedReq:   map[string]bool{},
+		},
+		{
+			name: "When parent persistent flag is marked required it should detect annotation on child",
+			setupCmd: func() *cobra.Command {
+				parent := &cobra.Command{Use: "parent"}
+				parent.PersistentFlags().String("name", "", "A required parent flag")
+				_ = parent.MarkPersistentFlagRequired("name")
+
+				child := &cobra.Command{Use: "child"}
+				parent.AddCommand(child)
+				return child
+			},
+			expectedFlags: map[string]bool{"name": true},
+			expectedReq:   map[string]bool{"name": true},
+		},
+		{
+			name: "When grandparent persistent flag is marked required it should detect annotation on grandchild",
+			setupCmd: func() *cobra.Command {
+				grandparent := &cobra.Command{Use: "grandparent"}
+				grandparent.PersistentFlags().String("pull-secret", "", "A required grandparent flag")
+				_ = grandparent.MarkPersistentFlagRequired("pull-secret")
+
+				parent := &cobra.Command{Use: "parent"}
+				grandparent.AddCommand(parent)
+
+				child := &cobra.Command{Use: "child"}
+				parent.AddCommand(child)
+				return child
+			},
+			expectedFlags: map[string]bool{"pull-secret": true},
+			expectedReq:   map[string]bool{"pull-secret": true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := tt.setupCmd()
+			flags := extractFlagMapFromCommand(cmd)
+
+			for flagName := range tt.expectedFlags {
+				if _, ok := flags[flagName]; !ok {
+					t.Errorf("expected flag %q to be extracted", flagName)
+				}
+			}
+
+			for flagName, shouldBeReq := range tt.expectedReq {
+				flag, ok := flags[flagName]
+				if !ok {
+					t.Errorf("expected flag %q to exist", flagName)
+					continue
+				}
+				// Check RequiredInHcp since addFlagToMap sets both fields the same
+				isRequired := flag.RequiredInHcp
+				if isRequired != shouldBeReq {
+					t.Errorf("flag %q: expected required=%v, got required=%v", flagName, shouldBeReq, isRequired)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractFlagMapFromCommand_MixedFlags(t *testing.T) {
+	t.Run("When command has local, persistent, and inherited flags it should extract all with correct required status", func(t *testing.T) {
+		// Setup: grandparent -> parent -> child with various flags
+		grandparent := &cobra.Command{Use: "grandparent"}
+		grandparent.PersistentFlags().String("name", "", "Required from grandparent")
+		_ = grandparent.MarkPersistentFlagRequired("name")
+
+		parent := &cobra.Command{Use: "parent"}
+		parent.PersistentFlags().String("namespace", "clusters", "Persistent from parent")
+		grandparent.AddCommand(parent)
+
+		child := &cobra.Command{Use: "child"}
+		child.Flags().String("region", "us-east-1", "Local flag on child")
+		child.Flags().String("instance-type", "", "Required local flag")
+		_ = child.MarkFlagRequired("instance-type")
+		parent.AddCommand(child)
+
+		flags := extractFlagMapFromCommand(child)
+
+		// Verify all flags are extracted
+		expectedFlags := []string{"name", "namespace", "region", "instance-type"}
+		for _, flagName := range expectedFlags {
+			if _, ok := flags[flagName]; !ok {
+				t.Errorf("expected flag %q to be extracted", flagName)
+			}
+		}
+
+		// Verify required status - check RequiredInHcp since addFlagToMap sets both fields the same
+		if !flags["name"].RequiredInHcp {
+			t.Errorf("flag 'name' should be required")
+		}
+		if !flags["instance-type"].RequiredInHcp {
+			t.Errorf("flag 'instance-type' should be required")
+		}
+		if flags["namespace"].RequiredInHcp {
+			t.Errorf("flag 'namespace' should not be required")
+		}
+		if flags["region"].RequiredInHcp {
+			t.Errorf("flag 'region' should not be required")
+		}
+	})
+}
+
+func TestAddFlagToMap(t *testing.T) {
+	t.Run("When flag has required annotation it should set RequiredInHcp and RequiredInHypershift", func(t *testing.T) {
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		fs.String("test-flag", "", "Test description")
+		f := fs.Lookup("test-flag")
+		f.Annotations = map[string][]string{
+			BashCompOneRequiredFlag: {"true"},
+		}
+
+		result := make(map[string]*FlagInfo)
+		addFlagToMap(result, f)
+
+		flagInfo := result["test-flag"]
+		if !flagInfo.RequiredInHcp || !flagInfo.RequiredInHypershift {
+			t.Errorf("expected RequiredInHcp and RequiredInHypershift to be true")
+		}
+		// Category should be "Other" since "test-flag" is not in FlagCategories
+		if flagInfo.Category != "Other" {
+			t.Errorf("expected category 'Other', got %q", flagInfo.Category)
+		}
+	})
+
+	t.Run("When flag has no annotation it should use category from FlagCategories", func(t *testing.T) {
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		fs.String("region", "us-east-1", "AWS region")
+		f := fs.Lookup("region")
+
+		result := make(map[string]*FlagInfo)
+		addFlagToMap(result, f)
+
+		flagInfo := result["region"]
+		if flagInfo.Category != "AWS Infrastructure" {
+			t.Errorf("expected category 'AWS Infrastructure', got %q", flagInfo.Category)
+		}
+		if flagInfo.RequiredInHcp || flagInfo.RequiredInHypershift {
+			t.Errorf("expected RequiredInHcp and RequiredInHypershift to be false")
+		}
+	})
+
+	t.Run("When flag is not in FlagCategories it should default to Other", func(t *testing.T) {
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		fs.String("unknown-flag", "", "Unknown flag")
+		f := fs.Lookup("unknown-flag")
+
+		result := make(map[string]*FlagInfo)
+		addFlagToMap(result, f)
+
+		flagInfo := result["unknown-flag"]
+		if flagInfo.Category != "Other" {
+			t.Errorf("expected category 'Other', got %q", flagInfo.Category)
+		}
+	})
+}
+
+func TestCleanDefault(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "When default is empty array it should return empty string",
+			input:    "[]",
+			expected: "",
+		},
+		{
+			name:     "When default is empty map it should return empty string",
+			input:    "map[]",
+			expected: "",
+		},
+		{
+			name:     "When default is zero duration it should return empty string",
+			input:    "0s",
+			expected: "",
+		},
+		{
+			name:     "When default is regular value it should return as-is",
+			input:    "us-east-1",
+			expected: "us-east-1",
+		},
+		{
+			name:     "When default is empty string it should return empty string",
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := cleanDefault(tt.input)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestMergeFlags(t *testing.T) {
+	t.Run("When merging hcp and hypershift flags it should mark availability correctly", func(t *testing.T) {
+		hcpFlags := map[string]*FlagInfo{
+			"name":      {Name: "name", Category: "Cluster Identity", RequiredInHcp: true, RequiredInHypershift: true},
+			"namespace": {Name: "namespace", Category: "Cluster Identity"},
+		}
+
+		hypershiftFlags := map[string]*FlagInfo{
+			"name":       {Name: "name", Category: "Cluster Identity", RequiredInHcp: true, RequiredInHypershift: true},
+			"aws-creds":  {Name: "aws-creds", Category: "Developer-Only"},
+			"infra-json": {Name: "infra-json", Category: "Developer-Only"},
+		}
+
+		merged := mergeFlags(hcpFlags, hypershiftFlags)
+
+		// Find flags by name
+		flagMap := make(map[string]FlagInfo)
+		for _, f := range merged {
+			flagMap[f.Name] = f
+		}
+
+		// name should be in both
+		if !flagMap["name"].InHcp || !flagMap["name"].InHypershift {
+			t.Errorf("flag 'name' should be in both CLIs")
+		}
+
+		// namespace should be hcp only
+		if !flagMap["namespace"].InHcp || flagMap["namespace"].InHypershift {
+			t.Errorf("flag 'namespace' should be in hcp only")
+		}
+
+		// aws-creds should be hypershift only
+		if flagMap["aws-creds"].InHcp || !flagMap["aws-creds"].InHypershift {
+			t.Errorf("flag 'aws-creds' should be in hypershift only")
+		}
+	})
+
+	t.Run("When merging flags it should preserve per-CLI required status", func(t *testing.T) {
+		// hcp has name required, hypershift has name required
+		hcpFlags := map[string]*FlagInfo{
+			"name": {Name: "name", Category: "Cluster Identity", RequiredInHcp: true, RequiredInHypershift: true},
+		}
+		hypershiftFlags := map[string]*FlagInfo{
+			"name": {Name: "name", Category: "Cluster Identity", RequiredInHcp: true, RequiredInHypershift: true},
+		}
+
+		merged := mergeFlags(hcpFlags, hypershiftFlags)
+		flagMap := make(map[string]FlagInfo)
+		for _, f := range merged {
+			flagMap[f.Name] = f
+		}
+
+		// name should be required in both
+		if !flagMap["name"].RequiredInHcp {
+			t.Errorf("flag 'name' should be RequiredInHcp")
+		}
+		if !flagMap["name"].RequiredInHypershift {
+			t.Errorf("flag 'name' should be RequiredInHypershift")
+		}
+		if flagMap["name"].Category != "Required" {
+			t.Errorf("flag 'name' should have category 'Required', got %q", flagMap["name"].Category)
+		}
+	})
+
+	t.Run("When flag is required in hcp only it should set RequiredInHcp only", func(t *testing.T) {
+		hcpFlags := map[string]*FlagInfo{
+			"hcp-only-req": {Name: "hcp-only-req", Category: "Other", RequiredInHcp: true, RequiredInHypershift: true},
+		}
+		hypershiftFlags := map[string]*FlagInfo{
+			"hcp-only-req": {Name: "hcp-only-req", Category: "Other", RequiredInHcp: false, RequiredInHypershift: false},
+		}
+
+		merged := mergeFlags(hcpFlags, hypershiftFlags)
+		flagMap := make(map[string]FlagInfo)
+		for _, f := range merged {
+			flagMap[f.Name] = f
+		}
+
+		// Should be required in hcp only
+		if !flagMap["hcp-only-req"].RequiredInHcp {
+			t.Errorf("flag 'hcp-only-req' should be RequiredInHcp")
+		}
+		if flagMap["hcp-only-req"].RequiredInHypershift {
+			t.Errorf("flag 'hcp-only-req' should NOT be RequiredInHypershift")
+		}
+		// Category should still be Required since it's required in at least one CLI
+		if flagMap["hcp-only-req"].Category != "Required" {
+			t.Errorf("flag 'hcp-only-req' should have category 'Required', got %q", flagMap["hcp-only-req"].Category)
+		}
+	})
+
+	t.Run("When flag is required in hypershift only it should set RequiredInHypershift only", func(t *testing.T) {
+		hcpFlags := map[string]*FlagInfo{
+			"hs-only-req": {Name: "hs-only-req", Category: "Other", RequiredInHcp: false, RequiredInHypershift: false},
+		}
+		hypershiftFlags := map[string]*FlagInfo{
+			"hs-only-req": {Name: "hs-only-req", Category: "Other", RequiredInHcp: true, RequiredInHypershift: true},
+		}
+
+		merged := mergeFlags(hcpFlags, hypershiftFlags)
+		flagMap := make(map[string]FlagInfo)
+		for _, f := range merged {
+			flagMap[f.Name] = f
+		}
+
+		// Should be required in hypershift only
+		if flagMap["hs-only-req"].RequiredInHcp {
+			t.Errorf("flag 'hs-only-req' should NOT be RequiredInHcp")
+		}
+		if !flagMap["hs-only-req"].RequiredInHypershift {
+			t.Errorf("flag 'hs-only-req' should be RequiredInHypershift")
+		}
+		// Category should still be Required since it's required in at least one CLI
+		if flagMap["hs-only-req"].Category != "Required" {
+			t.Errorf("flag 'hs-only-req' should have category 'Required', got %q", flagMap["hs-only-req"].Category)
+		}
+	})
+
+	t.Run("When flag only exists in hypershift and is required it should set RequiredInHypershift", func(t *testing.T) {
+		hcpFlags := map[string]*FlagInfo{}
+		hypershiftFlags := map[string]*FlagInfo{
+			"dev-only": {Name: "dev-only", Category: "Developer-Only", RequiredInHcp: true, RequiredInHypershift: true},
+		}
+
+		merged := mergeFlags(hcpFlags, hypershiftFlags)
+		flagMap := make(map[string]FlagInfo)
+		for _, f := range merged {
+			flagMap[f.Name] = f
+		}
+
+		// Should be in hypershift only and required in hypershift only
+		if flagMap["dev-only"].InHcp {
+			t.Errorf("flag 'dev-only' should NOT be InHcp")
+		}
+		if !flagMap["dev-only"].InHypershift {
+			t.Errorf("flag 'dev-only' should be InHypershift")
+		}
+		if flagMap["dev-only"].RequiredInHcp {
+			t.Errorf("flag 'dev-only' should NOT be RequiredInHcp")
+		}
+		if !flagMap["dev-only"].RequiredInHypershift {
+			t.Errorf("flag 'dev-only' should be RequiredInHypershift")
+		}
+	})
+}
+
+func TestGroupByCategory(t *testing.T) {
+	t.Run("When grouping flags by category it should follow CategoryOrder", func(t *testing.T) {
+		flags := []FlagInfo{
+			{Name: "region", Category: "AWS Infrastructure"},
+			{Name: "name", Category: "Required"},
+			{Name: "namespace", Category: "Cluster Identity"},
+			{Name: "aws-creds", Category: "Developer-Only"},
+		}
+
+		categories := groupByCategory(flags)
+
+		// Required should come first
+		if len(categories) == 0 || categories[0].Name != "Required" {
+			t.Errorf("expected first category to be 'Required'")
+		}
+
+		// Verify order matches CategoryOrder
+		categoryIndex := make(map[string]int)
+		for i, cat := range categories {
+			categoryIndex[cat.Name] = i
+		}
+
+		if categoryIndex["Required"] > categoryIndex["Cluster Identity"] {
+			t.Errorf("Required should come before Cluster Identity")
+		}
+		if categoryIndex["Cluster Identity"] > categoryIndex["AWS Infrastructure"] {
+			t.Errorf("Cluster Identity should come before AWS Infrastructure")
+		}
+		if categoryIndex["AWS Infrastructure"] > categoryIndex["Developer-Only"] {
+			t.Errorf("AWS Infrastructure should come before Developer-Only")
+		}
+	})
+
+	t.Run("When flags have unknown category it should be grouped under Other", func(t *testing.T) {
+		flags := []FlagInfo{
+			{Name: "unknown-flag", Category: "Other"},
+		}
+
+		categories := groupByCategory(flags)
+
+		found := false
+		for _, cat := range categories {
+			if cat.Name == "Other" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected 'Other' category to be present")
+		}
+	})
+}
+
+func TestFindSubcommand(t *testing.T) {
+	t.Run("When subcommand exists it should return it", func(t *testing.T) {
+		parent := &cobra.Command{Use: "parent"}
+		child := &cobra.Command{Use: "aws"}
+		parent.AddCommand(child)
+
+		found := findSubcommand(parent, "aws")
+		if found == nil {
+			t.Errorf("expected to find 'aws' subcommand")
+		}
+		if found != child {
+			t.Errorf("expected to find the correct child command")
+		}
+	})
+
+	t.Run("When subcommand does not exist it should return nil", func(t *testing.T) {
+		parent := &cobra.Command{Use: "parent"}
+		child := &cobra.Command{Use: "aws"}
+		parent.AddCommand(child)
+
+		found := findSubcommand(parent, "azure")
+		if found != nil {
+			t.Errorf("expected nil for non-existent subcommand")
+		}
+	})
+}

--- a/cmd/docs/templates/aws.md.tmpl
+++ b/cmd/docs/templates/aws.md.tmpl
@@ -1,0 +1,37 @@
+---
+title: AWS CLI Flags
+---
+
+# AWS CLI Flags
+
+This page documents CLI flags for AWS platform commands, comparing the supported `hcp` CLI with the internal `hypershift` developer CLI.
+
+---
+
+## Create Cluster
+
+Flags for `hcp create cluster aws` and `hypershift create cluster aws`.
+{{ range $cat := .Categories }}
+### {{ .Name }}
+{{ if .Description }}
+{{ .Description }}
+{{ end }}
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+{{- range .Flags }}
+{{- if eq $cat.Name "Required" }}
+| `--{{ .Name }}` | {{ .Type }} | {{ if .Default }}`{{ .Default }}`{{ end }} | {{ if .RequiredInHcp }}✓{{ else if .InHcp }}Optional{{ else }}Unavailable{{ end }} | {{ if .RequiredInHypershift }}✓{{ else if .InHypershift }}Optional{{ else }}Unavailable{{ end }} | {{ .Description }} |
+{{- else }}
+| `--{{ .Name }}` | {{ .Type }} | {{ if .Default }}`{{ .Default }}`{{ end }} | {{ if .InHcp }}✓{{ end }} | {{ if .InHypershift }}✓{{ end }} | {{ .Description }} |
+{{- end }}
+{{- end }}
+
+---
+{{ end }}
+### Summary
+
+| | hcp | hypershift |
+|---|:---:|:----------:|
+| **Shared Flags** | {{ .SharedCount }} | {{ .SharedCount }} |
+| **Developer-Only Flags** | - | {{ .DevOnlyCount }} |
+| **Total Flags** | {{ .HcpTotal }} | {{ .HypershiftTotal }} |

--- a/cmd/docs/templates/index.md.tmpl
+++ b/cmd/docs/templates/index.md.tmpl
@@ -1,0 +1,20 @@
+---
+title: CLI Flag Reference
+---
+
+# CLI Flag Reference
+
+HyperShift provides two command-line interfaces for creating hosted clusters:
+
+| CLI | Binary | Use Case |
+|-----|--------|----------|
+| **hcp** | `bin/hcp` | Supported product CLI for customers |
+| **hypershift** | `bin/hypershift` | Internal developer CLI (not supported for customer use) |
+
+The `hypershift` CLI includes additional flags for development, testing, and infrastructure reuse that are not available in `hcp`.
+
+## Platform-Specific References
+
+- [AWS](aws.md)
+
+*Additional platforms will be documented in future updates.*

--- a/cmd/docs/types.go
+++ b/cmd/docs/types.go
@@ -1,0 +1,32 @@
+package docs
+
+// FlagInfo contains metadata about a CLI flag
+type FlagInfo struct {
+	Name                 string
+	Type                 string
+	Default              string
+	Description          string
+	InHcp                bool
+	InHypershift         bool
+	RequiredInHcp        bool
+	RequiredInHypershift bool
+	Category             string
+}
+
+// CategoryInfo groups flags by category for template rendering
+type CategoryInfo struct {
+	Name        string
+	Description string
+	Flags       []FlagInfo
+}
+
+// TemplateData contains all data needed for template rendering
+type TemplateData struct {
+	Platform        string
+	Command         string
+	Categories      []CategoryInfo
+	SharedCount     int
+	DevOnlyCount    int
+	HcpTotal        int
+	HypershiftTotal int
+}

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -3,7 +3,7 @@
 This file contains all HyperShift documentation aggregated into a single file
 for use with AI tools like NotebookLM.
 
-Total documents: 248
+Total documents: 250
 
 ---
 
@@ -41054,6 +41054,237 @@ The diagram above provides an overview of the environment and how the workflow f
 8. Once the worker nodes of the HostedCluster have successfully booted up, an __Agent__ container will be initiated. This __Agent__ will establish contact with the Assisted Service, which will orchestrate the necessary actions to complete the deployment. Initially, you will need to scale the NodePool to the desired number of worker nodes for your HostedCluster, after which the AssistedService will manage the remaining tasks.
 
 9. At this point, you need to patiently await the completion of the deployment process.
+
+
+---
+
+## Source: docs/content/reference/cli-flags/aws.md
+
+---
+title: AWS CLI Flags
+---
+
+# AWS CLI Flags
+
+This page documents CLI flags for AWS platform commands, comparing the supported `hcp` CLI with the internal `hypershift` developer CLI.
+
+---
+
+## Create Cluster
+
+Flags for `hcp create cluster aws` and `hypershift create cluster aws`.
+
+### Required
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--name` | string |  | ✓ | ✓ | A name for the cluster |
+| `--pull-secret` | string |  | ✓ | ✓ | File path to a pull secret. |
+
+---
+
+### Cluster Identity
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--annotations` | stringArray |  | ✓ | ✓ | Annotations to apply to the hostedcluster (key=value). Can be specified multiple times. |
+| `--base-domain` | string |  | ✓ | ✓ | The ingress base domain for the cluster |
+| `--base-domain-prefix` | string |  | ✓ | ✓ | The ingress base domain prefix for the cluster, defaults to cluster name. Use 'none' for an empty prefix |
+| `--infra-id` | string |  | ✓ | ✓ | Infrastructure ID to use for hosted cluster resources. |
+| `--labels` | stringArray |  | ✓ | ✓ | Labels to apply to the hostedcluster (key=value). Can be specified multiple times. |
+| `--namespace` | string | `clusters` | ✓ | ✓ | A namespace to contain the generated resources |
+
+---
+
+### Release Configuration
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--arch` | string | `amd64` | ✓ | ✓ | The default processor architecture for the NodePool (e.g. arm64, amd64) |
+| `--disable-cluster-capabilities` | stringSlice |  | ✓ | ✓ | Optional cluster capabilities to disable. The only currently supported values are ImageRegistry,openshift-samples,Insights,baremetal,Console,NodeTuning,Ingress. |
+| `--enable-cluster-capabilities` | stringSlice |  | ✓ | ✓ | Optional cluster capabilities to enable. The only currently supported values are ImageRegistry,openshift-samples,Insights,baremetal,Console,NodeTuning,Ingress. |
+| `--feature-set` | string |  | ✓ | ✓ | The predefined feature set to use for the cluster (TechPreviewNoUpgrade or DevPreviewNoUpgrade) |
+| `--release-image` | string |  | ✓ | ✓ | The OCP release image for the cluster |
+| `--release-stream` | string |  | ✓ | ✓ | The OCP release stream for the cluster (e.g. 4-stable-multi), this flag is ignored if release-image is set |
+
+---
+
+### AWS Infrastructure
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--additional-tags` | stringSlice |  | ✓ | ✓ | Additional tags to set on AWS resources |
+| `--private-zones-in-cluster-account` | bool | `false` | ✓ | ✓ | In shared VPC infrastructure, create private hosted zones in cluster account |
+| `--public-only` | bool | `false` | ✓ | ✓ | If true, creates a cluster that does not have private subnets or NAT gateway and assigns public IPs to all instances. |
+| `--region` | string | `us-east-1` | ✓ | ✓ | Region to use for AWS infrastructure. |
+| `--vpc-cidr` | string |  | ✓ | ✓ | The CIDR to use for the cluster VPC (mask must be 16) |
+| `--zones` | stringSlice |  | ✓ | ✓ | The availability zones in which NodePools will be created |
+
+---
+
+### Networking
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--allocate-node-cidrs` | bool | `false` | ✓ | ✓ | When networkType=Other, it's recommended to set this field to 'true' when using Flannel as the CNI. |
+| `--cluster-cidr` | stringArray | `[10.132.0.0/14]` | ✓ | ✓ | The CIDR of the cluster network. Can be specified multiple times. |
+| `--default-dual` | bool | `false` | ✓ | ✓ | Defines the Service and Cluster CIDRs as dual-stack default values. Cannot be defined with service-cidr or cluster-cidr flag. |
+| `--disable-multi-network` | bool | `false` | ✓ | ✓ | Disables the Multus CNI plugin and related components in the hosted cluster |
+| `--endpoint-access` | string | `Public` | ✓ | ✓ | Access for control plane endpoints (Public, PublicAndPrivate, Private) |
+| `--external-dns-domain` | string |  | ✓ | ✓ | Sets hostname to opinionated values in the specified domain for services with publishing type LoadBalancer or Route. |
+| `--kas-dns-name` | string |  | ✓ | ✓ | The custom DNS name for the kube-apiserver service. Make sure the DNS name is valid and addressable. |
+| `--machine-cidr` | stringArray |  | ✓ | ✓ | The CIDR of the machine network. Can be specified multiple times. |
+| `--network-type` | string | `OVNKubernetes` | ✓ | ✓ | Enum specifying the cluster SDN provider. Supports either Calico, OVNKubernetes, OpenShiftSDN or Other. |
+| `--service-cidr` | stringArray | `[172.31.0.0/16]` | ✓ | ✓ | The CIDR of the service network. Can be specified multiple times. |
+
+---
+
+### Proxy Configuration
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--enable-proxy` | bool | `false` | ✓ | ✓ | If true, a proxy should be set up, rather than allowing direct internet access from the nodes |
+| `--enable-secure-proxy` | bool | `false` | ✓ | ✓ | If true, a secure proxy should be set up, rather than allowing direct internet access from the nodes |
+| `--proxy-vpc-endpoint-service-name` | string |  | ✓ | ✓ | The name of a VPC Endpoint Service offering a proxy service to use for the cluster |
+
+---
+
+### Node Pool Configuration
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--auto-node` | bool | `false` | ✓ | ✓ | If true, this flag indicates the Hosted Cluster will support AutoNode feature. |
+| `--auto-repair` | bool | `false` | ✓ | ✓ | Enables machine autorepair with machine health checks |
+| `--instance-type` | string |  | ✓ | ✓ | Instance type for AWS instances. |
+| `--node-drain-timeout` | duration |  | ✓ | ✓ | The NodeDrainTimeout on any created NodePools |
+| `--node-pool-replicas` | int32 | `0` | ✓ | ✓ | If 0 or greater, creates a nodepool with that many replicas; else if less than 0, does not create a nodepool. |
+| `--node-upgrade-type` | UpgradeType |  | ✓ | ✓ | The NodePool upgrade strategy for how nodes should behave when upgraded. Supported options: Replace, InPlace |
+| `--node-volume-detach-timeout` | duration |  | ✓ | ✓ | The NodeVolumeDetachTimeout on any created NodePools |
+| `--root-volume-iops` | int64 | `0` | ✓ | ✓ | The iops of the root volume when specifying type:io1 for machines in the NodePool |
+| `--root-volume-kms-key` | string |  | ✓ | ✓ | The KMS key ID or ARN to use for root volume encryption for machines in the NodePool |
+| `--root-volume-size` | int64 | `120` | ✓ | ✓ | The size of the root volume (min: 8) for machines in the NodePool |
+| `--root-volume-type` | string | `gp3` | ✓ | ✓ | The type of the root volume (e.g. gp3, io2) for machines in the NodePool |
+
+---
+
+### Security & Encryption
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--additional-trust-bundle` | string |  | ✓ | ✓ | Path to a file with user CA bundle |
+| `--fips` | bool | `false` | ✓ | ✓ | Enables FIPS mode for nodes in the cluster |
+| `--generate-ssh` | bool | `false` | ✓ | ✓ | If true, generate SSH keys |
+| `--image-content-sources` | string |  | ✓ | ✓ | Path to a file with image content sources |
+| `--kms-key-arn` | string |  | ✓ | ✓ | The ARN of the KMS key to use for Etcd encryption. If not supplied, etcd encryption will default to using a generated AESCBC key. |
+| `--oidc-issuer-url` | string |  | ✓ | ✓ | The OIDC provider issuer URL |
+| `--sa-token-issuer-private-key-path` | string |  | ✓ | ✓ | The file to the private key for the service account token issuer |
+| `--ssh-key` | string |  | ✓ | ✓ | Path to an SSH key file |
+
+---
+
+### AWS Credentials & IAM
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--role-arn` | string |  | ✓ | ✓ | The ARN of the role to assume. |
+| `--secret-creds` | string |  | ✓ | ✓ | A Kubernetes secret with needed AWS platform credentials: sts-creds, pull-secret, and a base-domain value. The secret must exist in the supplied "--namespace". If a value is provided through the flag '--pull-secret', that value will override the pull-secret value in 'secret-creds'. |
+| `--shared-role` | bool | `false` | ✓ | ✓ | Create a single shared role with all role policies instead of individual component roles |
+| `--sts-creds` | string |  | ✓ | ✓ | Path to the STS credentials file to use when assuming the role. Can be generated with 'aws sts get-session-token --output json' |
+| `--use-rosa-managed-policies` | bool | `false` | ✓ | ✓ | Use ROSA managed policies for the operator roles and worker instance profile |
+
+---
+
+### Control Plane Configuration
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--control-plane-availability-policy` | string | `HighlyAvailable` | ✓ | ✓ | Availability policy for hosted cluster components. Supported options: SingleReplica, HighlyAvailable |
+| `--etcd-storage-class` | string |  | ✓ | ✓ | The persistent volume storage class for etcd data volumes |
+| `--etcd-storage-size` | string |  | ✓ | ✓ | The storage size for etcd data volume. Example: 8Gi |
+| `--infra-availability-policy` | string |  | ✓ | ✓ | Availability policy for infrastructure services in guest cluster. Supported options: SingleReplica, HighlyAvailable |
+| `--node-selector` | stringToString |  | ✓ | ✓ | A comma separated list of key=value to use as node selector for the Hosted Control Plane pods to stick to. E.g. role=cp,disk=fast |
+| `--pods-labels` | stringToString |  | ✓ | ✓ | A comma separated list of key=value to use as labels for the Hosted Control Plane pods |
+| `--toleration` | stringArray |  | ✓ | ✓ | A comma separated list of options for a toleration that will be applied to the hcp pods. Valid options are, key, value, operator, effect, tolerationSeconds. E.g. key=node-role.kubernetes.io/master,operator=Exists,effect=NoSchedule. Can be specified multiple times to add multiple tolerations |
+
+---
+
+### OLM Configuration
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--olm-catalog-placement` | OLMCatalogPlacement | `management` | ✓ | ✓ | The OLM Catalog Placement for the HostedCluster. Supported options: Management, Guest |
+| `--olm-disable-default-sources` | bool | `false` | ✓ | ✓ | Disables the OLM default catalog sources for the HostedCluster. |
+
+---
+
+### Output & Execution
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--pausedUntil` | string |  | ✓ | ✓ | If a date is provided in RFC3339 format, HostedCluster creation is paused until that date. If the boolean true is provided, HostedCluster creation is paused until the field is removed. |
+| `--render` | bool | `false` | ✓ | ✓ | Render output as YAML to stdout instead of applying. Note: secrets are not rendered by default, additionally use the --render-sensitive flag to render secrets |
+| `--render-into` | string |  | ✓ | ✓ | Render output as YAML into this file instead of applying. If unset, YAML will be output to stdout. |
+| `--render-sensitive` | bool | `false` | ✓ | ✓ | When used along --render it enables rendering of secrets in the output |
+| `--timeout` | duration |  | ✓ | ✓ | If the --wait flag is set, set the optional timeout to limit the waiting duration. The format is duration; e.g. 30s or 1h30m45s; 0 means no timeout; default = 0 |
+| `--version-check` | bool | `false` | ✓ | ✓ | Checks version of CLI and Hypershift operator and blocks create if mismatched |
+| `--wait` | bool | `false` | ✓ | ✓ | If the create command should block until the cluster is up. Requires at least one node. |
+
+---
+
+### Developer-Only
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--aws-creds` | string |  |  | ✓ | Path to an AWS credentials file |
+| `--control-plane-operator-image` | string |  |  | ✓ | Override the default image used to deploy the control plane operator |
+| `--iam-json` | string |  |  | ✓ | Path to file containing IAM information for the cluster. If not specified, IAM will be created |
+| `--infra-json` | string |  |  | ✓ | Path to file containing infrastructure information for the cluster. If not specified, infrastructure will be created |
+| `--single-nat-gateway` | bool | `false` |  | ✓ | If enabled, only a single NAT gateway is created, even if multiple zones are specified |
+| `--vpc-owner-aws-creds` | string |  |  | ✓ | Path to VPC owner AWS credentials file |
+
+---
+
+### Deprecated
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--multi-arch` | bool | `false` | ✓ | ✓ | If true, this flag indicates the Hosted Cluster will support multi-arch NodePools and will perform additional validation checks to ensure a multi-arch release image or stream was used. |
+
+---
+
+### Summary
+
+| | hcp | hypershift |
+|---|:---:|:----------:|
+| **Shared Flags** | 74 | 74 |
+| **Developer-Only Flags** | - | 6 |
+| **Total Flags** | 74 | 80 |
+
+
+---
+
+## Source: docs/content/reference/cli-flags/index.md
+
+---
+title: CLI Flag Reference
+---
+
+# CLI Flag Reference
+
+HyperShift provides two command-line interfaces for creating hosted clusters:
+
+| CLI | Binary | Use Case |
+|-----|--------|----------|
+| **hcp** | `bin/hcp` | Supported product CLI for customers |
+| **hypershift** | `bin/hypershift` | Internal developer CLI (not supported for customer use) |
+
+The `hypershift` CLI includes additional flags for development, testing, and infrastructure reuse that are not available in `hcp`.
+
+## Platform-Specific References
+
+- AWS
+
+*Additional platforms will be documented in future updates.*
 
 
 ---

--- a/docs/content/reference/cli-flags/aws.md
+++ b/docs/content/reference/cli-flags/aws.md
@@ -1,0 +1,199 @@
+---
+title: AWS CLI Flags
+---
+
+# AWS CLI Flags
+
+This page documents CLI flags for AWS platform commands, comparing the supported `hcp` CLI with the internal `hypershift` developer CLI.
+
+---
+
+## Create Cluster
+
+Flags for `hcp create cluster aws` and `hypershift create cluster aws`.
+
+### Required
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--name` | string |  | ✓ | ✓ | A name for the cluster |
+| `--pull-secret` | string |  | ✓ | ✓ | File path to a pull secret. |
+
+---
+
+### Cluster Identity
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--annotations` | stringArray |  | ✓ | ✓ | Annotations to apply to the hostedcluster (key=value). Can be specified multiple times. |
+| `--base-domain` | string |  | ✓ | ✓ | The ingress base domain for the cluster |
+| `--base-domain-prefix` | string |  | ✓ | ✓ | The ingress base domain prefix for the cluster, defaults to cluster name. Use 'none' for an empty prefix |
+| `--infra-id` | string |  | ✓ | ✓ | Infrastructure ID to use for hosted cluster resources. |
+| `--labels` | stringArray |  | ✓ | ✓ | Labels to apply to the hostedcluster (key=value). Can be specified multiple times. |
+| `--namespace` | string | `clusters` | ✓ | ✓ | A namespace to contain the generated resources |
+
+---
+
+### Release Configuration
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--arch` | string | `amd64` | ✓ | ✓ | The default processor architecture for the NodePool (e.g. arm64, amd64) |
+| `--disable-cluster-capabilities` | stringSlice |  | ✓ | ✓ | Optional cluster capabilities to disable. The only currently supported values are ImageRegistry,openshift-samples,Insights,baremetal,Console,NodeTuning,Ingress. |
+| `--enable-cluster-capabilities` | stringSlice |  | ✓ | ✓ | Optional cluster capabilities to enable. The only currently supported values are ImageRegistry,openshift-samples,Insights,baremetal,Console,NodeTuning,Ingress. |
+| `--feature-set` | string |  | ✓ | ✓ | The predefined feature set to use for the cluster (TechPreviewNoUpgrade or DevPreviewNoUpgrade) |
+| `--release-image` | string |  | ✓ | ✓ | The OCP release image for the cluster |
+| `--release-stream` | string |  | ✓ | ✓ | The OCP release stream for the cluster (e.g. 4-stable-multi), this flag is ignored if release-image is set |
+
+---
+
+### AWS Infrastructure
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--additional-tags` | stringSlice |  | ✓ | ✓ | Additional tags to set on AWS resources |
+| `--private-zones-in-cluster-account` | bool | `false` | ✓ | ✓ | In shared VPC infrastructure, create private hosted zones in cluster account |
+| `--public-only` | bool | `false` | ✓ | ✓ | If true, creates a cluster that does not have private subnets or NAT gateway and assigns public IPs to all instances. |
+| `--region` | string | `us-east-1` | ✓ | ✓ | Region to use for AWS infrastructure. |
+| `--vpc-cidr` | string |  | ✓ | ✓ | The CIDR to use for the cluster VPC (mask must be 16) |
+| `--zones` | stringSlice |  | ✓ | ✓ | The availability zones in which NodePools will be created |
+
+---
+
+### Networking
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--allocate-node-cidrs` | bool | `false` | ✓ | ✓ | When networkType=Other, it's recommended to set this field to 'true' when using Flannel as the CNI. |
+| `--cluster-cidr` | stringArray | `[10.132.0.0/14]` | ✓ | ✓ | The CIDR of the cluster network. Can be specified multiple times. |
+| `--default-dual` | bool | `false` | ✓ | ✓ | Defines the Service and Cluster CIDRs as dual-stack default values. Cannot be defined with service-cidr or cluster-cidr flag. |
+| `--disable-multi-network` | bool | `false` | ✓ | ✓ | Disables the Multus CNI plugin and related components in the hosted cluster |
+| `--endpoint-access` | string | `Public` | ✓ | ✓ | Access for control plane endpoints (Public, PublicAndPrivate, Private) |
+| `--external-dns-domain` | string |  | ✓ | ✓ | Sets hostname to opinionated values in the specified domain for services with publishing type LoadBalancer or Route. |
+| `--kas-dns-name` | string |  | ✓ | ✓ | The custom DNS name for the kube-apiserver service. Make sure the DNS name is valid and addressable. |
+| `--machine-cidr` | stringArray |  | ✓ | ✓ | The CIDR of the machine network. Can be specified multiple times. |
+| `--network-type` | string | `OVNKubernetes` | ✓ | ✓ | Enum specifying the cluster SDN provider. Supports either Calico, OVNKubernetes, OpenShiftSDN or Other. |
+| `--service-cidr` | stringArray | `[172.31.0.0/16]` | ✓ | ✓ | The CIDR of the service network. Can be specified multiple times. |
+
+---
+
+### Proxy Configuration
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--enable-proxy` | bool | `false` | ✓ | ✓ | If true, a proxy should be set up, rather than allowing direct internet access from the nodes |
+| `--enable-secure-proxy` | bool | `false` | ✓ | ✓ | If true, a secure proxy should be set up, rather than allowing direct internet access from the nodes |
+| `--proxy-vpc-endpoint-service-name` | string |  | ✓ | ✓ | The name of a VPC Endpoint Service offering a proxy service to use for the cluster |
+
+---
+
+### Node Pool Configuration
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--auto-node` | bool | `false` | ✓ | ✓ | If true, this flag indicates the Hosted Cluster will support AutoNode feature. |
+| `--auto-repair` | bool | `false` | ✓ | ✓ | Enables machine autorepair with machine health checks |
+| `--instance-type` | string |  | ✓ | ✓ | Instance type for AWS instances. |
+| `--node-drain-timeout` | duration |  | ✓ | ✓ | The NodeDrainTimeout on any created NodePools |
+| `--node-pool-replicas` | int32 | `0` | ✓ | ✓ | If 0 or greater, creates a nodepool with that many replicas; else if less than 0, does not create a nodepool. |
+| `--node-upgrade-type` | UpgradeType |  | ✓ | ✓ | The NodePool upgrade strategy for how nodes should behave when upgraded. Supported options: Replace, InPlace |
+| `--node-volume-detach-timeout` | duration |  | ✓ | ✓ | The NodeVolumeDetachTimeout on any created NodePools |
+| `--root-volume-iops` | int64 | `0` | ✓ | ✓ | The iops of the root volume when specifying type:io1 for machines in the NodePool |
+| `--root-volume-kms-key` | string |  | ✓ | ✓ | The KMS key ID or ARN to use for root volume encryption for machines in the NodePool |
+| `--root-volume-size` | int64 | `120` | ✓ | ✓ | The size of the root volume (min: 8) for machines in the NodePool |
+| `--root-volume-type` | string | `gp3` | ✓ | ✓ | The type of the root volume (e.g. gp3, io2) for machines in the NodePool |
+
+---
+
+### Security & Encryption
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--additional-trust-bundle` | string |  | ✓ | ✓ | Path to a file with user CA bundle |
+| `--fips` | bool | `false` | ✓ | ✓ | Enables FIPS mode for nodes in the cluster |
+| `--generate-ssh` | bool | `false` | ✓ | ✓ | If true, generate SSH keys |
+| `--image-content-sources` | string |  | ✓ | ✓ | Path to a file with image content sources |
+| `--kms-key-arn` | string |  | ✓ | ✓ | The ARN of the KMS key to use for Etcd encryption. If not supplied, etcd encryption will default to using a generated AESCBC key. |
+| `--oidc-issuer-url` | string |  | ✓ | ✓ | The OIDC provider issuer URL |
+| `--sa-token-issuer-private-key-path` | string |  | ✓ | ✓ | The file to the private key for the service account token issuer |
+| `--ssh-key` | string |  | ✓ | ✓ | Path to an SSH key file |
+
+---
+
+### AWS Credentials & IAM
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--role-arn` | string |  | ✓ | ✓ | The ARN of the role to assume. |
+| `--secret-creds` | string |  | ✓ | ✓ | A Kubernetes secret with needed AWS platform credentials: sts-creds, pull-secret, and a base-domain value. The secret must exist in the supplied "--namespace". If a value is provided through the flag '--pull-secret', that value will override the pull-secret value in 'secret-creds'. |
+| `--shared-role` | bool | `false` | ✓ | ✓ | Create a single shared role with all role policies instead of individual component roles |
+| `--sts-creds` | string |  | ✓ | ✓ | Path to the STS credentials file to use when assuming the role. Can be generated with 'aws sts get-session-token --output json' |
+| `--use-rosa-managed-policies` | bool | `false` | ✓ | ✓ | Use ROSA managed policies for the operator roles and worker instance profile |
+
+---
+
+### Control Plane Configuration
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--control-plane-availability-policy` | string | `HighlyAvailable` | ✓ | ✓ | Availability policy for hosted cluster components. Supported options: SingleReplica, HighlyAvailable |
+| `--etcd-storage-class` | string |  | ✓ | ✓ | The persistent volume storage class for etcd data volumes |
+| `--etcd-storage-size` | string |  | ✓ | ✓ | The storage size for etcd data volume. Example: 8Gi |
+| `--infra-availability-policy` | string |  | ✓ | ✓ | Availability policy for infrastructure services in guest cluster. Supported options: SingleReplica, HighlyAvailable |
+| `--node-selector` | stringToString |  | ✓ | ✓ | A comma separated list of key=value to use as node selector for the Hosted Control Plane pods to stick to. E.g. role=cp,disk=fast |
+| `--pods-labels` | stringToString |  | ✓ | ✓ | A comma separated list of key=value to use as labels for the Hosted Control Plane pods |
+| `--toleration` | stringArray |  | ✓ | ✓ | A comma separated list of options for a toleration that will be applied to the hcp pods. Valid options are, key, value, operator, effect, tolerationSeconds. E.g. key=node-role.kubernetes.io/master,operator=Exists,effect=NoSchedule. Can be specified multiple times to add multiple tolerations |
+
+---
+
+### OLM Configuration
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--olm-catalog-placement` | OLMCatalogPlacement | `management` | ✓ | ✓ | The OLM Catalog Placement for the HostedCluster. Supported options: Management, Guest |
+| `--olm-disable-default-sources` | bool | `false` | ✓ | ✓ | Disables the OLM default catalog sources for the HostedCluster. |
+
+---
+
+### Output & Execution
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--pausedUntil` | string |  | ✓ | ✓ | If a date is provided in RFC3339 format, HostedCluster creation is paused until that date. If the boolean true is provided, HostedCluster creation is paused until the field is removed. |
+| `--render` | bool | `false` | ✓ | ✓ | Render output as YAML to stdout instead of applying. Note: secrets are not rendered by default, additionally use the --render-sensitive flag to render secrets |
+| `--render-into` | string |  | ✓ | ✓ | Render output as YAML into this file instead of applying. If unset, YAML will be output to stdout. |
+| `--render-sensitive` | bool | `false` | ✓ | ✓ | When used along --render it enables rendering of secrets in the output |
+| `--timeout` | duration |  | ✓ | ✓ | If the --wait flag is set, set the optional timeout to limit the waiting duration. The format is duration; e.g. 30s or 1h30m45s; 0 means no timeout; default = 0 |
+| `--version-check` | bool | `false` | ✓ | ✓ | Checks version of CLI and Hypershift operator and blocks create if mismatched |
+| `--wait` | bool | `false` | ✓ | ✓ | If the create command should block until the cluster is up. Requires at least one node. |
+
+---
+
+### Developer-Only
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--aws-creds` | string |  |  | ✓ | Path to an AWS credentials file |
+| `--control-plane-operator-image` | string |  |  | ✓ | Override the default image used to deploy the control plane operator |
+| `--iam-json` | string |  |  | ✓ | Path to file containing IAM information for the cluster. If not specified, IAM will be created |
+| `--infra-json` | string |  |  | ✓ | Path to file containing infrastructure information for the cluster. If not specified, infrastructure will be created |
+| `--single-nat-gateway` | bool | `false` |  | ✓ | If enabled, only a single NAT gateway is created, even if multiple zones are specified |
+| `--vpc-owner-aws-creds` | string |  |  | ✓ | Path to VPC owner AWS credentials file |
+
+---
+
+### Deprecated
+
+| Flag | Type | Default | hcp | hypershift | Description |
+|------|------|---------|:---:|:----------:|-------------|
+| `--multi-arch` | bool | `false` | ✓ | ✓ | If true, this flag indicates the Hosted Cluster will support multi-arch NodePools and will perform additional validation checks to ensure a multi-arch release image or stream was used. |
+
+---
+
+### Summary
+
+| | hcp | hypershift |
+|---|:---:|:----------:|
+| **Shared Flags** | 74 | 74 |
+| **Developer-Only Flags** | - | 6 |
+| **Total Flags** | 74 | 80 |

--- a/docs/content/reference/cli-flags/index.md
+++ b/docs/content/reference/cli-flags/index.md
@@ -1,0 +1,20 @@
+---
+title: CLI Flag Reference
+---
+
+# CLI Flag Reference
+
+HyperShift provides two command-line interfaces for creating hosted clusters:
+
+| CLI | Binary | Use Case |
+|-----|--------|----------|
+| **hcp** | `bin/hcp` | Supported product CLI for customers |
+| **hypershift** | `bin/hypershift` | Internal developer CLI (not supported for customer use) |
+
+The `hypershift` CLI includes additional flags for development, testing, and infrastructure reuse that are not available in `hcp`.
+
+## Platform-Specific References
+
+- [AWS](aws.md)
+
+*Additional platforms will be documented in future updates.*

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -296,6 +296,9 @@ nav:
         - reference/architecture/managed-azure/secrets-csi.md
         - reference/architecture/managed-azure/shared-ingress.md
   - reference/api.md
+  - 'CLI Flags':
+    - reference/cli-flags/index.md
+    - 'AWS': reference/cli-flags/aws.md
   - reference/concepts-and-personas.md
   - reference/controller-architecture.md
   - reference/goals-and-design-invariants.md

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/hypershift/cmd/consolelogs"
 	createcmd "github.com/openshift/hypershift/cmd/create"
 	destroycmd "github.com/openshift/hypershift/cmd/destroy"
+	docscmd "github.com/openshift/hypershift/cmd/docs"
 	dumpcmd "github.com/openshift/hypershift/cmd/dump"
 	installcmd "github.com/openshift/hypershift/cmd/install"
 	cliversion "github.com/openshift/hypershift/cmd/version"
@@ -63,6 +64,7 @@ func main() {
 	cmd.AddCommand(installcmd.NewCommand())
 	cmd.AddCommand(createcmd.NewCommand())
 	cmd.AddCommand(destroycmd.NewCommand())
+	cmd.AddCommand(docscmd.NewCommand())
 	cmd.AddCommand(dumpcmd.NewCommand())
 	cmd.AddCommand(consolelogs.NewCommand())
 	cmd.AddCommand(cliversion.NewVersionCommand())

--- a/product-cli/cmd/cluster/cluster.go
+++ b/product-cli/cmd/cluster/cluster.go
@@ -26,6 +26,9 @@ func NewCreateCommands() *cobra.Command {
 
 	core.BindOptions(opts, cmd.PersistentFlags())
 
+	_ = cmd.MarkPersistentFlagRequired("name")
+	_ = cmd.MarkPersistentFlagRequired("pull-secret")
+
 	cmd.MarkFlagsMutuallyExclusive("service-cidr", "default-dual")
 	cmd.MarkFlagsMutuallyExclusive("cluster-cidr", "default-dual")
 	cmd.AddCommand(agent.NewCreateCommand(opts))


### PR DESCRIPTION
## What this PR does / why we need it:

### Background

The hcp (product/customer) and hypershift (developer/internal) CLIs share underlying code but expose different sets of flags. This creates several challenges:

1. **No visibility on exposed flags** - There's no single place documenting which flags are exposed in the hcp CLI vs developer-only flags in hypershift
2. **Risk of developer flags leaking to hcp** - Without clear visibility, developer-only flags could accidentally be exposed in the product CLI
3. **No CLI documentation exists** - Currently there's no dedicated place in the docs for CLI flag reference
4. **Required flag ambiguity** - Some flags (e.g.  `--name` and `--pull-secret` )  were validated as required at runtime but not marked as such in cobra, making it impossible to auto-detect requirements

### Solution

This PR introduces a CLI flag documentation generator that:

1. **Extracts flags programmatically** from both hcp and hypershift CLI commands using the actual cobra command structures
2. **Detects required flags dynamically** via cobra's `MarkFlagRequired` and `MarkPersistentFlagRequired` annotations instead of hardcoding
3. **Organizes flags by category** using a mapping in `categories.go` (AWS Infrastructure, Cluster Identity, Security, Networking, etc.) for better readability
4. **Generates markdown documentation** comparing flags side-by-side with per-CLI availability and required status
5. **Integrates with the build system** via `make cli-docs` target (included in `make update`)

### Changes

**New `hypershift docs generate` command** (`cmd/docs/`):
- `generate.go` - Main generator logic, extracts flags from both CLIs by walking the cobra command tree
- `types.go` - `FlagInfo` struct with `RequiredInHcp` and `RequiredInHypershift` fields for per-CLI tracking
- `categories.go` - Flag categorization (AWS Infrastructure, Cluster Identity, Security, etc.)
- `templates/aws.md.tmpl` - Template with three-state display for Required section
- `generate_test.go` - 27 unit tests covering flag extraction, merging, and required detection

**Required flag annotations** (`cmd/cluster/cluster.go`, `product-cli/cmd/cluster/cluster.go`):
- Added `MarkPersistentFlagRequired("name")` and `MarkPersistentFlagRequired("pull-secret")`
- These flags were already effectively required through runtime validation in `cmd/cluster/core/create.go` but not marked using cobra's mechanism

**Generated documentation** (`docs/content/reference/cli-flags/`):
- `index.md` - Overview page explaining hcp vs hypershift CLIs
- `aws.md` - Generated flag reference for `create cluster aws` command

**Three-state display in Required section:**
| Symbol | Meaning |
|--------|---------|
| `✓` | Required and available in this CLI |
| `Optional` | Available but not required in this CLI |
| `Unavailable` | Flag does not exist in this CLI |

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-2600](https://issues.redhat.com//browse/CNTRLPLANE-2600)

## Documentation Preview

### 📖 **[Preview the generated docs](https://pr-7564.hypershift.pages.dev/)**

## Special notes for your reviewer:

1. **Scope**: Currently only covers AWS `create cluster` command. The generator is designed to be extensible to other platforms and commands.

2. **Required flag detection**: The generator walks up the cobra command tree to access flags directly where annotations are stored, ensuring annotations set by `MarkFlagRequired` and `MarkPersistentFlagRequired` are visible (cobra's `InheritedFlags()` returns copies without annotations).

3. **No breaking changes**: The `MarkPersistentFlagRequired` calls don't change runtime behavior - these flags were already validated as required. This just makes it explicit to cobra for better `--help` output and annotation-based detection.

4. **Regenerating docs**: Run `make cli-docs` or `make update` to regenerate after flag changes.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [x] This change includes docs.
- [x] This change includes unit tests.
