### PR TITLE
OCPBUGS-65824: Add dynamic NodePort range validation to prevent cluster creation failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ tools/bin
 # Mocked interface generate through mockgen
 *_mock.go
 
+# Claude Code working directory
+.work/
+
 # dev
 dev/
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -4135,7 +4135,11 @@ func parseNodePortRange(rangeStr string) (min, max int32, err error) {
 		return 0, 0, fmt.Errorf("invalid maximum port: %s", parts[1])
 	}
 
-	return int32(minVal), int32(maxVal), nil
+	minPort, maxPort := int32(minVal), int32(maxVal)
+	if minPort > maxPort {
+		return 0, 0, fmt.Errorf("invalid range: minimum port %d must be less than or equal to maximum port %d", minPort, maxPort)
+	}
+	return minPort, maxPort, nil
 }
 
 // validateNodePortPortRange validates that NodePort.Port is within the configured ServiceNodePortRange.


### PR DESCRIPTION
## What this PR does / why we need it:

This PR adds validation for NodePort.Port to ensure ports fall within the cluster's configured ServiceNodePortRange. This prevents late failures during cluster provisioning when the control-plane-operator rejects ports outside the acceptable range.

**The problem**: When creating a hosted cluster with NodePort set to values like 10000, the creation fails because the port is outside the acceptable range (typically 30000-32767), but this validation only happens late in the process after resources are already created.

**The solution**: 
- Adds dynamic validation that reads cluster-specific ServiceNodePortRange configuration
- Validates NodePort.Port against the configured range (supports custom ranges, not just default)
- Allows port 0 (dynamic assignment)
- Provides clear error messages with the actual configured range
- Ensures early failure with immediate feedback

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/OCPBUGS-65824

## Special notes for your reviewer:

- The validation is **dynamic** - it reads the cluster's ServiceNodePortRange configuration instead of hardcoding 30000-32767
- This supports customers who may have custom port ranges configured
- No CRD changes were made - validation is runtime-only to support configurable ranges
- One existing test was updated (port 4433 → 30443) because it was using an invalid NodePort
- All existing tests continue to pass

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. (Function documentation explains the validation logic)
- [x] This change includes unit tests. (Added comprehensive tests for range parsing and validation)

🤖 Generated with Claude Code via `/jira:solve OCPBUGS-65824 origin`