### PR TITLE
GCP-386: feat(gcp): enable DNS delegation for hosted cluster ingress via DNSEndpoint

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -356,6 +356,19 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 			"--azure-config-file=/etc/provider/credentials",
 		)
 	case GCPExternalDNSProvider:
+		// GCP-386: Add DNSEndpoint CRD source for ingress zone delegation
+		// This allows external-dns to process DNSEndpoint resources created by
+		// the control-plane-operator for NS record delegation to hosted clusters
+		deployment.Spec.Template.Spec.Containers[0].Args = append(
+			deployment.Spec.Template.Spec.Containers[0].Args,
+			"--source=crd",
+			// Enable NS record management for zone delegation (required opt-in)
+			// External-dns only manages A, AAAA, CNAME by default
+			"--managed-record-types=A",
+			"--managed-record-types=AAAA",
+			"--managed-record-types=CNAME",
+			"--managed-record-types=NS",
+		)
 		if len(o.GoogleProject) > 0 {
 			deployment.Spec.Template.Spec.Containers[0].Args = append(
 				deployment.Spec.Template.Spec.Containers[0].Args,
@@ -1016,6 +1029,18 @@ func (o ExternalDNSClusterRole) Build() *rbacv1.ClusterRole {
 				},
 				Verbs: []string{"get", "list", "watch"},
 			},
+			// GCP-386: Allow external-dns to read/update DNSEndpoint resources for ingress zone delegation
+			// Matches: https://github.com/openshift/external-dns/blob/master/charts/external-dns/templates/clusterrole.yaml
+			{
+				APIGroups: []string{"externaldns.k8s.io"},
+				Resources: []string{"dnsendpoints"},
+				Verbs:     []string{"get", "watch", "list"},
+			},
+			{
+				APIGroups: []string{"externaldns.k8s.io"},
+				Resources: []string{"dnsendpoints/status"},
+				Verbs:     []string{rbacv1.VerbAll},
+			},
 		},
 	}
 	return role
@@ -1386,6 +1411,12 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 				APIGroups: []string{"admissionregistration.k8s.io"},
 				Resources: []string{"validatingadmissionpolicies", "validatingadmissionpolicybindings"},
 				Verbs:     []string{rbacv1.VerbAll},
+			},
+			// This allows hypershift operator to grant RBAC permissions for DNSEndpoints to the control-plane-operator.
+			{
+				APIGroups: []string{"externaldns.k8s.io"},
+				Resources: []string{"dnsendpoints"},
+				Verbs:     []string{"create", "get", "update", "delete"},
 			},
 		},
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/control-plane-operator/role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/control-plane-operator/role.yaml
@@ -57,6 +57,15 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - externaldns.k8s.io
+  resources:
+  - dnsendpoints
+  verbs:
+  - create
+  - get
+  - update
+  - delete
+- apiGroups:
   - ""
   resources:
   - events


### PR DESCRIPTION
## Summary

Enable DNS delegation for hosted cluster ingress zones on GCP using external-dns DNSEndpoint CRDs. This completes the DNS delegation chain: regional DNS zone → customer public ingress zone, making hosted cluster ingress automatically resolvable.

Resolves: [GCP-386](https://issues.redhat.com//browse/GCP-386)

## What does this PR do?

This PR implements automatic NS record delegation from regional DNS zones to hosted cluster ingress zones by:

1. **Control-plane-operator (PSC controller)**:
   - Creates DNSEndpoint resources after successful DNS zone reconciliation
   - Uses PublicIngressNSRecords from DNS setup as NS targets
   - Implements graceful error handling (CRD missing, webhooks, permissions, etc.)
   - Adds explicit cleanup in `cleanupDNS()`

2. **RBAC permissions**:
   - hypershift-operator ClusterRole: DNSEndpoint permissions for delegation
   - control-plane-operator Role: Namespace-scoped DNSEndpoint CRUD
   - external-dns ClusterRole: DNSEndpoint list/watch/status permissions

3. **External-DNS configuration**:
   - Adds `--source=crd` to enable DNSEndpoint resource processing
   - Adds `--managed-record-types` for A, AAAA, CNAME, NS records
   - Enables NS record management for zone delegation

4. **Testing**:
   - Adds 5 new unit tests covering DNSEndpoint logic and error handling
   - All existing tests pass

## Dependency

**Critical Dependency:** This PR depends on external-dns support for DNSEndpoint on Google Cloud Platform, which is **not yet available** in the current deployed version.

- **Required Fix**: https://github.com/openshift/external-dns/pull/125 (by @alebedev87)
- **Current Status**: Not yet released - **GCP-HCP project team is using a home-built image**
- **Expected Release**: Approximately March 2026 with the next OpenShift release
- **Follow-up Action**: Once released, we'll create another PR to bump the openshift-external-dns version, including CRD deployment

## How to test

1. Deploy a hosted cluster on GCP with this change
2. Verify DNSEndpoint resource is created in the management cluster namespace:
   ```bash
   oc get dnsendpoint -n clusters-{cluster-name}
   ```
3. Verify NS delegation records are created in regional DNS zone pointing to customer ingress zone nameservers
4. Verify hosted cluster ingress becomes resolvable through the delegation chain

## Error Handling

DNSEndpoint creation is best-effort. Any error (CRD missing, validation webhook, permissions, timeout) is logged but doesn't fail PSC reconciliation. The DNSEndpoint will be retried on next reconciliation.

---

cc: @alebedev87 for external-dns DNSEndpoint GCP support