### PR TITLE
CNTRLPLANE-2864: Migrate universal cluster health validations to v2

### DIFF
--- a/test/e2e/util/aws.go
+++ b/test/e2e/util/aws.go
@@ -83,6 +83,12 @@ func GetIAMClient(ctx context.Context, awsCreds, awsRegion string) awsapi.IAMAPI
 	})
 }
 
+func GetEC2Client(awsCreds, awsRegion string) *ec2.EC2 {
+	awsSession := awsutil.NewSession("e2e-ec2", awsCreds, "", "", awsRegion)
+	awsConfig := awsutil.NewConfig()
+	return ec2.New(awsSession, awsConfig)
+}
+
 func GetSQSClient(awsCreds, awsRegion string) *sqs.SQS {
 	awsSession := awsutil.NewSession("e2e-sqs", awsCreds, "", "", awsRegion)
 	awsConfig := awsutil.NewConfig()

--- a/test/e2e/util/client.go
+++ b/test/e2e/util/client.go
@@ -31,6 +31,14 @@ func GetClient() (crclient.Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to get kubernetes config: %w", err)
 	}
+	return GetClientFromConfig(config)
+}
+
+// GetClientFromConfig creates a controller-runtime client from the given REST config.
+func GetClientFromConfig(config *rest.Config) (crclient.Client, error) {
+	if config == nil {
+		return nil, fmt.Errorf("unable to get kubernetes client: nil REST config")
+	}
 	client, err := crclient.New(config, crclient.Options{Scheme: scheme})
 	if err != nil {
 		return nil, fmt.Errorf("unable to get kubernetes client: %w", err)

--- a/test/e2e/util/version.go
+++ b/test/e2e/util/version.go
@@ -103,6 +103,17 @@ func CPOAtLeast(t *testing.T, version semver.Version, hc *hyperv1.HostedCluster)
 	}
 }
 
+func GinkgoCPOAtLeast(version semver.Version, hc *hyperv1.HostedCluster) {
+	if hc.Status.Version == nil || hc.Status.Version.Desired.Version == "" {
+		GinkgoAtLeast(version)
+		return
+	}
+	cpoVersion := semver.MustParse(hc.Status.Version.Desired.Version)
+	if cpoVersion.LT(version) {
+		ginkgo.Skip(fmt.Sprintf("Only tested in CPO %s and later", version))
+	}
+}
+
 func IsLessThan(version semver.Version) bool {
 	return releaseVersion.LT(version)
 }

--- a/test/e2e/v2/internal/env_vars.go
+++ b/test/e2e/v2/internal/env_vars.go
@@ -152,4 +152,9 @@ func init() {
 		false,
 		"/tmp/artifacts",
 	)
+	RegisterEnvVar(
+		"AWS_CREDENTIALS_FILE",
+		"Path to an AWS credentials file. Required for AWS-specific tests that need EC2, IAM, or SQS clients.",
+		false,
+	)
 }

--- a/test/e2e/v2/internal/test_context.go
+++ b/test/e2e/v2/internal/test_context.go
@@ -20,10 +20,20 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/sqs"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
+	"github.com/openshift/hypershift/support/awsapi"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/tools/clientcmd"
 
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -41,36 +51,228 @@ type TestContext struct {
 	ControlPlaneNamespace string
 	ArtifactDir           string
 	hostedCluster         *hyperv1.HostedCluster
-	hostedClusterOnce     sync.Once
+	hostedClusterMu       sync.RWMutex
+	guestClient           crclient.Client
+	guestClientOnce       sync.Once
+	awsCredentialsFile    string
+	awsRegion             string
+	awsRegionMu           sync.RWMutex
+}
+
+// GetNodePools returns all NodePools associated with this HostedCluster.
+// It performs a fresh list on each call (NodePools are mutable during test execution).
+// Filters by Spec.ClusterName to ensure only NodePools for this HostedCluster are returned.
+func (tc *TestContext) GetNodePools() ([]*hyperv1.NodePool, error) {
+	nodePools := &hyperv1.NodePoolList{}
+	if err := tc.MgmtClient.List(tc.Context, nodePools, crclient.InNamespace(tc.ClusterNamespace)); err != nil {
+		return nil, fmt.Errorf("failed to list NodePools in namespace %s: %w", tc.ClusterNamespace, err)
+	}
+
+	var result []*hyperv1.NodePool
+	for i := range nodePools.Items {
+		if nodePools.Items[i].Spec.ClusterName == tc.ClusterName {
+			result = append(result, &nodePools.Items[i])
+		}
+	}
+	return result, nil
+}
+
+// GetNodePool returns a specific NodePool by name.
+// Performs a direct Get rather than listing.
+func (tc *TestContext) GetNodePool(name string) (*hyperv1.NodePool, error) {
+	np := &hyperv1.NodePool{}
+	if err := tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
+		Namespace: tc.ClusterNamespace,
+		Name:      name,
+	}, np); err != nil {
+		return nil, fmt.Errorf("failed to get NodePool %s/%s: %w", tc.ClusterNamespace, name, err)
+	}
+	if np.Spec.ClusterName != tc.ClusterName {
+		return nil, fmt.Errorf(
+			"NodePool %s/%s belongs to cluster %q, not %q",
+			tc.ClusterNamespace, name, np.Spec.ClusterName, tc.ClusterName,
+		)
+	}
+	return np, nil
 }
 
 // GetHostedCluster returns the HostedCluster associated with this test context.
