### PR TITLE
[release-4.21] OCPBUGS-77456: Add dynamic NodePort range validation

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3825,6 +3825,7 @@ func (r *HostedClusterReconciler) validateNetworks(hc *hyperv1.HostedCluster) er
 	errs = append(errs, validateSliceNetworkCIDRs(hc)...)
 	errs = append(errs, checkAdvertiseAddressOverlapping(hc)...)
 	errs = append(errs, validateNodePortVsServiceNetwork(hc)...)
+	errs = append(errs, validateNodePortPortRange(hc)...)
 
 	return errs.ToAggregate()
 }
@@ -4008,6 +4009,83 @@ func validateNodePortVsServiceNetwork(hc *hyperv1.HostedCluster) field.ErrorList
 			netCIDR := (net.IPNet)(cidr.CIDR)
 			if netCIDR.Contains(ip) {
 				errs = append(errs, field.Invalid(field.NewPath("spec.networking.ServiceNetwork"), cidr.CIDR.String(), fmt.Sprintf("Nodeport IP is within the service network range: %s is within %s", ip, cidr.CIDR.String())))
+			}
+		}
+	}
+	return errs
+}
+
+// parseNodePortRange parses a ServiceNodePortRange string like "30000-32767" into min/max values.
+// This range defines which ports on worker nodes are available for NodePort services.
+// The range is configurable per cluster via spec.configuration.network.serviceNodePortRange,
+// with a default of 30000-32767 (following Kubernetes standard).
+func parseNodePortRange(rangeStr string) (min, max int32, err error) {
+	if rangeStr == "" {
+		return 30000, 32767, nil // Default range
+	}
+
+	parts := strings.Split(rangeStr, "-")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid range format: %s", rangeStr)
+	}
+
+	minVal, err := strconv.ParseInt(parts[0], 10, 32)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid minimum port: %s", parts[0])
+	}
+
+	maxVal, err := strconv.ParseInt(parts[1], 10, 32)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid maximum port: %s", parts[1])
+	}
+
+	return int32(minVal), int32(maxVal), nil
+}
+
+// validateNodePortPortRange validates that NodePort.Port is within the configured ServiceNodePortRange.
+//
+// NodePort services expose applications on worker nodes using a specific port. The available port range
+// is controlled by the kube-apiserver's --service-node-port-range flag, which prevents conflicts with
+// system services and other applications running on nodes.
+//
+// This validation ensures:
+// 1. Specified ports fall within the cluster's configured range (preventing kube-apiserver rejection)
+// 2. Port 0 (dynamic assignment) is always allowed (kube-apiserver will auto-assign from valid range)
+// 3. Early feedback to users instead of late failure during cluster provisioning
+//
+// The range is configurable via spec.configuration.network.serviceNodePortRange, defaulting to
+// the Kubernetes standard of 30000-32767.
+func validateNodePortPortRange(hc *hyperv1.HostedCluster) field.ErrorList {
+	var errs field.ErrorList
+
+	// Get the configured NodePort range for this cluster
+	nodePortRange := ""
+	if hc.Spec.Configuration != nil && hc.Spec.Configuration.Network != nil {
+		nodePortRange = hc.Spec.Configuration.Network.ServiceNodePortRange
+	}
+	if nodePortRange == "" {
+		nodePortRange = config.DefaultServiceNodePortRange
+	}
+
+	// Parse the range
+	minPort, maxPort, err := parseNodePortRange(nodePortRange)
+	if err != nil {
+		errs = append(errs, field.Invalid(
+			field.NewPath("spec.configuration.network.serviceNodePortRange"),
+			nodePortRange,
+			fmt.Sprintf("invalid ServiceNodePortRange format: %v", err)))
+		return errs
+	}
+
+	// Validate NodePort.Port against the configured range
+	for idx, svc := range hc.Spec.Services {
+		if svc.Service == hyperv1.APIServer && svc.Type == hyperv1.NodePort && svc.NodePort != nil {
+			port := svc.NodePort.Port
+			if port > 0 && (port < minPort || port > maxPort) {
+				errs = append(errs, field.Invalid(
+					field.NewPath(fmt.Sprintf("spec.services[%d].nodePort.port", idx)),
+					port,
+					fmt.Sprintf("port must be within the configured range %d-%d or 0 for dynamic assignment", minPort, maxPort)))
 			}
 		}
 	}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -2064,7 +2064,7 @@ func TestValidateConfigAndClusterCapabilities(t *testing.T) {
 								Type: hyperv1.NodePort,
 								NodePort: &hyperv1.NodePortPublishingStrategy{
 									Address: "172.16.3.3",
-									Port:    4433,
+									Port:    30443,
 								},
 							},
 						},
