### PR TITLE
OCPBUGS-70152: Correct route labeling logic for HCP router infratructure

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -103,6 +103,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1108,6 +1109,10 @@ func (r *HostedControlPlaneReconciler) reconcileCPOV2(ctx context.Context, hcp *
 		if err := r.cleanupOldRouterResources(ctx, hcp); err != nil {
 			return fmt.Errorf("failed to cleanup old router resources: %w", err)
 		}
+	} else {
+		if err := r.removeHCPIngressFromRoutes(ctx, hcp); err != nil {
+			return fmt.Errorf("failed to remove HCP ingress from routes: %w", err)
+		}
 	}
 
 	if _, exists := hcp.Annotations[hyperv1.DisableIgnitionServerAnnotation]; !exists {
@@ -1993,6 +1998,43 @@ func (r *HostedControlPlaneReconciler) cleanupOldRouterResources(ctx context.Con
 	for _, resource := range oldRouterResources {
 		if _, err := util.DeleteIfNeeded(ctx, r.Client, resource); err != nil {
 			return fmt.Errorf("failed to delete %T %s: %w", resource, resource.GetName(), err)
+		}
+	}
+
+	return nil
+}
+
+func (r *HostedControlPlaneReconciler) removeHCPIngressFromRoutes(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
+	routeList := &routev1.RouteList{}
+	if err := r.List(ctx, routeList, client.InNamespace(hcp.Namespace)); err != nil {
+		return fmt.Errorf("failed to list routes: %w", err)
+	}
+
+	for i := range routeList.Items {
+		route := &routeList.Items[i]
+		if _, hasHCPLabel := route.Labels[util.HCPRouteLabel]; hasHCPLabel {
+			// Skip routes that should be managed by the HCP router
+			continue
+		}
+		// Only clear ingress entries that correspond to router named "router".
+		// This matches the RouterName used by ReconcileRouteStatus in ingress/router.go
+		// when the HCP router admits routes. We filter by this specific name to ensure
+		// we only remove ingress entries from the HCP router, not from other routers
+		// (e.g., the default ingress controller router).
+		originalRoute := route.DeepCopy()
+		filteredIngress := make([]routev1.RouteIngress, 0, len(route.Status.Ingress))
+		for _, ingress := range route.Status.Ingress {
+			if ingress.RouterName != "router" {
+				filteredIngress = append(filteredIngress, ingress)
+			}
+		}
+		if len(filteredIngress) != len(route.Status.Ingress) {
+			route.Status.Ingress = filteredIngress
+			if !equality.Semantic.DeepEqual(originalRoute.Status, route.Status) {
+				if err := r.Status().Patch(ctx, route, client.MergeFrom(originalRoute)); err != nil {
+					return fmt.Errorf("failed to clear route %s ingress: %w", route.Name, err)
+				}
+			}
 		}
 	}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_AWS_PublicAndPrivate_KAS_LoadBalancer.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_AWS_PublicAndPrivate_KAS_LoadBalancer.yaml
@@ -26,8 +26,6 @@ routes:
         weight: null
     status: {}
   - metadata:
-      labels:
-        hypershift.openshift.io/hosted-control-plane: test-namespace
       name: oauth
       namespace: test-namespace
       ownerReferences:
@@ -253,25 +251,6 @@ services:
       labels:
         app: private-router
       name: private-router
-      namespace: test-namespace
-    spec:
-      ports:
-      - name: https
-        port: 443
-        protocol: TCP
-        targetPort: https
-      selector:
-        app: private-router
-      type: LoadBalancer
-    status:
-      loadBalancer: {}
-  - metadata:
-      annotations:
-        service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-        service.beta.kubernetes.io/aws-load-balancer-type: nlb
-      labels:
-        app: private-router
-      name: router
       namespace: test-namespace
     spec:
       ports:

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_AWS_Public_KAS_LoadBalancer.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_AWS_Public_KAS_LoadBalancer.yaml
@@ -3,8 +3,6 @@ routes:
   - metadata:
       annotations:
         haproxy.router.openshift.io/balance: roundrobin
-      labels:
-        hypershift.openshift.io/hosted-control-plane: test-namespace
       name: konnectivity-server
       namespace: test-namespace
       ownerReferences:
@@ -25,8 +23,6 @@ routes:
         weight: null
     status: {}
   - metadata:
-      labels:
-        hypershift.openshift.io/hosted-control-plane: test-namespace
       name: oauth
       namespace: test-namespace
       ownerReferences:
@@ -192,24 +188,6 @@ services:
         app: packageserver
         hypershift.openshift.io/control-plane-component: packageserver
       type: ClusterIP
-    status:
-      loadBalancer: {}
-  - metadata:
-      annotations:
-        service.beta.kubernetes.io/aws-load-balancer-type: nlb
-      labels:
-        app: private-router
-      name: router
-      namespace: test-namespace
-    spec:
-      ports:
-      - name: https
-        port: 443
-        protocol: TCP
-        targetPort: https
-      selector:
-        app: private-router
-      type: LoadBalancer
     status:
       loadBalancer: {}
   metadata: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_route.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_route.yaml
@@ -1,6 +1,8 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
+  labels:
+    hypershift.openshift.io/hosted-control-plane: hcp-namespace
   name: ignition-server
   namespace: hcp-namespace
   ownerReferences:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_route.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_route.yaml
@@ -1,6 +1,8 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
+  labels:
+    hypershift.openshift.io/hosted-control-plane: hcp-namespace
   name: ignition-server
   namespace: hcp-namespace
   ownerReferences:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/zz_fixture_TestControlPlaneComponents_ignition_server_route.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/zz_fixture_TestControlPlaneComponents_ignition_server_route.yaml
@@ -1,6 +1,8 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
+  labels:
+    hypershift.openshift.io/hosted-control-plane: hcp-namespace
   name: ignition-server
   namespace: hcp-namespace
   ownerReferences:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/route_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/route_test.go
@@ -20,6 +20,7 @@ func TestIgnitionRouteAdapt(t *testing.T) {
 		hcp                 *hyperv1.HostedControlPlane
 		route               *routev1.Route
 		expectedHost        string
+		expectHCPRouteLabel bool
 		expectInternalLabel bool
 	}{
 		{
@@ -44,6 +45,7 @@ func TestIgnitionRouteAdapt(t *testing.T) {
 				},
 			},
 			expectedHost:        "ignition-server.apps.test-hcp.hypershift.local",
+			expectHCPRouteLabel: true,
 			expectInternalLabel: true,
 		},
 		{
@@ -79,6 +81,7 @@ func TestIgnitionRouteAdapt(t *testing.T) {
 				},
 			},
 			expectedHost:        "ignition.example.com",
+			expectHCPRouteLabel: false,
 			expectInternalLabel: false,
 		},
 	}
