### PR TITLE
OCPBUGS-77224: fix(routing): add Azure platform to LabelHCPRoutes() switch

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/infra/infra_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/infra_test.go
@@ -414,6 +414,30 @@ func TestReconcileInfrastructure(t *testing.T) {
 				NeedExternalRouter:    false,
 			},
 		},
+		// Azure self-managed test cases
+		{
+			name: "When Azure self-managed cluster has KAS Route with hostname, it should need an external router",
+			hcp: withServices(
+				baseAzureHCP(),
+				allServicesRouteWithHostnames(),
+			),
+			expectError: false,
+			// For Azure self-managed with Route:
+			// - LabelHCPRoutes returns true (KAS uses Route with hostname)
+			// - External router is needed to admit labeled routes
+			expectedStatus: &InfrastructureStatus{
+				APIHost:               testKASHostname,
+				APIPort:               443,
+				OAuthEnabled:          true,
+				OAuthHost:             testOAuthHostname,
+				OAuthPort:             443,
+				KonnectivityHost:      testKonnectivityHost,
+				KonnectivityPort:      443,
+				NeedInternalRouter:    false,
+				NeedExternalRouter:    true,
+				ExternalHCPRouterHost: testRouterLBHostname,
+			},
+		},
 		// ARO HCP test cases - use shared ingress
 		{
 			name: "ARO_Route_SharedIngress",

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_When_Azure_self_managed_cluster_has_KAS_Route_with_hostname__it_should_need_an_external_router.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_When_Azure_self_managed_cluster_has_KAS_Route_with_hostname__it_should_need_an_external_router.yaml
@@ -1,0 +1,256 @@
+routes:
+  items:
+  - metadata:
+      annotations:
+        haproxy.router.openshift.io/balance: roundrobin
+      labels:
+        hypershift.openshift.io/hosted-control-plane: test-namespace
+      name: konnectivity-server
+      namespace: test-namespace
+      ownerReferences:
+      - apiVersion: hypershift.openshift.io/v1beta1
+        blockOwnerDeletion: true
+        controller: true
+        kind: HostedControlPlane
+        name: test-cluster
+        uid: ""
+    spec:
+      host: konnectivity.test.example.com
+      tls:
+        insecureEdgeTerminationPolicy: None
+        termination: passthrough
+      to:
+        kind: Service
+        name: konnectivity-server
+        weight: null
+    status: {}
+  - metadata:
+      labels:
+        hypershift.openshift.io/hosted-control-plane: test-namespace
+      name: kube-apiserver
+      namespace: test-namespace
+      ownerReferences:
+      - apiVersion: hypershift.openshift.io/v1beta1
+        blockOwnerDeletion: true
+        controller: true
+        kind: HostedControlPlane
+        name: test-cluster
+        uid: ""
+    spec:
+      host: api.test.example.com
+      tls:
+        insecureEdgeTerminationPolicy: None
+        termination: passthrough
+      to:
+        kind: Service
+        name: kube-apiserver
+        weight: null
+    status: {}
+  - metadata:
+      labels:
+        hypershift.openshift.io/hosted-control-plane: test-namespace
+        hypershift.openshift.io/internal-route: "true"
+      name: kube-apiserver-internal
+      namespace: test-namespace
+      ownerReferences:
+      - apiVersion: hypershift.openshift.io/v1beta1
+        blockOwnerDeletion: true
+        controller: true
+        kind: HostedControlPlane
+        name: test-cluster
+        uid: ""
+    spec:
+      host: api.test-cluster.hypershift.local
+      tls:
+        insecureEdgeTerminationPolicy: None
+        termination: passthrough
+      to:
+        kind: Service
+        name: kube-apiserver
+        weight: null
+    status: {}
+  - metadata:
+      labels:
+        hypershift.openshift.io/hosted-control-plane: test-namespace
+      name: oauth
+      namespace: test-namespace
+      ownerReferences:
+      - apiVersion: hypershift.openshift.io/v1beta1
+        blockOwnerDeletion: true
+        controller: true
+        kind: HostedControlPlane
+        name: test-cluster
+        uid: ""
+    spec:
+      host: oauth.test.example.com
+      tls:
+        insecureEdgeTerminationPolicy: None
+        termination: passthrough
+      to:
+        kind: Service
+        name: oauth-openshift
+        weight: null
+    status: {}
+  metadata: {}
+services:
+  items:
+  - metadata:
+      name: konnectivity-server
+      namespace: test-namespace
+      ownerReferences:
+      - apiVersion: hypershift.openshift.io/v1beta1
+        blockOwnerDeletion: true
+        controller: true
+        kind: HostedControlPlane
+        name: test-cluster
+        uid: ""
+    spec:
+      ports:
+      - port: 8091
+        protocol: TCP
+        targetPort: 8091
+      selector:
+        app: kube-apiserver
+        hypershift.openshift.io/control-plane-component: kube-apiserver
+      type: ClusterIP
+    status:
+      loadBalancer: {}
+  - metadata:
+      labels:
+        app: kube-apiserver
+        hypershift.openshift.io/control-plane-component: kube-apiserver
+      name: kube-apiserver
+      namespace: test-namespace
+      ownerReferences:
+      - apiVersion: hypershift.openshift.io/v1beta1
+        blockOwnerDeletion: true
+        controller: true
+        kind: HostedControlPlane
+        name: test-cluster
+        uid: ""
+    spec:
+      ipFamilyPolicy: PreferDualStack
+      ports:
+      - port: 6443
+        protocol: TCP
+        targetPort: client
+      selector:
+        app: kube-apiserver
+        hypershift.openshift.io/control-plane-component: kube-apiserver
+      type: ClusterIP
+    status:
+      loadBalancer: {}
+  - metadata:
+      name: oauth-openshift
+      namespace: test-namespace
+      ownerReferences:
+      - apiVersion: hypershift.openshift.io/v1beta1
+        blockOwnerDeletion: true
+        controller: true
+        kind: HostedControlPlane
+        name: test-cluster
+        uid: ""
+    spec:
+      ipFamilyPolicy: PreferDualStack
+      ports:
+      - port: 6443
+        protocol: TCP
+        targetPort: 6443
+      selector:
+        app: oauth-openshift
+        hypershift.openshift.io/control-plane-component: oauth-openshift
+      type: ClusterIP
+    status:
+      loadBalancer: {}
+  - metadata:
+      labels:
+        app: openshift-apiserver
+        hypershift.openshift.io/control-plane-component: openshift-apiserver
+      name: openshift-apiserver
+      namespace: test-namespace
+      ownerReferences:
+      - apiVersion: hypershift.openshift.io/v1beta1
+        blockOwnerDeletion: true
+        controller: true
+        kind: HostedControlPlane
+        name: test-cluster
+        uid: ""
+    spec:
+      ports:
+      - name: https
+        port: 443
+        protocol: TCP
+        targetPort: 8443
+      selector:
+        app: openshift-apiserver
+        hypershift.openshift.io/control-plane-component: openshift-apiserver
+      type: ClusterIP
+    status:
+      loadBalancer: {}
+  - metadata:
+      labels:
+        app: openshift-apiserver
+        hypershift.openshift.io/control-plane-component: openshift-apiserver
+      name: openshift-oauth-apiserver
+      namespace: test-namespace
+      ownerReferences:
+      - apiVersion: hypershift.openshift.io/v1beta1
+        blockOwnerDeletion: true
+        controller: true
+        kind: HostedControlPlane
+        name: test-cluster
+        uid: ""
+    spec:
+      ports:
+      - name: https
+        port: 443
+        protocol: TCP
+        targetPort: 8443
+      selector:
+        app: openshift-oauth-apiserver
+        hypershift.openshift.io/control-plane-component: openshift-oauth-apiserver
+      type: ClusterIP
+    status:
+      loadBalancer: {}
+  - metadata:
+      labels:
+        app: openshift-apiserver
+        hypershift.openshift.io/control-plane-component: openshift-apiserver
+      name: packageserver
+      namespace: test-namespace
+      ownerReferences:
+      - apiVersion: hypershift.openshift.io/v1beta1
+        blockOwnerDeletion: true
+        controller: true
+        kind: HostedControlPlane
+        name: test-cluster
+        uid: ""
+    spec:
+      ports:
+      - name: https
+        port: 443
+        protocol: TCP
+        targetPort: 5443
+      selector:
+        app: packageserver
+        hypershift.openshift.io/control-plane-component: packageserver
+      type: ClusterIP
+    status:
+      loadBalancer: {}
+  - metadata:
+      labels:
+        app: private-router
+      name: router
+      namespace: test-namespace
+    spec:
+      ports:
+      - name: https
+        port: 443
+        protocol: TCP
+        targetPort: https
+      selector:
+        app: private-router
+      type: LoadBalancer
+    status:
+      loadBalancer: {}
+  metadata: {}

--- a/support/util/visibility.go
+++ b/support/util/visibility.go
@@ -148,7 +148,7 @@ func LabelHCPRoutes(hcp *hyperv1.HostedControlPlane) bool {
 		// This avoids creating an unnecessary public LoadBalancer service.
 		return !IsPublicHCP(hcp) || UseDedicatedDNSForKAS(hcp)
 
-	case hyperv1.AgentPlatform, hyperv1.KubevirtPlatform, hyperv1.OpenStackPlatform, hyperv1.NonePlatform:
+	case hyperv1.AzurePlatform, hyperv1.AgentPlatform, hyperv1.KubevirtPlatform, hyperv1.OpenStackPlatform, hyperv1.NonePlatform:
 		// These platforms do not have endpoint access mode concepts (no Private/PublicAndPrivate).
 		// Label routes for HCP router ONLY when KAS explicitly uses Route with a hostname.
 		//

--- a/support/util/visibility_test.go
+++ b/support/util/visibility_test.go
@@ -419,6 +419,49 @@ func TestLabelHCPRoutes(t *testing.T) {
 			want: true,
 		},
 
+		// Azure Platform Tests (Self-Managed)
+		{
+			name: "When Azure self-managed cluster has KAS Route with hostname, it should label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+								Route: &hyperv1.RoutePublishingStrategy{
+									Hostname: "api.azure.example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "When Azure self-managed cluster has KAS Route but no hostname, it should not label routes for HCP router",
+			hcp: &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.Route,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+
 		// Agent Platform Tests (Bare Metal) - Critical for OCPBUGS-70152
 		{
 			name: "When Agent cluster has KAS LoadBalancer, it should not label routes for HCP router",


### PR DESCRIPTION
## What this PR does / why we need it:

PR #7605 replaced `IsPublicWithDNS()` with `LabelHCPRoutes()` as the single source of truth for route labeling decisions, but omitted `hyperv1.AzurePlatform` from the switch statement. Azure fell through to `default: return false`, which prevented HCP router infrastructure from being created for self-managed Azure clusters using KAS Route.

Meanwhile, `kas/service.go:reconcileExternalRoute()` unconditionally labels the kube-apiserver route with `hypershift.openshift.io/hosted-control-plane`. The default IngressController's `routeSelector` excludes routes with that label. With no HCP router created and the default IngressController rejecting the route, the kube-apiserver route was never admitted, ExternalDNS had no target, and the cluster could not progress.

This PR adds `hyperv1.AzurePlatform` to the same case as Agent, KubeVirt, OpenStack, and None platforms in `LabelHCPRoutes()`, which returns `UseDedicatedDNSForKAS(hcp)`. This ensures the HCP router is created when KAS uses Route with a hostname on Azure.

**Empirical evidence from a live cluster confirmed the fix resolves the issue.**

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/OCPBUGS-77224

## Special notes for your reviewer:

This is a one-line fix. The regression was introduced by PR #7605 (`csrwng/fix_unnecessary_router`, OCPBUGS-70152) which added `LabelHCPRoutes()` but did not include a case for `AzurePlatform`.

Before PR #7605, `IsPublicWithDNS()` was platform-agnostic — it checked if any service had dedicated DNS regardless of platform, so Azure worked. After PR #7605, Azure falls through to the `default` case which returns `false`.

Evidence from the live cluster:

| Route | HCP Label | Admitted | DNS Record |
|-------|-----------|----------|------------|
| oauth | No | Yes | Yes |
| konnectivity | No | Yes | Yes |
| kube-apiserver | Yes (always) | No | No |

After applying the fix and redeploying the CPO, the HCP router was created, the kube-apiserver route was admitted, and the cluster began progressing.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Azure platform now follows the same routing and DNS behaviour as other supported clouds, ensuring consistent control-plane routing and hostname handling.

* **Tests**
  * Added tests and test fixtures covering Azure self-managed route scenarios (with and without KAS hostnames), verifying labeling, external-router requirements, and status reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->