### PR TITLE
CNTRLPLANE-2203: reintroduce ControlPlaneConnectionAvailable condition with conformance fix

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -218,7 +218,20 @@ const (
 	// A failure here suggests potential issues such as: network policy restrictions,
 	// firewall rules, missing data plane nodes, or problems with infrastructure
 	// components like the konnectivity-agent workload.
+	// **Unknown** means the status cannot be determined (e.g., no worker nodes available or unable to inspect).
 	DataPlaneConnectionAvailable ConditionType = "DataPlaneConnectionAvailable"
+
+	// ControlPlaneConnectionAvailable indicates whether data plane workloads have a successful
+	// network connection to the control plane components. This condition is computed using
+	// a 3-replica Deployment that tests the full data path (DNS resolution of kubernetes.default.svc
+	// -> advertise address on lo -> apiserver proxy -> KAS on HCP) and reports results to a shared
+	// ConfigMap. The HCCO evaluates the staleness of the lastSucceeded timestamp in the ConfigMap.
+	// **True** means the data plane can successfully reach the control plane (a recent successful check was recorded).
+	// **False** means there are connectivity failures preventing the data plane from reaching the control plane,
+	// or the last successful check is stale (older than 5 minutes).
+	// **Unknown** means the status cannot be determined due to true inability to inspect (e.g., no worker nodes exist or inspection cannot be performed),
+	// not due to missing required components.
+	ControlPlaneConnectionAvailable ConditionType = "ControlPlaneConnectionAvailable"
 )
 
 // Reasons.
@@ -284,6 +297,14 @@ const (
 	DataPlaneConnectionLogsAccessFailedReason = "LogsAccessFailed"
 
 	DataPlaneConnectionNoWorkerNodesAvailableReason = "NoWorkerNodesAvailable"
+
+	ControlPlaneConnectionKASAccessFailedReason = "KASAccessFailed"
+
+	ControlPlaneConnectionCheckStaleReason = "ConnectionCheckStale"
+
+	ControlPlaneConnectionConfigMapNotFoundReason = "ConfigMapNotFound"
+
+	ControlPlaneConnectionNoWorkerNodesAvailableReason = "NoWorkerNodesAvailable"
 
 	ControlPlaneComponentsNotAvailable = "ComponentsNotAvailable"
 )

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/kasconnectionchecker.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/kasconnectionchecker.go
@@ -1,0 +1,67 @@
+package manifests
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// KASConnectionCheckerName is the name of the KAS connection checker Deployment
+	KASConnectionCheckerName = "kas-connection-checker"
+	// KASConnectionCheckerNamespace is the namespace where the Deployment is deployed
+	KASConnectionCheckerNamespace = "kube-system"
+	// KASConnectionCheckerConfigMapName is the name of the ConfigMap used to report connectivity check results
+	KASConnectionCheckerConfigMapName = "control-plane-connectivity-check"
+)
+
+// KASConnectionCheckerServiceAccount returns a ServiceAccount for the KAS connection checker
+func KASConnectionCheckerServiceAccount() *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      KASConnectionCheckerName,
+			Namespace: KASConnectionCheckerNamespace,
+		},
+	}
+}
+
+// KASConnectionCheckerDeployment returns an empty Deployment object for the KAS connection checker
+func KASConnectionCheckerDeployment() *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      KASConnectionCheckerName,
+			Namespace: KASConnectionCheckerNamespace,
+		},
+	}
+}
+
+// KASConnectionCheckerConfigMap returns an empty ConfigMap for reporting connectivity check results
+func KASConnectionCheckerConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      KASConnectionCheckerConfigMapName,
+			Namespace: KASConnectionCheckerNamespace,
+		},
+	}
+}
+
+// KASConnectionCheckerRole returns a Role for the KAS connection checker
+func KASConnectionCheckerRole() *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      KASConnectionCheckerName,
+			Namespace: KASConnectionCheckerNamespace,
+		},
+	}
+}
+
+// KASConnectionCheckerRoleBinding returns a RoleBinding for the KAS connection checker
+func KASConnectionCheckerRoleBinding() *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      KASConnectionCheckerName,
+			Namespace: KASConnectionCheckerNamespace,
+		},
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
@@ -296,6 +296,34 @@ func ReconcileAuthenticatedReaderForAuthenticatedUserRolebinding(r *rbacv1.RoleB
 	return nil
 }
 
