### PR TITLE
NO-JIRA: Add OWNERS file to test directory

### DIFF
--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- cblecker


### PR DESCRIPTION
## What this PR does / why we need it:

Adds an OWNERS file to the `test/` directory to establish proper code ownership for the test suite. This is part of efforts to refactor and improve HyperShift's e2e suite.

## Which issue(s) this PR fixes:

Contributes to [OCPSTRAT-2499](https://issues.redhat.com//browse/OCPSTRAT-2499)

## Special notes for your reviewer:

Simple addition of an OWNERS file with no code changes.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. (N/A - OWNERS file is self-documenting)
- [x] This change includes unit tests. (N/A - no code changes)