### PR TITLE
NO-JIRA: chore(ai): Add skills for dev workflow

### DIFF
--- a/.claude/skills/dev/build-cpo-image/SKILL.md
+++ b/.claude/skills/dev/build-cpo-image/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: Build CPO Image
+description: "Build and push control-plane-operator container image. Auto-applies when testing CPO changes that require deploying to a live cluster."
+---
+
+# Build Control-Plane-Operator Image
+
+This skill enables building and pushing custom control-plane-operator (CPO) images for testing changes in a live HyperShift environment.
+
+## When to Use This Skill
+
+This skill automatically applies when:
+- You've made changes to code in `control-plane-operator/`
+- You need to test CPO changes against a live cluster
+- The user asks to build/push a CPO image
+- You need to iterate on CPO fixes with e2e tests
+
+## Prerequisites
+
+Source the environment file before using this skill:
+
+```bash
+source dev/claude-env.sh
+```
+
+## Image Registry Configuration
+
+Environment variables from `dev/claude-env.sh`:
+
+| Variable | Description |
+|----------|-------------|
+| `CPO_IMAGE_REPO` | Container registry for CPO images |
+| `RUNTIME` | Container runtime (podman/docker) |
+
+## Building the CPO Image
+
+### Step 1: Generate a Unique Tag
+
+Use a tag that identifies the change (branch name, feature, or timestamp):
+
+```bash
+# Option 1: Use branch name
+TAG=$(git rev-parse --abbrev-ref HEAD | tr '/' '-')
+
+# Option 2: Use short commit hash
+TAG=$(git rev-parse --short HEAD)
+
+# Option 3: Use descriptive name + number for iterations
+TAG="feature-name-1"
+```
+
+### Step 2: Build the Image
+
+The CPO image uses `Dockerfile.control-plane`:
+
+```bash
+$RUNTIME build -f Dockerfile.control-plane --platform linux/amd64 -t $CPO_IMAGE_REPO:$TAG .
+```
+
+**Note**: The build runs `make control-plane-operator` and `make control-plane-pki-operator` inside the container, so you don't need to pre-build locally.
+
+### Step 3: Push the Image
+
+```bash
+$RUNTIME push $CPO_IMAGE_REPO:$TAG
+```
+
+## Quick One-Liner
+
+Build and push in one command:
+
+```bash
+TAG="my-fix-1" && $RUNTIME build -f Dockerfile.control-plane --platform linux/amd64 -t $CPO_IMAGE_REPO:$TAG . && $RUNTIME push $CPO_IMAGE_REPO:$TAG
+```
+
+## Iteration Workflow
+
+When iterating on CPO fixes:
+
+1. Make code changes in `control-plane-operator/`
+2. Build and push image with incremented tag (e.g., `fix-1`, `fix-2`, `fix-3`)
+3. Run e2e test with new image
+4. Analyze results
+5. Repeat until test passes
+
+## What Gets Built
+
+The `Dockerfile.control-plane` builds:
+- `control-plane-operator` binary
+- `control-plane-pki-operator` binary
+
+Both are included in the final image.
+
+## Image Labels
+
+The CPO image includes important capability labels that HyperShift uses:
+- `io.openshift.hypershift.control-plane-operator-subcommands=true`
+- `io.openshift.hypershift.control-plane-operator.v2-isdefault=true`
+- Various other feature capability labels
+
+## Troubleshooting
+
+### Build Fails
+- Check that vendored dependencies are up to date: `go mod vendor`
+- Ensure code compiles locally: `make control-plane-operator`
+
+### Push Fails
+- Verify registry login: `$RUNTIME login quay.io`
+- Check repository permissions
+
+### Image Not Used by Cluster
+- Verify the image tag is correct in e2e flags
+- Check that the image was pushed successfully
+- Ensure the cluster can pull from the registry (public or authenticated)

