### PR TITLE
[release-4.21] fix(cpo): external route labeling for PublicAndPrivate clusters with LoadBalancer KAS

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1173,7 +1173,18 @@ func useHCPRouter(hostedControlPlane *hyperv1.HostedControlPlane) bool {
 	if hostedControlPlane.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
 		return false
 	}
-	return util.IsPrivateHCP(hostedControlPlane) || util.IsPublicWithDNS(hostedControlPlane)
+	return labelHCPRoutes(hostedControlPlane)
+}
+
+func labelHCPRoutes(hcp *hyperv1.HostedControlPlane) bool {
+	// Only label routes for the private HCP router when:
+	// 1. Cluster has no public access (Private-only), OR
+	// 2. Cluster is Public with dedicated DNS for KAS (KAS uses Route with explicit hostname)
+	//
+	// For PublicAndPrivate clusters using LoadBalancer for KAS, external routes without
+	// explicit hostnames should use the management cluster router instead of requiring
+	// a separate public HCP router infrastructure.
+	return !util.IsPublicHCP(hcp) || util.IsPublicKASWithDNS(hcp)
 }
 
 func IsStorageAndCSIManaged(hostedControlPlane *hyperv1.HostedControlPlane) bool {

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -2282,7 +2282,7 @@ func TestUseHCPRouter(t *testing.T) {
 					},
 				},
 			},
-			expectedResult: true,
+			expectedResult: false,
 		},
 		{
 			name: "Provider is AWS, Private",
@@ -2339,7 +2339,7 @@ func TestUseHCPRouter(t *testing.T) {
 					},
 				},
 			},
-			expectedResult: true,
+			expectedResult: false,
 		},
 	}
 	for _, tc := range testsCases {

--- a/support/util/visibility.go
+++ b/support/util/visibility.go
@@ -68,3 +68,7 @@ func IsPublicWithDNSByHC(hc *hyperv1.HostedCluster) bool {
 		UseDedicatedDNSByHC(hc, hyperv1.Konnectivity) ||
 		UseDedicatedDNSByHC(hc, hyperv1.Ignition))
 }
+
+func IsPublicKASWithDNS(hostedControlPlane *hyperv1.HostedControlPlane) bool {
+	return IsPublicHCP(hostedControlPlane) && UseDedicatedDNSForKAS(hostedControlPlane)
+}


### PR DESCRIPTION
## What this PR does / why we need it:
Manual backport of https://github.com/openshift/hypershift/pull/7605