### PR TITLE
OCPBUGS-77254: fix(globalps): watch Machine updates to fix node labeling race condition

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps_test.go
@@ -15,6 +15,7 @@ import (
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
 var (
@@ -532,6 +533,47 @@ func TestLabelNodesForGlobalPullSecret(t *testing.T) {
 			},
 			expectedLabeled: []string{"replace-node-1", "replace-node-2"}, // All Replace nodes should be labeled
 		},
+		{
+			name: "When Machine.Status.NodeRef is nil it should skip the node for labeling",
+			nodes: []corev1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "new-node-1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "existing-node-1"}},
+			},
+			machineSets: []capiv1.MachineSet{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "replace-machineset-1",
+						Namespace: "test-namespace",
+					},
+					Spec: capiv1.MachineSetSpec{
+						Selector: metav1.LabelSelector{
+							MatchLabels: map[string]string{"machineset": "replace-1"},
+						},
+					},
+				},
+			},
+			machines: []capiv1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "machine-with-noderef",
+						Namespace: "test-namespace",
+						Labels:    map[string]string{"machineset": "replace-1"},
+					},
+					Status: capiv1.MachineStatus{
+						NodeRef: &corev1.ObjectReference{Name: "existing-node-1"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "machine-without-noderef",
+						Namespace: "test-namespace",
+						Labels:    map[string]string{"machineset": "replace-1"},
+					},
+					Status: capiv1.MachineStatus{NodeRef: nil},
+				},
+			},
+			expectedLabeled: []string{"existing-node-1"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -595,4 +637,77 @@ func TestLabelNodesForGlobalPullSecret(t *testing.T) {
 			g.Expect(len(labeledNodes)).To(Equal(len(tt.expectedLabeled)), "Number of labeled nodes doesn't match expected")
 		})
 	}
+}
+
+func TestMachineNodeRefPredicate(t *testing.T) {
+	p := machineNodeRefPredicate()
+
+	t.Run("When a Machine is created it should not trigger reconciliation", func(t *testing.T) {
+		g := NewWithT(t)
+		e := event.TypedCreateEvent[*capiv1.Machine]{
+			Object: &capiv1.Machine{},
+		}
+		g.Expect(p.Create(e)).To(BeFalse())
+	})
+
+	t.Run("When a Machine is deleted it should not trigger reconciliation", func(t *testing.T) {
+		g := NewWithT(t)
+		e := event.TypedDeleteEvent[*capiv1.Machine]{
+			Object: &capiv1.Machine{},
+		}
+		g.Expect(p.Delete(e)).To(BeFalse())
+	})
+
+	t.Run("When a generic event occurs it should not trigger reconciliation", func(t *testing.T) {
+		g := NewWithT(t)
+		e := event.TypedGenericEvent[*capiv1.Machine]{
+			Object: &capiv1.Machine{},
+		}
+		g.Expect(p.Generic(e)).To(BeFalse())
+	})
+
+	t.Run("When NodeRef transitions from nil to non-nil it should trigger reconciliation", func(t *testing.T) {
+		g := NewWithT(t)
+		e := event.TypedUpdateEvent[*capiv1.Machine]{
+			ObjectOld: &capiv1.Machine{
+				Status: capiv1.MachineStatus{NodeRef: nil},
+			},
+			ObjectNew: &capiv1.Machine{
+				Status: capiv1.MachineStatus{
+					NodeRef: &corev1.ObjectReference{Name: "node-1"},
+				},
+			},
+		}
+		g.Expect(p.Update(e)).To(BeTrue())
+	})
+
+	t.Run("When NodeRef is already set on both old and new it should not trigger reconciliation", func(t *testing.T) {
+		g := NewWithT(t)
+		e := event.TypedUpdateEvent[*capiv1.Machine]{
+			ObjectOld: &capiv1.Machine{
+				Status: capiv1.MachineStatus{
+					NodeRef: &corev1.ObjectReference{Name: "node-1"},
+				},
+			},
+			ObjectNew: &capiv1.Machine{
+				Status: capiv1.MachineStatus{
+					NodeRef: &corev1.ObjectReference{Name: "node-1"},
+				},
+			},
+		}
+		g.Expect(p.Update(e)).To(BeFalse())
+	})
+
+	t.Run("When NodeRef is nil on both old and new it should not trigger reconciliation", func(t *testing.T) {
+		g := NewWithT(t)
+		e := event.TypedUpdateEvent[*capiv1.Machine]{
+			ObjectOld: &capiv1.Machine{
+				Status: capiv1.MachineStatus{NodeRef: nil},
+			},
+			ObjectNew: &capiv1.Machine{
+				Status: capiv1.MachineStatus{NodeRef: nil},
+			},
+		}
+		g.Expect(p.Update(e)).To(BeFalse())
+	})
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/setup.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/setup.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -156,5 +157,40 @@ func Setup(ctx context.Context, opts *operator.HostedClusterConfigOperatorConfig
 		return fmt.Errorf("failed to watch nodes: %w", err)
 	}
 
+	// Watch for Machine updates on the management cluster.
+	// When CAPI sets Machine.Status.NodeRef (linking a Machine to a Node),
+	// we need to reconcile so that labelNodesForGlobalPullSecret can label
+	// the newly linked node. This closes a race where the Node CREATE event
+	// fires before NodeRef is set, causing the node to be skipped.
+	if err := c.Watch(source.Kind(opts.CPCluster.GetCache(), &capiv1.Machine{},
+		// The reconciler does not use the request key; it always runs a full reconciliation.
+		// We enqueue the Machine's name/namespace for logging and observability only.
+		handler.TypedEnqueueRequestsFromMapFunc(func(ctx context.Context, o *capiv1.Machine) []crreconcile.Request {
+			return []crreconcile.Request{{NamespacedName: types.NamespacedName{Name: o.GetName(), Namespace: o.GetNamespace()}}}
+		}),
+		machineNodeRefPredicate(),
+	)); err != nil {
+		return fmt.Errorf("failed to watch Machines: %w", err)
+	}
+
 	return nil
+}
+
+// machineNodeRefPredicate returns a predicate that only triggers on Machine
+// updates where Status.NodeRef transitions from nil to non-nil.
+func machineNodeRefPredicate() predicate.TypedPredicate[*capiv1.Machine] {
+	return predicate.TypedFuncs[*capiv1.Machine]{
+		CreateFunc: func(e event.TypedCreateEvent[*capiv1.Machine]) bool {
+			return false
+		},
+		UpdateFunc: func(e event.TypedUpdateEvent[*capiv1.Machine]) bool {
+			return e.ObjectOld.Status.NodeRef == nil && e.ObjectNew.Status.NodeRef != nil
+		},
+		DeleteFunc: func(e event.TypedDeleteEvent[*capiv1.Machine]) bool {
+			return false
+		},
+		GenericFunc: func(e event.TypedGenericEvent[*capiv1.Machine]) bool {
+			return false
+		},
+	}
 }


