### PR TITLE
[release-4.20] fix: OCPBUGS-76469: ignore nodepool-globalps-enabled label in cluster-autoscaler

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_autoscaler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_autoscaler_deployment.yaml
@@ -83,6 +83,7 @@ spec:
         - --balancing-ignore-label=topology.disk.csi.azure.com/zone
         - --balancing-ignore-label=ibm-cloud.kubernetes.io/worker-id
         - --balancing-ignore-label=vpc-block-csi-driver-labels
+        - --balancing-ignore-label=hypershift.openshift.io/nodepool-globalps-enabled
         command:
         - /usr/bin/cluster-autoscaler
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_autoscaler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_autoscaler_deployment.yaml
@@ -83,6 +83,7 @@ spec:
         - --balancing-ignore-label=topology.disk.csi.azure.com/zone
         - --balancing-ignore-label=ibm-cloud.kubernetes.io/worker-id
         - --balancing-ignore-label=vpc-block-csi-driver-labels
+        - --balancing-ignore-label=hypershift.openshift.io/nodepool-globalps-enabled
         - --balancing-ignore-label=lifecycle
         - --balancing-ignore-label=k8s.amazonaws.com/eniConfig
         - --balancing-ignore-label=topology.k8s.aws/zone-id

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/zz_fixture_TestControlPlaneComponents_cluster_autoscaler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/zz_fixture_TestControlPlaneComponents_cluster_autoscaler_deployment.yaml
@@ -83,6 +83,7 @@ spec:
         - --balancing-ignore-label=topology.disk.csi.azure.com/zone
         - --balancing-ignore-label=ibm-cloud.kubernetes.io/worker-id
         - --balancing-ignore-label=vpc-block-csi-driver-labels
+        - --balancing-ignore-label=hypershift.openshift.io/nodepool-globalps-enabled
         - --balancing-ignore-label=lifecycle
         - --balancing-ignore-label=k8s.amazonaws.com/eniConfig
         - --balancing-ignore-label=topology.k8s.aws/zone-id

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/autoscaler/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/autoscaler/deployment.go
@@ -75,6 +75,7 @@ const (
 	CommonIgnoredLabelAzureDiskZone     = "topology.disk.csi.azure.com/zone"
 	CommonIgnoredLabelIBMCloudWorkerID  = "ibm-cloud.kubernetes.io/worker-id"
 	CommonIgnoredLabelVPCBlockCSIDriver = "vpc-block-csi-driver-labels"
+	CommonIgnoredLabelGlobalPSENABLED   = "hypershift.openshift.io/nodepool-globalps-enabled"
 )
 
 func (a AutoscalerArg) String() string {
@@ -185,7 +186,8 @@ func appendBasicIgnoreLabels(args []string, platformType hyperv1.PlatformType) [
 		BalancingIgnoreLabelArg.Value(CommonIgnoredLabelAWSEBSZone),
 		BalancingIgnoreLabelArg.Value(CommonIgnoredLabelAzureDiskZone),
 		BalancingIgnoreLabelArg.Value(CommonIgnoredLabelIBMCloudWorkerID),
-		BalancingIgnoreLabelArg.Value(CommonIgnoredLabelVPCBlockCSIDriver))
+		BalancingIgnoreLabelArg.Value(CommonIgnoredLabelVPCBlockCSIDriver),
+		BalancingIgnoreLabelArg.Value(CommonIgnoredLabelGlobalPSENABLED))
 
 	// Add platform-specific labels
 	switch platformType {


### PR DESCRIPTION

The hypershift.openshift.io/nodepool-globalps-enabled label is added to worker nodes by the globalps controller to indicate eligibility for the global-pull-secret-syncer daemonset (Replace nodes only).

This label should be ignored for cluster-autoscaling balancing purposes.

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

This is a manual back port of https://github.com/openshift/hypershift/pull/7480 to `release-4.20` branch.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://issues.redhat.com//browse/OCPBUGS-76469

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.