+func ReconcileKASConnectionCheckerRole(r *rbacv1.Role) error {
+	r.Rules = []rbacv1.PolicyRule{
+		{
+			APIGroups:     []string{""},
+			Resources:     []string{"configmaps"},
+			ResourceNames: []string{hccomanifests.KASConnectionCheckerConfigMapName},
+			Verbs:         []string{"get", "update", "patch"},
+		},
+	}
+	return nil
+}
+
+func ReconcileKASConnectionCheckerRoleBinding(r *rbacv1.RoleBinding) error {
+	r.RoleRef = rbacv1.RoleRef{
+		APIGroup: rbacv1.SchemeGroupVersion.Group,
+		Kind:     "Role",
+		Name:     hccomanifests.KASConnectionCheckerRole().Name,
+	}
+	r.Subjects = []rbacv1.Subject{
+		{
+			Kind:      "ServiceAccount",
+			Name:      hccomanifests.KASConnectionCheckerName,
+			Namespace: hccomanifests.KASConnectionCheckerNamespace,
+		},
+	}
+	return nil
+}
+
 func ReconcileKCMLeaderElectionRole(r *rbacv1.Role) error {
 	r.Rules = []rbacv1.PolicyRule{
 		{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1542,10 +1542,26 @@ done`, endpoint, manifests.KASConnectionCheckerConfigMapName, manifests.KASConne
 			},
 		}
 
-		// Tolerate all taints so it can be scheduled on any node
+		// Tolerate NoSchedule taints so it can be scheduled on tainted nodes,
+		// and specific NoExecute taints so it is not evicted from unhealthy nodes.
+		// A catch-all {Operator: Exists} toleration is NOT used because it also
+		// bypasses the NodeUnschedulable filter, causing replacement pods to be
+		// scheduled back onto cordoned nodes during drain — creating an infinite
+		// eviction loop that blocks node rollouts.
 		deployment.Spec.Template.Spec.Tolerations = []corev1.Toleration{
 			{
 				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+			{
+				Key:      "node.kubernetes.io/unreachable",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoExecute,
+			},
+			{
+				Key:      "node.kubernetes.io/not-ready",
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoExecute,
 			},
 		}
 

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -500,9 +500,24 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 		errs = append(errs, fmt.Errorf("failed to reconcile konnectivity agent: %w", err))
 	}
 
-	log.Info("reconciling control-Plane to data-Plane status conditions")
-	if err := r.reconcileControlPlaneDataPlaneConnectivityConditions(ctx, hcp, log); err != nil {
-		errs = append(errs, fmt.Errorf("failed to update ControlPlaneToDataPlaneConnectivity condition: %w", err))
+	log.Info("reconciling KAS connection checker deployment")
+	cliImage, ok := releaseImage.ComponentImages()["cli"]
+	if !ok {
+		errs = append(errs, fmt.Errorf("failed to find cli image in release"))
+	} else {
+		if err := r.reconcileKASConnectionCheckerDeployment(ctx, hcp, cliImage); err != nil {
+			errs = append(errs, fmt.Errorf("failed to reconcile KAS connection checker deployment: %w", err))
+		}
+	}
+
+	log.Info("reconciling data plane connection available condition")
+	if err := r.reconcileDataPlaneConnectionAvailable(ctx, hcp, log); err != nil {
+		errs = append(errs, fmt.Errorf("failed to reconcile DataPlaneConnectionAvailable condition: %w", err))
+	}
+
+	log.Info("reconciling control plane connection available condition")
+	if err := r.reconcileControlPlaneConnectionAvailable(ctx, hcp); err != nil {
+		errs = append(errs, fmt.Errorf("failed to update ControlPlaneConnectionAvailable condition: %w", err))
 	}
 
 	log.Info("reconciling openshift apiserver apiservices")
@@ -1090,6 +1105,9 @@ func (r *reconciler) reconcileRBAC(ctx context.Context, hcp *hyperv1.HostedContr
 		// Let this go by for now
 		manifestAndReconcile[*rbacv1.ClusterRole]{manifest: manifests.UserOAuthClusterRole, reconcile: rbac.ReconcileUserOAuthClusterRole},
 		manifestAndReconcile[*rbacv1.ClusterRoleBinding]{manifest: manifests.UserOAuthClusterRoleBinding, reconcile: rbac.ReconcileUserOAuthClusterRoleBinding},
+
+		manifestAndReconcile[*rbacv1.Role]{manifest: manifests.KASConnectionCheckerRole, reconcile: rbac.ReconcileKASConnectionCheckerRole},
+		manifestAndReconcile[*rbacv1.RoleBinding]{manifest: manifests.KASConnectionCheckerRoleBinding, reconcile: rbac.ReconcileKASConnectionCheckerRoleBinding},
 	}
 
 	if azureutil.IsAroHCP() {
@@ -1362,19 +1380,7 @@ func (r *reconciler) reconcileClusterVersion(ctx context.Context, hcp *hyperv1.H
 	return nil
 }
 
-func (r *reconciler) reconcileControlPlaneDataPlaneConnectivityConditions(ctx context.Context, hcp *hyperv1.HostedControlPlane, log logr.Logger) error {
-	patchHCPWithCondition := func(hcp *hyperv1.HostedControlPlane, condition *metav1.Condition) error {
-		originalHCP := hcp.DeepCopy()
-		if !meta.SetStatusCondition(&hcp.Status.Conditions, *condition) {
-			return nil // No status change; avoid unnecessary API call.
-		}
-		if err := r.cpClient.Status().Patch(ctx, hcp, client.MergeFrom(originalHCP)); err != nil {
-			return fmt.Errorf("failed to update HostedControlPlane status with %s condition: %w", condition.Type, err)
-		}
-		log.Info(string(hyperv1.DataPlaneConnectionAvailable) + " updated")
-		return nil
-	}
-
+func (r *reconciler) reconcileDataPlaneConnectionAvailable(ctx context.Context, hcp *hyperv1.HostedControlPlane, log logr.Logger) error {
 	condition := &metav1.Condition{
 		Type:   string(hyperv1.DataPlaneConnectionAvailable),
 		Status: metav1.ConditionFalse, // False by default
@@ -1384,20 +1390,20 @@ func (r *reconciler) reconcileControlPlaneDataPlaneConnectivityConditions(ctx co
 		condition.Status = metav1.ConditionUnknown
 		condition.Reason = hyperv1.ReconcileErrorReason
 		condition.Message = "Unable to count worker nodes: " + err.Error()
-		return patchHCPWithCondition(hcp, condition)
+		return r.patchHCPStatusCondition(ctx, hcp, condition)
 	}
 	if totalNodes == 0 {
 		condition.Status = metav1.ConditionUnknown
 		condition.Reason = hyperv1.DataPlaneConnectionNoWorkerNodesAvailableReason
 		condition.Message = "No worker nodes available"
-		return patchHCPWithCondition(hcp, condition)
+		return r.patchHCPStatusCondition(ctx, hcp, condition)
 	}
 	var podList corev1.PodList
 	if err := r.uncachedClient.List(ctx, &podList,
 		client.MatchingLabels{"app": "konnectivity-agent"}, client.InNamespace("kube-system")); err != nil {
 		condition.Reason = hyperv1.ReconciliationErrorReason
 		condition.Message = "Couldn't list konnectivity-agent PODs in kube-system namespace: " + err.Error()
-		return patchHCPWithCondition(hcp, condition)
+		return r.patchHCPStatusCondition(ctx, hcp, condition)
 	}
 
 	logsFound := false
@@ -1432,7 +1438,188 @@ func (r *reconciler) reconcileControlPlaneDataPlaneConnectivityConditions(ctx co
 		}
 	}
 
-	return patchHCPWithCondition(hcp, condition)
+	return r.patchHCPStatusCondition(ctx, hcp, condition)
+}
+
+// getKASHealthCheckEndpoint returns the appropriate KAS health check endpoint based on the platform type.
+// IBM Cloud uses a different liveness endpoint that excludes etcd and log checks.
+func getKASHealthCheckEndpoint(platformType hyperv1.PlatformType) string {
+	if platformType == hyperv1.IBMCloudPlatform {
+		return "/livez?exclude=etcd&exclude=log"
+	}
+	return "/version"
+}
+
+// patchHCPStatusCondition patches the HostedControlPlane status with the provided condition.
+// It only performs the API call if the condition actually changed.
+func (r *reconciler) patchHCPStatusCondition(ctx context.Context, hcp *hyperv1.HostedControlPlane, condition *metav1.Condition) error {
+	log := ctrl.LoggerFrom(ctx)
+	originalHCP := hcp.DeepCopy()
+	if !meta.SetStatusCondition(&hcp.Status.Conditions, *condition) {
+		return nil // No status change; avoid unnecessary API call.
+	}
+	if err := r.cpClient.Status().Patch(ctx, hcp, client.MergeFrom(originalHCP)); err != nil {
+		return fmt.Errorf("failed to update HostedControlPlane status with %s condition: %w", condition.Type, err)
+	}
+	log.Info(string(condition.Type) + " condition updated")
+	return nil
+}
+
+func (r *reconciler) reconcileKASConnectionCheckerDeployment(ctx context.Context, hcp *hyperv1.HostedControlPlane, cliImage string) error {
+	endpoint := getKASHealthCheckEndpoint(hcp.Spec.Platform.Type)
+
+	serviceAccount := manifests.KASConnectionCheckerServiceAccount()
+	if _, err := r.CreateOrUpdate(ctx, r.client, serviceAccount, func() error { return nil }); err != nil {
+		return fmt.Errorf("failed to reconcile kas-connection-checker service account: %w", err)
+	}
+
+	// Create the ConfigMap that pods will update with their check results.
+	cm := manifests.KASConnectionCheckerConfigMap()
+	if _, err := r.CreateOrUpdate(ctx, r.client, cm, func() error { return nil }); err != nil {
+		return fmt.Errorf("failed to reconcile kas-connection-checker configmap: %w", err)
+	}
+
+	// Build the curl-based check script. Each pod tests the full data path:
+	// DNS resolution of kubernetes.default.svc -> advertise address on lo -> apiserver proxy -> KAS on HCP.
+	// On success the pod PATCHes the shared ConfigMap with a lastSucceeded timestamp via the Kubernetes API.
+	// The token is re-read each iteration to handle rotation.
+	// See: https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/
+	checkScript := fmt.Sprintf(`#!/bin/sh
+ENDPOINT=%s
+CONFIGMAP_NAME=%s
+NAMESPACE=%s
+while true; do
+  TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+  CACERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  HTTP_CODE=$(curl --cacert ${CACERT} -s -o /dev/null -w "%%{http_code}" \
+    --connect-timeout 5 --max-time 10 \
+    "https://kubernetes.default.svc${ENDPOINT}" 2>/dev/null)
+  if [ "$HTTP_CODE" = "200" ]; then
+    NOW=$(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ)
+    curl --cacert ${CACERT} -s -o /dev/null \
+      -X PATCH \
+      -H "Authorization: Bearer ${TOKEN}" \
+      -H "Content-Type: application/strategic-merge-patch+json" \
+      --data "{\"data\":{\"lastSucceeded\":\"${NOW}\"}}" \
+      "https://kubernetes.default.svc/api/v1/namespaces/${NAMESPACE}/configmaps/${CONFIGMAP_NAME}" 2>/dev/null
+  fi
+  sleep 60
+done`, endpoint, manifests.KASConnectionCheckerConfigMapName, manifests.KASConnectionCheckerNamespace)
+
+	var replicas int32 = 3
+	deployment := manifests.KASConnectionCheckerDeployment()
+	if _, err := r.CreateOrUpdate(ctx, r.client, deployment, func() error {
+		deployment.Spec.Replicas = &replicas
+		deployment.Spec.Selector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app": manifests.KASConnectionCheckerName,
+			},
+		}
+
+		deployment.Spec.Template.ObjectMeta.Labels = map[string]string{
+			"app": manifests.KASConnectionCheckerName,
+		}
+		deployment.Spec.Template.ObjectMeta.Annotations = map[string]string{
+			"openshift.io/required-scc": "restricted-v2",
+		}
+
+		deployment.Spec.Template.Spec.ServiceAccountName = manifests.KASConnectionCheckerName
+		deployment.Spec.Template.Spec.PriorityClassName = "system-node-critical"
+		automount := true
+		deployment.Spec.Template.Spec.AutomountServiceAccountToken = &automount
+
+		deployment.Spec.Template.Spec.Containers = []corev1.Container{
+			{
+				Name:    "connection-checker",
+				Image:   cliImage,
+				Command: []string{"/bin/sh", "-c", checkScript},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("5m"),
+						corev1.ResourceMemory: resource.MustParse("10Mi"),
+					},
+				},
+			},
+		}
+
+		// Tolerate all taints so it can be scheduled on any node
+		deployment.Spec.Template.Spec.Tolerations = []corev1.Toleration{
+			{
+				Operator: corev1.TolerationOpExists,
+			},
+		}
+
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile kas-connection-checker deployment: %w", err)
+	}
+
+	return nil
+}
+
+func (r *reconciler) reconcileControlPlaneConnectionAvailable(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
+	condition := &metav1.Condition{
+		Type:   string(hyperv1.ControlPlaneConnectionAvailable),
+		Status: metav1.ConditionUnknown,
+		Reason: hyperv1.StatusUnknownReason,
+	}
+
+	// Check if there are any worker nodes available
+	totalNodes, err := util.CountAvailableNodes(ctx, r.client)
+	if err != nil {
+		condition.Reason = hyperv1.ReconcileErrorReason
+		condition.Message = "Unable to count worker nodes: " + err.Error()
+		return r.patchHCPStatusCondition(ctx, hcp, condition)
+	}
+	if totalNodes == 0 {
+		condition.Reason = hyperv1.ControlPlaneConnectionNoWorkerNodesAvailableReason
+		condition.Message = "No worker nodes available to verify control plane connectivity"
+		return r.patchHCPStatusCondition(ctx, hcp, condition)
+	}
+
+	// Get the connectivity check ConfigMap
+	cm := manifests.KASConnectionCheckerConfigMap()
+	if err := r.client.Get(ctx, client.ObjectKeyFromObject(cm), cm); err != nil {
+		if apierrors.IsNotFound(err) {
+			condition.Reason = hyperv1.ControlPlaneConnectionConfigMapNotFoundReason
+			condition.Message = fmt.Sprintf("Connectivity check ConfigMap %s/%s not found; the hosted cluster config operator may not have reconciled it yet",
+				manifests.KASConnectionCheckerNamespace, manifests.KASConnectionCheckerConfigMapName)
+			return r.patchHCPStatusCondition(ctx, hcp, condition)
+		}
+		condition.Reason = hyperv1.ReconcileErrorReason
+		condition.Message = fmt.Sprintf("Failed to get connectivity check ConfigMap %s/%s: %v",
+			manifests.KASConnectionCheckerNamespace, manifests.KASConnectionCheckerConfigMapName, err)
+		return r.patchHCPStatusCondition(ctx, hcp, condition)
+	}
+
+	// Check the lastSucceeded timestamp
+	lastSucceededStr, ok := cm.Data["lastSucceeded"]
+	if !ok || lastSucceededStr == "" {
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = hyperv1.ControlPlaneConnectionKASAccessFailedReason
+		condition.Message = "Data plane to control plane connection is not available: no successful connectivity check recorded"
+		return r.patchHCPStatusCondition(ctx, hcp, condition)
+	}
+
+	lastSucceeded, err := time.Parse(time.RFC3339, lastSucceededStr)
+	if err != nil {
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = hyperv1.ControlPlaneConnectionKASAccessFailedReason
+		condition.Message = fmt.Sprintf("Data plane to control plane connection is not available: failed to parse lastSucceeded timestamp: %v", err)
+		return r.patchHCPStatusCondition(ctx, hcp, condition)
+	}
+
+	if time.Since(lastSucceeded) > 5*time.Minute {
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = hyperv1.ControlPlaneConnectionCheckStaleReason
+		condition.Message = fmt.Sprintf("Data plane to control plane connection is not available: last successful check was at %s, which is older than 5 minutes", lastSucceededStr)
+		return r.patchHCPStatusCondition(ctx, hcp, condition)
+	}
+
+	condition.Status = metav1.ConditionTrue
+	condition.Reason = hyperv1.AsExpectedReason
+	condition.Message = hyperv1.AllIsWellMessage
+	return r.patchHCPStatusCondition(ctx, hcp, condition)
 }
 
 func (r *reconciler) reconcileOpenshiftAPIServerAPIServices(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1554,14 +1554,16 @@ done`, endpoint, manifests.KASConnectionCheckerConfigMapName, manifests.KASConne
 				Effect:   corev1.TaintEffectNoSchedule,
 			},
 			{
-				Key:      "node.kubernetes.io/unreachable",
-				Operator: corev1.TolerationOpExists,
-				Effect:   corev1.TaintEffectNoExecute,
+				Key:               "node.kubernetes.io/unreachable",
+				Operator:          corev1.TolerationOpExists,
+				Effect:            corev1.TaintEffectNoExecute,
+				TolerationSeconds: ptr.To[int64](120),
 			},
 			{
-				Key:      "node.kubernetes.io/not-ready",
-				Operator: corev1.TolerationOpExists,
-				Effect:   corev1.TaintEffectNoExecute,
+				Key:               "node.kubernetes.io/not-ready",
+				Operator:          corev1.TolerationOpExists,
+				Effect:            corev1.TaintEffectNoExecute,
+				TolerationSeconds: ptr.To[int64](120),
 			},
 		}
 

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -2779,12 +2779,34 @@ func Test_reconciler_reconcileKASConnectionCheckerDeployment(t *testing.T) {
 					t.Error("HostNetwork should be false (not set)")
 				}
 
-				// Validate tolerations
-				if len(dep.Spec.Template.Spec.Tolerations) != 1 {
-					t.Fatalf("Expected 1 toleration, got %d", len(dep.Spec.Template.Spec.Tolerations))
+				// Validate tolerations - should NOT use catch-all {Operator: Exists}
+				// because that bypasses the NodeUnschedulable filter, causing replacement
+				// pods to be scheduled back onto cordoned nodes during drain.
+				expectedTolerations := []corev1.Toleration{
+					{
+						Operator: corev1.TolerationOpExists,
+						Effect:   corev1.TaintEffectNoSchedule,
+					},
+					{
+						Key:      "node.kubernetes.io/unreachable",
+						Operator: corev1.TolerationOpExists,
+						Effect:   corev1.TaintEffectNoExecute,
+					},
+					{
+						Key:      "node.kubernetes.io/not-ready",
+						Operator: corev1.TolerationOpExists,
+						Effect:   corev1.TaintEffectNoExecute,
+					},
 				}
-				if dep.Spec.Template.Spec.Tolerations[0].Operator != corev1.TolerationOpExists {
-					t.Error("Expected toleration operator Exists")
+				if len(dep.Spec.Template.Spec.Tolerations) != len(expectedTolerations) {
+					t.Fatalf("Expected %d tolerations, got %d", len(expectedTolerations), len(dep.Spec.Template.Spec.Tolerations))
+				}
+				for i, expected := range expectedTolerations {
+					actual := dep.Spec.Template.Spec.Tolerations[i]
+					if actual.Operator != expected.Operator || actual.Effect != expected.Effect || actual.Key != expected.Key {
+						t.Errorf("Toleration[%d] mismatch: got {Key:%q, Operator:%q, Effect:%q}, want {Key:%q, Operator:%q, Effect:%q}",
+							i, actual.Key, actual.Operator, actual.Effect, expected.Key, expected.Operator, expected.Effect)
+					}
 				}
 
 				// Validate ServiceAccountName

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -2788,14 +2788,16 @@ func Test_reconciler_reconcileKASConnectionCheckerDeployment(t *testing.T) {
 						Effect:   corev1.TaintEffectNoSchedule,
 					},
 					{
-						Key:      "node.kubernetes.io/unreachable",
-						Operator: corev1.TolerationOpExists,
-						Effect:   corev1.TaintEffectNoExecute,
+						Key:               "node.kubernetes.io/unreachable",
+						Operator:          corev1.TolerationOpExists,
+						Effect:            corev1.TaintEffectNoExecute,
+						TolerationSeconds: ptr.To[int64](120),
 					},
 					{
-						Key:      "node.kubernetes.io/not-ready",
-						Operator: corev1.TolerationOpExists,
-						Effect:   corev1.TaintEffectNoExecute,
+						Key:               "node.kubernetes.io/not-ready",
+						Operator:          corev1.TolerationOpExists,
+						Effect:            corev1.TaintEffectNoExecute,
+						TolerationSeconds: ptr.To[int64](120),
 					},
 				}
 				if len(dep.Spec.Template.Spec.Tolerations) != len(expectedTolerations) {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -32,6 +32,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -92,6 +93,8 @@ var initialObjects = []client.Object{
 	manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", kas.AdmissionPolicyNameInfra)),
 
 	fakeOperatorHub(),
+	manifests.KASConnectionCheckerDeployment(),
+	manifests.KASConnectionCheckerServiceAccount(),
 }
 
 func shouldNotError(key client.ObjectKey) bool {
@@ -166,8 +169,12 @@ func TestReconcileErrorHandling(t *testing.T) {
 			cpClient:               fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(cpObjects...).WithStatusSubresource(&hyperv1.HostedControlPlane{}).Build(),
 			hcpName:                "foo",
 			hcpNamespace:           "bar",
-			releaseProvider:        &fakereleaseprovider.FakeReleaseProvider{},
-			ImageMetaDataProvider:  &imageMetaDataProvider,
+			releaseProvider: &fakereleaseprovider.FakeReleaseProvider{
+				Components: map[string]string{
+					"cli": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cli-fake",
+				},
+			},
+			ImageMetaDataProvider: &imageMetaDataProvider,
 		}
 		_, err := r.Reconcile(ctx, controllerruntime.Request{})
 		if err != nil {
@@ -196,8 +203,12 @@ func TestReconcileErrorHandling(t *testing.T) {
 			cpClient:               fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(cpObjects...).Build(),
 			hcpName:                "foo",
 			hcpNamespace:           "bar",
-			releaseProvider:        &fakereleaseprovider.FakeReleaseProvider{},
-			ImageMetaDataProvider:  &imageMetaDataProvider,
+			releaseProvider: &fakereleaseprovider.FakeReleaseProvider{
+				Components: map[string]string{
+					"cli": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cli-fake",
+				},
+			},
+			ImageMetaDataProvider: &imageMetaDataProvider,
 		}
 		_, err := r.Reconcile(ctx, controllerruntime.Request{})
 		if err != nil {
@@ -2308,7 +2319,7 @@ func newCondition(conditionType string, status metav1.ConditionStatus, reason, m
 	}
 }
 
-func Test_reconciler_reconcileControlPlaneDataPlaneConnectivityConditions(t *testing.T) {
+func Test_reconciler_reconcileDataPlaneConnectionAvailable(t *testing.T) {
 	newKonnectivityAgentPod := func(name string, phase corev1.PodPhase) corev1.Pod {
 		return corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2475,15 +2486,15 @@ func Test_reconciler_reconcileControlPlaneDataPlaneConnectivityConditions(t *tes
 			r.cpClient = fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(tt.hcp).WithStatusSubresource(&hyperv1.HostedControlPlane{}).Build()
 			r.GetPodLogs = tt.mockedGetPodLogs
 
-			gotErr := r.reconcileControlPlaneDataPlaneConnectivityConditions(ctx, tt.hcp, log)
+			gotErr := r.reconcileDataPlaneConnectionAvailable(ctx, tt.hcp, log)
 			if gotErr != nil {
 				if !tt.wantErr {
-					t.Errorf("reconcileControlPlaneDataPlaneConnectivityConditions() failed: %v", gotErr)
+					t.Errorf("reconcileDataPlaneConnectionAvailable() failed: %v", gotErr)
 				}
 				return
 			}
 			if tt.wantErr {
-				t.Fatal("reconcileControlPlaneDataPlaneConnectivityConditions() succeeded unexpectedly")
+				t.Fatal("reconcileDataPlaneConnectionAvailable() succeeded unexpectedly")
 			}
 			if tt.expectedCondition != nil {
 				found := false
@@ -2498,6 +2509,433 @@ func Test_reconciler_reconcileControlPlaneDataPlaneConnectivityConditions(t *tes
 				if !found {
 					t.Fatal("couldn't find expected condition")
 				}
+			}
+		})
+	}
+}
+
+func Test_reconciler_reconcileControlPlaneConnectionAvailable(t *testing.T) {
+	newConnectivityConfigMap := func(data map[string]string) *corev1.ConfigMap {
+		return &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      manifests.KASConnectionCheckerConfigMapName,
+				Namespace: manifests.KASConnectionCheckerNamespace,
+			},
+			Data: data,
+		}
+	}
+
+	newReadyNode := func(name string) corev1.Node {
+		return corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Spec: corev1.NodeSpec{
+				Unschedulable: false,
+			},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name              string
+		hcp               *hyperv1.HostedControlPlane
+		wantErr           bool
+		expectedCondition *metav1.Condition
+		configMap         *corev1.ConfigMap
+		nodes             []corev1.Node
+	}{
+		{
+			name:    "When no worker nodes exist it should set condition to Unknown with NoWorkerNodesAvailable reason",
+			hcp:     fakeHCP(),
+			wantErr: false,
+			expectedCondition: newCondition(
+				string(hyperv1.ControlPlaneConnectionAvailable),
+				metav1.ConditionUnknown,
+				hyperv1.ControlPlaneConnectionNoWorkerNodesAvailableReason,
+				"No worker nodes available to verify control plane connectivity",
+			),
+			configMap: nil,
+			nodes:     []corev1.Node{},
+		},
+		{
+			name:    "When ConfigMap does not exist it should set condition to Unknown with ConfigMapNotFound reason",
+			hcp:     fakeHCP(),
+			wantErr: false,
+			expectedCondition: newCondition(
+				string(hyperv1.ControlPlaneConnectionAvailable),
+				metav1.ConditionUnknown,
+				hyperv1.ControlPlaneConnectionConfigMapNotFoundReason,
+				fmt.Sprintf("Connectivity check ConfigMap %s/%s not found; the hosted cluster config operator may not have reconciled it yet",
+					manifests.KASConnectionCheckerNamespace, manifests.KASConnectionCheckerConfigMapName),
+			),
+			configMap: nil,
+			nodes:     []corev1.Node{newReadyNode("node1")},
+		},
+		{
+			name:    "When ConfigMap has no lastSucceeded key it should set condition to False with KASAccessFailed reason",
+			hcp:     fakeHCP(),
+			wantErr: false,
+			expectedCondition: newCondition(
+				string(hyperv1.ControlPlaneConnectionAvailable),
+				metav1.ConditionFalse,
+				hyperv1.ControlPlaneConnectionKASAccessFailedReason,
+				"Data plane to control plane connection is not available: no successful connectivity check recorded",
+			),
+			configMap: newConnectivityConfigMap(map[string]string{}),
+			nodes:     []corev1.Node{newReadyNode("node1")},
+		},
+		{
+			name:    "When ConfigMap has empty lastSucceeded it should set condition to False with KASAccessFailed reason",
+			hcp:     fakeHCP(),
+			wantErr: false,
+			expectedCondition: newCondition(
+				string(hyperv1.ControlPlaneConnectionAvailable),
+				metav1.ConditionFalse,
+				hyperv1.ControlPlaneConnectionKASAccessFailedReason,
+				"Data plane to control plane connection is not available: no successful connectivity check recorded",
+			),
+			configMap: newConnectivityConfigMap(map[string]string{"lastSucceeded": ""}),
+			nodes:     []corev1.Node{newReadyNode("node1")},
+		},
+		{
+			name:    "When lastSucceeded is recent it should set condition to True",
+			hcp:     fakeHCP(),
+			wantErr: false,
+			expectedCondition: newCondition(
+				string(hyperv1.ControlPlaneConnectionAvailable),
+				metav1.ConditionTrue,
+				hyperv1.AsExpectedReason,
+				hyperv1.AllIsWellMessage,
+			),
+			configMap: newConnectivityConfigMap(map[string]string{
+				"lastSucceeded": time.Now().UTC().Format(time.RFC3339),
+			}),
+			nodes: []corev1.Node{newReadyNode("node1")},
+		},
+		{
+			name:    "When lastSucceeded is stale it should set condition to False with ConnectionCheckStale reason",
+			hcp:     fakeHCP(),
+			wantErr: false,
+			expectedCondition: newCondition(
+				string(hyperv1.ControlPlaneConnectionAvailable),
+				metav1.ConditionFalse,
+				hyperv1.ControlPlaneConnectionCheckStaleReason,
+				"Data plane to control plane connection is not available: last successful check was at 2020-01-01T00:00:00Z, which is older than 5 minutes",
+			),
+			configMap: newConnectivityConfigMap(map[string]string{
+				"lastSucceeded": "2020-01-01T00:00:00Z",
+			}),
+			nodes: []corev1.Node{newReadyNode("node1")},
+		},
+	}
+
+	log := zapr.NewLogger(zaptest.NewLogger(t))
+	ctx := logr.NewContext(context.Background(), log)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var r reconciler
+
+			// Build client with ConfigMap and nodes
+			var objects []client.Object
+			if tt.configMap != nil {
+				objects = append(objects, tt.configMap)
+			}
+			nodeList := &corev1.NodeList{Items: tt.nodes}
+
+			r.client = fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(objects...).WithLists(nodeList).Build()
+			r.cpClient = fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(tt.hcp).WithStatusSubresource(&hyperv1.HostedControlPlane{}).Build()
+
+			gotErr := r.reconcileControlPlaneConnectionAvailable(ctx, tt.hcp)
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("reconcileControlPlaneConnectionAvailable() failed: %v", gotErr)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Fatal("reconcileControlPlaneConnectionAvailable() succeeded unexpectedly")
+			}
+			if tt.expectedCondition != nil {
+				found := false
+				for _, c := range tt.hcp.Status.Conditions {
+					if tt.expectedCondition.Type == c.Type &&
+						tt.expectedCondition.Message == c.Message &&
+						tt.expectedCondition.Status == c.Status &&
+						tt.expectedCondition.Reason == c.Reason {
+						found = true
+					}
+				}
+				if !found {
+					t.Fatalf("couldn't find expected condition. Expected: %+v, Got: %+v", tt.expectedCondition, tt.hcp.Status.Conditions)
+				}
+			}
+		})
+	}
+}
+
+func Test_reconciler_reconcileKASConnectionCheckerDeployment(t *testing.T) {
+	const testCLIImage = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cli-test"
+
+	tests := []struct {
+		name               string
+		hcp                *hyperv1.HostedControlPlane
+		existingDeployment *appsv1.Deployment
+		wantErr            bool
+		validate           func(t *testing.T, c client.Client)
+	}{
+		{
+			name:               "When Deployment does not exist it should create it with correct spec",
+			hcp:                fakeHCP(),
+			existingDeployment: nil,
+			wantErr:            false,
+			validate: func(t *testing.T, c client.Client) {
+				dep := &appsv1.Deployment{}
+				if err := c.Get(context.Background(), client.ObjectKey{Name: manifests.KASConnectionCheckerName, Namespace: manifests.KASConnectionCheckerNamespace}, dep); err != nil {
+					t.Fatalf("Deployment should be created: %v", err)
+				}
+
+				// Validate replicas
+				if dep.Spec.Replicas == nil || *dep.Spec.Replicas != 3 {
+					t.Error("Replicas should be set to 3")
+				}
+
+				// Validate labels and selectors
+				if dep.Spec.Selector == nil || dep.Spec.Selector.MatchLabels["app"] != manifests.KASConnectionCheckerName {
+					t.Error("Selector labels not set correctly")
+				}
+				if dep.Spec.Template.ObjectMeta.Labels["app"] != manifests.KASConnectionCheckerName {
+					t.Error("Pod template labels not set correctly")
+				}
+
+				// Validate container spec
+				if len(dep.Spec.Template.Spec.Containers) != 1 {
+					t.Fatalf("Expected 1 container, got %d", len(dep.Spec.Template.Spec.Containers))
+				}
+				container := dep.Spec.Template.Spec.Containers[0]
+				if container.Name != "connection-checker" {
+					t.Errorf("Expected container name 'connection-checker', got %s", container.Name)
+				}
+				if container.Image != testCLIImage {
+					t.Errorf("Expected cli image %s, got %s", testCLIImage, container.Image)
+				}
+
+				// Validate command runs a curl-based check script using kubernetes.default.svc
+				if len(container.Command) != 3 || container.Command[0] != "/bin/sh" || container.Command[1] != "-c" {
+					t.Fatalf("Expected command [/bin/sh -c <script>], got %v", container.Command)
+				}
+				script := container.Command[2]
+				if !strings.Contains(script, "curl") {
+					t.Error("Check script should use curl")
+				}
+				if !strings.Contains(script, "kubernetes.default.svc") {
+					t.Error("Check script should use kubernetes.default.svc for full data path testing")
+				}
+				if !strings.Contains(script, "/version") {
+					t.Error("Check script should check /version endpoint")
+				}
+				if !strings.Contains(script, "sleep 60") {
+					t.Error("Check script should sleep 60 seconds between checks")
+				}
+				if !strings.Contains(script, "curl") && !strings.Contains(script, "PATCH") {
+					t.Error("Check script should PATCH the ConfigMap on success")
+				}
+				if !strings.Contains(script, manifests.KASConnectionCheckerConfigMapName) {
+					t.Errorf("Check script should reference ConfigMap name %s", manifests.KASConnectionCheckerConfigMapName)
+				}
+
+				// Validate no readiness probe
+				if container.ReadinessProbe != nil {
+					t.Error("ReadinessProbe should not be set")
+				}
+
+				// Validate priority class
+				if dep.Spec.Template.Spec.PriorityClassName != "system-node-critical" {
+					t.Errorf("Expected PriorityClassName system-node-critical, got %s", dep.Spec.Template.Spec.PriorityClassName)
+				}
+
+				// Validate automount service account token is enabled
+				if dep.Spec.Template.Spec.AutomountServiceAccountToken == nil || !*dep.Spec.Template.Spec.AutomountServiceAccountToken {
+					t.Error("AutomountServiceAccountToken should be set to true")
+				}
+
+				// Validate resource requests
+				expectedCPU := resource.MustParse("5m")
+				expectedMemory := resource.MustParse("10Mi")
+				if !container.Resources.Requests.Cpu().Equal(expectedCPU) {
+					t.Errorf("Expected CPU request 5m, got %s", container.Resources.Requests.Cpu())
+				}
+				if !container.Resources.Requests.Memory().Equal(expectedMemory) {
+					t.Errorf("Expected memory request 10Mi, got %s", container.Resources.Requests.Memory())
+				}
+
+				// Validate that host network is NOT used
+				if dep.Spec.Template.Spec.HostNetwork {
+					t.Error("HostNetwork should be false (not set)")
+				}
+
+				// Validate tolerations
+				if len(dep.Spec.Template.Spec.Tolerations) != 1 {
+					t.Fatalf("Expected 1 toleration, got %d", len(dep.Spec.Template.Spec.Tolerations))
+				}
+				if dep.Spec.Template.Spec.Tolerations[0].Operator != corev1.TolerationOpExists {
+					t.Error("Expected toleration operator Exists")
+				}
+
+				// Validate ServiceAccountName
+				if dep.Spec.Template.Spec.ServiceAccountName != manifests.KASConnectionCheckerName {
+					t.Errorf("Expected ServiceAccountName %s, got %s", manifests.KASConnectionCheckerName, dep.Spec.Template.Spec.ServiceAccountName)
+				}
+
+				// Validate required-scc annotation
+				if dep.Spec.Template.ObjectMeta.Annotations["openshift.io/required-scc"] != "restricted-v2" {
+					t.Errorf("Expected openshift.io/required-scc annotation 'restricted-v2', got %s", dep.Spec.Template.ObjectMeta.Annotations["openshift.io/required-scc"])
+				}
+
+				// Validate ConfigMap was created
+				cm := &corev1.ConfigMap{}
+				if err := c.Get(context.Background(), client.ObjectKey{Name: manifests.KASConnectionCheckerConfigMapName, Namespace: manifests.KASConnectionCheckerNamespace}, cm); err != nil {
+					t.Errorf("ConfigMap should be created: %v", err)
+				}
+			},
+		},
+		{
+			name: "When platform is IBM Cloud it should use IBM Cloud specific endpoint in curl script",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: "test-namespace",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.IBMCloudPlatform,
+					},
+				},
+			},
+			existingDeployment: nil,
+			wantErr:            false,
+			validate: func(t *testing.T, c client.Client) {
+				dep := &appsv1.Deployment{}
+				if err := c.Get(context.Background(), client.ObjectKey{Name: manifests.KASConnectionCheckerName, Namespace: manifests.KASConnectionCheckerNamespace}, dep); err != nil {
+					t.Fatalf("Deployment should be created: %v", err)
+				}
+				container := dep.Spec.Template.Spec.Containers[0]
+				script := container.Command[2]
+				if !strings.Contains(script, "/livez?exclude=etcd&exclude=log") {
+					t.Errorf("Expected IBM Cloud endpoint in curl script, got script: %s", script)
+				}
+			},
+		},
+		{
+			name: "When Deployment already exists it should update it",
+			hcp:  fakeHCP(),
+			existingDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      manifests.KASConnectionCheckerName,
+					Namespace: manifests.KASConnectionCheckerNamespace,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "old-label",
+						},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app": "old-label",
+							},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "old-container",
+									Image: "old-image",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			validate: func(t *testing.T, c client.Client) {
+				dep := &appsv1.Deployment{}
+				if err := c.Get(context.Background(), client.ObjectKey{Name: manifests.KASConnectionCheckerName, Namespace: manifests.KASConnectionCheckerNamespace}, dep); err != nil {
+					t.Fatalf("Deployment should exist: %v", err)
+				}
+				// Verify it was updated with new spec
+				if dep.Spec.Selector.MatchLabels["app"] != manifests.KASConnectionCheckerName {
+					t.Error("Deployment should be updated with correct selector")
+				}
+				if len(dep.Spec.Template.Spec.Containers) != 1 {
+					t.Fatalf("Expected 1 container after update, got %d", len(dep.Spec.Template.Spec.Containers))
+				}
+				container := dep.Spec.Template.Spec.Containers[0]
+				if container.Name != "connection-checker" {
+					t.Error("Container should be updated to connection-checker")
+				}
+				if container.Image != testCLIImage {
+					t.Errorf("Image should be updated to cli image, got %s", container.Image)
+				}
+				if container.ReadinessProbe != nil {
+					t.Error("ReadinessProbe should not be set")
+				}
+
+				// Validate replicas
+				if dep.Spec.Replicas == nil || *dep.Spec.Replicas != 3 {
+					t.Error("Replicas should be set to 3")
+				}
+
+				// Validate ServiceAccountName
+				if dep.Spec.Template.Spec.ServiceAccountName != manifests.KASConnectionCheckerName {
+					t.Errorf("Expected ServiceAccountName %s, got %s", manifests.KASConnectionCheckerName, dep.Spec.Template.Spec.ServiceAccountName)
+				}
+
+				// Validate required-scc annotation
+				if dep.Spec.Template.ObjectMeta.Annotations["openshift.io/required-scc"] != "restricted-v2" {
+					t.Errorf("Expected openshift.io/required-scc annotation 'restricted-v2', got %s", dep.Spec.Template.ObjectMeta.Annotations["openshift.io/required-scc"])
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var r reconciler
+
+			// Setup fake client with existing Deployment if provided
+			var objects []client.Object
+			if tt.existingDeployment != nil {
+				objects = append(objects, tt.existingDeployment)
+			}
+			r.client = fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(objects...).Build()
+			r.CreateOrUpdateProvider = &simpleCreateOrUpdater{}
+
+			ctx := context.Background()
+			err := r.reconcileKASConnectionCheckerDeployment(ctx, tt.hcp, testCLIImage)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("reconcileKASConnectionCheckerDeployment() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			// Verify ServiceAccount was created
+			sa := &corev1.ServiceAccount{}
+			saKey := client.ObjectKey{
+				Name:      manifests.KASConnectionCheckerName,
+				Namespace: manifests.KASConnectionCheckerNamespace,
+			}
+			if err := r.client.Get(ctx, saKey, sa); err != nil {
+				t.Errorf("Failed to get ServiceAccount: %v", err)
+			}
+
+			if tt.validate != nil {
+				tt.validate(t, r.client)
 			}
 		})
 	}

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -33787,6 +33787,18 @@ underlying cluster&rsquo;s ClusterVersion.</p>
 </tr><tr><td><p>&#34;RolloutComplete&#34;</p></td>
 <td><p>ControlPlaneComponentRolloutComplete indicates whether the ControlPlaneComponent has completed its rollout.</p>
 </td>
