### PR TITLE
AUTOSCALE-559: PrivateLink plumbing for karpenter ec2nodeclass subnets 

### DIFF
--- a/hypershift-operator/controllers/platform/aws/controller.go
+++ b/hypershift-operator/controllers/platform/aws/controller.go
@@ -2,9 +2,9 @@ package aws
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -12,6 +12,7 @@ import (
 	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/awsapi"
+	karpenterutil "github.com/openshift/hypershift/support/karpenter"
 	"github.com/openshift/hypershift/support/upsert"
 	supportutil "github.com/openshift/hypershift/support/util"
 
@@ -25,6 +26,7 @@ import (
 	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"github.com/aws/smithy-go"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -34,11 +36,13 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/go-logr/logr"
@@ -97,6 +101,16 @@ func (r *AWSEndpointServiceReconciler) SetupWithManager(mgr ctrl.Manager) error 
 			DeleteFunc: r.enqueueOnNodePoolDelete(mgr),
 		}).
 		Watches(&hyperv1.HostedCluster{}, handler.Funcs{UpdateFunc: r.enqueueOnHostedClusterChange(mgr)}).
+		// We can't filter this to just our configmaps at the cache level because there are
+		// other things (e.g. nodepool reconciler) that are registered with this same manager
+		// and share the infrastructure, but what we can do is limit the events with a predicate
+		Watches(&corev1.ConfigMap{}, handler.Funcs{
+			CreateFunc: r.enqueueOnKarpenterConfigMapCreate(mgr),
+			UpdateFunc: r.enqueueOnKarpenterConfigMapChange(mgr),
+		}, builder.WithPredicates(predicate.NewPredicateFuncs(func(o client.Object) bool {
+			return o.GetName() == karpenterutil.KarpenterSubnetsConfigMapName &&
+				o.GetLabels()["hypershift.openshift.io/managed-by"] == "karpenter"
+		}))).
 		WithOptions(controller.Options{
 			RateLimiter:             workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](3*time.Second, 30*time.Second),
 			MaxConcurrentReconciles: 10,
@@ -188,6 +202,56 @@ func (r *AWSEndpointServiceReconciler) enqueueOnHostedClusterChange(mgr ctrl.Man
 		if newHC.Spec.Platform.AWS != nil && oldHC.Spec.Platform.AWS != nil &&
 			!equality.Semantic.DeepEqual(newHC.Spec.Platform.AWS.AdditionalAllowedPrincipals, oldHC.Spec.Platform.AWS.AdditionalAllowedPrincipals) {
 			for _, req := range awsEndpointServicesByName(fmt.Sprintf("%s-%s", newHC.Namespace, newHC.Name)) {
+				q.Add(req)
+			}
+		}
+	}
+}
+
+func (r *AWSEndpointServiceReconciler) enqueueOnKarpenterConfigMapCreate(mgr ctrl.Manager) func(context.Context, event.CreateEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	return func(ctx context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+		logger := mgr.GetLogger()
+		cm, isOk := e.Object.(*corev1.ConfigMap)
+		if !isOk {
+			logger.Info("WARNING: enqueueOnKarpenterConfigMapCreate: resource is not of type ConfigMap")
+			return
+		}
+		// Only enqueue for the karpenter-managed subnet ConfigMap
+		if cm.Name != karpenterutil.KarpenterSubnetsConfigMapName ||
+			cm.GetLabels()["hypershift.openshift.io/managed-by"] != "karpenter" {
+			return
+		}
+		for _, req := range awsEndpointServicesByName(cm.Namespace) {
+			q.Add(req)
+		}
+	}
+}
+
+func (r *AWSEndpointServiceReconciler) enqueueOnKarpenterConfigMapChange(mgr ctrl.Manager) func(context.Context, event.UpdateEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	return func(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+		logger := mgr.GetLogger()
+		newCM, isOk := e.ObjectNew.(*corev1.ConfigMap)
+		if !isOk {
+			logger.Info("WARNING: enqueueOnKarpenterConfigMapChange: new resource is not of type ConfigMap")
+			return
+		}
+		oldCM, isOk := e.ObjectOld.(*corev1.ConfigMap)
+		if !isOk {
+			logger.Info("WARNING: enqueueOnKarpenterConfigMapChange: old resource is not of type ConfigMap")
+			return
+		}
+
+		// Only enqueue for the karpenter-managed subnet ConfigMap
+		if newCM.Name != karpenterutil.KarpenterSubnetsConfigMapName ||
+			newCM.GetLabels()["hypershift.openshift.io/managed-by"] != "karpenter" {
+			return
+		}
+
+		// Only enqueue if subnet IDs actually changed
+		oldSubnets := oldCM.Data["subnetIDs"]
+		newSubnets := newCM.Data["subnetIDs"]
+		if oldSubnets != newSubnets {
+			for _, req := range awsEndpointServicesByName(newCM.Namespace) {
 				q.Add(req)
 			}
 		}
@@ -322,7 +386,7 @@ func reconcileAWSEndpointService(ctx context.Context, c client.Client, awsEndpoi
 }
 
 func reconcileAWSEndpointServiceSubnetIDs(ctx context.Context, c client.Client, awsEndpointService *hyperv1.AWSEndpointService, hc *hyperv1.HostedCluster) error {
-	subnetIDs, err := listSubnetIDs(ctx, c, hc.Name, hc.Namespace)
+	subnetIDs, err := listSubnetIDs(ctx, c, hc.Name, hc.Namespace, awsEndpointService.Namespace)
 	if err != nil {
 		return fmt.Errorf("failed to list subnetIDs: %w", err)
 	}
@@ -344,19 +408,56 @@ func listNodePools(ctx context.Context, c client.Client, nodePoolNamespace strin
 	return filtered, nil
 }
 
-func listSubnetIDs(ctx context.Context, c client.Client, clusterName, nodePoolNamespace string) ([]string, error) {
+func listSubnetIDs(ctx context.Context, c client.Client, clusterName, nodePoolNamespace, hcpNamespace string) ([]string, error) {
+	// Get subnets from NodePools
 	nodePools, err := listNodePools(ctx, c, nodePoolNamespace, clusterName)
 	if err != nil {
 		return nil, err
 	}
-	subnetIDs := []string{}
+	subnetIDSet := sets.NewString()
 	for _, nodePool := range nodePools {
 		if nodePool.Spec.Platform.AWS != nil &&
 			nodePool.Spec.Platform.AWS.Subnet.ID != nil {
-			subnetIDs = append(subnetIDs, *nodePool.Spec.Platform.AWS.Subnet.ID)
+			subnetIDSet.Insert(*nodePool.Spec.Platform.AWS.Subnet.ID)
 		}
 	}
-	sort.Strings(subnetIDs)
+
+	// Get subnets from Karpenter ConfigMap
+	karpenterSubnets, err := listKarpenterSubnetIDs(ctx, c, hcpNamespace)
+	if err != nil {
+		// Log but don't fail - ConfigMap might not exist yet
+		ctrl.LoggerFrom(ctx).V(4).Info("Failed to get Karpenter subnets, continuing with NodePool subnets only", "error", err)
+	} else if len(karpenterSubnets) > 0 {
+		subnetIDSet.Insert(karpenterSubnets...)
+	}
+
+	subnetIDs := subnetIDSet.List()
+	return subnetIDs, nil
+}
+
+func listKarpenterSubnetIDs(ctx context.Context, c client.Client, namespace string) ([]string, error) {
+	configMap := &corev1.ConfigMap{}
+	err := c.Get(ctx, client.ObjectKey{
+		Namespace: namespace,
+		Name:      karpenterutil.KarpenterSubnetsConfigMapName,
+	}, configMap)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return []string{}, nil // Not an error
+		}
+		return nil, fmt.Errorf("failed to get karpenter subnets configmap: %w", err)
+	}
+
+	subnetIDsJSON := configMap.Data["subnetIDs"]
+	if subnetIDsJSON == "" {
+		return []string{}, nil
+	}
+
+	var subnetIDs []string
+	if err := json.Unmarshal([]byte(subnetIDsJSON), &subnetIDs); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal subnet IDs: %w", err)
+	}
+
 	return subnetIDs, nil
 }
 

--- a/hypershift-operator/controllers/platform/aws/controller_test.go
+++ b/hypershift-operator/controllers/platform/aws/controller_test.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	hyperapi "github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/awsapi"
+	karpenterutil "github.com/openshift/hypershift/support/karpenter"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -17,11 +20,18 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
 
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/testr"
 	"go.uber.org/mock/gomock"
 )
