### PR TITLE
GCP-367: enable multizone support in CCM cloud config

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_gcp_cloud_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_gcp_cloud_config_configmap.yaml
@@ -5,6 +5,7 @@ data:
     project-id = my-project
     network-name = my-network
     node-tags = -worker
+    multizone = true
     token-url = "nil"
 kind: ConfigMap
 metadata:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/AROSwift/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
@@ -25,7 +25,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: 9d5be281
+        component.hypershift.openshift.io/config-hash: eafd03f7
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_gcp_cloud_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_gcp_cloud_config_configmap.yaml
@@ -5,6 +5,7 @@ data:
     project-id = my-project
     network-name = my-network
     node-tags = -worker
+    multizone = true
     token-url = "nil"
 kind: ConfigMap
 metadata:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/GCP/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
@@ -25,7 +25,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token,tmp-dir
-        component.hypershift.openshift.io/config-hash: 9d5be281
+        component.hypershift.openshift.io/config-hash: eafd03f7
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_gcp_cloud_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_gcp_cloud_config_configmap.yaml
@@ -5,6 +5,7 @@ data:
     project-id = my-project
     network-name = my-network
     node-tags = -worker
+    multizone = true
     token-url = "nil"
 kind: ConfigMap
 metadata:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/IBMCloud/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
@@ -25,7 +25,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
-        component.hypershift.openshift.io/config-hash: 9d5be281
+        component.hypershift.openshift.io/config-hash: eafd03f7
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_gcp_cloud_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_gcp_cloud_config_configmap.yaml
@@ -5,6 +5,7 @@ data:
     project-id = my-project
     network-name = my-network
     node-tags = -worker
+    multizone = true
     token-url = "nil"
 kind: ConfigMap
 metadata:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
@@ -25,7 +25,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token,tmp-dir
-        component.hypershift.openshift.io/config-hash: 9d5be281
+        component.hypershift.openshift.io/config-hash: eafd03f7
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_gcp_cloud_config_configmap.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_gcp_cloud_config_configmap.yaml
@@ -5,6 +5,7 @@ data:
     project-id = my-project
     network-name = my-network
     node-tags = -worker
+    multizone = true
     token-url = "nil"
 kind: ConfigMap
 metadata:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/gcp-cloud-controller-manager/zz_fixture_TestControlPlaneComponents_gcp_cloud_controller_manager_deployment.yaml
@@ -25,7 +25,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cloud-token,tmp-dir
-        component.hypershift.openshift.io/config-hash: 9d5be281
+        component.hypershift.openshift.io/config-hash: eafd03f7
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
         app: cloud-controller-manager

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/gcp-cloud-controller-manager/config.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/gcp-cloud-controller-manager/config.yaml
@@ -5,6 +5,7 @@ data:
     project-id = %s
     network-name = %s
     node-tags = %s
+    multizone = true
     token-url = "nil"
 kind: ConfigMap
 metadata:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/gcp/testdata/zz_fixture_TestConfig.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/gcp/testdata/zz_fixture_TestConfig.yaml
@@ -5,6 +5,7 @@ data:
     project-id = my-project
     network-name = my-network
     node-tags = my-infra-id-worker
+    multizone = true
     token-url = "nil"
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

The GCP CCM discovers its zone from the GCE metadata server, which returns the management cluster node's zone. In HCP, this causes the CCM to only search that zone for guest cluster worker nodes, failing to find nodes in other zones within the same region.

Add multizone = true to the cloud config so the CCM searches all zones in the region for instances.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes [GCP-367](https://issues.redhat.com/browse/GCP-367)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.