--- a/.claude/skills/dev/build-ho-image/SKILL.md
+++ b/.claude/skills/dev/build-ho-image/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: Build HO Image
+description: "Build and push hypershift-operator container image. Auto-applies when testing HO changes that require deploying to a live cluster."
+---
+
+# Build HyperShift-Operator Image
+
+This skill enables building and pushing custom hypershift-operator (HO) images for testing changes in a live HyperShift environment.
+
+## When to Use This Skill
+
+This skill automatically applies when:
+- You've made changes to code in `hypershift-operator/`
+- You need to test HO changes against a live cluster
+- The user asks to build/push a HO image
+- You need to iterate on HO fixes with e2e tests
+
+## Prerequisites
+
+Source the environment file before using this skill:
+
+```bash
+source dev/claude-env.sh
+```
+
+## Image Registry Configuration
+
+Environment variables from `dev/claude-env.sh`:
+
+| Variable | Description |
+|----------|-------------|
+| `HO_IMAGE_REPO` | Container registry for HO images |
+| `RUNTIME` | Container runtime (podman/docker) |
+
+## Building the HO Image
+
+### Step 1: Generate a Unique Tag
+
+Use a tag that identifies the change (branch name, feature, or timestamp):
+
+```bash
+# Option 1: Use branch name
+TAG=$(git rev-parse --abbrev-ref HEAD | tr '/' '-')
+
+# Option 2: Use short commit hash
+TAG=$(git rev-parse --short HEAD)
+
+# Option 3: Use descriptive name + number for iterations
+TAG="feature-name-1"
+```
+
+### Step 2: Build the Image
+
+The HO image uses the main `Dockerfile`:
+
+```bash
+$RUNTIME build -f Dockerfile --platform linux/amd64 -t $HO_IMAGE_REPO:$TAG .
+```
+
+**Note**: The build runs `make hypershift`, `make hypershift-operator`, `make karpenter-operator`, and `make product-cli` inside the container.
+
+### Step 3: Push the Image
+
+```bash
+$RUNTIME push $HO_IMAGE_REPO:$TAG
+```
+
+## Quick One-Liner
+
+Build and push in one command:
+
+```bash
+TAG="my-fix-1" && $RUNTIME build -f Dockerfile --platform linux/amd64 -t $HO_IMAGE_REPO:$TAG . && $RUNTIME push $HO_IMAGE_REPO:$TAG
+```
+
+## Iteration Workflow
+
+When iterating on HO fixes:
+
+1. Make code changes in `hypershift-operator/`
+2. Build and push image with incremented tag (e.g., `fix-1`, `fix-2`, `fix-3`)
+3. Reinstall HyperShift with new image
+4. Run e2e test or manual validation
+5. Analyze results
+6. Repeat until test passes
+
+## What Gets Built
+
+The main `Dockerfile` builds:
+- `hypershift` CLI binary
+- `hypershift-no-cgo` binary
+- `hypershift-operator` binary
+- `karpenter-operator` binary
+- `hcp` (product CLI) binary
+
+All are included in the final image.
+
+## Troubleshooting
+
+### Build Fails
+- Check that vendored dependencies are up to date: `go mod vendor`
+- Ensure code compiles locally: `make hypershift-operator`
+- Check for API generation issues: `make api`
+
+### Push Fails
+- Verify registry login: `$RUNTIME login quay.io`
+- Check repository permissions
+
+### Operator Not Running After Install
+- Check operator logs: `kubectl logs -n hypershift deployment/operator`
+- Verify image pull succeeded: `kubectl describe pod -n hypershift -l app=operator`
+- Ensure cluster can pull from registry
+
+### Changes Not Reflected
+- Make sure you're using the correct image tag
+- Check if old pods are still running: `kubectl get pods -n hypershift`
+- Force rollout: `kubectl rollout restart deployment/operator -n hypershift`

