### PR TITLE
OCPBUGS-73915: Use openshift golang builder for MCE builds

### DIFF
--- a/Containerfile.cli
+++ b/Containerfile.cli
@@ -1,8 +1,8 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.3-1765311584 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
 
 WORKDIR /hypershift
 
-COPY --chown=default . .
+COPY . .
 
 RUN make product-cli-release && \
     # Create tar.gz files for Linux architectures \
@@ -14,16 +14,18 @@ RUN make product-cli-release && \
       for ARCH in amd64 arm64; do \
         tar -czvf ./bin/${OS}/${ARCH}/hcp.tar.gz -C ./bin/${OS}/${ARCH} ./hcp || exit 1; \
       done; \
-    done
+    done && \
+    # Remove raw binaries, keep only tar.gz files \
+    find ./bin -type f ! -name "*.tar.gz" -delete
 
 FROM registry.redhat.io/ubi9/nginx-124:1-1767745334
 
-COPY --from=builder /hypershift/bin/    /opt/app-root/src/
-RUN find /opt/app-root/src/ -type f ! -name "*.tar.gz" -delete
+COPY --from=builder /hypershift/bin/ /opt/app-root/src/
 
 CMD ["nginx", "-g", "daemon off;"]
 
 LABEL name="multicluster-engine/hypershift-cli-rhel9" \
+      cpe="cpe:/a:redhat:multicluster_engine:2.12::el9" \
       description="HyperShift HCP CLI is to manage the lifecycle of Hosted Clusters in command lines" \
       summary="HyperShift HCP CLI" \
       url="https://catalog.redhat.com/software/containers/multicluster-engine/hypershift-cli-rhel9/" \

--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -21,6 +21,7 @@ COPY --from=builder /hypershift/bin/hypershift \
 ENTRYPOINT ["/usr/bin/hypershift"]
 
 LABEL name="multicluster-engine/hypershift-operator"
+LABEL cpe="cpe:/a:redhat:multicluster_engine:2.12::el9"
 LABEL description="HyperShift Operator is an operator to manage the lifecycle of Hosted Clusters"
 LABEL summary="HyperShift Operator"
 LABEL url="https://catalog.redhat.com/software/containers/multicluster-engine/hypershift-rhel9-operator/"


### PR DESCRIPTION
## What this PR does / why we need it:

Updates base image for HCP cli and HO to pick up security fixes.

It also sets the cpe label

Squashes #7486

## Which issue(s) this PR fixes:

Fixes: OCPBUGS-73915

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.