### PR TITLE
OCPBUGS-77703: fix(api): add omitempty to NodePoolAutoScaling.Min for N-1 compatibility

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -1,0 +1,29 @@
+# HyperShift API Module
+
+This module (`github.com/openshift/hypershift/api`) is consumed by external Go clients that vendor it directly. Changes to types in this module affect not only the HyperShift operator but also downstream consumers that embed, serialize, and deserialize these types independently of the Kubernetes API server.
+
+## API Type Change Guidelines
+
+### N-1 and N+1 Compatibility
+
+Every change to an API type must be safe for both:
+- **N+1 (forward):** New code reading data written by old code
+- **N-1 (rollback):** Old code reading data written by new code
+
+This matters because consumers like ARO-HCP embed these types directly into their own structs and serialize them to storage (e.g., Cosmos DB) outside of CRD validation. If a consumer must revert to a previous code level, they need to deserialize data that was written by the newer version without errors or data corruption.
+
+### Common Pitfalls
+
+- **Changing a value type to a pointer** (e.g., `int32` to `*int32`): Without `omitempty`, a nil pointer serializes as `null`, which cannot be deserialized back into the non-pointer type. Always pair pointer types with `omitempty` on required fields.
+- **Removing or renaming a field**: Old code will fail to deserialize the new format if it expects the field.
+- **Changing a field's type**: Ensure the JSON representation is compatible in both directions.
+
+### Required Tests
+
+When modifying API types, add serialization compatibility tests that:
+1. Define a struct matching the **previous** version of the type
+2. Serialize the **current** type and verify the previous version can deserialize it
+3. Serialize the **previous** type and verify the current version can deserialize it
+4. Cover edge cases: zero values, nil pointers, omitted fields
+
+See `api/hypershift/v1beta1/nodepool_types_test.go` for an example of this pattern.

--- a/api/go.mod
+++ b/api/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/openshift/api v0.0.0-20260120150926-4c643a652d54
 	k8s.io/api v0.34.3
 	k8s.io/apimachinery v0.34.3
