### PR TITLE
CNTRLPLANE-2709: Update Dependabot to use conventional commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       time: "01:00"
       timezone: "Etc/UTC"
     commit-message:
-      prefix: "NO-JIRA"
+      prefix: "build(deps)"
     labels:
       - "area/ci-tooling"
       - "ok-to-test"
@@ -46,7 +46,7 @@ updates:
       time: "01:00"
       timezone: "Etc/UTC"
     commit-message:
-      prefix: "NO-JIRA"
+      prefix: "build(deps)"
     labels:
       - "area/ci-tooling"
       - "ok-to-test"
@@ -67,7 +67,7 @@ updates:
       time: "01:00"
       timezone: "Etc/UTC"
     commit-message:
-      prefix: "NO-JIRA"
+      prefix: "build(deps)"
     labels:
       - "area/ci-tooling"
       - "ok-to-test"


### PR DESCRIPTION
## What this PR does / why we need it:

Updates the Dependabot configuration to use conventional commits format (`build(deps):` prefix) instead of `NO-JIRA:`. This ensures Dependabot commits pass gitlint validation and follow the project's commit message conventions.

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/CNTRLPLANE-2709

## Special notes for your reviewer:

This PR is part of a two-part change:
1. **This PR (hypershift)**: Updates Dependabot to use `build(deps):` prefix
2. **Companion [PR](https://github.com/openshift/release/pull/74513) (openshift/release)**: Exempts `dependabot[bot]` from the `jira/valid-reference` requirement

After both PRs merge, Dependabot PRs will:
- Use conventional commit format
- No longer require a JIRA ticket reference
- Still require `approved`, `lgtm`, and `verified` labels

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. (N/A - configuration change only)
- [ ] This change includes unit tests. (N/A - configuration change only)

---
🤖 Generated with [Claude Code](https://claude.ai/code) via `/jira:solve [CNTRLPLANE-2709](https://issues.redhat.com//browse/CNTRLPLANE-2709)`