@@ -92,7 +95,12 @@ func TestIgnitionRouteAdapt(t *testing.T) {
 			err := ign.adaptRoute(cpContext, tc.route)
 			g.Expect(err).To(BeNil())
 			g.Expect(tc.route.Spec.Host).To(Equal(tc.expectedHost))
-			g.Expect(tc.route.Labels).To(HaveKeyWithValue(util.HCPRouteLabel, tc.route.Namespace))
+
+			if tc.expectHCPRouteLabel {
+				g.Expect(tc.route.Labels).To(HaveKeyWithValue(util.HCPRouteLabel, tc.route.Namespace))
+			} else {
+				g.Expect(tc.route.Labels).ToNot(HaveKeyWithValue(util.HCPRouteLabel, tc.route.Namespace))
+			}
 
 			if tc.expectInternalLabel {
 				g.Expect(tc.route.Labels).To(HaveKeyWithValue(util.InternalRouteLabel, "true"))

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/component_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/component_test.go
@@ -28,7 +28,7 @@ func TestUseHCPRouter(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "When ARO Swift is enabled it should return true",
+			name: "When ARO Swift is enabled it should return true because the HCP router handles routing",
 			hcp: &hyperv1.HostedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
@@ -61,6 +61,55 @@ func TestUseHCPRouter(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "When NonePlatform has services exposed with Routes it should return true",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.NonePlatform,
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "cluster1.api.tenant1.com",
+								},
+							},
+						},
+						{
+							Service: hyperv1.Konnectivity,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "cluster1.tunnel.tenant1.com",
+								},
+							},
+						},
+						{
+							Service: hyperv1.Ignition,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "cluster1.ignition.tenant1.com",
+								},
+							},
+						},
+						{
+							Service: hyperv1.OAuthServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "cluster1.oauth.tenant1.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
 			name: "When AWS has private endpoint access it should return true",
 			hcp: &hyperv1.HostedControlPlane{
 				Spec: hyperv1.HostedControlPlaneSpec{
@@ -75,13 +124,46 @@ func TestUseHCPRouter(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "When AWS has public and private endpoint access it should return true",
+			name: "When AWS has public and private endpoint access with KAS LoadBalancer it should return true",
 			hcp: &hyperv1.HostedControlPlane{
 				Spec: hyperv1.HostedControlPlaneSpec{
 					Platform: hyperv1.PlatformSpec{
 						Type: hyperv1.AWSPlatform,
 						AWS: &hyperv1.AWSPlatformSpec{
 							EndpointAccess: hyperv1.PublicAndPrivate,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want: true, // Router infrastructure needed for internal routes
+		},
+		{
+			name: "When AWS has public and private endpoint access with KAS Route it should return true",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: hyperv1.PublicAndPrivate,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "cluster1.api.tenant1.com",
+								},
+							},
 						},
 					},
 				},
@@ -142,13 +224,71 @@ func TestUseHCPRouter(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "When GCP has public and private endpoint access it should return true",
+			name: "When GCP has public and private endpoint access with KAS Route it should return true",
 			hcp: &hyperv1.HostedControlPlane{
 				Spec: hyperv1.HostedControlPlaneSpec{
 					Platform: hyperv1.PlatformSpec{
 						Type: hyperv1.GCPPlatform,
 						GCP: &hyperv1.GCPPlatformSpec{
 							EndpointAccess: hyperv1.GCPEndpointAccessPublicAndPrivate,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "cluster1.api.tenant1.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "When Agent platform has KAS LoadBalancer it should return false",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AgentPlatform,
+						Agent: &hyperv1.AgentPlatformSpec{
+							AgentNamespace: "agent-ns",
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want: false, // Router infrastructure not needed when KAS uses LoadBalancer
+		},
+		{
+			name: "When Agent platform has KAS Route it should return true",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AgentPlatform,
+						Agent: &hyperv1.AgentPlatformSpec{
+							AgentNamespace: "agent-ns",
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "cluster1.api.tenant1.com",
+								},
+							},
 						},
 					},
 				},

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3804,10 +3804,6 @@ func (r *HostedClusterReconciler) validateAWSConfig(hc *hyperv1.HostedCluster) e
 		if !hyperutil.UseDedicatedDNSForKASByHC(hc) && kasPublishingStrategy.Type != hyperv1.LoadBalancer {
 			errs = append(errs, fmt.Errorf("service type %v with publishing strategy %v is not supported, use Route or LoadBalancer", hyperv1.APIServer, kasPublishingStrategy.Type))
 		}
-		// When using dedicated DNS, the KAS should be exposed as Route.
-		if hyperutil.IsPublicWithDNSByHC(hc) && hyperutil.IsLBKASByHC(hc) {
-			errs = append(errs, fmt.Errorf("service type %v with publishing strategy %v is not supported when any service specifies external DNS, use Route", hyperv1.APIServer, kasPublishingStrategy.Type))
-		}
 	}
 
 	return utilerrors.NewAggregate(errs)

--- a/support/upsert/apply_test.go
+++ b/support/upsert/apply_test.go
@@ -4,6 +4,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/util"
+
+	routev1 "github.com/openshift/api/route/v1"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -77,5 +82,241 @@ func TestApplyManifest(t *testing.T) {
 	}
 	if result != controllerutil.OperationResultNone {
 		t.Errorf("expected result %s, got %s", controllerutil.OperationResultNone, result)
+	}
+}
+
+// TestApplyManifestLabelRemoval proves that the label removal mechanism works correctly
+// when using ApplyManifest with the component framework. This test demonstrates why
+// the changes in apply.go are necessary:
+//
+//  1. preserveOriginalMetadata must process RemoveLabelMarker to remove labels
+//  2. The update function must detect label removal and perform updates even when
+//     DeepDerivative says objects are equal (because DeepDerivative ignores empty maps)
+//
+// Without these changes, labels marked for removal would not be removed from cluster
+// objects when using ApplyManifest, which is needed when transitioning routes from
+// HCP-managed to default ingress controller-managed.
+func TestApplyManifestLabelRemoval(t *testing.T) {
+	const namespace = "test-ns"
+	const routeName = "test-route"
+
+	// Existing route in cluster with HCPRouteLabel
+	existingRoute := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      routeName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				util.HCPRouteLabel: namespace,
+				"other-label":      "keep-me",
+			},
+		},
+		Spec: routev1.RouteSpec{
+			To: routev1.RouteTargetReference{
+				Kind: "Service",
+				Name: "test-service",
+			},
+		},
+	}
+
+	// Manifest route that marks HCPRouteLabel for removal (using RemoveLabelMarker)
+	// This simulates the scenario where we want to remove the HCP route label
+	// when transitioning from HCP router to default ingress controller
+	manifestRoute := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      routeName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				util.HCPRouteLabel: util.RemoveLabelMarker, // Mark for removal
+				"other-label":      "keep-me",              // Keep this label
+			},
+		},
+		Spec: routev1.RouteSpec{
+			To: routev1.RouteTargetReference{
+				Kind: "Service",
+				Name: "test-service",
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(api.Scheme).
+		WithObjects(existingRoute).
+		Build()
+	provider := &applyProvider{}
+
+	// Apply the manifest - this should remove the HCPRouteLabel
+	result, err := provider.ApplyManifest(t.Context(), client, manifestRoute)
+	if err != nil {
+		t.Fatalf("ApplyManifest failed: %v", err)
+	}
+
+	// The update should have occurred because we're removing a label
+	if result != controllerutil.OperationResultUpdated {
+		t.Errorf("expected result %s, got %s", controllerutil.OperationResultUpdated, result)
+	}
+
+	// Verify the label was actually removed from the cluster object
+	var updatedRoute routev1.Route
+	if err := client.Get(t.Context(), types.NamespacedName{Name: routeName, Namespace: namespace}, &updatedRoute); err != nil {
+		t.Fatalf("failed to get updated route: %v", err)
+	}
+
+	// HCPRouteLabel should be removed
+	if _, exists := updatedRoute.Labels[util.HCPRouteLabel]; exists {
+		t.Errorf("expected HCPRouteLabel to be removed, but it still exists")
+	}
+
+	// Other labels should be preserved
+	if updatedRoute.Labels["other-label"] != "keep-me" {
+		t.Errorf("expected other-label to be preserved, got %v", updatedRoute.Labels["other-label"])
+	}
+
+	// Verify that only one label remains
+	if len(updatedRoute.Labels) != 1 {
+		t.Errorf("expected 1 label remaining, got %d: %v", len(updatedRoute.Labels), updatedRoute.Labels)
+	}
+}
+
+// TestApplyManifestLabelRemovalWithEmptyLabels tests the edge case where removing
+// the last label results in an empty label map. This proves that the special handling
+// in update() correctly detects label removal even when DeepDerivative would normally
+// say the objects are equal (because it ignores empty maps).
+func TestApplyManifestLabelRemovalWithEmptyLabels(t *testing.T) {
+	const namespace = "test-ns"
+	const routeName = "test-route-empty"
+
+	// Existing route with only HCPRouteLabel
+	existingRoute := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      routeName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				util.HCPRouteLabel: namespace,
+			},
+		},
+		Spec: routev1.RouteSpec{
+			To: routev1.RouteTargetReference{
+				Kind: "Service",
+				Name: "test-service",
+			},
+		},
+	}
+
+	// Manifest route that marks HCPRouteLabel for removal, resulting in empty labels
+	manifestRoute := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      routeName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				util.HCPRouteLabel: util.RemoveLabelMarker,
+			},
+		},
+		Spec: routev1.RouteSpec{
+			To: routev1.RouteTargetReference{
+				Kind: "Service",
+				Name: "test-service",
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(api.Scheme).
+		WithObjects(existingRoute).
+		Build()
+	provider := &applyProvider{}
+
+	// Apply the manifest - this should remove the only label, resulting in empty labels
+	result, err := provider.ApplyManifest(t.Context(), client, manifestRoute)
+	if err != nil {
+		t.Fatalf("ApplyManifest failed: %v", err)
+	}
+
+	// The update should have occurred even though DeepDerivative would say they're equal
+	// (because empty maps are ignored), but we need the update to remove the label
+	if result != controllerutil.OperationResultUpdated {
+		t.Errorf("expected result %s, got %s", controllerutil.OperationResultUpdated, result)
+	}
+
+	// Verify the label was actually removed
+	var updatedRoute routev1.Route
+	if err := client.Get(t.Context(), types.NamespacedName{Name: routeName, Namespace: namespace}, &updatedRoute); err != nil {
+		t.Fatalf("failed to get updated route: %v", err)
+	}
+
+	// HCPRouteLabel should be removed
+	if _, exists := updatedRoute.Labels[util.HCPRouteLabel]; exists {
+		t.Errorf("expected HCPRouteLabel to be removed, but it still exists")
+	}
+
+	// Labels should be empty or nil
+	if len(updatedRoute.Labels) != 0 {
+		t.Errorf("expected empty labels, got %d labels: %v", len(updatedRoute.Labels), updatedRoute.Labels)
+	}
+}
+
+// TestApplyManifestLabelRemovalOnCreate tests that removal markers are cleaned up
+// when creating a new object. This is critical because Kubernetes validates label
+// values during creation, and the removal marker value is not a valid label value.
+// This test ensures the fix for Azure ignition server Route creation failures.
+func TestApplyManifestLabelRemovalOnCreate(t *testing.T) {
+	const namespace = "test-ns"
+	const routeName = "test-route-new"
+
+	// Manifest route with removal marker - simulates the Azure scenario where
+	// a Route is being created with a removal marker (e.g., when transitioning
+	// from HCP router to default ingress controller)
+	manifestRoute := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      routeName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				util.HCPRouteLabel: util.RemoveLabelMarker, // Mark for removal
+				"other-label":      "keep-me",              // Keep this label
+			},
+		},
+		Spec: routev1.RouteSpec{
+			To: routev1.RouteTargetReference{
+				Kind: "Service",
+				Name: "test-service",
+			},
+		},
+	}
+
+	// Empty client - route doesn't exist yet, so it will be created
+	client := fake.NewClientBuilder().
+		WithScheme(api.Scheme).
+		Build()
+	provider := &applyProvider{}
+
+	// Apply the manifest - this should create the route with removal marker cleaned up
+	result, err := provider.ApplyManifest(t.Context(), client, manifestRoute)
+	if err != nil {
+		t.Fatalf("ApplyManifest failed: %v", err)
+	}
+
+	// The route should have been created
+	if result != controllerutil.OperationResultCreated {
+		t.Errorf("expected result %s, got %s", controllerutil.OperationResultCreated, result)
+	}
+
+	// Verify the route was created and removal marker was cleaned up
+	var createdRoute routev1.Route
+	if err := client.Get(t.Context(), types.NamespacedName{Name: routeName, Namespace: namespace}, &createdRoute); err != nil {
+		t.Fatalf("failed to get created route: %v", err)
+	}
+
+	// HCPRouteLabel should not exist (removal marker was cleaned up before creation)
+	if _, exists := createdRoute.Labels[util.HCPRouteLabel]; exists {
+		t.Errorf("expected HCPRouteLabel to be removed before creation, but it still exists")
+	}
+
+	// Other labels should be preserved
+	if createdRoute.Labels["other-label"] != "keep-me" {
+		t.Errorf("expected other-label to be preserved, got %v", createdRoute.Labels["other-label"])
+	}
+
+	// Verify that only one label remains
+	if len(createdRoute.Labels) != 1 {
+		t.Errorf("expected 1 label remaining, got %d: %v", len(createdRoute.Labels), createdRoute.Labels)
 	}
 }

