### PR TITLE
NO-JIRA: chore: add powervs-reviewers to OWNERS_ALIASES and OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -43,6 +43,8 @@ filters:
     labels:
     - area/platform/openstack
   "^(api|cmd|control-plane-operator|docs|hypershift-operator|product-cli|test)/.*powervs.*":
+    reviewers:
+    - powervs-reviewers
     labels:
     - area/platform/powervs
   "^test/integration/.*":

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -61,6 +61,11 @@ aliases:
     - cristianoveiga
     - jimdaga
     - patjlm
+  powervs-reviewers:
+    - alishaIBM
+    - bkhadars
+    - mkumatag
+    - prb112
   openstack-approvers:
     - mandre
     - stephenfin


### PR DESCRIPTION
## What this PR does / why we need it:

Adds a `powervs-reviewers` alias to `OWNERS_ALIASES` with the PowerVS team members
(`alishaIBM`, `bkhadars`, `mkumatag`, `prb112`) and references it in the root `OWNERS`
file so they are automatically requested for review on PowerVS-related changes.

This brings PowerVS in line with how other platforms (GCP, KubeVirt, OpenStack) configure
their reviewers.

## Which issue(s) this PR fixes:

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [x] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This pull request contains internal administrative updates to code review configuration and does not introduce any user-facing changes or new functionality. No end-user impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->