### PR TITLE
NO-JIRA fix e2e flakyness allowing partial nodes for OVN-Kube DaemonSet in E2E verification

### DIFF
--- a/test/e2e/util/globalps.go
+++ b/test/e2e/util/globalps.go
@@ -216,9 +216,9 @@ func VerifyKubeletConfigWithDaemonSet(t *testing.T, ctx context.Context, guestCl
 	g.Expect(err).NotTo(HaveOccurred(), "failed to count available nodes")
 
 	daemonSetsToCheck := []DaemonSetManifest{
-		{GetFunc: OpenshiftOVNKubeDaemonSet, AllowPartialNodes: false},
 		// Allow partial nodes to prevent E2E flakes when tests run in parallel
 		// and some nodes may be temporarily unavailable, causing "X/1 pods ready" where X > 1 scenarios
+		{GetFunc: OpenshiftOVNKubeDaemonSet, AllowPartialNodes: true},
 		{GetFunc: hccomanifests.GlobalPullSecretDaemonSet, AllowPartialNodes: true},
 		{GetFunc: hccomanifests.KonnectivityAgentDaemonSet, AllowPartialNodes: true},
 		{GetFunc: KubeletConfigVerifierDaemonSet, AllowPartialNodes: true},


### PR DESCRIPTION
…tion

When E2E tests run in parallel, nodes can become temporarily unavailable, causing the OVN-Kube DaemonSet readiness check to fail with pod count mismatches. Set AllowPartialNodes to true for OpenshiftOVNKubeDaemonSet, consistent with the other DaemonSets in the same verification list.

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.