### PR TITLE
GCP-368: add GCP CCM v2 e2e tests

### DIFF
--- a/test/e2e/v2/internal/test_context.go
+++ b/test/e2e/v2/internal/test_context.go
@@ -38,15 +38,15 @@ type TestContextGetter func() *TestContext
 // TestContext holds the test context including clients and hosted cluster reference
 type TestContext struct {
 	context.Context
-	MgmtClient            crclient.Client
-	ClusterName           string
-	ClusterNamespace      string
-	ControlPlaneNamespace string
-	ArtifactDir           string
-	hostedCluster         *hyperv1.HostedCluster
-	hostedClusterOnce     sync.Once
-	guestClient           crclient.Client
-	guestClientOnce       sync.Once
+	MgmtClient              crclient.Client
+	ClusterName             string
+	ClusterNamespace        string
+	ControlPlaneNamespace   string
+	ArtifactDir             string
+	hostedCluster           *hyperv1.HostedCluster
+	hostedClusterOnce       sync.Once
+	hostedClusterClient     crclient.Client
+	hostedClusterClientOnce sync.Once
 }
 
 // GetHostedCluster returns the HostedCluster associated with this test context.
@@ -78,13 +78,13 @@ func (tc *TestContext) GetHostedCluster() *hyperv1.HostedCluster {
 	return tc.hostedCluster
 }
 
-// GetGuestClient returns a controller-runtime client for the guest cluster.
+// GetHostedClusterClient returns a controller-runtime client for the hosted cluster.
 // It reads the kubeconfig from the secret referenced by the HostedCluster status.
 // The client is lazily initialized and cached.
 // Returns nil if the HostedCluster is not available or its KubeConfig status is not set.
 // Panics on any other initialization failure (e.g., kubeconfig secret not found, invalid kubeconfig data).
