### PR TITLE
NO-JIRA: Fix teardown flag timing in e2e tests

### DIFF
--- a/test/e2e/util/hypershift_framework.go
+++ b/test/e2e/util/hypershift_framework.go
@@ -230,15 +230,18 @@ func (h *hypershiftTest) teardown(hostedCluster *hyperv1.HostedCluster, opts *Pl
 		h.Logf("skipping teardown, already called")
 		return
 	}
-	h.hasBeenTornedDown = true
 
 	// t.Run() is not supported in cleanup phase
 	if cleanupPhase {
+		h.hasBeenTornedDown = true
 		teardownHostedCluster(h.T, context.Background(), hostedCluster, h.client, opts, artifactDir)
 		return
 	}
 
 	h.Run("Teardown", func(t *testing.T) {
+		// Set the flag inside the subtest callback to ensure it's only set
+		// when the subtest actually runs (not filtered out by -test.run)
+		h.hasBeenTornedDown = true
 		teardownHostedCluster(t, h.ctx, hostedCluster, h.client, opts, artifactDir)
 	})
 }


### PR DESCRIPTION
## Summary
- Move the `hasBeenTornedDown` flag assignment inside the subtest callback to ensure it's only set when the teardown subtest actually runs
- Fixes issue where the flag was marked as complete even when the subtest was filtered out by `-test.run` patterns

## Test plan
- [x] Verified the logic change is correct by code review
- [ ] Run e2e tests with filtered test patterns to verify proper cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)