### PR TITLE
NO-JIRA: fix KubeVirtAdvancedMultinetTest IPv6 and apk errors

### DIFF
--- a/test/e2e/nodepool_kv_advanced_multinet_test.go
+++ b/test/e2e/nodepool_kv_advanced_multinet_test.go
@@ -279,8 +279,10 @@ func (k KubeVirtAdvancedMultinetTest) firstMachineAddress() (string, error) {
 			continue
 		}
 		// Use only IPv4 addresses since iptables DNAT rules require IPv4.
-		if ip.To4() != nil {
-			internalAddress = address.Address
+		// Use v4.String() to ensure canonical dotted-decimal form even if
+		// the address was stored as IPv4-mapped IPv6 (::ffff:x.x.x.x).
+		if v4 := ip.To4(); v4 != nil {
+			internalAddress = v4.String()
 			break
 		}
 	}


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes two bugs in `KubeVirtAdvancedMultinetTest` that cause the e2e test to fail:

1. **`apk` on UBI9 image**: `configureDNAT()` ran `apk update && apk add iptables` but the dnsmasq pod uses `registry.access.redhat.com/ubi9/ubi:latest` (a `dnf`-based image). Since the pod's init script already runs `dnf install -y iptables`, the `apk` commands are both wrong and unnecessary.

2. **IPv6 address passed to `iptables`**: `firstMachineAddress()` iterated over all `InternalIP` addresses and kept the last one, which could be an IPv6 link-local address (e.g. `fe80::...`). This address was then used in an `iptables` (IPv4-only) DNAT rule, causing `Bad IP address` errors.

## Which issue(s) this PR fixes:

Fixes the `KubeVirtNodeAdvancedMultinetTest` failure in `pull-ci-openshift-cluster-api-provider-kubevirt-main-e2e-hypershift-kubevirt`

## Special notes for your reviewer:

The two fixes are:
- Remove the `apk` lines from `configureDNAT()` — iptables is already installed by the pod's init command
- Filter for IPv4 addresses in `firstMachineAddress()` using `net.ParseIP` and `ip.To4()`, and break on first match

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved IPv4 validation and stricter selection of machine internal addresses in network tests.
  * Consolidated network configuration steps to use a single command for DNAT setup.
  * Clarified error messaging for missing IPv4 internal addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->