### PR TITLE
OCPBUGS-77822: test/e2e/util/fixture: Infra resource deletion timeout is fatal

### DIFF
--- a/test/e2e/util/fixture.go
+++ b/test/e2e/util/fixture.go
@@ -326,9 +326,8 @@ func validateAWSGuestResourcesDeletedFunc(ctx context.Context, t *testing.T, inf
 
 			return true, nil
 		})
-
 		if wait.Interrupted(err) {
-			t.Errorf("Failed to wait for infra resources in guest cluster to be deleted: %v", err)
+			t.Fatalf("Failed to wait for infra resources in guest cluster to be deleted: %v", err)
 		} else if err != nil {
 			// Failing to list tagged resource is not fatal, but we should log it
 			t.Logf("Failed to list resources by tag: %v. Not verifying cluster is cleaned up.", err)


### PR DESCRIPTION
We cannot continue here, because `output` might be nil still, and if it is, the subsequent:

```go
hasGuestResources(t, output.ResourceTagMappingList)
```

call [panics][1]:

```
  === NAME  TestUpgradeControlPlane/Teardown
      fixture.go:331: Failed to wait for infra resources in guest cluster to be deleted: operation error Resource Groups Tagging API: GetResources, context deadline exceeded
  E0304 23:05:28.566385      39 panic.go:262] "Observed a panic" panic="runtime error: invalid memory address or nil pointer dereference" panicGoValue="\"invalid memory address or nil pointer dereference\"" stacktrace=<
  	goroutine 26552 [running]:
  	k8s.io/apimachinery/pkg/util/runtime.logPanic({0xbcd4de8, 0xc002e25dd0}, {0x9ed2980, 0xefbeeb0})
  		/hypershift/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:132 +0x12b
  	k8s.io/apimachinery/pkg/util/runtime.handleCrash({0xbcd4de8, 0xc002e25dd0}, {0x9ed2980, 0xefbeeb0}, {0x0, 0x0, 0x0})
  		/hypershift/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:107 +0x13d
  	k8s.io/apimachinery/pkg/util/runtime.HandleCrashWithContext({0xbcd4e20, 0xc000cf60a0}, {0x0, 0x0, 0x0})
  		/hypershift/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:78 +0x71
  	panic({0x9ed2980?, 0xefbeeb0?})
  		/usr/lib/golang/src/runtime/panic.go:783 +0x136
  push_pin
  	github.com/openshift/hypershift/test/e2e/util.validateAWSGuestResourcesDeletedFunc.func2()
  		/hypershift/test/e2e/util/fixture.go:339 +0x580
  	github.com/openshift/hypershift/cmd/cluster/aws.destroyPlatformSpecifics({
```

[1]: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_kubernetes/2523/pull-ci-openshift-kubernetes-master-e2e-aws-ovn-hypershift/2029282740901253120#1:build-log.txt%3A2298-2299

## What this PR does / why we need it:

Fail on timeout instead of panicking.

## Which issue(s) this PR fixes:
Fixes OCPBUGS-77822
## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test error handling to enforce stricter failure conditions in validation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->