+	k8s.io/utils v0.0.0-20260108192941-914a6e750570
 )
 
 require (
@@ -78,7 +79,6 @@ require (
 	k8s.io/csi-translation-lib v0.34.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
-	k8s.io/utils v0.0.0-20260108192941-914a6e750570 // indirect
 	sigs.k8s.io/controller-runtime v0.22.4 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/karpenter v1.8.2 // indirect

--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -453,7 +453,7 @@ type NodePoolAutoScaling struct {
 	//
 	// +kubebuilder:validation:Minimum=0
 	// +required
-	Min *int32 `json:"min"`
+	Min *int32 `json:"min,omitempty"`
 
 	// max is the maximum number of nodes allowed in the pool. Must be >= 1 and >= Min.
 	//

--- a/api/hypershift/v1beta1/nodepool_types_test.go
+++ b/api/hypershift/v1beta1/nodepool_types_test.go
@@ -1,0 +1,95 @@
+package v1beta1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"k8s.io/utils/ptr"
+)
+
+// These types represent the N-1 (previous) version of the API structs,
+// before the int32 -> *int32 pointer change. They are used to verify
+// that JSON produced by the current types can be deserialized by
+// previous versions of the code, and vice versa.
+type nodePoolAutoScalingNMinus1 struct {
+	Min int32 `json:"min"`
+	Max int32 `json:"max"`
+}
+
+func TestNodePoolAutoScalingSerializationCompatibility(t *testing.T) {
+	tests := []struct {
+		name string
+		// current is the N (current) version of the struct
+		current NodePoolAutoScaling
+		// expectedJSON is the expected JSON output from marshalling current
+		expectedJSON string
+		// nMinus1Result is the expected result when unmarshalling into the N-1 struct
+		nMinus1Result nodePoolAutoScalingNMinus1
+	}{
+		{
+			name: "When Min is set to a positive value it should round-trip to N-1",
+			current: NodePoolAutoScaling{
+				Min: ptr.To[int32](3),
+				Max: 5,
+			},
+			expectedJSON:  `{"min":3,"max":5}`,
+			nMinus1Result: nodePoolAutoScalingNMinus1{Min: 3, Max: 5},
+		},
+		{
+			name: "When Min is explicitly zero it should round-trip to N-1",
+			current: NodePoolAutoScaling{
+				Min: ptr.To[int32](0),
+				Max: 5,
+			},
+			expectedJSON:  `{"min":0,"max":5}`,
+			nMinus1Result: nodePoolAutoScalingNMinus1{Min: 0, Max: 5},
+		},
+		{
+			name: "When Min is nil it should be omitted and N-1 should deserialize as zero value",
+			current: NodePoolAutoScaling{
+				Min: nil,
+				Max: 5,
+			},
+			expectedJSON:  `{"max":5}`,
+			nMinus1Result: nodePoolAutoScalingNMinus1{Min: 0, Max: 5},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Marshal current (N) version
+			data, err := json.Marshal(tt.current)
+			if err != nil {
+				t.Fatalf("failed to marshal current struct: %v", err)
+			}
+			if string(data) != tt.expectedJSON {
+				t.Errorf("unexpected JSON output: got %s, want %s", string(data), tt.expectedJSON)
+			}
+
+			// Deserialize into N-1 struct
+			var nMinus1 nodePoolAutoScalingNMinus1
+			if err := json.Unmarshal(data, &nMinus1); err != nil {
+				t.Fatalf("N-1 failed to unmarshal JSON from N: %v", err)
+			}
+			if nMinus1 != tt.nMinus1Result {
+				t.Errorf("N-1 deserialization mismatch: got %+v, want %+v", nMinus1, tt.nMinus1Result)
+			}
+
+			// Reverse: marshal N-1 and deserialize into current (N)
+			nMinus1Data, err := json.Marshal(tt.nMinus1Result)
+			if err != nil {
+				t.Fatalf("failed to marshal N-1 struct: %v", err)
+			}
+			var roundTripped NodePoolAutoScaling
+			if err := json.Unmarshal(nMinus1Data, &roundTripped); err != nil {
+				t.Fatalf("N failed to unmarshal JSON from N-1: %v", err)
+			}
+			if roundTripped.Max != tt.nMinus1Result.Max {
+				t.Errorf("Max mismatch after N-1 round-trip: got %d, want %d", roundTripped.Max, tt.nMinus1Result.Max)
+			}
+			if ptr.Deref(roundTripped.Min, -1) != tt.nMinus1Result.Min {
+				t.Errorf("Min mismatch after N-1 round-trip: got %v, want %d", roundTripped.Min, tt.nMinus1Result.Min)
+			}
+		})
+	}
+}

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -453,7 +453,7 @@ type NodePoolAutoScaling struct {
 	//
 	// +kubebuilder:validation:Minimum=0
 	// +required
-	Min *int32 `json:"min"`
+	Min *int32 `json:"min,omitempty"`
 
 	// max is the maximum number of nodes allowed in the pool. Must be >= 1 and >= Min.
 	//


### PR DESCRIPTION
## What this PR does / why we need it:

The `NodePoolAutoScaling.Min` field was changed from `int32` to `*int32` (PR #6975) to support scale-from-zero. However, the JSON struct tag was set to `json:"min"` without `omitempty`.

Without `omitempty`, a nil `*int32` pointer serializes as `"min": null` in JSON. Consumers that embed and directly serialize these types (rather than going through CRD validation) cannot deserialize `null` back into `int32` if they revert to the previous code level. This causes permanent data corruption for the affected resources.

Adding `omitempty` ensures a nil `Min` is omitted from JSON rather than serialized as `null`, making the `int32` to `*int32` change N-1 compatible.

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/OCPBUGS-77703

## Special notes for your reviewer:

- The CRD schema is unchanged — `omitempty` on a `+required` field does not affect the OpenAPI spec, only Go JSON serialization behavior.
- This is important for consumers like ARO-HCP that embed HyperShift types directly and serialize to their own storage (Cosmos DB), where N-1 rollback must be safe.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Updates**
  * JSON responses now omit an empty Min field, reducing extraneous fields in payloads.

* **Tests**
  * Added serialization compatibility tests covering nil, zero, and positive Min scenarios with round-trip checks.

* **Documentation**
  * Added guidance on API forward/backward compatibility and recommended serialization test patterns.

* **Chores**
  * Promoted a utility module to a direct dependency for build consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->