### PR DESCRIPTION
## Summary

- Fixes a ~15-minute delay in scheduling the `global-pull-secret-syncer` DaemonSet pod on newly created nodes
- Adds a watch on `capiv1.Machine` updates on the management cluster, triggering reconciliation when `Machine.Status.NodeRef` transitions from nil to non-nil
- Adds a unit test verifying that nodes with nil `Machine.Status.NodeRef` are correctly skipped during labeling

## Problem

The globalps controller had a race condition: when a new Node was created on the hosted cluster, the controller received the Node CREATE event and ran `labelNodesForGlobalPullSecret()`. However, the CAPI Machine controller on the management cluster had not yet set `Machine.Status.NodeRef`, so the new node could not be mapped to its Machine and was skipped for labeling with `hypershift.openshift.io/nodepool-globalps-enabled: "true"`.

With no Machine watch, no Node update handling, and no `RequeueAfter`, the node remained unlabeled until an unrelated event (e.g., a kube-system Secret change) triggered a reconcile -- often ~15 minutes later.

## Solution

Watch `capiv1.Machine` on the CP cluster cache with a predicate that only fires when `Status.NodeRef` transitions from nil to non-nil. This ensures the controller reconciles at the exact moment CAPI links the Machine to the Node, so `labelNodesForGlobalPullSecret` can label the node and the DaemonSet pod is scheduled promptly.

## Test plan

- [x] New unit test: "When Machine.Status.NodeRef is nil it should skip the node for labeling"
- [x] All existing globalps unit tests pass with race detection
- [x] `make lint-fix` passes with 0 issues

## Fixes

- [OCPBUGS-77254](https://issues.redhat.com/browse/OCPBUGS-77254)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests covering node-labeling behavior and event predicates, including cases where machines lack node references and when node references appear.

* **Improvements**
  * Controller now watches machine state changes and reconciles when a machine becomes linked to a node, ensuring timely labeling and consistent cluster state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->