### PR TITLE
OCPBUGS-78297: use ClusterImagePolicy v1 instead of v1alpha1

### DIFF
--- a/hypershift-operator/controllers/nodepool/config.go
+++ b/hypershift-operator/controllers/nodepool/config.go
@@ -18,7 +18,6 @@ import (
 	supportutil "github.com/openshift/hypershift/support/util"
 
 	configv1 "github.com/openshift/api/config/v1"
-	configv1alpha1 "github.com/openshift/api/config/v1alpha1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	"github.com/openshift/api/operator/v1alpha1"
 
@@ -269,7 +268,6 @@ func (cg *ConfigGenerator) defaultAndValidateConfigManifest(manifest []byte) ([]
 	_ = mcfgv1.Install(scheme)
 	_ = v1alpha1.Install(scheme)
 	_ = configv1.Install(scheme)
-	_ = configv1alpha1.Install(scheme)
 
 	yamlSerializer := serializer.NewSerializerWithOptions(
 		serializer.DefaultMetaFactory, scheme, scheme,
@@ -293,7 +291,7 @@ func (cg *ConfigGenerator) defaultAndValidateConfigManifest(manifest []byte) ([]
 		}
 	case *v1alpha1.ImageContentSourcePolicy:
 	case *configv1.ImageDigestMirrorSet:
-	case *configv1alpha1.ClusterImagePolicy:
+	case *configv1.ClusterImagePolicy:
 	case *mcfgv1.KubeletConfig:
 		obj.Spec.MachineConfigPoolSelector = &metav1.LabelSelector{
 			MatchLabels: map[string]string{


### PR DESCRIPTION


<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:
Migrate the ClusterImagePolicy API from v1alpha1 to v1. As v1alpha1 was 
a TechPreview API, it is being dropped in favor of the v1(GA) version.

Rendering v1alpha1 ClusterImagePolicy via the Machine Config Operator (MCO) 
become a no-op after the upgrade to the v1 API. It is safe to 
remove the v1alpha1 definition at this stage of the lifecycle.
## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes: https://issues.redhat.com/browse/OCPBUGS-78297 

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched image policy handling from the legacy alpha API to the stable API to improve platform stability and compatibility.
  * Removed dependency on the legacy alpha configuration during initialization, simplifying startup behavior and reducing potential integration issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->