### PR TITLE
CNTRLPLANE-2740: Set unhealthyPodEvictionPolicy to AlwaysAllow on all PDBs

### DIFF
--- a/hypershift-operator/controllers/sharedingress/router.go
+++ b/hypershift-operator/controllers/sharedingress/router.go
@@ -267,6 +267,7 @@ func ReconcileRouterPodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, owner
 	}
 	ownerRef.ApplyTo(pdb)
 	pdb.Spec.MinAvailable = ptr.To(intstr.FromInt32(1))
+	pdb.Spec.UnhealthyPodEvictionPolicy = ptr.To(policyv1.AlwaysAllow)
 }
 
 func ReconcileRouterNetworkPolicy(policy *networkingv1.NetworkPolicy, isOpenShiftDNS bool, managementClusterNetwork *configv1.Network) {

--- a/hypershift-operator/controllers/sharedingress/router_test.go
+++ b/hypershift-operator/controllers/sharedingress/router_test.go
@@ -4,9 +4,14 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/openshift/hypershift/support/config"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 )
 
 func TestReconcileRouterDeployment(t *testing.T) {
@@ -88,4 +93,28 @@ func TestReconcileRouterDeployment(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconcileRouterPodDisruptionBudget(t *testing.T) {
+	t.Run("When reconciling a new PDB it should set unhealthyPodEvictionPolicy to AlwaysAllow", func(t *testing.T) {
+		pdb := &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "router",
+				Namespace: "test-namespace",
+			},
+		}
+		ownerRef := config.OwnerRef{}
+
+		ReconcileRouterPodDisruptionBudget(pdb, ownerRef)
+
+		if !reflect.DeepEqual(pdb.Spec.MinAvailable, ptr.To(intstr.FromInt32(1))) {
+			t.Errorf("Expected minAvailable to be 1, got %v", pdb.Spec.MinAvailable)
+		}
+		if pdb.Spec.UnhealthyPodEvictionPolicy == nil {
+			t.Fatal("Expected unhealthyPodEvictionPolicy to be set, got nil")
+		}
+		if *pdb.Spec.UnhealthyPodEvictionPolicy != policyv1.AlwaysAllow {
+			t.Errorf("Expected unhealthyPodEvictionPolicy to be AlwaysAllow, got %v", *pdb.Spec.UnhealthyPodEvictionPolicy)
+		}
+	})
 }

--- a/support/controlplane-component/common.go
+++ b/support/controlplane-component/common.go
@@ -24,6 +24,7 @@ func AdaptPodDisruptionBudget() option {
 
 		pdb.Spec.MinAvailable = minAvailable
 		pdb.Spec.MaxUnavailable = maxUnavailable
+		pdb.Spec.UnhealthyPodEvictionPolicy = ptr.To(policyv1.AlwaysAllow)
 		return nil
 	})
 }

--- a/support/controlplane-component/common_test.go
+++ b/support/controlplane-component/common_test.go
@@ -1,0 +1,69 @@
+package controlplanecomponent
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+)
+
+func TestAdaptPodDisruptionBudget(t *testing.T) {
+	tests := []struct {
+		name               string
+		availabilityPolicy hyperv1.AvailabilityPolicy
+		wantMinAvailable   *intstr.IntOrString
+		wantMaxUnavailable *intstr.IntOrString
+	}{
+		{
+			name:               "When SingleReplica it should set minAvailable to 1",
+			availabilityPolicy: hyperv1.SingleReplica,
+			wantMinAvailable:   ptr.To(intstr.FromInt32(1)),
+			wantMaxUnavailable: nil,
+		},
+		{
+			name:               "When HighlyAvailable it should set maxUnavailable to 1",
+			availabilityPolicy: hyperv1.HighlyAvailable,
+			wantMinAvailable:   nil,
+			wantMaxUnavailable: ptr.To(intstr.FromInt32(1)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			pdb := &policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pdb",
+					Namespace: "test-ns",
+				},
+			}
+
+			opt := AdaptPodDisruptionBudget()
+			ga := &genericAdapter{}
+			opt(ga)
+
+			cpContext := WorkloadContext{
+				HCP: &hyperv1.HostedControlPlane{
+					Spec: hyperv1.HostedControlPlaneSpec{
+						ControllerAvailabilityPolicy: tt.availabilityPolicy,
+					},
+				},
+			}
+
+			err := ga.adapt(cpContext, pdb)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(pdb.Spec.MinAvailable).To(Equal(tt.wantMinAvailable))
+			g.Expect(pdb.Spec.MaxUnavailable).To(Equal(tt.wantMaxUnavailable))
+			g.Expect(pdb.Spec.UnhealthyPodEvictionPolicy).ToNot(BeNil())
+			g.Expect(*pdb.Spec.UnhealthyPodEvictionPolicy).To(Equal(policyv1.AlwaysAllow))
+		})
+	}
+}

