### PR TITLE
OCPBUGS-74620: test(e2e): increase default node ready timeout to 45 minutes

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -548,15 +548,8 @@ func WaitForNReadyNodesWithOptions(t *testing.T, ctx context.Context, client crc
 		opt(options)
 	}
 	// waitTimeout for nodes to become Ready
-	waitTimeout := 30 * time.Minute
+	waitTimeout := 45 * time.Minute
 	switch platform {
-	case hyperv1.AzurePlatform:
-		// Azure VMs are experiencing slow provisioning (30+ minutes instead of 10-15 minutes).
-		// Azure platform has a hardcoded 20-minute timeout that marks VMs as failed,
-		// but VMs often succeed eventually. Give them 45 minutes to complete.
-		waitTimeout = 45 * time.Minute
-	case hyperv1.KubevirtPlatform:
-		waitTimeout = 45 * time.Minute
 	case hyperv1.PowerVSPlatform:
 		waitTimeout = 60 * time.Minute
 	}


### PR DESCRIPTION
Remove platform-specific timeout logic for Azure and KubeVirt,
setting the default wait timeout to 45 minutes for all platforms
except PowerVS which remains at 60 minutes.

This change addresses slow node provisioning observed across
multiple platforms, not just Azure and KubeVirt.