### PR TITLE
NO-JIRA: test(e2e): add CloudController field to GCP ServiceAccountsEmails structs

### DIFF
--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -318,8 +318,9 @@ func TestOnCreateAPIUX(t *testing.T) {
 									PoolID:        "my-wif-pool",
 									ProviderID:    "my-wif-provider",
 									ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
-										NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
-										ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
+										NodePool:        "nodepool@my-project-123.iam.gserviceaccount.com",
+										ControlPlane:    "controlplane@my-project-123.iam.gserviceaccount.com",
+										CloudController: "cloudcontroller@my-project-123.iam.gserviceaccount.com",
 									},
 								},
 							}
@@ -342,8 +343,9 @@ func TestOnCreateAPIUX(t *testing.T) {
 									PoolID:        "my-wif-pool",
 									ProviderID:    "my-wif-provider",
 									ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
-										NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
-										ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
+										NodePool:        "nodepool@my-project-123.iam.gserviceaccount.com",
+										ControlPlane:    "controlplane@my-project-123.iam.gserviceaccount.com",
+										CloudController: "cloudcontroller@my-project-123.iam.gserviceaccount.com",
 									},
 								},
 							}
@@ -366,8 +368,9 @@ func TestOnCreateAPIUX(t *testing.T) {
 									PoolID:        "my-wif-pool",
 									ProviderID:    "my-wif-provider",
 									ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
-										NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
-										ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
+										NodePool:        "nodepool@my-project-123.iam.gserviceaccount.com",
+										ControlPlane:    "controlplane@my-project-123.iam.gserviceaccount.com",
+										CloudController: "cloudcontroller@my-project-123.iam.gserviceaccount.com",
 									},
 								},
 							}
@@ -404,8 +407,9 @@ func TestOnCreateAPIUX(t *testing.T) {
 									PoolID:        "my-wif-pool",
 									ProviderID:    "my-wif-provider",
 									ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
-										NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
-										ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
+										NodePool:        "nodepool@my-project-123.iam.gserviceaccount.com",
+										ControlPlane:    "controlplane@my-project-123.iam.gserviceaccount.com",
+										CloudController: "cloudcontroller@my-project-123.iam.gserviceaccount.com",
 									},
 								},
 							}
@@ -432,8 +436,9 @@ func TestOnCreateAPIUX(t *testing.T) {
 									PoolID:        "my-wif-pool",
 									ProviderID:    "my-wif-provider",
 									ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
-										NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
-										ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
+										NodePool:        "nodepool@my-project-123.iam.gserviceaccount.com",
+										ControlPlane:    "controlplane@my-project-123.iam.gserviceaccount.com",
+										CloudController: "cloudcontroller@my-project-123.iam.gserviceaccount.com",
 									},
 								},
 							}
@@ -460,8 +465,9 @@ func TestOnCreateAPIUX(t *testing.T) {
 									PoolID:        "my-wif-pool",
 									ProviderID:    "my-wif-provider",
 									ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
-										NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
-										ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
+										NodePool:        "nodepool@my-project-123.iam.gserviceaccount.com",
+										ControlPlane:    "controlplane@my-project-123.iam.gserviceaccount.com",
+										CloudController: "cloudcontroller@my-project-123.iam.gserviceaccount.com",
 									},
 								},
 							}
@@ -488,8 +494,9 @@ func TestOnCreateAPIUX(t *testing.T) {
 									PoolID:        "my-wif-pool",
 									ProviderID:    "my-wif-provider",
 									ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
-										NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
-										ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
+										NodePool:        "nodepool@my-project-123.iam.gserviceaccount.com",
+										ControlPlane:    "controlplane@my-project-123.iam.gserviceaccount.com",
+										CloudController: "cloudcontroller@my-project-123.iam.gserviceaccount.com",
 									},
 								},
 							}
@@ -517,8 +524,9 @@ func TestOnCreateAPIUX(t *testing.T) {
 									PoolID:        "my-wif-pool",
 									ProviderID:    "my-wif-provider",
 									ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
-										NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
-										ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
+										NodePool:        "nodepool@my-project-123.iam.gserviceaccount.com",
+										ControlPlane:    "controlplane@my-project-123.iam.gserviceaccount.com",
+										CloudController: "cloudcontroller@my-project-123.iam.gserviceaccount.com",
 									},
 								},
 							}
@@ -546,8 +554,9 @@ func TestOnCreateAPIUX(t *testing.T) {
 									PoolID:        "my-wif-pool",
 									ProviderID:    "my-wif-provider",
 									ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
-										NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
-										ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
+										NodePool:        "nodepool@my-project-123.iam.gserviceaccount.com",
+										ControlPlane:    "controlplane@my-project-123.iam.gserviceaccount.com",
+										CloudController: "cloudcontroller@my-project-123.iam.gserviceaccount.com",
 									},
 								},
 							}
@@ -575,8 +584,9 @@ func TestOnCreateAPIUX(t *testing.T) {
 									PoolID:        "my-wif-pool",
 									ProviderID:    "my-wif-provider",
 									ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
-										NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
-										ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
+										NodePool:        "nodepool@my-project-123.iam.gserviceaccount.com",
+										ControlPlane:    "controlplane@my-project-123.iam.gserviceaccount.com",
+										CloudController: "cloudcontroller@my-project-123.iam.gserviceaccount.com",
 									},
 								},
 							}
@@ -604,8 +614,9 @@ func TestOnCreateAPIUX(t *testing.T) {
 									PoolID:        "my-wif-pool",
 									ProviderID:    "my-wif-provider",
 									ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
-										NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
-										ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
+										NodePool:        "nodepool@my-project-123.iam.gserviceaccount.com",
+										ControlPlane:    "controlplane@my-project-123.iam.gserviceaccount.com",
+										CloudController: "cloudcontroller@my-project-123.iam.gserviceaccount.com",
 									},
 								},
 							}
@@ -633,8 +644,9 @@ func TestOnCreateAPIUX(t *testing.T) {
 									PoolID:        "my-wif-pool",
 									ProviderID:    "my-wif-provider",
 									ServiceAccountsEmails: hyperv1.GCPServiceAccountsEmails{
-										NodePool:     "nodepool@my-project-123.iam.gserviceaccount.com",
-										ControlPlane: "controlplane@my-project-123.iam.gserviceaccount.com",
+										NodePool:        "nodepool@my-project-123.iam.gserviceaccount.com",
+										ControlPlane:    "controlplane@my-project-123.iam.gserviceaccount.com",
+										CloudController: "cloudcontroller@my-project-123.iam.gserviceaccount.com",
 									},
 								},
 							}


### PR DESCRIPTION
`e2e-aws-techpreview` is permafailing

https://prow.ci.openshift.org/job-history/gs/test-platform-results/pr-logs/directory/pull-ci-openshift-hypershift-main-e2e-aws-techpreview

The TestOnCreateAPIUX test was failing because the CloudController field is now required in the GCPServiceAccountsEmails struct. This field was added to support the Cloud Controller Manager which manages LoadBalancer services and node lifecycle in hosted clusters.

Updated all 12 test cases in create_cluster_test.go to include the CloudController service account email.

Commit-Message-Assisted-by: Claude (via Claude Code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that add a required struct field; no production logic or API behavior is modified.
> 
> **Overview**
> Updates `TestOnCreateAPIUX` GCP HostedCluster validation cases in `test/e2e/create_cluster_test.go` to populate the new required `GCPServiceAccountsEmails.CloudController` field alongside `NodePool` and `ControlPlane`, aligning tests with the current API schema and unblocking CI failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06036df2f828bc09d6693e81d1a890ef4d33c519. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->