### PR TITLE
OCPBUGS-75930: [release-4.21] fix(cpo): Correct route labeling logic for HCP router infrastructure

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -66,7 +67,6 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/go-logr/zapr"
-	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap/zaptest"
 )
@@ -396,11 +396,8 @@ func TestReconcileOAuthService(t *testing.T) {
 	oauthExternalPublicRoute := func(m ...func(*routev1.Route)) routev1.Route {
 		route := routev1.Route{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: targetNamespace,
-				Name:      "oauth",
-				Labels: map[string]string{
-					"hypershift.openshift.io/hosted-control-plane": targetNamespace,
-				},
+				Namespace:       targetNamespace,
+				Name:            "oauth",
 				OwnerReferences: []metav1.OwnerReference{ownerRef},
 			},
 			Spec: routev1.RouteSpec{
@@ -1443,6 +1440,24 @@ func TestReconcileHCPRouterServices(t *testing.T) {
 			},
 		},
 		{
+			name:                         "Private LB gets removed when switching to Public",
+			endpointAccess:               hyperv1.Public,
+			exposeAPIServerThroughRouter: true,
+			existingObjects:              []client.Object{privateService()},
+			expectedServices: []corev1.Service{
+				*publicService(),
+			},
+		},
+		{
+			name:                         "Public LB gets removed when PublicAndPrivate but not using Route",
+			endpointAccess:               hyperv1.PublicAndPrivate,
+			exposeAPIServerThroughRouter: false,
+			existingObjects:              []client.Object{publicService()},
+			expectedServices: []corev1.Service{
+				*privateService(withCrossZoneAnnotation),
+			},
+		},
+		{
 			name:                         "No LB created when public and not using Route",
 			endpointAccess:               hyperv1.Public,
 			exposeAPIServerThroughRouter: false,
@@ -2189,166 +2204,6 @@ func componentsFakeDependencies(componentName string, namespace string) []client
 	return fakeComponents
 }
 
-func TestUseHCPRouter(t *testing.T) {
-	testsCases := []struct {
-		name           string
-		hcp            *hyperv1.HostedControlPlane
-		expectedResult bool
-	}{
-		{
-			name: "Provider is IBM Cloud",
-			hcp: &hyperv1.HostedControlPlane{
-				TypeMeta: metav1.TypeMeta{},
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "tenant1",
-					Name:      "cluster1",
-				},
-				Spec: hyperv1.HostedControlPlaneSpec{
-					Platform: hyperv1.PlatformSpec{
-						Type: hyperv1.IBMCloudPlatform,
-					},
-				},
-			},
-			expectedResult: false,
-		},
-		{
-			name: "Provider is NonePlatform, services are exposed with Routes",
-			hcp: &hyperv1.HostedControlPlane{
-				TypeMeta: metav1.TypeMeta{},
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "tenant1",
-					Name:      "cluster1",
-				},
-				Spec: hyperv1.HostedControlPlaneSpec{
-					Platform: hyperv1.PlatformSpec{
-						Type: hyperv1.NonePlatform,
-					},
-					Services: []hyperv1.ServicePublishingStrategyMapping{
-						{
-							Service: hyperv1.APIServer,
-							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
-								Type: hyperv1.Route,
-								Route: &hyperv1.RoutePublishingStrategy{
-									Hostname: "cluster1.api.tenant1.com",
-								},
-							},
-						},
-						{
-							Service: hyperv1.Konnectivity,
-							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
-								Type: hyperv1.Route,
-								Route: &hyperv1.RoutePublishingStrategy{
-									Hostname: "cluster1.tunnel.tenant1.com",
-								},
-							},
-						},
-						{
-							Service: hyperv1.Ignition,
-							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
-								Type: hyperv1.Route,
-								Route: &hyperv1.RoutePublishingStrategy{
-									Hostname: "cluster1.ignition.tenant1.com",
-								},
-							},
-						},
-						{
-							Service: hyperv1.OAuthServer,
-							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
-								Type: hyperv1.Route,
-								Route: &hyperv1.RoutePublishingStrategy{
-									Hostname: "cluster1.oauth.tenant1.com",
-								},
-							},
-						},
-					},
-				},
-			},
-			expectedResult: true,
-		},
-		{
-			name: "Provider is AWS, Public and Private",
-			hcp: &hyperv1.HostedControlPlane{
-				TypeMeta: metav1.TypeMeta{},
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "tenant1",
-					Name:      "cluster1",
-				},
-				Spec: hyperv1.HostedControlPlaneSpec{
-					Platform: hyperv1.PlatformSpec{
-						Type: hyperv1.AWSPlatform,
-						AWS: &hyperv1.AWSPlatformSpec{
-							EndpointAccess: hyperv1.PublicAndPrivate,
-						},
-					},
-				},
-			},
-			expectedResult: true,
-		},
-		{
-			name: "Provider is AWS, Private",
-			hcp: &hyperv1.HostedControlPlane{
-				TypeMeta: metav1.TypeMeta{},
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "tenant1",
-					Name:      "cluster1",
-				},
-				Spec: hyperv1.HostedControlPlaneSpec{
-					Platform: hyperv1.PlatformSpec{
-						Type: hyperv1.AWSPlatform,
-						AWS: &hyperv1.AWSPlatformSpec{
-							EndpointAccess: hyperv1.Private,
-						},
-					},
-				},
-			},
-			expectedResult: true,
-		},
-		{
-			name: "Provider is GCP, Private",
-			hcp: &hyperv1.HostedControlPlane{
-				TypeMeta: metav1.TypeMeta{},
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "tenant1",
-					Name:      "cluster1",
-				},
-				Spec: hyperv1.HostedControlPlaneSpec{
-					Platform: hyperv1.PlatformSpec{
-						Type: hyperv1.GCPPlatform,
-						GCP: &hyperv1.GCPPlatformSpec{
-							EndpointAccess: hyperv1.GCPEndpointAccessPrivate,
-						},
-					},
-				},
-			},
-			expectedResult: true,
-		},
-		{
-			name: "Provider is GCP, PublicAndPrivate",
-			hcp: &hyperv1.HostedControlPlane{
-				TypeMeta: metav1.TypeMeta{},
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "tenant1",
-					Name:      "cluster1",
-				},
-				Spec: hyperv1.HostedControlPlaneSpec{
-					Platform: hyperv1.PlatformSpec{
-						Type: hyperv1.GCPPlatform,
-						GCP: &hyperv1.GCPPlatformSpec{
-							EndpointAccess: hyperv1.GCPEndpointAccessPublicAndPrivate,
-						},
-					},
-				},
-			},
-			expectedResult: true,
-		},
-	}
-	for _, tc := range testsCases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expectedResult, useHCPRouter(tc.hcp))
-		})
-	}
-}
-
 func TestControlPlaneComponentsAvailable(t *testing.T) {
 	testNamespace := "test-namespace"
 
@@ -2578,6 +2433,391 @@ func TestControlPlaneComponentsAvailable(t *testing.T) {
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(msg).To(Equal(tc.expectedMsg))
+			}
+		})
+	}
+}
+
+func TestRemoveHCPIngressFromRoutes(t *testing.T) {
+	const namespace = "test-ns"
+
+	tests := []struct {
+		name           string
+		hcp            *hyperv1.HostedControlPlane
+		existingRoutes []*routev1.Route
+		expectedRoutes []routev1.Route
+		expectError    bool
+		errorContains  string
+	}{
+		{
+			name: "Route with HCPRouteLabel is skipped",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hcp",
+					Namespace: namespace,
+				},
+			},
+			existingRoutes: []*routev1.Route{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "hcp-managed-route",
+						Namespace: namespace,
+						Labels: map[string]string{
+							util.HCPRouteLabel: namespace,
+						},
+					},
+					Status: routev1.RouteStatus{
+						Ingress: []routev1.RouteIngress{
+							{RouterName: "router", Host: "example.com"},
+							{RouterName: "other-router", Host: "other.com"},
+						},
+					},
+				},
+			},
+			expectedRoutes: []routev1.Route{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "hcp-managed-route",
+						Namespace: namespace,
+						Labels: map[string]string{
+							util.HCPRouteLabel: namespace,
+						},
+					},
+					Status: routev1.RouteStatus{
+						Ingress: []routev1.RouteIngress{
+							{RouterName: "router", Host: "example.com"},
+							{RouterName: "other-router", Host: "other.com"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Route without HCPRouteLabel has router ingress removed",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hcp",
+					Namespace: namespace,
+				},
+			},
+			existingRoutes: []*routev1.Route{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "regular-route",
+						Namespace: namespace,
+					},
+					Status: routev1.RouteStatus{
+						Ingress: []routev1.RouteIngress{
+							{RouterName: "router", Host: "example.com"},
+							{RouterName: "other-router", Host: "other.com"},
+						},
+					},
+				},
+			},
+			expectedRoutes: []routev1.Route{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "regular-route",
+						Namespace: namespace,
+					},
+					Status: routev1.RouteStatus{
+						Ingress: []routev1.RouteIngress{
+							{RouterName: "other-router", Host: "other.com"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Route without router ingress is unchanged",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hcp",
+					Namespace: namespace,
+				},
+			},
+			existingRoutes: []*routev1.Route{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "regular-route",
+						Namespace: namespace,
+					},
+					Status: routev1.RouteStatus{
+						Ingress: []routev1.RouteIngress{
+							{RouterName: "other-router", Host: "other.com"},
+							{RouterName: "another-router", Host: "another.com"},
+						},
+					},
+				},
+			},
+			expectedRoutes: []routev1.Route{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "regular-route",
+						Namespace: namespace,
+					},
+					Status: routev1.RouteStatus{
+						Ingress: []routev1.RouteIngress{
+							{RouterName: "other-router", Host: "other.com"},
+							{RouterName: "another-router", Host: "another.com"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Route with only router ingress has all ingress removed",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hcp",
+					Namespace: namespace,
+				},
+			},
+			existingRoutes: []*routev1.Route{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "router-only-route",
+						Namespace: namespace,
+					},
+					Status: routev1.RouteStatus{
+						Ingress: []routev1.RouteIngress{
+							{RouterName: "router", Host: "example.com"},
+						},
+					},
+				},
+			},
+			expectedRoutes: []routev1.Route{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "router-only-route",
+						Namespace: namespace,
+					},
+					Status: routev1.RouteStatus{
+						Ingress: []routev1.RouteIngress{},
+					},
+				},
+			},
+		},
+		{
+			name: "Multiple routes handled correctly",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hcp",
+					Namespace: namespace,
+				},
+			},
+			existingRoutes: []*routev1.Route{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "hcp-managed",
+						Namespace: namespace,
+						Labels: map[string]string{
+							util.HCPRouteLabel: namespace,
+						},
+					},
+					Status: routev1.RouteStatus{
+						Ingress: []routev1.RouteIngress{
+							{RouterName: "router", Host: "hcp.example.com"},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "regular-route-1",
+						Namespace: namespace,
+					},
+					Status: routev1.RouteStatus{
+						Ingress: []routev1.RouteIngress{
+							{RouterName: "router", Host: "route1.example.com"},
+							{RouterName: "other-router", Host: "route1.other.com"},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "regular-route-2",
+						Namespace: namespace,
+					},
+					Status: routev1.RouteStatus{
+						Ingress: []routev1.RouteIngress{
+							{RouterName: "other-router", Host: "route2.other.com"},
+						},
+					},
+				},
+			},
+			expectedRoutes: []routev1.Route{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "hcp-managed",
+						Namespace: namespace,
+						Labels: map[string]string{
+							util.HCPRouteLabel: namespace,
+						},
+					},
+					Status: routev1.RouteStatus{
+						Ingress: []routev1.RouteIngress{
+							{RouterName: "router", Host: "hcp.example.com"},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "regular-route-1",
+						Namespace: namespace,
+					},
+					Status: routev1.RouteStatus{
+						Ingress: []routev1.RouteIngress{
+							{RouterName: "other-router", Host: "route1.other.com"},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "regular-route-2",
+						Namespace: namespace,
+					},
+					Status: routev1.RouteStatus{
+						Ingress: []routev1.RouteIngress{
+							{RouterName: "other-router", Host: "route2.other.com"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Route with empty ingress list is unchanged",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hcp",
+					Namespace: namespace,
+				},
+			},
+			existingRoutes: []*routev1.Route{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "empty-ingress-route",
+						Namespace: namespace,
+					},
+					Status: routev1.RouteStatus{
+						Ingress: []routev1.RouteIngress{},
+					},
+				},
+			},
+			expectedRoutes: []routev1.Route{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "empty-ingress-route",
+						Namespace: namespace,
+					},
+					Status: routev1.RouteStatus{
+						Ingress: []routev1.RouteIngress{},
+					},
+				},
+			},
+		},
+		{
+			name: "Route with multiple router ingress entries removes all",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hcp",
+					Namespace: namespace,
+				},
+			},
+			existingRoutes: []*routev1.Route{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "multi-router-route",
+						Namespace: namespace,
+					},
+					Status: routev1.RouteStatus{
+						Ingress: []routev1.RouteIngress{
+							{RouterName: "router", Host: "example1.com"},
+							{RouterName: "router", Host: "example2.com"},
+							{RouterName: "other-router", Host: "other.com"},
+							{RouterName: "router", Host: "example3.com"},
+						},
+					},
+				},
+			},
+			expectedRoutes: []routev1.Route{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "multi-router-route",
+						Namespace: namespace,
+					},
+					Status: routev1.RouteStatus{
+						Ingress: []routev1.RouteIngress{
+							{RouterName: "other-router", Host: "other.com"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			ctx := ctrl.LoggerInto(context.Background(), zapr.NewLogger(zaptest.NewLogger(t)))
+
+			// Convert existing routes to client.Object slice
+			existingObjects := make([]client.Object, 0, len(tc.existingRoutes))
+			for _, route := range tc.existingRoutes {
+				existingObjects = append(existingObjects, route)
+			}
+			existingObjects = append(existingObjects, tc.hcp)
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(api.Scheme).
+				WithObjects(existingObjects...).
+				WithStatusSubresource(&routev1.Route{}).
+				Build()
+
+			r := &HostedControlPlaneReconciler{
+				Client: fakeClient,
+				Log:    ctrl.LoggerFrom(ctx),
+			}
+
+			err := r.removeHCPIngressFromRoutes(ctx, tc.hcp)
+
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+				if tc.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tc.errorContains))
+				}
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+
+				// Verify routes match expected state
+				var actualRoutes routev1.RouteList
+				err = fakeClient.List(ctx, &actualRoutes, client.InNamespace(namespace))
+				g.Expect(err).NotTo(HaveOccurred())
+
+				// Sort routes by name for comparison
+				sort.Slice(actualRoutes.Items, func(i, j int) bool {
+					return actualRoutes.Items[i].Name < actualRoutes.Items[j].Name
+				})
+				sort.Slice(tc.expectedRoutes, func(i, j int) bool {
+					return tc.expectedRoutes[i].Name < tc.expectedRoutes[j].Name
+				})
+
+				g.Expect(len(actualRoutes.Items)).To(Equal(len(tc.expectedRoutes)))
+
+				for i := range actualRoutes.Items {
+					actual := actualRoutes.Items[i]
+					expected := tc.expectedRoutes[i]
+
+					g.Expect(actual.Name).To(Equal(expected.Name))
+					g.Expect(actual.Labels).To(Equal(expected.Labels))
+					g.Expect(actual.Status.Ingress).To(HaveLen(len(expected.Status.Ingress)))
+
+					// Compare ingress entries
+					for j := range actual.Status.Ingress {
+						g.Expect(actual.Status.Ingress[j].RouterName).To(Equal(expected.Status.Ingress[j].RouterName))
+						g.Expect(actual.Status.Ingress[j].Host).To(Equal(expected.Status.Ingress[j].Host))
+					}
+				}
 			}
 		})
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_route.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/GCP/zz_fixture_TestControlPlaneComponents_ignition_server_route.yaml
@@ -1,6 +1,8 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
+  labels:
+    hypershift.openshift.io/hosted-control-plane: hcp-namespace
   name: ignition-server
   namespace: hcp-namespace
   ownerReferences:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_route.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ignition_server_route.yaml
