### PR TITLE
OCPBUGS-53083: ci: Improves the `isLeaderElectionFailure` function

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/x509"
@@ -777,7 +778,7 @@ func EnsureNoCrashingPods(t *testing.T, ctx context.Context, client crclient.Cli
 						}
 					}
 
-					if isLeaderElectionFailure(ctx, guestClient, &pod, containerStatus.Name) {
+					if isLeaderElectionFailure(ctx, guestClient, &pod, containerStatus.Name, t) {
 						t.Logf("Leader election failure detected in container %s in pod %s", containerStatus.Name, pod.Name)
 						continue
 					}
@@ -788,7 +789,7 @@ func EnsureNoCrashingPods(t *testing.T, ctx context.Context, client crclient.Cli
 	})
 }
 
-func isLeaderElectionFailure(ctx context.Context, guestClient *kubeclient.Clientset, pod *corev1.Pod, containerName string) bool {
+func isLeaderElectionFailure(ctx context.Context, guestClient *kubeclient.Clientset, pod *corev1.Pod, containerName string, t *testing.T) bool {
 	podLogOpts := corev1.PodLogOptions{
 		Container: containerName,
 		Previous:  true,
@@ -797,17 +798,30 @@ func isLeaderElectionFailure(ctx context.Context, guestClient *kubeclient.Client
 	req := guestClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &podLogOpts)
 	podLogs, err := req.Stream(ctx)
 	if err != nil {
+		t.Logf("couldn't stream pod log; pod namespace: %s, pod name: %s, error: %v", pod.Namespace, pod.Name, err)
 		return false
 	}
 	defer podLogs.Close()
 
-	buf := new(bytes.Buffer)
-	_, err = buf.ReadFrom(podLogs)
-	if err != nil {
-		return false
+	scanner := bufio.NewScanner(podLogs)
+	const (
+		bufSize          = 256 * 1024
+		maxScanTokenSize = 512 * 1024
+	)
+
+	buf := make([]byte, bufSize)
+	scanner.Buffer(buf, maxScanTokenSize)
+	for scanner.Scan() {
+		if strings.Contains(strings.ToLower(scanner.Text()), "election lost") {
+			return true
+		}
 	}
 
-	return strings.Contains(buf.String(), "election lost")
+	if err = scanner.Err(); err != nil {
+		t.Logf("failed to read pod log; pod namespace: %s, pod name: %s, error: %v", pod.Namespace, pod.Name, err)
+	}
+
+	return false
 }
 
 func NoticePreemptionOrFailedScheduling(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {


### PR DESCRIPTION
## What this PR does / why we need it:
The `EnsureNoCrashingPods` function should ignore restarts that happened as result of leader election lost. But this is not always happening, and there is no way to understand why. For example, in this case, the function missed the leader election lost failure, and failed the test because of the pod restart; see [here](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_cluster-api-provider-kubevirt/347/pull-ci-openshift-cluster-api-provider-kubevirt-main-e2e-hypershift-kubevirt/2015780962863943680/artifacts/e2e-hypershift-kubevirt/run-e2e-local/artifacts/TestCreateCluster/namespaces/e2e-clusters-hf726-create-cluster-7975c/core/pods/logs/kubevirt-cloud-controller-manager-5bb7949f94-f8mmb-cloud-controller-manager-previous.log)

This PR adds logging from the `isLeaderElectionFailure` function, to help debugging the issue. It also changes the algorithm, to use the `bufio.Scanner` from the standard library, in order to search the log for leader election lost, guessing that maybe reading the whole stream, maybe miss newer output.