-func (tc *TestContext) GetGuestClient() crclient.Client {
-	tc.guestClientOnce.Do(func() {
+func (tc *TestContext) GetHostedClusterClient() crclient.Client {
+	tc.hostedClusterClientOnce.Do(func() {
 		hc := tc.GetHostedCluster()
 		if hc == nil || hc.Status.KubeConfig == nil {
 			return
@@ -111,11 +111,11 @@ func (tc *TestContext) GetGuestClient() crclient.Client {
 
 		client, err := crclient.New(restConfig, crclient.Options{Scheme: hyperapi.Scheme})
 		if err != nil {
-			panic(fmt.Sprintf("failed to create guest cluster client: %v", err))
+			panic(fmt.Sprintf("failed to create hosted cluster client: %v", err))
 		}
-		tc.guestClient = client
+		tc.hostedClusterClient = client
 	})
-	return tc.guestClient
+	return tc.hostedClusterClient
 }
 
 var (

--- a/test/e2e/v2/tests/control_plane_workloads_test.go
+++ b/test/e2e/v2/tests/control_plane_workloads_test.go
@@ -816,78 +816,6 @@ func SecurityContextUIDTest(getTestCtx internal.TestContextGetter) {
 	})
 }
 
-// GCPCloudControllerManagerTest registers tests for GCP CCM node initialization validation.
-// These tests verify that the CCM workload is producing the expected effects on the guest cluster:
-// providerID assignment, topology labels, and taint removal.
-func GCPCloudControllerManagerTest(getTestCtx internal.TestContextGetter) {
-	Context("GCP Cloud Controller Manager", Label("GCP", "CCM"), func() {
-		BeforeEach(func() {
-			testCtx := getTestCtx()
-			hc := testCtx.GetHostedCluster()
-			if hc == nil || hc.Spec.Platform.Type != hyperv1.GCPPlatform {
-				Skip("GCP Cloud Controller Manager test is only for GCP platform")
-			}
-		})
-
-		Context("When nodes are initialized by the CCM", func() {
-			var nodes *corev1.NodeList
-
-			BeforeEach(func() {
-				testCtx := getTestCtx()
-				guestClient := testCtx.GetGuestClient()
-				Expect(guestClient).NotTo(BeNil(), "guest client is nil; HostedCluster may not have KubeConfig status set")
-
-				nodes = &corev1.NodeList{}
-				Expect(guestClient.List(context.Background(), nodes)).To(Succeed())
-				Expect(nodes.Items).NotTo(BeEmpty(), "cluster should have nodes")
-			})
-
-			It("should set providerID on all nodes", func() {
-				testCtx := getTestCtx()
-				hc := testCtx.GetHostedCluster()
-				Expect(hc.Spec.Platform.GCP).NotTo(BeNil(), "GCP platform spec must be set for GCP HostedCluster %s/%s", hc.Namespace, hc.Name)
-				gcpProject := hc.Spec.Platform.GCP.Project
-
-				for _, node := range nodes.Items {
-					Expect(node.Spec.ProviderID).NotTo(BeEmpty(),
-						"node %s should have providerID set", node.Name)
-					// GCP providerID format: gce://<project>/<zone>/<instance-name>
-					Expect(node.Spec.ProviderID).To(HavePrefix("gce://"+gcpProject+"/"),
-						"node %s providerID should reference project %s", node.Name, gcpProject)
-					parts := strings.Split(node.Spec.ProviderID, "/")
-					Expect(parts).To(HaveLen(5),
-						"node %s providerID should have format gce://<project>/<zone>/<instance-name>", node.Name)
-				}
-			})
-
-			It("should set zone and region topology labels on all nodes", func() {
-				for _, node := range nodes.Items {
-					zone, ok := node.Labels["topology.kubernetes.io/zone"]
-					Expect(ok).To(BeTrue(),
-						"node %s should have topology.kubernetes.io/zone label", node.Name)
-					Expect(zone).NotTo(BeEmpty(),
-						"node %s zone label should not be empty", node.Name)
-
-					region, ok := node.Labels["topology.kubernetes.io/region"]
-					Expect(ok).To(BeTrue(),
-						"node %s should have topology.kubernetes.io/region label", node.Name)
-					Expect(region).NotTo(BeEmpty(),
-						"node %s region label should not be empty", node.Name)
-				}
-			})
-
-			It("should remove the uninitialized taint from all nodes", func() {
-				for _, node := range nodes.Items {
-					for _, taint := range node.Spec.Taints {
-						Expect(taint.Key).NotTo(Equal("node.cloudprovider.kubernetes.io/uninitialized"),
-							"node %s should not have the cloud provider uninitialized taint", node.Name)
-					}
-				}
-			})
-		})
-	})
-}
-
 // RegisterControlPlaneWorkloadsTests registers all control plane workloads tests
 func RegisterControlPlaneWorkloadsTests(getTestCtx internal.TestContextGetter) {
 	WorkloadRegistryValidationTest(getTestCtx)
@@ -902,7 +830,6 @@ func RegisterControlPlaneWorkloadsTests(getTestCtx internal.TestContextGetter) {
 	ServiceAccountTokenMountingTest(getTestCtx)
 	PodAffinitiesAndTolerationsTest(getTestCtx)
 	SecurityContextUIDTest(getTestCtx)
-	GCPCloudControllerManagerTest(getTestCtx)
 }
 
 var _ = Describe("Control Plane Workloads", Label("control-plane-workloads"), func() {

--- a/test/e2e/v2/tests/hosted_cluster_ccm_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_ccm_test.go
@@ -1,0 +1,118 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/test/e2e/v2/internal"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// GCPCloudControllerManagerTest registers tests for GCP CCM node initialization validation.
+// These tests verify that the CCM workload is producing the expected effects on the hosted cluster:
+// providerID assignment, topology labels, and taint removal.
+func GCPCloudControllerManagerTest(getTestCtx internal.TestContextGetter) {
+	Context("GCP Cloud Controller Manager", Label("GCP", "CCM"), func() {
+		BeforeEach(func() {
+			testCtx := getTestCtx()
+			hc := testCtx.GetHostedCluster()
+			if hc == nil || hc.Spec.Platform.Type != hyperv1.GCPPlatform {
+				Skip("GCP Cloud Controller Manager test is only for GCP platform")
+			}
+		})
+
+		Context("When nodes are initialized by the CCM", func() {
+			var nodes *corev1.NodeList
+
+			BeforeEach(func() {
+				testCtx := getTestCtx()
+				hostedClusterClient := testCtx.GetHostedClusterClient()
+				Expect(hostedClusterClient).NotTo(BeNil(), "hosted cluster client is nil; HostedCluster may not have KubeConfig status set")
+
+				nodes = &corev1.NodeList{}
+				Expect(hostedClusterClient.List(context.Background(), nodes)).To(Succeed())
+				Expect(nodes.Items).NotTo(BeEmpty(), "cluster should have nodes")
+			})
+
+			It("should set providerID on all nodes", func() {
+				testCtx := getTestCtx()
+				hc := testCtx.GetHostedCluster()
+				Expect(hc.Spec.Platform.GCP).NotTo(BeNil(), "GCP platform spec must be set for GCP HostedCluster %s/%s", hc.Namespace, hc.Name)
+				gcpProject := hc.Spec.Platform.GCP.Project
+
+				for _, node := range nodes.Items {
+					Expect(node.Spec.ProviderID).NotTo(BeEmpty(),
+						"node %s should have providerID set", node.Name)
+					// GCP providerID format: gce://<project>/<zone>/<instance-name>
+					Expect(node.Spec.ProviderID).To(HavePrefix("gce://"+gcpProject+"/"),
+						"node %s providerID should reference project %s", node.Name, gcpProject)
+					parts := strings.Split(node.Spec.ProviderID, "/")
+					Expect(parts).To(HaveLen(5),
+						"node %s providerID should have format gce://<project>/<zone>/<instance-name>", node.Name)
+				}
+			})
+
+			It("should set zone and region topology labels on all nodes", func() {
+				for _, node := range nodes.Items {
+					zone, ok := node.Labels["topology.kubernetes.io/zone"]
+					Expect(ok).To(BeTrue(),
+						"node %s should have topology.kubernetes.io/zone label", node.Name)
+					Expect(zone).NotTo(BeEmpty(),
+						"node %s zone label should not be empty", node.Name)
+
+					region, ok := node.Labels["topology.kubernetes.io/region"]
+					Expect(ok).To(BeTrue(),
+						"node %s should have topology.kubernetes.io/region label", node.Name)
+					Expect(region).NotTo(BeEmpty(),
+						"node %s region label should not be empty", node.Name)
+				}
+			})
+
+			It("should remove the uninitialized taint from all nodes", func() {
+				for _, node := range nodes.Items {
+					for _, taint := range node.Spec.Taints {
+						Expect(taint.Key).NotTo(Equal("node.cloudprovider.kubernetes.io/uninitialized"),
+							"node %s should not have the cloud provider uninitialized taint", node.Name)
+					}
+				}
+			})
+		})
+	})
+}
+
+// RegisterHostedClusterCCMTests registers all hosted cluster CCM tests
+func RegisterHostedClusterCCMTests(getTestCtx internal.TestContextGetter) {
+	GCPCloudControllerManagerTest(getTestCtx)
+}
+
+var _ = Describe("Hosted Cluster CCM", Label("hosted-cluster-ccm"), func() {
+	var testCtx *internal.TestContext
+
+	BeforeEach(func() {
+		testCtx = internal.GetTestContext()
+		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
+	})
+
+	RegisterHostedClusterCCMTests(func() *internal.TestContext { return testCtx })
+})


### PR DESCRIPTION
## What this PR does / why we need it:

Adds v2 e2e tests validating GCP Cloud Controller Manager node initialization. Changes:

- **Workload registry**: Register `gcp-cloud-controller-manager` deployment so existing workload tests (resource requests, security contexts, etc.) automatically cover it
- **Guest cluster client**: Add `GetGuestClient()` to `TestContext` for tests that need to inspect guest cluster state
- **GCP CCM tests**: Add `GCPCloudControllerManagerTest` to `control_plane_workloads_test.go` validating:
  - ProviderID assignment (`gce://<project>/<zone>/<instance>`)
  - Zone/region topology labels
  - Uninitialized taint removal

Tests are GCP-specific (skipped on other platforms via `BeforeEach` guard), confirmed working on AWS CI run (properly skipped, 0 failures).

## Which issue(s) this PR fixes:

Fixes [GCP-368](https://issues.redhat.com/browse/GCP-368)

## Special notes for your reviewer:

- LoadBalancer service provisioning tests were descoped to a follow-up card

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.