### PR TITLE
OCPBUGS-74247: CAPI image overrides aware of registry config

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/none"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/openstack"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster/internal/platform/powervs"
+	"github.com/openshift/hypershift/support/backwardcompat"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/upsert"
 	imgUtil "github.com/openshift/hypershift/support/util"
@@ -35,13 +36,15 @@ const (
 	GCPCAPIProvider             = "gcp-cluster-api-controllers"
 )
 
-var _ Platform = aws.AWS{}
-var _ Platform = azure.Azure{}
-var _ Platform = ibmcloud.IBMCloud{}
-var _ Platform = none.None{}
-var _ Platform = agent.Agent{}
-var _ Platform = kubevirt.Kubevirt{}
-var _ Platform = gcp.GCP{}
+var (
+	_ Platform = aws.AWS{}
+	_ Platform = azure.Azure{}
+	_ Platform = ibmcloud.IBMCloud{}
+	_ Platform = none.None{}
+	_ Platform = agent.Agent{}
+	_ Platform = kubevirt.Kubevirt{}
+	_ Platform = gcp.GCP{}
+)
 
 type Platform interface {
 	// ReconcileCAPIInfraCR is called during HostedCluster reconciliation prior to reconciling the CAPI Cluster CR.
@@ -105,14 +108,18 @@ func GetPlatform(ctx context.Context, hcluster *hyperv1.HostedCluster, releasePr
 			if err != nil {
 				return nil, fmt.Errorf("failed to fetch payload version: %w", err)
 			}
+
+			if payloadVersion != nil {
+				imageOverride, err := backwardcompat.GetBackwardCompatibleCAPIImage(ctx, pullSecretBytes, releaseProvider, *payloadVersion, AWSCAPIProvider)
+				if err != nil {
+					return nil, err
+				}
+				if imageOverride != "" {
+					capiImageProvider = imageOverride
+				}
+			}
 		}
 
-		// temporary override for 4.21 to unblock CAPI bump to 1.11 which introduces a new API version.
-		// used image from multiArch release payload 4.20.5 (quay.io/openshift-release-dev/ocp-release@sha256:1f2c28ac126453a3b9e83b349822b9f1fb7662973a212f936b90fdc40e06eb58)
-		// TODO(https://issues.redhat.com/browse/CNTRLPLANE-1200): Remove this override once Hypershift installs the CAPI v1beta2 API version
-		if payloadVersion != nil && payloadVersion.GTE(semver.MustParse("4.21.0-0")) {
-			capiImageProvider = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b8881eafb5fdb31bdaffe03d2cb74ee6729a4776ce879c550e0ea26c489e2cf6"
-		}
 		platform = aws.New(utilitiesImage, capiImageProvider, payloadVersion)
 	case hyperv1.IBMCloudPlatform:
 		platform = &ibmcloud.IBMCloud{}
@@ -132,14 +139,18 @@ func GetPlatform(ctx context.Context, hcluster *hyperv1.HostedCluster, releasePr
 			if err != nil {
 				return nil, fmt.Errorf("failed to fetch payload version: %w", err)
 			}
+
+			if payloadVersion != nil {
+				imageOverride, err := backwardcompat.GetBackwardCompatibleCAPIImage(ctx, pullSecretBytes, releaseProvider, *payloadVersion, AzureCAPIProvider)
+				if err != nil {
+					return nil, err
+				}
+				if imageOverride != "" {
+					capiImageProvider = imageOverride
+				}
+			}
 		}
 
-		// temporary override for 4.21 to unblock CAPI bump to 1.11 which introduces a new API version.
-		// used image from multiArch release payload 4.20.5 (quay.io/openshift-release-dev/ocp-release@sha256:1f2c28ac126453a3b9e83b349822b9f1fb7662973a212f936b90fdc40e06eb58)
-		// TODO(https://issues.redhat.com/browse/CNTRLPLANE-1200): Remove this override once Hypershift installs the CAPI v1beta2 API version
-		if payloadVersion != nil && payloadVersion.GTE(semver.MustParse("4.21.0-0")) {
-			capiImageProvider = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:54c33e77c60da570e9f18dcae94c4c320145a77a78df9de615a9949fbebf6b40"
-		}
 		platform = azure.New(utilitiesImage, capiImageProvider, payloadVersion)
 	case hyperv1.PowerVSPlatform:
 		if pullSecretBytes != nil {

--- a/support/backwardcompat/backwardcompat.go
+++ b/support/backwardcompat/backwardcompat.go
@@ -1,8 +1,14 @@
 package backwardcompat
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/releaseinfo"
 	supportutil "github.com/openshift/hypershift/support/util"
+
+	"github.com/blang/semver"
 )
 
 const ImageStreamImportModeField = "imageStreamImportMode"
@@ -24,4 +30,27 @@ func GetBackwardCompatibleConfigHash(config *v1beta1.ClusterConfiguration) (stri
 	// We need to drop the field when it shows up as empty in the marshaled string to keep backward compatibility.
 	// Implementing this at the marshal operation level might result in undesired impact as we might potentially modify other fields and ordering is not deterministic
 	return supportutil.HashStructWithJSONMapper(config, supportutil.NewOmitFieldIfEmptyJSONMapper(ImageStreamImportModeField))
+}
+
+// GetBackwardCompatibleCAPIImage returns a CAPI image pinned to a CAPI 1.10 compatible version.
+// If the releaseVersion is 4.21 or higher. Otherwise an empty string is returned.
+func GetBackwardCompatibleCAPIImage(ctx context.Context, pullSecret []byte, releaseProvider releaseinfo.Provider, releaseVersion semver.Version, component string) (string, error) {
+	// TODO(https://issues.redhat.com/browse/CNTRLPLANE-1200): Remove this override once Hypershift installs the CAPI v1beta2 API version
+	// temporary override for 4.21 to unblock CAPI bump to 1.11 which introduces a new API version.
+	// The images returned are pinned to version 4.20.10.
+	const (
+		pinnedRelease = "quay.io/openshift-release-dev/ocp-release@sha256:7f183e9b5610a2c9f9aabfd5906b418adfbe659f441b019933426a19bf6a5962"
+		minRelease    = "4.21.0-0"
+	)
+
+	if releaseVersion.GTE(semver.MustParse(minRelease)) {
+		imageOverride, err := supportutil.GetPayloadImageFromRelease(ctx, releaseProvider, pinnedRelease, component, pullSecret)
+		if err != nil {
+			return "", fmt.Errorf("error getting backwards compatible image for %s:%s: %w", component, pinnedRelease, err)
+		}
+
+		return imageOverride, nil
+	}
+
+	return "", nil
 }

--- a/support/backwardcompat/backwardcompat_test.go
+++ b/support/backwardcompat/backwardcompat_test.go
@@ -1,12 +1,21 @@
 package backwardcompat
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/util"
 
 	v1 "github.com/openshift/api/config/v1"
+	imagev1 "github.com/openshift/api/image/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/blang/semver"
 )
 
 func TestGetBackwardCompatibleConfigHash(t *testing.T) {
@@ -86,6 +95,123 @@ func TestGetBackwardCompatibleConfigHash(t *testing.T) {
 				}
 			}
 