@@ -621,4 +631,350 @@ func Test_controlPlaneOperatorRoleARNWithoutPath(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestListKarpenterSubnetIDs(t *testing.T) {
+	testCases := []struct {
+		name            string
+		namespace       string
+		objects         []client.Object
+		expectedSubnets []string
+		expectError     bool
+	}{
+		{
+			name:            "When the ConfigMap is missing it should return empty list without error",
+			namespace:       "test-namespace",
+			objects:         []client.Object{},
+			expectedSubnets: []string{},
+		},
+		{
+			name:      "When a valid ConfigMap exists it should return parsed subnet IDs",
+			namespace: "test-namespace",
+			objects: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      karpenterutil.KarpenterSubnetsConfigMapName,
+						Namespace: "test-namespace",
+					},
+					Data: map[string]string{
+						"subnetIDs": `["subnet-aaa","subnet-bbb","subnet-ccc"]`,
+					},
+				},
+			},
+			expectedSubnets: []string{"subnet-aaa", "subnet-bbb", "subnet-ccc"},
+		},
+		{
+			name:      "When the ConfigMap exists with empty subnetIDs it should return empty list",
+			namespace: "test-namespace",
+			objects: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      karpenterutil.KarpenterSubnetsConfigMapName,
+						Namespace: "test-namespace",
+					},
+					Data: map[string]string{},
+				},
+			},
+			expectedSubnets: []string{},
+		},
+		{
+			name:      "When the ConfigMap contains malformed JSON it should return an error",
+			namespace: "test-namespace",
+			objects: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      karpenterutil.KarpenterSubnetsConfigMapName,
+						Namespace: "test-namespace",
+					},
+					Data: map[string]string{
+						"subnetIDs": `not-valid-json`,
+					},
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(hyperapi.Scheme).
+				WithObjects(tc.objects...).
+				Build()
+
+			subnets, err := listKarpenterSubnetIDs(t.Context(), fakeClient, tc.namespace)
+
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(subnets).To(Equal(tc.expectedSubnets))
+			}
+		})
+	}
+}
+
+func TestListSubnetIDs(t *testing.T) {
+	testCases := []struct {
+		name            string
+		clusterName     string
+		namespace       string
+		hcpNamespace    string
+		objects         []client.Object
+		expectedSubnets []string
+	}{
+		{
+			name:         "When a karpenter-subnets ConfigMap exists it should include subnets from both NodePools and the ConfigMap",
+			clusterName:  "my-cluster",
+			namespace:    "clusters",
+			hcpNamespace: "clusters-my-cluster",
+			objects: []client.Object{
+				&hyperv1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "nodepool-1",
+						Namespace: "clusters",
+					},
+					Spec: hyperv1.NodePoolSpec{
+						ClusterName: "my-cluster",
+						Platform: hyperv1.NodePoolPlatform{
+							AWS: &hyperv1.AWSNodePoolPlatform{
+								Subnet: hyperv1.AWSResourceReference{
+									ID: aws.String("subnet-nodepool"),
+								},
+							},
+						},
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      karpenterutil.KarpenterSubnetsConfigMapName,
+						Namespace: "clusters-my-cluster",
+					},
+					Data: map[string]string{
+						"subnetIDs": `["subnet-karpenter-a","subnet-karpenter-b"]`,
+					},
+				},
+			},
+			expectedSubnets: []string{"subnet-karpenter-a", "subnet-karpenter-b", "subnet-nodepool"},
+		},
+		{
+			name:         "When no karpenter-subnets ConfigMap exists it should return only NodePool subnets",
+			clusterName:  "my-cluster",
+			namespace:    "clusters",
+			hcpNamespace: "clusters-my-cluster",
+			objects: []client.Object{
+				&hyperv1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "nodepool-1",
+						Namespace: "clusters",
+					},
+					Spec: hyperv1.NodePoolSpec{
+						ClusterName: "my-cluster",
+						Platform: hyperv1.NodePoolPlatform{
+							AWS: &hyperv1.AWSNodePoolPlatform{
+								Subnet: hyperv1.AWSResourceReference{
+									ID: aws.String("subnet-nodepool"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedSubnets: []string{"subnet-nodepool"},
+		},
+		{
+			name:            "When there are no NodePools and no ConfigMap it should return an empty list",
+			clusterName:     "my-cluster",
+			namespace:       "clusters",
+			hcpNamespace:    "clusters-my-cluster",
+			objects:         []client.Object{},
+			expectedSubnets: []string{},
+		},
+		{
+			name:         "When NodePool and ConfigMap have overlapping subnets it should deduplicate",
+			clusterName:  "my-cluster",
+			namespace:    "clusters",
+			hcpNamespace: "clusters-my-cluster",
+			objects: []client.Object{
+				&hyperv1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "nodepool-1",
+						Namespace: "clusters",
+					},
+					Spec: hyperv1.NodePoolSpec{
+						ClusterName: "my-cluster",
+						Platform: hyperv1.NodePoolPlatform{
+							AWS: &hyperv1.AWSNodePoolPlatform{
+								Subnet: hyperv1.AWSResourceReference{
+									ID: aws.String("subnet-shared"),
+								},
+							},
+						},
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      karpenterutil.KarpenterSubnetsConfigMapName,
+						Namespace: "clusters-my-cluster",
+					},
+					Data: map[string]string{
+						"subnetIDs": `["subnet-shared","subnet-karpenter-only"]`,
+					},
+				},
+			},
+			expectedSubnets: []string{"subnet-karpenter-only", "subnet-shared"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(hyperapi.Scheme).
+				WithObjects(tc.objects...).
+				Build()
+
+			subnets, err := listSubnetIDs(t.Context(), fakeClient, tc.clusterName, tc.namespace, tc.hcpNamespace)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(subnets).To(Equal(tc.expectedSubnets))
+		})
+	}
+}
+
+// captureQueue is a simple workqueue that captures added items for test inspection.
+type captureQueue struct {
+	workqueue.TypedRateLimitingInterface[reconcile.Request]
+	added []reconcile.Request
+}
+
+func (q *captureQueue) Add(item reconcile.Request) {
+	q.added = append(q.added, item)
+}
+
+func TestEnqueueOnKarpenterConfigMapChange(t *testing.T) {
+	testCases := []struct {
+		name           string
+		oldCM          *corev1.ConfigMap
+		newCM          *corev1.ConfigMap
+		expectedQueued int
+	}{
+		{
+			name: "When a non-karpenter ConfigMap is updated it should not enqueue",
+			oldCM: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "some-other-configmap",
+					Namespace: "clusters-my-cluster",
+				},
+				Data: map[string]string{"subnetIDs": `["subnet-a"]`},
+			},
+			newCM: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "some-other-configmap",
+					Namespace: "clusters-my-cluster",
+				},
+				Data: map[string]string{"subnetIDs": `["subnet-a","subnet-b"]`},
+			},
+			expectedQueued: 0,
+		},
+		{
+			name: "When karpenter ConfigMap subnet data changes it should enqueue AWSEndpointServices",
+			oldCM: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      karpenterutil.KarpenterSubnetsConfigMapName,
+					Namespace: "clusters-my-cluster",
+					Labels: map[string]string{
+						"hypershift.openshift.io/managed-by": "karpenter",
+					},
+				},
+				Data: map[string]string{"subnetIDs": `["subnet-a"]`},
+			},
+			newCM: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      karpenterutil.KarpenterSubnetsConfigMapName,
+					Namespace: "clusters-my-cluster",
+					Labels: map[string]string{
+						"hypershift.openshift.io/managed-by": "karpenter",
+					},
+				},
+				Data: map[string]string{"subnetIDs": `["subnet-a","subnet-b"]`},
+			},
+			// awsEndpointServicesByName returns 3 entries for any given namespace
+			expectedQueued: 3,
+		},
+		{
+			name: "When karpenter ConfigMap subnet data is unchanged it should not enqueue",
+			oldCM: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      karpenterutil.KarpenterSubnetsConfigMapName,
+					Namespace: "clusters-my-cluster",
+					Labels: map[string]string{
+						"hypershift.openshift.io/managed-by": "karpenter",
+					},
+				},
+				Data: map[string]string{"subnetIDs": `["subnet-a","subnet-b"]`},
+			},
+			newCM: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      karpenterutil.KarpenterSubnetsConfigMapName,
+					Namespace: "clusters-my-cluster",
+					Labels: map[string]string{
+						"hypershift.openshift.io/managed-by": "karpenter",
+					},
+				},
+				Data: map[string]string{"subnetIDs": `["subnet-a","subnet-b"]`},
+			},
+			expectedQueued: 0,
+		},
+		{
+			name: "When a ConfigMap named karpenter-subnets lacks the managed-by label it should not enqueue",
+			oldCM: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      karpenterutil.KarpenterSubnetsConfigMapName,
+					Namespace: "clusters-my-cluster",
+				},
+				Data: map[string]string{"subnetIDs": `["subnet-a"]`},
+			},
+			newCM: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      karpenterutil.KarpenterSubnetsConfigMapName,
+					Namespace: "clusters-my-cluster",
+				},
+				Data: map[string]string{"subnetIDs": `["subnet-a","subnet-b"]`},
+			},
+			expectedQueued: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			mgr := &fakeManager{}
+
+			r := &AWSEndpointServiceReconciler{}
+			handler := r.enqueueOnKarpenterConfigMapChange(mgr)
+
+			q := &captureQueue{}
+			handler(t.Context(), event.UpdateEvent{
+				ObjectOld: tc.oldCM,
+				ObjectNew: tc.newCM,
+			}, q)
+
+			g.Expect(q.added).To(HaveLen(tc.expectedQueued))
+		})
+	}
+}
+
+// fakeManager implements just enough of ctrl.Manager for tests that need mgr.GetLogger().
+// All unimplemented methods are delegated to the embedded nil Manager, which will
+// panic if called — intentionally, as tests should never trigger those paths.
+type fakeManager struct {
+	ctrl.Manager
+}
+
+func (m *fakeManager) GetLogger() logr.Logger {
+	return logr.Discard()
 }