@@ -1,6 +1,8 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
+  labels:
+    hypershift.openshift.io/hosted-control-plane: hcp-namespace
   name: ignition-server
   namespace: hcp-namespace
   ownerReferences:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/zz_fixture_TestControlPlaneComponents_ignition_server_route.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ignition-server/zz_fixture_TestControlPlaneComponents_ignition_server_route.yaml
@@ -1,6 +1,8 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
+  labels:
+    hypershift.openshift.io/hosted-control-plane: hcp-namespace
   name: ignition-server
   namespace: hcp-namespace
   ownerReferences:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
@@ -47,18 +47,27 @@ func NewComponent() component.ControlPlaneComponent {
 		Build()
 }
 
-// useHCPRouter returns true if a dedicated common router is created for a HCP to handle ingress for the managed endpoints.
-// This is true when the API input specifies intent for the following:
-// 1 - AWS endpointAccess is private somehow (i.e. publicAndPrivate or private) or is public and configured with external DNS.
-// 2 - When 1 is true, we recommend (and automate via CLI) ServicePublishingStrategy to be "Route" for all endpoints but the KAS
-// which needs a dedicated Service type LB external to be exposed if no external DNS is supported.
-// Otherwise, the Routes use the management cluster Domain and resolve through the default ingress controller.
-func useHCPRouter(cpContext component.WorkloadContext) (bool, error) {
+// UseHCPRouter returns true when the HCP routes should be served by a dedicated
+// HCP router, as determined by util.LabelHCPRoutes. This occurs when:
+//  1. The cluster has no public internet access (Private endpoint access), OR
+//  2. The cluster has public internet access (Public or PublicAndPrivate endpoint access)
+//     but uses a dedicated Route for KAS DNS (rather than a LoadBalancer)
+//
+// Excludes shared ingress configurations and IBM Cloud platform.
+func UseHCPRouter(hcp *hyperv1.HostedControlPlane) bool {
 	if sharedingress.UseSharedIngress() {
-		return false, nil
+		return false
 	}
-	if cpContext.HCP.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
-		return false, nil
+	if hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
+		return false
 	}
-	return util.IsPrivateHCP(cpContext.HCP) || util.IsPublicWithDNS(cpContext.HCP), nil
+	// Router infrastructure is needed when:
+	// 1. Cluster has private access (Private or PublicAndPrivate) - for internal routes, OR
+	// 2. External routes are labeled for HCP router (Public with KAS DNS)
+	return util.IsPrivateHCP(hcp) || util.LabelHCPRoutes(hcp)
+}
+
+// useHCPRouter is an adapter for the component predicate interface.
+func useHCPRouter(cpContext component.WorkloadContext) (bool, error) {
+	return UseHCPRouter(cpContext.HCP), nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/component_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/component_test.go
@@ -1,0 +1,277 @@
+package router
+
+import (
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUseHCPRouter(t *testing.T) {
+	testsCases := []struct {
+		name           string
+		hcp            *hyperv1.HostedControlPlane
+		expectedResult bool
+	}{
+		{
+			name: "Provider is IBM Cloud",
+			hcp: &hyperv1.HostedControlPlane{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "tenant1",
+					Name:      "cluster1",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.IBMCloudPlatform,
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "Provider is NonePlatform, services are exposed with Routes",
+			hcp: &hyperv1.HostedControlPlane{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "tenant1",
+					Name:      "cluster1",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.NonePlatform,
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "cluster1.api.tenant1.com",
+								},
+							},
+						},
+						{
+							Service: hyperv1.Konnectivity,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "cluster1.tunnel.tenant1.com",
+								},
+							},
+						},
+						{
+							Service: hyperv1.Ignition,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "cluster1.ignition.tenant1.com",
+								},
+							},
+						},
+						{
+							Service: hyperv1.OAuthServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "cluster1.oauth.tenant1.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Provider is AWS, Public and Private, KAS Loadbalancer",
+			hcp: &hyperv1.HostedControlPlane{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "tenant1",
+					Name:      "cluster1",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: hyperv1.PublicAndPrivate,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			expectedResult: true, // Router infrastructure needed for internal routes
+		},
+		{
+			name: "Provider is AWS, Public and Private, KAS Route",
+			hcp: &hyperv1.HostedControlPlane{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "tenant1",
+					Name:      "cluster1",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: hyperv1.PublicAndPrivate,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "cluster1.api.tenant1.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Provider is AWS, Private",
+			hcp: &hyperv1.HostedControlPlane{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "tenant1",
+					Name:      "cluster1",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: hyperv1.Private,
+						},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Provider is GCP, Private",
+			hcp: &hyperv1.HostedControlPlane{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "tenant1",
+					Name:      "cluster1",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.GCPPlatform,
+						GCP: &hyperv1.GCPPlatformSpec{
+							EndpointAccess: hyperv1.GCPEndpointAccessPrivate,
+						},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Provider is GCP, PublicAndPrivate, KAS Route",
+			hcp: &hyperv1.HostedControlPlane{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "tenant1",
+					Name:      "cluster1",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.GCPPlatform,
+						GCP: &hyperv1.GCPPlatformSpec{
+							EndpointAccess: hyperv1.GCPEndpointAccessPublicAndPrivate,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "cluster1.api.tenant1.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Provider is Agent, KAS LoadBalancer",
+			hcp: &hyperv1.HostedControlPlane{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "tenant1",
+					Name:      "cluster1",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AgentPlatform,
+						Agent: &hyperv1.AgentPlatformSpec{
+							AgentNamespace: "agent-ns",
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			expectedResult: false, // Router infrastructure not needed when KAS uses LoadBalancer
+		},
+		{
+			name: "Provider is Agent, KAS Route",
+			hcp: &hyperv1.HostedControlPlane{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "tenant1",
+					Name:      "cluster1",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AgentPlatform,
+						Agent: &hyperv1.AgentPlatformSpec{
+							AgentNamespace: "agent-ns",
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "cluster1.api.tenant1.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+	}
+	for _, tc := range testsCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedResult, UseHCPRouter(tc.hcp))
+		})
+	}
+}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3693,10 +3693,6 @@ func (r *HostedClusterReconciler) validateAWSConfig(hc *hyperv1.HostedCluster) e
 		if !hyperutil.UseDedicatedDNSForKASByHC(hc) && kasPublishingStrategy.Type != hyperv1.LoadBalancer {
 			errs = append(errs, fmt.Errorf("service type %v with publishing strategy %v is not supported, use Route or LoadBalancer", hyperv1.APIServer, kasPublishingStrategy.Type))
 		}
-		// When using dedicated DNS, the KAS should be exposed as Route.
-		if hyperutil.IsPublicWithDNSByHC(hc) && hyperutil.IsLBKASByHC(hc) {
-			errs = append(errs, fmt.Errorf("service type %v with publishing strategy %v is not supported when any service specifies external DNS, use Route", hyperv1.APIServer, kasPublishingStrategy.Type))
-		}
 	}
 
 	return utilerrors.NewAggregate(errs)

--- a/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
+++ b/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
@@ -377,8 +377,7 @@ func ReconcileRouteStatus(route *routev1.Route, canonicalHostname string) {
 }
 
 func UseSharedIngress() bool {
-	managedService, _ := os.LookupEnv("MANAGED_SERVICE")
-	return managedService == hyperv1.AroHCP
+	return util.UseSharedIngress()
 }
 
 func Hostname(hcp *hyperv1.HostedControlPlane) string {

--- a/support/upsert/apply_test.go
+++ b/support/upsert/apply_test.go
@@ -4,6 +4,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/util"
+
+	routev1 "github.com/openshift/api/route/v1"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -77,5 +82,241 @@ func TestApplyManifest(t *testing.T) {
 	}
 	if result != controllerutil.OperationResultNone {
 		t.Errorf("expected result %s, got %s", controllerutil.OperationResultNone, result)
+	}
+}
+
+// TestApplyManifestLabelRemoval proves that the label removal mechanism works correctly
+// when using ApplyManifest with the component framework. This test demonstrates why
+// the changes in apply.go are necessary:
+//
+//  1. preserveOriginalMetadata must process RemoveLabelMarker to remove labels
+//  2. The update function must detect label removal and perform updates even when
+//     DeepDerivative says objects are equal (because DeepDerivative ignores empty maps)
+//
+// Without these changes, labels marked for removal would not be removed from cluster
+// objects when using ApplyManifest, which is needed when transitioning routes from
+// HCP-managed to default ingress controller-managed.
+func TestApplyManifestLabelRemoval(t *testing.T) {
+	const namespace = "test-ns"
+	const routeName = "test-route"
+
+	// Existing route in cluster with HCPRouteLabel
+	existingRoute := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      routeName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				util.HCPRouteLabel: namespace,
+				"other-label":      "keep-me",
+			},
+		},
+		Spec: routev1.RouteSpec{
+			To: routev1.RouteTargetReference{
+				Kind: "Service",
+				Name: "test-service",
+			},
+		},
+	}
+
+	// Manifest route that marks HCPRouteLabel for removal (using RemoveLabelMarker)
+	// This simulates the scenario where we want to remove the HCP route label
+	// when transitioning from HCP router to default ingress controller
+	manifestRoute := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      routeName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				util.HCPRouteLabel: util.RemoveLabelMarker, // Mark for removal
+				"other-label":      "keep-me",              // Keep this label
+			},
+		},
+		Spec: routev1.RouteSpec{
+			To: routev1.RouteTargetReference{
+				Kind: "Service",
+				Name: "test-service",
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(api.Scheme).
+		WithObjects(existingRoute).
+		Build()
+	provider := &applyProvider{}
+
+	// Apply the manifest - this should remove the HCPRouteLabel
+	result, err := provider.ApplyManifest(t.Context(), client, manifestRoute)
+	if err != nil {
+		t.Fatalf("ApplyManifest failed: %v", err)
+	}
+
+	// The update should have occurred because we're removing a label
+	if result != controllerutil.OperationResultUpdated {
+		t.Errorf("expected result %s, got %s", controllerutil.OperationResultUpdated, result)
+	}
+
+	// Verify the label was actually removed from the cluster object
+	var updatedRoute routev1.Route
+	if err := client.Get(t.Context(), types.NamespacedName{Name: routeName, Namespace: namespace}, &updatedRoute); err != nil {
+		t.Fatalf("failed to get updated route: %v", err)
+	}
+
+	// HCPRouteLabel should be removed
+	if _, exists := updatedRoute.Labels[util.HCPRouteLabel]; exists {
+		t.Errorf("expected HCPRouteLabel to be removed, but it still exists")
+	}
+
+	// Other labels should be preserved
+	if updatedRoute.Labels["other-label"] != "keep-me" {
+		t.Errorf("expected other-label to be preserved, got %v", updatedRoute.Labels["other-label"])
+	}
+
+	// Verify that only one label remains
+	if len(updatedRoute.Labels) != 1 {
+		t.Errorf("expected 1 label remaining, got %d: %v", len(updatedRoute.Labels), updatedRoute.Labels)
+	}
+}
+
+// TestApplyManifestLabelRemovalWithEmptyLabels tests the edge case where removing
+// the last label results in an empty label map. This proves that the special handling
+// in update() correctly detects label removal even when DeepDerivative would normally
+// say the objects are equal (because it ignores empty maps).
+func TestApplyManifestLabelRemovalWithEmptyLabels(t *testing.T) {
+	const namespace = "test-ns"
+	const routeName = "test-route-empty"
+
+	// Existing route with only HCPRouteLabel
+	existingRoute := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      routeName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				util.HCPRouteLabel: namespace,
+			},
+		},
+		Spec: routev1.RouteSpec{
+			To: routev1.RouteTargetReference{
+				Kind: "Service",
+				Name: "test-service",
+			},
+		},
+	}
+
+	// Manifest route that marks HCPRouteLabel for removal, resulting in empty labels
+	manifestRoute := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      routeName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				util.HCPRouteLabel: util.RemoveLabelMarker,
+			},
+		},
+		Spec: routev1.RouteSpec{
+			To: routev1.RouteTargetReference{
+				Kind: "Service",
+				Name: "test-service",
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(api.Scheme).
+		WithObjects(existingRoute).
+		Build()
+	provider := &applyProvider{}
+
+	// Apply the manifest - this should remove the only label, resulting in empty labels
+	result, err := provider.ApplyManifest(t.Context(), client, manifestRoute)
+	if err != nil {
+		t.Fatalf("ApplyManifest failed: %v", err)
+	}
+
+	// The update should have occurred even though DeepDerivative would say they're equal
+	// (because empty maps are ignored), but we need the update to remove the label
+	if result != controllerutil.OperationResultUpdated {
+		t.Errorf("expected result %s, got %s", controllerutil.OperationResultUpdated, result)
+	}
+
+	// Verify the label was actually removed
+	var updatedRoute routev1.Route
+	if err := client.Get(t.Context(), types.NamespacedName{Name: routeName, Namespace: namespace}, &updatedRoute); err != nil {
+		t.Fatalf("failed to get updated route: %v", err)
+	}
+
+	// HCPRouteLabel should be removed
+	if _, exists := updatedRoute.Labels[util.HCPRouteLabel]; exists {
+		t.Errorf("expected HCPRouteLabel to be removed, but it still exists")
+	}
+
+	// Labels should be empty or nil
+	if len(updatedRoute.Labels) != 0 {
+		t.Errorf("expected empty labels, got %d labels: %v", len(updatedRoute.Labels), updatedRoute.Labels)
+	}
+}
+
+// TestApplyManifestLabelRemovalOnCreate tests that removal markers are cleaned up
+// when creating a new object. This is critical because Kubernetes validates label
+// values during creation, and the removal marker value is not a valid label value.
+// This test ensures the fix for Azure ignition server Route creation failures.
+func TestApplyManifestLabelRemovalOnCreate(t *testing.T) {
+	const namespace = "test-ns"
+	const routeName = "test-route-new"
+
+	// Manifest route with removal marker - simulates the Azure scenario where
+	// a Route is being created with a removal marker (e.g., when transitioning
+	// from HCP router to default ingress controller)
+	manifestRoute := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      routeName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				util.HCPRouteLabel: util.RemoveLabelMarker, // Mark for removal
+				"other-label":      "keep-me",              // Keep this label
+			},
+		},
+		Spec: routev1.RouteSpec{
+			To: routev1.RouteTargetReference{
+				Kind: "Service",
+				Name: "test-service",
+			},
+		},
+	}
+
+	// Empty client - route doesn't exist yet, so it will be created
+	client := fake.NewClientBuilder().
+		WithScheme(api.Scheme).
+		Build()
+	provider := &applyProvider{}
+
+	// Apply the manifest - this should create the route with removal marker cleaned up
+	result, err := provider.ApplyManifest(t.Context(), client, manifestRoute)
+	if err != nil {
+		t.Fatalf("ApplyManifest failed: %v", err)
+	}
+
+	// The route should have been created
+	if result != controllerutil.OperationResultCreated {
+		t.Errorf("expected result %s, got %s", controllerutil.OperationResultCreated, result)
+	}
+
+	// Verify the route was created and removal marker was cleaned up
+	var createdRoute routev1.Route
+	if err := client.Get(t.Context(), types.NamespacedName{Name: routeName, Namespace: namespace}, &createdRoute); err != nil {
+		t.Fatalf("failed to get created route: %v", err)
+	}
+
+	// HCPRouteLabel should not exist (removal marker was cleaned up before creation)
+	if _, exists := createdRoute.Labels[util.HCPRouteLabel]; exists {
+		t.Errorf("expected HCPRouteLabel to be removed before creation, but it still exists")
+	}
+
+	// Other labels should be preserved
+	if createdRoute.Labels["other-label"] != "keep-me" {
+		t.Errorf("expected other-label to be preserved, got %v", createdRoute.Labels["other-label"])
+	}
+
+	// Verify that only one label remains
+	if len(createdRoute.Labels) != 1 {
+		t.Errorf("expected 1 label remaining, got %d: %v", len(createdRoute.Labels), createdRoute.Labels)
 	}
 }

