### PR TITLE
fix(ho): make e2e HostedCluster interactions platform-aware

### DIFF
--- a/cmd/infra/aws/util/sts_test.go
+++ b/cmd/infra/aws/util/sts_test.go
@@ -317,12 +317,8 @@ func TestParseSTSCredentialsFileV2_RealWorldFormat(t *testing.T) {
 	}
 
 	creds, err := ParseSTSCredentialsFileV2(tmpFile.Name())
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-
-	if creds == nil {
-		t.Fatal("Expected non-nil credentials")
+	if err != nil || creds == nil {
+		t.Fatalf("Unexpected error or nil credentials: err=%v, creds=%v", err, creds)
 	}
 
 	expectedAccessKey := "ASIAIOSFODNN7EXAMPLE"

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -2857,7 +2857,7 @@ func ValidatePublicCluster(t *testing.T, ctx context.Context, client crclient.Cl
 	}
 
 	// Wait for Nodes to be Ready
-	numNodes := clusterOpts.NodePoolReplicas * int32(len(clusterOpts.AWSPlatform.Zones))
+	numNodes := numExpectedNodes(clusterOpts, hostedCluster.Spec.Platform.Type)
 	WaitForNReadyNodes(t, ctx, guestClient, numNodes, hostedCluster.Spec.Platform.Type)
 
 	// rollout will not complete if there are no worker nodes.
@@ -2910,7 +2910,7 @@ func ValidatePrivateCluster(t *testing.T, ctx context.Context, client crclient.C
 	// Ensure NodePools have all Nodes ready.
 	WaitForNodePoolDesiredNodes(t, ctx, client, hostedCluster)
 
-	numNodes := clusterOpts.NodePoolReplicas * int32(len(clusterOpts.AWSPlatform.Zones))
+	numNodes := numExpectedNodes(clusterOpts, hostedCluster.Spec.Platform.Type)
 	// rollout will not complete if there are no worker nodes.
 	if numNodes > 0 {
 		WaitForImageRollout(t, ctx, client, hostedCluster)


### PR DESCRIPTION
## What this PR does / why we need it:

Removes hardcoded AWS platform assumptions from e2e tests so they can run correctly on non-AWS platforms (GCP, Azure, etc.).

- Add a `platformType` field to each test case group in `TestOnCreateAPIUX` so platform intent is explicit. GCP and Azure groups declare their platform; platform-agnostic groups fall back to `globalOpts.Platform`.
- Remove redundant `Platform.Type` assignments from individual `mutateInput` functions.
- The GCP skip condition now checks `tc.platformType` instead of `hostedCluster.Spec.Platform.Type`, preventing platform-agnostic tests from being incorrectly skipped on GCP environments.
- Add `numExpectedNodes` helper that computes node count based on platform instead of always multiplying by `AWSPlatform.Zones`.
- Add nil guard for `Platform.AWS` in the metrics collector to prevent nil pointer dereference on non-AWS hosted clusters.
- Fix pre-existing nil-pointer warning in `sts_test.go`.

## Why:

When running e2e tests on non-AWS environments (e.g. e2e-aks), the test framework was creating HostedCluster objects with `platform.type: AWS` hardcoded in the YAML template. The HO would then receive these HostedClusters with an AWS platform type but no `Platform.AWS` spec populated. This triggered unexpected code paths in the metrics collector, which assumed `Platform.AWS` was non-nil whenever `Platform.Type == AWS`, causing a nil pointer dereference. Additionally, the test harness unconditionally multiplied node counts by `AWSPlatform.Zones` and checked `AWSPlatform.EndpointAccess` regardless of the actual platform, leading to incorrect node expectations and wrong cluster validation paths on non-AWS runs.

## Which issue(s) this PR fixes:

Fixes

## Special notes for your reviewer:

The `hostedcluster-base.yaml` asset still has `type: AWS` — this is intentional since our loop always overrides it, and changing the asset would affect `test/e2e/v2/tests/api_ux_validation_test.go` which is out of scope.## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved test assertions for credential parsing validation.
  * Enhanced platform-specific test case handling for cluster creation scenarios.
  * Added helper utilities for consistent node count calculations across different cloud platforms.
  * Refined test setup to ensure accurate platform-specific configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->