### PR TITLE
CNTRLPLANE-2801: fix(router): deploy router services for private ARO and remove KAS/OAPI dependencies

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -62,6 +62,7 @@ import (
 	registryoperatorv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/registryoperator"
 	routecmv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/routecm"
 	routerv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/router"
+	routerutil "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/router/util"
 	snapshotcontrollerv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/snapshotcontroller"
 	storagev2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/storage"
 	pkimanifests "github.com/openshift/hypershift/control-plane-pki-operator/manifests"
@@ -1122,7 +1123,7 @@ func (r *HostedControlPlaneReconciler) reconcileCPOV2(ctx context.Context, hcp *
 		return fmt.Errorf("failed to reconcile metrics config: %w", err)
 	}
 
-	if routerv2.UseHCPRouter(hcp) {
+	if routerutil.UseHCPRouter(hcp) {
 		if err := infra.NewReconciler(r.Client, r.DefaultIngressDomain).
 			AdmitHCPManagedRoutes(ctx, hcp, infraStatus.InternalHCPRouterHost, infraStatus.ExternalHCPRouterHost); err != nil {
 			return fmt.Errorf("failed to admit HCP managed routes: %w", err)

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/infra.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/infra.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/oapi"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/oauth"
+	routerutil "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/router/util"
 	sharedingress "github.com/openshift/hypershift/hypershift-operator/controllers/sharedingress"
 	hyperazureutil "github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/config"
@@ -440,7 +441,7 @@ func (r *Reconciler) reconcileOLMPackageServerService(ctx context.Context, hcp *
 func (r *Reconciler) reconcileHCPRouterServices(ctx context.Context, hcp *hyperv1.HostedControlPlane, createOrUpdate upsert.CreateOrUpdateFN) error {
 	pubSvc := manifests.RouterPublicService(hcp.Namespace)
 	privSvc := manifests.PrivateRouterService(hcp.Namespace)
-	if sharedingress.UseSharedIngress() || hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform || (!util.IsPrivateHCP(hcp) && !util.LabelHCPRoutes(hcp)) {
+	if !routerutil.UseHCPRouter(hcp) {
 		if _, err := util.DeleteIfNeeded(ctx, r.Client, pubSvc); err != nil {
 			return fmt.Errorf("failed to delete public router service: %w", err)
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_ARO_Route_SharedIngress_And_Swift.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_ARO_Route_SharedIngress_And_Swift.yaml
@@ -261,4 +261,36 @@ services:
       type: ClusterIP
     status:
       loadBalancer: {}
+  - metadata:
+      labels:
+        app: private-router
+      name: private-router
+      namespace: test-namespace
+    spec:
+      ports:
+      - name: https
+        port: 443
+        protocol: TCP
+        targetPort: https
+      selector:
+        app: private-router
+      type: LoadBalancer
+    status:
+      loadBalancer: {}
+  - metadata:
+      labels:
+        app: private-router
+      name: router
+      namespace: test-namespace
+    spec:
+      ports:
+      - name: https
+        port: 443
+        protocol: TCP
+        targetPort: https
+      selector:
+        app: private-router
+      type: LoadBalancer
+    status:
+      loadBalancer: {}
   metadata: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/component.go
@@ -1,11 +1,8 @@
 package router
 
 import (
-	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
-	oapiv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/oapi"
-	"github.com/openshift/hypershift/support/azureutil"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/router/util"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
 )
 
 const (
@@ -35,7 +32,7 @@ func (k *router) NeedsManagementKASAccess() bool {
 func NewComponent() component.ControlPlaneComponent {
 	return component.NewDeploymentComponent(ComponentName, &router{}).
 		WithPredicate(func(cpContext component.WorkloadContext) (bool, error) {
-			return UseHCPRouter(cpContext.HCP), nil
+			return util.UseHCPRouter(cpContext.HCP), nil
 		}).
 		WithAdaptFunction(adaptDeployment).
 		WithManifestAdapter(
@@ -46,29 +43,5 @@ func NewComponent() component.ControlPlaneComponent {
 			"pdb.yaml",
 			component.AdaptPodDisruptionBudget(),
 		).
-		WithDependencies(oapiv2.ComponentName).
 		Build()
-}
-
-// UseHCPRouter returns true when the HCP routes should be served by a dedicated
-// HCP router. This occurs when:
-//  1. The cluster is private (e.g. AWS/GCP Private or PublicAndPrivate endpoint access,
-//     or ARO with Swift enabled), OR
-//  2. The cluster is public but uses a dedicated Route for KAS DNS (rather than a LoadBalancer)
-//
-// Excludes IBM Cloud platform.
-func UseHCPRouter(hcp *hyperv1.HostedControlPlane) bool {
-	if hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
-		return false
-	}
-	// For ARO HCP, the dedicated HCP router is only needed when the cluster is private
-	// (Swift enabled). LabelHCPRoutes returns true for all ARO to support the
-	// SharedIngressReconciler, but that doesn't mean a dedicated router deployment is needed.
-	if azureutil.IsAroHCP() {
-		return util.IsPrivateHCP(hcp)
-	}
-	// Router infrastructure is needed when:
-	// 1. Cluster has private access (Private or PublicAndPrivate) - for internal routes, OR
-	// 2. External routes are labeled for HCP router (Public with KAS DNS)
-	return util.IsPrivateHCP(hcp) || util.LabelHCPRoutes(hcp)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/component_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/component_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/router/util"
 	"github.com/openshift/hypershift/support/azureutil"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -312,7 +313,7 @@ func TestUseHCPRouter(t *testing.T) {
 			if tt.setupEnv != nil {
 				tt.setupEnv(t)
 			}
-			if got := UseHCPRouter(tt.hcp); got != tt.want {
+			if got := util.UseHCPRouter(tt.hcp); got != tt.want {
 				t.Errorf("UseHCPRouter() = %v, want %v", got, tt.want)
 			}
 		})

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/router/util/util.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/router/util/util.go
@@ -1,0 +1,30 @@
+package util
+
+import (
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/azureutil"
+	"github.com/openshift/hypershift/support/util"
+)
+
+// UseHCPRouter returns true when the HCP routes should be served by a dedicated
+// HCP router. This occurs when:
+//  1. The cluster is private (e.g. AWS/GCP Private or PublicAndPrivate endpoint access,
+//     or ARO with Swift enabled), OR
+//  2. The cluster is public but uses a dedicated Route for KAS DNS (rather than a LoadBalancer)
+//
+// Excludes IBM Cloud platform.
+func UseHCPRouter(hcp *hyperv1.HostedControlPlane) bool {
+	if hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
+		return false
+	}
+	// For ARO HCP, the dedicated HCP router is only needed when the cluster is private
+	// (Swift enabled). LabelHCPRoutes returns true for all ARO to support the
+	// SharedIngressReconciler, but that doesn't mean a dedicated router deployment is needed.
+	if azureutil.IsAroHCP() {
+		return util.IsPrivateHCP(hcp)
+	}
+	// Router infrastructure is needed when:
+	// 1. Cluster has private access (Private or PublicAndPrivate) - for internal routes, OR
+	// 2. External routes are labeled for HCP router (Public with KAS DNS)
+	return util.IsPrivateHCP(hcp) || util.LabelHCPRoutes(hcp)
+}

--- a/support/controlplane-component/status.go
+++ b/support/controlplane-component/status.go
@@ -35,6 +35,7 @@ var (
 		"capi-provider",
 		"karpenter-operator",
 		"karpenter",
+		"router",
 	)
 )
 


### PR DESCRIPTION
## Summary
- Move `UseHCPRouter()` to a shared `router/util` package to break the import cycle, allowing `infra.go` to use it directly for determining whether router services should be deployed
- Fix an issue where router services were not deployed alongside the router deployment for private ARO clusters (Swift enabled) — the condition in `infra.go` was inconsistent with `UseHCPRouter()`
- Remove the router component's explicit dependency on OAPI and exclude it from the automatic kube-apiserver dependency, since the router doesn't require either to start

## Test plan
- [ ] Verify private ARO HCP clusters deploy router services correctly
- [ ] Verify public ARO HCP clusters do not deploy unnecessary router services
- [ ] Verify AWS private/public-and-private clusters still deploy router services
- [ ] Verify router deployment starts without waiting for KAS and OAPI
- [ ] Run unit tests: `go test ./control-plane-operator/controllers/hostedcontrolplane/v2/router/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized router decision logic into a shared util and simplified routing branch logic.

* **Bug Fixes**
  * When the HCP router is not used, both public and private router services are removed early to avoid stale services.

* **Chores**
  * Excluded the router from automatic kube-apiserver dependency checks and updated related test fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->