--- a/.claude/skills/dev/create-hc-aws/SKILL.md
+++ b/.claude/skills/dev/create-hc-aws/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: Create HC AWS
+description: "Create a HyperShift HostedCluster on AWS for development and testing, with optional custom CPO/HO images."
+---
+
+# Create HostedCluster
+
+This skill creates a HyperShift HostedCluster on AWS for development and testing purposes. The clusters created are intended for local development workflows, not for production use.
+
+## When to Use This Skill
+
+Use this skill when:
+- You need to create a dev/test HostedCluster for manual verification
+- You want to test HyperShift features against a live cluster
+- You need a HostedCluster with custom CPO or HO images
+- You are iterating on code changes and need a cluster to validate them
+
+## Prerequisites
+
+Source the environment file before using this skill:
+
+```bash
+source dev/claude-env.sh
+```
+
+Additional requirements:
+- AWS credentials loaded (source `$AWS_CREDS_SOURCE`)
+- KUBECONFIG pointing to management cluster (`$MGMT_KUBECONFIG`)
+- hypershift binary built (`./bin/hypershift` or run `make hypershift`)
+- Pull secret available (`$PULL_SECRET`)
+
+## Environment Configuration
+
+Environment variables from `dev/claude-env.sh`:
+
+| Variable | Description |
+|----------|-------------|
+| `AWS_CREDENTIALS` | Path to AWS credentials file |
+| `AWS_CREDS_SOURCE` | Script to source AWS env vars |
+| `BASE_DOMAIN` | Base DNS domain for clusters |
+| `PULL_SECRET` | Path to pull secret file |
+| `AWS_REGION` | AWS region |
+| `MGMT_KUBECONFIG` | Path to management cluster kubeconfig |
+| `CPO_IMAGE_REPO` | Custom CPO image repository |
+
+## Basic Command
+
+```bash
+source $AWS_CREDS_SOURCE && \
+KUBECONFIG=$MGMT_KUBECONFIG \
+./bin/hypershift create cluster aws \
+  --name <CLUSTER_NAME> \
+  --namespace clusters \
+  --base-domain $BASE_DOMAIN \
+  --aws-creds $AWS_CREDENTIALS \
+  --pull-secret $PULL_SECRET \
+  --region $AWS_REGION \
+  --release-image quay.io/openshift-release-dev/ocp-release:4.21.0-multi \
+  --node-pool-replicas 2
+```
+
+## Common Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `--name` | Name of the HostedCluster | Required |
+| `--namespace` | Namespace for the HostedCluster | `clusters` |
+| `--base-domain` | Base DNS domain | `$BASE_DOMAIN` |
+| `--aws-creds` | Path to AWS credentials file | `$AWS_CREDENTIALS` |
+| `--pull-secret` | Path to pull secret file | `$PULL_SECRET` |
+| `--region` | AWS region | `$AWS_REGION` |
+| `--release-image` | OCP release image | Latest 4.21.0 multi-arch |
+| `--node-pool-replicas` | Initial node count | `0` (add nodes later) |
+| `--control-plane-operator-image` | Custom CPO image | Optional |
+
+## With Custom CPO Image
+
+When testing CPO changes, add the custom image:
+
+```bash
+source $AWS_CREDS_SOURCE && \
+KUBECONFIG=$MGMT_KUBECONFIG \
+./bin/hypershift create cluster aws \
+  --name my-test-cluster \
+  --namespace clusters \
+  --base-domain $BASE_DOMAIN \
+  --aws-creds $AWS_CREDENTIALS \
+  --pull-secret $PULL_SECRET \
+  --region $AWS_REGION \
+  --release-image quay.io/openshift-release-dev/ocp-release:4.21.0-multi \
+  --node-pool-replicas 2 \
+  --control-plane-operator-image $CPO_IMAGE_REPO:YOUR_TAG
+```
+
+## What Gets Created
+
+The command creates:
+- AWS VPC with public and private subnets
+- NAT gateway and internet gateway
+- Route tables
+- Private hosted zones (Route53)
+- OIDC provider for STS
+- IAM roles for control plane components
+- Worker instance profile
+- HostedCluster and NodePool resources
+
+## Post-Creation Steps
+
+1. **Check HostedCluster status:**
+   ```bash
+   KUBECONFIG=$MGMT_KUBECONFIG kubectl get hostedcluster -n clusters
+   ```
+
+2. **Wait for control plane to be available:**
+   ```bash
+   KUBECONFIG=$MGMT_KUBECONFIG kubectl wait --for=condition=Available \
+     hostedcluster/<CLUSTER_NAME> -n clusters --timeout=10m
+   ```
+
+3. **Scale NodePool to add nodes:**
+   ```bash
+   KUBECONFIG=$MGMT_KUBECONFIG kubectl scale nodepool <NODEPOOL_NAME> \
+     -n clusters --replicas=1
+   ```
+
+4. **Get guest cluster kubeconfig:**
+   ```bash
+   KUBECONFIG=$MGMT_KUBECONFIG kubectl get secret <CLUSTER_NAME>-admin-kubeconfig \
+     -n clusters -o jsonpath='{.data.kubeconfig}' | base64 -d > /tmp/guest-kubeconfig.yaml
+   ```
+
+## Cleanup
+
+Use the `dev:destroy-hc-aws` skill or run:
+
+```bash
+source $AWS_CREDS_SOURCE && \
+KUBECONFIG=$MGMT_KUBECONFIG \
+./bin/hypershift destroy cluster aws \
+  --name <CLUSTER_NAME> \
+  --namespace clusters \
+  --aws-creds $AWS_CREDENTIALS \
+  --region $AWS_REGION
+```
+
+## Troubleshooting
+
+### Cluster Creation Fails
+- Check AWS credentials are valid
+- Verify base domain exists in Route53
+- Ensure OIDC S3 bucket is accessible
+
+### Control Plane Not Available
+- Check HCP pods: `kubectl get pods -n clusters-<CLUSTER_NAME>`
+- Check HCP conditions: `kubectl get hcp -n clusters-<CLUSTER_NAME> -o yaml`
+
+### Nodes Not Joining
+- Check machines: `kubectl get machines -n clusters-<CLUSTER_NAME>`
+- Check NodePool conditions: `kubectl get nodepool -n clusters -o yaml`