--- a/support/util/pdb.go
+++ b/support/util/pdb.go
@@ -19,4 +19,5 @@ func ReconcilePodDisruptionBudget(pdb *policyv1.PodDisruptionBudget, availabilit
 	}
 	pdb.Spec.MinAvailable = minAvailable
 	pdb.Spec.MaxUnavailable = maxUnavailable
+	pdb.Spec.UnhealthyPodEvictionPolicy = ptr.To(policyv1.AlwaysAllow)
 }

--- a/support/util/pdb_test.go
+++ b/support/util/pdb_test.go
@@ -1,0 +1,56 @@
+package util
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+)
+
+func TestReconcilePodDisruptionBudget(t *testing.T) {
+	tests := []struct {
+		name               string
+		availability       hyperv1.AvailabilityPolicy
+		wantMinAvailable   *intstr.IntOrString
+		wantMaxUnavailable *intstr.IntOrString
+	}{
+		{
+			name:               "When SingleReplica it should set minAvailable to 1",
+			availability:       hyperv1.SingleReplica,
+			wantMinAvailable:   ptr.To(intstr.FromInt32(1)),
+			wantMaxUnavailable: nil,
+		},
+		{
+			name:               "When HighlyAvailable it should set maxUnavailable to 1",
+			availability:       hyperv1.HighlyAvailable,
+			wantMinAvailable:   nil,
+			wantMaxUnavailable: ptr.To(intstr.FromInt32(1)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			pdb := &policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pdb",
+					Namespace: "test-ns",
+				},
+			}
+
+			ReconcilePodDisruptionBudget(pdb, tt.availability)
+
+			g.Expect(pdb.Spec.MinAvailable).To(Equal(tt.wantMinAvailable))
+			g.Expect(pdb.Spec.MaxUnavailable).To(Equal(tt.wantMaxUnavailable))
+			g.Expect(pdb.Spec.UnhealthyPodEvictionPolicy).ToNot(BeNil())
+			g.Expect(*pdb.Spec.UnhealthyPodEvictionPolicy).To(Equal(policyv1.AlwaysAllow))
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it:

Sets `unhealthyPodEvictionPolicy: AlwaysAllow` on every PodDisruptionBudget managed by the HostedControlPlane operator.

This allows running-but-unhealthy hosted control-plane pods to be evicted during management cluster node drains. Unready pods are unlikely to be contributing to service availability, so blocking drains on their behalf adds risk without meaningful availability benefit.

The `unhealthyPodEvictionPolicy` field is GA since Kubernetes 1.31 / OpenShift 4.18.

### Components affected
All PDBs managed by the HCP operator:
- etcd
- kube-apiserver
- openshift-apiserver
- openshift-oauth-apiserver
- oauth-openshift
- HCP private router
- Shared ingress router

### Changes
- `support/controlplane-component/common.go` – `AdaptPodDisruptionBudget()` now sets `UnhealthyPodEvictionPolicy` to `AlwaysAllow` (covers the 6 v2 control-plane components)
- `support/util/pdb.go` – `ReconcilePodDisruptionBudget()` updated for consistency
- `hypershift-operator/controllers/sharedingress/router.go` – `ReconcileRouterPodDisruptionBudget()` updated for the shared ingress router PDB

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-2740](https://issues.redhat.com//browse/CNTRLPLANE-2740)

## Special notes for your reviewer:

The `unhealthyPodEvictionPolicy` field is set programmatically in the Go adapter function that already mutates PDB specs at reconciliation time. No YAML asset changes are needed.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve [CNTRLPLANE-2740](https://issues.redhat.com//browse/CNTRLPLANE-2740) enxebre`