### PR TITLE
OCPBUGS-55916: fix Azure load balancer scope not updating on IngressController change

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -45,6 +45,17 @@ func ReconcileRouterService(svc *corev1.Service, internal, crossZoneLoadBalancin
 		}
 	}
 
+	if hcp.Spec.Platform.Type == hyperv1.AzurePlatform {
+		if svc.Annotations == nil {
+			svc.Annotations = map[string]string{}
+		}
+		if internal {
+			svc.Annotations["service.beta.kubernetes.io/azure-load-balancer-internal"] = "true"
+		} else {
+			delete(svc.Annotations, "service.beta.kubernetes.io/azure-load-balancer-internal")
+		}
+	}
+
 	if svc.Labels == nil {
 		svc.Labels = map[string]string{}
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router_test.go
@@ -143,6 +143,67 @@ func TestReconcileRouterService_AppliesLoadBalancerSourceRanges(t *testing.T) {
 	})
 }
 
+// When Azure platform is used it should handle azure-load-balancer-internal annotation correctly
+func TestReconcileRouterService_AzureLoadBalancer(t *testing.T) {
+	testCases := []struct {
+		name                string
+		internal            bool
+		existingAnnotations map[string]string
+		expectAnnotation    bool
+	}{
+		{
+			name:             "When internal is true it should set azure-load-balancer-internal annotation",
+			internal:         true,
+			expectAnnotation: true,
+		},
+		{
+			name:             "When internal is false it should not set azure-load-balancer-internal annotation",
+			internal:         false,
+			expectAnnotation: false,
+		},
+		{
+			name:     "When scope changes from internal to external it should remove azure-load-balancer-internal annotation",
+			internal: false,
+			existingAnnotations: map[string]string{
+				"service.beta.kubernetes.io/azure-load-balancer-internal": "true",
+			},
+			expectAnnotation: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hcp := &hyperv1.HostedControlPlane{}
+			hcp.Spec.Platform.Type = hyperv1.AzurePlatform
+
+			svc := &corev1.Service{}
+			if tc.existingAnnotations != nil {
+				svc.Annotations = tc.existingAnnotations
+			}
+
+			if err := ReconcileRouterService(svc, tc.internal, false, hcp); err != nil {
+				t.Fatalf("ReconcileRouterService returned error: %v", err)
+			}
+
+			const annKey = "service.beta.kubernetes.io/azure-load-balancer-internal"
+			val, exists := svc.Annotations[annKey]
+			if tc.expectAnnotation {
+				if !exists || val != "true" {
+					t.Fatalf("expected %s annotation to be 'true', got %q (exists=%v)", annKey, val, exists)
+				}
+			} else {
+				if exists {
+					t.Fatalf("expected %s annotation to be absent, but it was set to %q", annKey, val)
+				}
+			}
+
+			if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+				t.Fatalf("expected service type to be LoadBalancer, got %v", svc.Spec.Type)
+			}
+		})
+	}
+}
+
 // Test that GCP router service is configured with Internal Load Balancer
 func TestReconcileRouterService_GCPInternalLoadBalancer(t *testing.T) {
 	// Given a HostedControlPlane on GCP platform

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile.go
@@ -83,6 +83,13 @@ func ReconcileDefaultIngressController(ingressController *operatorv1.IngressCont
 					},
 				},
 			}
