### PR TITLE
Private kv via proxy

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -327,6 +327,12 @@ const (
 	// When set to "servicenodeport", each service gets its own dedicated health probe.
 	AzureLoadBalancerHealthProbeModeAnnotation = "hypershift.openshift.io/azure-load-balancer-health-probe-mode"
 
+	// SwiftPodNetworkInstanceAnnotation specifies the Swift pod network instance ID for Azure CNI Swift networking.
+	// When set on a HostedCluster, it enables Swift networking for control plane pods that need access to
+	// customer VNet resources (e.g., Azure Private Link endpoints for Key Vault).
+	// The value should be the ID of the Swift pod network instance resource in Azure.
+	SwiftPodNetworkInstanceAnnotation = "hypershift.openshift.io/swift-pod-network-instance"
+
 	// DisableClusterAutoscalerAnnotation allows disabling the cluster autoscaler for a hosted cluster.
 	// This annotation is only set by the hypershift-operator on HosterControlPlanes.
 	// It is not set by the end-user.

--- a/azure-dns-proxy/main.go
+++ b/azure-dns-proxy/main.go
@@ -1,0 +1,229 @@
+package azurednsproxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/openshift/hypershift/support/supportedversion"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+const (
+	azureDNSServer = "168.63.129.16:53"
+)
+
+func NewStartCommand() *cobra.Command {
+	l := log.Log.WithName("azure-dns-proxy")
+	log.SetLogger(zap.New(zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
+		o.EncodeTime = zapcore.RFC3339TimeEncoder
+	})))
+
+	cmd := &cobra.Command{
+		Use:   "azure-dns-proxy",
+		Short: "Runs the Azure DNS HTTP CONNECT proxy server.",
+	}
+
+	var listenAddr string
+	var requestTimeout time.Duration
+	var connectTimeout time.Duration
+	var tunnelIdleTimeout time.Duration
+
+	cmd.Flags().StringVar(&listenAddr, "listen-addr", "0.0.0.0:8888", "Address to listen on for HTTP CONNECT requests")
+	cmd.Flags().DurationVar(&requestTimeout, "request-timeout", 30*time.Second, "Timeout for proxy request handling")
+	cmd.Flags().DurationVar(&connectTimeout, "connect-timeout", 10*time.Second, "Timeout for establishing connections to target hosts")
+	cmd.Flags().DurationVar(&tunnelIdleTimeout, "tunnel-idle-timeout", 5*time.Minute, "Idle timeout for connection tunnels")
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		l.Info("Starting Azure DNS HTTP CONNECT proxy", "version", supportedversion.String())
+
+		azureDomains := []string{
+			".vault.azure.net",
+			".vaultcore.azure.net",
+			".privatelink.vaultcore.azure.net",
+		}
+
+		proxy := &AzureDNSProxy{
+			log:               l,
+			azureDNSServer:    azureDNSServer,
+			azureDomains:      azureDomains,
+			connectTimeout:    connectTimeout,
+			tunnelIdleTimeout: tunnelIdleTimeout,
+		}
+
+		server := &http.Server{
+			Addr:         listenAddr,
+			Handler:      proxy,
+			ReadTimeout:  requestTimeout,
+			WriteTimeout: requestTimeout,
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+
+		go func() {
+			<-sigChan
+			l.Info("Received shutdown signal")
+			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer shutdownCancel()
+			if err := server.Shutdown(shutdownCtx); err != nil {
+				l.Error(err, "Error during shutdown")
+			}
+			cancel()
+		}()
+
+		l.Info("HTTP CONNECT proxy listening", "addr", listenAddr)
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			l.Error(err, "Server failed")
+			os.Exit(1)
+		}
+
+		<-ctx.Done()
+		l.Info("Azure DNS proxy stopped")
+	}
+
+	return cmd
+}
+
+type AzureDNSProxy struct {
+	log               logr.Logger
+	azureDNSServer    string
+	azureDomains      []string
+	connectTimeout    time.Duration
+	tunnelIdleTimeout time.Duration
+}
+
+func (p *AzureDNSProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodConnect {
+		http.Error(w, "Method not allowed. Only CONNECT is supported.", http.StatusMethodNotAllowed)
+		return
+	}
+
+	p.log.V(1).Info("Received CONNECT request", "host", r.Host)
+
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "Hijacking not supported", http.StatusInternalServerError)
+		return
+	}
+
+	clientConn, _, err := hijacker.Hijack()
+	if err != nil {
+		p.log.Error(err, "Failed to hijack connection")
+		return
+	}
+	defer clientConn.Close()
+
+	host, port, err := net.SplitHostPort(r.Host)
+	if err != nil {
+		p.log.Error(err, "Invalid host:port")
+		clientConn.Write([]byte("HTTP/1.1 400 Bad Request\r\n\r\n"))
+		return
+	}
+
+	targetAddr, err := p.resolveHost(host, port)
+	if err != nil {
+		p.log.Error(err, "Failed to resolve host")
+		clientConn.Write([]byte("HTTP/1.1 502 Bad Gateway\r\n\r\n"))
+		return
+	}
+
+	dialer := &net.Dialer{Timeout: p.connectTimeout}
+	targetConn, err := dialer.Dial("tcp", targetAddr)
+	if err != nil {
+		p.log.Error(err, "Failed to connect to target")
+		clientConn.Write([]byte("HTTP/1.1 502 Bad Gateway\r\n\r\n"))
+		return
+	}
+	defer targetConn.Close()
+
+	_, err = clientConn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+	if err != nil {
+		p.log.Error(err, "Failed to write success response")
+		return
+	}
+
+	p.log.Info("Established tunnel", "host", host, "target", targetAddr)
+	p.tunnel(clientConn, targetConn)
+}
+
+func (p *AzureDNSProxy) resolveHost(host, port string) (string, error) {
+	useAzureDNS := false
+	for _, domain := range p.azureDomains {
+		if strings.HasSuffix(host, domain) {
+			useAzureDNS = true
+			break
+		}
+	}
+
+	if useAzureDNS {
+		p.log.V(1).Info("Resolving via Azure DNS", "host", host)
+		return p.resolveViaAzureDNS(host, port)
+	}
+
+	return net.JoinHostPort(host, port), nil
+}
+
+func (p *AzureDNSProxy) resolveViaAzureDNS(host, port string) (string, error) {
+	resolver := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			d := net.Dialer{Timeout: 5 * time.Second}
+			return d.DialContext(ctx, network, p.azureDNSServer)
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ips, err := resolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return "", fmt.Errorf("DNS resolution failed for %s: %w", host, err)
+	}
+
+	if len(ips) == 0 {
+		return "", fmt.Errorf("no IP addresses found for %s", host)
+	}
+
+	resolvedIP := ips[0].IP.String()
+	p.log.Info("Resolved via Azure DNS", "host", host, "ip", resolvedIP)
+
+	return net.JoinHostPort(resolvedIP, port), nil
+}
+
+func (p *AzureDNSProxy) tunnel(client, target net.Conn) {
+	deadline := time.Now().Add(p.tunnelIdleTimeout)
+	client.SetDeadline(deadline)
+	target.SetDeadline(deadline)
+
+	done := make(chan struct{}, 2)
+
+	go func() {
+		defer func() { done <- struct{}{} }()
+		io.Copy(target, client)
+	}()
+
+	go func() {
+		defer func() { done <- struct{}{} }()
+		io.Copy(client, target)
+	}()
+
+	<-done
+	client.Close()
+	target.Close()
+	<-done
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/router/azure-dns-proxy-service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/router/azure-dns-proxy-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: azure-dns-proxy
+  namespace: HCP_NAMESPACE
+spec:
+  type: ClusterIP
+  ports:
+  - name: proxy
+    port: 8888
+    protocol: TCP
+    targetPort: 8888
+  selector:
+    app: private-router

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/deployment.go
@@ -98,7 +98,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		applyGenericSecretEncryptionConfig(&deployment.Spec.Template.Spec)
 		switch secretEncryption.Type {
 		case hyperv1.KMS:
-			if err := applyKMSConfig(&deployment.Spec.Template.Spec, secretEncryption, newKMSImages(hcp)); err != nil {
+			if err := applyKMSConfig(&deployment.Spec.Template.Spec, secretEncryption, newKMSImages(hcp), hcp); err != nil {
 				return err
 			}
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
@@ -33,9 +33,7 @@ func (k *router) NeedsManagementKASAccess() bool {
 
 func NewComponent() component.ControlPlaneComponent {
 	return component.NewDeploymentComponent(ComponentName, &router{}).
-		WithPredicate(func(cpContext component.WorkloadContext) (bool, error) {
-			return UseHCPRouter(cpContext.HCP), nil
-		}).
+		WithPredicate(useHCPRouter).
 		WithAdaptFunction(adaptDeployment).
 		WithManifestAdapter(
 			"config.yaml",

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
@@ -2,7 +2,6 @@ package router
 
 import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
-	oapiv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/oapi"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/sharedingress"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/util"
@@ -34,7 +33,9 @@ func (k *router) NeedsManagementKASAccess() bool {
 
 func NewComponent() component.ControlPlaneComponent {
 	return component.NewDeploymentComponent(ComponentName, &router{}).
-		WithPredicate(useHCPRouter).
+		WithPredicate(func(cpContext component.WorkloadContext) (bool, error) {
+			return UseHCPRouter(cpContext.HCP), nil
+		}).
 		WithAdaptFunction(adaptDeployment).
 		WithManifestAdapter(
 			"config.yaml",
@@ -48,7 +49,6 @@ func NewComponent() component.ControlPlaneComponent {
 			"azure-dns-proxy-service.yaml",
 			component.WithPredicate(enableAzureDNSProxyService),
 		).
-		WithDependencies(oapiv2.ComponentName).
 		Build()
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/deployment.go
@@ -76,10 +76,8 @@ func addAzureDNSProxySidecar(deployment *appsv1.Deployment, image string) {
 		},
 		LivenessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/",
-					Port:   intstr.FromInt(8888),
-					Scheme: corev1.URISchemeHTTP,
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.FromInt(8888),
 				},
 			},
 			InitialDelaySeconds: 10,
@@ -90,10 +88,8 @@ func addAzureDNSProxySidecar(deployment *appsv1.Deployment, image string) {
 		},
 		ReadinessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/",
-					Port:   intstr.FromInt(8888),
-					Scheme: corev1.URISchemeHTTP,
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.FromInt(8888),
 				},
 			},
 			InitialDelaySeconds: 5,

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/deployment.go
@@ -2,7 +2,9 @@ package router
 
 import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/azureutil"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/util"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -11,21 +13,32 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-// adaptDeployment adds the Azure DNS HTTP CONNECT proxy sidecar when Swift networking is enabled
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
-	hcp := cpContext.HCP
-
-	// Add Azure DNS proxy sidecar when Swift networking is enabled
-	// The proxy will be used by Azure KMS and other containers via HTTP_PROXY environment variable
-	if swiftPodNetworkInstance := hcp.Annotations[hyperv1.SwiftPodNetworkInstanceAnnotation]; swiftPodNetworkInstance != "" {
-		// Add Swift pod network instance label to router pod
+	if swiftPodNetworkInstance := cpContext.HCP.Annotations[hyperv1.SwiftPodNetworkInstanceAnnotation]; swiftPodNetworkInstance != "" {
 		if deployment.Spec.Template.Labels == nil {
 			deployment.Spec.Template.Labels = map[string]string{}
 		}
 		deployment.Spec.Template.Labels["kubernetes.azure.com/pod-network-instance"] = swiftPodNetworkInstance
 
-		// Add Azure DNS proxy sidecar
-		addAzureDNSProxySidecar(deployment)
+		// Add Azure DNS proxy sidecar when Swift networking is enabled
+		// The proxy will be used by Azure KMS and other containers via HTTP_PROXY environment variable
+		image := cpContext.ReleaseImageProvider.GetImage("azure-dns-proxy")
+		addAzureDNSProxySidecar(deployment, image)
+	}
+
+	if azureutil.IsAroHCP() && util.IsPrivateHCP(cpContext.HCP) {
+		// In ARO with Swift, connections go directly to the router pod without a service,
+		// so we need to listen on the standard HTTPS port 443.
+		// The NET_BIND_SERVICE capability in the deployment allows binding to privileged ports.
+		for i, container := range deployment.Spec.Template.Spec.Containers {
+			if container.Name == "router" {
+				for j, port := range container.Ports {
+					if port.Name == "https" {
+						deployment.Spec.Template.Spec.Containers[i].Ports[j].ContainerPort = 443
+					}
+				}
+			}
+		}
 	}
 
 	return nil
@@ -33,10 +46,11 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 
 // addAzureDNSProxySidecar adds the HTTP CONNECT proxy sidecar to the router deployment
 // This proxy resolves Azure domains via Azure DNS (168.63.129.16) and enables access to Private Link endpoints
-func addAzureDNSProxySidecar(deployment *appsv1.Deployment) {
+func addAzureDNSProxySidecar(deployment *appsv1.Deployment, image string) {
 	sidecar := corev1.Container{
-		Name:  "azure-dns-proxy",
-		Image: "azure-dns-proxy",
+		Name:    "azure-dns-proxy",
+		Image:   image,
+		Command: []string{"/usr/bin/control-plane-operator", "azure-dns-proxy"},
 		Args: []string{
 			"--listen-addr=0.0.0.0:8888",
 			"--request-timeout=30s",

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/deployment.go
@@ -1,0 +1,101 @@
+package router
+
+import (
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+)
+
+// adaptDeployment adds the Azure DNS HTTP CONNECT proxy sidecar when Swift networking is enabled
+func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
+	hcp := cpContext.HCP
+
+	// Add Azure DNS proxy sidecar when Swift networking is enabled
+	// The proxy will be used by Azure KMS and other containers via HTTP_PROXY environment variable
+	if swiftPodNetworkInstance := hcp.Annotations[hyperv1.SwiftPodNetworkInstanceAnnotation]; swiftPodNetworkInstance != "" {
+		// Add Swift pod network instance label to router pod
+		if deployment.Spec.Template.Labels == nil {
+			deployment.Spec.Template.Labels = map[string]string{}
+		}
+		deployment.Spec.Template.Labels["kubernetes.azure.com/pod-network-instance"] = swiftPodNetworkInstance
+
+		// Add Azure DNS proxy sidecar
+		addAzureDNSProxySidecar(deployment)
+	}
+
+	return nil
+}
+
+// addAzureDNSProxySidecar adds the HTTP CONNECT proxy sidecar to the router deployment
+// This proxy resolves Azure domains via Azure DNS (168.63.129.16) and enables access to Private Link endpoints
+func addAzureDNSProxySidecar(deployment *appsv1.Deployment) {
+	sidecar := corev1.Container{
+		Name:  "azure-dns-proxy",
+		Image: "azure-dns-proxy",
+		Args: []string{
+			"--listen-addr=0.0.0.0:8888",
+			"--request-timeout=30s",
+			"--connect-timeout=10s",
+			"--tunnel-idle-timeout=5m",
+		},
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "proxy",
+				ContainerPort: 8888,
+				Protocol:      corev1.ProtocolTCP,
+			},
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("20Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+		},
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path:   "/",
+					Port:   intstr.FromInt(8888),
+					Scheme: corev1.URISchemeHTTP,
+				},
+			},
+			InitialDelaySeconds: 10,
+			PeriodSeconds:       10,
+			TimeoutSeconds:      1,
+			SuccessThreshold:    1,
+			FailureThreshold:    3,
+		},
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path:   "/",
+					Port:   intstr.FromInt(8888),
+					Scheme: corev1.URISchemeHTTP,
+				},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       5,
+			TimeoutSeconds:      1,
+			SuccessThreshold:    1,
+			FailureThreshold:    3,
+		},
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.To(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+			RunAsNonRoot: ptr.To(true),
+		},
+	}
+
+	deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, sidecar)
+}

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -10,6 +10,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	availabilityprober "github.com/openshift/hypershift/availability-prober"
+	azurednsproxy "github.com/openshift/hypershift/azure-dns-proxy"
 	hyperclient "github.com/openshift/hypershift/client/clientset/clientset"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/awsprivatelink"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/gcpprivateserviceconnect"
@@ -91,6 +92,8 @@ func commandFor(name string) *cobra.Command {
 		cmd = konnectivityhttpsproxy.NewStartCommand()
 	case "availability-prober":
 		cmd = availabilityprober.NewStartCommand()
+	case "azure-dns-proxy":
+		cmd = azurednsproxy.NewStartCommand()
 	case "token-minter":
 		cmd = tokenminter.NewStartCommand()
 	case "etcd-defrag-controller":
@@ -143,6 +146,7 @@ func defaultCommand() *cobra.Command {
 	cmd.AddCommand(konnectivitysocks5proxy.NewStartCommand())
 	cmd.AddCommand(konnectivityhttpsproxy.NewStartCommand())
 	cmd.AddCommand(availabilityprober.NewStartCommand())
+	cmd.AddCommand(azurednsproxy.NewStartCommand())
 	cmd.AddCommand(tokenminter.NewStartCommand())
 	cmd.AddCommand(ignitionserver.NewStartCommand())
 	cmd.AddCommand(etcddefrag.NewStartCommand())

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -396,6 +396,7 @@ func NewStartCommand() *cobra.Command {
 			"hosted-cluster-config-operator": hostedClusterConfigOperatorImage,
 			"socks5-proxy":                   socks5ProxyImage,
 			"token-minter":                   tokenMinterImage,
+			"azure-dns-proxy":                cpoImage,
 			util.CPOImageName:                cpoImage,
 			util.CPPKIOImageName:             cpoImage,
 		}

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -327,6 +327,12 @@ const (
 	// When set to "servicenodeport", each service gets its own dedicated health probe.
 	AzureLoadBalancerHealthProbeModeAnnotation = "hypershift.openshift.io/azure-load-balancer-health-probe-mode"
 
+	// SwiftPodNetworkInstanceAnnotation specifies the Swift pod network instance ID for Azure CNI Swift networking.
+	// When set on a HostedCluster, it enables Swift networking for control plane pods that need access to
+	// customer VNet resources (e.g., Azure Private Link endpoints for Key Vault).
+	// The value should be the ID of the Swift pod network instance resource in Azure.
+	SwiftPodNetworkInstanceAnnotation = "hypershift.openshift.io/swift-pod-network-instance"
+
 	// DisableClusterAutoscalerAnnotation allows disabling the cluster autoscaler for a hosted cluster.
 	// This annotation is only set by the hypershift-operator on HosterControlPlanes.
 	// It is not set by the end-user.


### PR DESCRIPTION
## What this PR does / why we need it:

- Implements a HTTP CONNECT azure-dns-proxy to handle DNS resolution for Private KV
- Runs the azure-dns-proxy as a container in the router
- Reorders predicates so that the router starts as a dependency of the kube-apiserver (ARO HCP Swift only)

Alternative to DNS sidecar in https://github.com/openshift/hypershift/pull/7679