### PR TITLE
OCPBUGS-76997: remove resource limits from Agent CAPI provider [4.16 backport]

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
@@ -116,10 +116,6 @@ func (p Agent) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hy
 							PeriodSeconds:       20,
 						},
 						Resources: corev1.ResourceRequirements{
-							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("200m"),
-								corev1.ResourceMemory: resource.MustParse("100Mi"),
-							},
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("100m"),
 								corev1.ResourceMemory: resource.MustParse("20Mi"),


### PR DESCRIPTION
## What this PR does / why we need it:

Backport of https://github.com/openshift/hypershift/pull/7812 to release-4.16.

Removes resource limits (cpu: 200m, memory: 100Mi) from the Agent CAPI provider deployment spec, keeping only requests (cpu: 100m, memory: 20Mi).

The limits were copy-pasted from the upstream `cluster-api-provider-agent` operator-sdk scaffold defaults when the deployment was first added to HyperShift in 2021. They were never intentionally sized for the workload and are the only platform in HyperShift with resource limits on the main CAPI provider container. All other platforms (AWS, KubeVirt, PowerVS, GCP, Azure) only set requests.

Removing the limits aligns the Agent platform with the established convention and prevents unnecessary CPU throttling and OOM kills.

## Which issue(s) this PR fixes:

Fixes OCPBUGS-76977

## Special notes for your reviewer:

- Cherry-pick of the main branch fix, applied cleanly
- Customer is running 4.16, needs this backport

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve OCPBUGS-76977`