--- a/support/util/expose.go
+++ b/support/util/expose.go
@@ -31,18 +31,6 @@ func UseDedicatedDNSForKAS(hcp *hyperv1.HostedControlPlane) bool {
 	return UseDedicatedDNS(hcp, hyperv1.APIServer)
 }
 
-func UseDedicatedDNSForOAuth(hcp *hyperv1.HostedControlPlane) bool {
-	return UseDedicatedDNS(hcp, hyperv1.OAuthServer)
-}
-
-func UseDedicatedDNSForKonnectivity(hcp *hyperv1.HostedControlPlane) bool {
-	return UseDedicatedDNS(hcp, hyperv1.Konnectivity)
-}
-
-func UseDedicatedDNSForIgnition(hcp *hyperv1.HostedControlPlane) bool {
-	return UseDedicatedDNS(hcp, hyperv1.Ignition)
-}
-
 func UseDedicatedDNS(hcp *hyperv1.HostedControlPlane, svcType hyperv1.ServiceType) bool {
 	svc := ServicePublishingStrategyByTypeForHCP(hcp, svcType)
 	return IsRoute(hcp, svcType) &&

--- a/support/util/route_test.go
+++ b/support/util/route_test.go
@@ -5,6 +5,9 @@ import (
 	"math/rand"
 	"testing"
 
+	routev1 "github.com/openshift/api/route/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kvalidation "k8s.io/apimachinery/pkg/util/validation"
 )
 
@@ -101,4 +104,365 @@ func randSeq(n int) string {
 		b[i] = letters[rand.Intn(len(letters))]
 	}
 	return string(b)
+}
+
+func TestReconcileExternalRoute(t *testing.T) {
+	tests := []struct {
+		name            string
+		route           *routev1.Route
+		hostname        string
+		defaultDomain   string
+		serviceName     string
+		labelHCPRoutes  bool
+		expectedLabels  map[string]string
+		expectedHost    string
+		expectedService string
+	}{
+		{
+			name: "When labelHCPRoutes is true and route has no labels, it should add HCP label",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			hostname:       "test.example.com",
+			defaultDomain:  "example.com",
+			serviceName:    "test-service",
+			labelHCPRoutes: true,
+			expectedLabels: map[string]string{
+				HCPRouteLabel: "test-namespace",
+			},
+			expectedHost:    "test.example.com",
+			expectedService: "test-service",
+		},
+		{
+			name: "When labelHCPRoutes is true and route has existing labels, it should add HCP label",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						"existing-label": "existing-value",
+					},
+				},
+			},
+			hostname:       "test.example.com",
+			defaultDomain:  "example.com",
+			serviceName:    "test-service",
+			labelHCPRoutes: true,
+			expectedLabels: map[string]string{
+				"existing-label": "existing-value",
+				HCPRouteLabel:    "test-namespace",
+			},
+			expectedHost:    "test.example.com",
+			expectedService: "test-service",
+		},
+		{
+			name: "When labelHCPRoutes is false and route has no labels, it should not add HCP label",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			hostname:        "test.example.com",
+			defaultDomain:   "example.com",
+			serviceName:     "test-service",
+			labelHCPRoutes:  false,
+			expectedLabels:  nil,
+			expectedHost:    "test.example.com",
+			expectedService: "test-service",
+		},
+		{
+			name: "When labelHCPRoutes is false and route has HCP label, it should remove HCP label",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						HCPRouteLabel:    "test-namespace",
+						"existing-label": "existing-value",
+					},
+				},
+			},
+			hostname:       "test.example.com",
+			defaultDomain:  "example.com",
+			serviceName:    "test-service",
+			labelHCPRoutes: false,
+			expectedLabels: map[string]string{
+				"existing-label": "existing-value",
+			},
+			expectedHost:    "test.example.com",
+			expectedService: "test-service",
+		},
+		{
+			name: "When labelHCPRoutes is false and route has only HCP label, it should remove HCP label and leave empty map",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						HCPRouteLabel: "test-namespace",
+					},
+				},
+			},
+			hostname:        "test.example.com",
+			defaultDomain:   "example.com",
+			serviceName:     "test-service",
+			labelHCPRoutes:  false,
+			expectedLabels:  map[string]string{},
+			expectedHost:    "test.example.com",
+			expectedService: "test-service",
+		},
+		{
+			name: "When hostname is empty and route name is short, it should leave hostname empty for default generation",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			hostname:       "",
+			defaultDomain:  "example.com",
+			serviceName:    "test-service",
+			labelHCPRoutes: true,
+			expectedLabels: map[string]string{
+				HCPRouteLabel: "test-namespace",
+			},
+			expectedHost:    "", // ShortenRouteHostnameIfNeeded returns empty when name is short enough
+			expectedService: "test-service",
+		},
+		{
+			name: "When hostname is empty and route already has a hostname, it should preserve existing hostname",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "existing.example.com",
+				},
+			},
+			hostname:       "",
+			defaultDomain:  "example.com",
+			serviceName:    "test-service",
+			labelHCPRoutes: true,
+			expectedLabels: map[string]string{
+				HCPRouteLabel: "test-namespace",
+			},
+			expectedHost:    "existing.example.com",
+			expectedService: "test-service",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ReconcileExternalRoute(tt.route, tt.hostname, tt.defaultDomain, tt.serviceName, tt.labelHCPRoutes)
+			if err != nil {
+				t.Fatalf("ReconcileExternalRoute() error = %v, wantErr false", err)
+			}
+
+			// Check labels
+			if tt.expectedLabels == nil {
+				if len(tt.route.Labels) != 0 {
+					t.Errorf("Expected no labels, but got %v", tt.route.Labels)
+				}
+			} else {
+				if len(tt.route.Labels) != len(tt.expectedLabels) {
+					t.Errorf("Labels length mismatch: got %d, want %d. Got: %v, Want: %v", len(tt.route.Labels), len(tt.expectedLabels), tt.route.Labels, tt.expectedLabels)
+				}
+				for k, v := range tt.expectedLabels {
+					if got, ok := tt.route.Labels[k]; !ok || got != v {
+						t.Errorf("Label %s: got %v, want %v", k, got, v)
+					}
+				}
+				// Check that HCP label is not present when not expected
+				if _, ok := tt.expectedLabels[HCPRouteLabel]; !ok {
+					if _, hasLabel := tt.route.Labels[HCPRouteLabel]; hasLabel {
+						t.Errorf("Expected HCP label to be removed, but it still exists")
+					}
+				}
+			}
+
+			// Check hostname
+			if tt.route.Spec.Host != tt.expectedHost {
+				t.Errorf("Host: got %v, want %v", tt.route.Spec.Host, tt.expectedHost)
+			}
+
+			// Check service name
+			if tt.route.Spec.To.Name != tt.expectedService {
+				t.Errorf("Service name: got %v, want %v", tt.route.Spec.To.Name, tt.expectedService)
+			}
+
+			// Check TLS config
+			if tt.route.Spec.TLS == nil {
+				t.Errorf("Expected TLS config to be set")
+			} else {
+				if tt.route.Spec.TLS.Termination != routev1.TLSTerminationPassthrough {
+					t.Errorf("TLS termination: got %v, want %v", tt.route.Spec.TLS.Termination, routev1.TLSTerminationPassthrough)
+				}
+				if tt.route.Spec.TLS.InsecureEdgeTerminationPolicy != routev1.InsecureEdgeTerminationPolicyNone {
+					t.Errorf("Insecure edge termination policy: got %v, want %v", tt.route.Spec.TLS.InsecureEdgeTerminationPolicy, routev1.InsecureEdgeTerminationPolicyNone)
+				}
+			}
+		})
+	}
+}
+
+func TestAddHCPRouteLabel(t *testing.T) {
+	tests := []struct {
+		name           string
+		route          *routev1.Route
+		expectedLabels map[string]string
+	}{
+		{
+			name: "When route has no labels, it should add HCP label",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			expectedLabels: map[string]string{
+				HCPRouteLabel: "test-namespace",
+			},
+		},
+		{
+			name: "When route has existing labels, it should add HCP label without removing existing ones",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						"existing-label": "existing-value",
+					},
+				},
+			},
+			expectedLabels: map[string]string{
+				"existing-label": "existing-value",
+				HCPRouteLabel:    "test-namespace",
+			},
+		},
+		{
+			name: "When route already has HCP label, it should update it",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						HCPRouteLabel: "old-namespace",
+					},
+				},
+			},
+			expectedLabels: map[string]string{
+				HCPRouteLabel: "test-namespace",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			AddHCPRouteLabel(tt.route)
+
+			if len(tt.route.Labels) != len(tt.expectedLabels) {
+				t.Errorf("Labels length mismatch: got %d, want %d. Got: %v, Want: %v", len(tt.route.Labels), len(tt.expectedLabels), tt.route.Labels, tt.expectedLabels)
+			}
+			for k, v := range tt.expectedLabels {
+				if got, ok := tt.route.Labels[k]; !ok || got != v {
+					t.Errorf("Label %s: got %v, want %v", k, got, v)
+				}
+			}
+		})
+	}
+}
+
+func TestRemoveHCPRouteLabel(t *testing.T) {
+	tests := []struct {
+		name           string
+		route          *routev1.Route
+		expectedLabels map[string]string
+	}{
+		{
+			name: "When route has no labels, it should not error",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+				},
+			},
+			expectedLabels: nil,
+		},
+		{
+			name: "When route has HCP label only, it should remove it and leave empty map",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						HCPRouteLabel: "test-namespace",
+					},
+				},
+			},
+			expectedLabels: map[string]string{},
+		},
+		{
+			name: "When route has HCP label and other labels, it should remove only HCP label",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						HCPRouteLabel:    "test-namespace",
+						"existing-label": "existing-value",
+						"another-label":  "another-value",
+					},
+				},
+			},
+			expectedLabels: map[string]string{
+				"existing-label": "existing-value",
+				"another-label":  "another-value",
+			},
+		},
+		{
+			name: "When route does not have HCP label but has other labels, it should not modify labels",
+			route: &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						"existing-label": "existing-value",
+					},
+				},
+			},
+			expectedLabels: map[string]string{
+				"existing-label": "existing-value",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RemoveHCPRouteLabel(tt.route)
+
+			if tt.expectedLabels == nil {
+				if len(tt.route.Labels) != 0 {
+					t.Errorf("Expected no labels, but got %v", tt.route.Labels)
+				}
+			} else {
+				if len(tt.route.Labels) != len(tt.expectedLabels) {
+					t.Errorf("Labels length mismatch: got %d, want %d. Got: %v, Want: %v", len(tt.route.Labels), len(tt.expectedLabels), tt.route.Labels, tt.expectedLabels)
+				}
+				for k, v := range tt.expectedLabels {
+					if got, ok := tt.route.Labels[k]; !ok || got != v {
+						t.Errorf("Label %s: got %v, want %v", k, got, v)
+					}
+				}
+				// Ensure HCP label is not present
+				if _, hasLabel := tt.route.Labels[HCPRouteLabel]; hasLabel {
+					t.Errorf("Expected HCP label to be removed, but it still exists")
+				}
+			}
+		})
+	}
 }