--- a/support/util/expose.go
+++ b/support/util/expose.go
@@ -31,18 +31,6 @@ func UseDedicatedDNSForKAS(hcp *hyperv1.HostedControlPlane) bool {
 	return UseDedicatedDNS(hcp, hyperv1.APIServer)
 }
 
-func UseDedicatedDNSForOAuth(hcp *hyperv1.HostedControlPlane) bool {
-	return UseDedicatedDNS(hcp, hyperv1.OAuthServer)
-}
-
-func UseDedicatedDNSForKonnectivity(hcp *hyperv1.HostedControlPlane) bool {
-	return UseDedicatedDNS(hcp, hyperv1.Konnectivity)
-}
-
-func UseDedicatedDNSForIgnition(hcp *hyperv1.HostedControlPlane) bool {
-	return UseDedicatedDNS(hcp, hyperv1.Ignition)
-}
-
 func UseDedicatedDNS(hcp *hyperv1.HostedControlPlane, svcType hyperv1.ServiceType) bool {
 	svc := ServicePublishingStrategyByTypeForHCP(hcp, svcType)
 	return IsRoute(hcp, svcType) &&

--- a/support/util/route_test.go
+++ b/support/util/route_test.go
@@ -5,6 +5,9 @@ import (
 	"math/rand"
 	"testing"
 
+	routev1 "github.com/openshift/api/route/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kvalidation "k8s.io/apimachinery/pkg/util/validation"
 )
 
@@ -101,4 +104,365 @@ func randSeq(n int) string {
 		b[i] = letters[rand.Intn(len(letters))]
 	}
 	return string(b)
+}
+
+func TestReconcileExternalRoute(t *testing.T) {
+	tests := []struct {
+		name            string
+		route           *routev1.Route
+		hostname        string
+		defaultDomain   string
+		serviceName     string
+		labelHCPRoutes  bool
+		expectedLabels  map[string]string
+		expectedHost    string
+		expectedService string
+	}{
+		{
+			name: "When labelHCPRoutes is true and route has no labels, it should add HCP label",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			hostname:       "test.example.com",
+			defaultDomain:  "example.com",
+			serviceName:    "test-service",
+			labelHCPRoutes: true,
+			expectedLabels: map[string]string{
+				HCPRouteLabel: "test-namespace",
+			},
+			expectedHost:    "test.example.com",
+			expectedService: "test-service",
+		},
+		{
+			name: "When labelHCPRoutes is true and route has existing labels, it should add HCP label",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						"existing-label": "existing-value",
+					},
+				},
+			},
+			hostname:       "test.example.com",
+			defaultDomain:  "example.com",
+			serviceName:    "test-service",
+			labelHCPRoutes: true,
+			expectedLabels: map[string]string{
+				"existing-label": "existing-value",
+				HCPRouteLabel:    "test-namespace",
+			},
+			expectedHost:    "test.example.com",
+			expectedService: "test-service",
+		},
+		{
+			name: "When labelHCPRoutes is false and route has no labels, it should not add HCP label",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			hostname:        "test.example.com",
+			defaultDomain:   "example.com",
+			serviceName:     "test-service",
+			labelHCPRoutes:  false,
+			expectedLabels:  nil,
+			expectedHost:    "test.example.com",
+			expectedService: "test-service",
+		},
+		{
+			name: "When labelHCPRoutes is false and route has HCP label, it should remove HCP label",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						HCPRouteLabel:    "test-namespace",
+						"existing-label": "existing-value",
+					},
+				},
+			},
+			hostname:       "test.example.com",
+			defaultDomain:  "example.com",
+			serviceName:    "test-service",
+			labelHCPRoutes: false,
+			expectedLabels: map[string]string{
+				"existing-label": "existing-value",
+			},
+			expectedHost:    "test.example.com",
+			expectedService: "test-service",
+		},
+		{
+			name: "When labelHCPRoutes is false and route has only HCP label, it should remove HCP label and leave empty map",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						HCPRouteLabel: "test-namespace",
+					},
+				},
+			},
+			hostname:        "test.example.com",
+			defaultDomain:   "example.com",
+			serviceName:     "test-service",
+			labelHCPRoutes:  false,
+			expectedLabels:  map[string]string{},
+			expectedHost:    "test.example.com",
+			expectedService: "test-service",
+		},
+		{
+			name: "When hostname is empty and route name is short, it should leave hostname empty for default generation",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			hostname:       "",
+			defaultDomain:  "example.com",
+			serviceName:    "test-service",
+			labelHCPRoutes: true,
+			expectedLabels: map[string]string{
+				HCPRouteLabel: "test-namespace",
+			},
+			expectedHost:    "", // ShortenRouteHostnameIfNeeded returns empty when name is short enough
+			expectedService: "test-service",
+		},
+		{
+			name: "When hostname is empty and route already has a hostname, it should preserve existing hostname",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "existing.example.com",
+				},
+			},
+			hostname:       "",
+			defaultDomain:  "example.com",
+			serviceName:    "test-service",
+			labelHCPRoutes: true,
+			expectedLabels: map[string]string{
+				HCPRouteLabel: "test-namespace",
+			},
+			expectedHost:    "existing.example.com",
+			expectedService: "test-service",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ReconcileExternalRoute(tt.route, tt.hostname, tt.defaultDomain, tt.serviceName, tt.labelHCPRoutes)
+			if err != nil {
+				t.Fatalf("ReconcileExternalRoute() error = %v, wantErr false", err)
+			}
+
+			// Check labels
+			if tt.expectedLabels == nil {
+				if len(tt.route.Labels) != 0 {
+					t.Errorf("Expected no labels, but got %v", tt.route.Labels)
+				}
+			} else {
+				if len(tt.route.Labels) != len(tt.expectedLabels) {
+					t.Errorf("Labels length mismatch: got %d, want %d. Got: %v, Want: %v", len(tt.route.Labels), len(tt.expectedLabels), tt.route.Labels, tt.expectedLabels)
+				}
+				for k, v := range tt.expectedLabels {
+					if got, ok := tt.route.Labels[k]; !ok || got != v {
+						t.Errorf("Label %s: got %v, want %v", k, got, v)
+					}
+				}
+				// Check that HCP label is not present when not expected
+				if _, ok := tt.expectedLabels[HCPRouteLabel]; !ok {
+					if _, hasLabel := tt.route.Labels[HCPRouteLabel]; hasLabel {
+						t.Errorf("Expected HCP label to be removed, but it still exists")
+					}
+				}
+			}
+
+			// Check hostname
+			if tt.route.Spec.Host != tt.expectedHost {
+				t.Errorf("Host: got %v, want %v", tt.route.Spec.Host, tt.expectedHost)
+			}
+
+			// Check service name
+			if tt.route.Spec.To.Name != tt.expectedService {
+				t.Errorf("Service name: got %v, want %v", tt.route.Spec.To.Name, tt.expectedService)
+			}
+
+			// Check TLS config
+			if tt.route.Spec.TLS == nil {
+				t.Errorf("Expected TLS config to be set")
+			} else {
+				if tt.route.Spec.TLS.Termination != routev1.TLSTerminationPassthrough {
+					t.Errorf("TLS termination: got %v, want %v", tt.route.Spec.TLS.Termination, routev1.TLSTerminationPassthrough)
+				}
+				if tt.route.Spec.TLS.InsecureEdgeTerminationPolicy != routev1.InsecureEdgeTerminationPolicyNone {
+					t.Errorf("Insecure edge termination policy: got %v, want %v", tt.route.Spec.TLS.InsecureEdgeTerminationPolicy, routev1.InsecureEdgeTerminationPolicyNone)
+				}
+			}
+		})
+	}
+}
+
+func TestAddHCPRouteLabel(t *testing.T) {
+	tests := []struct {
+		name           string
+		route          *routev1.Route
+		expectedLabels map[string]string
+	}{
+		{
+			name: "When route has no labels, it should add HCP label",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			expectedLabels: map[string]string{
+				HCPRouteLabel: "test-namespace",
+			},
+		},
+		{
+			name: "When route has existing labels, it should add HCP label without removing existing ones",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						"existing-label": "existing-value",
+					},
+				},
+			},
+			expectedLabels: map[string]string{
+				"existing-label": "existing-value",
+				HCPRouteLabel:    "test-namespace",
+			},
+		},
+		{
+			name: "When route already has HCP label, it should update it",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						HCPRouteLabel: "old-namespace",
+					},
+				},
+			},
+			expectedLabels: map[string]string{
+				HCPRouteLabel: "test-namespace",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			AddHCPRouteLabel(tt.route)
+
+			if len(tt.route.Labels) != len(tt.expectedLabels) {
+				t.Errorf("Labels length mismatch: got %d, want %d. Got: %v, Want: %v", len(tt.route.Labels), len(tt.expectedLabels), tt.route.Labels, tt.expectedLabels)
+			}
+			for k, v := range tt.expectedLabels {
+				if got, ok := tt.route.Labels[k]; !ok || got != v {
+					t.Errorf("Label %s: got %v, want %v", k, got, v)
+				}
+			}
+		})
+	}
+}
+
+func TestRemoveHCPRouteLabel(t *testing.T) {
+	tests := []struct {
+		name           string
+		route          *routev1.Route
+		expectedLabels map[string]string
+	}{
+		{
+			name: "When route has no labels, it should not error",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			expectedLabels: nil,
+		},
+		{
+			name: "When route has HCP label only, it should remove it and leave empty map",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						HCPRouteLabel: "test-namespace",
+					},
+				},
+			},
+			expectedLabels: map[string]string{},
+		},
+		{
+			name: "When route has HCP label and other labels, it should remove only HCP label",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						HCPRouteLabel:    "test-namespace",
+						"existing-label": "existing-value",
+						"another-label":  "another-value",
+					},
+				},
+			},
+			expectedLabels: map[string]string{
+				"existing-label": "existing-value",
+				"another-label":  "another-value",
+			},
+		},
+		{
+			name: "When route does not have HCP label but has other labels, it should not modify labels",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						"existing-label": "existing-value",
+					},
+				},
+			},
+			expectedLabels: map[string]string{
+				"existing-label": "existing-value",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RemoveHCPRouteLabel(tt.route)
+
+			if tt.expectedLabels == nil {
+				if len(tt.route.Labels) != 0 {
+					t.Errorf("Expected no labels, but got %v", tt.route.Labels)
+				}
+			} else {
+				if len(tt.route.Labels) != len(tt.expectedLabels) {
+					t.Errorf("Labels length mismatch: got %d, want %d. Got: %v, Want: %v", len(tt.route.Labels), len(tt.expectedLabels), tt.route.Labels, tt.expectedLabels)
+				}
+				for k, v := range tt.expectedLabels {
+					if got, ok := tt.route.Labels[k]; !ok || got != v {
+						t.Errorf("Label %s: got %v, want %v", k, got, v)
+					}
+				}
+				// Ensure HCP label is not present
+				if _, hasLabel := tt.route.Labels[HCPRouteLabel]; hasLabel {
+					t.Errorf("Expected HCP label to be removed, but it still exists")
+				}
+			}
+		})
+	}
 }