--- a/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller.go
+++ b/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller.go
@@ -2,6 +2,7 @@ package nodeclass
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -29,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
 
@@ -156,6 +158,12 @@ func (r *EC2NodeClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			return ctrl.Result{RequeueAfter: time.Second * 5}, nil
 		}
 
+		// Update ConfigMap to remove this OpenshiftEC2NodeClass's subnets.
+		// This handles the case where other OpenshiftEC2NodeClass resources still exist.
+		if err := r.reconcileKarpenterSubnetsConfigMap(ctx, hcp); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to reconcile karpenter subnets configmap during deletion: %w", err)
+		}
+
 		if controllerutil.ContainsFinalizer(openshiftEC2NodeClass, finalizer) {
 			original := openshiftEC2NodeClass.DeepCopy()
 			controllerutil.RemoveFinalizer(openshiftEC2NodeClass, finalizer)
@@ -166,7 +174,7 @@ func (r *EC2NodeClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
-	if !controllerutil.ContainsFinalizer(hcp, finalizer) {
+	if !controllerutil.ContainsFinalizer(openshiftEC2NodeClass, finalizer) {
 		original := openshiftEC2NodeClass.DeepCopy()
 		controllerutil.AddFinalizer(openshiftEC2NodeClass, finalizer)
 		if err := r.guestClient.Patch(ctx, openshiftEC2NodeClass, client.MergeFromWithOptions(original, client.MergeFromWithOptimisticLock{})); err != nil {
@@ -193,6 +201,10 @@ func (r *EC2NodeClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	if err := r.reconcileStatus(ctx, ec2NodeClass, openshiftEC2NodeClass); err != nil {
 		return ctrl.Result{}, err
+	}
+
+	if err := r.reconcileKarpenterSubnetsConfigMap(ctx, hcp); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to reconcile karpenter subnets configmap: %w", err)
 	}
 
 	if err := r.reconcileVAP(ctx); err != nil {
@@ -406,6 +418,84 @@ func (r *EC2NodeClassReconciler) computeReadyCondition(openshiftNodeClass *hyper
 			Message:            message,
 		})
 	}
+}
+
+func (r *EC2NodeClassReconciler) reconcileKarpenterSubnetsConfigMap(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	// List all OpenshiftEC2NodeClass resources in guest cluster
+	openshiftEC2NodeClassList := &hyperkarpenterv1.OpenshiftEC2NodeClassList{}
+	if err := r.guestClient.List(ctx, openshiftEC2NodeClassList); err != nil {
+		return fmt.Errorf("failed to list OpenshiftEC2NodeClass: %w", err)
+	}
+
+	subnetIDSet := sets.NewString()
+	for _, nodeClass := range openshiftEC2NodeClassList.Items {
+		// Skip NodeClasses that are being deleted — their subnets should no
+		// longer be propagated to VPC endpoints.
+		if !nodeClass.DeletionTimestamp.IsZero() {
+			continue
+		}
+		for _, subnet := range nodeClass.Status.Subnets {
+			if subnet.ID != "" {
+				subnetIDSet.Insert(subnet.ID)
+			}
+		}
+	}
+
+	subnetIDs := subnetIDSet.List() // Sorted list
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      karpenterutil.KarpenterSubnetsConfigMapName,
+			Namespace: r.Namespace,
+		},
+	}
+
+	// If there are no OpenshiftEC2NodeClass resources with resolved subnets,
+	// delete the ConfigMap (no NodeClasses exist, or none have subnets in status yet).
+	// The ConfigMap is also cleaned up automatically via owner reference when HCP is deleted.
+	if subnetIDSet.Len() == 0 {
+		if _, err := util.DeleteIfNeeded(ctx, r.managementClient, configMap); err != nil {
+			return fmt.Errorf("failed to delete karpenter subnets configmap: %w", err)
+		}
+		log.Info("Deleted karpenter subnets configmap (no OpenshiftEC2NodeClass resources with resolved subnets)")
+		return nil
+	}
+
+	// Create or update ConfigMap in management cluster
+
+	_, err := r.CreateOrUpdate(ctx, r.managementClient, configMap, func() error {
+		// Set owner reference to HostedControlPlane for automatic cleanup
+		ownerRef := config.OwnerRefFrom(hcp)
+		ownerRef.ApplyTo(configMap)
+
+		if configMap.Labels == nil {
+			configMap.Labels = make(map[string]string)
+		}
+		configMap.Labels["hypershift.openshift.io/managed-by"] = "karpenter"
+		configMap.Labels["hypershift.openshift.io/infra-id"] = hcp.Spec.InfraID
+
+		if configMap.Data == nil {
+			configMap.Data = make(map[string]string)
+		}
+
+		// Store as JSON array
+		subnetIDsJSON, err := json.Marshal(subnetIDs)
+		if err != nil {
+			return fmt.Errorf("failed to marshal subnet IDs: %w", err)
+		}
+		configMap.Data["subnetIDs"] = string(subnetIDsJSON)
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to reconcile karpenter subnets configmap: %w", err)
+	}
+
+	log.Info("Reconciled karpenter subnets configmap", "subnetCount", len(subnetIDs))
+	return nil
 }
 
 func (r *EC2NodeClassReconciler) reconcileVAP(ctx context.Context) error {

--- a/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller_test.go
+++ b/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller_test.go
@@ -2,6 +2,7 @@ package nodeclass
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -12,7 +13,9 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	hyperkarpenterv1 "github.com/openshift/hypershift/api/karpenter/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/nodepool"
+	hyperapi "github.com/openshift/hypershift/support/api"
 	karpenterutil "github.com/openshift/hypershift/support/karpenter"
+	"github.com/openshift/hypershift/support/upsert"
 
 	awskarpenterv1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
 
@@ -894,6 +897,235 @@ func TestAMISelectorTerms(t *testing.T) {
 			}
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(amis).To(Equal(tc.expectedAMIs))
+		})
+	}
+}
+
+func TestReconcileKarpenterSubnetsConfigMap(t *testing.T) {
+	const testNamespace = "clusters-my-cluster"
+
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cluster",
+			Namespace: testNamespace,
+		},
+		Spec: hyperv1.HostedControlPlaneSpec{
+			InfraID: testInfraID,
+		},
+	}
+
+	testCases := []struct {
+		name                string
+		guestObjects        []client.Object
+		managementObjects   []client.Object
+		expectConfigMap     bool
+		expectedSubnetCount int
+		expectedSubnets     []string
+	}{
+		{
+			name:         "When there are no OpenshiftEC2NodeClass resources it should delete the ConfigMap",
+			guestObjects: []client.Object{},
+			managementObjects: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      karpenterutil.KarpenterSubnetsConfigMapName,
+						Namespace: testNamespace,
+					},
+				},
+			},
+			expectConfigMap: false,
+		},
+		{
+			name: "When OpenshiftEC2NodeClass resources have subnets in status it should create ConfigMap with aggregated subnet IDs",
+			guestObjects: []client.Object{
+				&hyperkarpenterv1.OpenshiftEC2NodeClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nodeclass-1",
+					},
+					Spec: hyperkarpenterv1.OpenshiftEC2NodeClassSpec{
+						SubnetSelectorTerms: []hyperkarpenterv1.SubnetSelectorTerm{
+							{ID: "subnet-aaa"},
+						},
+					},
+					Status: hyperkarpenterv1.OpenshiftEC2NodeClassStatus{
+						Subnets: []hyperkarpenterv1.Subnet{
+							{ID: "subnet-aaa", Zone: "us-east-1a"},
+							{ID: "subnet-bbb", Zone: "us-east-1b"},
+						},
+					},
+				},
+			},
+			expectConfigMap:     true,
+			expectedSubnetCount: 2,
+			expectedSubnets:     []string{"subnet-aaa", "subnet-bbb"},
+		},
+		{
+			name: "When multiple OpenshiftEC2NodeClass resources have overlapping subnets it should deduplicate subnet IDs",
+			guestObjects: []client.Object{
+				&hyperkarpenterv1.OpenshiftEC2NodeClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nodeclass-1",
+					},
+					Spec: hyperkarpenterv1.OpenshiftEC2NodeClassSpec{
+						SubnetSelectorTerms: []hyperkarpenterv1.SubnetSelectorTerm{
+							{ID: "subnet-shared"},
+						},
+					},
+					Status: hyperkarpenterv1.OpenshiftEC2NodeClassStatus{
+						Subnets: []hyperkarpenterv1.Subnet{
+							{ID: "subnet-shared", Zone: "us-east-1a"},
+							{ID: "subnet-aaa", Zone: "us-east-1b"},
+						},
+					},
+				},
+				&hyperkarpenterv1.OpenshiftEC2NodeClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nodeclass-2",
+					},
+					Spec: hyperkarpenterv1.OpenshiftEC2NodeClassSpec{
+						SubnetSelectorTerms: []hyperkarpenterv1.SubnetSelectorTerm{
+							{ID: "subnet-bbb"},
+						},
+					},
+					Status: hyperkarpenterv1.OpenshiftEC2NodeClassStatus{
+						Subnets: []hyperkarpenterv1.Subnet{
+							{ID: "subnet-shared", Zone: "us-east-1a"},
+							{ID: "subnet-bbb", Zone: "us-east-1c"},
+						},
+					},
+				},
+			},
+			expectConfigMap:     true,
+			expectedSubnetCount: 3,
+			expectedSubnets:     []string{"subnet-aaa", "subnet-bbb", "subnet-shared"},
+		},
+		{
+			name: "When OpenshiftEC2NodeClass has nil SubnetSelectorTerms it should still include its status subnets",
+			guestObjects: []client.Object{
+				&hyperkarpenterv1.OpenshiftEC2NodeClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "default",
+					},
+					Spec: hyperkarpenterv1.OpenshiftEC2NodeClassSpec{
+						SubnetSelectorTerms: nil,
+					},
+					Status: hyperkarpenterv1.OpenshiftEC2NodeClassStatus{
+						Subnets: []hyperkarpenterv1.Subnet{
+							{ID: "subnet-default-1", Zone: "us-east-1a"},
+							{ID: "subnet-default-2", Zone: "us-east-1b"},
+						},
+					},
+				},
+			},
+			expectConfigMap:     true,
+			expectedSubnetCount: 2,
+			expectedSubnets:     []string{"subnet-default-1", "subnet-default-2"},
+		},
+		{
+			name: "When OpenshiftEC2NodeClass resources have no subnets in status it should delete the ConfigMap",
+			guestObjects: []client.Object{
+				&hyperkarpenterv1.OpenshiftEC2NodeClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nodeclass-1",
+					},
+					Spec: hyperkarpenterv1.OpenshiftEC2NodeClassSpec{
+						SubnetSelectorTerms: []hyperkarpenterv1.SubnetSelectorTerm{
+							{ID: "subnet-aaa"},
+						},
+					},
+					Status: hyperkarpenterv1.OpenshiftEC2NodeClassStatus{},
+				},
+			},
+			expectConfigMap: false,
+		},
+		{
+			name: "When an OpenshiftEC2NodeClass is being deleted it should exclude its subnets from the ConfigMap",
+			guestObjects: []client.Object{
+				&hyperkarpenterv1.OpenshiftEC2NodeClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "being-deleted",
+						DeletionTimestamp: &metav1.Time{Time: time.Now()},
+						Finalizers:        []string{finalizer},
+					},
+					Status: hyperkarpenterv1.OpenshiftEC2NodeClassStatus{
+						Subnets: []hyperkarpenterv1.Subnet{
+							{ID: "subnet-being-deleted", Zone: "us-east-1a"},
+						},
+					},
+				},
+				&hyperkarpenterv1.OpenshiftEC2NodeClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "remaining",
+					},
+					Status: hyperkarpenterv1.OpenshiftEC2NodeClassStatus{
+						Subnets: []hyperkarpenterv1.Subnet{
+							{ID: "subnet-keep", Zone: "us-east-1b"},
+						},
+					},
+				},
+			},
+			expectConfigMap:     true,
+			expectedSubnetCount: 1,
+			expectedSubnets:     []string{"subnet-keep"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			managementClient := fake.NewClientBuilder().
+				WithScheme(hyperapi.Scheme).
+				WithObjects(tc.managementObjects...).
+				Build()
+
+			guestClient := fake.NewClientBuilder().
+				WithScheme(hyperapi.Scheme).
+				WithStatusSubresource(&hyperkarpenterv1.OpenshiftEC2NodeClass{}).
+				WithObjects(tc.guestObjects...).
+				Build()
+
+			// Patch status for guest objects since fake client WithObjects doesn't set status
+			for _, obj := range tc.guestObjects {
+				if nc, ok := obj.(*hyperkarpenterv1.OpenshiftEC2NodeClass); ok {
+					if err := guestClient.Status().Update(context.Background(), nc); err != nil {
+						t.Fatalf("failed to set status on OpenshiftEC2NodeClass: %v", err)
+					}
+				}
+			}
+
+			r := &EC2NodeClassReconciler{
+				Namespace:              testNamespace,
+				managementClient:       managementClient,
+				guestClient:            guestClient,
+				CreateOrUpdateProvider: upsert.New(false),
+			}
+
+			err := r.reconcileKarpenterSubnetsConfigMap(context.Background(), hcp)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			cm := &corev1.ConfigMap{}
+			getErr := managementClient.Get(context.Background(), client.ObjectKey{
+				Namespace: testNamespace,
+				Name:      karpenterutil.KarpenterSubnetsConfigMapName,
+			}, cm)
+
+			if !tc.expectConfigMap {
+				g.Expect(getErr).To(HaveOccurred(), "ConfigMap should have been deleted")
+				return
+			}
+
+			g.Expect(getErr).NotTo(HaveOccurred(), "ConfigMap should exist")
+			g.Expect(cm.Labels).To(HaveKeyWithValue("hypershift.openshift.io/managed-by", "karpenter"))
+			g.Expect(cm.Labels).To(HaveKeyWithValue("hypershift.openshift.io/infra-id", testInfraID))
+
+			subnetIDsJSON := cm.Data["subnetIDs"]
+			g.Expect(subnetIDsJSON).NotTo(BeEmpty())
+
+			var subnetIDs []string
+			g.Expect(json.Unmarshal([]byte(subnetIDsJSON), &subnetIDs)).To(Succeed())
+			g.Expect(subnetIDs).To(HaveLen(tc.expectedSubnetCount))
+			g.Expect(subnetIDs).To(ConsistOf(tc.expectedSubnets))
 		})
 	}
 }