--- a/.claude/skills/dev/destroy-hc-aws/SKILL.md
+++ b/.claude/skills/dev/destroy-hc-aws/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: Destroy HC AWS
+description: "Destroy a HyperShift HostedCluster and all associated AWS infrastructure (VPC, IAM, Route53, etc.)."
+---
+
+# Destroy HostedCluster
+
+This skill destroys a HyperShift HostedCluster and all associated AWS infrastructure.
+
+## When to Use This Skill
+
+Use this skill when:
+- You need to clean up a test HostedCluster
+- You want to destroy a HostedCluster and its AWS resources (VPC, subnets, NAT gateways, IAM roles, etc.)
+- You need to remove orphaned HostedClusters from previous test runs
+
+## Prerequisites
+
+Source the environment file before using this skill:
+
+```bash
+source dev/claude-env.sh
+```
+
+Additional requirements:
+- AWS credentials loaded (source `$AWS_CREDS_SOURCE`)
+- KUBECONFIG pointing to management cluster (`$MGMT_KUBECONFIG`)
+- hypershift binary built (`./bin/hypershift`)
+
+## Environment Configuration
+
+Environment variables from `dev/claude-env.sh`:
+
+| Variable | Description |
+|----------|-------------|
+| `AWS_CREDENTIALS` | Path to AWS credentials file |
+| `AWS_CREDS_SOURCE` | Script to source AWS env vars |
+| `AWS_REGION` | AWS region |
+| `MGMT_KUBECONFIG` | Path to management cluster kubeconfig |
+
+## Command
+
+```bash
+source $AWS_CREDS_SOURCE && \
+KUBECONFIG=$MGMT_KUBECONFIG \
+./bin/hypershift destroy cluster aws \
+  --name <CLUSTER_NAME> \
+  --namespace <NAMESPACE> \
+  --aws-creds $AWS_CREDENTIALS \
+  --region $AWS_REGION
+```
+
+## Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `--name` | Name of the HostedCluster to destroy | Required |
+| `--namespace` | Namespace where the HostedCluster exists | `clusters` |
+| `--aws-creds` | Path to AWS credentials file | `$AWS_CREDENTIALS` |
+| `--region` | AWS region | `$AWS_REGION` |
+
+## What Gets Destroyed
+
+The command destroys:
+- HostedCluster and NodePool resources
+- HostedControlPlane namespace and all resources
+- AWS VPC and subnets
+- NAT gateways and internet gateways
+- Route tables
+- Security groups
+- DHCP options
+- Private hosted zones (Route53)
+- OIDC provider
+- IAM roles and instance profiles
+- VPC endpoints
+- Elastic IPs
+
+## Quick Cleanup for Orphaned HCs
+
+If a HostedCluster is stuck deleting, you can force remove it:
+
+```bash
+# Remove cleanup annotation to skip cloud resource cleanup
+KUBECONFIG=$MGMT_KUBECONFIG kubectl annotate hostedcluster <NAME> -n <NAMESPACE> \
+  hypershift.openshift.io/cleanup-cloud-resources-
+```
+
+## Example Usage
+
+```bash
+# List existing HostedClusters
+KUBECONFIG=$MGMT_KUBECONFIG kubectl get hostedclusters -A
+
+# Destroy a specific HostedCluster
+source $AWS_CREDS_SOURCE && \
+KUBECONFIG=$MGMT_KUBECONFIG \
+./bin/hypershift destroy cluster aws \
+  --name my-test-cluster \
+  --namespace clusters \
+  --aws-creds $AWS_CREDENTIALS \
+  --region $AWS_REGION
+```
+
+## Troubleshooting
+
+### NAT Gateway Still Deleting
+NAT gateways take time to delete. The command will retry automatically.
+
+### VPC Has Dependencies
+The command will retry until all dependencies (subnets, gateways, etc.) are deleted.
+
+### HostedCluster Stuck in Deleting
+1. Check if there are stuck finalizers
+2. Remove the cleanup-cloud-resources annotation if you want to skip AWS cleanup
+3. Manually delete AWS resources if needed

