### PR TITLE
OCPBUGS-32770: fix(kubevirt): require CAPK image to be explicitly specified

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -1489,6 +1489,7 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 					Namespace: "test",
 					Annotations: map[string]string{
 						hyperv1.AllowUnsupportedKubeVirtRHCOSVariantsAnnotation: "true",
+						hyperv1.ClusterAPIKubeVirtProviderImage:                 "registry.ci.openshift.org/ocp/4.18:cluster-api-provider-kubevirt",
 					},
 				},
 				Spec: hyperv1.HostedClusterSpec{


### PR DESCRIPTION
Remove hardcoded CAPK provider image and require it to be specified via environment variable or annotation. This ensures the CI built image is not used in production environments.

@wking @csrwng 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the KubeVirt control plane reconciliation to error out when the CAPK image isn’t configured, which can break existing deployments relying on the previous implicit default.
> 
> **Overview**
> Stops defaulting KubeVirt’s CAPI provider (`CAPK`) deployment to a hardcoded CI image.
> 
> `CAPIProviderDeploymentSpec` now **requires** the provider image to be set via `KubevirtCAPIProviderEnvVar` or the `hyperv1.ClusterAPIKubeVirtProviderImage` annotation, and returns an error if neither is present; tests are updated to supply the annotation for the KubeVirt case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 053dd37e0b66e826c75aee7e0a9fae91f024935f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->