### PR TITLE
GCP-386: scope externaldns RBAC to GCP platform only

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -1031,18 +1031,6 @@ func (o ExternalDNSClusterRole) Build() *rbacv1.ClusterRole {
 				},
 				Verbs: []string{"get", "list", "watch"},
 			},
-			// GCP-386: Allow external-dns to read/update DNSEndpoint resources for ingress zone delegation
-			// Matches: https://github.com/openshift/external-dns/blob/master/charts/external-dns/templates/clusterrole.yaml
-			{
-				APIGroups: []string{"externaldns.k8s.io"},
-				Resources: []string{"dnsendpoints"},
-				Verbs:     []string{"get", "watch", "list"},
-			},
-			{
-				APIGroups: []string{"externaldns.k8s.io"},
-				Resources: []string{"dnsendpoints/status"},
-				Verbs:     []string{rbacv1.VerbAll},
-			},
 		},
 	}
 	return role

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -37,6 +37,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -964,6 +965,21 @@ func setupExternalDNS(opts Options, operatorNamespace *corev1.Namespace) ([]crcl
 	objects = append(objects, externalDNSServiceAccount)
 
 	externalDNSClusterRole := assets.ExternalDNSClusterRole{}.Build()
+	if opts.ExternalDNSProvider == "google" {
+		// GCP-386: Allow external-dns to read/update DNSEndpoint resources for ingress zone delegation
+		externalDNSClusterRole.Rules = append(externalDNSClusterRole.Rules,
+			rbacv1.PolicyRule{
+				APIGroups: []string{"externaldns.k8s.io"},
+				Resources: []string{"dnsendpoints"},
+				Verbs:     []string{"get", "watch", "list"},
+			},
+			rbacv1.PolicyRule{
+				APIGroups: []string{"externaldns.k8s.io"},
+				Resources: []string{"dnsendpoints/status"},
+				Verbs:     []string{rbacv1.VerbAll},
+			},
+		)
+	}
 	objects = append(objects, externalDNSClusterRole)
 
 	externalDNSClusterRoleBinding := assets.ExternalDNSClusterRoleBinding{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/control-plane-operator/role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/control-plane-operator/role.yaml
@@ -57,15 +57,6 @@ rules:
   verbs:
   - '*'
 - apiGroups:
-  - externaldns.k8s.io
-  resources:
-  - dnsendpoints
-  verbs:
-  - create
-  - get
-  - update
-  - delete
-- apiGroups:
   - ""
   resources:
   - events

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/controlplaneoperator/role.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/controlplaneoperator/role.go
@@ -3,6 +3,7 @@ package controlplaneoperator
 import (
 	"os"
 
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/awsutil"
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/config"
@@ -27,6 +28,14 @@ func adaptRole(cpContext component.WorkloadContext, role *rbacv1.Role) error {
 			APIGroups: []string{"metrics.k8s.io"},
 			Resources: []string{"pods"},
 			Verbs:     []string{"get"},
+		})
+	}
+
+	if cpContext.HCP.Spec.Platform.Type == hyperv1.GCPPlatform {
+		role.Rules = append(role.Rules, rbacv1.PolicyRule{
+			APIGroups: []string{"externaldns.k8s.io"},
+			Resources: []string{"dnsendpoints"},
+			Verbs:     []string{"create", "get", "update", "delete"},
 		})
 	}
 


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

PR #7702 added externaldns.k8s.io/dnsendpoints permissions unconditionally to the CPO role. On non-GCP platforms, the HO does not hold these permissions, causing RBAC escalation errors during reconciliation.

Move the externaldns rule from the static role.yaml to the adaptRole function in role.go, gated on GCPPlatform, consistent with how ARO HCP and ROSA HCP conditional rules are handled.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
[GCP-386](https://issues.redhat.com/browse/GCP-386)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened ExternalDNS RBAC by removing general DNSEndpoints permissions.
  * Restored limited DNSEndpoints permissions only when ExternalDNS is configured for Google/GCP.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->