+		})
+	}
+}
+
+// mockReleaseProvider is a mock implementation of releaseinfo.Provider for testing.
+type mockReleaseProvider struct {
+	components map[string]string
+	err        error
+}
+
+func (m *mockReleaseProvider) Lookup(_ context.Context, _ string, _ []byte) (*releaseinfo.ReleaseImage, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	tags := make([]imagev1.TagReference, 0, len(m.components))
+	for name, image := range m.components {
+		tags = append(tags, imagev1.TagReference{
+			Name: name,
+			From: &corev1.ObjectReference{Name: image},
+		})
+	}
+	return &releaseinfo.ReleaseImage{
+		ImageStream: &imagev1.ImageStream{
+			ObjectMeta: metav1.ObjectMeta{Name: "4.20.12"},
+			Spec: imagev1.ImageStreamSpec{
+				Tags: tags,
+			},
+		},
+	}, nil
+}
+
+func TestGetBackwardCompatibleCAPIImage(t *testing.T) {
+	tests := []struct {
+		name           string
+		releaseVersion semver.Version
+		component      string
+		provider       *mockReleaseProvider
+		expectedImage  string
+		expectError    bool
+	}{
+		{
+			name:           "When version is below 4.21.0 it should return empty string",
+			releaseVersion: semver.MustParse("4.20.0"),
+			component:      "cluster-capi-controllers",
+			provider: &mockReleaseProvider{
+				components: map[string]string{
+					"cluster-capi-controllers": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc123",
+				},
+			},
+			expectedImage: "",
+			expectError:   false,
+		},
+		{
+			name:           "When version is exactly 4.21.0-0 it should return the pinned image",
+			releaseVersion: semver.MustParse("4.21.0-0"),
+			component:      "cluster-capi-controllers",
+			provider: &mockReleaseProvider{
+				components: map[string]string{
+					"cluster-capi-controllers": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc123",
+				},
+			},
+			expectedImage: "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc123",
+			expectError:   false,
+		},
+		{
+			name:           "When version is above 4.21.0 it should return the pinned image",
+			releaseVersion: semver.MustParse("4.22.0"),
+			component:      "aws-cluster-api-controllers",
+			provider: &mockReleaseProvider{
+				components: map[string]string{
+					"aws-cluster-api-controllers": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:def456",
+				},
+			},
+			expectedImage: "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:def456",
+			expectError:   false,
+		},
+		{
+			name:           "When provider returns error it should propagate the error",
+			releaseVersion: semver.MustParse("4.21.0"),
+			component:      "cluster-capi-controllers",
+			provider: &mockReleaseProvider{
+				err: fmt.Errorf("lookup failed"),
+			},
+			expectedImage: "",
+			expectError:   true,
+		},
+		{
+			name:           "When component does not exist it should return error",
+			releaseVersion: semver.MustParse("4.21.0"),
+			component:      "nonexistent-component",
+			provider: &mockReleaseProvider{
+				components: map[string]string{
+					"cluster-capi-controllers": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc123",
+				},
+			},
+			expectedImage: "",
+			expectError:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			pullSecret := []byte(`{"auths":{}}`)
+
+			image, err := GetBackwardCompatibleCAPIImage(ctx, pullSecret, tt.provider, tt.releaseVersion, tt.component)
+			if tt.expectError && err == nil {
+				t.Errorf("GetBackwardCompatibleCAPIImage() expected error but got none")
+				return
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("GetBackwardCompatibleCAPIImage() unexpected error: %v", err)
+				return
+			}
+			if image != tt.expectedImage {
+				t.Errorf("GetBackwardCompatibleCAPIImage() = %q, want %q", image, tt.expectedImage)
+			}
 		})
 	}
 }

