### PR TITLE
NO-JIRA: bug(metrics): fix typo in `hypershift_cluster_waiting_initial_availability_duration_seconds` metric

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
@@ -43,7 +43,7 @@ const (
 
 	// Per hosted cluster metrics - name & help
 
-	WaitingInitialAvailabilityDurationMetricName = "hypershift_cluster_waiting_initial_avaibility_duration_seconds"
+	WaitingInitialAvailabilityDurationMetricName = "hypershift_cluster_waiting_initial_availability_duration_seconds"
 	waitingInitialAvailabilityDurationMetricHelp = "Time in seconds it is taking to get the HostedClusterAvailable condition becoming true since the creation of the HostedCluster. " +
 		"Undefined if the condition has already become true once or if the cluster no longer exists."
 


### PR DESCRIPTION
The metric `hypershift_cluster_waiting_initial_availbility_duration_seconds` had a typo in the word `availabilty`. This fixes that. Consumers will need to adjust their alerting as such.

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.