### PR TITLE
OCPBUGS-74345: kubevirt add IPFamilyPolicy PreferDualStack to LoadBalancer services

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -1369,6 +1369,7 @@ func TestNonReadyInfraTriggersRequeueAfter(t *testing.T) {
 func TestReconcileHCPRouterServices(t *testing.T) {
 	const namespace = "test-ns"
 	publicService := func(m ...func(*corev1.Service)) *corev1.Service {
+		ipFamilyPolicy := corev1.IPFamilyPolicyPreferDualStack
 		svc := corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "router",
@@ -1379,8 +1380,9 @@ func TestReconcileHCPRouterServices(t *testing.T) {
 				Labels: map[string]string{"app": "private-router"},
 			},
 			Spec: corev1.ServiceSpec{
-				Type:     corev1.ServiceTypeLoadBalancer,
-				Selector: map[string]string{"app": "private-router"},
+				Type:           corev1.ServiceTypeLoadBalancer,
+				Selector:       map[string]string{"app": "private-router"},
+				IPFamilyPolicy: &ipFamilyPolicy,
 				Ports: []corev1.ServicePort{
 					{Name: "https", Port: 443, TargetPort: intstr.FromString("https"), Protocol: corev1.ProtocolTCP},
 				},

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -21,6 +21,10 @@ func hcpRouterLabels() map[string]string {
 }
 
 func ReconcileRouterService(svc *corev1.Service, internal, crossZoneLoadBalancingEnabled bool, hcp *hyperv1.HostedControlPlane) error {
+	// Setting this to PreferDualStack will make the service to be created with IPv4 and IPv6 addresses if the management cluster is dual stack.
+	IPFamilyPolicy := corev1.IPFamilyPolicyPreferDualStack
+	svc.Spec.IPFamilyPolicy = &IPFamilyPolicy
+
 	if hcp.Spec.Platform.Type == hyperv1.AWSPlatform {
 		if svc.Annotations == nil {
 			svc.Annotations = map[string]string{}

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router_test.go
@@ -143,6 +143,29 @@ func TestReconcileRouterService_AppliesLoadBalancerSourceRanges(t *testing.T) {
 	})
 }
 
+// Test that router service is configured with PreferDualStack IPFamilyPolicy for DualStack support
+func TestReconcileRouterService_IPFamilyPolicy(t *testing.T) {
+	// Given a HostedControlPlane on KubeVirt platform (or any platform)
+	hcp := &hyperv1.HostedControlPlane{}
+	hcp.Spec.Platform.Type = hyperv1.KubevirtPlatform
+
+	// And an empty Service to reconcile
+	svc := &corev1.Service{}
+
+	// When reconciling the router service
+	if err := ReconcileRouterService(svc, false /* internal */, false /* cross-zone */, hcp); err != nil {
+		t.Fatalf("ReconcileRouterService returned error: %v", err)
+	}
+
+	// Then the service should be configured with PreferDualStack IPFamilyPolicy
+	if svc.Spec.IPFamilyPolicy == nil {
+		t.Fatalf("expected IPFamilyPolicy to be set, got nil")
+	}
+	if *svc.Spec.IPFamilyPolicy != corev1.IPFamilyPolicyPreferDualStack {
+		t.Fatalf("expected IPFamilyPolicy to be PreferDualStack, got %v", *svc.Spec.IPFamilyPolicy)
+	}
+}
+
 // Test that GCP router service is configured with Internal Load Balancer
 func TestReconcileRouterService_GCPInternalLoadBalancer(t *testing.T) {
 	// Given a HostedControlPlane on GCP platform

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -268,6 +268,11 @@ func ReconcileKonnectivityServerLocalService(svc *corev1.Service, ownerRef confi
 func ReconcileKonnectivityServerService(svc *corev1.Service, ownerRef config.OwnerRef, strategy *hyperv1.ServicePublishingStrategy, hcp *hyperv1.HostedControlPlane) error {
 	ownerRef.ApplyTo(svc)
 	svc.Spec.Selector = kasLabels()
+
+	// Setting this to PreferDualStack will make the service to be created with IPv4 and IPv6 addresses if the management cluster is dual stack.
+	IPFamilyPolicy := corev1.IPFamilyPolicyPreferDualStack
+	svc.Spec.IPFamilyPolicy = &IPFamilyPolicy
+
 	var portSpec corev1.ServicePort
 	if len(svc.Spec.Ports) > 0 {
 		portSpec = svc.Spec.Ports[0]

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service_test.go
@@ -225,3 +225,19 @@ func TestKonnectivityServiceReconcile(t *testing.T) {
 		})
 	}
 }
+
+func TestKonnectivityServiceReconcile_IPFamilyPolicy(t *testing.T) {
+	// Given a HostedControlPlane on KubeVirt platform with LoadBalancer strategy
+	hcp := hyperv1.HostedControlPlane{Spec: hyperv1.HostedControlPlaneSpec{Platform: hyperv1.PlatformSpec{Type: hyperv1.KubevirtPlatform}}}
+	strategy := hyperv1.ServicePublishingStrategy{Type: hyperv1.LoadBalancer}
+	svc := corev1.Service{}
+
+	// When reconciling the Konnectivity service
+	err := ReconcileKonnectivityServerService(&svc, config.OwnerRef{}, &strategy, &hcp)
+
+	// Then the service should be configured with PreferDualStack IPFamilyPolicy
+	g := NewWithT(t)
+	g.Expect(err).To(BeNil())
+	g.Expect(svc.Spec.IPFamilyPolicy).NotTo(BeNil())
+	g.Expect(*svc.Spec.IPFamilyPolicy).To(Equal(corev1.IPFamilyPolicyPreferDualStack))
+}


### PR DESCRIPTION
## What this PR does / why we need it:
On DualStack management clusters, LoadBalancer services for Konnectivity and Router were only receiving IPv4 addresses while the KAS service correctly received both IPv4 and IPv6. This was because the KAS service had IPFamilyPolicy set to PreferDualStack, but Konnectivity and Router services were missing this configuration.

This change adds IPFamilyPolicy: PreferDualStack to:
- ReconcileKonnectivityServerService() in kas/service.go
- ReconcileRouterService() in ingress/router.go

This ensures all LoadBalancer services receive dual-stack addresses when deployed on a DualStack cluster, fixing the issue for KubeVirt and other platforms.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.