### PR TITLE
OCPBUGS-77034: fix(ho): add nil guard for Platform.AWS in metrics collector

### DIFF
--- a/cmd/infra/aws/util/sts_test.go
+++ b/cmd/infra/aws/util/sts_test.go
@@ -319,10 +319,12 @@ func TestParseSTSCredentialsFileV2_RealWorldFormat(t *testing.T) {
 	creds, err := ParseSTSCredentialsFileV2(tmpFile.Name())
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
+		return
 	}
 
 	if creds == nil {
 		t.Fatal("Expected non-nil credentials")
+		return
 	}
 
 	expectedAccessKey := "ASIAIOSFODNN7EXAMPLE"

--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
@@ -489,7 +489,7 @@ func (c *hostedClustersMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 			// clusterSizeOverrideMetric
 			{
 				metricLabels := make(map[string]string, 0)
-				if hcluster.Spec.Platform.Type == hyperv1.AWSPlatform && hcluster.Spec.Platform.AWS.ResourceTags != nil {
+				if hcluster.Spec.Platform.Type == hyperv1.AWSPlatform && hcluster.Spec.Platform.AWS != nil && hcluster.Spec.Platform.AWS.ResourceTags != nil {
 					for _, resourceTag := range hcluster.Spec.Platform.AWS.ResourceTags {
 						switch resourceTag.Key {
 						case "api.openshift.com/environment":


### PR DESCRIPTION
## What this PR does / why we need it:
- Prevent nil pointer dereference when collecting cluster size override metrics on non-AWS hosted clusters.

## Which issue(s) this PR fixes:

Fixes OCPBUGS-77034

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.