### PR TITLE
HPCASE-206:Add TLSAdherence feature gate

### DIFF
--- a/api/hypershift/v1beta1/featuregates/featureGate-Hypershift-Default.yaml
+++ b/api/hypershift/v1beta1/featuregates/featureGate-Hypershift-Default.yaml
@@ -32,6 +32,9 @@
                     },
                     {
                         "name": "GCPPlatform"
+                    },
+                    {
+                        "name": "TLSAdherence"
                     }
                 ],
                 "enabled": [

--- a/api/hypershift/v1beta1/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/api/hypershift/v1beta1/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
@@ -42,6 +42,9 @@
                     },
                     {
                         "name": "GCPPlatform"
+                    },
+                    {
+                        "name": "TLSAdherence"
                     }
                 ],
                 "version": ""

--- a/api/hypershift/v1beta1/featuregates/featureGate-SelfManagedHA-Default.yaml
+++ b/api/hypershift/v1beta1/featuregates/featureGate-SelfManagedHA-Default.yaml
@@ -32,6 +32,9 @@
                     },
                     {
                         "name": "GCPPlatform"
+                    },
+                    {
+                        "name": "TLSAdherence"
                     }
                 ],
                 "enabled": [

--- a/api/hypershift/v1beta1/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/api/hypershift/v1beta1/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -42,6 +42,9 @@
                     },
                     {
                         "name": "GCPPlatform"
+                    },
+                    {
+                        "name": "TLSAdherence"
                     }
                 ],
                 "version": ""


### PR DESCRIPTION
## What this PR does / why we need it:
Adds the TLSAdherence feature gate entry to HyperShift's feature gate configuration files.
This is a sibling PR to openshift/api#2680 which adds a new tlsAdherence field to the APIServer config resource. Since HyperShift embeds configv1.APIServerSpec in the HostedCluster types 1, we need to ensure this new field is properly gated at the TechPreview level to prevent accidental GA exposure.
The feature gate is added as:
- Disabled in *-Default.yaml files (matching standalone OCP Default behavior)
- Enabled in *-TechPreviewNoUpgrade.yaml files (matching standalone OCP TechPreview behavior)

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes N/A
Related:
openshift/api#2680
openshift/enhancements#1910 

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.