### PR TITLE
[release-4.18] fix: OCPBUGS-76471: ignore nodepool-globalps-enabled label in cluster…

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/zz_fixture_TestControlPlaneComponents.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-autoscaler/zz_fixture_TestControlPlaneComponents.yaml
@@ -81,6 +81,7 @@ spec:
         - --balancing-ignore-label=topology.disk.csi.azure.com/zone
         - --balancing-ignore-label=ibm-cloud.kubernetes.io/worker-id
         - --balancing-ignore-label=vpc-block-csi-driver-labels
+        - --balancing-ignore-label=hypershift.openshift.io/nodepool-globalps-enabled
         command:
         - /usr/bin/cluster-autoscaler
         env:

--- a/support/autoscaler/ignorelabels.go
+++ b/support/autoscaler/ignorelabels.go
@@ -47,6 +47,7 @@ const (
 	CommonIgnoredLabelAzureDiskZone     = "topology.disk.csi.azure.com/zone"
 	CommonIgnoredLabelIBMCloudWorkerID  = "ibm-cloud.kubernetes.io/worker-id"
 	CommonIgnoredLabelVPCBlockCSIDriver = "vpc-block-csi-driver-labels"
+	CommonIgnoredLabelGlobalPSENABLED   = "hypershift.openshift.io/nodepool-globalps-enabled"
 )
 
 // GetIgnoreLabels returns a list of labels that the cluster autoscaler should ignore
@@ -60,6 +61,7 @@ func GetIgnoreLabels(platformType hyperv1.PlatformType) []string {
 		CommonIgnoredLabelAzureDiskZone,
 		CommonIgnoredLabelIBMCloudWorkerID,
 		CommonIgnoredLabelVPCBlockCSIDriver,
+		CommonIgnoredLabelGlobalPSENABLED,
 	}
 
 	// Platform-specific labels

--- a/support/autoscaler/ignorelabels_test.go
+++ b/support/autoscaler/ignorelabels_test.go
@@ -22,6 +22,7 @@ func TestGetIgnoreLabels(t *testing.T) {
 				CommonIgnoredLabelAzureDiskZone,
 				CommonIgnoredLabelIBMCloudWorkerID,
 				CommonIgnoredLabelVPCBlockCSIDriver,
+				CommonIgnoredLabelGlobalPSENABLED,
 			},
 			expectedPlatformSpecificLabels: []string{
 				AwsIgnoredLabelK8sEniconfig,
@@ -38,6 +39,7 @@ func TestGetIgnoreLabels(t *testing.T) {
 				CommonIgnoredLabelAzureDiskZone,
 				CommonIgnoredLabelIBMCloudWorkerID,
 				CommonIgnoredLabelVPCBlockCSIDriver,
+				CommonIgnoredLabelGlobalPSENABLED,
 			},
 			expectedPlatformSpecificLabels: []string{
 				AzureNodepoolLegacyLabel,
@@ -53,6 +55,7 @@ func TestGetIgnoreLabels(t *testing.T) {
 				CommonIgnoredLabelAzureDiskZone,
 				CommonIgnoredLabelIBMCloudWorkerID,
 				CommonIgnoredLabelVPCBlockCSIDriver,
+				CommonIgnoredLabelGlobalPSENABLED,
 			},
 			expectedPlatformSpecificLabels: []string{},
 		},


### PR DESCRIPTION
…-autoscaler

The hypershift.openshift.io/nodepool-globalps-enabled label is added to worker nodes by the globalps controller to indicate eligibility for the global-pull-secret-syncer daemonset (Replace nodes only).

This label should be ignored for cluster-autoscaling balancing purposes.

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

This is a manual back port of https://github.com/openshift/hypershift/pull/7480 to `release-4.18` branch.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://issues.redhat.com//browse/OCPBUGS-76471

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.