-// It fetches the HostedCluster lazily on first call if ClusterName and ClusterNamespace are set.
-// Returns nil if the HostedCluster cannot be fetched or if ClusterName/ClusterNamespace are not set.
-func (tc *TestContext) GetHostedCluster() *hyperv1.HostedCluster {
-	tc.hostedClusterOnce.Do(func() {
-		if tc.ClusterName == "" || tc.ClusterNamespace == "" {
-			return
-		}
+// It fetches the HostedCluster lazily on first call if ClusterName and ClusterNamespace are set,
+// caching the result for subsequent calls. Pass refresh=true to bypass the cache and fetch a
+// fresh copy (e.g. to pick up status changes).
+// Returns (nil, nil) if ClusterName/ClusterNamespace are not set.
+func (tc *TestContext) GetHostedCluster(refresh ...bool) (*hyperv1.HostedCluster, error) {
+	shouldRefresh := len(refresh) > 0 && refresh[0]
 
-		hostedCluster := &hyperv1.HostedCluster{}
-		err := tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
-			Namespace: tc.ClusterNamespace,
-			Name:      tc.ClusterName,
-		}, hostedCluster)
+	if !shouldRefresh {
+		tc.hostedClusterMu.RLock()
+		if tc.hostedCluster != nil {
+			hc := tc.hostedCluster
+			tc.hostedClusterMu.RUnlock()
+			return hc, nil
+		}
+		tc.hostedClusterMu.RUnlock()
+	}
+
+	if tc.ClusterName == "" || tc.ClusterNamespace == "" {
+		return nil, nil
+	}
+
+	hostedCluster := &hyperv1.HostedCluster{}
+	err := tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
+		Namespace: tc.ClusterNamespace,
+		Name:      tc.ClusterName,
+	}, hostedCluster)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get HostedCluster %s/%s: %w", tc.ClusterNamespace, tc.ClusterName, err)
+	}
+
+	err = e2eutil.SetReleaseVersionFromHostedCluster(tc.Context, hostedCluster)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set release version from HostedCluster: %w", err)
+	}
+
+	tc.hostedClusterMu.Lock()
+	tc.hostedCluster = hostedCluster
+	tc.hostedClusterMu.Unlock()
+
+	return hostedCluster, nil
+}
+
+// GetAWSRegion returns the AWS region from the HostedCluster spec.
+// Returns an error if the HostedCluster is not available or is not an AWS platform.
+func (tc *TestContext) GetAWSRegion() (string, error) {
+	tc.awsRegionMu.RLock()
+	if tc.awsRegion != "" {
+		region := tc.awsRegion
+		tc.awsRegionMu.RUnlock()
+		return region, nil
+	}
+	tc.awsRegionMu.RUnlock()
+
+	hc, err := tc.GetHostedCluster()
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve AWS region: %w", err)
+	}
+	if hc == nil {
+		return "", fmt.Errorf("cannot resolve AWS region: HostedCluster is not available")
+	}
+	if hc.Spec.Platform.AWS == nil {
+		return "", fmt.Errorf("cannot resolve AWS region: HostedCluster %s/%s is not an AWS platform", hc.Namespace, hc.Name)
+	}
+	region := hc.Spec.Platform.AWS.Region
+
+	tc.awsRegionMu.Lock()
+	if tc.awsRegion == "" {
+		tc.awsRegion = region
+	}
+	region = tc.awsRegion
+	tc.awsRegionMu.Unlock()
+	return region, nil
+}
+
+func (tc *TestContext) requireAWSCredentials() error {
+	if tc.awsCredentialsFile == "" {
+		return fmt.Errorf("AWS_CREDENTIALS_FILE environment variable is not set. It is required for AWS-specific tests")
+	}
+	return nil
+}
+
+// GetEC2Client returns an EC2 client configured for the HostedCluster's region.
+func (tc *TestContext) GetEC2Client() (*ec2.EC2, error) {
+	if err := tc.requireAWSCredentials(); err != nil {
+		return nil, err
+	}
+	region, err := tc.GetAWSRegion()
+	if err != nil {
+		return nil, err
+	}
+	return e2eutil.GetEC2Client(tc.awsCredentialsFile, region), nil
+}
+
+// GetIAMClient returns an IAM client configured for the HostedCluster's region.
+func (tc *TestContext) GetIAMClient() (awsapi.IAMAPI, error) {
+	if err := tc.requireAWSCredentials(); err != nil {
+		return nil, err
+	}
+	region, err := tc.GetAWSRegion()
+	if err != nil {
+		return nil, err
+	}
+	return e2eutil.GetIAMClient(tc.Context, tc.awsCredentialsFile, region), nil
+}
+
+// GetSQSClient returns an SQS client configured for the HostedCluster's region.
+func (tc *TestContext) GetSQSClient() (*sqs.SQS, error) {
+	if err := tc.requireAWSCredentials(); err != nil {
+		return nil, err
+	}
+	region, err := tc.GetAWSRegion()
+	if err != nil {
+		return nil, err
+	}
+	return e2eutil.GetSQSClient(tc.awsCredentialsFile, region), nil
+}
+
+// GetGuestClient returns a controller-runtime client for the guest (hosted) cluster.
+// It fetches the admin kubeconfig from the HostedCluster status lazily on first call via sync.Once.
+// Retries handle transient DNS propagation failures when connecting to the guest API server.
+// Panics if the guest client cannot be created, as tests cannot proceed without it.
+func (tc *TestContext) GetGuestClient() crclient.Client {
+	tc.guestClientOnce.Do(func() {
+		hc, err := tc.GetHostedCluster()
 		if err != nil {
-			// In test code, panicking is acceptable and will fail the test appropriately
-			panic(fmt.Sprintf("failed to get HostedCluster %s/%s: %v", tc.ClusterNamespace, tc.ClusterName, err))
+			panic(fmt.Sprintf("failed to get HostedCluster: %v", err))
+		}
+		if hc == nil || hc.Status.KubeConfig == nil {
+			panic("HostedCluster has no kubeconfig in status")
 		}
 
-		err = e2eutil.SetReleaseVersionFromHostedCluster(tc.Context, hostedCluster)
+		var secret corev1.Secret
+		err = tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
+			Namespace: hc.Namespace,
+			Name:      hc.Status.KubeConfig.Name,
+		}, &secret)
 		if err != nil {
-			panic(fmt.Sprintf("failed to set release version from HostedCluster: %v", err))
+			panic(fmt.Sprintf("failed to get kubeconfig secret: %v", err))
 		}
 
-		tc.hostedCluster = hostedCluster
+		kubeconfigData, ok := secret.Data["kubeconfig"]
+		if !ok {
+			panic("kubeconfig secret does not contain 'kubeconfig' key")
+		}
+
+		restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigData)
+		if err != nil {
+			panic(fmt.Sprintf("failed to parse guest kubeconfig: %v", err))
+		}
+		restConfig.QPS = -1
+		restConfig.Burst = -1
+
+		var guestClient crclient.Client
+		var lastErr error
+		err = wait.PollUntilContextTimeout(tc.Context, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+			guestClient, err = e2eutil.GetClientFromConfig(restConfig)
+			if err != nil {
+				lastErr = fmt.Errorf("build guest client: %w", err)
+				return false, nil
+			}
+			_, apiErr := discovery.NewDiscoveryClientForConfigOrDie(restConfig).ServerVersion()
+			if apiErr != nil {
+				lastErr = fmt.Errorf("discover guest API server version: %w", apiErr)
+				return false, nil
+			}
+			return true, nil
+		})
+		if err != nil {
+			if lastErr != nil {
+				panic(fmt.Sprintf("failed to connect to guest cluster: %v (last error: %v)", err, lastErr))
+			}
+			panic(fmt.Sprintf("failed to connect to guest cluster: %v", err))
+		}
+		tc.guestClient = guestClient
 	})
-	return tc.hostedCluster
+	return tc.guestClient
 }
 
 var (
@@ -102,6 +304,7 @@ func SetupTestContext(ctx context.Context, hostedClusterName, hostedClusterNames
 		ClusterName:           hostedClusterName,
 		ClusterNamespace:      hostedClusterNamespace,
 		ControlPlaneNamespace: manifests.HostedControlPlaneNamespace(hostedClusterNamespace, hostedClusterName),
+		awsCredentialsFile:    GetEnvVarValue("AWS_CREDENTIALS_FILE"),
 	}
 
 	return testCtx, nil
@@ -133,6 +336,9 @@ func SetupTestContextFromEnv(ctx context.Context) (*TestContext, error) {
 		testCtx.ControlPlaneNamespace = manifests.HostedControlPlaneNamespace(hostedClusterNamespace, hostedClusterName)
 	}
 	testCtx.ArtifactDir = artifactDir
+
+	// AWS credentials file path from environment (optional, required only for AWS-specific tests)
+	testCtx.awsCredentialsFile = GetEnvVarValue("AWS_CREDENTIALS_FILE")
 
 	return testCtx, nil
 }

--- a/test/e2e/v2/internal/test_context.go
+++ b/test/e2e/v2/internal/test_context.go
@@ -33,8 +33,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
+	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
+	cr "sigs.k8s.io/controller-runtime"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -54,6 +56,8 @@ type TestContext struct {
 	hostedClusterMu       sync.RWMutex
 	guestClient           crclient.Client
 	guestClientOnce       sync.Once
+	kubeClient            *kubeclient.Clientset
+	kubeClientOnce        sync.Once
 	awsCredentialsFile    string
 	awsRegion             string
 	awsRegionMu           sync.RWMutex
@@ -273,6 +277,20 @@ func (tc *TestContext) GetGuestClient() crclient.Client {
 		tc.guestClient = guestClient
 	})
 	return tc.guestClient
