### PR TITLE
CNTRLPLANE-418: fix shared ingress AllowedCIDRs to use fc_src for PROXY protocol

### DIFF
--- a/sharedingress-config-generator/router_config.template
+++ b/sharedingress-config-generator/router_config.template
@@ -31,7 +31,7 @@ frontend dataplane-kas-svc
   {{- range $b := .Backends }}
   acl is_{{ $b.Name }} var(sess.cluster_id) -m str {{ $b.ClusterID }}
   {{- range $cidr := $b.AllowedCIDRs }}
-  acl is_{{ $b.Name }}_request_allowed src {{ $cidr }}
+  acl is_{{ $b.Name }}_request_allowed fc_src {{ $cidr }}
   {{- end }}
   {{- end }}
 
@@ -54,7 +54,7 @@ frontend external-dns
   {{- range $b := .ExternalDNSBackends }}
   acl is_{{ $b.Name }} req_ssl_sni -i {{ $b.HostName }}
   {{- range $cidr := $b.AllowedCIDRs }}
-  acl is_{{ $b.Name }}_request_allowed src {{ $cidr }}
+  acl is_{{ $b.Name }}_request_allowed fc_src {{ $cidr }}
   {{- end }}
   {{- end }}
 

--- a/sharedingress-config-generator/testdata/zz_fixture_TestGenerateConfig_When_there_s_two_HostedClusters_with_all_their_Routes_and_SVCs_it_should_generate_the_config_with_frontends_and_backends_for_both.cfg
+++ b/sharedingress-config-generator/testdata/zz_fixture_TestGenerateConfig_When_there_s_two_HostedClusters_with_all_their_Routes_and_SVCs_it_should_generate_the_config_with_frontends_and_backends_for_both.cfg
@@ -29,8 +29,8 @@ frontend dataplane-kas-svc
   log-format "%{+Q}o\ cluster_id = %[var(sess.cluster_id)], %ci:%cp -> %fi:%fp [%t] %ft %b/%s %Tw/%Tc/%Tt %B %ts %ac/%fc/%bc/%sc/%rc %sq/%bq"
   acl is_test-hc1-kube-apiserver var(sess.cluster_id) -m str hc1-UUID
   acl is_test-hc2-kube-apiserver var(sess.cluster_id) -m str hc2-UUID
-  acl is_test-hc2-kube-apiserver_request_allowed src 1.1.1.1/32
-  acl is_test-hc2-kube-apiserver_request_allowed src 192.168.1.1/24
+  acl is_test-hc2-kube-apiserver_request_allowed fc_src 1.1.1.1/32
+  acl is_test-hc2-kube-apiserver_request_allowed fc_src 192.168.1.1/24
   use_backend test-hc1-kube-apiserver if is_test-hc1-kube-apiserver
   use_backend test-hc2-kube-apiserver if is_test-hc2-kube-apiserver is_test-hc2-kube-apiserver_request_allowed
 
@@ -51,17 +51,17 @@ frontend external-dns
   acl is_test-hc1-oauth req_ssl_sni -i oauth-public.example.com
   acl is_test-hc1-apiserver-custom req_ssl_sni -i kube-apiserver-public-custom.example.com
   acl is_test-hc2-ignition req_ssl_sni -i ignition-server.example.com
-  acl is_test-hc2-ignition_request_allowed src 1.1.1.1/32
-  acl is_test-hc2-ignition_request_allowed src 192.168.1.1/24
+  acl is_test-hc2-ignition_request_allowed fc_src 1.1.1.1/32
+  acl is_test-hc2-ignition_request_allowed fc_src 192.168.1.1/24
   acl is_test-hc2-konnectivity req_ssl_sni -i konnectivity.example.com
-  acl is_test-hc2-konnectivity_request_allowed src 1.1.1.1/32
-  acl is_test-hc2-konnectivity_request_allowed src 192.168.1.1/24
+  acl is_test-hc2-konnectivity_request_allowed fc_src 1.1.1.1/32
+  acl is_test-hc2-konnectivity_request_allowed fc_src 192.168.1.1/24
   acl is_test-hc2-apiserver req_ssl_sni -i kube-apiserver-public.example.com
-  acl is_test-hc2-apiserver_request_allowed src 1.1.1.1/32
-  acl is_test-hc2-apiserver_request_allowed src 192.168.1.1/24
+  acl is_test-hc2-apiserver_request_allowed fc_src 1.1.1.1/32
+  acl is_test-hc2-apiserver_request_allowed fc_src 192.168.1.1/24
   acl is_test-hc2-oauth req_ssl_sni -i oauth-public.example.com
-  acl is_test-hc2-oauth_request_allowed src 1.1.1.1/32
-  acl is_test-hc2-oauth_request_allowed src 192.168.1.1/24
+  acl is_test-hc2-oauth_request_allowed fc_src 1.1.1.1/32
+  acl is_test-hc2-oauth_request_allowed fc_src 192.168.1.1/24
   use_backend test-hc1-ignition if is_test-hc1-ignition
   use_backend test-hc1-konnectivity if is_test-hc1-konnectivity
   use_backend test-hc1-apiserver if is_test-hc1-apiserver


### PR DESCRIPTION
## Summary
- Change the HAProxy AllowedCIDRs ACL to use `fc_src` instead of `src` for checking allowed CIDRs
- When PROXY protocol is enabled (`accept-proxy`), `src` results in the internal IP of the connection rather than the unique outbound IP
- Using `fc_src` results in the unique outbound IP (e.g., Azure LB) which is what should be checked against the allowed CIDRs

## Problem
When traffic flows through a proxy chain (e.g., data plane -> shared ingress), the `src` variable in HAProxy results in the internal IP of the connection (e.g., `169.254.0.1`, `172.20.0.1`, or pod IPs like `10.132.0.x`), not the unique outbound IP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)