--- a/support/util/imagemetadata.go
+++ b/support/util/imagemetadata.go
@@ -118,7 +118,6 @@ type RegistryClientImageMetadataProvider struct {
 // The ICSPs/IDMSs are checked first for overrides and then the cache is checked using the image
 // pull spec. If not found in the cache, the manifest is looked up and added to the cache.
 func (r *RegistryClientImageMetadataProvider) ImageMetadata(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, error) {
-
 	parsedImageRef, err := reference.Parse(imageRef)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse image reference %q: %w", imageRef, err)
@@ -159,7 +158,6 @@ func (r *RegistryClientImageMetadataProvider) ImageMetadata(ctx context.Context,
 
 // GetOverride returns the image reference override based on the source/mirrors in the ICSPs/IDMSs
 func (r *RegistryClientImageMetadataProvider) GetOverride(ctx context.Context, imageRef string, pullSecret []byte) (*reference.DockerImageReference, error) {
-
 	var (
 		ref            *reference.DockerImageReference
 		parsedImageRef reference.DockerImageReference
@@ -177,7 +175,6 @@ func (r *RegistryClientImageMetadataProvider) GetOverride(ctx context.Context, i
 }
 
 func (r *RegistryClientImageMetadataProvider) GetDigest(ctx context.Context, imageRef string, pullSecret []byte) (digest.Digest, *reference.DockerImageReference, error) {
-
 	var (
 		repo           distribution.Repository
 		ref            *reference.DockerImageReference
@@ -245,7 +242,6 @@ func (r *RegistryClientImageMetadataProvider) GetDigest(ctx context.Context, ima
 // The ICSPs/IDMSs are checked first for overrides and then the cache is checked using the image
 // pull spec. If not found in the cache, the manifest is looked up and added to the cache.
 func (r *RegistryClientImageMetadataProvider) GetManifest(ctx context.Context, imageRef string, pullSecret []byte) (distribution.Manifest, error) {
-
 	parsedImageRef, err := reference.Parse(imageRef)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse image reference %q: %w", imageRef, err)
@@ -272,7 +268,6 @@ func (r *RegistryClientImageMetadataProvider) GetManifest(ctx context.Context, i
 }
 
 func (r *RegistryClientImageMetadataProvider) GetMetadata(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, []distribution.Descriptor, distribution.BlobStore, error) {
-
 	var (
 		ref            *reference.DockerImageReference
 		parsedImageRef reference.DockerImageReference
@@ -486,7 +481,11 @@ func GetRegistryOverrides(ctx context.Context, ref reference.DockerImageReferenc
 }
 
 func GetPayloadImage(ctx context.Context, releaseImageProvider releaseinfo.Provider, hc *hyperv1.HostedCluster, component string, pullSecret []byte) (string, error) {
-	releaseImage, err := releaseImageProvider.Lookup(ctx, HCControlPlaneReleaseImage(hc), pullSecret)
+	return GetPayloadImageFromRelease(ctx, releaseImageProvider, HCControlPlaneReleaseImage(hc), component, pullSecret)
+}
+
+func GetPayloadImageFromRelease(ctx context.Context, releaseImageProvider releaseinfo.Provider, release string, component string, pullSecret []byte) (string, error) {
+	releaseImage, err := releaseImageProvider.Lookup(ctx, release, pullSecret)
 	if err != nil {
 		return "", fmt.Errorf("failed to lookup release image: %w", err)
 	}


### PR DESCRIPTION
## What this PR does / why we need it:
The current behavior of the CAPI image overrides is not aware of registry configuration and does not apply it, causing CAPI images to be downloaded from quay.io even if a different registry is configured.

To fix the issue:
- CAPI image overrides now apply registry overrides by using the registry Provider instead of being hardcoded.
- the override version has been pinned to 4.20.10 instead of a hash.
- Moved all the logic to the `support/backwardscompat` package for better isolation and future cleanup.

## Which issue(s) this PR fixes:
Fixes [OCPBUGS-74247](https://issues.redhat.com/browse/OCPBUGS-74247)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.