### PR TITLE
AUTOSCALE-535: default block device mappings

### DIFF
--- a/api/karpenter/v1beta1/karpenter_types.go
+++ b/api/karpenter/v1beta1/karpenter_types.go
@@ -94,6 +94,7 @@ type OpenshiftEC2NodeClassSpec struct {
 	Tags map[string]string `json:"tags,omitempty"`
 
 	// BlockDeviceMappings to be applied to provisioned nodes.
+	// For OpenShift nodes, a default root volume size of 120Gi and type gp3 is set if no blockDeviceMapping overrides are specified.
 	// +kubebuilder:validation:XValidation:message="must have only one blockDeviceMappings with rootVolume",rule="self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1"
 	// +kubebuilder:validation:MaxItems:=50
 	// +optional

--- a/karpenter-operator/controllers/karpenter/assets/karpenter.hypershift.openshift.io_openshiftec2nodeclasses.yaml
+++ b/karpenter-operator/controllers/karpenter/assets/karpenter.hypershift.openshift.io_openshiftec2nodeclasses.yaml
@@ -53,7 +53,9 @@ spec:
                   are assigned to instances that are launched with the nodeclass.
                 type: boolean
               blockDeviceMappings:
-                description: BlockDeviceMappings to be applied to provisioned nodes.
+                description: |-
+                  BlockDeviceMappings to be applied to provisioned nodes.
+                  For OpenShift nodes, a default root volume size of 120Gi and type gp3 is set if no blockDeviceMapping overrides are specified.
                 items:
                   properties:
                     deviceName:

--- a/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller_test.go
+++ b/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller_test.go
@@ -68,6 +68,16 @@ func TestReconcileEC2NodeClass(t *testing.T) {
 						},
 					},
 				},
+				BlockDeviceMappings: []*awskarpenterv1.BlockDeviceMapping{
+					{
+						DeviceName: ptr.To("/dev/xvda"),
+						EBS: &awskarpenterv1.BlockDevice{
+							VolumeSize: ptr.To(resource.MustParse("120Gi")),
+							VolumeType: ptr.To("gp3"),
+							Encrypted:  ptr.To(true),
+						},
+					},
+				},
 			},
 		},
 		{
@@ -167,6 +177,16 @@ func TestReconcileEC2NodeClass(t *testing.T) {
 						},
 					},
 				},
+				BlockDeviceMappings: []*awskarpenterv1.BlockDeviceMapping{
+					{
+						DeviceName: ptr.To("/dev/xvda"),
+						EBS: &awskarpenterv1.BlockDevice{
+							VolumeSize: ptr.To(resource.MustParse("120Gi")),
+							VolumeType: ptr.To("gp3"),
+							Encrypted:  ptr.To(true),
+						},
+					},
+				},
 				InstanceProfile: ptr.To("test-instance-profile"),
 			},
 		},
@@ -198,6 +218,16 @@ func TestReconcileEC2NodeClass(t *testing.T) {
 						},
 					},
 				},
+				BlockDeviceMappings: []*awskarpenterv1.BlockDeviceMapping{
+					{
+						DeviceName: ptr.To("/dev/xvda"),
+						EBS: &awskarpenterv1.BlockDevice{
+							VolumeSize: ptr.To(resource.MustParse("120Gi")),
+							VolumeType: ptr.To("gp3"),
+							Encrypted:  ptr.To(true),
+						},
+					},
+				},
 			},
 		},
 		{
@@ -215,6 +245,16 @@ func TestReconcileEC2NodeClass(t *testing.T) {
 					{
 						Tags: map[string]string{
 							"karpenter.sh/discovery": testInfraID,
+						},
+					},
+				},
+				BlockDeviceMappings: []*awskarpenterv1.BlockDeviceMapping{
+					{
+						DeviceName: ptr.To("/dev/xvda"),
+						EBS: &awskarpenterv1.BlockDevice{
+							VolumeSize: ptr.To(resource.MustParse("120Gi")),
+							VolumeType: ptr.To("gp3"),
+							Encrypted:  ptr.To(true),
 						},
 					},
 				},
@@ -263,6 +303,16 @@ func TestReconcileEC2NodeClass(t *testing.T) {
 					"red-hat-managed":     "true",
 					"red-hat-clustertype": "rosa",
 				},
+				BlockDeviceMappings: []*awskarpenterv1.BlockDeviceMapping{
+					{
+						DeviceName: ptr.To("/dev/xvda"),
+						EBS: &awskarpenterv1.BlockDevice{
+							VolumeSize: ptr.To(resource.MustParse("120Gi")),
+							VolumeType: ptr.To("gp3"),
+							Encrypted:  ptr.To(true),
+						},
+					},
+				},
 			},
 		},
 		{
@@ -305,6 +355,16 @@ func TestReconcileEC2NodeClass(t *testing.T) {
 					"red-hat-clustertype": "rosa",            // Platform tag won over nodeclass tag
 					"red-hat-managed":     "true",            // Platform tag added
 					"nodeclass-only-tag":  "nodeclass-value", // Nodeclass tag preserved
+				},
+				BlockDeviceMappings: []*awskarpenterv1.BlockDeviceMapping{
+					{
+						DeviceName: ptr.To("/dev/xvda"),
+						EBS: &awskarpenterv1.BlockDevice{
+							VolumeSize: ptr.To(resource.MustParse("120Gi")),
+							VolumeType: ptr.To("gp3"),
+							Encrypted:  ptr.To(true),
+						},
+					},
 				},
 			},
 		},

--- a/vendor/github.com/openshift/hypershift/api/karpenter/v1beta1/karpenter_types.go
+++ b/vendor/github.com/openshift/hypershift/api/karpenter/v1beta1/karpenter_types.go
@@ -94,6 +94,7 @@ type OpenshiftEC2NodeClassSpec struct {
 	Tags map[string]string `json:"tags,omitempty"`
 
 	// BlockDeviceMappings to be applied to provisioned nodes.
+	// For OpenShift nodes, a default root volume size of 120Gi and type gp3 is set if no blockDeviceMapping overrides are specified.
 	// +kubebuilder:validation:XValidation:message="must have only one blockDeviceMappings with rootVolume",rule="self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1"
 	// +kubebuilder:validation:MaxItems:=50
 	// +optional


### PR DESCRIPTION
## What this PR does / why we need it:

Default block device mappings if the user doesn't set them in OpenshiftEC2NodeClass.

We've seen a lot of flakes in the e2e-test-techpreview and e2e-aws-autonode prow jobs where what happens is that nodes churn because of DiskPressure.

I've also seen it in manual smoketesting as well, and to get around this I've created a custom nodeclass with more block device root storage.

## Which issue(s) this PR fixes:
Fixes 

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.