### PR TITLE
CNTRLPLANE-2840: fix(endpoint-resolver): sort pods by name for deterministic ordering

### DIFF
--- a/control-plane-operator/endpoint-resolver/server.go
+++ b/control-plane-operator/endpoint-resolver/server.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -82,6 +83,11 @@ func (h *resolverHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "no ready pods found matching selector", http.StatusNotFound)
 		return
 	}
+
+	// Sort pods by name for deterministic ordering
+	sort.Slice(pods, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
 
 	buf, err := json.Marshal(ResolveResponse{Pods: pods})
 	if err != nil {


### PR DESCRIPTION
The endpoint resolver was returning pods in non-deterministic order due to Go's randomized map iteration when listing pods from the cache indexer. This caused intermittent test failures when the order didn't match expected results.

Pods are now sorted by name before being returned, ensuring consistent API responses and reliable tests.

Follow on to https://github.com/openshift/hypershift/pull/7786

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, isolated change that only affects response ordering from the endpoint-resolver without altering selection/filtering logic.
> 
> **Overview**
> The endpoint-resolver’s `/resolve` handler now **returns pods in deterministic order** by sorting the resolved `PodEndpoint` list by pod name before JSON encoding.
> 
> This adds the `sort` import and applies `sort.Slice` after filtering to stabilize API output and avoid flaky order-dependent callers/tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4300ffa49cbf0f7f8409644021a8351a657d2ca7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Endpoint resolver now returns pods in a deterministic, consistent order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->