### PR TITLE
CNTRLPLANE-2807: Fix version showing <unknown> in git worktree builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,11 @@ PROMTOOL=$(abspath $(TOOLS_BIN_DIR)/promtool)
 GO_GCFLAGS ?= -gcflags=all='-N -l'
 GO=GO111MODULE=on GOWORK=off GOFLAGS=-mod=vendor go
 GOWS=GO111MODULE=on GOWORK=$(shell pwd)/hack/workspace/go.work GOFLAGS=-mod=vendor go
-GO_BUILD_RECIPE=CGO_ENABLED=1 $(GO) build $(GO_GCFLAGS)
-GO_CLI_RECIPE=CGO_ENABLED=0 $(GO) build $(GO_GCFLAGS) -ldflags '-extldflags "-static"'
+COMMIT_HASH ?= $(shell git rev-parse HEAD 2>/dev/null)
+VERSION_PKG=github.com/openshift/hypershift/support/supportedversion
+GO_LDFLAGS=-ldflags '-X $(VERSION_PKG).commitHash=$(COMMIT_HASH)'
+GO_BUILD_RECIPE=CGO_ENABLED=1 $(GO) build $(GO_GCFLAGS) $(GO_LDFLAGS)
+GO_CLI_RECIPE=CGO_ENABLED=0 $(GO) build $(GO_GCFLAGS) -ldflags '-X $(VERSION_PKG).commitHash=$(COMMIT_HASH) -extldflags "-static"'
 GO_E2E_RECIPE=CGO_ENABLED=1 $(GO) test $(GO_GCFLAGS) -tags e2e -c
 GO_E2EV2_RECIPE=CGO_ENABLED=1 $(GO) test $(GO_GCFLAGS) -tags e2ev2 -c
 GO_REQSERVING_E2E_RECIPE=CGO_ENABLED=1 $(GO) test $(GO_GCFLAGS) -tags reqserving -c

--- a/support/supportedversion/version.go
+++ b/support/supportedversion/version.go
@@ -235,18 +235,24 @@ func LookupLatestSupportedRelease(ctx context.Context, hc *hyperv1.HostedCluster
 	return version.PullSpec, nil
 }
 
+// commitHash is set via -ldflags at build time as a fallback when
+// Go's VCS stamping is unavailable (e.g. git worktrees, vendored builds).
+var commitHash string
+
 // GetRevision returns the overall codebase version. It's for detecting
 // what code a binary was built from.
 func GetRevision() string {
 	bi, ok := debug.ReadBuildInfo()
-	if !ok {
-		return "<unknown>"
+	if ok {
+		for _, setting := range bi.Settings {
+			if setting.Key == "vcs.revision" {
+				return setting.Value
+			}
+		}
 	}
 
-	for _, setting := range bi.Settings {
-		if setting.Key == "vcs.revision" {
-			return setting.Value
-		}
+	if commitHash != "" {
+		return commitHash
 	}
 	return "<unknown>"
 }


### PR DESCRIPTION
## Summary
- `hypershift --version` shows `<unknown>` instead of the git commit hash when built from a git worktree or with `-mod=vendor`, because Go's VCS stamping is unavailable in those scenarios.
- Adds a `commitHash` variable to `supportedversion` injected via `-ldflags -X` at build time as a fallback when `debug.ReadBuildInfo()` doesn't provide `vcs.revision`.
- Updates Makefile build recipes (`GO_BUILD_RECIPE`, `GO_CLI_RECIPE`) to pass `git rev-parse HEAD` through ldflags.

## Test plan
- [x] Built `hypershift` binary via `make hypershift` from a git worktree
- [x] Verified `./bin/hypershift --version` displays the correct commit hash
- [x] Verified `./bin/hypershift version --client-only` and `--commit-only` output correct values

Jira: https://issues.redhat.com/browse/CNTRLPLANE-2807

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined build process to capture and embed commit hash information into compiled binaries, improving version identification accuracy for deployed instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->