### PR TITLE
OCPBUGS-65879: Mirror image-overrides annotation from HC to HCP

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2224,6 +2224,7 @@ func reconcileHostedControlPlaneAnnotations(hcp *hyperv1.HostedControlPlane, hcl
 	mirroredAnnotations := []string{
 		hyperv1.DisablePKIReconciliationAnnotation,
 		hyperv1.OauthLoginURLOverrideAnnotation,
+		hyperv1.ImageOverridesAnnotation,
 		hyperv1.KonnectivityAgentImageAnnotation,
 		hyperv1.KonnectivityServerImageAnnotation,
 		hyperv1.ClusterAutoscalerImage,

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -788,6 +788,31 @@ func TestReconcileHostedControlPlaneAnnotations(t *testing.T) {
 			},
 		},
 		{
+			name: "When HostedCluster has image-overrides annotation it should propagate to HCP",
+			hcAnnotations: map[string]string{
+				hyperv1.ImageOverridesAnnotation: "cluster-version-operator=example.com/cvo:latest",
+			},
+			hcpAnnotations: map[string]string{},
+			expectedAnnotations: map[string]string{
+				hyperutil.HostedClusterAnnotation:                  hcKey,
+				hyperv1.ImageOverridesAnnotation:                   "cluster-version-operator=example.com/cvo:latest",
+				hyperv1.DisableClusterAutoscalerAnnotation:         "true",
+				hyperv1.DisableAWSNodeTerminationHandlerAnnotation: "true",
+			},
+		},
+		{
+			name:          "When image-overrides annotation is removed from HostedCluster it should be removed from HCP",
+			hcAnnotations: map[string]string{},
+			hcpAnnotations: map[string]string{
+				hyperv1.ImageOverridesAnnotation: "cluster-version-operator=example.com/cvo:latest",
+			},
+			expectedAnnotations: map[string]string{
+				hyperutil.HostedClusterAnnotation:                  hcKey,
+				hyperv1.DisableClusterAutoscalerAnnotation:         "true",
+				hyperv1.DisableAWSNodeTerminationHandlerAnnotation: "true",
+			},
+		},
+		{
 			name:                              "When AWS node termination handler is needed, disable annotation should not be set",
 			isAWSNodeTerminationHandlerNeeded: true,
 			hcAnnotations:                     map[string]string{},


### PR DESCRIPTION
## What this PR does / why we need it:

Adds `ImageOverridesAnnotation` to the `mirroredAnnotations` list in `reconcileHostedControlPlaneAnnotations()`. Without this, removing the `hypershift.openshift.io/image-overrides` annotation from a HostedCluster was silently ignored - the annotation remained on the HostedControlPlane and the control-plane-operator kept using the stale overridden images.

The existing mirroring logic already handles both setting and deleting annotations. The only issue was that `ImageOverridesAnnotation` was not included in the list of annotations to mirror.

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/OCPBUGS-65879

## Special notes for your reviewer:

The fix is a single line addition to the `mirroredAnnotations` slice. Two test cases are added:
1. Propagation: verifies the annotation is copied from HC to HCP
2. Removal: verifies removing the annotation from HC also removes it from HCP

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve OCPBUGS-65879 enxebre`