### PR TITLE
NO-JIRA: test(scheduler): add pair loss recovery unit coverage

### DIFF
--- a/hypershift-operator/controllers/scheduler/aws/dedicated_request_serving_nodes_test.go
+++ b/hypershift-operator/controllers/scheduler/aws/dedicated_request_serving_nodes_test.go
@@ -528,6 +528,21 @@ func TestHostedClusterSchedulerAndSizer(t *testing.T) {
 		}
 		return result
 	}
+	pairConfigMap := func(hc *hyperv1.HostedCluster, pairLabel string) *corev1.ConfigMap {
+		return &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: placeholderNamespace,
+				Name:      pairLabel,
+				Labels: map[string]string{
+					pairLabelKey: pairLabel,
+				},
+			},
+			Data: map[string]string{
+				clusterNamespaceKey: hc.Namespace,
+				clusterNameKey:      hc.Name,
+			},
+		}
+	}
 
 	tests := []struct {
 		name                  string
@@ -549,6 +564,31 @@ func TestHostedClusterSchedulerAndSizer(t *testing.T) {
 			),
 			checkScheduledCluster: true,
 			checkScheduledNodes:   true,
+		},
+		{
+			name: "When a scheduled hosted cluster loses one node from its pair, it should claim and label an available replacement node from the same pair",
+			hc:   hostedcluster(scheduledHC),
+			nodes: nodes(
+				node("n1", "zone-a", "small", "id1", withCluster(hostedcluster())),
+				node("n3", "zone-b", "small", "id1"),
+			),
+			additionalObjects: []client.Object{
+				pairConfigMap(hostedcluster(), "id1"),
+			},
+			checkScheduledCluster: true,
+			checkScheduledNodes:   true,
+		},
+		{
+			name: "When a scheduled hosted cluster loses one node and no same-pair replacement is available, it should create placeholder deployment",
+			hc:   hostedcluster(scheduledHC),
+			nodes: nodes(
+				node("n1", "zone-a", "small", "id1", withCluster(hostedcluster())),
+				node("n4", "zone-b", "small", "id2"),
+			),
+			additionalObjects: []client.Object{
+				pairConfigMap(hostedcluster(), "id1"),
+			},
+			expectPlaceholder: true,
 		},
 		{
 			name: "ensure allocated cluster node is labeled for cluster",


### PR DESCRIPTION
## Summary
- add unit coverage for `DedicatedServingComponentSchedulerAndSizer` when a scheduled hosted cluster loses one node in its assigned pair
- validate successful recovery when a same-pair replacement node is available and can be claimed/labeled
- validate placeholder deployment creation when no same-pair replacement node is available

## Test plan
- [x] `go test ./hypershift-operator/controllers/scheduler/aws -run TestHostedClusterSchedulerAndSizer -count=1`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test helper to simulate node-pair mappings.
  * Added scenarios verifying that a scheduled hosted cluster:
    * claims and labels an available replacement node from the same pair when one is lost, and
    * creates a placeholder deployment when no same-pair replacement exists.
  * Applied these scenarios across the scheduler/sizer test suite to ensure coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->