### PR TITLE
ROSAENG-132: fix(karpenter): Set Ready condition to False when version resolution fails

### DIFF
--- a/api/karpenter/v1beta1/karpenter_types.go
+++ b/api/karpenter/v1beta1/karpenter_types.go
@@ -20,6 +20,11 @@ const (
 	// UserDataAMILabel is a label set in the userData secret generated for karpenter instances.
 	UserDataAMILabel = "hypershift.openshift.io/ami"
 
+	// ConditionTypeReady is the top-level readiness condition for the OpenshiftEC2NodeClass.
+	// It is computed atomically by the EC2 node class controller, combining the upstream
+	// EC2NodeClass readiness with the VersionResolved condition status.
+	ConditionTypeReady = "Ready"
+
 	// ConditionTypeVersionResolved indicates whether the spec.version was successfully resolved to a release image.
 	ConditionTypeVersionResolved = "VersionResolved"
 

--- a/karpenter-operator/controllers/karpenterignition/karpenterignition_controller.go
+++ b/karpenter-operator/controllers/karpenterignition/karpenterignition_controller.go
@@ -531,6 +531,7 @@ func (r *KarpenterIgnitionReconciler) updateVersionStatus(ctx context.Context, o
 	}
 
 	conditionChanged := meta.SetStatusCondition(&openshiftEC2NodeClass.Status.Conditions, condition)
+
 	releaseImageChanged := original.Status.ReleaseImage != resolvedImage
 	versionChanged := original.Status.Version != resolvedVersion
 	if conditionChanged || releaseImageChanged || versionChanged {

--- a/karpenter-operator/controllers/karpenterignition/karpenterignition_controller_test.go
+++ b/karpenter-operator/controllers/karpenterignition/karpenterignition_controller_test.go
@@ -651,6 +651,7 @@ kind: Config`),
 		g.Expect(versionCondition).NotTo(BeNil(), "VersionResolved condition should be set")
 		g.Expect(versionCondition.Status).To(Equal(metav1.ConditionFalse))
 		g.Expect(versionCondition.Reason).To(Equal("ResolutionFailed"))
+
 	})
 
 	t.Run("When channel is set it should pass HCP channel to resolver", func(t *testing.T) {

--- a/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller.go
+++ b/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller.go
@@ -349,6 +349,11 @@ func (r *EC2NodeClassReconciler) reconcileStatus(ctx context.Context, ec2NodeCla
 		meta.SetStatusCondition(&openshiftNodeClass.Status.Conditions, metav1.Condition(condition))
 	}
 
+	// Compute the top-level Ready condition atomically by combining EC2 readiness
+	// with version resolution status. This ensures a single controller owns the
+	// Ready semantic rather than having multiple controllers race to set it.
+	r.computeReadyCondition(openshiftNodeClass)
+
 	if !reflect.DeepEqual(originalObj.Status, openshiftNodeClass.Status) {
 		if err := r.guestClient.Status().Patch(ctx, openshiftNodeClass, client.MergeFrom(originalObj)); err != nil {
 			return fmt.Errorf("failed to update status: %v", err)
@@ -357,6 +362,29 @@ func (r *EC2NodeClassReconciler) reconcileStatus(ctx context.Context, ec2NodeCla
 
 	log.Info("Reconciled OpenshiftEC2NodeClass status")
 	return nil
+}
+
+// computeReadyCondition computes the top-level Ready condition by combining
+// the upstream EC2NodeClass Ready status with the VersionResolved condition.
+// If VersionResolved is False, Ready is set to False regardless of EC2 readiness.
+func (r *EC2NodeClassReconciler) computeReadyCondition(openshiftNodeClass *hyperkarpenterv1.OpenshiftEC2NodeClass) {
+	versionResolved := meta.FindStatusCondition(openshiftNodeClass.Status.Conditions, hyperkarpenterv1.ConditionTypeVersionResolved)
+	if versionResolved == nil || versionResolved.Status != metav1.ConditionTrue {
+		reason := hyperkarpenterv1.ConditionReasonResolutionFailed
+		message := "Version resolution status is unknown"
+		if versionResolved != nil {
+			reason = versionResolved.Reason
+			message = fmt.Sprintf("Version resolution failed: %s", versionResolved.Message)
+		}
+		meta.SetStatusCondition(&openshiftNodeClass.Status.Conditions, metav1.Condition{
+			Type:               hyperkarpenterv1.ConditionTypeReady,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: openshiftNodeClass.Generation,
+			LastTransitionTime: metav1.Now(),
+			Reason:             reason,
+			Message:            message,
+		})
+	}
 }
 
 func (r *EC2NodeClassReconciler) reconcileVAP(ctx context.Context) error {

--- a/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller_test.go
+++ b/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller_test.go
@@ -548,6 +548,124 @@ func TestGetUserDataSecret(t *testing.T) {
 	}
 }
 
+func TestComputeReadyCondition(t *testing.T) {
+	testCases := []struct {
+		name                string
+		conditions          []metav1.Condition
+		expectedReadyStatus metav1.ConditionStatus
+		expectedReadyReason string
+		readyShouldChange   bool
+	}{
+		{
+			name: "When VersionResolved is False it should set Ready to False",
+			conditions: []metav1.Condition{
+				{
+					Type:    hyperkarpenterv1.ConditionTypeReady,
+					Status:  metav1.ConditionTrue,
+					Reason:  "Ready",
+					Message: "EC2NodeClass is ready",
+				},
+				{
+					Type:    hyperkarpenterv1.ConditionTypeVersionResolved,
+					Status:  metav1.ConditionFalse,
+					Reason:  hyperkarpenterv1.ConditionReasonResolutionFailed,
+					Message: "Failed to resolve version \"4.17.0\": Cincinnati API unavailable",
+				},
+			},
+			expectedReadyStatus: metav1.ConditionFalse,
+			expectedReadyReason: hyperkarpenterv1.ConditionReasonResolutionFailed,
+			readyShouldChange:   true,
+		},
+		{
+			name: "When VersionResolved is True it should not override Ready",
+			conditions: []metav1.Condition{
+				{
+					Type:    hyperkarpenterv1.ConditionTypeReady,
+					Status:  metav1.ConditionTrue,
+					Reason:  "Ready",
+					Message: "EC2NodeClass is ready",
+				},
+				{
+					Type:    hyperkarpenterv1.ConditionTypeVersionResolved,
+					Status:  metav1.ConditionTrue,
+					Reason:  hyperkarpenterv1.ConditionReasonVersionResolved,
+					Message: "Version resolved",
+				},
+			},
+			expectedReadyStatus: metav1.ConditionTrue,
+			expectedReadyReason: "Ready",
+			readyShouldChange:   false,
+		},
+		{
+			name: "When VersionResolved condition is absent it should set Ready to False",
+			conditions: []metav1.Condition{
+				{
+					Type:    hyperkarpenterv1.ConditionTypeReady,
+					Status:  metav1.ConditionTrue,
+					Reason:  "Ready",
+					Message: "EC2NodeClass is ready",
+				},
+			},
+			expectedReadyStatus: metav1.ConditionFalse,
+			expectedReadyReason: hyperkarpenterv1.ConditionReasonResolutionFailed,
+			readyShouldChange:   true,
+		},
+		{
+			name: "When VersionResolved is Unknown it should set Ready to False",
+			conditions: []metav1.Condition{
+				{
+					Type:    hyperkarpenterv1.ConditionTypeReady,
+					Status:  metav1.ConditionTrue,
+					Reason:  "Ready",
+					Message: "EC2NodeClass is ready",
+				},
+				{
+					Type:    hyperkarpenterv1.ConditionTypeVersionResolved,
+					Status:  metav1.ConditionUnknown,
+					Reason:  "Unknown",
+					Message: "Version resolution status is unknown",
+				},
+			},
+			expectedReadyStatus: metav1.ConditionFalse,
+			expectedReadyReason: "Unknown",
+			readyShouldChange:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			openshiftNodeClass := &hyperkarpenterv1.OpenshiftEC2NodeClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-nodeclass",
+					Generation: 1,
+				},
+				Status: hyperkarpenterv1.OpenshiftEC2NodeClassStatus{
+					Conditions: tc.conditions,
+				},
+			}
+
+			r := &EC2NodeClassReconciler{}
+			r.computeReadyCondition(openshiftNodeClass)
+
+			readyCond := findCondition(openshiftNodeClass.Status.Conditions, hyperkarpenterv1.ConditionTypeReady)
+			g.Expect(readyCond).NotTo(BeNil())
+			g.Expect(readyCond.Status).To(Equal(tc.expectedReadyStatus))
+			g.Expect(readyCond.Reason).To(Equal(tc.expectedReadyReason))
+		})
+	}
+}
+
+func findCondition(conditions []metav1.Condition, condType string) *metav1.Condition {
+	for i, c := range conditions {
+		if c.Type == condType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}
+
 func TestKarpenterSecretPredicate(t *testing.T) {
 	testCases := []struct {
 		name           string

--- a/vendor/github.com/openshift/hypershift/api/karpenter/v1beta1/karpenter_types.go
+++ b/vendor/github.com/openshift/hypershift/api/karpenter/v1beta1/karpenter_types.go
@@ -20,6 +20,11 @@ const (
 	// UserDataAMILabel is a label set in the userData secret generated for karpenter instances.
 	UserDataAMILabel = "hypershift.openshift.io/ami"
 
+	// ConditionTypeReady is the top-level readiness condition for the OpenshiftEC2NodeClass.
+	// It is computed atomically by the EC2 node class controller, combining the upstream
+	// EC2NodeClass readiness with the VersionResolved condition status.
+	ConditionTypeReady = "Ready"
+
 	// ConditionTypeVersionResolved indicates whether the spec.version was successfully resolved to a release image.
 	ConditionTypeVersionResolved = "VersionResolved"
 


### PR DESCRIPTION
## What this PR does / why we need it:

Compute the Ready condition atomically in the EC2 node class controller
by combining the upstream EC2NodeClass Ready status with the
VersionResolved condition. When VersionResolved is False, Ready is
overridden to False regardless of EC2 readiness.

## Which issue(s) this PR fixes:
Fixes [ROSAENG-132](https://issues.redhat.com/browse/ROSAENG-132)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level Ready condition to indicate node class readiness, derived from version resolution and underlying readiness.
* **Bug Fixes**
  * Ready is now set to False when version resolution fails, preventing use of unresolved configurations and centralizing Ready semantics.
* **Tests**
  * New unit tests covering Ready computation across resolved, unresolved, unknown, and missing version scenarios.
* **Chores**
  * Minor formatting tidy-ups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->