### PR TITLE
AUTOSCALE-571: fix(karpenter): don't associate public IP addresses for the default OpenshiftEC2NodeClass

### DIFF
--- a/karpenter-operator/controllers/karpenter/karpenter_controller.go
+++ b/karpenter-operator/controllers/karpenter/karpenter_controller.go
@@ -342,9 +342,6 @@ func (r *Reconciler) reconcileOpenshiftEC2NodeClassDefault(ctx context.Context, 
 			},
 		}
 
-		if hcp.Annotations[hyperv1.AWSMachinePublicIPs] == "true" {
-			ec2NodeClass.Spec.IPAddressAssociation = hyperkarpenterv1.IPAddressAssociationPublic
-		}
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
## What this PR does / why we need it:
Previously, Karpenter would reconcile the default named OpenshiftEC2NodeClass to use public IPs if the annotation was set. This annotation was used for testing purposes, and was likely added as the initial e2e test suite had public subnets only.

The default behavior for this OpenshiftEC2NodeClass should be that it works in private subnets. However, if you use a public subnet, you should not expect to get a public IP.

If a user wants to use public subnets with a public IP for nodes, they should make their own OpenshiftEC2NodeClass and set `spec.AssociatePublicIPAddress: true` there.

## Which issue(s) this PR fixes:
Fixes [AUTOSCALE-571](https://issues.redhat.com/browse/AUTOSCALE-571)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic public IP address assignment for OpenShift Karpenter EC2 node classes based on HCP annotations. The `AssociatePublicIPAddress` setting now defaults to unset during reconciliation, changing how public IP addresses are managed for EC2 nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->