@@ -4847,6 +4847,291 @@ func TestValidateNodePortVsServiceNetwork(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			actual := validateNodePortVsServiceNetwork(tc.hostedCluster)
+			if diff := cmp.Diff(actual, tc.expectedErrorList, equateErrorMessage); diff != "" {
+				t.Errorf("actual validation result differs from expected: %s", diff)
+			}
+		})
+	}
+}
+
+func TestParseNodePortRange(t *testing.T) {
+	testCases := []struct {
+		name        string
+		rangeStr    string
+		expectedMin int32
+		expectedMax int32
+		expectError bool
+	}{
+		{
+			name:        "empty range uses default",
+			rangeStr:    "",
+			expectedMin: 30000,
+			expectedMax: 32767,
+			expectError: false,
+		},
+		{
+			name:        "valid default range",
+			rangeStr:    "30000-32767",
+			expectedMin: 30000,
+			expectedMax: 32767,
+			expectError: false,
+		},
+		{
+			name:        "valid custom range",
+			rangeStr:    "25000-35000",
+			expectedMin: 25000,
+			expectedMax: 35000,
+			expectError: false,
+		},
+		{
+			name:        "valid small range",
+			rangeStr:    "31000-31010",
+			expectedMin: 31000,
+			expectedMax: 31010,
+			expectError: false,
+		},
+		{
+			name:        "invalid format - no dash",
+			rangeStr:    "30000",
+			expectError: true,
+		},
+		{
+			name:        "invalid format - multiple dashes",
+			rangeStr:    "30000-31000-32000",
+			expectError: true,
+		},
+		{
+			name:        "invalid minimum port",
+			rangeStr:    "abc-32767",
+			expectError: true,
+		},
+		{
+			name:        "invalid maximum port",
+			rangeStr:    "30000-xyz",
+			expectError: true,
+		},
+		{
+			name:        "negative port",
+			rangeStr:    "-1-32767",
+			expectError: true,
+		},
+		{
+			name:        "port too large",
+			rangeStr:    "30000-99999",
+			expectedMin: 30000,
+			expectedMax: 99999,
+			expectError: false, // parseNodePortRange doesn't validate port limits
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			min, max, err := parseNodePortRange(tc.rangeStr)
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if min != tc.expectedMin {
+					t.Errorf("expected min %d, got %d", tc.expectedMin, min)
+				}
+				if max != tc.expectedMax {
+					t.Errorf("expected max %d, got %d", tc.expectedMax, max)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateNodePortPortRange(t *testing.T) {
+	testCases := []struct {
+		name              string
+		hostedCluster     *hyperv1.HostedCluster
+		expectedErrorList field.ErrorList
+	}{
+		{
+			name: "valid port in default range",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.NodePort,
+								NodePort: &hyperv1.NodePortPublishingStrategy{
+									Address: "1.1.1.1",
+									Port:    31000,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "port 0 for dynamic assignment - always valid",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.NodePort,
+								NodePort: &hyperv1.NodePortPublishingStrategy{
+									Address: "1.1.1.1",
+									Port:    0,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "port below default range",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.NodePort,
+								NodePort: &hyperv1.NodePortPublishingStrategy{
+									Address: "1.1.1.1",
+									Port:    10000,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErrorList: field.ErrorList{
+				field.Invalid(field.NewPath("spec.services[0].nodePort.port"), int32(10000), "port must be within the configured range 30000-32767 or 0 for dynamic assignment"),
+			},
+		},
+		{
+			name: "port above default range",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.NodePort,
+								NodePort: &hyperv1.NodePortPublishingStrategy{
+									Address: "1.1.1.1",
+									Port:    65000,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErrorList: field.ErrorList{
+				field.Invalid(field.NewPath("spec.services[0].nodePort.port"), int32(65000), "port must be within the configured range 30000-32767 or 0 for dynamic assignment"),
+			},
+		},
+		{
+			name: "valid port in custom range",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						Network: &configv1.NetworkSpec{
+							ServiceNodePortRange: "25000-35000",
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.NodePort,
+								NodePort: &hyperv1.NodePortPublishingStrategy{
+									Address: "1.1.1.1",
+									Port:    28000,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "port outside custom range",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						Network: &configv1.NetworkSpec{
+							ServiceNodePortRange: "25000-35000",
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.NodePort,
+								NodePort: &hyperv1.NodePortPublishingStrategy{
+									Address: "1.1.1.1",
+									Port:    40000,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErrorList: field.ErrorList{
+				field.Invalid(field.NewPath("spec.services[0].nodePort.port"), int32(40000), "port must be within the configured range 25000-35000 or 0 for dynamic assignment"),
+			},
+		},
+		{
+			name: "invalid range format",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						Network: &configv1.NetworkSpec{
+							ServiceNodePortRange: "invalid-range",
+						},
+					},
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.NodePort,
+								NodePort: &hyperv1.NodePortPublishingStrategy{
+									Address: "1.1.1.1",
+									Port:    31000,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErrorList: field.ErrorList{
+				field.Invalid(field.NewPath("spec.configuration.network.serviceNodePortRange"), "invalid-range", "invalid ServiceNodePortRange format: invalid minimum port: invalid"),
+			},
+		},
+		{
+			name: "no nodeport service - no validation",
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Services: []hyperv1.ServicePublishingStrategyMapping{
+						{
+							Service: hyperv1.APIServer,
+							ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+								Type: hyperv1.LoadBalancer,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := validateNodePortPortRange(tc.hostedCluster)
 			if diff := cmp.Diff(actual, tc.expectedErrorList, equateErrorMessage); diff != "" {
 				t.Errorf("actual validation result differs from expected: %s", diff)
 			}


### PR DESCRIPTION
## Summary

Manual backport of https://github.com/openshift/hypershift/pull/7652

- Add validation for `NodePort.Port` to ensure ports fall within the cluster's configured `ServiceNodePortRange`
- Reads cluster-specific `ServiceNodePortRange` or uses default (30000-32767)
- Allows port 0 (dynamic assignment) and provides clear error messages with the actual configured range
- Prevents late failures during cluster provisioning when the control-plane-operator rejects ports outside the acceptable range

## Test plan
- [x] Unit tests for `TestParseNodePortRange` pass
- [x] Unit tests for `TestValidateNodePortPortRange` pass
- [ ] Verify validation rejects ports outside configured range
- [ ] Verify validation allows port 0 for dynamic assignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)