### PR TITLE
OCPBUGS-74775: feat(cpo): check components are available before setting HostedCluster available

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -249,6 +249,8 @@ const (
 	KubeVirtNodesLiveMigratableReason = "KubeVirtNodesNotLiveMigratable"
 
 	RecoveryFinishedReason = "RecoveryFinished"
+
+	ControlPlaneComponentsNotAvailable = "ComponentsNotAvailable"
 )
 
 // Messages.

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -249,6 +249,8 @@ const (
 	KubeVirtNodesLiveMigratableReason = "KubeVirtNodesNotLiveMigratable"
 
 	RecoveryFinishedReason = "RecoveryFinished"
+
+	ControlPlaneComponentsNotAvailable = "ComponentsNotAvailable"
 )
 
 // Messages.


### PR DESCRIPTION
manual pick of https://github.com/openshift/hypershift/pull/7604

conflict due to other new conditions in API not present in 4.20

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the control-plane availability/ready gating logic by adding an extra runtime check over `ControlPlaneComponent` CRs, which could keep clusters from being marked available if conditions are misreported or components are missing.
> 
> **Overview**
> **HostedControlPlane availability is now gated on control plane component readiness.** The reconciler lists `ControlPlaneComponent` resources in the HCP namespace and, when the HCP is not already `Available`, requires all to have `ControlPlaneComponentAvailable=True` before setting `HostedControlPlaneAvailable`/`Ready` true.
> 
> Adds a new status reason `ControlPlaneComponentsNotAvailable` (also vendored) and emits clearer messages when components are missing, not yet available, or when listing components fails. Includes focused unit tests for `controlPlaneComponentsAvailable` covering empty, partial, and error scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90b5f67c5b37e5d422dba024955fe2d80555fe9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->