### PR TITLE
NO-JIRA: Skip ./dev directory in codespell checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -382,7 +382,7 @@ run-operator-locally-aws-dev:
 
 .PHONY: verify-codespell
 verify-codespell: codespell ## Verify codespell.
-	@$(CODESPELL) --count --ignore-words=./.codespellignore --skip="./hack/tools/bin/codespell_dist,./docs/site/*,./vendor/*,./api/vendor/*,./hack/tools/vendor/*,./api/hypershift/v1alpha1/*,./support/thirdparty/*,./docs/content/reference/*,./hack/tools/bin/*,./cmd/install/assets/*,./go.sum,./hack/workspace/go.work.sum,./api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests,./hack/tools/go.mod,./hack/tools/go.sum,./karpenter-operator/controllers/karpenter/assets/*.yaml"
+	@$(CODESPELL) --count --ignore-words=./.codespellignore --skip="./hack/tools/bin/codespell_dist,./docs/site/*,./vendor/*,./api/vendor/*,./hack/tools/vendor/*,./api/hypershift/v1alpha1/*,./support/thirdparty/*,./docs/content/reference/*,./hack/tools/bin/*,./cmd/install/assets/*,./go.sum,./hack/workspace/go.work.sum,./api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests,./hack/tools/go.mod,./hack/tools/go.sum,./karpenter-operator/controllers/karpenter/assets/*.yaml,./dev/*"
 
 .PHONY: run-gitlint
 run-gitlint: $(GITLINT)


### PR DESCRIPTION
## Summary
- Add `./dev/*` to the codespell skip list in the Makefile
- The `dev/` directory contains local development files that are not part of the repository and cause false positives when running `make verify` locally

## Test plan
- [ ] Run `make verify-codespell` locally with a `dev/` directory present and confirm it no longer fails on files in that directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development build configuration to expand the code quality tool's ignored paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->