### PR TITLE
CNTRLPLANE-2801: api: remove redundant kubebuilder enum marker from KeyVaultAccess field

### DIFF
--- a/api/.golangci.yml
+++ b/api/.golangci.yml
@@ -21,6 +21,7 @@ linters:
               - "*"
             enable:
               - conditions
+              - duplicatemarkers
               - maxlength
               - nobools
               - nomaps
@@ -180,24 +181,6 @@ linters:
           - kubeapilinter
         path: hypershift/v1beta1/kubevirt.go
         text: 'defaultorrequired: field KubevirtNodePoolPlatform.RootVolume has conflicting markers: default_or_required: \{\[kubebuilder:default\], \[required\]\}. A field with a default value cannot be required. A required field must be provided by the user, so a default value is not meaningful'
-
-      # duplicatemarkers (4 issues)
-      - linters:
-          - kubeapilinter
-        path: hypershift/v1beta1/azure.go
-        text: 'duplicatemarkers: Diagnostics.StorageAccountType has duplicated markers kubebuilder:validation:Enum'
-      - linters:
-          - kubeapilinter
-        path: hypershift/v1beta1/azure.go
-        text: 'duplicatemarkers: ManagedIdentity.ObjectEncoding has duplicated markers kubebuilder:default'
-      - linters:
-          - kubeapilinter
-        path: hypershift/v1beta1/azure.go
-        text: 'duplicatemarkers: ManagedIdentity.ObjectEncoding has duplicated markers kubebuilder:validation:Enum'
-      - linters:
-          - kubeapilinter
-        path: hypershift/v1beta1/hostedcluster_types.go
-        text: 'duplicatemarkers: ProvisionerConfig.Name has duplicated markers kubebuilder:validation:Enum'
 
       # integers (6 issues)
       - linters:

