### PR TITLE
CNTRLPLANE-2736: Rename review-agent-single-pr to address-review-comments

### DIFF
--- a/docs/content/how-to/ci/ai-assisted-ci-jobs.md
+++ b/docs/content/how-to/ci/ai-assisted-ci-jobs.md
@@ -16,7 +16,7 @@ HyperShift uses two AI-assisted CI jobs powered by Claude Code to help with deve
 |-----|---------|----------|
 | `periodic-jira-agent` | Analyzes Jira issues and creates draft PRs with fixes | Weekly on Mondays at 8:30 AM UTC |
 | `periodic-review-agent` | Addresses PR review comments on agent-created PRs | Every 3 hours (8:00-23:00 UTC) daily |
-| `review-agent-single-pr` | On-demand review agent for a single PR | Triggered via `/test review-agent-single-pr` |
+| `address-review-comments` | On-demand job to address review comments on a single PR | Triggered via `/test address-review-comments` |
 
 ### Usage Scope
 
@@ -113,7 +113,7 @@ The Review Agent (`periodic-review-agent`) automatically addresses PR review com
 - **Schedule**: Every 3 hours (8:00-23:00 UTC) daily (`0 8-23/3 * * *`)
 - **Max PRs per run**: 10 (configurable via `REVIEW_AGENT_MAX_PRS`)
 - **Max agentic turns**: 100 per PR
-- **On-demand job**: `review-agent-single-pr` (trigger with `/test review-agent-single-pr`)
+- **On-demand job**: `address-review-comments` (trigger with `/test address-review-comments`)
 
 ### How It Works
 
@@ -244,7 +244,7 @@ To have an issue reprocessed:
 For a single PR, you can trigger the review agent manually:
 
 ```
-/test review-agent-single-pr
+/test address-review-comments
 ```
 
 This runs the review agent for that specific PR only.

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -9657,7 +9657,7 @@ HyperShift uses two AI-assisted CI jobs powered by Claude Code to help with deve
 |-----|---------|----------|
 | `periodic-jira-agent` | Analyzes Jira issues and creates draft PRs with fixes | Weekly on Mondays at 8:30 AM UTC |
 | `periodic-review-agent` | Addresses PR review comments on agent-created PRs | Every 3 hours (8:00-23:00 UTC) daily |
-| `review-agent-single-pr` | On-demand review agent for a single PR | Triggered via `/test review-agent-single-pr` |
+| `address-review-comments` | On-demand job to address review comments on a single PR | Triggered via `/test address-review-comments` |
 
 ### Usage Scope
 
@@ -9754,7 +9754,7 @@ The Review Agent (`periodic-review-agent`) automatically addresses PR review com
 - **Schedule**: Every 3 hours (8:00-23:00 UTC) daily (`0 8-23/3 * * *`)
 - **Max PRs per run**: 10 (configurable via `REVIEW_AGENT_MAX_PRS`)
 - **Max agentic turns**: 100 per PR
-- **On-demand job**: `review-agent-single-pr` (trigger with `/test review-agent-single-pr`)
+- **On-demand job**: `address-review-comments` (trigger with `/test address-review-comments`)
 
 ### How It Works
 
@@ -9885,7 +9885,7 @@ To have an issue reprocessed:
 For a single PR, you can trigger the review agent manually:
 
 ```
-/test review-agent-single-pr
+/test address-review-comments
 ```
 
 This runs the review agent for that specific PR only.


### PR DESCRIPTION
## What this PR does / why we need it:

Renames the on-demand CI job `/test review-agent-single-pr` to `/test address-review-comments` in HyperShift documentation.

The current name is misleading — it sounds like it triggers a code review, when it actually addresses and resolves existing review comments on a PR. The new name makes the intent immediately clear.

**Note:** The corresponding `openshift/release` job configuration change will need a separate PR in that repository.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-2736](https://issues.redhat.com//browse/CNTRLPLANE-2736)

## Special notes for your reviewer:

This is a docs-only change. The `openshift/release` side (actual job definition rename) is tracked separately.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.
- [ ] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve [CNTRLPLANE-2736](https://issues.redhat.com//browse/CNTRLPLANE-2736)`