### PR TITLE
OCPBUGS-62177: fix(pki): use pod container port instead of kubeconfig service port

### DIFF
--- a/control-plane-pki-operator/certificaterevocationcontroller/certificaterevocationcontroller_test.go
+++ b/control-plane-pki-operator/certificaterevocationcontroller/certificaterevocationcontroller_test.go
@@ -1125,7 +1125,94 @@ func TestIsPodReady(t *testing.T) {
 	}
 }
 
-func TestTestCertificateAgainstAllKASPods_SkipsTerminatingPods(t *testing.T) {
+func kasPodSpec() corev1.PodSpec {
+	return corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name: "kube-apiserver",
+			Ports: []corev1.ContainerPort{{
+				Name:          "client",
+				ContainerPort: 6443,
+				Protocol:      corev1.ProtocolTCP,
+			}},
+		}},
+	}
+}
+
+func TestContainerPort(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		portName string
+		fallback int32
+		expected int32
+	}{
+		{
+			name: "When named port exists it should return container port",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Ports: []corev1.ContainerPort{
+							{Name: "client", ContainerPort: 6443},
+						},
+					}},
+				},
+			},
+			portName: "client",
+			fallback: 9999,
+			expected: 6443,
+		},
+		{
+			name: "When named port is missing it should return fallback",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Ports: []corev1.ContainerPort{
+							{Name: "metrics", ContainerPort: 8080},
+						},
+					}},
+				},
+			},
+			portName: "client",
+			fallback: 6443,
+			expected: 6443,
+		},
+		{
+			name: "When pod has no ports it should return fallback",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{}},
+				},
+			},
+			portName: "client",
+			fallback: 6443,
+			expected: 6443,
+		},
+		{
+			name: "When named port is in a non-first container it should return container port",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Ports: []corev1.ContainerPort{{Name: "metrics", ContainerPort: 8080}}},
+						{Ports: []corev1.ContainerPort{{Name: "client", ContainerPort: 7443}}},
+					},
+				},
+			},
+			portName: "client",
+			fallback: 6443,
+			expected: 7443,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := containerPort(tc.pod, tc.portName, tc.fallback); got != tc.expected {
+				t.Errorf("containerPort() = %d, expected %d", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestVerifyCertificateAgainstAllKASPods(t *testing.T) {
 	now := metav1.Now()
 	fakeKubeconfig := []byte(`apiVersion: v1
 kind: Config
@@ -1160,6 +1247,7 @@ users:
 						Name:              "kube-apiserver-old-abc123",
 						DeletionTimestamp: &now,
 					},
+					Spec: kasPodSpec(),
 					Status: corev1.PodStatus{
 						PodIP: "10.0.0.1",
 						Conditions: []corev1.PodCondition{
@@ -1182,6 +1270,7 @@ users:
 			pods: []*corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-new-xyz789"},
+					Spec:       kasPodSpec(),
 					Status: corev1.PodStatus{
 						PodIP: "10.0.0.2",
 						Conditions: []corev1.PodCondition{
@@ -1201,6 +1290,7 @@ users:
 						Name:              "kube-apiserver-old-abc123",
 						DeletionTimestamp: &now,
 					},
+					Spec: kasPodSpec(),
 					Status: corev1.PodStatus{
 						PodIP: "10.0.0.1",
 						Conditions: []corev1.PodCondition{
@@ -1210,6 +1300,7 @@ users:
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-new-xyz789"},
+					Spec:       kasPodSpec(),
 					Status: corev1.PodStatus{
 						PodIP: "10.0.0.2",
 						Conditions: []corev1.PodCondition{
@@ -1226,6 +1317,7 @@ users:
 			pods: []*corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-abc123"},
+					Spec:       kasPodSpec(),
 					Status: corev1.PodStatus{
 						PodIP: "10.0.0.1",
 						Conditions: []corev1.PodCondition{
@@ -1235,6 +1327,7 @@ users:
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-def456"},
+					Spec:       kasPodSpec(),
 					Status: corev1.PodStatus{
 						PodIP: "10.0.0.2",
 						Conditions: []corev1.PodCondition{


### PR DESCRIPTION
## Summary

- Fix certificate revocation controller to extract the KAS port from the pod container spec instead of the kubeconfig service URL
- The kubeconfig contains the service port which can differ from the container port (e.g. IBMCloud uses service port 2040 while the container always listens on 6443)
- When connecting directly to pod IPs, the container port must be used
- Add `containerPort()` helper with fallback to `KASPodDefaultPort` (6443)
- Add unit tests for the new helper and populate existing test pods with container port specs

## Test plan

- [x] Unit tests pass (`go test ./control-plane-pki-operator/certificaterevocationcontroller/...`)
- [ ] Verify certificate revocation flow works on IBMCloud clusters with service port 2040

🤖 Generated with [Claude Code](https://claude.com/claude-code)