### PR TITLE
WIP: Add configsync condition

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -215,6 +215,12 @@ const (
 	// firewall rules, missing data plane nodes, or problems with infrastructure
 	// components like the konnectivity-agent workload.
 	DataPlaneConnectionAvailable ConditionType = "DataPlaneConnectionAvailable"
+
+	// HostedClusterConfigSynced indicates whether the hosted cluster configuration
+	// (Infrastructure, DNS, Ingress, Network, etc.) is successfully synced to the guest cluster.
+	// **True** means all configuration resources are successfully synced.
+	// **False** means one or more configuration resources failed to sync.
+	HostedClusterConfigSynced ConditionType = "HostedClusterConfigSynced"
 )
 
 // Reasons.
@@ -279,6 +285,14 @@ const (
 	DataPlaneConnectionLogsAccessFailedReason = "LogsAccessFailed"
 
 	DataPlaneConnectionNoWorkerNodesAvailableReason = "NoWorkerNodesAvailable"
+
+	// HostedClusterConfigSynced reasons
+	ConfigSyncedReason             = "ConfigSynced"
+	InfrastructureSyncFailedReason = "InfrastructureSyncFailed"
+	DNSSyncFailedReason            = "DNSSyncFailed"
+	IngressSyncFailedReason        = "IngressSyncFailed"
+	NetworkSyncFailedReason        = "NetworkSyncFailed"
+	MultipleConfigSyncFailedReason = "MultipleConfigSyncFailed"
 )
 
 // Messages.

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/config_sync_errors.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/config_sync_errors.go
@@ -1,0 +1,113 @@
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+)
+
+// ConfigSyncErrorType represents the type of config that failed to sync.
+type ConfigSyncErrorType string
+
+const (
+	ConfigSyncErrorInfrastructure ConfigSyncErrorType = "Infrastructure"
+	ConfigSyncErrorDNS            ConfigSyncErrorType = "DNS"
+	ConfigSyncErrorIngress        ConfigSyncErrorType = "Ingress"
+	ConfigSyncErrorNetwork        ConfigSyncErrorType = "Network"
+	ConfigSyncErrorImage          ConfigSyncErrorType = "Image"
+	ConfigSyncErrorProxy          ConfigSyncErrorType = "Proxy"
+	ConfigSyncErrorAuthentication ConfigSyncErrorType = "Authentication"
+	ConfigSyncErrorAPIServer      ConfigSyncErrorType = "APIServer"
+	ConfigSyncErrorOther          ConfigSyncErrorType = "Other"
+)
+
+// ConfigSyncError represents an error that occurred during config sync.
+type ConfigSyncError struct {
+	Type    ConfigSyncErrorType
+	Message string
+	Err     error
+}
+
+func (e *ConfigSyncError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("%s: %s: %v", e.Type, e.Message, e.Err)
+	}
+	return fmt.Sprintf("%s: %s", e.Type, e.Message)
+}
+
+func (e *ConfigSyncError) Unwrap() error {
+	return e.Err
+}
+
+// ConfigSyncErrors is a collection of ConfigSyncError that occurred during reconciliation.
+type ConfigSyncErrors struct {
+	Errors []*ConfigSyncError
+}
+
+func (e *ConfigSyncErrors) Error() string {
+	if len(e.Errors) == 0 {
+		return ""
+	}
+	if len(e.Errors) == 1 {
+		return e.Errors[0].Error()
+	}
+	var msgs []string
+	for _, err := range e.Errors {
+		msgs = append(msgs, err.Error())
+	}
+	return fmt.Sprintf("multiple config sync errors: [%s]", strings.Join(msgs, "; "))
+}
+
+func (e *ConfigSyncErrors) Add(errType ConfigSyncErrorType, message string, err error) {
+	e.Errors = append(e.Errors, &ConfigSyncError{
+		Type:    errType,
+		Message: message,
+		Err:     err,
+	})
+}
+
+func (e *ConfigSyncErrors) HasErrors() bool {
+	return len(e.Errors) > 0
+}
+
+// ToError returns nil if no errors, or the ConfigSyncErrors if there are errors.
+func (e *ConfigSyncErrors) ToError() error {
+	if !e.HasErrors() {
+		return nil
+	}
+	return e
+}
+
+// determineConfigSyncReason analyzes the error from reconcileConfig and returns
+// the appropriate reason for the HostedClusterConfigSynced condition.
+func determineConfigSyncReason(err error) string {
+	if err == nil {
+		return hyperv1.ConfigSyncedReason
+	}
+
+	var configErrs *ConfigSyncErrors
+	if errors.As(err, &configErrs) {
+		if len(configErrs.Errors) > 1 {
+			return hyperv1.MultipleConfigSyncFailedReason
+		}
+		if len(configErrs.Errors) == 1 {
+			switch configErrs.Errors[0].Type {
+			case ConfigSyncErrorInfrastructure:
+				return hyperv1.InfrastructureSyncFailedReason
+			case ConfigSyncErrorDNS:
+				return hyperv1.DNSSyncFailedReason
+			case ConfigSyncErrorIngress:
+				return hyperv1.IngressSyncFailedReason
+			case ConfigSyncErrorNetwork:
+				return hyperv1.NetworkSyncFailedReason
+			default:
+				return hyperv1.ReconcileErrorReason
+			}
+		}
+	}
+
+	// Fallback for non-typed errors
+	return hyperv1.ReconcileErrorReason
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/config_sync_errors_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/config_sync_errors_test.go
@@ -1,0 +1,286 @@
+package resources
+
+import (
+	"errors"
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+)
+
+func TestConfigSyncError_Error(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *ConfigSyncError
+		expected string
+	}{
+		{
+			name: "When error has wrapped error it should include it in message",
+			err: &ConfigSyncError{
+				Type:    ConfigSyncErrorInfrastructure,
+				Message: "failed to update",
+				Err:     errors.New("CEL validation failed"),
+			},
+			expected: "Infrastructure: failed to update: CEL validation failed",
+		},
+		{
+			name: "When error has no wrapped error it should show type and message only",
+			err: &ConfigSyncError{
+				Type:    ConfigSyncErrorDNS,
+				Message: "DNS config invalid",
+				Err:     nil,
+			},
+			expected: "DNS: DNS config invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.expected {
+				t.Errorf("ConfigSyncError.Error() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConfigSyncError_Unwrap(t *testing.T) {
+	t.Run("When error has wrapped error it should return it", func(t *testing.T) {
+		wrappedErr := errors.New("underlying error")
+		err := &ConfigSyncError{
+			Type:    ConfigSyncErrorNetwork,
+			Message: "network sync failed",
+			Err:     wrappedErr,
+		}
+
+		if got := err.Unwrap(); got != wrappedErr {
+			t.Errorf("ConfigSyncError.Unwrap() = %v, want %v", got, wrappedErr)
+		}
+	})
+
+	t.Run("When error has no wrapped error it should return nil", func(t *testing.T) {
+		err := &ConfigSyncError{
+			Type:    ConfigSyncErrorNetwork,
+			Message: "network sync failed",
+			Err:     nil,
+		}
+
+		if got := err.Unwrap(); got != nil {
+			t.Errorf("ConfigSyncError.Unwrap() = %v, want nil", got)
+		}
+	})
+}
+
+func TestConfigSyncErrors_Error(t *testing.T) {
+	tests := []struct {
+		name     string
+		errs     *ConfigSyncErrors
+		expected string
+	}{
+		{
+			name:     "When no errors it should return empty string",
+			errs:     &ConfigSyncErrors{},
+			expected: "",
+		},
+		{
+			name: "When single error it should return that error's message",
+			errs: &ConfigSyncErrors{
+				Errors: []*ConfigSyncError{
+					{Type: ConfigSyncErrorInfrastructure, Message: "infra failed"},
+				},
+			},
+			expected: "Infrastructure: infra failed",
+		},
+		{
+			name: "When multiple errors it should combine them",
+			errs: &ConfigSyncErrors{
+				Errors: []*ConfigSyncError{
+					{Type: ConfigSyncErrorInfrastructure, Message: "infra failed"},
+					{Type: ConfigSyncErrorDNS, Message: "dns failed"},
+				},
+			},
+			expected: "multiple config sync errors: [Infrastructure: infra failed; DNS: dns failed]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.errs.Error(); got != tt.expected {
+				t.Errorf("ConfigSyncErrors.Error() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConfigSyncErrors_Add(t *testing.T) {
+	t.Run("When adding errors it should accumulate them", func(t *testing.T) {
+		errs := &ConfigSyncErrors{}
+
+		errs.Add(ConfigSyncErrorInfrastructure, "infra failed", nil)
+		if len(errs.Errors) != 1 {
+			t.Errorf("Expected 1 error, got %d", len(errs.Errors))
+		}
+
+		errs.Add(ConfigSyncErrorDNS, "dns failed", errors.New("underlying"))
+		if len(errs.Errors) != 2 {
+			t.Errorf("Expected 2 errors, got %d", len(errs.Errors))
+		}
+
+		if errs.Errors[0].Type != ConfigSyncErrorInfrastructure {
+			t.Errorf("First error type = %s, want %s", errs.Errors[0].Type, ConfigSyncErrorInfrastructure)
+		}
+		if errs.Errors[1].Type != ConfigSyncErrorDNS {
+			t.Errorf("Second error type = %s, want %s", errs.Errors[1].Type, ConfigSyncErrorDNS)
+		}
+	})
+}
+
+func TestConfigSyncErrors_HasErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		errs     *ConfigSyncErrors
+		expected bool
+	}{
+		{
+			name:     "When no errors it should return false",
+			errs:     &ConfigSyncErrors{},
+			expected: false,
+		},
+		{
+			name: "When has errors it should return true",
+			errs: &ConfigSyncErrors{
+				Errors: []*ConfigSyncError{
+					{Type: ConfigSyncErrorInfrastructure, Message: "failed"},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.errs.HasErrors(); got != tt.expected {
+				t.Errorf("ConfigSyncErrors.HasErrors() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConfigSyncErrors_ToError(t *testing.T) {
+	t.Run("When no errors it should return nil", func(t *testing.T) {
+		errs := &ConfigSyncErrors{}
+		if got := errs.ToError(); got != nil {
+			t.Errorf("ConfigSyncErrors.ToError() = %v, want nil", got)
+		}
+	})
+
+	t.Run("When has errors it should return self", func(t *testing.T) {
+		errs := &ConfigSyncErrors{
+			Errors: []*ConfigSyncError{
+				{Type: ConfigSyncErrorInfrastructure, Message: "failed"},
+			},
+		}
+		got := errs.ToError()
+		if got != errs {
+			t.Errorf("ConfigSyncErrors.ToError() should return self")
+		}
+	})
+}
+
+func TestDetermineConfigSyncReason(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{
+			name:     "When nil error it should return ConfigSyncedReason",
+			err:      nil,
+			expected: hyperv1.ConfigSyncedReason,
+		},
+		{
+			name: "When single infrastructure error it should return InfrastructureSyncFailedReason",
+			err: &ConfigSyncErrors{
+				Errors: []*ConfigSyncError{
+					{Type: ConfigSyncErrorInfrastructure, Message: "failed"},
+				},
+			},
+			expected: hyperv1.InfrastructureSyncFailedReason,
+		},
+		{
+			name: "When single DNS error it should return DNSSyncFailedReason",
+			err: &ConfigSyncErrors{
+				Errors: []*ConfigSyncError{
+					{Type: ConfigSyncErrorDNS, Message: "failed"},
+				},
+			},
+			expected: hyperv1.DNSSyncFailedReason,
+		},
+		{
+			name: "When single Ingress error it should return IngressSyncFailedReason",
+			err: &ConfigSyncErrors{
+				Errors: []*ConfigSyncError{
+					{Type: ConfigSyncErrorIngress, Message: "failed"},
+				},
+			},
+			expected: hyperv1.IngressSyncFailedReason,
+		},
+		{
+			name: "When single Network error it should return NetworkSyncFailedReason",
+			err: &ConfigSyncErrors{
+				Errors: []*ConfigSyncError{
+					{Type: ConfigSyncErrorNetwork, Message: "failed"},
+				},
+			},
+			expected: hyperv1.NetworkSyncFailedReason,
+		},
+		{
+			name: "When single Other error it should return ReconcileErrorReason",
+			err: &ConfigSyncErrors{
+				Errors: []*ConfigSyncError{
+					{Type: ConfigSyncErrorOther, Message: "failed"},
+				},
+			},
+			expected: hyperv1.ReconcileErrorReason,
+		},
+		{
+			name: "When multiple errors it should return MultipleConfigSyncFailedReason",
+			err: &ConfigSyncErrors{
+				Errors: []*ConfigSyncError{
+					{Type: ConfigSyncErrorInfrastructure, Message: "infra failed"},
+					{Type: ConfigSyncErrorDNS, Message: "dns failed"},
+				},
+			},
+			expected: hyperv1.MultipleConfigSyncFailedReason,
+		},
+		{
+			name:     "When non-ConfigSyncErrors error it should return ReconcileErrorReason",
+			err:      errors.New("some random error"),
+			expected: hyperv1.ReconcileErrorReason,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := determineConfigSyncReason(tt.err); got != tt.expected {
+				t.Errorf("determineConfigSyncReason() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConfigSyncErrors_ErrorsAs(t *testing.T) {
+	t.Run("When using errors.As it should unwrap ConfigSyncErrors", func(t *testing.T) {
+		original := &ConfigSyncErrors{
+			Errors: []*ConfigSyncError{
+				{Type: ConfigSyncErrorInfrastructure, Message: "failed"},
+			},
+		}
+
+		var target *ConfigSyncErrors
+		if !errors.As(original, &target) {
+			t.Error("errors.As should return true for ConfigSyncErrors")
+		}
+		if target != original {
+			t.Error("errors.As should set target to original")
+		}
+	})
+}

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1899,7 +1899,7 @@ addition to any security groups specified in the NodePool.</p>
 ###AWSResourceReference { #hypershift.openshift.io/v1beta1.AWSResourceReference }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.AWSCloudProviderConfig">AWSCloudProviderConfig</a>, 
+<a href="#hypershift.openshift.io/v1beta1.AWSCloudProviderConfig">AWSCloudProviderConfig</a>,
 <a href="#hypershift.openshift.io/v1beta1.AWSNodePoolPlatform">AWSNodePoolPlatform</a>)
 </p>
 <p>
@@ -1948,7 +1948,7 @@ They are applied according to the rules defined by the AWS API:
 ###AWSResourceTag { #hypershift.openshift.io/v1beta1.AWSResourceTag }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.AWSNodePoolPlatform">AWSNodePoolPlatform</a>, 
+<a href="#hypershift.openshift.io/v1beta1.AWSNodePoolPlatform">AWSNodePoolPlatform</a>,
 <a href="#hypershift.openshift.io/v1beta1.AWSPlatformSpec">AWSPlatformSpec</a>)
 </p>
 <p>
@@ -2843,7 +2843,7 @@ string
 ###AutoNode { #hypershift.openshift.io/v1beta1.AutoNode }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -2875,7 +2875,7 @@ ProvisionerConfig
 ###AvailabilityPolicy { #hypershift.openshift.io/v1beta1.AvailabilityPolicy }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -3000,7 +3000,7 @@ This is only valid for self-managed Azure.</p>
 ###AzureClientID { #hypershift.openshift.io/v1beta1.AzureClientID }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.ManagedIdentity">ManagedIdentity</a>, 
+<a href="#hypershift.openshift.io/v1beta1.ManagedIdentity">ManagedIdentity</a>,
 <a href="#hypershift.openshift.io/v1beta1.WorkloadIdentity">WorkloadIdentity</a>)
 </p>
 <p>
@@ -3952,7 +3952,7 @@ workload identity authentication.</p>
 ###Capabilities { #hypershift.openshift.io/v1beta1.Capabilities }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -4122,7 +4122,7 @@ of an instance</p>
 ###ClusterAutoscaling { #hypershift.openshift.io/v1beta1.ClusterAutoscaling }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -4297,7 +4297,7 @@ Maximum of 3 expanders can be specified.</p>
 ###ClusterConfiguration { #hypershift.openshift.io/v1beta1.ClusterConfiguration }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -4577,7 +4577,7 @@ This is only consumed when NetworkType is OVNKubernetes.</p>
 ###ClusterNetworking { #hypershift.openshift.io/v1beta1.ClusterNetworking }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -4737,7 +4737,7 @@ Defaults to &ldquo;Normal&rdquo;.</p>
 ###ClusterVersionStatus { #hypershift.openshift.io/v1beta1.ClusterVersionStatus }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterStatus">HostedClusterStatus</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterStatus">HostedClusterStatus</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneStatus">HostedControlPlaneStatus</a>)
 </p>
 <p>
@@ -5005,6 +5005,12 @@ has been created for the specified Internal Load Balancer in the management VPC<
 control plane.
 When this is false for too long and there&rsquo;s no clear indication in the &ldquo;Reason&rdquo;, please check the remaining more granular conditions.</p>
 </td>
+</tr><tr><td><p>&#34;HostedClusterConfigSynced&#34;</p></td>
+<td><p>HostedClusterConfigSynced indicates whether the hosted cluster configuration
+(Infrastructure, DNS, Ingress, Network, etc.) is successfully synced to the guest cluster.
+<strong>True</strong> means all configuration resources are successfully synced.
+<strong>False</strong> means one or more configuration resources failed to sync.</p>
+</td>
 </tr><tr><td><p>&#34;Degraded&#34;</p></td>
 <td><p>HostedClusterDegraded indicates whether the HostedCluster is encountering
 an error that may require user intervention to resolve.</p>
@@ -5156,7 +5162,7 @@ and reports missing images if any.</p>
 ###ConfigurationStatus { #hypershift.openshift.io/v1beta1.ConfigurationStatus }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterStatus">HostedClusterStatus</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterStatus">HostedClusterStatus</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneStatus">HostedControlPlaneStatus</a>)
 </p>
 <p>
@@ -5464,7 +5470,7 @@ ManagedIdentity
 ###DNSSpec { #hypershift.openshift.io/v1beta1.DNSSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -5667,7 +5673,7 @@ and the user is responsible for doing so.</p>
 ###EtcdSpec { #hypershift.openshift.io/v1beta1.EtcdSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -5831,8 +5837,8 @@ string
 ###FilterByNeutronTags { #hypershift.openshift.io/v1beta1.FilterByNeutronTags }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.NetworkFilter">NetworkFilter</a>, 
-<a href="#hypershift.openshift.io/v1beta1.RouterFilter">RouterFilter</a>, 
+<a href="#hypershift.openshift.io/v1beta1.NetworkFilter">NetworkFilter</a>,
+<a href="#hypershift.openshift.io/v1beta1.RouterFilter">RouterFilter</a>,
 <a href="#hypershift.openshift.io/v1beta1.SubnetFilter">SubnetFilter</a>)
 </p>
 <p>
@@ -8257,7 +8263,7 @@ call IBM Cloud KMS APIs</p>
 ###IBMCloudPlatformSpec { #hypershift.openshift.io/v1beta1.IBMCloudPlatformSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.NodePoolPlatform">NodePoolPlatform</a>, 
+<a href="#hypershift.openshift.io/v1beta1.NodePoolPlatform">NodePoolPlatform</a>,
 <a href="#hypershift.openshift.io/v1beta1.PlatformSpec">PlatformSpec</a>)
 </p>
 <p>
@@ -8290,7 +8296,7 @@ github.com/openshift/api/config/v1.IBMCloudProviderType
 ###ImageContentSource { #hypershift.openshift.io/v1beta1.ImageContentSource }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -9136,7 +9142,7 @@ Value of Filesystem is implied when not included in claim spec.</p>
 ###KubevirtPlatformCredentials { #hypershift.openshift.io/v1beta1.KubevirtPlatformCredentials }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.KubeVirtNodePoolStatus">KubeVirtNodePoolStatus</a>, 
+<a href="#hypershift.openshift.io/v1beta1.KubeVirtNodePoolStatus">KubeVirtNodePoolStatus</a>,
 <a href="#hypershift.openshift.io/v1beta1.KubevirtPlatformSpec">KubevirtPlatformSpec</a>)
 </p>
 <p>
@@ -9809,7 +9815,7 @@ is empty.</p>
 ###ManagedIdentity { #hypershift.openshift.io/v1beta1.ManagedIdentity }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.AzureKMSSpec">AzureKMSSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.AzureKMSSpec">AzureKMSSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.ControlPlaneManagedIdentities">ControlPlaneManagedIdentities</a>)
 </p>
 <p>
@@ -9993,7 +9999,7 @@ FilterByNeutronTags
 ###NetworkParam { #hypershift.openshift.io/v1beta1.NetworkParam }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.OpenStackPlatformSpec">OpenStackPlatformSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.OpenStackPlatformSpec">OpenStackPlatformSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.PortSpec">PortSpec</a>)
 </p>
 <p>
@@ -10838,7 +10844,7 @@ assigned when the service is created.</p>
 ###OLMCatalogPlacement { #hypershift.openshift.io/v1beta1.OLMCatalogPlacement }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -11262,7 +11268,7 @@ This value must be a valid IPv4 or IPv6 address.</p>
 ###OperatorConfiguration { #hypershift.openshift.io/v1beta1.OperatorConfiguration }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -11488,7 +11494,7 @@ do not support Capacity Reservations. Compatible with &ldquo;default&rdquo; and 
 ###PlatformSpec { #hypershift.openshift.io/v1beta1.PlatformSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -11634,7 +11640,7 @@ GCPPlatformSpec
 ###PlatformStatus { #hypershift.openshift.io/v1beta1.PlatformStatus }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterStatus">HostedClusterStatus</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterStatus">HostedClusterStatus</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneStatus">HostedControlPlaneStatus</a>)
 </p>
 <p>
@@ -11667,8 +11673,8 @@ AWSPlatformStatus
 ###PlatformType { #hypershift.openshift.io/v1beta1.PlatformType }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.KarpenterConfig">KarpenterConfig</a>, 
-<a href="#hypershift.openshift.io/v1beta1.NodePoolPlatform">NodePoolPlatform</a>, 
+<a href="#hypershift.openshift.io/v1beta1.KarpenterConfig">KarpenterConfig</a>,
+<a href="#hypershift.openshift.io/v1beta1.NodePoolPlatform">NodePoolPlatform</a>,
 <a href="#hypershift.openshift.io/v1beta1.PlatformSpec">PlatformSpec</a>)
 </p>
 <p>
@@ -12232,7 +12238,7 @@ credentials for image registry operator to get authenticated with ibm cloud.</p>
 ###PowerVSResourceReference { #hypershift.openshift.io/v1beta1.PowerVSResourceReference }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.PowerVSNodePoolPlatform">PowerVSNodePoolPlatform</a>, 
+<a href="#hypershift.openshift.io/v1beta1.PowerVSNodePoolPlatform">PowerVSNodePoolPlatform</a>,
 <a href="#hypershift.openshift.io/v1beta1.PowerVSPlatformSpec">PowerVSPlatformSpec</a>)
 </p>
 <p>
@@ -12440,7 +12446,7 @@ KarpenterConfig
 ###Release { #hypershift.openshift.io/v1beta1.Release }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.NodePoolSpec">NodePoolSpec</a>)
 </p>
 <p>
@@ -12874,7 +12880,7 @@ When omitted, the autoscaler defaults to 50%.</p>
 ###SecretEncryptionSpec { #hypershift.openshift.io/v1beta1.SecretEncryptionSpec }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>
@@ -13063,7 +13069,7 @@ The specifics of the setup are platform dependent.</p>
 ###ServicePublishingStrategyMapping { #hypershift.openshift.io/v1beta1.ServicePublishingStrategyMapping }
 <p>
 (<em>Appears on:</em>
-<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>, 
+<a href="#hypershift.openshift.io/v1beta1.HostedClusterSpec">HostedClusterSpec</a>,
 <a href="#hypershift.openshift.io/v1beta1.HostedControlPlaneSpec">HostedControlPlaneSpec</a>)
 </p>
 <p>

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -827,6 +827,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 			hyperv1.ValidIDPConfiguration,
 			hyperv1.HostedClusterRestoredFromBackup,
 			hyperv1.DataPlaneConnectionAvailable,
+			hyperv1.HostedClusterConfigSynced,
 		}
 
 		for _, conditionType := range hcpConditions {

--- a/support/conditions/conditions.go
+++ b/support/conditions/conditions.go
@@ -28,6 +28,7 @@ func ExpectedHCConditions(hostedCluster *hyperv1.HostedCluster) map[hyperv1.Cond
 		hyperv1.ValidReleaseImage:                    metav1.ConditionTrue,
 		hyperv1.PlatformCredentialsFound:             metav1.ConditionTrue,
 		hyperv1.DataPlaneConnectionAvailable:         metav1.ConditionTrue,
+		hyperv1.HostedClusterConfigSynced:            metav1.ConditionTrue,
 
 		hyperv1.HostedClusterProgressing:  metav1.ConditionFalse,
 		hyperv1.HostedClusterDegraded:     metav1.ConditionFalse,

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -2934,6 +2934,10 @@ func ValidateHostedClusterConditions(t *testing.T, ctx context.Context, client c
 		delete(expectedConditions, hyperv1.DataPlaneConnectionAvailable)
 	}
 
+	if IsLessThan(Version422) {
+		delete(expectedConditions, hyperv1.HostedClusterConfigSynced)
+	}
+
 	var predicates []Predicate[*hyperv1.HostedCluster]
 	for conditionType, conditionStatus := range expectedConditions {
 		predicates = append(predicates, ConditionPredicate[*hyperv1.HostedCluster](Condition{


### PR DESCRIPTION
> [!Warning]
> Very rough code that I didn't thoroughly review.

## What this PR does / why we need it:

Adds a new `HostedClusterConfigSynced` condition to surface HCCO config sync errors to users.

When `reconcileConfig` fails, the error is now visible via a condition on HCP/HC instead of failing silently with infinite retries.

## Which issue(s) this PR fixes:

Fixes <!-- add Jira ticket if applicable -->

## Special notes for your reviewer:

- Uses typed errors (`ConfigSyncError`, `ConfigSyncErrors`) to determine failure reason
- Condition reasons: `InfrastructureSyncFailed`, `DNSSyncFailed`, `IngressSyncFailed`, `NetworkSyncFailed`, `MultipleConfigSyncFailed`
- Condition added to expected e2e conditions with a version guardrail for clusters < 4.22

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.