--- a/support/util/visibility.go
+++ b/support/util/visibility.go
@@ -1,10 +1,17 @@
 package util
 
 import (
+	"os"
+
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 
 	"k8s.io/utils/ptr"
 )
+
+func UseSharedIngress() bool {
+	managedService, _ := os.LookupEnv("MANAGED_SERVICE")
+	return managedService == hyperv1.AroHCP
+}
 
 func IsPrivateHCP(hcp *hyperv1.HostedControlPlane) bool {
 	if hcp.Spec.Platform.Type == hyperv1.AWSPlatform {
@@ -55,16 +62,104 @@ func IsPublicHC(hc *hyperv1.HostedCluster) bool {
 	return true
 }
 
-func IsPublicWithDNS(hcp *hyperv1.HostedControlPlane) bool {
-	return IsPublicHCP(hcp) && (UseDedicatedDNS(hcp, hyperv1.APIServer) ||
-		UseDedicatedDNS(hcp, hyperv1.OAuthServer) ||
-		UseDedicatedDNS(hcp, hyperv1.Konnectivity) ||
-		UseDedicatedDNS(hcp, hyperv1.Ignition))
-}
+// LabelHCPRoutes determines if routes should be labeled for admission by the HCP router.
+// Routes with the label "hypershift.openshift.io/hosted-control-plane" are served by a
+// dedicated HCP router (HAProxy deployment in the HCP namespace). Routes without this label
+// are served by the management cluster's default OpenShift ingress controller.
+//
+// This function is the single source of truth for route labeling decisions and is called by:
+// - OAuth route reconciliation (external public/private routes)
+// - Konnectivity route reconciliation (external routes)
+// - Ignition server route reconciliation (external routes)
+// - Router component predicate (determines if router Deployment/ConfigMap/PDB are created)
+// - Router service creation (determines if public router LoadBalancer service is created)
+//
+// The HCP router infrastructure (Deployment, Services) is created when routes need to be labeled.
+// This ensures routes and router services stay synchronized.
+//
+// # Platform-Specific Behavior
+//
+// AWS Platform:
+//   - Private: Always labels routes (no public access)
+//   - PublicAndPrivate + KAS LoadBalancer: Does NOT label external routes (uses mgmt cluster router)
+//   - PublicAndPrivate + KAS Route: Labels routes (uses HCP router for all routes)
+//   - Public + KAS LoadBalancer: Does NOT label routes (uses mgmt cluster router)
+//   - Public + KAS Route: Labels routes (uses HCP router)
+//
+// GCP Platform:
+//   - Same behavior as AWS platform
+//
+// Agent Platform (bare metal):
+//   - No EndpointAccess field (no Private/PublicAndPrivate concept)
+//   - Labels routes ONLY when KAS uses Route with explicit hostname
+//   - KAS LoadBalancer/NodePort: Does NOT label routes (uses mgmt cluster router)
+//
+// KubeVirt, OpenStack, None Platforms:
+//   - Same behavior as Agent platform
+//   - Labels routes ONLY when KAS uses Route with explicit hostname
+//
+// IBM Cloud Platform:
+//   - Never labels routes (uses different routing mechanism)
+//
+// # Internal Routes
+//
+// Note that internal routes (*.apps.<cluster>.hypershift.local) are ALWAYS labeled for
+// HCP router regardless of this function's return value. This function only controls
+// EXTERNAL route labeling. Internal routes are handled separately in ReconcileInternalRoute().
+//
+// # Architecture Reference
+//
+// For complete details on the HCP ingress architecture, see HCP_INGRESS_ARCHITECTURE.md
+// in the repository root, which documents the full decision flow, code references, and
+// interaction between route labeling and router service creation.
+//
+// Returns true when routes should be labeled for HCP router; false when routes should
+// use the management cluster router.
+func LabelHCPRoutes(hcp *hyperv1.HostedControlPlane) bool {
+	// When shared ingress is active (e.g., ARO HCP), all routes must be labeled
+	// so the SharedIngressReconciler can discover and admit them.
+	if UseSharedIngress() {
+		return true
+	}
 
-func IsPublicWithDNSByHC(hc *hyperv1.HostedCluster) bool {
-	return IsPublicHC(hc) && (UseDedicatedDNSByHC(hc, hyperv1.APIServer) ||
-		UseDedicatedDNSByHC(hc, hyperv1.OAuthServer) ||
-		UseDedicatedDNSByHC(hc, hyperv1.Konnectivity) ||
-		UseDedicatedDNSByHC(hc, hyperv1.Ignition))
+	switch hcp.Spec.Platform.Type {
+	case hyperv1.AWSPlatform, hyperv1.GCPPlatform:
+		// AWS and GCP support endpoint access modes (Private/PublicAndPrivate/Public).
+		// Label routes for HCP router when:
+		// 1. Cluster has no public access (Private-only), OR
+		// 2. Public cluster with dedicated DNS for KAS (KAS uses Route with hostname)
+		//
+		// For PublicAndPrivate clusters using LoadBalancer for KAS:
+		// - Internal routes (Konnectivity, Ignition) are served by internal HCP router
+		// - External routes (OAuth) use the management cluster router (no public HCP router needed)
+		// This avoids creating an unnecessary public LoadBalancer service.
+		return !IsPublicHCP(hcp) || UseDedicatedDNSForKAS(hcp)
+
+	case hyperv1.AgentPlatform, hyperv1.KubevirtPlatform, hyperv1.OpenStackPlatform, hyperv1.NonePlatform:
+		// These platforms do not have endpoint access mode concepts (no Private/PublicAndPrivate).
+		// Label routes for HCP router ONLY when KAS explicitly uses Route with a hostname.
+		//
+		// This prevents creating HCP router infrastructure when:
+		// - KAS uses LoadBalancer (routes should use management cluster router)
+		// - KAS uses NodePort (routes should use management cluster router)
+		//
+		// When KAS uses Route with hostname, all routes are labeled for HCP router to ensure
+		// consistent routing through dedicated infrastructure.
+		return UseDedicatedDNSForKAS(hcp)
+
+	case hyperv1.IBMCloudPlatform:
+		// IBM Cloud uses a different routing mechanism (shared ingress with HAProxy and
+		// kube-apiserver-proxy on worker nodes). Never use HCP router.
+		return false
+
+	case hyperv1.PowerVSPlatform:
+		// PowerVS (IBM Cloud Power Virtual Servers) follows the same pattern as other
+		// platforms without endpoint access modes.
+		return UseDedicatedDNSForKAS(hcp)
+
+	default:
+		// Conservative default for unknown platforms: do not create HCP router infrastructure.
+		// Routes will use the management cluster router.
+		return false
+	}
 }

--- a/support/util/visibility_test.go
+++ b/support/util/visibility_test.go
@@ -229,3 +229,604 @@ func TestIsPublicHCP(t *testing.T) {
 		})
 	}
 }