+</tr><tr><td><p>&#34;ControlPlaneConnectionAvailable&#34;</p></td>
+<td><p>ControlPlaneConnectionAvailable indicates whether data plane workloads have a successful
+network connection to the control plane components. This condition is computed using
+a 3-replica Deployment that tests the full data path (DNS resolution of kubernetes.default.svc
+-&gt; advertise address on lo -&gt; apiserver proxy -&gt; KAS on HCP) and reports results to a shared
+ConfigMap. The HCCO evaluates the staleness of the lastSucceeded timestamp in the ConfigMap.
+<strong>True</strong> means the data plane can successfully reach the control plane (a recent successful check was recorded).
+<strong>False</strong> means there are connectivity failures preventing the data plane from reaching the control plane,
+or the last successful check is stale (older than 5 minutes).
+<strong>Unknown</strong> means the status cannot be determined due to true inability to inspect (e.g., no worker nodes exist or inspection cannot be performed),
+not due to missing required components.</p>
+</td>
 </tr><tr><td><p>&#34;DataPlaneConnectionAvailable&#34;</p></td>
 <td><p>DataPlaneConnectionAvailable indicates whether the control plane has a successful
 network connection to the data plane components.
@@ -33794,7 +33806,8 @@ network connection to the data plane components.
 <strong>False</strong> means there are network connection issues preventing the control plane from reaching the data plane.
 A failure here suggests potential issues such as: network policy restrictions,
 firewall rules, missing data plane nodes, or problems with infrastructure