+		case hyperv1.AzurePlatform:
+			ingressController.Spec.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{
+				Type: operatorv1.LoadBalancerServiceStrategyType,
+				LoadBalancer: &operatorv1.LoadBalancerStrategy{
+					Scope: loadBalancerScope,
+				},
+			}
 		default:
 			ingressController.Spec.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{
 				Type: operatorv1.LoadBalancerServiceStrategyType,

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/ingress/reconcile_test.go
@@ -123,6 +123,56 @@ func TestReconcileDefaultIngressController(t *testing.T) {
 			},
 		},
 		{
+			name:                   "Azure uses LoadBalancer publishing strategy (External)",
+			inputIngressController: manifests.IngressDefaultIngressController(),
+			inputIngressDomain:     fakeIngressDomain,
+			inputPlatformType:      hyperv1.AzurePlatform,
+			inputReplicas:          fakeInputReplicas,
+			inputIsPrivate:         false,
+			inputLoadBalancerScope: operatorv1.ExternalLoadBalancer,
+			expectedIngressController: &operatorv1.IngressController{
+				ObjectMeta: manifests.IngressDefaultIngressController().ObjectMeta,
+				Spec: operatorv1.IngressControllerSpec{
+					Domain:   fakeIngressDomain,
+					Replicas: &fakeInputReplicas,
+					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.LoadBalancerServiceStrategyType,
+						LoadBalancer: &operatorv1.LoadBalancerStrategy{
+							Scope: operatorv1.ExternalLoadBalancer,
+						},
+					},
+					DefaultCertificate: &corev1.LocalObjectReference{
+						Name: manifests.IngressDefaultIngressControllerCert().Name,
+					},
+				},
+			},
+		},
+		{
+			name:                   "Azure uses LoadBalancer publishing strategy (Internal)",
+			inputIngressController: manifests.IngressDefaultIngressController(),
+			inputIngressDomain:     fakeIngressDomain,
+			inputPlatformType:      hyperv1.AzurePlatform,
+			inputReplicas:          fakeInputReplicas,
+			inputIsPrivate:         false,
+			inputLoadBalancerScope: operatorv1.InternalLoadBalancer,
+			expectedIngressController: &operatorv1.IngressController{
+				ObjectMeta: manifests.IngressDefaultIngressController().ObjectMeta,
+				Spec: operatorv1.IngressControllerSpec{
+					Domain:   fakeIngressDomain,
+					Replicas: &fakeInputReplicas,
+					EndpointPublishingStrategy: &operatorv1.EndpointPublishingStrategy{
+						Type: operatorv1.LoadBalancerServiceStrategyType,
+						LoadBalancer: &operatorv1.LoadBalancerStrategy{
+							Scope: operatorv1.InternalLoadBalancer,
+						},
+					},
+					DefaultCertificate: &corev1.LocalObjectReference{
+						Name: manifests.IngressDefaultIngressControllerCert().Name,
+					},
+				},
+			},
+		},
+		{
 			name:                   "Kubevirt uses NodePort publishing strategy",
 			inputIngressController: manifests.IngressDefaultIngressController(),
 			inputIngressDomain:     fakeIngressDomain,


### PR DESCRIPTION
## What this PR does / why we need it:

Adds missing Azure platform support for load balancer internal/external annotation handling in HyperShift.

On ARO HCP (Azure AKS HyperShift) clusters, when changing an IngressController's `endpointPublishingStrategy.loadBalancer.scope` from Internal to External (or vice versa), the load balancer service's IP was not updated because:

1. **`ReconcileRouterService`** handled AWS (`aws-load-balancer-internal`) and GCP (`networking.gke.io/load-balancer-type`) platform-specific annotations but had no Azure handling. The `service.beta.kubernetes.io/azure-load-balancer-internal` annotation is now set/removed based on the `internal` parameter.

2. **`ReconcileDefaultIngressController`** had no explicit Azure case, falling through to a default that created a `LoadBalancerServiceStrategyType` without setting the `loadBalancerScope`. Azure now gets the same treatment as IBM Cloud, with the scope properly set.

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/OCPBUGS-55916

## Special notes for your reviewer:

- The `ReconcileRouterService` change also handles the scope change case (Internal→External) by explicitly removing the `azure-load-balancer-internal` annotation via `delete()`.
- `ReconcileDefaultIngressController` only runs on initial creation (early return if `ResourceVersion != ""`), so the Azure case ensures the default IngressController is created with the correct scope from the start.
- All pre-existing `make test` failures are unrelated (missing mock types in other packages).

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve OCPBUGS-55916`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Azure platform support for ingress routing with configurable internal/external load balancer options, aligning with existing cloud provider functionality.

* **Tests**
  * Added comprehensive test coverage for Azure load balancer configuration across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->