+}
+
+// GetKubeClient returns a kubernetes.Clientset for the management cluster.
+// It is lazy-initialized on first call via sync.Once using the same REST config as MgmtClient.
+// Useful for operations like streaming pod logs that require the typed client.
+func (tc *TestContext) GetKubeClient() *kubeclient.Clientset {
+	tc.kubeClientOnce.Do(func() {
+		cfg, err := cr.GetConfig()
+		if err != nil {
+			panic(fmt.Sprintf("failed to get REST config for kube client: %v", err))
+		}
+		tc.kubeClient = kubeclient.NewForConfigOrDie(cfg)
+	})
+	return tc.kubeClient
 }
 
 var (

--- a/test/e2e/v2/internal/test_context_aws_test.go
+++ b/test/e2e/v2/internal/test_context_aws_test.go
@@ -1,0 +1,151 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+)
+
+func TestGetAWSRegion_WhenHostedClusterIsAWS_ItShouldReturnRegion(t *testing.T) {
+	tc := &TestContext{
+		Context: context.Background(),
+		hostedCluster: &hyperv1.HostedCluster{
+			Spec: hyperv1.HostedClusterSpec{
+				Platform: hyperv1.PlatformSpec{
+					AWS: &hyperv1.AWSPlatformSpec{
+						Region: "us-east-1",
+					},
+				},
+			},
+		},
+	}
+
+	region, err := tc.GetAWSRegion()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if region != "us-east-1" {
+		t.Errorf("expected region %q, got %q", "us-east-1", region)
+	}
+}
+
+func TestGetAWSRegion_WhenHostedClusterIsNotAWS_ItShouldReturnError(t *testing.T) {
+	tc := &TestContext{
+		Context: context.Background(),
+		hostedCluster: &hyperv1.HostedCluster{
+			Spec: hyperv1.HostedClusterSpec{
+				Platform: hyperv1.PlatformSpec{},
+			},
+		},
+	}
+
+	_, err := tc.GetAWSRegion()
+	if err == nil {
+		t.Error("expected error for non-AWS platform, but got nil")
+	}
+}
+
+func TestGetAWSRegion_WhenRegionIsCached_ItShouldReturnCachedValue(t *testing.T) {
+	tc := &TestContext{
+		Context:   context.Background(),
+		awsRegion: "eu-west-1",
+	}
+
+	region, err := tc.GetAWSRegion()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if region != "eu-west-1" {
+		t.Errorf("expected cached region %q, got %q", "eu-west-1", region)
+	}
+}
+
+func TestGetAWSRegion_WhenHostedClusterIsNil_ItShouldReturnError(t *testing.T) {
+	tc := &TestContext{
+		Context: context.Background(),
+	}
+
+	_, err := tc.GetAWSRegion()
+	if err == nil {
+		t.Error("expected error when HostedCluster is nil, but got nil")
+	}
+}
+
+func TestGetAWSRegion_WhenCalledConcurrently_ItShouldReturnConsistentRegion(t *testing.T) {
+	tc := &TestContext{
+		Context: context.Background(),
+		hostedCluster: &hyperv1.HostedCluster{
+			Spec: hyperv1.HostedClusterSpec{
+				Platform: hyperv1.PlatformSpec{
+					AWS: &hyperv1.AWSPlatformSpec{
+						Region: "us-west-2",
+					},
+				},
+			},
+		},
+	}
+
+	const goroutines = 10
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	regions := make([]string, goroutines)
+	errs := make([]error, goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			regions[idx], errs[idx] = tc.GetAWSRegion()
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < goroutines; i++ {
+		if errs[i] != nil {
+			t.Fatalf("goroutine %d: unexpected error: %v", i, errs[i])
+		}
+		if regions[i] != "us-west-2" {
+			t.Errorf("goroutine %d: expected region %q, got %q", i, "us-west-2", regions[i])
+		}
+	}
+}
+
+func TestRequireAWSCredentials_WhenNotSet_ItShouldReturnError(t *testing.T) {
+	tc := &TestContext{
+		Context: context.Background(),
+	}
+
+	err := tc.requireAWSCredentials()
+	if err == nil {
+		t.Error("expected error when AWS credentials file is not set, but got nil")
+	}
+}
+
+func TestRequireAWSCredentials_WhenSet_ItShouldNotReturnError(t *testing.T) {
+	tc := &TestContext{
+		Context:            context.Background(),
+		awsCredentialsFile: "/tmp/fake-creds",
+	}
+
+	err := tc.requireAWSCredentials()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/test/e2e/v2/internal/workload_registry.go
+++ b/test/e2e/v2/internal/workload_registry.go
@@ -503,8 +503,12 @@ func ShouldSkipWorkloadForPlatform(workload WorkloadSpec, hostedCluster *hyperv1
 // This is a generic function that handles both Deployments and StatefulSets.
 func validateControlPlaneWorkloadsByType(testCtx *TestContext, workloadTypes []string, excludeWorkloads []string) error {
 	workloads := GetControlPlaneWorkloads()
+	hc, err := testCtx.GetHostedCluster()
+	if err != nil {
+		return fmt.Errorf("failed to get HostedCluster: %w", err)
+	}
 	for _, workload := range workloads {
-		if ShouldSkipWorkloadForPlatform(workload, testCtx.GetHostedCluster()) {
+		if ShouldSkipWorkloadForPlatform(workload, hc) {
 			continue
 		}
 		if !slices.Contains(workloadTypes, workload.Type) {

--- a/test/e2e/v2/tests/api_ux_validation_test.go
+++ b/test/e2e/v2/tests/api_ux_validation_test.go
@@ -21,6 +21,7 @@ import (
 	"embed"
 	"fmt"
 	"net"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -29,11 +30,14 @@ import (
 	"github.com/openshift/hypershift/api/util/ipnet"
 	"github.com/openshift/hypershift/support/assets"
 	"github.com/openshift/hypershift/test/e2e/util"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
 
 	configv1 "github.com/openshift/api/config/v1"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
 
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -481,6 +485,61 @@ var _ = Describe("API UX Validation", Label("API"), func() {
 					},
 					"must have at most 60 items"),
 			)
+		})
+
+		Context("Immutability validation", Label("Immutability"), func() {
+			It("should reject Services changes", func() {
+				testCtx := ctx.(*internal.TestContext)
+				hostedCluster, err := testCtx.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
+
+				err = patchHostedCluster(testCtx, hostedCluster, func(obj *hyperv1.HostedCluster) {
+					for i, svc := range obj.Spec.Services {
+						if svc.Service == hyperv1.APIServer {
+							svc.Type = hyperv1.NodePort
+							obj.Spec.Services[i] = svc
+						}
+					}
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Services is immutable"))
+			})
+
+			It("should reject ControllerAvailabilityPolicy changes", func() {
+				testCtx := ctx.(*internal.TestContext)
+				hostedCluster, err := testCtx.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
+
+				err = patchHostedCluster(testCtx, hostedCluster, func(obj *hyperv1.HostedCluster) {
+					if obj.Spec.ControllerAvailabilityPolicy == hyperv1.HighlyAvailable {
+						obj.Spec.ControllerAvailabilityPolicy = hyperv1.SingleReplica
+					} else if obj.Spec.ControllerAvailabilityPolicy == hyperv1.SingleReplica {
+						obj.Spec.ControllerAvailabilityPolicy = hyperv1.HighlyAvailable
+					}
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("ControllerAvailabilityPolicy is immutable"))
+			})
+
+			Context("Capabilities immutability", Label("Capabilities"), func() {
+				BeforeEach(func() {
+					e2eutil.GinkgoAtLeast(e2eutil.Version419)
+				})
+
+				It("should reject Capabilities changes", func() {
+					testCtx := ctx.(*internal.TestContext)
+					hostedCluster, err := testCtx.GetHostedCluster()
+					Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
+
+					err = patchHostedCluster(testCtx, hostedCluster, func(obj *hyperv1.HostedCluster) {
+						obj.Spec.Capabilities = &hyperv1.Capabilities{
+							Disabled: []hyperv1.OptionalCapability{hyperv1.ImageRegistryCapability},
+						}
+					})
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("Capabilities is immutable"))
+				})
+			})
 		})
 
 		Context("Cluster and Infra ID validation", Label("ClusterID", "InfraID"), func() {
@@ -1789,5 +1848,30 @@ func testNodePoolCreation(ctx context.Context, client crclient.Client, file stri
 	// Explicitly delete the resource after creation attempt, in addition to defer
 	// This matches the original test behavior and ensures cleanup even if creation fails
 	_ = client.Delete(ctx, nodePool)
+	return err
+}
+
+// patchHostedCluster fetches the latest HostedCluster, applies a mutation, and patches it.
+// Returns the patch error (which may be an admission webhook rejection).
+func patchHostedCluster(testCtx *internal.TestContext, original *hyperv1.HostedCluster, mutate func(*hyperv1.HostedCluster)) error {
+	var patchErr error
+	err := wait.PollUntilContextTimeout(testCtx, time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
+		if err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(original), original); err != nil {
+			return false, nil
+		}
+		obj := original.DeepCopy()
+		mutate(obj)
+		if err := testCtx.MgmtClient.Patch(ctx, obj, crclient.MergeFrom(original)); err != nil {
+			if apierrors.IsConflict(err) {
+				return false, nil
+			}
+			patchErr = err
+			return true, nil
+		}
+		return true, nil
+	})
+	if patchErr != nil {
+		return patchErr
+	}
 	return err
 }

--- a/test/e2e/v2/tests/backup_restore_test.go
+++ b/test/e2e/v2/tests/backup_restore_test.go
@@ -76,14 +76,15 @@ var _ = Describe("BackupRestore", Label("backup-restore", "aws"), Ordered, Seria
 		if err := testCtx.ValidateControlPlaneNamespace(); err != nil {
 			AbortSuite(err.Error())
 		}
-		hostedCluster := testCtx.GetHostedCluster()
+		hostedCluster, err := testCtx.GetHostedCluster()
+		Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
 		Expect(hostedCluster).NotTo(BeNil(), "HostedCluster should be set up")
 		if hostedCluster.Spec.Platform.Type != hyperv1.AWSPlatform {
 			Skip("Test is only supported on AWS platform")
 		}
 
 		// Ensure Velero pod is running before proceeding with backup/restore tests
-		err := backuprestore.EnsureVeleroPodRunning(testCtx)
+		err = backuprestore.EnsureVeleroPodRunning(testCtx)
 		if err != nil {
 			Fail(fmt.Sprintf("Velero is not running: %v", err))
 		}

--- a/test/e2e/v2/tests/cluster_health_test.go
+++ b/test/e2e/v2/tests/cluster_health_test.go
@@ -1,0 +1,412 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hccokasvap "github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas"
+	hcc "github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster"
+	hyperutil "github.com/openshift/hypershift/support/util"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	"github.com/openshift/hypershift/test/e2e/v2/internal"
+
+	configv1 "github.com/openshift/api/config/v1"
+	routev1 "github.com/openshift/api/route/v1"
+
+	k8sadmissionv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// isKubeVirtPod returns true if the pod is a KubeVirt-managed pod that should be
+// excluded from control plane validation checks.
+func isKubeVirtPod(pod *corev1.Pod) bool {
+	return pod.Labels["kubevirt.io"] == "virt-launcher" || pod.Labels["app"] == "vmi-console-debug"
+}
+
+// FeatureGateStatusTest validates that the guest cluster FeatureGate status contains
+// the current version from ClusterVersion.
+func FeatureGateStatusTest(getTestCtx internal.TestContextGetter) {
+	Context("Feature gate status", func() {
+		BeforeEach(func() {
+			e2eutil.GinkgoAtLeast(e2eutil.Version419)
+		})
+
+		It("When checking feature gates it should contain the current cluster version", func() {
+			testCtx := getTestCtx()
+			guestClient := testCtx.GetGuestClient()
+
+			// Wait for ClusterVersion to have a completed history entry
+			var currentVersion string
+			Eventually(func(g Gomega) {
+				cv := &configv1.ClusterVersion{}
+				err := guestClient.Get(testCtx, crclient.ObjectKey{Name: "version"}, cv)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cv.Status.History).NotTo(BeEmpty(), "ClusterVersion history is empty")
+				g.Expect(cv.Status.History[0].State).To(Equal(configv1.CompletedUpdate),
+					"most recent ClusterVersion history entry is %s, not Completed", cv.Status.History[0].State)
+				currentVersion = cv.Status.History[0].Version
+			}, 10*time.Minute, 10*time.Second).Should(Succeed())
+
+			// Verify FeatureGate contains the current version
+			Eventually(func(g Gomega) {
+				fg := &configv1.FeatureGate{}
+				err := guestClient.Get(testCtx, crclient.ObjectKey{Name: "cluster"}, fg)
+				g.Expect(err).NotTo(HaveOccurred())
+				found := false
+				for _, details := range fg.Status.FeatureGates {
+					if details.Version == currentVersion {
+						found = true
+						break
+					}
+				}
+				g.Expect(found).To(BeTrue(),
+					"current version %s from ClusterVersion not found in FeatureGate status", currentVersion)
+			}, 10*time.Minute, 10*time.Second).Should(Succeed())
+		})
+	})
+}
+
+// CAPIFinalizersTest validates that CAPI component deployments have the expected finalizer.
+func CAPIFinalizersTest(getTestCtx internal.TestContextGetter) {
+	Context("CAPI finalizers", func() {
+		It("When checking CAPI deployments it should have the component finalizer", func() {
+			testCtx := getTestCtx()
+
+			for _, name := range hcc.CAPIComponents {
+				deployment := &appsv1.Deployment{}
+				err := testCtx.MgmtClient.Get(testCtx, crclient.ObjectKey{
+					Namespace: testCtx.ControlPlaneNamespace,
+					Name:      name,
+				}, deployment)
+				Expect(err).NotTo(HaveOccurred(), "failed to get CAPI deployment %s", name)
+				Expect(controllerutil.ContainsFinalizer(deployment, hcc.ControlPlaneComponentFinalizer)).To(BeTrue(),
+					"CAPI deployment %s is expected to have finalizer: %s", name, hcc.ControlPlaneComponentFinalizer)
+			}
+		})
+	})
+}
+
+// GuestWebhooksValidatedTest validates that invalid guest webhooks are automatically deleted.
+func GuestWebhooksValidatedTest(getTestCtx internal.TestContextGetter) {
+	Context("Guest webhooks validated", func() {
+		It("When creating an invalid webhook it should be automatically deleted", func() {
+			testCtx := getTestCtx()
+			guestClient := testCtx.GetGuestClient()
+
+			sideEffectsNone := k8sadmissionv1.SideEffectClassNone
+			guestWebhookConf := &k8sadmissionv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-webhook",
+					Annotations: map[string]string{
+						"service.beta.openshift.io/inject-cabundle": "true",
+					},
+				},
+				Webhooks: []k8sadmissionv1.ValidatingWebhook{{
+					AdmissionReviewVersions: []string{"v1"},
+					Name:                    "etcd-client.example.com",
+					ClientConfig: k8sadmissionv1.WebhookClientConfig{
+						URL: ptr.To("https://etcd-client:2379"),
+					},
+					Rules: []k8sadmissionv1.RuleWithOperations{{
+						Operations: []k8sadmissionv1.OperationType{k8sadmissionv1.Create},
+						Rule: k8sadmissionv1.Rule{
+							APIGroups:   []string{""},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"pods"},
+						},
+					}},
+					SideEffects: &sideEffectsNone,
+				}},
+			}
+
+			err := guestClient.Create(testCtx, guestWebhookConf)
+			Expect(err).NotTo(HaveOccurred(), "failed to create test webhook")
+
+			Eventually(func() bool {
+				webhook := &k8sadmissionv1.ValidatingWebhookConfiguration{}
+				err := guestClient.Get(testCtx, crclient.ObjectKeyFromObject(guestWebhookConf), webhook)
+				return apierrors.IsNotFound(err)
+			}, 1*time.Minute, 5*time.Second).Should(BeTrue(),
+				"violating webhook %s was not deleted", guestWebhookConf.Name)
+		})
+	})
+}
+
+// PayloadArchTest validates that the HostedCluster status reports the correct payload architecture.
+func PayloadArchTest(getTestCtx internal.TestContextGetter) {
+	Context("Payload architecture", func() {
+		It("When checking payload arch it should match the determined architecture", func() {
+			testCtx := getTestCtx()
+			hostedCluster, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
+
+			Eventually(func(g Gomega) {
+				hc := &hyperv1.HostedCluster{}
+				err := testCtx.MgmtClient.Get(testCtx, crclient.ObjectKeyFromObject(hostedCluster), hc)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				imageMetadataProvider := &hyperutil.RegistryClientImageMetadataProvider{}
+				payloadArch, err := hyperutil.DetermineHostedClusterPayloadArch(
+					testCtx, testCtx.MgmtClient, hc, imageMetadataProvider)
+				g.Expect(err).NotTo(HaveOccurred(), "failed to determine payload arch")
+				g.Expect(hc.Status.PayloadArch).To(Equal(payloadArch),
+					"expected payload arch %s, got %s", payloadArch, hc.Status.PayloadArch)
+			}, 30*time.Minute, 30*time.Second).Should(Succeed())
+		})
+	})
+}
+
+// AdmissionPoliciesTest validates validating admission policies in the guest cluster.
+func AdmissionPoliciesTest(getTestCtx internal.TestContextGetter) {
+	Context("Admission policies", func() {
+		BeforeEach(func() {
+			testCtx := getTestCtx()
+			hostedCluster, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
+			if !hyperutil.IsPublicHC(hostedCluster) {
+				Skip("Admission policies are only validated for public clusters")
+			}
+		})
+
+		It("When checking admission policies it should have all required ValidatingAdmissionPolicies", func() {
+			testCtx := getTestCtx()
+			hostedCluster, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			e2eutil.GinkgoCPOAtLeast(e2eutil.Version418, hostedCluster)
+
+			guestClient := testCtx.GetGuestClient()
+			var validatingAdmissionPolicies k8sadmissionv1.ValidatingAdmissionPolicyList
+			err = guestClient.List(testCtx, &validatingAdmissionPolicies)
+			Expect(err).NotTo(HaveOccurred(), "failed to list ValidatingAdmissionPolicies")
+			Expect(validatingAdmissionPolicies.Items).NotTo(BeEmpty(), "no ValidatingAdmissionPolicies found")
+
+			requiredVAPs := []string{
+				hccokasvap.AdmissionPolicyNameConfig,
+				hccokasvap.AdmissionPolicyNameMirror,
+				hccokasvap.AdmissionPolicyNameICSP,
+				hccokasvap.AdmissionPolicyNameInfra,
+				hccokasvap.AdmissionPolicyNameNTOMirroredConfigs,
+			}
+			var presentVAPs []string
+			for _, vap := range validatingAdmissionPolicies.Items {
+				presentVAPs = append(presentVAPs, vap.Name)
+			}
+			for _, required := range requiredVAPs {
+				Expect(presentVAPs).To(ContainElement(required),
+					"ValidatingAdmissionPolicy %s not found", required)
+			}
+		})
+
+		It("When checking admission policies it should deny unauthorized spec modifications", func() {
+			testCtx := getTestCtx()
+			hostedCluster, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			e2eutil.GinkgoCPOAtLeast(e2eutil.Version418, hostedCluster)
+
+			guestClient := testCtx.GetGuestClient()
+			apiServer := &configv1.APIServer{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+			}
+			err = guestClient.Get(testCtx, crclient.ObjectKeyFromObject(apiServer), apiServer)
+			Expect(err).NotTo(HaveOccurred(), "failed to get APIServer configuration")
+
+			apiServerCopy := apiServer.DeepCopy()
+			apiServerCopy.Spec.Audit.Profile = configv1.AllRequestBodiesAuditProfileType
+			err = guestClient.Update(testCtx, apiServerCopy)
+			Expect(err).To(HaveOccurred(), "APIServer spec update should have been denied")
+		})
+
+		It("When checking admission policies it should allow status modifications", func() {
+			testCtx := getTestCtx()
+			guestClient := testCtx.GetGuestClient()
+
+			network := &configv1.Network{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+			}
+			err := guestClient.Get(testCtx, crclient.ObjectKeyFromObject(network), network)
+			Expect(err).NotTo(HaveOccurred(), "failed to get Network configuration")
+
+			networkCopy := network.DeepCopy()
+			networkCopy.Status.ClusterNetworkMTU = 9180
+			err = guestClient.Update(testCtx, networkCopy)
+			Expect(err).NotTo(HaveOccurred(), "Network status update should be allowed")
+		})
+
+		It("When checking admission policies it should allow OperatorHub changes with guest OLM placement", func() {
+			testCtx := getTestCtx()
+			hostedCluster, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred())
+			if hostedCluster.Spec.OLMCatalogPlacement != hyperv1.GuestOLMCatalogPlacement {
+				Skip("OperatorHub test only applicable with GuestOLMCatalogPlacement")
+			}
+
+			guestClient := testCtx.GetGuestClient()
+			operatorHub := &configv1.OperatorHub{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+			}
+			err = guestClient.Get(testCtx, crclient.ObjectKeyFromObject(operatorHub), operatorHub)
+			Expect(err).NotTo(HaveOccurred(), "failed to get OperatorHub")
+
+			operatorHubCopy := operatorHub.DeepCopy()
+			operatorHubCopy.Spec.DisableAllDefaultSources = true
+			err = guestClient.Update(testCtx, operatorHubCopy)
+			Expect(err).NotTo(HaveOccurred(), "OperatorHub update should be allowed")
+		})
+	})
+}
+
+// AllRoutesUseHCPRouterTest validates that all routes in the HCP namespace use the per-HCP router.
+func AllRoutesUseHCPRouterTest(getTestCtx internal.TestContextGetter) {
+	Context("Routes use HCP router", func() {
+		BeforeEach(func() {
+			testCtx := getTestCtx()
+			hostedCluster, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
+			for _, svc := range hostedCluster.Spec.Services {
+				if svc.Service == hyperv1.APIServer && svc.Type != hyperv1.Route {
+					Skip("APIServer is not exposed through a route")
+				}
+			}
+		})
+
+		It("When the API Server is exposed through a route, all routes should use the per-HCP router labels", func() {
+			testCtx := getTestCtx()
+
+			var routes routev1.RouteList
+			err := testCtx.MgmtClient.List(testCtx, &routes, crclient.InNamespace(testCtx.ControlPlaneNamespace))
+			Expect(err).NotTo(HaveOccurred(), "failed to list routes")
+
+			for _, route := range routes.Items {
+				original := route.DeepCopy()
+				hyperutil.AddHCPRouteLabel(&route)
+				diff := cmp.Diff(route.GetLabels(), original.GetLabels())
+				Expect(diff).To(BeEmpty(),
+					"route %s is missing the label to use the per-HCP router: %s", route.Name, diff)
+			}
+		})
+	})
+}
+
+// PSANotPrivilegedTest validates that Pod Security Admission enforcement rejects privileged pods.
+func PSANotPrivilegedTest(getTestCtx internal.TestContextGetter) {
+	Context("PSA not privileged", func() {
+		BeforeEach(func() {
+			e2eutil.GinkgoAtLeast(e2eutil.Version421)
+		})
+
+		It("When PSA is enabled it should reject pods with HostPID", func() {
+			testCtx := getTestCtx()
+			guestClient := testCtx.GetGuestClient()
+
+			// Check if OpenShiftPodSecurityAdmission feature gate is enabled
+			featureGate := &configv1.FeatureGate{}
+			err := guestClient.Get(testCtx, crclient.ObjectKey{Name: "cluster"}, featureGate)
+			if err != nil {
+				Skip(fmt.Sprintf("failed to get FeatureGate resource: %v", err))
+			}
+
+			var psaEnabled bool
+			for _, details := range featureGate.Status.FeatureGates {
+				for _, enabled := range details.Enabled {
+					if enabled.Name == "OpenShiftPodSecurityAdmission" {
+						psaEnabled = true
+						break
+					}
+				}
+				if psaEnabled {
+					break
+				}
+			}
+			if !psaEnabled {
+				Skip("OpenShiftPodSecurityAdmission feature gate is not enabled")
+			}
+
+			testNamespaceName := "e2e-psa-check"
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: testNamespaceName},
+			}
+			err = guestClient.Create(testCtx, namespace)
+			Expect(err).NotTo(HaveOccurred(), "failed to create test namespace")
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: testNamespaceName,
+				},
+				Spec: corev1.PodSpec{
+					NodeSelector: map[string]string{
+						"e2e.openshift.io/unschedulable": "should-not-run",
+					},
+					Containers: []corev1.Container{
+						{Name: "first", Image: "something-innocuous"},
+					},
+					HostPID: true,
+				},
+			}
+			err = guestClient.Create(testCtx, pod)
+			Expect(err).To(HaveOccurred(), "pod should have been rejected")
+			Expect(apierrors.IsForbidden(err)).To(BeTrue(), "expected Forbidden error, got %v", err)
+		})
+	})
+}
+
+// RegisterClusterHealthTests registers all cluster health validation tests.
+func RegisterClusterHealthTests(getTestCtx internal.TestContextGetter) {
+	FeatureGateStatusTest(getTestCtx)
+	CAPIFinalizersTest(getTestCtx)
+	GuestWebhooksValidatedTest(getTestCtx)
+	PayloadArchTest(getTestCtx)
+	AdmissionPoliciesTest(getTestCtx)
+	AllRoutesUseHCPRouterTest(getTestCtx)
+	PSANotPrivilegedTest(getTestCtx)
+}
+
+var _ = Describe("Cluster Health", Label("cluster-health"), func() {
+	var (
+		testCtx *internal.TestContext
+	)
+
+	BeforeEach(func() {
+		testCtx = internal.GetTestContext()
+		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
+
+		if testCtx.ControlPlaneNamespace == "" {
+			AbortSuite("ControlPlaneNamespace is required but not set. Please set the following environment variables:\n" +
+				"  E2E_HOSTED_CLUSTER_NAME - Name of the HostedCluster to test\n" +
+				"  E2E_HOSTED_CLUSTER_NAMESPACE - Namespace of the HostedCluster to test")
+		}
+	})
+
+	RegisterClusterHealthTests(func() *internal.TestContext { return testCtx })
+})

