### PR TITLE
OCPBUGS-76452: update OAuth certificate configuration doc

### DIFF
--- a/docs/content/how-to/configure-ocp-components/oauth-serving-certificates.md
+++ b/docs/content/how-to/configure-ocp-components/oauth-serving-certificates.md
@@ -158,7 +158,7 @@ spec:
 `spec.configuration.apiServer.servingCerts.namedCertificates`
 must exist in the HostedCluster namespace. Creating the secret in the hosted control plane namespace will not apply the certificate.
 
-Save and apply the changes. The Hosted Cluster Operator will reconcile the changes. The configuration will propagate to the control plane, and the OAuth server will begin serving the new certificate.
+Save and apply the changes. The Control Plane Operator will reconcile the changes. The configuration will propagate to the control plane, and the OAuth server will begin serving the new certificate.
 
 There is no separate OAuth certificate configuration field in a HostedCluster.
 
@@ -182,6 +182,6 @@ X509v3 Subject Alternative Name:
 ```
 
 This proves:
-* The OAuth route is serving
-* The cert comes from your `my-oauth-cert-secret` secret
-* The change is externally observable
+- The OAuth route is serving the custom certificate
+- The cert comes from your `my-oauth-cert-secret` secret
+- The change is externally observable

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -11713,7 +11713,7 @@ spec:
 `spec.configuration.apiServer.servingCerts.namedCertificates`
 must exist in the HostedCluster namespace. Creating the secret in the hosted control plane namespace will not apply the certificate.
 
-Save and apply the changes. The Hosted Cluster Operator will reconcile the changes. The configuration will propagate to the control plane, and the OAuth server will begin serving the new certificate.
+Save and apply the changes. The Control Plane Operator will reconcile the changes. The configuration will propagate to the control plane, and the OAuth server will begin serving the new certificate.
 
 There is no separate OAuth certificate configuration field in a HostedCluster.
 
@@ -11737,9 +11737,9 @@ X509v3 Subject Alternative Name:
 ```
 
 This proves:
-* The OAuth route is serving
-* The cert comes from your `my-oauth-cert-secret` secret
-* The change is externally observable
+- The OAuth route is serving the custom certificate
+- The cert comes from your `my-oauth-cert-secret` secret
+- The change is externally observable
 
 
 ---


### PR DESCRIPTION
This updates some information in OAuth certificate configuration documentation.

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

OAuth certificate configuration doc: https://github.com/openshift/hypershift/pull/7351 is merged, but still has some need to update, like comments: https://github.com/openshift/hypershift/pull/7351#discussion_r2766891304 and https://github.com/openshift/hypershift/pull/7351#discussion_r2766895159


## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://issues.redhat.com/browse/OCPBUGS-76452

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * OAuth certificate guide updated to reference the correct control plane component for reconciliation and to clarify verification steps for serving a custom OAuth certificate.
  * Architecture docs and diagrams revised for consistent naming and clearer control-flow: improved diagrams and descriptions show component responsibilities, lifecycle phases (create/reconcile/delete), and interactions for control plane and hosted cluster management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->