### PR TITLE
Add Swift networking to KAS, Add DNS side car to route MSFT DNS reque…

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -445,6 +445,16 @@ const (
 	// SkipKASCertificateConflicSANValidation allows skipping the validation of the KAS certificate SANs so they do not conflict with ServicePublishingStrategy Hostname.
 	// This annotation is useful as a escape hatch, that IBM could use.
 	SkipKASConflicSANValidation = "hypershift.openshift.io/skip-kas-conflict-san-validation"
+
+	// SwiftPodNetworkInstanceAnnotation indicates that Swift networking is enabled for the HostedCluster.
+	// This is used by ARO. The value of this annotation is the name of the Swift pod network instance to be attached to the router pods.
+	// We still support absence of this annotation in ARO to keep CI working until swift is available there.
+	SwiftPodNetworkInstanceAnnotation = "hypershift.openshift.io/swift-pod-network-instance"
+	// Swift PodNetworkInstanceAnnotationCpo indicates that swift network is enabled for the HostedCluster and a specific set of IPs are reserved
+	// for the control plane operator.
+	// This is used by ARO. The value of this annotation is the name of the Swift pod network instance specifically created to be attached to the
+	// kube-apiserver pods
+	SwiftPodNetworkInstanceAnnotationCpo = "hypershift.openshift.io/swift-pod-network-instance-cpo"
 )
 
 // RetentionPolicy defines the policy for handling resources associated with a cluster when the cluster is deleted.

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-apiserver/dns-proxy-configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-apiserver/dns-proxy-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kas-dns-proxy
+  namespace: HCP_NAMESPACE
+data:
+  Corefile: ""

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/component.go
@@ -115,6 +115,11 @@ func NewComponent() component.ControlPlaneComponent {
 			component.WithAdaptFunction(kms.AdaptAzureSecretProvider),
 			component.WithPredicate(enableAzureKMSSecretProvider),
 		).
