### PR TITLE
OCPBUGS-77160: include NMStateConfig in Agent platform OADP backup resources

### DIFF
--- a/cmd/oadp/types.go
+++ b/cmd/oadp/types.go
@@ -70,7 +70,7 @@ var (
 	}
 	agentResources = []string{
 		"agentclusters.infrastructure.cluster.x-k8s.io", "agentmachinetemplates.infrastructure.cluster.x-k8s.io", "agentmachines.infrastructure.cluster.x-k8s.io",
-		"agents.agent-install.openshift.io", "infraenvs.agent-install.openshift.io", "baremetalhosts.metal3.io",
+		"agents.agent-install.openshift.io", "infraenvs.agent-install.openshift.io", "nmstateconfigs.agent-install.openshift.io", "baremetalhosts.metal3.io",
 	}
 	kubevirtResources = []string{
 		"kubevirtclusters.infrastructure.cluster.x-k8s.io", "kubevirtmachinetemplates.infrastructure.cluster.x-k8s.io",

--- a/docs/content/how-to/disaster-recovery/dr-cli.md
+++ b/docs/content/how-to/disaster-recovery/dr-cli.md
@@ -129,6 +129,7 @@ By default, the backup includes the following resources. The exact set of resour
 
 **Additional Resources (always included):**
 - Routes (`routes.route.openshift.io`), ClusterDeployments (`clusterdeployments.hive.openshift.io`)
+- NMStateConfig (`nmstateconfigs.agent-install.openshift.io`)
 
 **Platform-Specific Resources (automatically detected):**
 
@@ -198,6 +199,7 @@ The following table lists all available resource types for the `--included-resou
 | | `machines.cluster.x-k8s.io` | Machine resources |
 | **OpenShift** | `routes.route.openshift.io` | OpenShift Routes |
 | | `clusterdeployments.hive.openshift.io` | ClusterDeployment resources |
+| | `nmstateconfigs.agent-install.openshift.io` | NMStateConfig resources |
 
 > **Platform Detection**: When using default resources (no `--included-resources` flag), only the platform-specific resources matching your HostedCluster's platform will be included automatically.
 

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -13882,6 +13882,7 @@ By default, the backup includes the following resources. The exact set of resour
 
 **Additional Resources (always included):**
 - Routes (`routes.route.openshift.io`), ClusterDeployments (`clusterdeployments.hive.openshift.io`)
+- NMStateConfig (`nmstateconfigs.agent-install.openshift.io`)
 
 **Platform-Specific Resources (automatically detected):**
 
@@ -13951,6 +13952,7 @@ The following table lists all available resource types for the `--included-resou
 | | `machines.cluster.x-k8s.io` | Machine resources |
 | **OpenShift** | `routes.route.openshift.io` | OpenShift Routes |
 | | `clusterdeployments.hive.openshift.io` | ClusterDeployment resources |
+| | `nmstateconfigs.agent-install.openshift.io` | NMStateConfig resources |
 
 > **Platform Detection**: When using default resources (no `--included-resources` flag), only the platform-specific resources matching your HostedCluster's platform will be included automatically.
 


### PR DESCRIPTION
## Summary
- Add `nmstateconfigs.agent-install.openshift.io` to `agentResources` in the OADP CLI so NMStateConfig resources are included in backups **only for the Agent platform**
- Update disaster recovery CLI documentation to reflect the new resource

## Fixes
- [OCPBUGS-77160](https://issues.redhat.com/browse/OCPBUGS-77160)

## Context
NMStateConfig resources (tied to InfraEnv) were missing from the OADP backup resource list, making backups incomplete. Since NMStateConfig belongs to the `agent-install.openshift.io` API group, it is specific to the Agent platform and should not be included in base resources common to all platforms.

A related PR in the OADP plugin repo ([hypershift-oadp-plugin#185](https://github.com/openshift/hypershift-oadp-plugin/pull/185)) adds NMStateConfig to the BareMetal examples but does not update the plugin Go code.

## Test plan
- [x] Unit tests pass (`go test ./cmd/oadp/...`)
- [ ] Verify `hypershift create oadp-backup --render` output includes `nmstateconfigs.agent-install.openshift.io` only for Agent platform
- [ ] Verify backup/restore cycle includes NMStateConfig resources on Agent platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NMStateConfig added as a recognized resource type, now supported for backup and recovery workflows.

* **Documentation**
  * Docs updated across platform references and how-to guides to list NMStateConfig among available resource types and additional included resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->