### PR TITLE
SREP-3855: unpause leaked child objects on deleting clusters (OCPBUGS-77530)

### DIFF
--- a/contrib/oadp-recovery/README.md
+++ b/contrib/oadp-recovery/README.md
@@ -12,6 +12,7 @@ This script provides automated recovery for HyperShift clusters that may get stu
 - **Backup Status Monitoring**: Monitors Velero backup states in real-time
 - **Intelligent Recovery**: Resumes clusters when backups complete, fail, or are deleted
 - **NodePool Management**: Automatically resumes associated NodePools
+- **Cascading Unpause**: Propagates unpause to HostedControlPlane, MachineDeployments, and CAPI Cluster objects ([OCPBUGS-77530](https://issues.redhat.com/browse/OCPBUGS-77530))
 - **Dry-run Mode**: Supports testing without making actual changes
 - **Structured Logging**: Comprehensive logging with cluster context
 - **Simple Deployment**: Single manifest file with minimal dependencies
@@ -33,9 +34,16 @@ This script provides automated recovery for HyperShift clusters that may get stu
    - `Deleted`: Backup was manually deleted
 
 4. **Recovery**: When terminal state detected or no backups found:
-   - Removes OADP pause annotations
-   - Clears `pausedUntil` field
-   - Resumes all associated NodePools
+    - Removes OADP pause annotations
+    - Clears `pausedUntil` field
+    - Resumes all associated NodePools
+
+Additionally, independently of the OADP recovery flow above:
+
+5. **Cascading Unpause** ([OCPBUGS-77530](https://issues.redhat.com/browse/OCPBUGS-77530)): For any HostedCluster being deleted (`deletionTimestamp` set), checks for leaked paused state on child objects. Due to a race condition in the nodepool controller, the operator may not propagate the unpause to inner resources even after the HC itself is unpaused. The script removes leaked pauses from:
+    - HostedControlPlane: removes `spec.pausedUntil`
+    - MachineDeployments: removes `cluster.x-k8s.io/paused` annotation
+    - CAPI Cluster: removes `cluster.x-k8s.io/paused` annotation and sets `spec.paused` to false
 
 ## Quick Start
 
@@ -142,7 +150,7 @@ The script requires minimal permissions:
 ```yaml
 rules:
 - apiGroups: ["hypershift.openshift.io"]
-  resources: ["hostedclusters", "nodepools"]
+  resources: ["hostedclusters", "nodepools", "hostedcontrolplanes"]
   verbs: ["get", "list", "patch", "update"]
 - apiGroups: ["velero.io"]
   resources: ["backups"]
@@ -150,6 +158,9 @@ rules:
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["get"]
+- apiGroups: ["cluster.x-k8s.io"]
+  resources: ["machinedeployments", "clusters"]
+  verbs: ["get", "list", "patch", "update"]
 ```
 
 ### Container Image

--- a/contrib/oadp-recovery/manifests/rbac-cronjob.yaml
+++ b/contrib/oadp-recovery/manifests/rbac-cronjob.yaml
@@ -10,7 +10,7 @@ metadata:
   name: oadp-recovery
 rules:
 - apiGroups: ["hypershift.openshift.io"]
-  resources: ["hostedclusters", "nodepools"]
+  resources: ["hostedclusters", "nodepools", "hostedcontrolplanes"]
   verbs: ["get", "list", "patch", "update"]
 - apiGroups: ["velero.io"]
   resources: ["backups"]
@@ -18,6 +18,9 @@ rules:
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["get"]
+- apiGroups: ["cluster.x-k8s.io"]
+  resources: ["machinedeployments", "clusters"]
+  verbs: ["get", "list", "patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/contrib/oadp-recovery/oadp-recovery.sh
+++ b/contrib/oadp-recovery/oadp-recovery.sh
@@ -207,6 +207,136 @@ check_oadp_recovery() {
     return 1
 }
 
+# Function to unpause cascading objects (HCP, MachineDeployments, CAPI Cluster)
+# These objects can retain paused state due to OCPBUGS-77530
+# Returns 0 if leaked pauses were found (and acted on), 1 if none were found.
+resume_cascading_objects() {
+    local cluster_name="$1"
+    local cluster_namespace="$2"
+    local hcp_namespace="${cluster_namespace}-${cluster_name}"
+
+    if ! kubectl get namespace "$hcp_namespace" &>/dev/null; then
+        log_verbose "Control plane namespace $hcp_namespace does not exist for cluster $cluster_name, skipping cascading unpause"
+        return 1
+    fi
+
+    log_info "Checking cascading objects in namespace $hcp_namespace for cluster $cluster_name (OCPBUGS-77530)"
+
+    local found_leaked_pause=false
+
+    # 1. Unpause HostedControlPlane
+    local hcp_paused
+    hcp_paused=$(kubectl get hostedcontrolplane "$cluster_name" -n "$hcp_namespace" \
+        -o jsonpath="{.spec.pausedUntil}" 2>/dev/null || echo "")
+
+    if [[ -n "$hcp_paused" ]]; then
+        found_leaked_pause=true
+        log_info "HostedControlPlane $cluster_name has leaked pausedUntil=\"$hcp_paused\""
+
+        if [[ "$DRY_RUN" == "true" ]]; then
+            log_info "DRY RUN: Would remove spec.pausedUntil from HostedControlPlane $cluster_name"
+        else
+            if kubectl patch hostedcontrolplane "$cluster_name" -n "$hcp_namespace" \
+                --type=json -p='[{"op":"remove","path":"/spec/pausedUntil"}]'; then
+                log_info "Successfully removed pausedUntil from HostedControlPlane $cluster_name"
+            else
+                log_error "Failed to remove pausedUntil from HostedControlPlane $cluster_name"
+                MARK_AS_FAILED=true
+            fi
+        fi
+    else
+        log_debug "HostedControlPlane $cluster_name is not paused"
+    fi
+
+    # 2. Unpause MachineDeployments
+    local md_names
+    md_names=$(kubectl get machinedeployment -n "$hcp_namespace" --no-headers \
+        -o custom-columns=NAME:.metadata.name 2>/dev/null || echo "")
+
+    if [[ -n "$md_names" ]]; then
+        while read -r md; do
+            if [[ -z "$md" ]]; then
+                continue
+            fi
+
+            local md_paused
+            md_paused=$(kubectl get machinedeployment "$md" -n "$hcp_namespace" \
+                -o jsonpath="{.metadata.annotations.cluster\.x-k8s\.io/paused}" 2>/dev/null || echo "")
+
+            if [[ -n "$md_paused" ]]; then
+                found_leaked_pause=true
+                log_info "MachineDeployment $md has leaked paused annotation=\"$md_paused\""
+
+                if [[ "$DRY_RUN" == "true" ]]; then
+                    log_info "DRY RUN: Would remove cluster.x-k8s.io/paused annotation from MachineDeployment $md"
+                else
+                    if kubectl annotate machinedeployment "$md" -n "$hcp_namespace" \
+                        cluster.x-k8s.io/paused-; then
+                        log_info "Successfully removed paused annotation from MachineDeployment $md"
+                    else
+                        log_error "Failed to remove paused annotation from MachineDeployment $md"
+                        MARK_AS_FAILED=true
+                    fi
+                fi
+            else
+                log_debug "MachineDeployment $md is not paused"
+            fi
+        done <<< "$md_names"
+    else
+        log_debug "No MachineDeployments found in namespace $hcp_namespace"
+    fi
+
+    # 3. Unpause CAPI Cluster
+    local cc_anno_paused cc_spec_paused
+    cc_anno_paused=$(kubectl get cluster.cluster.x-k8s.io "$cluster_name" -n "$hcp_namespace" \
+        -o jsonpath="{.metadata.annotations.cluster\.x-k8s\.io/paused}" 2>/dev/null || echo "")
+    cc_spec_paused=$(kubectl get cluster.cluster.x-k8s.io "$cluster_name" -n "$hcp_namespace" \
+        -o jsonpath="{.spec.paused}" 2>/dev/null || echo "")
+
+    if [[ -n "$cc_anno_paused" ]]; then
+        found_leaked_pause=true
+        log_info "CAPI Cluster $cluster_name has leaked paused annotation=\"$cc_anno_paused\""
+
+        if [[ "$DRY_RUN" == "true" ]]; then
+            log_info "DRY RUN: Would remove cluster.x-k8s.io/paused annotation from CAPI Cluster $cluster_name"
+        else
+            if kubectl annotate cluster.cluster.x-k8s.io "$cluster_name" -n "$hcp_namespace" \
+                cluster.x-k8s.io/paused-; then
+                log_info "Successfully removed paused annotation from CAPI Cluster $cluster_name"
+            else
+                log_error "Failed to remove paused annotation from CAPI Cluster $cluster_name"
+                MARK_AS_FAILED=true
+            fi
+        fi
+    else
+        log_debug "CAPI Cluster $cluster_name does not have paused annotation"
+    fi
+
+    if [[ "$cc_spec_paused" == "true" ]]; then
+        found_leaked_pause=true
+        log_info "CAPI Cluster $cluster_name has leaked spec.paused=true"
+
+        if [[ "$DRY_RUN" == "true" ]]; then
+            log_info "DRY RUN: Would set spec.paused=false on CAPI Cluster $cluster_name"
+        else
+            if kubectl patch cluster.cluster.x-k8s.io "$cluster_name" -n "$hcp_namespace" \
+                --type=merge -p='{"spec":{"paused":false}}'; then
+                log_info "Successfully set spec.paused=false on CAPI Cluster $cluster_name"
+            else
+                log_error "Failed to set spec.paused=false on CAPI Cluster $cluster_name"
+                MARK_AS_FAILED=true
+            fi
+        fi
+    else
+        log_debug "CAPI Cluster $cluster_name does not have spec.paused=true"
+    fi
+
+    if [[ "$found_leaked_pause" == "true" ]]; then
+        return 0
+    fi
+    return 1
+}
+
 # Function to resume cluster from OADP pause
 resume_cluster_from_oadp() {
     local cluster_name="$1"
@@ -276,15 +406,17 @@ process_clusters() {
     local total_clusters=0
     local processed_clusters=0
     local recovered_clusters=0
+    local unblocked_clusters=0
     local error_count=0
     local -a recovered_cluster_names=()
+    local -a unblocked_cluster_names=()
 
     log_info "Starting OADP recovery check (oadp-namespace: $OADP_NAMESPACE, dry-run: $DRY_RUN)"
 
     # Get all hosted clusters - simplified approach
     local clusters_output
     if ! clusters_output=$(kubectl get hostedclusters --all-namespaces --no-headers \
-        -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name 2>/dev/null); then
+        -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,DELETED:.metadata.deletionTimestamp 2>/dev/null); then
         log_error "Failed to list hosted clusters"
         return 1
     fi
@@ -300,13 +432,17 @@ process_clusters() {
             continue
         fi
 
-        # Parse namespace and name with explicit field extraction
-        local cluster_namespace cluster_name
+        local cluster_namespace cluster_name deletion_ts
         cluster_namespace=$(echo "$line" | awk '{print $1}')
         cluster_name=$(echo "$line" | awk '{print $2}')
+        deletion_ts=$(echo "$line" | awk '{print $3}')
 
         if [[ -z "$cluster_name" ]]; then
             continue
+        fi
+
+        if [[ "$deletion_ts" == "<none>" ]]; then
+            deletion_ts=""
         fi
 
         total_clusters=$((total_clusters + 1))
@@ -325,6 +461,16 @@ process_clusters() {
             fi
         fi
 
+        # OCPBUGS-77530: for deleting clusters, check child objects for
+        # leaked paused state that the operator failed to propagate.
+        if [[ -n "$deletion_ts" ]]; then
+            log_verbose "Cluster $cluster_name is being deleted (since $deletion_ts), checking child objects for leaked pauses"
+            if resume_cascading_objects "$cluster_name" "$cluster_namespace"; then
+                unblocked_clusters=$((unblocked_clusters + 1))
+                unblocked_cluster_names+=("$cluster_name")
+            fi
+        fi
+
         processed_clusters=$((processed_clusters + 1))
 
     done <<< "$clusters_output"
@@ -333,6 +479,10 @@ process_clusters() {
 
     if [[ ${#recovered_cluster_names[@]} -gt 0 ]]; then
         log_info "Recovered clusters: ${recovered_cluster_names[*]}"
+    fi
+
+    if [[ ${#unblocked_cluster_names[@]} -gt 0 ]]; then
+        log_info "Unblocked $unblocked_clusters deleting cluster(s) with leaked pauses (OCPBUGS-77530): ${unblocked_cluster_names[*]}"
     fi
 
     # Check if any operation failed during recovery


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

Adds cascading unpause logic to the `oadp-recovery` cronjob as a stopgap for OCPBUGS-77530.  

The cronjob now checks every HostedCluster with a `deletionTimestamp`
for leaked paused state on inner objects (HostedControlPlane, MachineDeployments, CAPI Cluster) and removes it.

This is a stopgap to reduce toil from stuck uninstallations until the OCPBUG fix is implemented.

See the below example output tested on a stage cluster:
```
$ ./contrib/oadp-recovery/oadp-recovery.sh --log-level debug --dry-run
[INFO] 2026-03-05 12:46:38 Starting OADP recovery check (oadp-namespace: openshift-adp, dry-run: true)
...
[VERBOSE] 2026-03-05 12:46:57 Processing hosted cluster: klmno (namespace: ocm-ENVIRONMENT-CCCCC)
[DEBUG] 2026-03-05 12:47:00 Cluster klmno is not paused by OADP plugin
[VERBOSE] 2026-03-05 12:47:00 Cluster klmno is being deleted (since 2026-03-05T00:00:00Z), checking child objects for leaked pauses
[INFO] 2026-03-05 12:47:02 Checking cascading objects in namespace ocm-ENVIRONMENT-CCCCC-klmno for cluster klmno (OCPBUGS-77530)
[INFO] 2026-03-05 12:47:04 HostedControlPlane klmno has leaked pausedUntil="true"
[INFO] 2026-03-05 12:47:04 DRY RUN: Would remove spec.pausedUntil from HostedControlPlane klmno
[INFO] 2026-03-05 12:47:06 MachineDeployment klmno-workers has leaked paused annotation="true"
[INFO] 2026-03-05 12:47:06 DRY RUN: Would remove cluster.x-k8s.io/paused annotation from MachineDeployment klmno-workers
[DEBUG] 2026-03-05 12:47:13 CAPI Cluster klmno does not have paused annotation
[DEBUG] 2026-03-05 12:47:13 CAPI Cluster klmno does not have spec.paused=true
...
[INFO] 2026-03-05 12:47:25 OADP recovery completed: total=7, processed=7, recovered=0, errors=0
[INFO] 2026-03-05 12:47:25 Unblocked 1 deleting cluster(s) with leaked pauses (OCPBUGS-77530): klmno
```

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Addresses [SREP-3855](https://issues.redhat.com/browse/SREP-3855)

## Special notes for your reviewer:

The logic is largely ported over from the manual script created here: https://github.com/openshift/ops-sop/pull/3906

Please see also:
- [Slack thread](https://redhat-internal.slack.com/archives/C089VJ638AY/p1772650259619069?thread_ts=1772453952.137009&cid=C089VJ638AY)

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cascading Unpause: automatically resumes paused control plane, machine, and cluster objects when a host cluster is being deleted, reducing recovery blockages and reporting unblocked clusters.

* **Documentation**
  * Updated recovery guide and RBAC instructions to include required permissions for cascading unpause operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->