### PR TITLE
NO-JIRA: fix(aws): improve endpoint and security group teardown cleanup

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -374,7 +374,7 @@ func (r *HostedControlPlaneReconciler) reconcileDeletion(ctx context.Context, ho
 	if shouldCleanupCloudResources(r.Log, hostedControlPlane) {
 		if code, destroyErr := r.destroyAWSDefaultSecurityGroup(ctx, hostedControlPlane); destroyErr != nil {
 			condition.Message = "failed to delete AWS default security group"
-			if code == "DependencyViolation" {
+			if code == supportawsutil.DependencyViolation {
 				condition.Message = destroyErr.Error()
 			}
 			condition.Reason = hyperv1.AWSErrorReason
@@ -388,8 +388,9 @@ func (r *HostedControlPlaneReconciler) reconcileDeletion(ctx context.Context, ho
 			switch code {
 			case "UnauthorizedOperation":
 				r.Log.Error(destroyErr, "Skipping AWS default security group deletion because of unauthorized operation.")
-			case "DependencyViolation":
-				r.Log.Error(destroyErr, "Skipping AWS default security group deletion because of dependency violation.")
+			case supportawsutil.DependencyViolation:
+				r.Log.Info("AWS default security group has dependencies, will retry", "error", destroyErr.Error())
+				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 			default:
 				return ctrl.Result{}, fmt.Errorf("failed to delete AWS default security group: %w", destroyErr)
 			}
@@ -2876,9 +2877,11 @@ func (r *HostedControlPlaneReconciler) destroyAWSDefaultSecurityGroup(ctx contex
 			IpPermissions: sg.IpPermissions,
 		}); err != nil {
 			code := supportawsutil.AWSErrorCode(err)
-			log.Error(err, "failed to revoke security group ingress permissions", "SecurityGroupID", aws.ToString(sg.GroupId), "code", code)
-
-			return code, fmt.Errorf("failed to revoke security group ingress rules: %s", code)
+			if !supportawsutil.ShouldIgnoreRevokePermissionError(code) {
+				log.Error(err, "failed to revoke security group ingress permissions", "SecurityGroupID", aws.ToString(sg.GroupId), "code", code)
+				return code, fmt.Errorf("failed to revoke security group ingress rules: %s", code)
+			}
+			log.Info("security group ingress permission already revoked", "SecurityGroupID", aws.ToString(sg.GroupId))
 		}
 	}
 
@@ -2888,9 +2891,11 @@ func (r *HostedControlPlaneReconciler) destroyAWSDefaultSecurityGroup(ctx contex
 			IpPermissions: sg.IpPermissionsEgress,
 		}); err != nil {
 			code := supportawsutil.AWSErrorCode(err)
-			log.Error(err, "failed to revoke security group egress permissions", "SecurityGroupID", aws.ToString(sg.GroupId), "code", code)
-
-			return code, fmt.Errorf("failed to revoke security group egress rules: %s", code)
+			if !supportawsutil.ShouldIgnoreRevokePermissionError(code) {
+				log.Error(err, "failed to revoke security group egress permissions", "SecurityGroupID", aws.ToString(sg.GroupId), "code", code)
+				return code, fmt.Errorf("failed to revoke security group egress rules: %s", code)
+			}
+			log.Info("security group egress permission already revoked", "SecurityGroupID", aws.ToString(sg.GroupId))
 		}
 	}
 
@@ -2898,8 +2903,11 @@ func (r *HostedControlPlaneReconciler) destroyAWSDefaultSecurityGroup(ctx contex
 		GroupId: sg.GroupId,
 	}); err != nil {
 		code := supportawsutil.AWSErrorCode(err)
+		if supportawsutil.ShouldIgnoreSGNotFound(code) {
+			log.Info("security group already deleted", "SecurityGroupID", aws.ToString(sg.GroupId))
+			return "", nil
+		}
 		log.Error(err, "failed to delete security group", "SecurityGroupID", aws.ToString(sg.GroupId), "code", code)
-
 		return code, fmt.Errorf("failed to delete security group %s: %s", aws.ToString(sg.GroupId), code)
 	}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -4300,10 +4300,11 @@ func TestReconcileControlPlaneVersionStatus(t *testing.T) {
 
 func TestReconcileDeletion(t *testing.T) {
 	tests := []struct {
-		name           string
-		setupEC2Mock   func(*gomock.Controller) *awsapi.MockEC2API
-		wantErr        bool
-		wantCondStatus metav1.ConditionStatus
+		name             string
+		setupEC2Mock     func(*gomock.Controller) *awsapi.MockEC2API
+		wantErr          bool
+		wantCondStatus   metav1.ConditionStatus
+		wantRequeueAfter time.Duration
 	}{
 		{
 			name: "When destroyAWSDefaultSecurityGroup returns UnauthorizedOperation, it should skip gracefully and not return error",
@@ -4322,7 +4323,7 @@ func TestReconcileDeletion(t *testing.T) {
 			wantCondStatus: metav1.ConditionFalse,
 		},
 		{
-			name: "When destroyAWSDefaultSecurityGroup returns DependencyViolation, it should skip gracefully and not return error",
+			name: "When destroyAWSDefaultSecurityGroup returns DependencyViolation, it should requeue for retry",
 			setupEC2Mock: func(mockCtrl *gomock.Controller) *awsapi.MockEC2API {
 				m := awsapi.NewMockEC2API(mockCtrl)
 				m.EXPECT().DescribeSecurityGroups(gomock.Any(), gomock.Any()).Return(&ec2.DescribeSecurityGroupsOutput{
@@ -4334,8 +4335,9 @@ func TestReconcileDeletion(t *testing.T) {
 					&smithy.GenericAPIError{Code: "DependencyViolation", Message: "resource has dependent object"})
 				return m
 			},
-			wantErr:        false,
-			wantCondStatus: metav1.ConditionFalse,
+			wantErr:          false,
+			wantCondStatus:   metav1.ConditionFalse,
+			wantRequeueAfter: 5 * time.Second,
 		},
 		{
 			name: "When destroyAWSDefaultSecurityGroup returns unexpected error, it should propagate the error",
@@ -4357,14 +4359,51 @@ func TestReconcileDeletion(t *testing.T) {
 			name: "When destroyAWSDefaultSecurityGroup succeeds, it should set condition to true",
 			setupEC2Mock: func(mockCtrl *gomock.Controller) *awsapi.MockEC2API {
 				m := awsapi.NewMockEC2API(mockCtrl)
-				// First call: find the SG
 				m.EXPECT().DescribeSecurityGroups(gomock.Any(), gomock.Any()).Return(&ec2.DescribeSecurityGroupsOutput{
 					SecurityGroups: []ec2types.SecurityGroup{
 						{GroupId: aws.String("sg-123")},
 					},
 				}, nil)
 				m.EXPECT().DeleteSecurityGroup(gomock.Any(), gomock.Any()).Return(&ec2.DeleteSecurityGroupOutput{}, nil)
-				// Second call: verify SG is gone
+				m.EXPECT().DescribeSecurityGroups(gomock.Any(), gomock.Any()).Return(&ec2.DescribeSecurityGroupsOutput{
+					SecurityGroups: []ec2types.SecurityGroup{},
+				}, nil)
+				return m
+			},
+			wantErr:        false,
+			wantCondStatus: metav1.ConditionTrue,
+		},
+		{
+			name: "When DeleteSecurityGroup returns InvalidGroup.NotFound, it should treat as success",
+			setupEC2Mock: func(mockCtrl *gomock.Controller) *awsapi.MockEC2API {
+				m := awsapi.NewMockEC2API(mockCtrl)
+				m.EXPECT().DescribeSecurityGroups(gomock.Any(), gomock.Any()).Return(&ec2.DescribeSecurityGroupsOutput{
+					SecurityGroups: []ec2types.SecurityGroup{
+						{GroupId: aws.String("sg-123")},
+					},
+				}, nil)
+				m.EXPECT().DeleteSecurityGroup(gomock.Any(), gomock.Any()).Return(nil,
+					&smithy.GenericAPIError{Code: "InvalidGroup.NotFound", Message: "not found"})
+				return m
+			},
+			wantErr:        false,
+			wantCondStatus: metav1.ConditionTrue,
+		},
+		{
+			name: "When RevokeSecurityGroupIngress returns InvalidPermission.NotFound, it should continue with deletion",
+			setupEC2Mock: func(mockCtrl *gomock.Controller) *awsapi.MockEC2API {
+				m := awsapi.NewMockEC2API(mockCtrl)
+				m.EXPECT().DescribeSecurityGroups(gomock.Any(), gomock.Any()).Return(&ec2.DescribeSecurityGroupsOutput{
+					SecurityGroups: []ec2types.SecurityGroup{
+						{
+							GroupId:       aws.String("sg-123"),
+							IpPermissions: []ec2types.IpPermission{{IpProtocol: aws.String("-1")}},
+						},
+					},
+				}, nil)
+				m.EXPECT().RevokeSecurityGroupIngress(gomock.Any(), gomock.Any()).Return(nil,
+					&smithy.GenericAPIError{Code: "InvalidPermission.NotFound", Message: "not found"})
+				m.EXPECT().DeleteSecurityGroup(gomock.Any(), gomock.Any()).Return(&ec2.DeleteSecurityGroupOutput{}, nil)
 				m.EXPECT().DescribeSecurityGroups(gomock.Any(), gomock.Any()).Return(&ec2.DescribeSecurityGroupsOutput{
 					SecurityGroups: []ec2types.SecurityGroup{},
 				}, nil)
@@ -4414,7 +4453,6 @@ func TestReconcileDeletion(t *testing.T) {
 
 			ctx := ctrl.LoggerInto(t.Context(), ctrl.Log.WithName("test"))
 
-			// Re-read from fake client so the object has a ResourceVersion for OptimisticLock
 			g.Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(hcp), hcp)).To(Succeed())
 			originalHCP := hcp.DeepCopy()
 
@@ -4424,11 +4462,14 @@ func TestReconcileDeletion(t *testing.T) {
 				ec2Client: mockEC2,
 			}
 
-			_, err := r.reconcileDeletion(ctx, hcp, originalHCP)
+			result, err := r.reconcileDeletion(ctx, hcp, originalHCP)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
+			}
+			if tt.wantRequeueAfter > 0 {
+				g.Expect(result.RequeueAfter).To(Equal(tt.wantRequeueAfter))
 			}
 
 			cond := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.AWSDefaultSecurityGroupDeleted))

--- a/hypershift-operator/controllers/hostedcluster/awsendpointservices_test.go
+++ b/hypershift-operator/controllers/hostedcluster/awsendpointservices_test.go
@@ -1,0 +1,153 @@
+package hostedcluster
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/api"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func invalidAWSCredentialConditions() []metav1.Condition {
+	return []metav1.Condition{
+		{
+			Type:   string(hyperv1.ValidOIDCConfiguration),
+			Status: metav1.ConditionTrue,
+		},
+		{
+			Type:   string(hyperv1.ValidAWSIdentityProvider),
+			Status: metav1.ConditionFalse,
+		},
+	}
+}
+
+func invalidOIDCCredentialConditions() []metav1.Condition {
+	return []metav1.Condition{
+		{
+			Type:   string(hyperv1.ValidOIDCConfiguration),
+			Status: metav1.ConditionFalse,
+		},
+		{
+			Type:   string(hyperv1.ValidAWSIdentityProvider),
+			Status: metav1.ConditionTrue,
+		},
+	}
+}
+
+func validAWSCredentialConditions() []metav1.Condition {
+	return []metav1.Condition{
+		{
+			Type:   string(hyperv1.ValidOIDCConfiguration),
+			Status: metav1.ConditionTrue,
+		},
+		{
+			Type:   string(hyperv1.ValidAWSIdentityProvider),
+			Status: metav1.ConditionTrue,
+		},
+	}
+}
+
+func TestDeleteAWSEndpointServicesFinalizerHandling(t *testing.T) {
+	cpoFinalizer := "hypershift.openshift.io/control-plane-operator-finalizer"
+	namespace := "test-ns"
+	oldDeletionTimestamp := metav1.NewTime(time.Now().Add(-20 * time.Minute))
+	recentDeletionTimestamp := metav1.NewTime(time.Now().Add(-1 * time.Minute))
+
+	tests := []struct {
+		name               string
+		conditions         []metav1.Condition
+		deletionTimestamp  metav1.Time
+		expectFinalizerSet bool
+	}{
+		{
+			name:               "When credentials are valid and within grace period it should keep the CPO finalizer",
+			conditions:         validAWSCredentialConditions(),
+			deletionTimestamp:  recentDeletionTimestamp,
+			expectFinalizerSet: true,
+		},
+		{
+			name:               "When credentials are valid but grace period expired it should remove the CPO finalizer",
+			conditions:         validAWSCredentialConditions(),
+			deletionTimestamp:  oldDeletionTimestamp,
+			expectFinalizerSet: false,
+		},
+		{
+			name:               "When credentials are invalid it should remove the CPO finalizer",
+			conditions:         invalidAWSCredentialConditions(),
+			deletionTimestamp:  recentDeletionTimestamp,
+			expectFinalizerSet: false,
+		},
+		{
+			name:               "When credentials are unknown and within grace period it should keep the CPO finalizer",
+			conditions:         []metav1.Condition{},
+			deletionTimestamp:  recentDeletionTimestamp,
+			expectFinalizerSet: true,
+		},
+		{
+			name:               "When credentials are unknown and past grace period it should remove the CPO finalizer",
+			conditions:         []metav1.Condition{},
+			deletionTimestamp:  oldDeletionTimestamp,
+			expectFinalizerSet: false,
+		},
+		{
+			name:               "When OIDC configuration is invalid it should remove the CPO finalizer",
+			conditions:         invalidOIDCCredentialConditions(),
+			deletionTimestamp:  recentDeletionTimestamp,
+			expectFinalizerSet: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := ctrl.LoggerInto(t.Context(), ctrl.Log.WithName("test"))
+
+			ep := &hyperv1.AWSEndpointService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-ep",
+					Namespace:         namespace,
+					DeletionTimestamp: &tc.deletionTimestamp,
+					Finalizers:        []string{cpoFinalizer},
+				},
+			}
+
+			hc := &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hc",
+					Namespace: "clusters",
+				},
+				Status: hyperv1.HostedClusterStatus{
+					Conditions: tc.conditions,
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(api.Scheme).
+				WithObjects(ep).
+				Build()
+
+			_, err := deleteAWSEndpointServices(ctx, fakeClient, hc, namespace)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			updatedEp := &hyperv1.AWSEndpointService{}
+			getErr := fakeClient.Get(ctx, crclient.ObjectKeyFromObject(ep), updatedEp)
+			if tc.expectFinalizerSet {
+				g.Expect(getErr).ToNot(HaveOccurred())
+				g.Expect(controllerutil.ContainsFinalizer(updatedEp, cpoFinalizer)).To(BeTrue())
+			} else {
+				// When the finalizer is removed on an object with DeletionTimestamp,
+				// the fake client garbage-collects the object.
+				g.Expect(getErr).To(HaveOccurred(), "object should have been deleted after finalizer removal")
+			}
+		})
+	}
+}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -3302,7 +3302,10 @@ func (r *HostedClusterReconciler) deleteNodePools(ctx context.Context, c client.
 }
 
 // deleteAWSEndpointServices loops over AWSEndpointServiceList items and sends a delete request for each.
-// If the HC has no valid aws credentials it removes the CPO finalizer for each AWSEndpointService.
+// For items already being deleted, the CPO finalizer is preserved during the grace period when
+// credentials are valid or unknown, giving CPO time to clean up AWS resources. After the grace
+// period expires (or immediately when credentials are invalid), the finalizer is removed so
+// deletion can proceed.
 // It returns true if len(awsEndpointServiceList.Items) != 0.
 func deleteAWSEndpointServices(ctx context.Context, c client.Client, hc *hyperv1.HostedCluster, namespace string) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
@@ -3310,13 +3313,25 @@ func deleteAWSEndpointServices(ctx context.Context, c client.Client, hc *hyperv1
 	if err := c.List(ctx, &awsEndpointServiceList, &client.ListOptions{Namespace: namespace}); err != nil && !apierrors.IsNotFound(err) {
 		return false, fmt.Errorf("error listing awsendpointservices in namespace %s: %w", namespace, err)
 	}
+	credentialStatus := platformaws.GetCredentialStatus(hc)
 	for _, ep := range awsEndpointServiceList.Items {
 		if ep.DeletionTimestamp != nil {
-			if platformaws.GetCredentialStatus(hc) == platformaws.CredentialStatusValid && time.Since(ep.DeletionTimestamp.Time) < awsEndpointDeletionGracePeriod {
-				continue
+			withinGracePeriod := time.Since(ep.DeletionTimestamp.Time) < awsEndpointDeletionGracePeriod
+			switch credentialStatus {
+			case platformaws.CredentialStatusUnknown:
+				if withinGracePeriod {
+					log.Info("AWS credential status is unknown, preserving CPO finalizer during grace period", "name", ep.Name)
+					continue
+				}
+				log.Info("AWS credential status is unknown and grace period expired, removing CPO finalizer", "name", ep.Name)
+			case platformaws.CredentialStatusValid:
+				if withinGracePeriod {
+					continue
+				}
+			case platformaws.CredentialStatusInvalid:
+				// fall through to finalizer removal immediately
 			}
 
-			// We remove the CPO finalizer if there's no valid credentials so deletion can proceed.
 			cpoFinalizer := "hypershift.openshift.io/control-plane-operator-finalizer"
 			if controllerutil.ContainsFinalizer(&ep, cpoFinalizer) {
 				controllerutil.RemoveFinalizer(&ep, cpoFinalizer)
@@ -3324,7 +3339,7 @@ func deleteAWSEndpointServices(ctx context.Context, c client.Client, hc *hyperv1
 					return false, fmt.Errorf("failed to remove finalizer from awsendpointservice: %w", err)
 				}
 			}
-			log.Info("Removed CPO finalizer for awsendpointservice because the HC has no valid aws credentials", "name", ep.Name, "endpoint-id", ep.Status.EndpointID)
+			log.Info("Removed CPO finalizer for awsendpointservice", "name", ep.Name, "endpoint-id", ep.Status.EndpointID, "credentialStatus", credentialStatus)
 			continue
 		}
 

--- a/support/awsutil/errorcode.go
+++ b/support/awsutil/errorcode.go
@@ -7,9 +7,11 @@ import (
 )
 
 const (
-	AuthFailure           = "AuthFailure"
-	DependencyViolation   = "DependencyViolation"
-	UnauthorizedOperation = "UnauthorizedOperation"
+	AuthFailure               = "AuthFailure"
+	DependencyViolation       = "DependencyViolation"
+	UnauthorizedOperation     = "UnauthorizedOperation"
+	InvalidGroupNotFound      = "InvalidGroup.NotFound"
+	InvalidPermissionNotFound = "InvalidPermission.NotFound"
 )
 
 func AWSErrorCode(err error) string {

--- a/support/awsutil/sg_delete.go
+++ b/support/awsutil/sg_delete.go
@@ -1,0 +1,15 @@
+package awsutil
+
+// ShouldIgnoreRevokePermissionError returns true when revoking an ingress or
+// egress rule fails because the permission has already been removed.
+// This avoids treating an already-revoked rule as a hard error.
+func ShouldIgnoreRevokePermissionError(code string) bool {
+	return code == InvalidPermissionNotFound
+}
+
+// ShouldIgnoreSGNotFound returns true when a security group deletion fails
+// because the group was already deleted. This handles the race between
+// DescribeSecurityGroups and DeleteSecurityGroup.
+func ShouldIgnoreSGNotFound(code string) bool {
+	return code == InvalidGroupNotFound
+}

--- a/support/awsutil/sg_delete_test.go
+++ b/support/awsutil/sg_delete_test.go
@@ -1,0 +1,67 @@
+package awsutil
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestShouldIgnoreRevokePermissionError(t *testing.T) {
+	tests := []struct {
+		name     string
+		code     string
+		expected bool
+	}{
+		{
+			name:     "When error code is InvalidPermission.NotFound it should return true",
+			code:     InvalidPermissionNotFound,
+			expected: true,
+		},
+		{
+			name:     "When error code is DependencyViolation it should return false",
+			code:     DependencyViolation,
+			expected: false,
+		},
+		{
+			name:     "When error code is empty it should return false",
+			code:     "",
+			expected: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(ShouldIgnoreRevokePermissionError(tc.code)).To(Equal(tc.expected))
+		})
+	}
+}
+
+func TestShouldIgnoreSGNotFound(t *testing.T) {
+	tests := []struct {
+		name     string
+		code     string
+		expected bool
+	}{
+		{
+			name:     "When error code is InvalidGroup.NotFound it should return true",
+			code:     InvalidGroupNotFound,
+			expected: true,
+		},
+		{
+			name:     "When error code is DependencyViolation it should return false",
+			code:     DependencyViolation,
+			expected: false,
+		},
+		{
+			name:     "When error code is empty it should return false",
+			code:     "",
+			expected: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(ShouldIgnoreSGNotFound(tc.code)).To(Equal(tc.expected))
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it:
This PR fixes AWS teardown paths that can leak security groups and block VPC deletion after cluster uninstall.

It addresses three concrete cleanup issues:
- Keeps `AWSEndpointService` finalizers until cleanup can actually run, instead of skipping cleanup when AWS clients cannot be initialized during deletion.
- Handles interface endpoint deletion as asynchronous and requeues until endpoint deletion is fully observed before continuing SG cleanup.
- Treats security group `DependencyViolation` as retryable teardown progress and requeues instead of allowing teardown to continue with leaked SGs.

It also fixes a finalizer handling bug in `HostedCluster` deletion where CPO finalizers could be removed even with valid credentials after the grace period.

## Which issue(s) this PR fixes:

This is a run at helping fix the [OCPBUGS-74960](https://issues.redhat.com/browse/OCPBUGS-74960) bug witch already has another [PR](https://github.com/openshift/hypershift/pull/7868) for it, the intentions is to help even further to mitigate the issues with the cleanup

## Special notes for your reviewer:
- Opened in draft so CI can be run and reviewed before marking ready.
- Includes focused unit tests for new retry/finalizer behavior.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of AWS VPC endpoint and security group deletion with automatic retry mechanisms.
  * Enhanced finalizer handling for AWS endpoint services to prevent stuck cleanup operations.
  * Better error tolerance during resource cleanup for transient AWS API failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->