-components like the konnectivity-agent workload.</p>
+components like the konnectivity-agent workload.
+<strong>Unknown</strong> means the status cannot be determined (e.g., no worker nodes available or unable to inspect).</p>
 </td>
 </tr><tr><td><p>&#34;EtcdAvailable&#34;</p></td>
 <td><p>EtcdAvailable bubbles up the same condition from HCP. It signals if etcd is available.

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -5000,6 +5000,18 @@ underlying cluster&rsquo;s ClusterVersion.</p>
 </tr><tr><td><p>&#34;RolloutComplete&#34;</p></td>
 <td><p>ControlPlaneComponentRolloutComplete indicates whether the ControlPlaneComponent has completed its rollout.</p>
 </td>
+</tr><tr><td><p>&#34;ControlPlaneConnectionAvailable&#34;</p></td>
+<td><p>ControlPlaneConnectionAvailable indicates whether data plane workloads have a successful
+network connection to the control plane components. This condition is computed using
+a 3-replica Deployment that tests the full data path (DNS resolution of kubernetes.default.svc
+-&gt; advertise address on lo -&gt; apiserver proxy -&gt; KAS on HCP) and reports results to a shared
+ConfigMap. The HCCO evaluates the staleness of the lastSucceeded timestamp in the ConfigMap.
+<strong>True</strong> means the data plane can successfully reach the control plane (a recent successful check was recorded).
+<strong>False</strong> means there are connectivity failures preventing the data plane from reaching the control plane,
+or the last successful check is stale (older than 5 minutes).
+<strong>Unknown</strong> means the status cannot be determined due to true inability to inspect (e.g., no worker nodes exist or inspection cannot be performed),
+not due to missing required components.</p>
+</td>
 </tr><tr><td><p>&#34;DataPlaneConnectionAvailable&#34;</p></td>
 <td><p>DataPlaneConnectionAvailable indicates whether the control plane has a successful
 network connection to the data plane components.