+		WithManifestAdapter(
+			"dns-proxy-configmap.yaml",
+			component.WithAdaptFunction(adaptDNSProxyConfigMap),
+			component.WithPredicate(enableDNSProxySidecar),
+		).
 		Build()
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/dns-proxy-configmap.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/dns-proxy-configmap.go
@@ -1,0 +1,113 @@
+package kas
+
+import (
+	"fmt"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// DNSProxyConfigMap creates a ConfigMap containing the CoreDNS Corefile
+// for the DNS proxy sidecar that routes Azure vault domains to Azure DNS
+// and everything else to the management cluster DNS
+func DNSProxyConfigMap(namespace string, managementClusterDNS string) *corev1.ConfigMap {
+	corefile := fmt.Sprintf(`# DNS proxy for Azure Key Vault resolution via Swift interface
+.:53 {
+    # Forward Azure vault domains to Azure DNS (168.63.129.16)
+    # These will egress via eth1 (Swift interface) due to default route
+    forward vault.azure.net 168.63.129.16 {
+        policy sequential
+    }
+    forward vaultcore.azure.net 168.63.129.16 {
+        policy sequential
+    }
+
+    # Forward all other queries to management cluster DNS
+    # This handles etcd-client, cluster services, and external domains
+    forward . %s {
+        policy sequential
+    }
+
+    # Logging and health
+    errors
+    log {
+        class error
+    }
+    health {
+        lameduck 5s
+    }
+    ready
+    cache 30
+    reload
+}
+`, managementClusterDNS)
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kas-dns-proxy",
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"Corefile": corefile,
+		},
+	}
+}
+
+// adaptDNSProxyConfigMap adapts the DNS proxy ConfigMap for Swift networking
+func adaptDNSProxyConfigMap(cpContext component.WorkloadContext, cm *corev1.ConfigMap) error {
+	hcp := cpContext.HCP
+
+	// Get management cluster DNS IP (default for AKS/ARO)
+	mgmtClusterDNS := "10.130.0.10"
+	if customDNS := hcp.Annotations["hypershift.openshift.io/management-cluster-dns"]; customDNS != "" {
+		mgmtClusterDNS = customDNS
+	}
+
+	// Generate the Corefile configuration
+	corefile := fmt.Sprintf(`# DNS proxy for Azure Key Vault resolution via Swift interface
+.:53 {
+    # Forward Azure vault domains to Azure DNS (168.63.129.16)
+    # These will egress via eth1 (Swift interface) due to default route
+    forward vault.azure.net 168.63.129.16 {
+        policy sequential
+    }
+    forward vaultcore.azure.net 168.63.129.16 {
+        policy sequential
+    }
+
+    # Forward all other queries to management cluster DNS
+    # This handles etcd-client, cluster services, and external domains
+    forward . %s {
+        policy sequential
+    }
+
+    # Logging and health
+    errors
+    log {
+        class error
+    }
+    health {
+        lameduck 5s
+    }
+    ready
+    cache 30
+    reload
+}
+`, mgmtClusterDNS)
+
+	cm.Data = map[string]string{
+		"Corefile": corefile,
+	}
+
+	return nil
+}
+
+// enableDNSProxySidecar is a predicate that enables the DNS proxy ConfigMap
+// only when Swift networking is enabled for the cluster
+func enableDNSProxySidecar(cpContext component.WorkloadContext) bool {
+	swiftPodNetworkInstanceCpo := cpContext.HCP.Annotations[hyperv1.SwiftPodNetworkInstanceAnnotationCpo]
+	return swiftPodNetworkInstanceCpo != ""
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/dns-proxy-configmap_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/dns-proxy-configmap_test.go
@@ -1,0 +1,140 @@
+package kas
+
+import (
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAdaptDNSProxyConfigMap(t *testing.T) {
+	tests := []struct {
+		name                   string
+		annotations            map[string]string
+		expectedMgmtClusterDNS string
+	}{
+		{
+			name:                   "When no custom DNS annotation is provided, it should use default management cluster DNS",
+			annotations:            map[string]string{},
+			expectedMgmtClusterDNS: "10.130.0.10",
+		},
+		{
+			name: "When custom DNS annotation is provided, it should use custom management cluster DNS",
+			annotations: map[string]string{
+				"hypershift.openshift.io/management-cluster-dns": "10.96.0.10",
+			},
+			expectedMgmtClusterDNS: "10.96.0.10",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-cluster",
+					Namespace:   "test-namespace",
+					Annotations: tt.annotations,
+				},
+			}
+
+			cpContext := component.WorkloadContext{
+				HCP: hcp,
+			}
+
+			cm := &corev1.ConfigMap{}
+			err := adaptDNSProxyConfigMap(cpContext, cm)
+			if err != nil {
+				t.Fatalf("adaptDNSProxyConfigMap() error = %v", err)
+			}
+
+			corefile, ok := cm.Data["Corefile"]
+			if !ok {
+				t.Fatal("Corefile key not found in ConfigMap data")
+			}
+
+			// Verify the management cluster DNS is in the Corefile
+			expectedPattern := "forward . " + tt.expectedMgmtClusterDNS
+			if !contains(corefile, expectedPattern) {
+				t.Errorf("Expected Corefile to contain %q, but it doesn't.\nCorefile:\n%s", expectedPattern, corefile)
+			}
+
+			// Verify Azure DNS is in the Corefile
+			if !contains(corefile, "168.63.129.16") {
+				t.Error("Expected Corefile to contain Azure DNS 168.63.129.16")
+			}
+
+			// Verify vault domains are configured with separate forward directives
+			if !contains(corefile, "forward vault.azure.net 168.63.129.16") {
+				t.Error("Expected Corefile to contain 'forward vault.azure.net 168.63.129.16'")
+			}
+			if !contains(corefile, "forward vaultcore.azure.net 168.63.129.16") {
+				t.Error("Expected Corefile to contain 'forward vaultcore.azure.net 168.63.129.16'")
+			}
+		})
+	}
+}
+
+func TestEnableDNSProxySidecar(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			name:        "When Swift annotation is not present, it should return false",
+			annotations: map[string]string{},
+			expected:    false,
+		},
+		{
+			name: "When Swift annotation is present, it should return true",
+			annotations: map[string]string{
+				hyperv1.SwiftPodNetworkInstanceAnnotationCpo: "swift-instance-1",
+			},
+			expected: true,
+		},
+		{
+			name: "When Swift annotation is present but empty, it should return false",
+			annotations: map[string]string{
+				hyperv1.SwiftPodNetworkInstanceAnnotationCpo: "",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-cluster",
+					Namespace:   "test-namespace",
+					Annotations: tt.annotations,
+				},
+			}
+
+			cpContext := component.WorkloadContext{
+				HCP: hcp,
+			}
+
+			result := enableDNSProxySidecar(cpContext)
+			if result != tt.expected {
+				t.Errorf("enableDNSProxySidecar() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && containsAtIndex(s, substr))
+}
+
+func containsAtIndex(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2268,6 +2268,8 @@ func reconcileHostedControlPlaneAnnotations(hcp *hyperv1.HostedControlPlane, hcl
 		hyperv1.HostedClusterRestoredFromBackupAnnotation,
 		// TODO: Remove this once the the input is in the HostedCluster AWS API.
 		"hypershift.openshift.io/aws-termination-handler-queue-url",
+		hyperv1.SwiftPodNetworkInstanceAnnotation,
+		hyperv1.SwiftPodNetworkInstanceAnnotationCpo,
 	}
 	for _, key := range mirroredAnnotations {
 		val, hasVal := hcluster.Annotations[key]

--- a/support/azureutil/azureutil.go
+++ b/support/azureutil/azureutil.go
@@ -324,13 +324,9 @@ func GetKeyVaultDNSSuffixFromCloudType(cloud string) (string, error) {
 	switch cloud {
 	case "AZURECHINACLOUD":
 		return "vault.azure.cn", nil
-	case "AZURECLOUD":
+	case "AZURECLOUD", "AZUREPUBLICCLOUD":
 		return "vault.azure.net", nil
-	case "AZUREPUBLICCLOUD":
-		return "vault.azure.net", nil
-	case "AZUREUSGOVERNMENT":
-		return "vault.usgovcloudapi.net", nil
-	case "AZUREUSGOVERNMENTCLOUD":
+	case "AZUREUSGOVERNMENT", "AZUREUSGOVERNMENTCLOUD":
 		return "vault.usgovcloudapi.net", nil
 	default:
 		return "", fmt.Errorf("unknown cloud type %q", cloud)

--- a/support/secretproviderclass/secretproviderclass.go
+++ b/support/secretproviderclass/secretproviderclass.go
@@ -24,14 +24,16 @@ array:
 //
 // https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-identity-access?tabs=azure-portal&pivots=access-with-a-user-assigned-managed-identity
 func ReconcileManagedAzureSecretProviderClass(secretProviderClass *secretsstorev1.SecretProviderClass, hcp *hyperv1.HostedControlPlane, managedIdentity hyperv1.ManagedIdentity) {
+	keyVault := hcp.Spec.Platform.Azure.AzureAuthenticationConfig.ManagedIdentities.ControlPlane.ManagedIdentitiesKeyVault
+
 	secretProviderClass.Spec = secretsstorev1.SecretProviderClassSpec{
 		Provider: "azure",
 		Parameters: map[string]string{
 			"usePodIdentity":         "false",
 			"useVMManagedIdentity":   "true",
 			"userAssignedIdentityID": azureutil.GetKeyVaultAuthorizedUser(),
-			"keyvaultName":           hcp.Spec.Platform.Azure.AzureAuthenticationConfig.ManagedIdentities.ControlPlane.ManagedIdentitiesKeyVault.Name,
-			"tenantId":               hcp.Spec.Platform.Azure.AzureAuthenticationConfig.ManagedIdentities.ControlPlane.ManagedIdentitiesKeyVault.TenantID,
+			"keyvaultName":           keyVault.Name,
+			"tenantId":               keyVault.TenantID,
 			"objects":                formatSecretProviderClassObject(managedIdentity.CredentialsSecretName, string(managedIdentity.ObjectEncoding)),
 		},
 	}

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -445,6 +445,16 @@ const (
 	// SkipKASCertificateConflicSANValidation allows skipping the validation of the KAS certificate SANs so they do not conflict with ServicePublishingStrategy Hostname.
 	// This annotation is useful as a escape hatch, that IBM could use.
 	SkipKASConflicSANValidation = "hypershift.openshift.io/skip-kas-conflict-san-validation"
+
+	// SwiftPodNetworkInstanceAnnotation indicates that Swift networking is enabled for the HostedCluster.
+	// This is used by ARO. The value of this annotation is the name of the Swift pod network instance to be attached to the router pods.
+	// We still support absence of this annotation in ARO to keep CI working until swift is available there.
+	SwiftPodNetworkInstanceAnnotation = "hypershift.openshift.io/swift-pod-network-instance"
+	// Swift PodNetworkInstanceAnnotationCpo indicates that swift network is enabled for the HostedCluster and a specific set of IPs are reserved
+	// for the control plane operator.
+	// This is used by ARO. The value of this annotation is the name of the Swift pod network instance specifically created to be attached to the
+	// kube-apiserver pods
+	SwiftPodNetworkInstanceAnnotationCpo = "hypershift.openshift.io/swift-pod-network-instance-cpo"
 )
 
 // RetentionPolicy defines the policy for handling resources associated with a cluster when the cluster is deleted.


### PR DESCRIPTION
…sts via customer vNet

## What this PR does / why we need it:

This PR implements private keyvault for ARO HCP clusters. It does this by leveraging Swift networking, to make this work its required that DNS resolution is completed via the customer vNet.

This PR introduces a DNS sidecar to accomplish the above it also means that we need to disable the wait-for-etcd init container. 

## Which issue(s) this PR fixes:
This PR accompanies changes made in https://github.com/openshift/hypershift/pull/7613
Fixes 

## Special notes for your reviewer:

I don't have a way yet to discover the kube DNS service for the AKS cluster on which hypershift runs currently its hard coded or overwritten by an annotation. I could use some thoughts here.

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.