### PR TITLE
OCPBUGS-77503:CNTRLPLANE-753: test: add EC2 AMI related verification to Windows ImageType test

### DIFF
--- a/test/e2e/nodepool_imagetype_test.go
+++ b/test/e2e/nodepool_imagetype_test.go
@@ -4,18 +4,20 @@ package e2e
 
 import (
 	"context"
-	_ "embed"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	. "github.com/onsi/gomega"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -40,7 +42,6 @@ func NewNodePoolImageTypeTest(ctx context.Context, mgmtClient crclient.Client, h
 }
 
 func (it *NodePoolImageTypeTest) Setup(t *testing.T) {
-	// Skip test for non-AWS platforms since ImageType is currently AWS-specific
 	if globalOpts.Platform != hyperv1.AWSPlatform {
 		t.Skip("test is only supported for AWS platform")
 	}
@@ -52,7 +53,7 @@ func (it *NodePoolImageTypeTest) Setup(t *testing.T) {
 
 func (it *NodePoolImageTypeTest) BuildNodePoolManifest(defaultNodepool hyperv1.NodePool) (*hyperv1.NodePool, error) {
 	nodePool := &hyperv1.NodePool{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      it.hostedCluster.Name + "-" + "test-imagetype",
 			Namespace: it.hostedCluster.Namespace,
 		},
@@ -69,22 +70,38 @@ func (it *NodePoolImageTypeTest) Run(t *testing.T, nodePool hyperv1.NodePool, no
 	g := NewWithT(t)
 	ctx := it.ctx
 
-	// wait for the nodepool status conditions to populate
-	e2eutil.EventuallyObject(t, ctx, fmt.Sprintf("wait for nodepool %s/%s to have a populated PlatformImage status condition", nodePool.Namespace, nodePool.Name),
+	// Wait for the ValidPlatformImage condition to be populated with a settled status.
+	// The condition may be True (Windows AMI found) or False (AMI not available for region/version).
+	// We should not proceed while the status is Unknown (controller still discovering).
+	e2eutil.EventuallyObject(t, ctx, fmt.Sprintf("wait for nodepool %s/%s to have ValidPlatformImageType condition with settled status", nodePool.Namespace, nodePool.Name),
 		func(ctx context.Context) (*hyperv1.NodePool, error) {
 			np := &hyperv1.NodePool{}
 			err := it.mgmtClient.Get(ctx, crclient.ObjectKeyFromObject(&nodePool), np)
 			return np, err
 		},
 		[]e2eutil.Predicate[*hyperv1.NodePool]{
-			e2eutil.ConditionPredicate[*hyperv1.NodePool](e2eutil.Condition{
-				Type: hyperv1.NodePoolValidPlatformImageType,
-			}),
+			func(np *hyperv1.NodePool) (bool, string, error) {
+				// Find the ValidPlatformImageType condition
+				for _, condition := range np.Status.Conditions {
+					if condition.Type == hyperv1.NodePoolValidPlatformImageType {
+						// Check if status is settled (True or False, not Unknown)
+						if condition.Status == corev1.ConditionTrue || condition.Status == corev1.ConditionFalse {
+							return true, fmt.Sprintf("condition settled: %s=%s, message: %s",
+								condition.Type, condition.Status, condition.Message), nil
+						}
+						// Condition exists but status is still Unknown
+						return false, fmt.Sprintf("condition exists but status is %s (waiting for settled state True or False)",
+							condition.Status), nil
+					}
+				}
+				// Condition not found yet
+				return false, "ValidPlatformImageType condition not found", nil
+			},
 		},
 		e2eutil.WithInterval(10*time.Second), e2eutil.WithTimeout(5*time.Minute),
 	)
 
-	// Check that the ValidPlatformImageType condition exists
+	// Validate that the ValidPlatformImageType condition reflects the Windows AMI.
 	err := it.mgmtClient.Get(ctx, crclient.ObjectKeyFromObject(&nodePool), &nodePool)
 	g.Expect(err).NotTo(HaveOccurred(), "failed to get NodePool")
 	validImageCondition := hostedcluster.FindNodePoolStatusCondition(nodePool.Status.Conditions, hyperv1.NodePoolValidPlatformImageType)
@@ -92,22 +109,95 @@ func (it *NodePoolImageTypeTest) Run(t *testing.T, nodePool hyperv1.NodePool, no
 		t.Fatalf("ValidPlatformImageType condition not found")
 	}
 
-	// For Windows, the condition should be True if Windows AMI mapping exists
 	switch validImageCondition.Status {
 	case corev1.ConditionTrue:
-		// Verify message contains Windows AMI information
 		if !strings.Contains(strings.ToLower(validImageCondition.Message), "windows") {
 			t.Fatalf("Windows ImageType should show Windows AMI info in condition message, but got: %s", validImageCondition.Message)
 		}
-		t.Log("Windows ImageType test passed - Windows AMI found and validated")
+		t.Logf("ValidPlatformImageType condition confirmed Windows AMI: %s", validImageCondition.Message)
 	case corev1.ConditionFalse:
-		// If Windows AMI mapping doesn't exist for this region/version, that's also a valid test result
 		if strings.Contains(strings.ToLower(validImageCondition.Message), "couldn't discover a windows ami") {
-			t.Log("Windows ImageType test passed - Windows AMI not available for this region/version (expected behavior)")
-		} else {
-			t.Fatalf("unexpected validation failure for Windows ImageType: %s", validImageCondition.Message)
+			t.Skipf("Windows AMI not available for this region/version: %s", validImageCondition.Message)
 		}
+		t.Fatalf("unexpected validation failure for Windows ImageType: %s", validImageCondition.Message)
 	default:
 		t.Fatalf("ValidPlatformImageType condition has unexpected status %s", validImageCondition.Status)
 	}
+
+	// Extract the expected Windows LI AMI ID from the condition message.
+	// Message format: "Bootstrap Windows AMI is \"ami-0abcdef1234567890\""
+	expectedAMI := extractAMIFromMessage(validImageCondition.Message)
+	if expectedAMI == "" {
+		t.Fatalf("failed to extract AMI ID from condition message: %s", validImageCondition.Message)
+	}
+	t.Logf("Expected Windows LI AMI: %s", expectedAMI)
+
+	// Verify that nodes provisioned by the Windows LI AMI are running the expected RHCOS-based OS.
+	// The Windows License Included (WinLI) AMI is a RHCOS image with Windows licensing metadata,
+	// so nodes should report linux as their operating system and Red Hat Enterprise Linux CoreOS
+	// in their OS image string.
+	g.Expect(nodes).NotTo(BeEmpty(), "expected at least one ready node for the Windows ImageType nodepool")
+	for _, node := range nodes {
+		t.Logf("Checking node %s: OperatingSystem=%s, OSImage=%s",
+			node.Name, node.Status.NodeInfo.OperatingSystem, node.Status.NodeInfo.OSImage)
+		g.Expect(node.Status.NodeInfo.OperatingSystem).To(Equal("linux"),
+			"Windows LI node %s should report linux as OperatingSystem", node.Name)
+		g.Expect(strings.ToLower(node.Status.NodeInfo.OSImage)).To(ContainSubstring("red hat enterprise linux coreos"),
+			"Windows LI node %s should be running RHCOS", node.Name)
+	}
+
+	// Verify that the EC2 instances are actually using the Windows LI AMI.
+	// This is the critical validation that ensures customers will be compliant with AWS Windows LI terms.
+	ec2client := ec2Client(it.clusterOpts.AWSPlatform.Credentials.AWSCredentialsFile, it.clusterOpts.AWSPlatform.Region)
+	for _, node := range nodes {
+		// Check if context has been cancelled
+		if ctx.Err() != nil {
+			t.Fatalf("context cancelled while validating EC2 instances: %v", ctx.Err())
+		}
+
+		providerID := node.Spec.ProviderID
+		g.Expect(providerID).NotTo(BeEmpty(), "node %s should have a providerID", node.Name)
+
+		// Extract instance ID from providerID (format: aws:///us-east-1a/i-1234567890abcdef0)
+		parts := strings.Split(providerID, "/")
+		if len(parts) == 0 {
+			t.Fatalf("node %s has invalid providerID format: %s", node.Name, providerID)
+		}
+		instanceID := parts[len(parts)-1]
+		if instanceID == "" {
+			t.Fatalf("node %s has empty instance ID in providerID: %s", node.Name, providerID)
+		}
+		t.Logf("Verifying EC2 instance %s for node %s", instanceID, node.Name)
+
+		result, err := ec2client.DescribeInstancesWithContext(ctx, &ec2.DescribeInstancesInput{
+			InstanceIds: []*string{aws.String(instanceID)},
+		})
+		g.Expect(err).NotTo(HaveOccurred(), "failed to describe EC2 instance %s", instanceID)
+		g.Expect(result.Reservations).NotTo(BeEmpty(), "no reservations found for instance %s", instanceID)
+		g.Expect(result.Reservations[0].Instances).NotTo(BeEmpty(), "no instances found in reservation for instance %s", instanceID)
+
+		instance := result.Reservations[0].Instances[0]
+		actualAMI := aws.StringValue(instance.ImageId)
+		t.Logf("Node %s is running on EC2 instance %s with AMI %s", node.Name, instanceID, actualAMI)
+
+		// This is the critical validation: ensure the EC2 instance is using the Windows LI AMI.
+		// If this check fails, it means the NodePool controller found the Windows AMI but didn't
+		// actually apply it to the EC2 instances, which would result in compliance violations.
+		g.Expect(actualAMI).To(Equal(expectedAMI),
+			"EC2 instance %s for node %s should be using Windows LI AMI %s, but is using %s",
+			instanceID, node.Name, expectedAMI, actualAMI)
+	}
+
+	t.Log("NodePoolImageTypeTest passed - Windows LI AMI validated at all layers (NodePool condition, Node OS, EC2 AMI)")
+}
+
+// extractAMIFromMessage extracts the AMI ID from a NodePool condition message.
+// Expected message format: "Bootstrap Windows AMI is \"ami-0abcdef1234567890\""
+func extractAMIFromMessage(message string) string {
+	// Match AMI ID pattern: ami- followed by exactly 8 hex chars (old format) or 17 hex chars (new format)
+	// Old format: ami-12345678
+	// New format: ami-0abcdef1234567890
+	re := regexp.MustCompile(`ami-[0-9a-f]{8}(?:[0-9a-f]{9})?`)
+	matches := re.FindString(message)
+	return matches
 }


### PR DESCRIPTION
## Summary

Implements focused Windows ImageType validation per reviewer feedback, with critical EC2 AMI verification to ensure AWS billing compliance.

**Context**: Discussion: https://github.com/openshift/hypershift/pull/7429#discussion_r2753423826 , this PR follows the standard `BuildNodePoolManifest` pattern and adds the most critical validation: **verifying EC2 instances actually use the Windows LI AMI for billing compliance**.

## What This PR Tests

Validates Windows License Included (WinLI) AMI usage across **3 critical layers**:

### Layer 1: NodePool Discovery ✅
- Validates `ValidPlatformImageType` condition is populated
- Confirms controller discovered Windows LI AMI from stream metadata
- Extracts expected AMI ID from condition message

### Layer 2: Node Operating System ✅
- Verifies nodes boot successfully with RHCOS
- Confirms OS is Linux (WinLI AMI is RHCOS with Windows billing metadata)
- Validates OS image contains "Red Hat Enterprise Linux CoreOS"

### Layer 3: EC2 AMI Verification ✅ **[CRITICAL]**
- **Queries AWS EC2 API** to verify instances actually use Windows LI AMI
- Compares actual AMI (from EC2 DescribeInstances) with expected AMI
- **Prevents billing compliance violations** by catching AMI mismatches

## Why Layer 3 Is Critical

### The Business Problem
AWS bills based on the **actual AMI used by EC2 instances**, not what the controller thinks it should use. A bug could result in:
- ❌ Controller finds correct Windows LI AMI but applies wrong AMI to EC2
- ❌ Customers violate AWS Windows LI licensing terms
- ❌ Customers billed incorrectly (either overcharged or undercharged)

### Without Layer 3 Check
```go
// Example bug scenario:
ami, err := getWindowsAMI(...)  // Returns "ami-winli-12345"
SetCondition("Bootstrap Windows AMI is ami-winli-12345")  // Condition set ✅

// But template uses wrong AMI
awsMachineTemplate.Spec.AMI.ID = regularRHCOSAMI  // BUG! ❌
```

**Result**:
- ✅ Layer 1 passes: Condition shows correct AMI
- ✅ Layer 2 passes: Nodes boot (regular RHCOS works)
- ❌ **Customers face compliance violations and billing errors**

### With Layer 3 Check
```go
// Test queries EC2 API
actualAMI := ec2.DescribeInstances(instanceID).ImageId
g.Expect(actualAMI).To(Equal("ami-winli-12345"))  // FAILS! ❌
```

**Result**:
- ✅ **Bug caught in CI before reaching customers**
- ✅ **Prevents compliance violations**

## What This Test Does NOT Cover

### Windows VMs (Customer Workloads)

This test **intentionally does not validate Windows VMs** running on these nodes. Here's why:

**Separation of Concerns:**
```
┌─────────────────────────────────────────┐
│ HyperShift (Infrastructure Layer)       │  ◄── THIS TEST
├─────────────────────────────────────────┤
│ ✅ EC2 instance provisioning            │
│ ✅ NodePool management                   │
│ ✅ AMI selection & application           │
│ ✅ AWS billing compliance                │
└─────────────────────────────────────────┘
                  │
                  │ HyperShift provides the platform
                  ▼
┌─────────────────────────────────────────┐
│ OCP-Virt/CNV (Virtualization Layer)     │  ◄── CNV TEAM OWNS
├─────────────────────────────────────────┤
│ ✅ VirtualMachine lifecycle              │
│ ✅ Windows VM creation & boot            │
│ ✅ VM networking & storage               │
│ ✅ QEMU/KVM management                   │
└─────────────────────────────────────────┘
```

**Why Not Test Windows VMs Here:**

1. **Different Responsibility** 🏗️
   - HyperShift: Ensures infrastructure uses correct AMI for billing
   - CNV/OCP-Virt: Ensures VMs work on that infrastructure

2. **Test Time** ⏱️
   - Current test: ~25 minutes
   - With Windows VM: ~50-65 minutes (image download + VM boot)

3. **Dependencies** 📦
   - Current: Only NodePool and AWS (always available)
   - With VMs: OCP-Virt operator, CDI, storage classes (not guaranteed)

4. **Framework Design** 🎯
   - NodePool tests validate **infrastructure provisioning**
   - Windows VMs are **application workloads**, not infrastructure

5. **Licensing** ⚖️
   - Cannot distribute Windows images in open-source CI
   - Requires Microsoft licensing agreements

**Recommendation**: CNV/OCP-Virt team should own Windows VM validation in their E2E tests, using the infrastructure that HyperShift provides.

## What This PR Adds

### Added
- ✅ **EC2 AMI verification** via AWS SDK
- ✅ `extractAMIFromMessage()` helper function
- ✅ Node OS validation (RHCOS/Linux check)
- ✅ Comprehensive validation comments

### Kept
- ✅ `BuildNodePoolManifest` pattern following framework conventions
- ✅ Framework's `WaitForReadyNodesByNodePool` for node readiness
- ✅ `ValidPlatformImageType` condition check for AMI discovery

## Technical Details

### Windows License Included (WinLI) AMI

The WinLI AMI is **RHCOS with Windows billing metadata**, not actual Windows:

| Aspect | Value |
|--------|-------|
| **OS Image** | Red Hat Enterprise Linux CoreOS (Linux) |
| **AMI Metadata** | `BillingProducts: ["bp-windows-server"]` |
| **AWS Billing** | Charged at Windows LI rate |
| **Node OS** | Reports `linux` (not `windows`) |
| **Use Case** | Run Windows VMs via KubeVirt on RHCOS nodes |

## Related Links

- **JIRA Feature**: [OCPSTRAT-1949](https://issues.redhat.com/browse/OCPSTRAT-1949)
- **Test Story**: [CNTRLPLANE-753](https://issues.redhat.com/browse/CNTRLPLANE-753)

## Notes for Reviewers

### Key Points
1. **Layer 3 (EC2 AMI check) is the critical addition** - prevents billing compliance violations
2. Test follows standard `BuildNodePoolManifest` pattern
3. WinLI AMI is RHCOS with billing metadata, not actual Windows OS
4. **Windows VMs are intentionally out of scope** - different team responsibility (CNV/OCP-Virt)

### Why This Test Is Valuable
- Catches bugs where controller finds correct AMI but doesn't apply it
- Ensures AWS billing compliance (legal/business requirement)
- Simple, focused test following framework patterns
- Fast execution (~25 minutes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced validation for NodePool image type configurations with improved instance and operating system verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->