### PR TITLE
Add AWS ISO and ISOB region base domains to the list of cloud API DNS base suffix that should not be routed through Konnectivity but be reached through the management cluster

### DIFF
--- a/support/konnectivityproxy/dialer.go
+++ b/support/konnectivityproxy/dialer.go
@@ -475,6 +475,9 @@ func (p *konnectivityProxy) IsCloudAPI(host string) bool {
 		return false
 	}
 	if strings.HasSuffix(host, ".amazonaws.com") ||
+		strings.HasSuffix(host, ".c2s.ic.gov") ||
+		strings.HasSuffix(host, ".hci.ic.gov") ||
+		strings.HasSuffix(host, ".sc2s.sgov.gov") ||
 		strings.HasSuffix(host, ".microsoftonline.com") ||
 		strings.HasSuffix(host, ".azure.com") ||
 		strings.HasSuffix(host, ".cloud.ibm.com") {


### PR DESCRIPTION
Include the AWS ISO and ISOB regions to the list of cloud API DNS base suffix that should not be routed through Konnectivity but be reached through the management cluster.

## What this PR does / why we need it:

Include the AWS ISO and ISOB regions to the list of cloud API DNS base suffix that should not be routed through Konnectivity but be reached through the management cluster. Without the PR, users must add the Cloud Provider API endpoint DNS names to the ingress operator's NO_PROXY field which is not desirable as it has other effects on the cluster as a whole to do that.

https://github.com/openshift/hypershift/blob/e62906a22225b5072bee325b2a916ad701abc00f/control-plane-operator/controllers/hostedcontrolplane/v2/assets/ingress-operator/deployment.yaml#L48

## Which issue(s) this PR fixes:
Currently working on getting a JIRA ticket created and will update the title of the PR
