### PR TITLE
OCPBUGS-76337: feat(scale-from-zero): add DescribeInstanceTypes IAM permission

### DIFF
--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -466,6 +466,7 @@ var (
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstances",
+        "ec2:DescribeInstanceTypes",
         "ec2:DescribeInternetGateways",
         "ec2:DescribeNatGateways",
         "ec2:DescribeNetworkInterfaces",


### PR DESCRIPTION
## What this PR does / why we need it:
Scale from zero does not work properly for ROSA HCP clusters because the nodepool IAM policies are missing the `ec2:DescribeInstanceTypes` permission.  
For scale from zero to work correctly, the `AWSMachineTemplate.Status.Capacity` fields need to be populated with information from EC2 instances.
Without the permission, this information cannot be retrieved.

Previously, capacities were set by the nodepool controller (which already has this permission) as annotations.
With the latest changes in CAPA, this is reconciled by the provider instead, and therefore, it needs the same permission to gather the data from the EC2 instances.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.