### PR TITLE
OCPCLOUD-3347: Add RBAC for machine-approver to read APIServer TLS profile

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/machineapprover.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/machineapprover.go
@@ -1,0 +1,15 @@
+package manifests
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func MachineApproverServiceAccount(ns string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "machine-approver",
+			Namespace: ns,
+		},
+	}
+}


### PR DESCRIPTION
## Summary
Add cluster-scoped RBAC for the machine-approver to read `apiservers.config.openshift.io`, required after [openshift/cluster-machine-approver PR #286](https://github.com/openshift/cluster-machine-approver/pull/286) introduced `FetchAPIServerTLSProfile()`.

## Problem
The `cluster-machine-approver` binary now calls `FetchAPIServerTLSProfile()` at startup using its in-cluster (management cluster) client, which reads `apiservers.config.openshift.io/cluster`. HyperShift's existing machine-approver RBAC is a namespace-scoped `Role` granting only `cluster.x-k8s.io/machines` access. Since `apiservers` is cluster-scoped, the machine-approver crashes with:

```
unable to get TLS profile from API server: failed to get APIServer "/cluster": apiservers.config.openshift.io "cluster" is forbidden
```

This breaks all HyperShift e2e tests using 4.22 CI nightlies built after 2026-02-25T08:01Z ([evidence](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.22-periodics-e2e-aws-ovn/2026655914567667712)).

## Changes
- **`reconcileMachineApproverClusterRBAC`** in the HostedCluster controller: creates a `ClusterRole` and `ClusterRoleBinding` (named `<hcp-namespace>-machine-approver`) granting `get`, `list`, `watch` on `apiservers` in `config.openshift.io`
- **`DisableMachineManagement` guard**: skips RBAC creation when the annotation is set, matching the CPO's machine-approver component predicate
- **`MachineApproverServiceAccount` helper**: new `cpomanifests.MachineApproverServiceAccount()` for consistency with `PKIOperatorServiceAccount()` and `KubevirtCSIDriverInfraSA()`

Follows the existing pattern used by the PKI operator and KubeVirt CSI driver for cluster-scoped RBAC created by the hypershift-operator (since the CPO lacks cluster-scoped permissions).

## Test plan
- [ ] Verify unit tests pass
- [ ] Verify e2e tests pass with a 4.22 CI nightly containing the new cluster-machine-approver

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic cluster-level RBAC is now configured for the machine-approver during HostedCluster reconciliation, including role and binding creation and improved error reporting.
  * A machine-approver ServiceAccount is now defined and referenced so the component can be granted the needed permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->