### PR TITLE
OCPBUGS-77514: E2E filter rolling upgrade verification to current MachineSet

### DIFF
--- a/test/e2e/nodepool_rolling_upgrade_test.go
+++ b/test/e2e/nodepool_rolling_upgrade_test.go
@@ -5,6 +5,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -131,26 +132,68 @@ func (k *RollingUpgradeTest) Run(t *testing.T, nodePool hyperv1.NodePool, nodes 
 		e2eutil.WithTimeout(k.getRollingUpgradeTimeout()),
 	)
 
+	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(k.hostedCluster.Namespace, k.hostedCluster.Name)
+
+	// Find the current (latest revision) MachineSet for the MachineDeployment.
+	// After a rolling upgrade completes, the old MachineSet may still have machines
+	// that are being scaled down. We must only verify machines belonging to the
+	// current MachineSet to avoid false failures from stale machines.
+	currentMachineSetName := currentMachineSetForDeployment(t, k.ctx, k.mgmtClient, controlPlaneNamespace, nodePool.Name)
+	machineLabels := crclient.MatchingLabels{
+		capiv1.MachineDeploymentNameLabel: nodePool.Name,
+		capiv1.MachineSetNameLabel:        currentMachineSetName,
+	}
+
 	switch globalOpts.Platform {
 	case hyperv1.AWSPlatform:
-		// check all aws machines have the new instance type
-		controlPlaneNamespace := manifests.HostedControlPlaneNamespace(k.hostedCluster.Namespace, k.hostedCluster.Name)
 		awsMachines := &capiaws.AWSMachineList{}
-		err = k.mgmtClient.List(k.ctx, awsMachines, crclient.InNamespace(controlPlaneNamespace), crclient.MatchingLabels{capiv1.MachineDeploymentNameLabel: nodePool.Name})
+		err = k.mgmtClient.List(k.ctx, awsMachines, crclient.InNamespace(controlPlaneNamespace), machineLabels)
 		g.Expect(err).ToNot(HaveOccurred(), "failed to list aws machines")
+		g.Expect(awsMachines.Items).ToNot(BeEmpty(), "expected at least one aws machine in current MachineSet")
 
 		for _, machine := range awsMachines.Items {
 			g.Expect(machine.Spec.InstanceType).To(Equal(instanceType))
 		}
 	case hyperv1.AzurePlatform:
-		// check all azure machines have the new instance type
-		controlPlaneNamespace := manifests.HostedControlPlaneNamespace(k.hostedCluster.Namespace, k.hostedCluster.Name)
 		azureMachines := &capiazure.AzureMachineList{}
-		err = k.mgmtClient.List(k.ctx, azureMachines, crclient.InNamespace(controlPlaneNamespace), crclient.MatchingLabels{capiv1.MachineDeploymentNameLabel: nodePool.Name})
+		err = k.mgmtClient.List(k.ctx, azureMachines, crclient.InNamespace(controlPlaneNamespace), machineLabels)
 		g.Expect(err).ToNot(HaveOccurred(), "failed to list azure machines")
+		g.Expect(azureMachines.Items).ToNot(BeEmpty(), "expected at least one azure machine in current MachineSet")
 
 		for _, machine := range azureMachines.Items {
 			g.Expect(machine.Spec.VMSize).To(Equal(vmSize))
 		}
 	}