--- a/support/util/visibility.go
+++ b/support/util/visibility.go
@@ -75,16 +75,104 @@ func IsPublicHC(hc *hyperv1.HostedCluster) bool {
 	return true
 }
 
-func IsPublicWithDNS(hcp *hyperv1.HostedControlPlane) bool {
-	return IsPublicHCP(hcp) && (UseDedicatedDNS(hcp, hyperv1.APIServer) ||
-		UseDedicatedDNS(hcp, hyperv1.OAuthServer) ||
-		UseDedicatedDNS(hcp, hyperv1.Konnectivity) ||
-		UseDedicatedDNS(hcp, hyperv1.Ignition))
-}
+// LabelHCPRoutes determines if routes should be labeled for admission by the HCP router.
+// Routes with the label "hypershift.openshift.io/hosted-control-plane" are served by a
+// dedicated HCP router (HAProxy deployment in the HCP namespace). Routes without this label
+// are served by the management cluster's default OpenShift ingress controller.
+//
+// This function is the single source of truth for route labeling decisions and is called by:
+// - OAuth route reconciliation (external public/private routes)
+// - Konnectivity route reconciliation (external routes)
+// - Ignition server route reconciliation (external routes)
+// - Router component predicate (determines if router Deployment/ConfigMap/PDB are created)
+// - Router service creation (determines if public router LoadBalancer service is created)
+//
+// The HCP router infrastructure (Deployment, Services) is created when routes need to be labeled.
+// This ensures routes and router services stay synchronized.
+//
+// # Platform-Specific Behavior
+//
+// AWS Platform:
+//   - Private: Always labels routes (no public access)
+//   - PublicAndPrivate + KAS LoadBalancer: Does NOT label external routes (uses mgmt cluster router)
+//   - PublicAndPrivate + KAS Route: Labels routes (uses HCP router for all routes)
+//   - Public + KAS LoadBalancer: Does NOT label routes (uses mgmt cluster router)
+//   - Public + KAS Route: Labels routes (uses HCP router)
+//
+// GCP Platform:
+//   - Same behavior as AWS platform
+//
+// Agent Platform (bare metal):
+//   - No EndpointAccess field (no Private/PublicAndPrivate concept)
+//   - Labels routes ONLY when KAS uses Route with explicit hostname
+//   - KAS LoadBalancer/NodePort: Does NOT label routes (uses mgmt cluster router)
+//
+// KubeVirt, OpenStack, None Platforms:
+//   - Same behavior as Agent platform
+//   - Labels routes ONLY when KAS uses Route with explicit hostname
+//
+// IBM Cloud Platform:
+//   - Never labels routes (uses different routing mechanism)
+//
+// # Internal Routes
+//
+// Note that internal routes (*.apps.<cluster>.hypershift.local) are ALWAYS labeled for
+// HCP router regardless of this function's return value. This function only controls
+// EXTERNAL route labeling. Internal routes are handled separately in ReconcileInternalRoute().
+//
+// # Architecture Reference
+//
+// For complete details on the HCP ingress architecture, see HCP_INGRESS_ARCHITECTURE.md
+// in the repository root, which documents the full decision flow, code references, and
+// interaction between route labeling and router service creation.
+//
+// Returns true when routes should be labeled for HCP router; false when routes should
+// use the management cluster router.
+func LabelHCPRoutes(hcp *hyperv1.HostedControlPlane) bool {
+	// When shared ingress is active (e.g., ARO HCP), all routes must be labeled
+	// so the SharedIngressReconciler can discover and admit them.
+	if isAroHCP() {
+		return true
+	}
 
-func IsPublicWithDNSByHC(hc *hyperv1.HostedCluster) bool {
-	return IsPublicHC(hc) && (UseDedicatedDNSByHC(hc, hyperv1.APIServer) ||
-		UseDedicatedDNSByHC(hc, hyperv1.OAuthServer) ||
-		UseDedicatedDNSByHC(hc, hyperv1.Konnectivity) ||
-		UseDedicatedDNSByHC(hc, hyperv1.Ignition))
+	switch hcp.Spec.Platform.Type {
+	case hyperv1.AWSPlatform, hyperv1.GCPPlatform:
+		// AWS and GCP support endpoint access modes (Private/PublicAndPrivate/Public).
+		// Label routes for HCP router when:
+		// 1. Cluster has no public access (Private-only), OR
+		// 2. Public cluster with dedicated DNS for KAS (KAS uses Route with hostname)
+		//
+		// For PublicAndPrivate clusters using LoadBalancer for KAS:
+		// - Internal routes (Konnectivity, Ignition) are served by internal HCP router
+		// - External routes (OAuth) use the management cluster router (no public HCP router needed)
+		// This avoids creating an unnecessary public LoadBalancer service.
+		return !IsPublicHCP(hcp) || UseDedicatedDNSForKAS(hcp)
+
+	case hyperv1.AgentPlatform, hyperv1.KubevirtPlatform, hyperv1.OpenStackPlatform, hyperv1.NonePlatform:
+		// These platforms do not have endpoint access mode concepts (no Private/PublicAndPrivate).
+		// Label routes for HCP router ONLY when KAS explicitly uses Route with a hostname.
+		//
+		// This prevents creating HCP router infrastructure when:
+		// - KAS uses LoadBalancer (routes should use management cluster router)
+		// - KAS uses NodePort (routes should use management cluster router)
+		//
+		// When KAS uses Route with hostname, all routes are labeled for HCP router to ensure
+		// consistent routing through dedicated infrastructure.
+		return UseDedicatedDNSForKAS(hcp)
+
+	case hyperv1.IBMCloudPlatform:
+		// IBM Cloud uses a different routing mechanism (shared ingress with HAProxy and
+		// kube-apiserver-proxy on worker nodes). Never use HCP router.
+		return false
+
+	case hyperv1.PowerVSPlatform:
+		// PowerVS (IBM Cloud Power Virtual Servers) follows the same pattern as other
+		// platforms without endpoint access modes.
+		return UseDedicatedDNSForKAS(hcp)
+
+	default:
+		// Conservative default for unknown platforms: do not create HCP router infrastructure.
+		// Routes will use the management cluster router.
+		return false
+	}
 }

--- a/support/util/visibility_test.go
+++ b/support/util/visibility_test.go
@@ -178,3 +178,604 @@ func TestIsPublicHC(t *testing.T) {
 		})
 	}
 }
