### PR TITLE
CNTRLPLANE-2650: docs(ci): add security requirement for Jira agent issues

### DIFF
--- a/docs/content/how-to/ci/ai-assisted-ci-jobs.md
+++ b/docs/content/how-to/ci/ai-assisted-ci-jobs.md
@@ -220,6 +220,7 @@ To have an issue processed by the Jira Agent:
 2. Set status to **New** or **To Do**
 3. Ensure resolution is **Unresolved**
 4. Add the label **`issue-for-agent`**
+5. Security set to none
 
 The issue will be picked up on the next weekly run (Mondays at 8:30 AM UTC).
 

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -9861,6 +9861,7 @@ To have an issue processed by the Jira Agent:
 2. Set status to **New** or **To Do**
 3. Ensure resolution is **Unresolved**
 4. Add the label **`issue-for-agent`**
+5. Security set to none
 
 The issue will be picked up on the next weekly run (Mondays at 8:30 AM UTC).
 


### PR DESCRIPTION
## What this PR does / why we need it:

Adds a security requirement to the Jira issue processing criteria for the AI-assisted Jira Agent. Issues must have security set to none to be eligible for processing by the agent.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-2650](https://issues.redhat.com//browse/CNTRLPLANE-2650)

## Special notes for your reviewer:

Follow-up to #7598 - adds missing security requirement.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.