--- a/test/e2e/v2/tests/control_plane_workloads_test.go
+++ b/test/e2e/v2/tests/control_plane_workloads_test.go
@@ -56,7 +56,8 @@ func DeploymentGenerationTest(getTestCtx internal.TestContextGetter) {
 	Context("Deployment generation", func() {
 		BeforeEach(func() {
 			testCtx := getTestCtx()
-			hostedCluster := testCtx.GetHostedCluster()
+			hostedCluster, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
 			if hostedCluster == nil || hostedCluster.CreationTimestamp.IsZero() || time.Since(hostedCluster.CreationTimestamp.Time) > 4*time.Hour {
 				Skip("Deployment generation test is only for recently created hosted clusters")
 			}
@@ -72,13 +73,14 @@ func DeploymentGenerationTest(getTestCtx internal.TestContextGetter) {
 
 			It(fmt.Sprintf("should not indicate rapid rollouts for %s", workload.Name), func() {
 				testCtx := getTestCtx()
-				hostedCluster := testCtx.GetHostedCluster()
+				hostedCluster, err := testCtx.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
 				if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 					Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 				}
 
 				deployment := &appsv1.Deployment{}
-				err := testCtx.MgmtClient.Get(context.Background(), crclient.ObjectKey{
+				err = testCtx.MgmtClient.Get(context.Background(), crclient.ObjectKey{
 					Namespace: testCtx.ControlPlaneNamespace,
 					Name:      workload.Name,
 				}, deployment)
@@ -123,7 +125,8 @@ func SafeToEvictAnnotationsTest(getTestCtx internal.TestContextGetter) {
 		for _, workload := range workloads {
 			It(fmt.Sprintf("should exist for pods with emptyDir or hostPath volumes belonging to %s", workload.Name), func() {
 				testCtx := getTestCtx()
-				hostedCluster := testCtx.GetHostedCluster()
+				hostedCluster, err := testCtx.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
 				if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 					Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 				}
@@ -216,7 +219,8 @@ func ReadOnlyRootFilesystemTest(getTestCtx internal.TestContextGetter) {
 		for _, workload := range workloads {
 			It(fmt.Sprintf("should have read-only root filesystem for %s containers", workload.Name), func() {
 				testCtx := getTestCtx()
-				hostedCluster := testCtx.GetHostedCluster()
+				hostedCluster, err := testCtx.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
 				if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 					Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 				}
@@ -287,7 +291,8 @@ func ReadOnlyRootFilesystemTmpDirMountTest(getTestCtx internal.TestContextGetter
 		for _, workload := range workloads {
 			It(fmt.Sprintf("should have /tmp mounted for %s containers", workload.Name), func() {
 				testCtx := getTestCtx()
-				hostedCluster := testCtx.GetHostedCluster()
+				hostedCluster, err := testCtx.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
 				if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 					Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 				}
@@ -327,7 +332,8 @@ func ContainerImagePullPolicyTest(getTestCtx internal.TestContextGetter) {
 		for _, workload := range workloads {
 			It(fmt.Sprintf("should have IfNotPresent pull policy for %s containers", workload.Name), func() {
 				testCtx := getTestCtx()
-				hostedCluster := testCtx.GetHostedCluster()
+				hostedCluster, err := testCtx.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
 				if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 					Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 				}
@@ -375,7 +381,8 @@ func ContainerTerminationMessagePolicyTest(getTestCtx internal.TestContextGetter
 		for _, workload := range workloads {
 			It(fmt.Sprintf("should have FallbackToLogsOnError termination message policy for %s containers", workload.Name), func() {
 				testCtx := getTestCtx()
-				hostedCluster := testCtx.GetHostedCluster()
+				hostedCluster, err := testCtx.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
 				if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 					Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 				}
@@ -415,7 +422,8 @@ func ContainerResourceRequestsTest(getTestCtx internal.TestContextGetter) {
 		for _, workload := range workloads {
 			It(fmt.Sprintf("should have resource requests for %s containers", workload.Name), func() {
 				testCtx := getTestCtx()
-				hostedCluster := testCtx.GetHostedCluster()
+				hostedCluster, err := testCtx.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
 				if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 					Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 				}
@@ -450,7 +458,8 @@ func PodPriorityTest(getTestCtx internal.TestContextGetter) {
 		for _, workload := range workloads {
 			It(fmt.Sprintf("should not have too high priority for %s pods", workload.Name), func() {
 				testCtx := getTestCtx()
-				hostedCluster := testCtx.GetHostedCluster()
+				hostedCluster, err := testCtx.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
 				if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 					Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 				}
@@ -533,7 +542,8 @@ func ServiceAccountTokenMountingTest(getTestCtx internal.TestContextGetter) {
 		for _, workload := range workloads {
 			It(fmt.Sprintf("should not mount service account token unless necessary for %s pods", workload.Name), func() {
 				testCtx := getTestCtx()
-				hostedCluster := testCtx.GetHostedCluster()
+				hostedCluster, err := testCtx.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
 				if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 					Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 				}
@@ -565,7 +575,8 @@ func PodAffinitiesAndTolerationsTest(getTestCtx internal.TestContextGetter) {
 		// EnsureHCPPodsAffinitiesAndTolerations
 		BeforeEach(func() {
 			testCtx := getTestCtx()
-			hostedCluster := testCtx.GetHostedCluster()
+			hostedCluster, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
 			if hostedCluster == nil || hostedCluster.Spec.Platform.Type != hyperv1.AWSPlatform {
 				Skip("Pod affinities and tolerations test is only for AWS platform")
 			}
@@ -574,7 +585,8 @@ func PodAffinitiesAndTolerationsTest(getTestCtx internal.TestContextGetter) {
 		for _, workload := range workloads {
 			It(fmt.Sprintf("should have correct affinities and tolerations for %s pods", workload.Name), func() {
 				testCtx := getTestCtx()
-				hostedCluster := testCtx.GetHostedCluster()
+				hostedCluster, err := testCtx.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
 				if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 					Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 				}
@@ -695,10 +707,11 @@ func WorkloadRegistryValidationTest(getTestCtx internal.TestContextGetter) {
 		// Label("Informing"): failures skip (non-blocking) until registry is complete
 		It("all pods should belong to predefined workloads", Label("Informing"), func() {
 			testCtx := getTestCtx()
-			_ = testCtx.GetHostedCluster() // unused but kept for consistency
+			_, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
 			// List all pods in control plane namespace
 			podList := &corev1.PodList{}
-			err := testCtx.MgmtClient.List(context.Background(), podList, &crclient.ListOptions{
+			err = testCtx.MgmtClient.List(context.Background(), podList, &crclient.ListOptions{
 				Namespace: testCtx.ControlPlaneNamespace,
 			})
 			Expect(err).NotTo(HaveOccurred(), "failed to list pods in control plane namespace")
@@ -744,14 +757,15 @@ func SecurityContextUIDTest(getTestCtx internal.TestContextGetter) {
 
 		BeforeEach(func() {
 			testCtx := getTestCtx()
-			hostedCluster := testCtx.GetHostedCluster()
+			hostedCluster, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
 			if hostedCluster == nil || hostedCluster.Spec.Platform.Type != hyperv1.AzurePlatform {
 				Skip("Security context UID test is only for Azure platform")
 			}
 
 			// Get the control plane namespace to check for UID annotation
 			controlPlaneNamespace := &corev1.Namespace{}
-			err := testCtx.MgmtClient.Get(context.Background(), crclient.ObjectKey{Name: testCtx.ControlPlaneNamespace}, controlPlaneNamespace)
+			err = testCtx.MgmtClient.Get(context.Background(), crclient.ObjectKey{Name: testCtx.ControlPlaneNamespace}, controlPlaneNamespace)
 			Expect(err).NotTo(HaveOccurred(), "failed to get namespace %s", testCtx.ControlPlaneNamespace)
 
 			uid, ok := controlPlaneNamespace.Annotations["hypershift.openshift.io/default-security-context-uid"]
@@ -780,7 +794,8 @@ func SecurityContextUIDTest(getTestCtx internal.TestContextGetter) {
 		for _, workload := range workloads {
 			It(fmt.Sprintf("should have expected RunAsUser UID for %s pods", workload.Name), func() {
 				testCtx := getTestCtx()
-				hostedCluster := testCtx.GetHostedCluster()
+				hostedCluster, err := testCtx.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
 				if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
 					Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
 				}

--- a/test/e2e/v2/tests/control_plane_workloads_test.go
+++ b/test/e2e/v2/tests/control_plane_workloads_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tests
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"slices"
@@ -36,6 +37,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/utils/ptr"
 
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -48,6 +50,153 @@ func getWorkloadPods(testCtx *internal.TestContext, workload internal.WorkloadSp
 	pods, err := internal.GetWorkloadPodsBySelector(context.Background(), testCtx.MgmtClient, testCtx.ControlPlaneNamespace, workload)
 	Expect(err).NotTo(HaveOccurred(), "failed to list pods for workload %s", workload.Name)
 	return pods
+}
+
+// podCrashTolerations defines the tolerated number of restarts per workload.
+// Keys are workload names from the control plane workload registry.
+var podCrashTolerations = map[string]int32{
+	// TODO: Figure out why Route kind does not exist when ingress-operator first starts
+	"ingress-operator": 20,
+	// Seeing flakes due to https://issues.redhat.com/browse/OCPBUGS-30068
+	"cloud-credential-operator": 20,
+	// Restart built into OLM by design by
+	// https://github.com/openshift/operator-framework-olm/commit/1cf358424a0cbe353428eab9a16051c6cabbd002
+	"olm-operator":                20,
+	"catalog-operator":            20,
+	"certified-operators-catalog": 20,
+	"community-operators-catalog": 20,
+	"redhat-operators-catalog":    20,
+	"redhat-marketplace-catalog": 20,
+	// Temporary workaround for https://issues.redhat.com/browse/CNV-40820
+	"kubevirt-csi-controller": 20,
+	"aws-ebs-csi-driver-controller": 1,
+	// Allow 1 restart for network-node-identity webhook startup timing
+	"network-node-identity": 1,
+	// Temporary workaround for https://issues.redhat.com/browse/CNV-76520
+	"kubevirt-cloud-controller-manager": 2,
+}
+
+// isCertificateTriggeredRestart checks if a kube-controller-manager restart was triggered by certificate rotation.
+func isCertificateTriggeredRestart(testCtx *internal.TestContext, pod *corev1.Pod) bool {
+	hcpList := &hyperv1.HostedControlPlaneList{}
+	if err := testCtx.MgmtClient.List(testCtx, hcpList, crclient.InNamespace(pod.Namespace)); err != nil {
+		return false
+	}
+	for _, hcp := range hcpList.Items {
+		if restartAnnotation, ok := hcp.Annotations[hyperv1.RestartDateAnnotation]; ok {
+			if strings.HasPrefix(restartAnnotation, "CertHash:") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// workloadRestartExemption is a per-workload check that can exempt a restart from failing.
+// If the function returns true, the restart is considered acceptable (e.g. cert rotation, leader election loss).
+type workloadRestartExemption func(testCtx *internal.TestContext, pod *corev1.Pod, containerName string) bool
+
+// workloadRestartExemptions defines optional checks per workload. Only workloads in this map
+// get their exemption checked. Workloads with leader election should be listed here.
+var workloadRestartExemptions = map[string]workloadRestartExemption{
+	"kube-controller-manager": func(testCtx *internal.TestContext, pod *corev1.Pod, containerName string) bool {
+		if isCertificateTriggeredRestart(testCtx, pod) {
+			return true
+		}
+		return isLeaderElectionFailure(testCtx, pod, containerName)
+	},
+	"kube-scheduler":                          isLeaderElectionFailure,
+	"aws-cloud-controller-manager":             isLeaderElectionFailure,
+	"azure-cloud-controller-manager":           isLeaderElectionFailure,
+	"kubevirt-cloud-controller-manager":        isLeaderElectionFailure,
+	"openstack-cloud-controller-manager":       isLeaderElectionFailure,
+	"powervs-cloud-controller-manager":        isLeaderElectionFailure,
+}
+
+// isLeaderElectionFailure checks if a container restart was caused by leader election loss.
+func isLeaderElectionFailure(testCtx *internal.TestContext, pod *corev1.Pod, containerName string) bool {
+	k8sClient := testCtx.GetKubeClient()
+	podLogOpts := corev1.PodLogOptions{
+		Container: containerName,
+		Previous:  true,
+		TailLines: ptr.To[int64](10),
+	}
+	req := k8sClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &podLogOpts)
+	podLogs, err := req.Stream(testCtx)
+	if err != nil {
+		return false
+	}
+	defer podLogs.Close()
+
+	scanner := bufio.NewScanner(podLogs)
+	const (
+		bufSize          = 256 * 1024
+		maxScanTokenSize = 512 * 1024
+	)
+	buf := make([]byte, bufSize)
+	scanner.Buffer(buf, maxScanTokenSize)
+	for scanner.Scan() {
+		if strings.Contains(strings.ToLower(scanner.Text()), "election lost") {
+			return true
+		}
+	}
+	return false
+}
+
+// NoCrashingPodsTest registers per-workload tests that validate no pods are crashing.
+func NoCrashingPodsTest(getTestCtx internal.TestContextGetter) {
+	Context("No crashing pods", func() {
+		for _, workload := range workloads {
+			It(fmt.Sprintf("should have no crashing pods for %s", workload.Name), func() {
+				testCtx := getTestCtx()
+				hostedCluster, err := testCtx.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
+				if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
+					Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
+				}
+
+				pods := getWorkloadPods(testCtx, workload)
+				if len(pods) == 0 {
+					Skip(fmt.Sprintf("no pods found for workload %s", workload.Name))
+				}
+
+				// Determine default crash tolerance based on platform
+				var defaultCrashToleration int32
+				if hostedCluster != nil && hostedCluster.Spec.Platform.Type == hyperv1.KubevirtPlatform {
+					kvPlatform := hostedCluster.Spec.Platform.Kubevirt
+					if kvPlatform != nil && kvPlatform.Credentials != nil {
+						defaultCrashToleration = 1
+					}
+					if kvPlatform != nil && hostedCluster.Annotations != nil {
+						mgmtPlatform, ok := hostedCluster.Annotations[hyperv1.ManagementPlatformAnnotation]
+						if ok && mgmtPlatform == string(hyperv1.AzurePlatform) {
+							defaultCrashToleration = 1
+						}
+					}
+				}
+
+				for _, pod := range pods {
+					crashToleration := defaultCrashToleration
+					if toleration, ok := podCrashTolerations[workload.Name]; ok {
+						crashToleration = toleration
+					}
+
+					for _, containerStatus := range pod.Status.ContainerStatuses {
+						if containerStatus.RestartCount <= crashToleration {
+							continue
+						}
+
+						if exempt := workloadRestartExemptions[workload.Name]; exempt != nil && exempt(testCtx, &pod, containerStatus.Name) {
+							continue
+						}
+
+						Fail(fmt.Sprintf("container %s in pod %s has restartCount %d (toleration: %d)",
+							containerStatus.Name, pod.Name, containerStatus.RestartCount, crashToleration))
+					}
+				}
+			})
+		}
+	})
 }
 
 // DeploymentGenerationTest registers tests for deployment generation validation
@@ -701,6 +850,136 @@ func PodAffinitiesAndTolerationsTest(getTestCtx internal.TestContextGetter) {
 	})
 }
 
+// AppLabelTest registers per-workload tests that validate pods have an "app" label set.
+func AppLabelTest(getTestCtx internal.TestContextGetter) {
+	Context("App label", func() {
+		BeforeEach(func() {
+			e2eutil.GinkgoAtLeast(e2eutil.Version419)
+		})
+
+		// KubeVirt virt-launcher pods use kubevirt.io label instead of app
+		exemptions := []string{"virt-launcher"}
+
+		for _, workload := range workloads {
+			It(fmt.Sprintf("should have app label for %s pods", workload.Name), func() {
+				testCtx := getTestCtx()
+				hostedCluster, err := testCtx.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
+				if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
+					Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
+				}
+				if slices.Contains(exemptions, workload.Name) {
+					Skip(fmt.Sprintf("workload %s is exempt from app label check", workload.Name))
+				}
+
+				pods := getWorkloadPods(testCtx, workload)
+				if len(pods) == 0 {
+					Skip(fmt.Sprintf("no pods found for workload %s", workload.Name))
+				}
+
+				var podsWithoutAppLabel []string
+				for _, pod := range pods {
+					val, ok := pod.Labels["app"]
+					if ok && val != "" {
+						continue
+					}
+					podsWithoutAppLabel = append(podsWithoutAppLabel, pod.Name)
+				}
+
+				Expect(podsWithoutAppLabel).To(BeEmpty(),
+					"expected pods [%s] to have app label set", strings.Join(podsWithoutAppLabel, ", "))
+			})
+		}
+	})
+}
+
+// CustomLabelsTest registers per-workload tests that validate custom labels from HC configuration are applied to pods.
+func CustomLabelsTest(getTestCtx internal.TestContextGetter) {
+	Context("Custom labels", func() {
+		BeforeEach(func() {
+			e2eutil.GinkgoAtLeast(e2eutil.Version419)
+			testCtx := getTestCtx()
+			hostedCluster, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
+			if len(hostedCluster.Spec.Labels) == 0 {
+				Skip("no custom labels configured on HostedCluster")
+			}
+		})
+
+		// KubeVirt virt-launcher pods may not receive custom labels
+		exemptions := []string{"virt-launcher"}
+
+		for _, workload := range workloads {
+			It(fmt.Sprintf("should have custom labels for %s pods", workload.Name), func() {
+				testCtx := getTestCtx()
+				hostedCluster, err := testCtx.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
+				if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
+					Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
+				}
+				if slices.Contains(exemptions, workload.Name) {
+					Skip(fmt.Sprintf("workload %s is exempt from custom labels check", workload.Name))
+				}
+
+				pods := getWorkloadPods(testCtx, workload)
+				if len(pods) == 0 {
+					Skip(fmt.Sprintf("no pods found for workload %s", workload.Name))
+				}
+
+				for _, pod := range pods {
+					for key, expectedValue := range hostedCluster.Spec.Labels {
+						Expect(pod.Labels).To(HaveKeyWithValue(key, expectedValue),
+							"pod %s missing label %s=%s", pod.Name, key, expectedValue)
+					}
+				}
+			})
+		}
+	})
+}
+
+// CustomTolerationsTest registers per-workload tests that validate custom tolerations from HC configuration are applied to pods.
+func CustomTolerationsTest(getTestCtx internal.TestContextGetter) {
+	Context("Custom tolerations", func() {
+		BeforeEach(func() {
+			e2eutil.GinkgoAtLeast(e2eutil.Version419)
+			testCtx := getTestCtx()
+			hostedCluster, err := testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
+			if len(hostedCluster.Spec.Tolerations) == 0 {
+				Skip("no custom tolerations configured on HostedCluster")
+			}
+		})
+
+		// KubeVirt virt-launcher pods may not receive custom tolerations
+		exemptions := []string{"virt-launcher"}
+
+		for _, workload := range workloads {
+			It(fmt.Sprintf("should have custom tolerations for %s pods", workload.Name), func() {
+				testCtx := getTestCtx()
+				hostedCluster, err := testCtx.GetHostedCluster()
+				Expect(err).NotTo(HaveOccurred(), "failed to get HostedCluster")
+				if internal.ShouldSkipWorkloadForPlatform(workload, hostedCluster) {
+					Skip(fmt.Sprintf("workload %s is platform-specific and doesn't match cluster platform", workload.Name))
+				}
+				if slices.Contains(exemptions, workload.Name) {
+					Skip(fmt.Sprintf("workload %s is exempt from custom tolerations check", workload.Name))
+				}
+
+				pods := getWorkloadPods(testCtx, workload)
+				if len(pods) == 0 {
+					Skip(fmt.Sprintf("no pods found for workload %s", workload.Name))
+				}
+
+				for _, pod := range pods {
+					Expect(pod.Spec.Tolerations).To(ContainElements(hostedCluster.Spec.Tolerations),
+						"pod %s should have all tolerations from HostedCluster.Spec.Tolerations: %v",
+						pod.Name, hostedCluster.Spec.Tolerations)
+				}
+			})
+		}
+	})
+}
+
 // WorkloadRegistryValidationTest registers tests for workload registry validation
 func WorkloadRegistryValidationTest(getTestCtx internal.TestContextGetter) {
 	Context("Workload registry validation", func() {
@@ -834,6 +1113,10 @@ func SecurityContextUIDTest(getTestCtx internal.TestContextGetter) {
 // RegisterControlPlaneWorkloadsTests registers all control plane workloads tests
 func RegisterControlPlaneWorkloadsTests(getTestCtx internal.TestContextGetter) {
 	WorkloadRegistryValidationTest(getTestCtx)
+	NoCrashingPodsTest(getTestCtx)
+	AppLabelTest(getTestCtx)
+	CustomLabelsTest(getTestCtx)
+	CustomTolerationsTest(getTestCtx)
 	DeploymentGenerationTest(getTestCtx)
 	SafeToEvictAnnotationsTest(getTestCtx)
 	ReadOnlyRootFilesystemTest(getTestCtx)


### PR DESCRIPTION
## What this PR does / why we need it:

Migrates 12 universal cluster health validations from v1 test helpers (`test/e2e/util/util.go`) to v2 Ginkgo `It` blocks, organized across three test files by domain.

### Validations migrated (12 total):

**`cluster_health_test.go`** (new file — cluster-wide health checks):

| # | Validation | Client | Version Gate |
|---|-----------|--------|-------------|
| 1 | FeatureGateStatus | Guest | >= 4.19 |
| 2 | CAPIFinalizers | Mgmt | None |
| 3 | GuestWebhooksValidated | Guest | None |
| 4 | PayloadArchSetCorrectly | Mgmt | None |
| 5 | AdmissionPolicies | Mgmt+Guest | CPO >= 4.18 |
| 6 | AllRoutesUseHCPRouter | Mgmt | None |
| 7 | PSANotPrivileged | Guest | >= 4.21 |

**`control_plane_workloads_test.go`** (per-workload `It` blocks):

| # | Validation | Client | Version Gate |
|---|-----------|--------|-------------|
| 8 | NoCrashingPods | Mgmt | None |
| 9 | AppLabel | Mgmt | >= 4.19 |
| 10 | CustomLabels | Mgmt | >= 4.19 |
| 11 | CustomTolerations | Mgmt | >= 4.19 |

**`api_ux_validation_test.go`** (API immutability checks):

| # | Validation | Client | Version Gate |
|---|-----------|--------|-------------|
| 12 | APIUX (Services, ControllerAvailabilityPolicy, Capabilities) | Mgmt | Sub-test >= 4.19 |

### Key design decisions:

- **NoCrashingPods is per-workload**: One `It` block per workload from the registry, providing granular test reporting (which specific workload is crashing). AppLabel, CustomLabels, and CustomTolerations also use per-workload `It` blocks.
- **Auto-detection skip logic**: Each validation auto-detects applicability via `Skip()` for platform, version, endpoint access, and configuration conditions.
- **Version gating**: Uses `GinkgoAtLeast()` and new `GinkgoCPOAtLeast()` for version-dependent tests.
- **Guest client support**: Uses `GetGuestClient()` from TestContext (from [CNTRLPLANE-2888](https://issues.redhat.com/browse/CNTRLPLANE-2888) prerequisite).
- **KubeClient support**: Adds `GetKubeClient()` to TestContext for pod log streaming (leader election failure detection).

### Support changes:

- `GinkgoCPOAtLeast()` in `test/e2e/util/version.go` — Ginkgo-native equivalent of `CPOAtLeast()`
- `GetKubeClient()` in `test/e2e/v2/internal/test_context.go` — lazy-initialized `kubernetes.Clientset`

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-2864](https://issues.redhat.com/browse/CNTRLPLANE-2864)

## Special notes for your reviewer:

- This PR depends on [CNTRLPLANE-2888](https://issues.redhat.com/browse/CNTRLPLANE-2888) (guest client support in TestContext) which is cherry-picked as the first commit.
- The `patchHostedCluster` helper replaces v1's `UpdateObject` for API UX immutability tests, avoiding the `*testing.T` dependency.
- Tests are organized by domain: cluster-wide health in `cluster_health_test.go`, per-workload checks in `control_plane_workloads_test.go`, and API validation in `api_ux_validation_test.go`.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added AWS-specific testing capabilities including EC2, IAM, and SQS client support
  * Introduced comprehensive cluster health validation tests for feature gates, webhooks, and policies
  * Added immutability validation tests for cluster configuration

* **Improvements**
  * Enhanced test context with improved caching and error handling
  * Strengthened pod stability and workload validation tests
  * Better error propagation and validation across test framework

<!-- end of auto-generated comment: release notes by coderabbit.ai -->