### PR TITLE
CNTRLPLANE-2703: Disable Renovate dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "enabled": false,
     "baseBranchPatterns": [
         "main",
         "release-4.16",


### PR DESCRIPTION
## What this PR does / why we need it:

Disables Renovate bot by setting `enabled: false` at the root level of the `renovate.json` configuration. This prevents all automated dependency PRs from being created while preserving the configuration for potential future re-enablement.

Reference: https://docs.renovatebot.com/configuration-options/#enabled

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/CNTRLPLANE-2703

## Special notes for your reviewer:

This is a configuration-only change. No code, tests, or docs are affected.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

---
🤖 Generated with [Claude Code](https://claude.ai/code) via `/jira:solve [CNTRLPLANE-2703](https://issues.redhat.com//browse/CNTRLPLANE-2703) celebdor`