### PR TITLE
NO-JIRA: fix(test): add aws-node-termination-handler to safe-evict audited list

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -1614,6 +1614,7 @@ func EnsurePodsWithEmptyDirPVsHaveSafeToEvictAnnotations(t *testing.T, ctx conte
 			"openstack-manila-csi":                   "app",
 			"karpenter":                              "app",
 			"karpenter-operator":                     "app",
+			"aws-node-termination-handler":           "app",
 		}
 
 		hcpPods := &corev1.PodList{}


### PR DESCRIPTION
## Summary
- Add `aws-node-termination-handler` to the `auditedAppList` in the `EnsurePodsWithEmptyDirPVsHaveSafeToEvictAnnotations` e2e test
- The component uses the standard control plane component framework (`NewDeploymentComponent`), which automatically sets the `cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes` annotation on its pods
- Without this fix, the test fails because it expects non-audited pods to have no safe-to-evict volumes, but the component legitimately has them (`tmp`, `token`, `cloud-token`)

Fix this failure: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/7814/pull-ci-openshift-hypershift-main-e2e-aws/2027149274311036928 

## Test plan
- [ ] Verify `EnsurePodsWithEmptyDirPVsHaveSafeToEvictAnnotations` e2e test passes on AWS clusters with the termination handler enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added application configuration to test auditing utilities to support additional application validation scenarios in end-to-end testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->