--- a/support/karpenter/karpenter.go
+++ b/support/karpenter/karpenter.go
@@ -20,8 +20,13 @@ const (
 	ManagedByKarpenterLabel = "hypershift.openshift.io/managed-by-karpenter"
 )
 
-// KarpenterTaintConfigMapName is the name of the configmap containing the karpenter taint config
-const KarpenterTaintConfigMapName = "set-karpenter-taint"
+const (
+	// KarpenterTaintConfigMapName is the name of the configmap containing the karpenter taint config
+	KarpenterTaintConfigMapName = "set-karpenter-taint"
+	// KarpenterSubnetsConfigMapName is the name of the configmap containing the aggregated subnet IDs
+	// from all user-defined OpenshiftEC2NodeClass resources.
+	KarpenterSubnetsConfigMapName = "karpenter-subnets"
+)
 
 // ErrHCPNotFound is returned when no HostedControlPlane is found in the namespace.
 var ErrHCPNotFound = errors.New("hostedcontrolplane not found")

--- a/test/e2e/karpenter_test.go
+++ b/test/e2e/karpenter_test.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
 	"os"
@@ -11,7 +12,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	awskarpenterv1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
 	"github.com/blang/semver"
 	. "github.com/onsi/gomega"
@@ -21,6 +24,7 @@ import (
 	karpenteroperatorcpov2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	karpenterassets "github.com/openshift/hypershift/karpenter-operator/controllers/karpenter/assets"
+	karpenterutil "github.com/openshift/hypershift/support/karpenter"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	dto "github.com/prometheus/client_model/go"
@@ -52,6 +56,7 @@ func TestKarpenter(t *testing.T) {
 	clusterOpts := globalOpts.DefaultClusterOptions(t)
 	clusterOpts.AWSPlatform.AutoNode = true
 	clusterOpts.AWSPlatform.PublicOnly = false
+	clusterOpts.AWSPlatform.EndpointAccess = string(hyperv1.PublicAndPrivate)
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.HighlyAvailable)
 	clusterOpts.ReleaseImage = globalOpts.PreviousReleaseImage
 
@@ -697,6 +702,292 @@ func TestKarpenter(t *testing.T) {
 				e2eutil.WithTimeout(2*time.Minute),
 			)
 			t.Logf("OpenshiftEC2NodeClass %q has SupportedVersionSkew=False for version %s (exceeds n-3 skew from CP %s)", nc.Name, skewVersion, cpVersion)
+		})
+
+		t.Run("Arbitrary subnet propagation", func(t *testing.T) {
+			g := NewWithT(t)
+
+			// Get VPC ID and find an AZ that is:
+			// (a) supported by the VPC endpoint service (to avoid InvalidParameter), and
+			// (b) not already occupied by a VPC subnet (to avoid DuplicateSubnetsInSameZone).
+			// This exercises the real scenario: a customer brings a subnet in a new AZ,
+			// it propagates to the VPC endpoint, and nodes in that AZ can reach the cluster.
+			ec2client := ec2Client(clusterOpts.AWSPlatform.Credentials.AWSCredentialsFile, clusterOpts.AWSPlatform.Region)
+			vpcID := hostedCluster.Spec.Platform.AWS.CloudProviderConfig.VPC
+			subnetsOut, err := ec2client.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{
+				Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(subnetsOut.Subnets).NotTo(BeEmpty())
+
+			// Collect AZs already occupied by VPC subnets.
+			usedAZs := map[string]bool{}
+			for _, s := range subnetsOut.Subnets {
+				usedAZs[aws.ToString(s.AvailabilityZone)] = true
+			}
+
+			// Get the AZs supported by the VPC endpoint service.
+			hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
+			esList := &hyperv1.AWSEndpointServiceList{}
+			g.Expect(mgtClient.List(ctx, esList, crclient.InNamespace(hcpNamespace))).To(Succeed())
+			g.Expect(esList.Items).NotTo(BeEmpty(), "expected at least one AWSEndpointService")
+
+			var endpointServiceName string
+			for _, es := range esList.Items {
+				if es.Status.EndpointServiceName != "" {
+					endpointServiceName = es.Status.EndpointServiceName
+					break
+				}
+			}
+			g.Expect(endpointServiceName).NotTo(BeEmpty(), "no AWSEndpointService has an endpoint service name yet")
+
+			svcOut, err := ec2client.DescribeVpcEndpointServices(ctx, &ec2.DescribeVpcEndpointServicesInput{
+				ServiceNames: []string{endpointServiceName},
+			})
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(svcOut.ServiceDetails).NotTo(BeEmpty())
+			supportedAZs := svcOut.ServiceDetails[0].AvailabilityZones
+			t.Logf("VPC endpoint service %s supports AZs: %v", endpointServiceName, supportedAZs)
+
+			// Pick an AZ supported by the endpoint service but not already in the VPC.
+			var az string
+			for _, supportedAZ := range supportedAZs {
+				if !usedAZs[supportedAZ] {
+					az = supportedAZ
+					break
+				}
+			}
+			g.Expect(az).NotTo(BeEmpty(),
+				"no AZ found that is supported by VPC endpoint service %s and not already occupied in VPC %s (supported: %v, used: %v)",
+				endpointServiceName, vpcID, supportedAZs, usedAZs)
+			t.Logf("Selected AZ %s for test subnet (supported by endpoint service, not in VPC)", az)
+
+			// Create a small test subnet in the VPC.
+			subnetID, cleanupSubnet := e2eutil.CreateTestSubnet(ctx, t, ec2client, vpcID, az, hostedCluster.Spec.InfraID)
+			t.Logf("Created test subnet %s in AZ %s", subnetID, az)
+
+			// Create an OpenshiftEC2NodeClass that selects the subnet by ID.
+			customNodeClass := &hyperkarpenterv1.OpenshiftEC2NodeClass{
+				ObjectMeta: metav1.ObjectMeta{Name: "arbitrary-subnet-test"},
+				Spec: hyperkarpenterv1.OpenshiftEC2NodeClassSpec{
+					SubnetSelectorTerms: []hyperkarpenterv1.SubnetSelectorTerm{{ID: subnetID}},
+					SecurityGroupSelectorTerms: []hyperkarpenterv1.SecurityGroupSelectorTerm{
+						{Tags: map[string]string{"karpenter.sh/discovery": hostedCluster.Spec.InfraID}},
+					},
+				},
+			}
+			g.Expect(guestClient.Create(ctx, customNodeClass)).To(Succeed())
+			t.Cleanup(func() {
+				// Delete the NodeClass first so controllers stop referencing the subnet.
+				if err := guestClient.Delete(ctx, customNodeClass); err != nil {
+					t.Logf("cleanup: failed to delete OpenshiftEC2NodeClass %q: %v", customNodeClass.Name, err)
+				}
+				// Wait for the subnet to be removed from the karpenter-subnets ConfigMap.
+				// The karpenter-operator removes it during NodeClass deletion reconciliation.
+				hcpNS := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
+				if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+					cm := &corev1.ConfigMap{}
+					if err := mgtClient.Get(ctx, crclient.ObjectKey{
+						Namespace: hcpNS,
+						Name:      karpenterutil.KarpenterSubnetsConfigMapName,
+					}, cm); err != nil {
+						return false, nil
+					}
+					var ids []string
+					if err := json.Unmarshal([]byte(cm.Data["subnetIDs"]), &ids); err != nil {
+						return false, nil
+					}
+					for _, id := range ids {
+						if id == subnetID {
+							return false, nil
+						}
+					}
+					return true, nil
+				}); err != nil {
+					t.Logf("cleanup: timed out waiting for subnet %s to leave ConfigMap: %v", subnetID, err)
+				} else {
+					t.Logf("cleanup: subnet %s removed from karpenter-subnets ConfigMap", subnetID)
+				}
+				// Wait for the subnet to be removed from all AWSEndpointService.Spec.SubnetIDs.
+				// The hypershift-operator watches the ConfigMap and reconciles Spec.SubnetIDs.
+				if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+					list := &hyperv1.AWSEndpointServiceList{}
+					if err := mgtClient.List(ctx, list, crclient.InNamespace(hcpNS)); err != nil {
+						return false, nil
+					}
+					for _, es := range list.Items {
+						for _, id := range es.Spec.SubnetIDs {
+							if id == subnetID {
+								return false, nil
+							}
+						}
+					}
+					return true, nil
+				}); err != nil {
+					t.Logf("cleanup: timed out waiting for subnet %s to leave AWSEndpointService specs: %v", subnetID, err)
+				} else {
+					t.Logf("cleanup: subnet %s removed from all AWSEndpointService specs", subnetID)
+				}
+				// Wait for AWSEndpointAvailable=True to confirm the CPO has finished
+				// reconciling the VPC endpoint (subnet actually removed from AWS).
+				if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+					list := &hyperv1.AWSEndpointServiceList{}
+					if err := mgtClient.List(ctx, list, crclient.InNamespace(hcpNS)); err != nil {
+						return false, nil
+					}
+					for _, es := range list.Items {
+						for _, cond := range es.Status.Conditions {
+							if cond.Type == string(hyperv1.AWSEndpointAvailable) && cond.Status != metav1.ConditionTrue {
+								return false, nil
+							}
+						}
+					}
+					return true, nil
+				}); err != nil {
+					t.Logf("cleanup: timed out waiting for AWSEndpointAvailable=True after subnet removal: %v", err)
+				} else {
+					t.Logf("cleanup: all AWSEndpointServices have AWSEndpointAvailable=True")
+				}
+				cleanupSubnet()
+			})
+			t.Logf("Created OpenshiftEC2NodeClass %q selecting subnet %s", customNodeClass.Name, subnetID)
+
+			// Wait for OpenshiftEC2NodeClass.Status.Subnets to contain the subnet ID.
+			t.Logf("Waiting for OpenshiftEC2NodeClass status to reflect subnet %s", subnetID)
+			g.Eventually(func(g Gomega) {
+				nc := &hyperkarpenterv1.OpenshiftEC2NodeClass{}
+				g.Expect(guestClient.Get(ctx, crclient.ObjectKeyFromObject(customNodeClass), nc)).To(Succeed())
+				subnetIDs := make([]string, 0, len(nc.Status.Subnets))
+				for _, s := range nc.Status.Subnets {
+					subnetIDs = append(subnetIDs, s.ID)
+				}
+				g.Expect(subnetIDs).To(ContainElement(subnetID), "status.subnets should contain the test subnet")
+			}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+			t.Logf("OpenshiftEC2NodeClass status.subnets contains %s", subnetID)
+
+			// Wait for the karpenter-subnets ConfigMap in the HCP namespace to contain the subnet ID.
+			// hcpNamespace was already set above during AZ selection.
+			t.Logf("Waiting for karpenter-subnets ConfigMap in %s to contain subnet %s", hcpNamespace, subnetID)
+			g.Eventually(func(g Gomega) {
+				cm := &corev1.ConfigMap{}
+				g.Expect(mgtClient.Get(ctx, crclient.ObjectKey{
+					Namespace: hcpNamespace,
+					Name:      karpenterutil.KarpenterSubnetsConfigMapName,
+				}, cm)).To(Succeed())
+				g.Expect(cm.Data).To(HaveKey("subnetIDs"))
+				var cmSubnetIDs []string
+				g.Expect(json.Unmarshal([]byte(cm.Data["subnetIDs"]), &cmSubnetIDs)).To(Succeed())
+				g.Expect(cmSubnetIDs).To(ContainElement(subnetID), "karpenter-subnets ConfigMap should contain the test subnet")
+			}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+			t.Logf("karpenter-subnets ConfigMap contains subnet %s", subnetID)
+
+			// Wait for any AWSEndpointService in the HCP namespace to include the subnet ID.
+			// Which AWSEndpointService resources exist depends on the APIServer publishing
+			// strategy: with LoadBalancer publishing, "kube-apiserver-private" is created;
+			// with Route publishing (used when ExternalDNS is configured), only
+			// "private-router" exists. We check all of them to be independent of the
+			// publishing strategy.
+			t.Logf("Waiting for any AWSEndpointService in %s to include subnet %s", hcpNamespace, subnetID)
+			g.Eventually(func(g Gomega) {
+				list := &hyperv1.AWSEndpointServiceList{}
+				g.Expect(mgtClient.List(ctx, list, crclient.InNamespace(hcpNamespace))).To(Succeed())
+				g.Expect(list.Items).NotTo(BeEmpty(), "expected at least one AWSEndpointService in namespace %s", hcpNamespace)
+				found := false
+				for _, es := range list.Items {
+					for _, id := range es.Spec.SubnetIDs {
+						if id == subnetID {
+							t.Logf("AWSEndpointService %q includes subnet %s", es.Name, subnetID)
+							found = true
+							break
+						}
+					}
+				}
+				g.Expect(found).To(BeTrue(), "no AWSEndpointService in %s contains subnet %s", hcpNamespace, subnetID)
+			}).WithTimeout(3 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+
+			// Wait for all AWSEndpointServices to have AWSEndpointAvailable=True.
+			// This confirms the CPO successfully created/modified the VPC endpoint
+			// with the new subnet — the feature actually works end-to-end.
+			t.Logf("Waiting for AWSEndpointAvailable=True on all AWSEndpointServices in %s", hcpNamespace)
+			g.Eventually(func(g Gomega) {
+				list := &hyperv1.AWSEndpointServiceList{}
+				g.Expect(mgtClient.List(ctx, list, crclient.InNamespace(hcpNamespace))).To(Succeed())
+				for _, es := range list.Items {
+					available := false
+					for _, cond := range es.Status.Conditions {
+						if cond.Type == string(hyperv1.AWSEndpointAvailable) {
+							g.Expect(cond.Status).To(Equal(metav1.ConditionTrue),
+								"AWSEndpointService %q has AWSEndpointAvailable=%s: %s",
+								es.Name, cond.Status, cond.Message)
+							available = true
+							break
+						}
+					}
+					g.Expect(available).To(BeTrue(),
+						"AWSEndpointService %q has no AWSEndpointAvailable condition", es.Name)
+				}
+			}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+			t.Logf("All AWSEndpointServices have AWSEndpointAvailable=True")
+
+			// Launch a node in the custom subnet to verify it's functional.
+			testNodePool := karpenterNodePool.DeepCopy()
+			testNodePool.SetResourceVersion("")
+			testNodePool.SetName("arbitrary-subnet-test")
+			spec := testNodePool.Object["spec"].(map[string]interface{})
+			template := spec["template"].(map[string]interface{})
+			templateSpec := template["spec"].(map[string]interface{})
+			templateSpec["nodeClassRef"] = map[string]interface{}{
+				"group": "karpenter.k8s.aws",
+				"kind":  "EC2NodeClass",
+				"name":  customNodeClass.Name,
+			}
+
+			testWorkLoads := workLoads.DeepCopy()
+			testWorkLoads.SetResourceVersion("")
+			testWorkLoads.SetName("arbitrary-subnet-web-app")
+			replicas := 1
+			testWorkLoads.Object["spec"].(map[string]interface{})["replicas"] = replicas
+
+			g.Expect(guestClient.Create(ctx, testNodePool)).To(Succeed())
+			t.Logf("Created Karpenter NodePool %q", testNodePool.GetName())
+			g.Expect(guestClient.Create(ctx, testWorkLoads)).To(Succeed())
+			t.Logf("Created workload %q with %d replica(s)", testWorkLoads.GetName(), replicas)
+			defer func() {
+				_ = guestClient.Delete(ctx, testWorkLoads)
+				_ = guestClient.Delete(ctx, testNodePool)
+			}()
+
+			testNodeLabels := map[string]string{
+				"karpenter.sh/nodepool": testNodePool.GetName(),
+			}
+			nodes := e2eutil.WaitForReadyNodesByLabels(t, ctx, guestClient, hostedCluster.Spec.Platform.Type, int32(replicas), testNodeLabels)
+			t.Logf("Node launched in arbitrary subnet, verifying it used subnet %s", subnetID)
+
+			// Verify the launched node's EC2 instance is in the expected subnet.
+			for _, node := range nodes {
+				providerID := node.Spec.ProviderID
+				g.Expect(providerID).NotTo(BeEmpty(), "node should have a providerID")
+				parts := strings.Split(providerID, "/")
+				g.Expect(parts).To(HaveLen(5), "providerID should have 5 parts")
+				instanceID := parts[4]
+
+				result, err := ec2client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+					InstanceIds: []string{instanceID},
+				})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(result.Reservations).NotTo(BeEmpty())
+				g.Expect(result.Reservations[0].Instances).NotTo(BeEmpty())
+				instance := result.Reservations[0].Instances[0]
+				g.Expect(aws.ToString(instance.SubnetId)).To(Equal(subnetID),
+					"instance %s should be in subnet %s", instanceID, subnetID)
+				t.Logf("Instance %s confirmed in subnet %s", instanceID, subnetID)
+			}
+
+			// Clean up NodePool and workload; subnet cleanup is registered via t.Cleanup.
+			g.Expect(guestClient.Delete(ctx, testWorkLoads)).To(Succeed())
+			g.Expect(guestClient.Delete(ctx, testNodePool)).To(Succeed())
+			t.Logf("Waiting for arbitrary-subnet-test nodes to be removed")
+			_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, guestClient, hostedCluster.Spec.Platform.Type, 0, testNodeLabels)
 		})
 
 		// TODO(jkyros): This test doesn't clean up after itself (I think intentionally) so we can test general cluster