@@ -5007,7 +5019,8 @@ network connection to the data plane components.
 <strong>False</strong> means there are network connection issues preventing the control plane from reaching the data plane.
 A failure here suggests potential issues such as: network policy restrictions,
 firewall rules, missing data plane nodes, or problems with infrastructure
-components like the konnectivity-agent workload.</p>
+components like the konnectivity-agent workload.
+<strong>Unknown</strong> means the status cannot be determined (e.g., no worker nodes available or unable to inspect).</p>
 </td>
 </tr><tr><td><p>&#34;EtcdAvailable&#34;</p></td>
 <td><p>EtcdAvailable bubbles up the same condition from HCP. It signals if etcd is available.

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -829,6 +829,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 			hyperv1.ValidIDPConfiguration,
 			hyperv1.HostedClusterRestoredFromBackup,
 			hyperv1.DataPlaneConnectionAvailable,
+			hyperv1.ControlPlaneConnectionAvailable,
 		}
 
 		for _, conditionType := range hcpConditions {

--- a/support/conditions/conditions.go
+++ b/support/conditions/conditions.go
@@ -28,6 +28,7 @@ func ExpectedHCConditions(hostedCluster *hyperv1.HostedCluster) map[hyperv1.Cond
 		hyperv1.ValidReleaseImage:                    metav1.ConditionTrue,
 		hyperv1.PlatformCredentialsFound:             metav1.ConditionTrue,
 		hyperv1.DataPlaneConnectionAvailable:         metav1.ConditionTrue,
+		hyperv1.ControlPlaneConnectionAvailable:      metav1.ConditionTrue,
 
 		hyperv1.HostedClusterProgressing:  metav1.ConditionFalse,
 		hyperv1.HostedClusterDegraded:     metav1.ConditionFalse,

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -2961,6 +2961,7 @@ func ValidateHostedClusterConditions(t *testing.T, ctx context.Context, client c
 		expectedConditions[hyperv1.ClusterVersionProgressing] = metav1.ConditionTrue
 		delete(expectedConditions, hyperv1.ValidKubeVirtInfraNetworkMTU)
 		expectedConditions[hyperv1.DataPlaneConnectionAvailable] = metav1.ConditionUnknown
+		expectedConditions[hyperv1.ControlPlaneConnectionAvailable] = metav1.ConditionUnknown
 	}
 	if IsLessThan(Version415) {
 		// ValidKubeVirtInfraNetworkMTU condition is not present in versions < 4.15
@@ -2969,6 +2970,17 @@ func ValidateHostedClusterConditions(t *testing.T, ctx context.Context, client c
 
 	if IsLessThan(Version421) {
 		delete(expectedConditions, hyperv1.DataPlaneConnectionAvailable)
+	}
+
+	if IsLessThan(Version422) {
+		delete(expectedConditions, hyperv1.ControlPlaneConnectionAvailable)
+	}
+
+	// TODO: TEMPORARY - Remove this once ControlPlaneConnectionAvailable condition is merged and stable.
+	// Exclude ControlPlaneConnectionAvailable during upgrade tests as the condition
+	// may not be present in all builds during the upgrade window.
+	if strings.Contains(t.Name(), "Upgrade") {
+		delete(expectedConditions, hyperv1.ControlPlaneConnectionAvailable)
 	}
 
 	var predicates []Predicate[*hyperv1.HostedCluster]

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -218,7 +218,20 @@ const (
 	// A failure here suggests potential issues such as: network policy restrictions,
 	// firewall rules, missing data plane nodes, or problems with infrastructure
 	// components like the konnectivity-agent workload.
+	// **Unknown** means the status cannot be determined (e.g., no worker nodes available or unable to inspect).
 	DataPlaneConnectionAvailable ConditionType = "DataPlaneConnectionAvailable"
+
+	// ControlPlaneConnectionAvailable indicates whether data plane workloads have a successful
+	// network connection to the control plane components. This condition is computed using
+	// a 3-replica Deployment that tests the full data path (DNS resolution of kubernetes.default.svc
+	// -> advertise address on lo -> apiserver proxy -> KAS on HCP) and reports results to a shared
+	// ConfigMap. The HCCO evaluates the staleness of the lastSucceeded timestamp in the ConfigMap.
+	// **True** means the data plane can successfully reach the control plane (a recent successful check was recorded).
+	// **False** means there are connectivity failures preventing the data plane from reaching the control plane,
+	// or the last successful check is stale (older than 5 minutes).
+	// **Unknown** means the status cannot be determined due to true inability to inspect (e.g., no worker nodes exist or inspection cannot be performed),
+	// not due to missing required components.
+	ControlPlaneConnectionAvailable ConditionType = "ControlPlaneConnectionAvailable"
 )
 
 // Reasons.
@@ -284,6 +297,14 @@ const (
 	DataPlaneConnectionLogsAccessFailedReason = "LogsAccessFailed"
 
 	DataPlaneConnectionNoWorkerNodesAvailableReason = "NoWorkerNodesAvailable"
+
+	ControlPlaneConnectionKASAccessFailedReason = "KASAccessFailed"
+
+	ControlPlaneConnectionCheckStaleReason = "ConnectionCheckStale"
+
+	ControlPlaneConnectionConfigMapNotFoundReason = "ConfigMapNotFound"
+
+	ControlPlaneConnectionNoWorkerNodesAvailableReason = "NoWorkerNodesAvailable"
 
 	ControlPlaneComponentsNotAvailable = "ComponentsNotAvailable"
 )


### PR DESCRIPTION
## What this PR does / why we need it:

Reintroduces the `ControlPlaneConnectionAvailable` condition that was originally merged in #7489 and subsequently reverted in #7734 due to failing aggregated hypershift conformance tests ([TRT-2554](https://issues.redhat.com/browse/TRT-2554)).

The condition detects data-plane-to-control-plane connectivity problems by deploying a 3-replica `kas-connection-checker` Deployment in `kube-system`. Each pod tests the full data path (DNS resolution of `kubernetes.default.svc` → advertise address on lo → apiserver proxy → KAS on HCP) and writes a `lastSucceeded` timestamp to a shared ConfigMap. The HCCO evaluates the staleness of that timestamp to determine the condition status (stale threshold: 5 minutes).

### Root cause of the conformance failure

The original implementation used a DaemonSet with a catch-all toleration (`{Operator: Exists}`), which bypasses the `NodeUnschedulable` scheduler filter. This caused replacement pods to be scheduled back onto cordoned nodes during drain, creating an infinite eviction loop that blocked node rollouts and failed conformance tests.

### Fixes applied in this PR

1. **Replaced the DaemonSet with a 3-replica Deployment** to decouple from per-node scheduling. Pods use `PriorityClassName: system-node-critical` and resource requests (5m CPU, 10Mi memory) for proper scheduling.
2. **Replaced catch-all toleration with specific tolerations** — tolerate all `NoSchedule` taints (so pods can land on tainted nodes) plus explicit `NoExecute` tolerations for `node.kubernetes.io/unreachable` and `node.kubernetes.io/not-ready` (so pods stay running for connectivity checks on unhealthy nodes).
3. **Added `tolerationSeconds: 120` to the `NoExecute` tolerations** so pods are evicted from unhealthy nodes after 2 minutes, satisfying the conformance test "control plane operators do not make themselves unevictable".

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/CNTRLPLANE-2203
Reverts the revert https://github.com/openshift/hypershift/pull/7734
Re-applies https://github.com/openshift/hypershift/pull/7489

## Special notes for your reviewer:

Per the [revert PR](https://github.com/openshift/hypershift/pull/7734) instructions, please run:
```
/payload-job periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-aws-ovn-conformance
```
to confirm the conformance test passes before merging.

The upgrade e2e test temporarily excludes `ControlPlaneConnectionAvailable` since we may upgrade from a version that does not have this condition.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.
- [x] This change includes unit tests.