### PR TITLE
Support disabling PDBs on hosted clusters

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/component.go
@@ -3,6 +3,7 @@ package etcd
 import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/util"
 )
 
 const (
@@ -41,6 +42,7 @@ func NewComponent() component.ControlPlaneComponent {
 		WithManifestAdapter(
 			"pdb.yaml",
 			component.AdaptPodDisruptionBudget(),
+			component.DisableIfPDBDisabled(util.DisablePDBEtcdAnnotation),
 		).
 		WithManifestAdapter(
 			"defrag-role.yaml",

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/component.go
@@ -95,6 +95,7 @@ func NewComponent() component.ControlPlaneComponent {
 		WithManifestAdapter(
 			"pdb.yaml",
 			component.AdaptPodDisruptionBudget(),
+			component.DisableIfPDBDisabled(hyperutils.DisablePDBKubeAPIServerAnnotation),
 		).
 		WithManifestAdapter(
 			"servicemonitor.yaml",

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oapi/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oapi/component.go
@@ -48,6 +48,7 @@ func NewComponent() component.ControlPlaneComponent {
 		WithManifestAdapter(
 			"pdb.yaml",
 			component.AdaptPodDisruptionBudget(),
+			component.DisableIfPDBDisabled(util.DisablePDBOpenShiftAPIServerAnnotation),
 		).
 		InjectKonnectivityContainer(component.KonnectivityContainerOptions{
 			Mode: component.HTTPS,

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/component.go
@@ -49,6 +49,7 @@ func NewComponent() component.ControlPlaneComponent {
 		WithManifestAdapter(
 			"pdb.yaml",
 			component.AdaptPodDisruptionBudget(),
+			component.DisableIfPDBDisabled(util.DisablePDBOAuthOpenShiftAnnotation),
 		).
 		WithManifestAdapter(
 			"service-session-secret.yaml",

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/component.go
@@ -44,6 +44,7 @@ func NewComponent() component.ControlPlaneComponent {
 		WithManifestAdapter(
 			"pdb.yaml",
 			component.AdaptPodDisruptionBudget(),
+			component.DisableIfPDBDisabled(util.DisablePDBOAuthAPIServerAnnotation),
 		).
 		WithDependencies(oapiv2.ComponentName).
 		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{}).

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
@@ -42,6 +42,7 @@ func NewComponent() component.ControlPlaneComponent {
 		WithManifestAdapter(
 			"pdb.yaml",
 			component.AdaptPodDisruptionBudget(),
+			component.DisableIfPDBDisabled(util.DisablePDBRouterAnnotation),
 		).
 		WithDependencies(oapiv2.ComponentName).
 		Build()

--- a/support/controlplane-component/common.go
+++ b/support/controlplane-component/common.go
@@ -60,3 +60,11 @@ func EnableForPlatform(platform hyperv1.PlatformType) option {
 		return cpContext.HCP.Spec.Platform.Type == platform
 	})
 }
+
+// DisableIfPDBDisabled is a helper predicate that disables a PDB resource if either the global
+// disable-pdb-all annotation or the component-specific annotation is set to "true".
+func DisableIfPDBDisabled(componentAnnotation string) option {
+	return WithPredicate(func(cpContext WorkloadContext) bool {
+		return !util.IsPDBDisabled(cpContext.HCP.Annotations, componentAnnotation)
+	})
+}

--- a/support/util/pdb.go
+++ b/support/util/pdb.go
@@ -20,3 +20,25 @@ func ReconcilePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, availabilit
 	pdb.Spec.MinAvailable = minAvailable
 	pdb.Spec.MaxUnavailable = maxUnavailable
 }
+
+// IsPDBDisabled checks if PDB is disabled either globally or for a specific component.
+// It checks both the global disable-pdb-all annotation and the component-specific annotation.
+func IsPDBDisabled(annotations map[string]string, componentAnnotation string) bool {
+	if annotations == nil {
+		return false
+	}
+
+	// Check global disable annotation
+	if val, exists := annotations[DisablePDBsAllAnnotation]; exists && val == "true" {
+		return true
+	}
+
+	// Check component-specific annotation
+	if componentAnnotation != "" {
+		if val, exists := annotations[componentAnnotation]; exists && val == "true" {
+			return true
+		}
+	}
+
+	return false
+}

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -47,6 +47,17 @@ const (
 	HostedClustersScopeAnnotationEnv         = "HOSTEDCLUSTERS_SCOPE_ANNOTATION"
 	HostedClustersScopeAnnotation            = "hypershift.openshift.io/scope"
 	HostedClusterAnnotation                  = "hypershift.openshift.io/cluster"
+
+	// DisablePDBsAllAnnotation when set to "true" disables PDB creation for all control plane components.
+	DisablePDBsAllAnnotation = "hypershift.openshift.io/disable-pdb-all"
+
+	// Per-component PDB disable annotations. When set to "true", disables PDB creation for the specific component.
+	DisablePDBEtcdAnnotation                 = "hypershift.openshift.io/disable-pdb-etcd"
+	DisablePDBKubeAPIServerAnnotation        = "hypershift.openshift.io/disable-pdb-kube-apiserver"
+	DisablePDBOpenShiftAPIServerAnnotation   = "hypershift.openshift.io/disable-pdb-openshift-apiserver"
+	DisablePDBOAuthAPIServerAnnotation       = "hypershift.openshift.io/disable-pdb-openshift-oauth-apiserver"
+	DisablePDBOAuthOpenShiftAnnotation       = "hypershift.openshift.io/disable-pdb-oauth-openshift"
+	DisablePDBRouterAnnotation               = "hypershift.openshift.io/disable-pdb-router"
 )
 
 type JSONMapper func(jsonData []byte) []byte


### PR DESCRIPTION
This PR is a discussion prop, please don't review, the code doesn't matter.
Ref:
- https://issues.redhat.com/browse/AROSLSRE-421
- https://issues.redhat.com/browse/RFE-8779


Adds support for the following annotations on HostedClusters:
- hypershift.openshift.io/disable-pdb-all
- hypershift.openshift.io/disable-pdb-etcd
- hypershift.openshift.io/disable-pdb-kube-apiserver
- hypershift.openshift.io/disable-pdb-openshift-apiserver
- hypershift.openshift.io/disable-pdb-openshift-oauth-apiserver
- hypershift.openshift.io/disable-pdb-oauth-openshift
- hypershift.openshift.io/disable-pdb-router