--- a/test/e2e/util/aws.go
+++ b/test/e2e/util/aws.go
@@ -2,9 +2,12 @@ package util
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"net"
 	"strings"
+	"testing"
 	"time"
 
 	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
@@ -12,8 +15,8 @@ import (
 	"github.com/openshift/hypershift/support/oidc"
 	"github.com/openshift/hypershift/support/util"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	ec2v2 "github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
@@ -21,13 +24,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/smithy-go"
 
 	"github.com/go-logr/logr"
 )
 
 func GetKMSKeyArn(ctx context.Context, awsCreds, awsRegion, alias string) (*string, error) {
 	if alias == "" {
-		return aws.String(""), nil
+		return awsv2.String(""), nil
 	}
 
 	awsSession := awsutil.NewSession(ctx, "e2e-kms", awsCreds, "", "", awsRegion)
@@ -37,7 +41,7 @@ func GetKMSKeyArn(ctx context.Context, awsCreds, awsRegion, alias string) (*stri
 	})
 
 	input := &kms.DescribeKeyInput{
-		KeyId: aws.String(alias),
+		KeyId: awsv2.String(alias),
 	}
 	out, err := kmsClient.DescribeKey(ctx, input)
 	if err != nil {
@@ -53,11 +57,11 @@ func GetKMSKeyArn(ctx context.Context, awsCreds, awsRegion, alias string) (*stri
 func GetDefaultSecurityGroup(ctx context.Context, awsCreds, awsRegion, sgID string) (*ec2types.SecurityGroup, error) {
 	awsSession := awsutil.NewSession(ctx, "e2e-ec2", awsCreds, "", "", awsRegion)
 	awsConfig := awsutil.NewConfig()
-	ec2Client := ec2.NewFromConfig(*awsSession, func(o *ec2.Options) {
+	ec2Client := ec2v2.NewFromConfig(*awsSession, func(o *ec2v2.Options) {
 		o.Retryer = awsConfig()
 	})
 
-	describeSGResult, err := ec2Client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+	describeSGResult, err := ec2Client.DescribeSecurityGroups(ctx, &ec2v2.DescribeSecurityGroupsInput{
 		GroupIds: []string{sgID},
 	})
 	if err != nil {
@@ -99,9 +103,9 @@ func PutRolePolicy(ctx context.Context, awsCreds, awsRegion, roleARN string, pol
 	policyName := util.HashSimple(policy)
 
 	_, err := iamClient.PutRolePolicy(ctx, &iam.PutRolePolicyInput{
-		RoleName:       aws.String(roleName),
-		PolicyName:     aws.String(policyName),
-		PolicyDocument: aws.String(policy),
+		RoleName:       awsv2.String(roleName),
+		PolicyName:     awsv2.String(policyName),
+		PolicyDocument: awsv2.String(policy),
 	})
 	if err != nil {
 		var nse *iamtypes.NoSuchEntityException
@@ -115,8 +119,8 @@ func PutRolePolicy(ctx context.Context, awsCreds, awsRegion, roleARN string, pol
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer cancel()
 		_, err := iamClient.DeleteRolePolicy(ctx, &iam.DeleteRolePolicyInput{
-			RoleName:   aws.String(roleName),
-			PolicyName: aws.String(policyName),
+			RoleName:   awsv2.String(roleName),
+			PolicyName: awsv2.String(policyName),
 		})
 		if err != nil {
 			var nse *iamtypes.NoSuchEntityException
@@ -158,20 +162,179 @@ func DestroyOIDCProvider(ctx context.Context, log logr.Logger, iamClient awsapi.
 	}
 }
 
+// CreateTestSubnet creates a small (/28) subnet in the given VPC in the specified AZ,
+// associates it with an existing private route table (one with a NAT gateway route),
+// and returns the subnet ID plus a cleanup function that disassociates and deletes it.
+// The subnet CIDR is chosen dynamically to avoid overlapping with any existing subnets.
+func CreateTestSubnet(ctx context.Context, t *testing.T, client *ec2v2.Client, vpcID, az, infraID string) (string, func()) {
+	t.Helper()
+
+	// Fetch all existing subnets in the VPC to find a non-overlapping CIDR.
+	existing, err := client.DescribeSubnets(ctx, &ec2v2.DescribeSubnetsInput{
+		Filters: []ec2types.Filter{
+			{Name: awsv2.String("vpc-id"), Values: []string{vpcID}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateTestSubnet: failed to list subnets in VPC %s: %v", vpcID, err)
+	}
+
+	// Collect all occupied networks.
+	occupied := make([]*net.IPNet, 0, len(existing.Subnets))
+	for _, s := range existing.Subnets {
+		_, n, err := net.ParseCIDR(awsv2.ToString(s.CidrBlock))
+		if err != nil {
+			continue
+		}
+		occupied = append(occupied, n)
+	}
+
+	// Scan candidate /28 blocks in the 10.0.192.0/18 range (10.0.192.0–10.0.255.255)
+	// which is well above the /20 private (max 10.0.175.255) and public allocations.
+	_, searchSpace, _ := net.ParseCIDR("10.0.192.0/18")
+	candidateCIDR, err := findFreeCIDR(searchSpace, 28, occupied)
+	if err != nil {
+		t.Fatalf("CreateTestSubnet: %v", err)
+	}
+
+	subnetName := fmt.Sprintf("%s-karpenter-test-subnet", infraID)
+	createOut, err := client.CreateSubnet(ctx, &ec2v2.CreateSubnetInput{
+		VpcId:            awsv2.String(vpcID),
+		CidrBlock:        awsv2.String(candidateCIDR),
+		AvailabilityZone: awsv2.String(az),
+		TagSpecifications: []ec2types.TagSpecification{
+			{
+				ResourceType: ec2types.ResourceTypeSubnet,
+				Tags: []ec2types.Tag{
+					{Key: awsv2.String("Name"), Value: awsv2.String(subnetName)},
+					{Key: awsv2.String(fmt.Sprintf("kubernetes.io/cluster/%s", infraID)), Value: awsv2.String("owned")},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateTestSubnet: failed to create subnet %s in %s: %v", candidateCIDR, az, err)
+	}
+	subnetID := awsv2.ToString(createOut.Subnet.SubnetId)
+	t.Logf("CreateTestSubnet: created subnet %s (%s) in AZ %s", subnetID, candidateCIDR, az)
+
+	// Find a private route table in this VPC (one that has a NAT gateway route).
+	rtOut, err := client.DescribeRouteTables(ctx, &ec2v2.DescribeRouteTablesInput{
+		Filters: []ec2types.Filter{
+			{Name: awsv2.String("vpc-id"), Values: []string{vpcID}},
+			{Name: awsv2.String("route.nat-gateway-id"), Values: []string{"nat-*"}},
+		},
+	})
+	// Route table association is required for node launch. Fail fast rather than
+	// letting WaitForReadyNodesByLabels time out on a node that can never come up.
+	if err != nil || len(rtOut.RouteTables) == 0 {
+		_, _ = client.DeleteSubnet(ctx, &ec2v2.DeleteSubnetInput{SubnetId: awsv2.String(subnetID)})
+		t.Fatalf("CreateTestSubnet: no private route table with NAT gateway found in VPC %s (err: %v); deleted subnet %s", vpcID, err, subnetID)
+	}
+
+	routeTableID := awsv2.ToString(rtOut.RouteTables[0].RouteTableId)
+	assocOut, err := client.AssociateRouteTable(ctx, &ec2v2.AssociateRouteTableInput{
+		RouteTableId: awsv2.String(routeTableID),
+		SubnetId:     awsv2.String(subnetID),
+	})
+	if err != nil {
+		_, _ = client.DeleteSubnet(ctx, &ec2v2.DeleteSubnetInput{SubnetId: awsv2.String(subnetID)})
+		t.Fatalf("CreateTestSubnet: failed to associate route table %s with subnet %s: %v; deleted subnet", routeTableID, subnetID, err)
+	}
+
+	associationID := awsv2.ToString(assocOut.AssociationId)
+	t.Logf("CreateTestSubnet: associated route table %s with subnet %s (association %s)", routeTableID, subnetID, associationID)
+
+	cleanup := func() {
+		if _, err := client.DisassociateRouteTable(ctx, &ec2v2.DisassociateRouteTableInput{
+			AssociationId: awsv2.String(associationID),
+		}); err != nil {
+			t.Logf("CreateTestSubnet cleanup: failed to disassociate route table from subnet %s: %v", subnetID, err)
+		}
+		// Retry DeleteSubnet because VPC endpoint ENIs in this subnet are cleaned
+		// up asynchronously by AWS after ModifyVpcEndpoint removes the subnet.
+		var lastErr error
+		for attempt := 0; attempt < 12; attempt++ {
+			if attempt > 0 {
+				time.Sleep(10 * time.Second)
+			}
+			_, lastErr = client.DeleteSubnet(ctx, &ec2v2.DeleteSubnetInput{SubnetId: awsv2.String(subnetID)})
+			if lastErr == nil {
+				t.Logf("CreateTestSubnet cleanup: deleted subnet %s", subnetID)
+				return
+			}
+			// Only retry on DependencyViolation; other errors are not transient.
+			var apiErr smithy.APIError
+			if errors.As(lastErr, &apiErr) && apiErr.ErrorCode() == "DependencyViolation" {
+				t.Logf("CreateTestSubnet cleanup: subnet %s has dependencies (attempt %d/12), retrying in 10s", subnetID, attempt+1)
+				continue
+			}
+			break
+		}
+		t.Logf("CreateTestSubnet cleanup: failed to delete subnet %s: %v", subnetID, lastErr)
+	}
+	return subnetID, cleanup
+}
+
+// findFreeCIDR scans the given search space for the first /prefixLen block that
+// does not overlap with any of the occupied networks.
+func findFreeCIDR(searchSpace *net.IPNet, prefixLen int, occupied []*net.IPNet) (string, error) {
+	blockSize := uint32(1) << (32 - prefixLen)
+	startIP := ipToUint32(searchSpace.IP.To4())
+	_, endIP := networkRange(searchSpace)
+
+	for ip := startIP; ip+blockSize-1 <= endIP; ip += blockSize {
+		candidate := &net.IPNet{
+			IP:   uint32ToIP(ip),
+			Mask: net.CIDRMask(prefixLen, 32),
+		}
+		if !overlapsAny(candidate, occupied) {
+			return candidate.String(), nil
+		}
+	}
+	return "", fmt.Errorf("no free /%d block found in %s", prefixLen, searchSpace)
+}
+
+func overlapsAny(candidate *net.IPNet, occupied []*net.IPNet) bool {
+	for _, o := range occupied {
+		if candidate.Contains(o.IP) || o.Contains(candidate.IP) {
+			return true
+		}
+	}
+	return false
+}
+
+func ipToUint32(ip net.IP) uint32 {
+	return binary.BigEndian.Uint32(ip.To4())
+}
+
+func uint32ToIP(n uint32) net.IP {
+	ip := make(net.IP, 4)
+	binary.BigEndian.PutUint32(ip, n)
+	return ip
+}
+
+func networkRange(n *net.IPNet) (uint32, uint32) {
+	start := ipToUint32(n.IP.To4())
+	ones, bits := n.Mask.Size()
+	size := uint32(1) << uint(bits-ones)
+	return start, start + size - 1
+}
+
 func CleanupOIDCBucketObjects(ctx context.Context, log logr.Logger, s3Client awsapi.S3API, bucketName, issuerURL string) {
 	providerID := issuerURL[strings.LastIndex(issuerURL, "/")+1:]
 
 	objectsToDelete := []s3types.ObjectIdentifier{
 		{
-			Key: aws.String(providerID + "/.well-known/openid-configuration"),
+			Key: awsv2.String(providerID + "/.well-known/openid-configuration"),
 		},
 		{
-			Key: aws.String(providerID + oidc.JWKSURI),
+			Key: awsv2.String(providerID + oidc.JWKSURI),
 		},
 	}
 
 	if _, err := s3Client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
-		Bucket: aws.String(bucketName),
+		Bucket: awsv2.String(bucketName),
 		Delete: &s3types.Delete{Objects: objectsToDelete},
 	}); err != nil {
 		var nsbErr *s3types.NoSuchBucket


### PR DESCRIPTION

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

I don't love this, but this is basically: 
- Nodeclass controller grabs all subnets from non-default ec2nodeclasses 
- Stuffs those subnets into a configmap that gets read by the private link controller
- Private link controller adds them to its list when it runs 
- e2e to test that scenerio 

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes [AUTOSCALE-559](https://issues.redhat.com/browse/AUTOSCALE-559)

## Special notes for your reviewer:

Things that are not great: 
- UX: There is no feedback to the user/ec2nodeclass on whether it worked or not up at the privatelink controller level, and since it's just a configmap and the private link controller is in the control plane, so the user can't see the logs. If it goes bad, they will just find out when their node doesn't join :disappointed: 
- Tests: I wanted to test it against a cluster with no existing nodepool, so I did that test separately and stuffed it in before the rest of the karpenter tests run 

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic subnet discovery and synchronization between Karpenter and the operator via ConfigMap.
  * Subnets are now aggregated from multiple sources and dynamically propagated.

* **Tests**
  * Expanded test coverage for subnet management, ConfigMap handling, and Karpenter integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->