--- a/.claude/skills/dev/e2e-run-aws/SKILL.md
+++ b/.claude/skills/dev/e2e-run-aws/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: E2E Test Runner
+description: "Provides the ability to run and iterate on HyperShift e2e tests. Auto-applies when implementing features that require e2e validation, fixing e2e test failures, or working on tasks that need live cluster testing."
+---
+
+# HyperShift E2E Test Runner
+
+This skill enables autonomous iteration on e2e tests - running tests, analyzing failures, making fixes, and re-running until tests pass.
+
+## When to Use This Skill
+
+This skill automatically applies when:
+- Implementing a feature that needs e2e test validation
+- Fixing a failing e2e test
+- Working on a task where the user wants you to iterate until tests pass
+- Debugging test failures in the `test/e2e/` directory
+- The user mentions running e2e tests or validating changes against a live cluster
+
+## Prerequisites
+
+Source the environment file before using this skill:
+
+```bash
+source dev/claude-env.sh
+```
+
+## Environment Configuration
+
+Environment variables from `dev/claude-env.sh`:
+
+| Variable | Description |
+|----------|-------------|
+| `E2E_PLATFORM` | Test platform (AWS, Azure, etc.) |
+| `AWS_CREDENTIALS` | Path to AWS credentials file |
+| `OIDC_BUCKET` | S3 bucket for OIDC |
+| `BASE_DOMAIN` | Base DNS domain |
+| `PULL_SECRET` | Path to pull secret file |
+| `AWS_REGION` | AWS region |
+| `E2E_ARTIFACT_DIR` | Directory for test artifacts |
+| `MGMT_KUBECONFIG` | Path to management cluster kubeconfig |
+| `CPO_IMAGE_REPO` | Custom CPO image repository |
+| `RUNTIME` | Container runtime (podman/docker) |
+
+## Running E2E Tests
+
+### Step 1: Check if Test Binary Needs Rebuilding
+
+**CRITICAL**: Before running any e2e test, you MUST check if the test binary needs rebuilding:
+
+```bash
+# Check if binary exists
+if [ ! -f ./bin/test-e2e ]; then
+  echo "Test binary missing, building..."
+  make e2e
+fi
+
+# Check if any test files are newer than the binary
+NEWEST_TEST=$(find test/e2e -name "*.go" -newer ./bin/test-e2e 2>/dev/null | head -1)
+if [ -n "$NEWEST_TEST" ]; then
+  echo "Test files changed (e.g., $NEWEST_TEST), rebuilding..."
+  make e2e
+fi
+```
+
+### Step 2: Run the Test
+
+Build and execute the test command:
+
+```bash
+KUBECONFIG=$MGMT_KUBECONFIG \
+./bin/test-e2e -test.v -test.timeout 2h \
+  -test.run "TEST_PATTERN" \
+  -test.v \
+  --e2e.platform $E2E_PLATFORM \
+  --e2e.aws-credentials-file $AWS_CREDENTIALS \
+  --e2e.aws-oidc-s3-bucket-name $OIDC_BUCKET \
+  --e2e.base-domain $BASE_DOMAIN \
+  --e2e.pull-secret-file $PULL_SECRET \
+  --e2e.aws-region $AWS_REGION \
+  --e2e.artifact-dir $E2E_ARTIFACT_DIR
+```
+
+### Step 3: Add Custom CPO Image (When Testing Control Plane Changes)
+
+If you've made changes to control-plane-operator code and built a custom image, add:
+
+```bash
+-e2e.control-plane-operator-image $CPO_IMAGE_REPO:TAG
+```
+
+## Iteration Loop
+
+When working autonomously on a task that requires e2e validation:
+
+### 1. Initial Test Run
+Run the test to establish baseline:
+```bash
+KUBECONFIG=$MGMT_KUBECONFIG ./bin/test-e2e -test.v -test.run "TestName" [flags...]
+```
+
+### 2. On Failure - Analyze
+- Read the test output carefully
+- Check artifacts in `$E2E_ARTIFACT_DIR/` directory for:
+  - Pod logs
+  - Events
+  - Resource states
+- Identify the root cause
+
+### 3. Make Fixes
+- Edit the relevant code (test code, operator code, etc.)
+- If you modified `test/e2e/*.go` files, the binary will be rebuilt automatically on next run
+
+### 4. Rebuild Images (If Needed)
+If you modified control-plane-operator code:
+Use the build-cpo-image skill to build and push a new image.
+
+```bash
+$RUNTIME build -f Dockerfile.control-plane --platform linux/amd64 -t $CPO_IMAGE_REPO:NEW_TAG .
+$RUNTIME push $CPO_IMAGE_REPO:NEW_TAG
+```
+
+### 5. Re-run Test
+Run the test again with updated code/images. Repeat until passing.
+
+## Common Test Patterns
+
+| Test Pattern | Description |
+|--------------|-------------|
+| `TestNodePool` | All NodePool tests |
+| `TestNodePool/HostedCluster0/Main/TestSpotTerminationHandler` | Specific spot test |
+| `TestNodePool.*Karpenter` | All Karpenter-related tests |
+| `TestCreateCluster` | Cluster creation tests |
+| `TestUpgrade` | Upgrade tests |
+
+## Analyzing Test Failures
+
+### Check Test Output
+The test output includes:
+- Test name and status
+- Assertion failures with expected vs actual
+- Timeout information
+- Resource creation/deletion logs
+
+### Check Artifact Directory
+After a test failure, examine:
+```bash
+ls -la $E2E_ARTIFACT_DIR/
+# Contains: cluster manifests, pod logs, events, resource dumps
+```
+
+### Common Failure Patterns
+
+| Pattern | Likely Cause |
+|---------|--------------|
+| `context deadline exceeded` | Resource didn't reach expected state in time |
+| `not found` | Resource wasn't created or was deleted prematurely |
+| `connection refused` | Service not ready or network issue |
+| `forbidden` | RBAC or permission issue |
+
+## Building Test Binary
+
+When test code changes, rebuild:
+```bash
+make e2e
+```
+
+This compiles `./bin/test-e2e` with all tests from `test/e2e/`.
+
+## Notes
+
+- Tests typically take 10-30+ minutes depending on complexity
+- Some tests create real AWS resources (costs money, needs cleanup on failure)
+- Use `-test.timeout` to set appropriate timeouts (default: 2h)
+- The artifact directory is overwritten on each run
+- For long tests, consider running in background and checking periodically

