### PR TITLE
NO-JIRA: ci: update build root image to Go 1.25

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.24-openshift-4.22
+  tag: rhel-9-release-golang-1.25-openshift-4.22


### PR DESCRIPTION
## What this PR does / why we need it:

Updates the CI operator build root image to use Go 1.25, bumping from Go 1.24. This keeps the CI environment aligned with the latest Go release.

## Which issue(s) this PR fixes:

N/A - routine CI maintenance

## Special notes for your reviewer:

Simple one-line change to `.ci-operator.yaml` updating the image tag from `rhel-9-release-golang-1.24-openshift-4.22` to `rhel-9-release-golang-1.25-openshift-4.22`.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.