--- a/api/hypershift/v1beta1/azure.go
+++ b/api/hypershift/v1beta1/azure.go
@@ -241,7 +241,6 @@ const (
 type Diagnostics struct {
 	// storageAccountType determines if the storage account for storing the diagnostics data
 	// should be disabled (Disabled), provisioned by Azure (Managed) or by the user (UserManaged).
-	// +kubebuilder:validation:Enum=Managed;UserManaged;Disabled
 	// +kubebuilder:default:=Disabled
 	// +unionDiscriminator
 	// +optional
@@ -576,8 +575,6 @@ type ManagedIdentity struct {
 	//
 	// See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
 	//
-	// +kubebuilder:validation:Enum:=utf-8;hex;base64
-	// +kubebuilder:default:="utf-8"
 	// +required
 	ObjectEncoding ObjectEncodingFormat `json:"objectEncoding"`
 
@@ -718,10 +715,8 @@ type AzureKMSSpec struct {
 	// keyVaultAccess specifies how the Key Vault should be accessed.
 	// When set to "Private", the control plane routes Key Vault traffic through
 	// the private router to reach the Key Vault's private endpoint in the customer VNet.
-	// When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-	// Controllers treat an empty value the same as "Public".
+	// When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
 	//
-	// +kubebuilder:validation:Enum=Public;Private;""
 	// +optional
 	KeyVaultAccess AzureKeyVaultAccessType `json:"keyVaultAccess,omitempty"`
 }

--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -1362,7 +1362,6 @@ type AutoNode struct {
 type ProvisionerConfig struct {
 	// name specifies the name of the provisioner to use.
 	// +required
-	// +kubebuilder:validation:Enum=Karpenter
 	Name Provisioner `json:"name"`
 	// karpenter specifies the configuration for the Karpenter provisioner.
 	// +optional

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -4111,16 +4111,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4131,6 +4121,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4170,16 +4164,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4190,6 +4174,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4228,16 +4216,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4248,6 +4226,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4286,16 +4268,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4306,6 +4278,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4344,16 +4320,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4364,6 +4330,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4402,16 +4372,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4422,6 +4382,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4484,16 +4448,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4504,6 +4458,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4543,16 +4501,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4563,6 +4511,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5599,21 +5551,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -5647,16 +5593,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5667,6 +5603,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -143,13 +143,10 @@ spec:
                         - platform
                         type: object
                       name:
-                        allOf:
-                        - enum:
-                          - Karpenter
-                        - enum:
-                          - Karpenter
                         description: name specifies the name of the provisioner to
                           use.
+                        enum:
+                        - Karpenter
                         type: string
                     required:
                     - name
@@ -4149,16 +4146,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4169,6 +4156,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4208,16 +4199,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4228,6 +4209,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4266,16 +4251,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4286,6 +4261,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4324,16 +4303,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4344,6 +4313,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4382,16 +4355,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4402,6 +4365,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4440,16 +4407,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4460,6 +4417,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4522,16 +4483,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4542,6 +4493,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4581,16 +4536,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4601,6 +4546,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5629,21 +5578,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -5677,16 +5620,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5697,6 +5630,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -4102,16 +4102,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4122,6 +4112,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4161,16 +4155,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4181,6 +4165,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4219,16 +4207,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4239,6 +4217,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4277,16 +4259,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4297,6 +4269,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4335,16 +4311,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4355,6 +4321,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4393,16 +4363,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4413,6 +4373,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4475,16 +4439,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4495,6 +4449,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4534,16 +4492,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4554,6 +4502,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5582,21 +5534,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -5630,16 +5576,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5650,6 +5586,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -4122,16 +4122,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4142,6 +4132,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4181,16 +4175,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4201,6 +4185,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4239,16 +4227,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4259,6 +4237,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4297,16 +4279,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4317,6 +4289,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4355,16 +4331,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4375,6 +4341,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4413,16 +4383,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4433,6 +4393,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4495,16 +4459,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4515,6 +4469,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4554,16 +4512,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4574,6 +4522,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5602,21 +5554,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -5650,16 +5596,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5670,6 +5606,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -4470,16 +4470,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4490,6 +4480,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4529,16 +4523,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4549,6 +4533,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4587,16 +4575,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4607,6 +4585,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4645,16 +4627,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4665,6 +4637,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4703,16 +4679,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4723,6 +4689,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4761,16 +4731,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4781,6 +4741,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4843,16 +4807,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4863,6 +4817,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4902,16 +4860,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4922,6 +4870,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5950,21 +5902,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -5998,16 +5944,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -6018,6 +5954,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -4624,16 +4624,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4644,6 +4634,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4683,16 +4677,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4703,6 +4687,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4741,16 +4729,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4761,6 +4739,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4799,16 +4781,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4819,6 +4791,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4857,16 +4833,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4877,6 +4843,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4915,16 +4885,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4935,6 +4895,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4997,16 +4961,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5017,6 +4971,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5056,16 +5014,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5076,6 +5024,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -6104,21 +6056,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -6152,16 +6098,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -6172,6 +6108,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -4565,16 +4565,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4585,6 +4575,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4624,16 +4618,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4644,6 +4628,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4682,16 +4670,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4702,6 +4680,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4740,16 +4722,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4760,6 +4732,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4798,16 +4774,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4818,6 +4784,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4856,16 +4826,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4876,6 +4836,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4938,16 +4902,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4958,6 +4912,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4997,16 +4955,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5017,6 +4965,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -6045,21 +5997,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -6093,16 +6039,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -6113,6 +6049,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
@@ -4102,16 +4102,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4122,6 +4112,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4161,16 +4155,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4181,6 +4165,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4219,16 +4207,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4239,6 +4217,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4277,16 +4259,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4297,6 +4269,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4335,16 +4311,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4355,6 +4321,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4393,16 +4363,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4413,6 +4373,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4475,16 +4439,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4495,6 +4449,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4534,16 +4492,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4554,6 +4502,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5937,21 +5889,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -5985,16 +5931,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -6005,6 +5941,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -4124,16 +4124,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4144,6 +4134,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4183,16 +4177,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4203,6 +4187,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4241,16 +4229,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4261,6 +4239,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4299,16 +4281,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4319,6 +4291,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4357,16 +4333,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4377,6 +4343,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4415,16 +4385,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4435,6 +4395,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4497,16 +4461,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4517,6 +4471,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4556,16 +4514,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4576,6 +4524,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5604,21 +5556,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -5652,16 +5598,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5672,6 +5608,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -4120,16 +4120,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4140,6 +4130,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4179,16 +4173,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4199,6 +4183,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4237,16 +4225,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4257,6 +4235,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4295,16 +4277,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4315,6 +4287,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4353,16 +4329,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4373,6 +4339,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4411,16 +4381,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4431,6 +4391,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4493,16 +4457,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4513,6 +4467,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4552,16 +4510,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4572,6 +4520,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5600,21 +5552,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -5648,16 +5594,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5668,6 +5604,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -4178,16 +4178,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4198,6 +4188,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4237,16 +4231,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4257,6 +4241,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4295,16 +4283,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4315,6 +4293,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4353,16 +4335,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4373,6 +4345,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4411,16 +4387,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4431,6 +4397,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4469,16 +4439,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4489,6 +4449,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4551,16 +4515,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4571,6 +4525,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4610,16 +4568,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4630,6 +4578,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5658,21 +5610,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -5706,16 +5652,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5726,6 +5662,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -4254,16 +4254,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4274,6 +4264,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4313,16 +4307,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4333,6 +4317,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4371,16 +4359,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4391,6 +4369,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4429,16 +4411,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4449,6 +4421,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4487,16 +4463,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4507,6 +4473,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4545,16 +4515,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4565,6 +4525,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4627,16 +4591,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4647,6 +4601,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4686,16 +4644,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4706,6 +4654,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5734,21 +5686,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -5782,16 +5728,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5802,6 +5738,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -4102,16 +4102,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4122,6 +4112,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4161,16 +4155,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4181,6 +4165,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4219,16 +4207,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4239,6 +4217,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4277,16 +4259,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4297,6 +4269,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4335,16 +4311,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4355,6 +4321,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4393,16 +4363,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4413,6 +4373,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4475,16 +4439,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4495,6 +4449,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4534,16 +4492,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4554,6 +4502,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -6133,21 +6085,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -6181,16 +6127,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -6201,6 +6137,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -4003,16 +4003,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4023,6 +4013,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4062,16 +4056,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4082,6 +4066,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4120,16 +4108,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4140,6 +4118,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4178,16 +4160,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4198,6 +4170,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4236,16 +4212,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4256,6 +4222,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4294,16 +4264,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4314,6 +4274,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4376,16 +4340,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4396,6 +4350,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4435,16 +4393,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4455,6 +4403,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5467,21 +5419,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -5515,16 +5461,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5535,6 +5471,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -111,13 +111,10 @@ spec:
                         - platform
                         type: object
                       name:
-                        allOf:
-                        - enum:
-                          - Karpenter
-                        - enum:
-                          - Karpenter
                         description: name specifies the name of the provisioner to
                           use.
+                        enum:
+                        - Karpenter
                         type: string
                     required:
                     - name
@@ -4041,16 +4038,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4061,6 +4048,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4100,16 +4091,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4120,6 +4101,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4158,16 +4143,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4178,6 +4153,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4216,16 +4195,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4236,6 +4205,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4274,16 +4247,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4294,6 +4257,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4332,16 +4299,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4352,6 +4309,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4414,16 +4375,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4434,6 +4385,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4473,16 +4428,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4493,6 +4438,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5497,21 +5446,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -5545,16 +5488,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5565,6 +5498,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -3994,16 +3994,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4014,6 +4004,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4053,16 +4047,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4073,6 +4057,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4111,16 +4099,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4131,6 +4109,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4169,16 +4151,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4189,6 +4161,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4227,16 +4203,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4247,6 +4213,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4285,16 +4255,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4305,6 +4265,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4367,16 +4331,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4387,6 +4341,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4426,16 +4384,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4446,6 +4394,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5450,21 +5402,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -5498,16 +5444,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5518,6 +5454,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -4014,16 +4014,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4034,6 +4024,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4073,16 +4067,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4093,6 +4077,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4131,16 +4119,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4151,6 +4129,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4189,16 +4171,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4209,6 +4181,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4247,16 +4223,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4267,6 +4233,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4305,16 +4275,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4325,6 +4285,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4387,16 +4351,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4407,6 +4361,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4446,16 +4404,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4466,6 +4414,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5470,21 +5422,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -5518,16 +5464,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5538,6 +5474,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -4362,16 +4362,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4382,6 +4372,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4421,16 +4415,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4441,6 +4425,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4479,16 +4467,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4499,6 +4477,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4537,16 +4519,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4557,6 +4529,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4595,16 +4571,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4615,6 +4581,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4653,16 +4623,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4673,6 +4633,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4735,16 +4699,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4755,6 +4709,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4794,16 +4752,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4814,6 +4762,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5818,21 +5770,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -5866,16 +5812,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5886,6 +5822,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -4516,16 +4516,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4536,6 +4526,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4575,16 +4569,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4595,6 +4579,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4633,16 +4621,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4653,6 +4631,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4691,16 +4673,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4711,6 +4683,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4749,16 +4725,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4769,6 +4735,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4807,16 +4777,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4827,6 +4787,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4889,16 +4853,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4909,6 +4863,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4948,16 +4906,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4968,6 +4916,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5972,21 +5924,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -6020,16 +5966,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -6040,6 +5976,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -4457,16 +4457,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4477,6 +4467,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4516,16 +4510,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4536,6 +4520,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4574,16 +4562,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4594,6 +4572,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4632,16 +4614,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4652,6 +4624,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4690,16 +4666,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4710,6 +4676,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4748,16 +4718,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4768,6 +4728,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4830,16 +4794,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4850,6 +4804,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4889,16 +4847,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4909,6 +4857,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5913,21 +5865,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -5961,16 +5907,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5981,6 +5917,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
@@ -3994,16 +3994,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4014,6 +4004,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4053,16 +4047,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4073,6 +4057,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4111,16 +4099,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4131,6 +4109,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4169,16 +4151,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4189,6 +4161,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4227,16 +4203,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4247,6 +4213,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4285,16 +4255,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4305,6 +4265,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4367,16 +4331,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4387,6 +4341,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4426,16 +4384,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4446,6 +4394,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5805,21 +5757,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -5853,16 +5799,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5873,6 +5809,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -4016,16 +4016,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4036,6 +4026,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4075,16 +4069,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4095,6 +4079,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4133,16 +4121,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4153,6 +4131,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4191,16 +4173,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4211,6 +4183,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4249,16 +4225,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4269,6 +4235,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4307,16 +4277,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4327,6 +4287,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4389,16 +4353,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4409,6 +4363,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4448,16 +4406,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4468,6 +4416,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5472,21 +5424,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -5520,16 +5466,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5540,6 +5476,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -4012,16 +4012,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4032,6 +4022,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4071,16 +4065,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4091,6 +4075,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4129,16 +4117,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4149,6 +4127,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4187,16 +4169,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4207,6 +4179,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4245,16 +4221,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4265,6 +4231,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4303,16 +4273,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4323,6 +4283,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4385,16 +4349,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4405,6 +4359,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4444,16 +4402,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4464,6 +4412,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5468,21 +5420,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -5516,16 +5462,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5536,6 +5472,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -4070,16 +4070,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4090,6 +4080,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4129,16 +4123,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4149,6 +4133,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4187,16 +4175,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4207,6 +4185,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4245,16 +4227,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4265,6 +4237,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4303,16 +4279,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4323,6 +4289,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4361,16 +4331,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4381,6 +4341,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4443,16 +4407,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4463,6 +4417,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4502,16 +4460,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4522,6 +4470,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5526,21 +5478,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -5574,16 +5520,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5594,6 +5530,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -4146,16 +4146,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4166,6 +4156,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4205,16 +4199,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4225,6 +4209,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4263,16 +4251,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4283,6 +4261,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4321,16 +4303,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4341,6 +4313,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4379,16 +4355,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4399,6 +4365,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4437,16 +4407,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4457,6 +4417,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4519,16 +4483,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4539,6 +4493,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4578,16 +4536,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4598,6 +4546,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5602,21 +5554,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -5650,16 +5596,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5670,6 +5606,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -3994,16 +3994,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4014,6 +4004,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4053,16 +4047,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4073,6 +4057,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4111,16 +4099,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4131,6 +4109,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4169,16 +4151,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4189,6 +4161,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4227,16 +4203,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4247,6 +4213,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4285,16 +4255,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4305,6 +4265,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4367,16 +4331,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4387,6 +4341,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4426,16 +4384,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4446,6 +4394,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -6001,21 +5953,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -6049,16 +5995,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -6069,6 +6005,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
@@ -702,19 +702,14 @@ spec:
                           If not specified, then Boot diagnostics will be disabled.
                         properties:
                           storageAccountType:
-                            allOf:
-                            - enum:
-                              - Managed
-                              - UserManaged
-                              - Disabled
-                            - enum:
-                              - Managed
-                              - UserManaged
-                              - Disabled
                             default: Disabled
                             description: |-
                               storageAccountType determines if the storage account for storing the diagnostics data
                               should be disabled (Disabled), provisioned by Azure (Managed) or by the user (UserManaged).
+                            enum:
+                            - Managed
+                            - UserManaged
+                            - Disabled
                             type: string
                           userManaged:
                             description: userManaged specifies the diagnostics settings

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
@@ -702,19 +702,14 @@ spec:
                           If not specified, then Boot diagnostics will be disabled.
                         properties:
                           storageAccountType:
-                            allOf:
-                            - enum:
-                              - Managed
-                              - UserManaged
-                              - Disabled
-                            - enum:
-                              - Managed
-                              - UserManaged
-                              - Disabled
                             default: Disabled
                             description: |-
                               storageAccountType determines if the storage account for storing the diagnostics data
                               should be disabled (Disabled), provisioned by Azure (Managed) or by the user (UserManaged).
+                            enum:
+                            - Managed
+                            - UserManaged
+                            - Disabled
                             type: string
                           userManaged:
                             description: userManaged specifies the diagnostics settings

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
@@ -702,19 +702,14 @@ spec:
                           If not specified, then Boot diagnostics will be disabled.
                         properties:
                           storageAccountType:
-                            allOf:
-                            - enum:
-                              - Managed
-                              - UserManaged
-                              - Disabled
-                            - enum:
-                              - Managed
-                              - UserManaged
-                              - Disabled
                             default: Disabled
                             description: |-
                               storageAccountType determines if the storage account for storing the diagnostics data
                               should be disabled (Disabled), provisioned by Azure (Managed) or by the user (UserManaged).
+                            enum:
+                            - Managed
+                            - UserManaged
+                            - Disabled
                             type: string
                           userManaged:
                             description: userManaged specifies the diagnostics settings

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
@@ -145,13 +145,10 @@ spec:
                         - platform
                         type: object
                       name:
-                        allOf:
-                        - enum:
-                          - Karpenter
-                        - enum:
-                          - Karpenter
                         description: name specifies the name of the provisioner to
                           use.
+                        enum:
+                        - Karpenter
                         type: string
                     required:
                     - name
@@ -5061,16 +5058,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5081,6 +5068,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5120,16 +5111,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5140,6 +5121,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5178,16 +5163,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5198,6 +5173,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5236,16 +5215,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5256,6 +5225,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5294,16 +5267,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5314,6 +5277,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5352,16 +5319,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5372,6 +5329,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5434,16 +5395,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5454,6 +5405,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5493,16 +5448,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5513,6 +5458,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -7437,21 +7386,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -7485,16 +7428,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -7505,6 +7438,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
@@ -4805,16 +4805,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4825,6 +4815,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4864,16 +4858,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4884,6 +4868,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4922,16 +4910,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4942,6 +4920,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4980,16 +4962,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5000,6 +4972,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5038,16 +5014,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5058,6 +5024,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5096,16 +5066,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5116,6 +5076,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5178,16 +5142,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5198,6 +5152,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5237,16 +5195,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5257,6 +5205,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -6293,21 +6245,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -6341,16 +6287,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -6361,6 +6297,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -145,13 +145,10 @@ spec:
                         - platform
                         type: object
                       name:
-                        allOf:
-                        - enum:
-                          - Karpenter
-                        - enum:
-                          - Karpenter
                         description: name specifies the name of the provisioner to
                           use.
+                        enum:
+                        - Karpenter
                         type: string
                     required:
                     - name
@@ -4872,16 +4869,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4892,6 +4879,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4931,16 +4922,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4951,6 +4932,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4989,16 +4974,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5009,6 +4984,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5047,16 +5026,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5067,6 +5036,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5105,16 +5078,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5125,6 +5088,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5163,16 +5130,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5183,6 +5140,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5245,16 +5206,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5265,6 +5216,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5304,16 +5259,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5324,6 +5269,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -7248,21 +7197,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -7296,16 +7239,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -7316,6 +7249,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
@@ -113,13 +113,10 @@ spec:
                         - platform
                         type: object
                       name:
-                        allOf:
-                        - enum:
-                          - Karpenter
-                        - enum:
-                          - Karpenter
                         description: name specifies the name of the provisioner to
                           use.
+                        enum:
+                        - Karpenter
                         type: string
                     required:
                     - name
@@ -4953,16 +4950,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4973,6 +4960,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5012,16 +5003,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5032,6 +5013,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5070,16 +5055,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5090,6 +5065,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5128,16 +5107,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5148,6 +5117,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5186,16 +5159,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5206,6 +5169,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5244,16 +5211,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5264,6 +5221,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5326,16 +5287,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5346,6 +5297,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5385,16 +5340,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5405,6 +5350,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -7305,21 +7254,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -7353,16 +7296,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -7373,6 +7306,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
@@ -4697,16 +4697,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4717,6 +4707,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4756,16 +4750,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4776,6 +4760,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4814,16 +4802,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4834,6 +4812,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4872,16 +4854,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4892,6 +4864,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4930,16 +4906,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4950,6 +4916,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4988,16 +4958,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5008,6 +4968,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5070,16 +5034,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5090,6 +5044,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5129,16 +5087,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5149,6 +5097,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -6161,21 +6113,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -6209,16 +6155,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -6229,6 +6165,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -113,13 +113,10 @@ spec:
                         - platform
                         type: object
                       name:
-                        allOf:
-                        - enum:
-                          - Karpenter
-                        - enum:
-                          - Karpenter
                         description: name specifies the name of the provisioner to
                           use.
+                        enum:
+                        - Karpenter
                         type: string
                     required:
                     - name
@@ -4764,16 +4761,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4784,6 +4771,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4823,16 +4814,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4843,6 +4824,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4881,16 +4866,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4901,6 +4876,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4939,16 +4918,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -4959,6 +4928,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -4997,16 +4970,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5017,6 +4980,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5055,16 +5022,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5075,6 +5032,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5137,16 +5098,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5157,6 +5108,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -5196,16 +5151,6 @@ spec:
                                         pattern: ^[a-zA-Z0-9-]+$
                                         type: string
                                       objectEncoding:
-                                        allOf:
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        - enum:
-                                          - utf-8
-                                          - hex
-                                          - base64
-                                        default: utf-8
                                         description: |-
                                           objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                           the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -5216,6 +5161,10 @@ spec:
                                           The default value is utf-8.
 
                                           See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                        enum:
+                                        - utf-8
+                                        - hex
+                                        - base64
                                         type: string
                                     required:
                                     - credentialsSecretName
@@ -7116,21 +7065,15 @@ spec:
                             - keyVersion
                             type: object
                           keyVaultAccess:
-                            allOf:
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
-                            - enum:
-                              - Public
-                              - Private
-                              - ""
                             description: |-
                               keyVaultAccess specifies how the Key Vault should be accessed.
                               When set to "Private", the control plane routes Key Vault traffic through
                               the private router to reach the Key Vault's private endpoint in the customer VNet.
-                              When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-                              Controllers treat an empty value the same as "Public".
+                              When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
+                            enum:
+                            - Public
+                            - Private
+                            - ""
                             type: string
                           kms:
                             description: kms is a pre-existing managed identity used
@@ -7164,16 +7107,6 @@ spec:
                                 pattern: ^[a-zA-Z0-9-]+$
                                 type: string
                               objectEncoding:
-                                allOf:
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                - enum:
-                                  - utf-8
-                                  - hex
-                                  - base64
-                                default: utf-8
                                 description: |-
                                   objectEncoding represents the encoding for the Azure Key Vault secret containing the certificate related to
                                   the managed identity. objectEncoding needs to match the encoding format used when the certificate was stored in the
@@ -7184,6 +7117,10 @@ spec:
                                   The default value is utf-8.
 
                                   See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
+                                enum:
+                                - utf-8
+                                - hex
+                                - base64
                                 type: string
                             required:
                             - credentialsSecretName

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -705,19 +705,14 @@ spec:
                           If not specified, then Boot diagnostics will be disabled.
                         properties:
                           storageAccountType:
-                            allOf:
-                            - enum:
-                              - Managed
-                              - UserManaged
-                              - Disabled
-                            - enum:
-                              - Managed
-                              - UserManaged
-                              - Disabled
                             default: Disabled
                             description: |-
                               storageAccountType determines if the storage account for storing the diagnostics data
                               should be disabled (Disabled), provisioned by Azure (Managed) or by the user (UserManaged).
+                            enum:
+                            - Managed
+                            - UserManaged
+                            - Disabled
                             type: string
                           userManaged:
                             description: userManaged specifies the diagnostics settings

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -705,19 +705,14 @@ spec:
                           If not specified, then Boot diagnostics will be disabled.
                         properties:
                           storageAccountType:
-                            allOf:
-                            - enum:
-                              - Managed
-                              - UserManaged
-                              - Disabled
-                            - enum:
-                              - Managed
-                              - UserManaged
-                              - Disabled
                             default: Disabled
                             description: |-
                               storageAccountType determines if the storage account for storing the diagnostics data
                               should be disabled (Disabled), provisioned by Azure (Managed) or by the user (UserManaged).
+                            enum:
+                            - Managed
+                            - UserManaged
+                            - Disabled
                             type: string
                           userManaged:
                             description: userManaged specifies the diagnostics settings

--- a/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -705,19 +705,14 @@ spec:
                           If not specified, then Boot diagnostics will be disabled.
                         properties:
                           storageAccountType:
-                            allOf:
-                            - enum:
-                              - Managed
-                              - UserManaged
-                              - Disabled
-                            - enum:
-                              - Managed
-                              - UserManaged
-                              - Disabled
                             default: Disabled
                             description: |-
                               storageAccountType determines if the storage account for storing the diagnostics data
                               should be disabled (Disabled), provisioned by Azure (Managed) or by the user (UserManaged).
+                            enum:
+                            - Managed
+                            - UserManaged
+                            - Disabled
                             type: string
                           userManaged:
                             description: userManaged specifies the diagnostics settings

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -31752,8 +31752,7 @@ AzureKeyVaultAccessType
 <p>keyVaultAccess specifies how the Key Vault should be accessed.
 When set to &ldquo;Private&rdquo;, the control plane routes Key Vault traffic through
 the private router to reach the Key Vault&rsquo;s private endpoint in the customer VNet.
-When set to &ldquo;Public&rdquo; or omitted (empty), the Key Vault is accessed via its public endpoint.
-Controllers treat an empty value the same as &ldquo;Public&rdquo;.</p>
+When set to &ldquo;Public&rdquo; or omitted, the Key Vault is accessed via its public endpoint.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -3206,8 +3206,7 @@ AzureKeyVaultAccessType
 <p>keyVaultAccess specifies how the Key Vault should be accessed.
 When set to &ldquo;Private&rdquo;, the control plane routes Key Vault traffic through
 the private router to reach the Key Vault&rsquo;s private endpoint in the customer VNet.
-When set to &ldquo;Public&rdquo; or omitted (empty), the Key Vault is accessed via its public endpoint.
-Controllers treat an empty value the same as &ldquo;Public&rdquo;.</p>
+When set to &ldquo;Public&rdquo; or omitted, the Key Vault is accessed via its public endpoint.</p>
 </td>
 </tr>
 </tbody>

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/azure.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/azure.go
@@ -241,7 +241,6 @@ const (
 type Diagnostics struct {
 	// storageAccountType determines if the storage account for storing the diagnostics data
 	// should be disabled (Disabled), provisioned by Azure (Managed) or by the user (UserManaged).
-	// +kubebuilder:validation:Enum=Managed;UserManaged;Disabled
 	// +kubebuilder:default:=Disabled
 	// +unionDiscriminator
 	// +optional
@@ -576,8 +575,6 @@ type ManagedIdentity struct {
 	//
 	// See this for more info - https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/website/content/en/getting-started/usage/_index.md
 	//
-	// +kubebuilder:validation:Enum:=utf-8;hex;base64
-	// +kubebuilder:default:="utf-8"
 	// +required
 	ObjectEncoding ObjectEncodingFormat `json:"objectEncoding"`
 
@@ -718,10 +715,8 @@ type AzureKMSSpec struct {
 	// keyVaultAccess specifies how the Key Vault should be accessed.
 	// When set to "Private", the control plane routes Key Vault traffic through
 	// the private router to reach the Key Vault's private endpoint in the customer VNet.
-	// When set to "Public" or omitted (empty), the Key Vault is accessed via its public endpoint.
-	// Controllers treat an empty value the same as "Public".
+	// When set to "Public" or omitted, the Key Vault is accessed via its public endpoint.
 	//
-	// +kubebuilder:validation:Enum=Public;Private;""
 	// +optional
 	KeyVaultAccess AzureKeyVaultAccessType `json:"keyVaultAccess,omitempty"`
 }

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -1362,7 +1362,6 @@ type AutoNode struct {
 type ProvisionerConfig struct {
 	// name specifies the name of the provisioner to use.
 	// +required
-	// +kubebuilder:validation:Enum=Karpenter
 	Name Provisioner `json:"name"`
 	// karpenter specifies the configuration for the Karpenter provisioner.
 	// +optional


### PR DESCRIPTION
## Summary
- Removed duplicate `+kubebuilder:validation:Enum` markers from fields that already inherit them from their type definitions, following Kubernetes convention of defining enum constraints on the type only
- Fixed fields: `KeyVaultAccess`, `StorageAccountType`, `ObjectEncoding` (Enum + default), `ProvisionerConfig.Name`
- Enabled `duplicatemarkers` and kube-api-linter analyzer to catch these issues in the future
- Removed the now-unnecessary exclusion rules for the fixed duplicate marker violations

## Test plan
- [x] `make verify` passes (API generation, CRD generation, lint, staticcheck, fmt, vet)
- [x] Verified CRD schemas show single enum blocks instead of duplicated `allOf`
- [x] Confirmed `duplicatemarkers` linter runs clean with zero violations
- [x] Unit tests pass for `support/azureutil`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Simplified internal validation schemas for Azure configuration fields by consolidating enum declarations in CRD manifests.
  * Refined documentation for Key Vault access modes to clarify default behavior when unspecified or set to public.
  * Updated linting configuration to enforce validation consistency across API definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->