+}
+
+// currentMachineSetForDeployment returns the name of the current (highest revision)
+// MachineSet for the given MachineDeployment. This is needed because after a rolling
+// upgrade the old MachineSet may still have machines that haven't been fully cleaned up.
+func currentMachineSetForDeployment(t *testing.T, ctx context.Context, c crclient.Client, namespace, machineDeploymentName string) string {
+	t.Helper()
+	g := NewWithT(t)
+
+	machineSets := &capiv1.MachineSetList{}
+	err := c.List(ctx, machineSets,
+		crclient.InNamespace(namespace),
+		crclient.MatchingLabels{capiv1.MachineDeploymentNameLabel: machineDeploymentName},
+	)
+	g.Expect(err).ToNot(HaveOccurred(), "failed to list MachineSets")
+	g.Expect(machineSets.Items).ToNot(BeEmpty(), "expected at least one MachineSet for MachineDeployment %s", machineDeploymentName)
+
+	var current string
+	var maxRevision int64 = -1
+	for i := range machineSets.Items {
+		rev, err := strconv.ParseInt(machineSets.Items[i].Annotations[capiv1.RevisionAnnotation], 10, 64)
+		if err != nil {
+			continue
+		}
+		if rev > maxRevision {
+			maxRevision = rev
+			current = machineSets.Items[i].Name
+		}
+	}
+	g.Expect(current).ToNot(BeEmpty(), "no MachineSet with a valid revision annotation found")
+	t.Logf("Current MachineSet for MachineDeployment %s: %s (revision %d)", machineDeploymentName, current, maxRevision)
+	return current
 }

--- a/test/e2e/nodepool_rolling_upgrade_test.go
+++ b/test/e2e/nodepool_rolling_upgrade_test.go
@@ -18,6 +18,7 @@ import (
 	capiaws "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	capiazure "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/labels/format"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -141,7 +142,7 @@ func (k *RollingUpgradeTest) Run(t *testing.T, nodePool hyperv1.NodePool, nodes 
 	currentMachineSetName := currentMachineSetForDeployment(t, k.ctx, k.mgmtClient, controlPlaneNamespace, nodePool.Name)
 	machineLabels := crclient.MatchingLabels{
 		capiv1.MachineDeploymentNameLabel: nodePool.Name,
-		capiv1.MachineSetNameLabel:        currentMachineSetName,
+		capiv1.MachineSetNameLabel:        format.MustFormatValue(currentMachineSetName),
 	}
 
 	switch globalOpts.Platform {

--- a/test/e2e/nodepool_rolling_upgrade_test.go
+++ b/test/e2e/nodepool_rolling_upgrade_test.go
@@ -136,9 +136,11 @@ func (k *RollingUpgradeTest) Run(t *testing.T, nodePool hyperv1.NodePool, nodes 
 	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(k.hostedCluster.Namespace, k.hostedCluster.Name)
 
 	// Find the current (latest revision) MachineSet for the MachineDeployment.
-	// After a rolling upgrade completes, the old MachineSet may still have machines
-	// that are being scaled down. We must only verify machines belonging to the
+	// Currently in CAPI v1.11, after a rolling upgrade completes, the old MachineSet may still have machines
+	// that are being scaled down. As a temporary workaround We only verify machines belonging to the
 	// current MachineSet to avoid false failures from stale machines.
+	// TODO(bclement): Revert this change once the root cause is found and fixed:
+	// https://issues.redhat.com/browse/OCPBUGS-77922
 	currentMachineSetName := currentMachineSetForDeployment(t, k.ctx, k.mgmtClient, controlPlaneNamespace, nodePool.Name)
 	machineLabels := crclient.MatchingLabels{
 		capiv1.MachineDeploymentNameLabel: nodePool.Name,


### PR DESCRIPTION
## What this PR does / why we need it:
The rolling upgrade E2E test fails when bumping CAPI to 1.11 because old machines are still deleting when `MachineDeploymentComplete()` signals that the deployment is done. Then the test proceeds to check that all machines are on the new template, which is not true for the machine still in deletion.

Until the cause of this flake is found upstream, this PR adds filtering to the e2e test so that it verifies the current `MachineSet` only.

## Which issue(s) this PR fixes:
Fixes [OCPBUGS-77514](https://issues.redhat.com/browse/OCPBUGS-77514)

## Special notes for your reviewer:
There is a detailed RCA in [OCPBUGS-77514](https://issues.redhat.com/browse/OCPBUGS-77514). Please have a look at it to get the full picture.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tightened rolling-upgrade validations to target the current machine set during node pool upgrades
  * Added utilities to identify and constrain checks to the active machine set for both AWS and Azure rotations
  * Added non-empty assertions for cloud-provider machine lists and unified namespace handling to improve test reliability and clarity
<!-- end of auto-generated comment: release notes by coderabbit.ai -->