### PR TITLE
NO-JIRA: test(assets): add unit test for CAPI resources file paths

### DIFF
--- a/cmd/install/assets/assets_test.go
+++ b/cmd/install/assets/assets_test.go
@@ -1,0 +1,27 @@
+package assets
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestCapiResources(t *testing.T) {
+	t.Run("When loading all capiResources paths they should exist and parse correctly", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		for path := range capiResources {
+			// getCustomResourceDefinition panics if file doesn't exist or can't be parsed
+			g.Expect(func() {
+				crd := getCustomResourceDefinition(CRDS, path)
+				g.Expect(crd).ToNot(BeNil())
+			}).ToNot(Panic(), "path %s should exist and parse", path)
+		}
+	})
+
+	t.Run("When loading a non-existent path it should panic", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		g.Expect(func() {
+			getCustomResourceDefinition(CRDS, "cluster-api-provider-fake/nonexistent.yaml")
+		}).To(Panic())
+	})
+}


### PR DESCRIPTION
## Summary

Add a unit test to verify all entries in the `capiResources` map point to existing embedded files that parse correctly. This catches mismatches between the map and actual CRD file paths at test time rather than causing runtime panics.

## Problem

PR #7305 introduced an edge case CI failure where CRD file paths were renamed but the `capiResources` map wasn't updated to match, causing runtime panics when trying to open non-existent embedded files.

## Solution

The test iterates through all entries in `capiResources` and calls `getCustomResourceDefinition()` for each path, verifying:
- The embedded file exists
- The file parses correctly as YAML

## Changes

- **cmd/install/assets/assets_test.go** (new file): Implements `TestCapiResources` with:
  - Positive test case: Validates all current `capiResources` paths exist and parse
  - Negative test case: Verifies non-existent paths correctly panic

## Testing

```bash
go test -v ./cmd/install/assets/... -run TestCapiResources
```

All tests pass successfully. The test will catch any future mismatches between the `capiResources` map and embedded CRD file paths.