--- a/.claude/skills/dev/git-env/SKILL.md
+++ b/.claude/skills/dev/git-env/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: Git Environment
+description: "Create development environments with git worktrees, branches, commits, and push to remote. Auto-applies for git workflow tasks."
+---
+
+# Git Development Environment Workflow
+
+Automates common git development workflows for HyperShift including worktree creation, branching, committing (with proper format), and pushing to remotes.
+
+## Configuration
+
+Load environment variables from `dev/claude-env.sh`:
+
+```bash
+source dev/claude-env.sh
+```
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GIT_FORK_REMOTE` | `enxebre` | Your fork remote name |
+| `GIT_UPSTREAM_REMOTE` | `origin` | Upstream remote (openshift/hypershift) |
+| `GIT_BASE_BRANCH` | `main` | Base branch for new features |
+
+## Workflows
+
+### Create New Development Environment
+
+**With worktree (parallel development):**
+```bash
+# Fetch latest
+git fetch $GIT_UPSTREAM_REMOTE $GIT_BASE_BRANCH
+
+# Create worktree with new branch
+git worktree add -b <branch-name> <worktree-path> $GIT_UPSTREAM_REMOTE/$GIT_BASE_BRANCH
+
+# Example:
+git worktree add -b feat/privatelink-karpenter ../hs-privatelink $GIT_UPSTREAM_REMOTE/$GIT_BASE_BRANCH
+```
+
+**Without worktree (same repo):**
+```bash
+# Fetch latest
+git fetch $GIT_UPSTREAM_REMOTE $GIT_BASE_BRANCH
+
+# Create and checkout new branch
+git checkout -b <branch-name> $GIT_UPSTREAM_REMOTE/$GIT_BASE_BRANCH
+
+# Example:
+git checkout -b fix/bug-123 $GIT_UPSTREAM_REMOTE/$GIT_BASE_BRANCH
+```
+
+### Branch Naming Conventions
+
+Use conventional prefixes:
+- `feat/<description>` - New features
+- `fix/<description>` - Bug fixes
+- `docs/<description>` - Documentation
+- `refactor/<description>` - Code refactoring
+- `test/<description>` - Test additions
+- `chore/<description>` - Maintenance tasks
+
+### Commit Changes
+
+**Always follow the git-commit-format skill for commits.**
+
+1. **Stage changes:**
+   ```bash
+   git add <specific-files>
+   ```
+
+2. **Check what's staged:**
+   ```bash
+   git status
+   git diff --cached
+   ```
+
+3. **Commit with proper format:**
+   ```bash
+   git commit -m "$(cat <<'EOF'
+   <type>(<scope>): <description>
+
+   [optional body]
+
+   Signed-off-by: <name> <email>
+   Commit-Message-Assisted-by: Claude (via Claude Code)
+   EOF
+   )"
+   ```
+
+4. **Validate commit message:**
+   ```bash
+   make run-gitlint
+   ```
+
+### Push to Remote
+
+**First push (set upstream):**
+```bash
+git push -u $GIT_FORK_REMOTE <branch-name>
+```
+
+**Subsequent pushes:**
+```bash
+git push
+```
+
+**Force push (after rebase):**
+```bash
+# Always use --force-with-lease for safety
+git push --force-with-lease
+```
+
+### Sync with Upstream
+
+```bash
+# Fetch latest from upstream
+git fetch $GIT_UPSTREAM_REMOTE $GIT_BASE_BRANCH
+
+# Rebase current branch on base branch
+git rebase $GIT_UPSTREAM_REMOTE/$GIT_BASE_BRANCH
+
+# If conflicts, resolve them, then:
+git rebase --continue
+
+# Push updated branch (force required after rebase)
+git push --force-with-lease
+```
+
+### Cleanup Worktree
+
+```bash
+# Remove the worktree
+git worktree remove <worktree-path>
+
+# Optionally delete the branch
+git branch -D <branch-name>
+
+# Prune stale worktree references
+git worktree prune
+```
+
+### List Worktrees
+
+```bash
+git worktree list
+```
+
+## Quick Reference Commands
+
+| Task | Command |
+|------|---------|
+| New worktree + branch | `git worktree add -b <branch> <path> $GIT_UPSTREAM_REMOTE/$GIT_BASE_BRANCH` |
+| New branch (no worktree) | `git checkout -b <branch> $GIT_UPSTREAM_REMOTE/$GIT_BASE_BRANCH` |
+| Stage all changes | `git add -A` |
+| Stage specific files | `git add <file1> <file2>` |
+| Check status | `git status` |
+| View staged diff | `git diff --cached` |
+| Commit | `git commit -m "<message>"` |
+| Validate commit | `make run-gitlint` |
+| Push (first time) | `git push -u $GIT_FORK_REMOTE <branch>` |
+| Push | `git push` |
+| Force push (safe) | `git push --force-with-lease` |
+| Sync with upstream | `git fetch $GIT_UPSTREAM_REMOTE $GIT_BASE_BRANCH && git rebase $GIT_UPSTREAM_REMOTE/$GIT_BASE_BRANCH` |
+| Remove worktree | `git worktree remove <path>` |
+| Delete branch | `git branch -D <branch>` |
+| List worktrees | `git worktree list` |
+
+## Example Full Workflow
+
+```bash
+# 0. Load environment
+source dev/claude-env.sh
+
+# 1. Create new feature environment
+git fetch $GIT_UPSTREAM_REMOTE $GIT_BASE_BRANCH
+git worktree add -b feat/aws-privatelink-subnets ../hs-privatelink $GIT_UPSTREAM_REMOTE/$GIT_BASE_BRANCH
+cd ../hs-privatelink
+
+# 2. Make changes...
+# ... edit files ...
+
+# 3. Stage and commit
+git add -A
+git commit -m "$(cat <<'EOF'
+feat(aws): add dynamic subnet discovery for privatelink
+
+Implement subnet discovery from Karpenter EC2NodeClass resources
+to ensure PrivateLink VPC Endpoints have ENIs in all required
+availability zones.
+
+Signed-off-by: Alberto Garcia <agarcia@redhat.com>
+Commit-Message-Assisted-by: Claude (via Claude Code)
+EOF
+)"
+
+# 4. Validate
+make run-gitlint
+
+# 5. Push to fork
+git push -u $GIT_FORK_REMOTE feat/aws-privatelink-subnets
+
+# 6. Create PR via gh cli
+gh pr create --title "feat(aws): add dynamic subnet discovery for privatelink" --body "..."
+
+# 7. After PR merged, cleanup
+cd ../hypershift
+git worktree remove ../hs-privatelink
+git branch -D feat/aws-privatelink-subnets
+```
+
+## Notes
+
+- Always use `--force-with-lease` instead of `--force` for safety
+- Worktrees allow parallel development on multiple features
+- Each worktree shares the same git repository but has its own working directory
+- Run `git remote -v` to verify remote configuration
+- Configure your fork remote in `dev/claude-env.sh` by setting `GIT_FORK_REMOTE`

--- a/.claude/skills/dev/install-ho-aws/SKILL.md
+++ b/.claude/skills/dev/install-ho-aws/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: Install HO AWS
+description: "Install HyperShift Operator with private AWS and external-dns settings."
+---
+
+# Install HyperShift Operator (HO)
+
+Use this skill to install HyperShift Operator with a custom image, external-dns, and private AWS settings.
+
+## When to Use This Skill
+
+Use when:
+- You need to install HO with a custom image
+- You want external-dns configured for AWS
+- You are using private AWS settings for the management cluster
+- Changes to the CRDs generated APIs don't need an image rebuild, just a make api && make build
+
+## Prerequisites
+
+Source the environment file before using this skill:
+
+```bash
+source dev/claude-env.sh
+```
+
+## Environment Configuration
+
+Environment variables from `dev/claude-env.sh`:
+
+| Variable | Description |
+|----------|-------------|
+| `HO_IMAGE_REPO` | Container registry for HO images |
+| `AWS_CREDENTIALS` | Path to AWS credentials file |
+| `EXTERNAL_DNS_DOMAIN` | Domain filter for external-dns |
+| `OIDC_BUCKET` | S3 bucket for OIDC |
+| `AWS_REGION` | AWS region |
+| `MGMT_KUBECONFIG` | Path to management cluster kubeconfig |
+
+## Parameters
+
+- `HO_IMAGE` should point to the image you want to install, for example `$HO_IMAGE_REPO:autonode`.
+
+## Command
+
+Run make build first if needed
+
+```bash
+KUBECONFIG=$MGMT_KUBECONFIG \
+./bin/hypershift install \
+  --hypershift-image $HO_IMAGE_REPO:YOUR_TAG \
+  --external-dns-provider=aws \
+  --external-dns-credentials $AWS_CREDENTIALS \
+  --external-dns-domain-filter=$EXTERNAL_DNS_DOMAIN \
+  --oidc-storage-provider-s3-bucket-name $OIDC_BUCKET \
+  --oidc-storage-provider-s3-credentials $AWS_CREDENTIALS \
+  --oidc-storage-provider-s3-region $AWS_REGION \
+  --private-platform=AWS \
+  --aws-private-creds $AWS_CREDENTIALS \
+  --enable-conversion-webhook=false \
+  --aws-private-region=$AWS_REGION
+```
+
+## Notes
+
+- Build the CLI first: `make hypershift` (this produces `./bin/hypershift`).
+- Ensure the AWS credentials file exists and is readable.
+- The `MGMT_KUBECONFIG` must point to your management cluster.

--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ tools/bin
 *_mock.go
 
 # dev
-dev/
+/dev/
 
 # Python
 __pycache__/


### PR DESCRIPTION
Create 7 skills into .claude/skills/dev/:
- build-cpo-image: Build and push control-plane-operator images
- build-ho-image: Build and push hypershift-operator images
- create-hc-aws: Create dev/test HostedClusters on AWS
- destroy-hc-aws: Destroy HostedClusters and AWS infrastructure
- e2e-run-aws: Run and iterate on e2e tests
- git-env: Create dev environments with git worktrees and branches
- install-ho-aws: Install HyperShift Operator with custom settings

Update .gitignore to only ignore /dev/ at the repository root,
allowing .claude/skills/dev/ to be tracked.

Skills use environment variables from dev/claude-env.sh which is
in .gitignore and must be created locally.

These skills are the building blocks I use for my agentic workflows. I leverage this building blocks for both success criteria on long running tasks and also pairing approaches.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>