### PR TITLE
Update documentation link to new URL Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ cross cloud with strong separation of concerns between management and workloads.
 Clusters are fully compliant [OpenShift Container Platform](https://www.redhat.com/en/technologies/cloud-computing/openshift/container-platform) (OCP)
 clusters and are compatible with standard OCP and Kubernetes toolchains.
 
-To get started, visit [the documentation](https://hypershift-docs.netlify.app/).
+To get started, visit [the documentation](https://hypershift.pages.dev/).
 
 ![Overview](docs/content/images/high-level-overview.png)


### PR DESCRIPTION


## What this PR does / why we need it:

As https://hypershift-docs.netlify.app has been deprecated for a while

Update the project README.md to new URL https://hypershift.pages.dev/

## Which issue(s) this PR fixes:
Wrong document website URL