+
+func TestLabelHCPRoutes(t *testing.T) {
+	tests := []struct {
+		name    string
+		hcp     *hyperv1.HostedControlPlane
+		want    bool
+		envVars map[string]string
+	}{
+		// Shared Ingress Tests
+		{
+			name: "When shared ingress is active (ARO HCP), it should always label routes regardless of platform",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want:    true,
+			envVars: map[string]string{"MANAGED_SERVICE": "ARO-HCP"},
+		},
+
+		// AWS Platform Tests
+		{
+			name: "When AWS cluster is Private, it should label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: hyperv1.Private,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "When AWS cluster is PublicAndPrivate with KAS LoadBalancer, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: hyperv1.PublicAndPrivate,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "When AWS cluster is PublicAndPrivate with KAS Route and hostname, it should label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: hyperv1.PublicAndPrivate,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "api.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "When AWS cluster is Public with KAS LoadBalancer, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: hyperv1.Public,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "When AWS cluster is Public with KAS Route and hostname, it should label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: hyperv1.Public,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "api.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "When AWS cluster is Public with KAS Route but no hostname, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: hyperv1.Public,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+
+		// GCP Platform Tests
+		{
+			name: "When GCP cluster is Private, it should label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.GCPPlatform,
+						GCP: &hyperv1.GCPPlatformSpec{
+							EndpointAccess: hyperv1.GCPEndpointAccessPrivate,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "When GCP cluster is PublicAndPrivate with KAS LoadBalancer, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.GCPPlatform,
+						GCP: &hyperv1.GCPPlatformSpec{
+							EndpointAccess: hyperv1.GCPEndpointAccessPublicAndPrivate,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "When GCP cluster is PublicAndPrivate with KAS Route and hostname, it should label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.GCPPlatform,
+						GCP: &hyperv1.GCPPlatformSpec{
+							EndpointAccess: hyperv1.GCPEndpointAccessPublicAndPrivate,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "api.gcp.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+
+		// Agent Platform Tests (Bare Metal) - Critical for OCPBUGS-70152
+		{
+			name: "When Agent cluster has KAS LoadBalancer, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AgentPlatform,
+						Agent: &hyperv1.AgentPlatformSpec{
+							AgentNamespace: "agent-ns",
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "When Agent cluster has KAS Route with hostname, it should label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AgentPlatform,
+						Agent: &hyperv1.AgentPlatformSpec{
+							AgentNamespace: "agent-ns",
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "api.agent.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "When Agent cluster has KAS NodePort, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AgentPlatform,
+						Agent: &hyperv1.AgentPlatformSpec{
+							AgentNamespace: "agent-ns",
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.NodePort,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "When Agent cluster has OAuth Route with hostname but KAS LoadBalancer, it should not label routes for HCP router (OCPBUGS-70152 bug scenario)",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AgentPlatform,
+						Agent: &hyperv1.AgentPlatformSpec{
+							AgentNamespace: "agent-ns",
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+						{
+							Service: hyperv1.OAuthServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "oauth.agent.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false, // Should NOT create HCP router - this was the bug
+		},
+
+		// KubeVirt Platform Tests
+		{
+			name: "When KubeVirt cluster has KAS LoadBalancer, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: &hyperv1.KubevirtPlatformSpec{
+							GenerateID: "kubevirt-cluster",
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "When KubeVirt cluster has KAS Route with hostname, it should label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: &hyperv1.KubevirtPlatformSpec{
+							GenerateID: "kubevirt-cluster",
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "api.kubevirt.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+
+		// OpenStack Platform Tests
+		{
+			name: "When OpenStack cluster has KAS LoadBalancer, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.OpenStackPlatform,
+						OpenStack: &hyperv1.OpenStackPlatformSpec{
+							IdentityRef: hyperv1.OpenStackIdentityReference{
+								Name: "openstack-creds",
+							},
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "When OpenStack cluster has KAS Route with hostname, it should label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.OpenStackPlatform,
+						OpenStack: &hyperv1.OpenStackPlatformSpec{
+							IdentityRef: hyperv1.OpenStackIdentityReference{
+								Name: "openstack-creds",
+							},
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "api.openstack.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+
+		// IBM Cloud Platform Tests
+		{
+			name: "When IBM Cloud cluster has KAS LoadBalancer, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.IBMCloudPlatform,
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "When IBM Cloud cluster has KAS Route with hostname, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.IBMCloudPlatform,
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "api.ibmcloud.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false, // IBM Cloud never uses HCP router
+		},
+
+		// PowerVS Platform Tests
+		{
+			name: "When PowerVS cluster has KAS LoadBalancer, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.PowerVSPlatform,
+						PowerVS: &hyperv1.PowerVSPlatformSpec{
+							AccountID:      "test-account",
+							CISInstanceCRN: "test-crn",
+							ResourceGroup:  "test-rg",
+							Region:         "us-south",
+							Zone:           "us-south-1",
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "When PowerVS cluster has KAS Route with hostname, it should label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.PowerVSPlatform,
+						PowerVS: &hyperv1.PowerVSPlatformSpec{
+							AccountID:      "test-account",
+							CISInstanceCRN: "test-crn",
+							ResourceGroup:  "test-rg",
+							Region:         "us-south",
+							Zone:           "us-south-1",
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "api.powervs.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+
+		// None Platform Tests
+		{
+			name: "When None platform cluster has KAS LoadBalancer, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.NonePlatform,
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "When None platform cluster has KAS Route with hostname, it should label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.NonePlatform,
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "api.none.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.envVars {
+				t.Setenv(k, v)
+			}
+			got := LabelHCPRoutes(tt.hcp)
+			if got != tt.want {
+				t.Errorf("LabelHCPRoutes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it:
During upgrades from 4.18 to 4.19, an unexpected LoadBalancer service named
"router" was created, blocking upgrades on platforms with limited LoadBalancer
IPs. This occurred because the previous fix (https://github.com/csrwng/hypershift-1/commit/f0f8b085c970d21f0a6b55cb102eb45af7c6e990) used incorrect logic
to determine when to create the HCP router infrastructure.

Root Cause:
Previous fixes treated route labeling as a per-service decision, checking if
individual services had DNS hostnames. This created router infrastructure even
when routes should use the management cluster router.

For PublicAndPrivate + KAS LoadBalancer + OAuth Route with hostname:
- Old logic: IsPublicWithDNS() checked if ANY service had DNS
- Result: Created router LB when not needed -> upgrade blocked

Solution:
Routes should be labeled for HCP router based on infrastructure availability,
which is determined by KAS publishing strategy:
- PrivateLink clusters (AWS PublicAndPrivate or Private), OR
- Public clusters with dedicated DNS for KAS (KAS uses Route with hostname)

Implementation:
- Added util.LabelHCPRoutes() as single source of truth for labeling decisions
- Updated route reconciliation (OAuth, Konnectivity, Ignition) to use unified logic
- Added support for removing HCP route labels when not needed
- Fixed upsert logic to detect label removal (DeepDerivative ignores empty maps)
- Added comprehensive test coverage for visibility, routing, and upsert logic
- Removed incorrect per-service DNS functions and IsPublicWithDNS() variants
- Removed validation that relied on IsPublicWithDNS()

Result:
For PublicAndPrivate + KAS LoadBalancer + OAuth with hostname:
- OAuth route NOT labeled -> uses management cluster router
- Internal Router LB created -> only for internal routes

## Which issue(s) this PR fixes:
Fixes OCPBUGS-70152