### PR TITLE
GCP-441: tolerate 1 restart for GCP CCM token-minter race condition

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -133,6 +133,8 @@ var (
 		"network-node-identity": 1,
 		// temporary workaround for https://issues.redhat.com/browse/CNV-76520
 		"kubevirt-cloud-controller-manager": 2,
+		// Allow 1 restart for token-minter sidecar race condition: https://issues.redhat.com/browse/GCP-441
+		"gcp-cloud-controller-manager": 1,
 	}
 )
 


### PR DESCRIPTION

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

The GCP CCM intermittently crashes on startup when the token-minter sidecar hasn't written the token file yet. Allow 1 restart in EnsureNoCrashingPods to unblock CI. Proper fix tracked in GCP-447.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 
[GCP-441](https://issues.redhat.com/browse/GCP-441)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test robustness by increasing crash tolerance for GCP cloud controller manager component, allowing for graceful handling of a known race condition during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->