+
+func TestLabelHCPRoutes(t *testing.T) {
+	tests := []struct {
+		name    string
+		hcp     *hyperv1.HostedControlPlane
+		want    bool
+		envVars map[string]string
+	}{
+		// Shared Ingress Tests
+		{
+			name: "When shared ingress is active (ARO HCP), it should always label routes regardless of platform",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want:    true,
+			envVars: map[string]string{"MANAGED_SERVICE": "ARO-HCP"},
+		},
+
+		// AWS Platform Tests
+		{
+			name: "When AWS cluster is Private, it should label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: hyperv1.Private,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "When AWS cluster is PublicAndPrivate with KAS LoadBalancer, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: hyperv1.PublicAndPrivate,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "When AWS cluster is PublicAndPrivate with KAS Route and hostname, it should label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: hyperv1.PublicAndPrivate,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "api.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "When AWS cluster is Public with KAS LoadBalancer, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: hyperv1.Public,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "When AWS cluster is Public with KAS Route and hostname, it should label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: hyperv1.Public,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "api.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "When AWS cluster is Public with KAS Route but no hostname, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: hyperv1.Public,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+
+		// GCP Platform Tests
+		{
+			name: "When GCP cluster is Private, it should label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.GCPPlatform,
+						GCP: &hyperv1.GCPPlatformSpec{
+							EndpointAccess: hyperv1.GCPEndpointAccessPrivate,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "When GCP cluster is PublicAndPrivate with KAS LoadBalancer, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.GCPPlatform,
+						GCP: &hyperv1.GCPPlatformSpec{
+							EndpointAccess: hyperv1.GCPEndpointAccessPublicAndPrivate,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "When GCP cluster is PublicAndPrivate with KAS Route and hostname, it should label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.GCPPlatform,
+						GCP: &hyperv1.GCPPlatformSpec{
+							EndpointAccess: hyperv1.GCPEndpointAccessPublicAndPrivate,
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "api.gcp.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+
+		// Agent Platform Tests (Bare Metal) - Critical for OCPBUGS-70152
+		{
+			name: "When Agent cluster has KAS LoadBalancer, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AgentPlatform,
+						Agent: &hyperv1.AgentPlatformSpec{
+							AgentNamespace: "agent-ns",
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "When Agent cluster has KAS Route with hostname, it should label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AgentPlatform,
+						Agent: &hyperv1.AgentPlatformSpec{
+							AgentNamespace: "agent-ns",
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "api.agent.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "When Agent cluster has KAS NodePort, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AgentPlatform,
+						Agent: &hyperv1.AgentPlatformSpec{
+							AgentNamespace: "agent-ns",
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.NodePort,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "When Agent cluster has OAuth Route with hostname but KAS LoadBalancer, it should not label routes for HCP router (OCPBUGS-70152 bug scenario)",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AgentPlatform,
+						Agent: &hyperv1.AgentPlatformSpec{
+							AgentNamespace: "agent-ns",
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+						{
+							Service: hyperv1.OAuthServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "oauth.agent.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false, // Should NOT create HCP router - this was the bug
+		},
+
+		// KubeVirt Platform Tests
+		{
+			name: "When KubeVirt cluster has KAS LoadBalancer, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: &hyperv1.KubevirtPlatformSpec{
+							GenerateID: "kubevirt-cluster",
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "When KubeVirt cluster has KAS Route with hostname, it should label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.KubevirtPlatform,
+						Kubevirt: &hyperv1.KubevirtPlatformSpec{
+							GenerateID: "kubevirt-cluster",
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "api.kubevirt.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+
+		// OpenStack Platform Tests
+		{
+			name: "When OpenStack cluster has KAS LoadBalancer, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.OpenStackPlatform,
+						OpenStack: &hyperv1.OpenStackPlatformSpec{
+							IdentityRef: hyperv1.OpenStackIdentityReference{
+								Name: "openstack-creds",
+							},
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "When OpenStack cluster has KAS Route with hostname, it should label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.OpenStackPlatform,
+						OpenStack: &hyperv1.OpenStackPlatformSpec{
+							IdentityRef: hyperv1.OpenStackIdentityReference{
+								Name: "openstack-creds",
+							},
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "api.openstack.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+
+		// IBM Cloud Platform Tests
+		{
+			name: "When IBM Cloud cluster has KAS LoadBalancer, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.IBMCloudPlatform,
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "When IBM Cloud cluster has KAS Route with hostname, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.IBMCloudPlatform,
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "api.ibmcloud.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false, // IBM Cloud never uses HCP router
+		},
+
+		// PowerVS Platform Tests
+		{
+			name: "When PowerVS cluster has KAS LoadBalancer, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.PowerVSPlatform,
+						PowerVS: &hyperv1.PowerVSPlatformSpec{
+							AccountID:      "test-account",
+							CISInstanceCRN: "test-crn",
+							ResourceGroup:  "test-rg",
+							Region:         "us-south",
+							Zone:           "us-south-1",
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "When PowerVS cluster has KAS Route with hostname, it should label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.PowerVSPlatform,
+						PowerVS: &hyperv1.PowerVSPlatformSpec{
+							AccountID:      "test-account",
+							CISInstanceCRN: "test-crn",
+							ResourceGroup:  "test-rg",
+							Region:         "us-south",
+							Zone:           "us-south-1",
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "api.powervs.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+
+		// None Platform Tests
+		{
+			name: "When None platform cluster has KAS LoadBalancer, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.NonePlatform,
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "When None platform cluster has KAS Route with hostname, it should label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.NonePlatform,
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "api.none.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.envVars {
+				t.Setenv(k, v)
+			}
+			got := LabelHCPRoutes(tt.hcp)
+			if got != tt.want {
+				t.Errorf("LabelHCPRoutes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Manual backport of #7605