### PR TITLE
OCPBUGS-65879: Mirror image-overrides annotation from HostedCluster to HCP

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2296,6 +2296,7 @@ func reconcileHostedControlPlaneAnnotations(hcp *hyperv1.HostedControlPlane, hcl
 		// TODO: Remove this once the the input is in the HostedCluster AWS API.
 		"hypershift.openshift.io/aws-termination-handler-queue-url",
 		hyperv1.SwiftPodNetworkInstanceAnnotation,
+		hyperv1.ImageOverridesAnnotation,
 	}
 	for _, key := range mirroredAnnotations {
 		val, hasVal := hcluster.Annotations[key]

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -832,6 +832,31 @@ func TestReconcileHostedControlPlaneAnnotations(t *testing.T) {
 				hyperv1.DisableClusterAutoscalerAnnotation: "true",
 			},
 		},
+		{
+			name: "When HostedCluster has image-overrides annotation it should propagate to HCP",
+			hcAnnotations: map[string]string{
+				hyperv1.ImageOverridesAnnotation: "cluster-version-operator=quay.io/example/cvo:latest",
+			},
+			hcpAnnotations: map[string]string{},
+			expectedAnnotations: map[string]string{
+				hyperutil.HostedClusterAnnotation:                  hcKey,
+				hyperv1.ImageOverridesAnnotation:                   "cluster-version-operator=quay.io/example/cvo:latest",
+				hyperv1.DisableClusterAutoscalerAnnotation:         "true",
+				hyperv1.DisableAWSNodeTerminationHandlerAnnotation: "true",
+			},
+		},
+		{
+			name:          "When image-overrides annotation is removed from HostedCluster it should be removed from HCP",
+			hcAnnotations: map[string]string{},
+			hcpAnnotations: map[string]string{
+				hyperv1.ImageOverridesAnnotation: "cluster-version-operator=quay.io/example/cvo:latest",
+			},
+			expectedAnnotations: map[string]string{
+				hyperutil.HostedClusterAnnotation:                  hcKey,
+				hyperv1.DisableClusterAutoscalerAnnotation:         "true",
+				hyperv1.DisableAWSNodeTerminationHandlerAnnotation: "true",
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## What this PR does / why we need it:

The `hypershift.openshift.io/image-overrides` annotation was missing from the `mirroredAnnotations` list in `reconcileHostedControlPlaneAnnotations()`. This caused the following behavior:

- **Setting** the annotation on a HostedCluster worked because the CPO deployment reads directly from the fresh HostedCluster object
- **Removing** the annotation from a HostedCluster did **not** propagate the removal to the HostedControlPlane, leaving stale image override values in effect

This PR adds `ImageOverridesAnnotation` to the `mirroredAnnotations` list so that both setting and removing the annotation is correctly mirrored from HostedCluster to HostedControlPlane.

## Which issue(s) this PR fixes:

Fixes OCPBUGS-65879

## Special notes for your reviewer:

The fix is a single-line addition to the `mirroredAnnotations` slice. The existing mirroring logic at lines 2300-2307 already handles both the set and delete cases correctly — the annotation was simply missing from the list.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve OCPBUGS-65879 enxebre`