### PR TITLE
OCPBUGS-77621: fix(nodepool): preserve ignition-reached annotation on token secret after restore

### DIFF
--- a/hypershift-operator/controllers/nodepool/token.go
+++ b/hypershift-operator/controllers/nodepool/token.go
@@ -313,6 +313,16 @@ func (t *Token) reconcileTokenSecret(tokenSecret *corev1.Secret) error {
 	// active token should never be marked as expired.
 	delete(tokenSecret.Annotations, hyperv1.IgnitionServerTokenExpirationTimestampAnnotation)
 
+	// During a backup/restore the token secret may be deleted by the secret janitor
+	// before the NodePool is restored, causing the NodePool controller to create a new
+	// token secret without the ignition-reached annotation. Since the nodes are already
+	// running and won't contact the ignition endpoint again, the annotation must be
+	// carried over so that ReachedIgnitionEndpoint remains True and MachineHealthChecks
+	// continue to be created.
+	if _, restored := t.hostedCluster.Annotations[hyperv1.HostedClusterRestoredFromBackupAnnotation]; restored {
+		tokenSecret.Annotations[TokenSecretIgnitionReachedAnnotation] = "True"
+	}
+
 	if tokenSecret.Data == nil {
 		// 2. - Reconcile towards expected state of the world.
 		compressedConfig, err := t.CompressedAndEncoded()

--- a/hypershift-operator/controllers/nodepool/token_test.go
+++ b/hypershift-operator/controllers/nodepool/token_test.go
@@ -627,6 +627,68 @@ func TestTokenReconcile(t *testing.T) {
 				DecompressAndDecodeConfig: true,
 			},
 		},
+		{
+			name: "when HostedCluster is restored from backup it should set ignition-reached annotation on the token secret",
+			configGenerator: &ConfigGenerator{
+				hostedCluster: &hyperv1.HostedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      hcName,
+						Namespace: hcNamespace,
+						Annotations: map[string]string{
+							hyperv1.HostedClusterRestoredFromBackupAnnotation: "",
+						},
+					},
+					Spec: hyperv1.HostedClusterSpec{
+						PullSecret: corev1.LocalObjectReference{
+							Name: pullSecret.GetName(),
+						},
+						AdditionalTrustBundle: &corev1.LocalObjectReference{
+							Name: additionalTrustBundle.GetName(),
+						},
+						Configuration: &hyperv1.ClusterConfiguration{
+							Proxy: &expectedProxyConfig.Spec,
+						},
+					},
+					Status: hyperv1.HostedClusterStatus{
+						IgnitionEndpoint: "https://example.com",
+					},
+				},
+				nodePool: &hyperv1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "name",
+						Namespace: "namespace",
+					},
+					Spec: hyperv1.NodePoolSpec{
+						Management: hyperv1.NodePoolManagement{
+							UpgradeType: hyperv1.UpgradeTypeReplace,
+						},
+						Release: hyperv1.Release{
+							Image: "image:4.17",
+						},
+					},
+				},
+				controlplaneNamespace: controlplaneNamespace,
+				rolloutConfig: &rolloutConfig{
+					releaseImage: &releaseinfo.ReleaseImage{
+						ImageStream: &imageapi.ImageStream{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "4.17",
+							},
+						},
+					},
+					globalConfig: "test-global-config",
+					mcoRawConfig: "raw-config",
+				},
+			},
+			fakeObjects: []crclient.Object{
+				pullSecret,
+				additionalTrustBundle,
+				ignitionServerCACert,
+			},
+			cpoCapabilities: &CPOCapabilities{
+				DecompressAndDecodeConfig: true,
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -654,6 +716,14 @@ func TestTokenReconcile(t *testing.T) {
 
 			// Active token should never be marked as expired.
 			g.Expect(gotTokenSecret.Annotations).ToNot(HaveKey(hyperv1.IgnitionServerTokenExpirationTimestampAnnotation))
+
+			// When the HostedCluster was restored from backup, the ignition-reached
+			// annotation should be set so ReachedIgnitionEndpoint stays True.
+			if _, restored := tc.configGenerator.hostedCluster.Annotations[hyperv1.HostedClusterRestoredFromBackupAnnotation]; restored {
+				g.Expect(gotTokenSecret.Annotations[TokenSecretIgnitionReachedAnnotation]).To(Equal("True"))
+			} else {
+				g.Expect(gotTokenSecret.Annotations).ToNot(HaveKey(TokenSecretIgnitionReachedAnnotation))
+			}
 
 			// Generation time should be from ~now.
 			generationTime, err := time.Parse(time.RFC3339Nano, gotTokenSecret.Annotations[TokenSecretTokenGenerationTime])


### PR DESCRIPTION
## Summary

- During backup/restore with OADP, the secret janitor deletes the token secret before the NodePool is restored. The NodePool controller then creates a new token secret **without** the `ignition-reached` annotation, causing `ReachedIgnitionEndpoint=False` and blocking `MachineHealthCheck` creation and `AutoRepair`.
- When the HostedCluster has the `hypershift.openshift.io/restored-from-backup` annotation (already set by the OADP plugin), the token secret is now created with `ignition-reached=True` so the condition is preserved.

## Root Cause

The restore sequence triggers a race condition:

1. Velero restores the token secret (with `ignition-reached=True`)
2. Secret janitor deletes it (NodePool doesn't exist yet)
3. Velero restores the NodePool
4. NodePool controller creates a **new** token secret without `ignition-reached`
5. Nodes are already running and won't contact the ignition endpoint again

## Fix

In `reconcileTokenSecret`, when the HostedCluster has the `restored-from-backup` annotation, set `ignition-reached=True` on the token secret. This follows the same pattern used for InPlace upgrades where nodes also don't re-contact the ignition endpoint.

Ref: https://issues.redhat.com/browse/OCPBUGS-77621

## Test plan

- [ ] New unit test `TestTokenReconcile` case validates that `ignition-reached` annotation is set when HostedCluster has `restored-from-backup` annotation
- [ ] Existing test case validates that `ignition-reached` is NOT set without the restore annotation (no regression)
- [ ] E2E: Run backup/restore tests from https://github.com/openshift/hypershift/pull/7837 using `make test-backup-restore` and verify NodePool conditions after restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve ignition-reached state when a hosted cluster is restored from backup so node pools and machine health checks continue to be created and operate correctly.
* **Tests**
  * Added tests verifying the ignition-reached state is preserved on restore, ensuring expected reconciliation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->