### PR TITLE
NO-JIRA: Add ldflags to suppress warnings on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,10 @@ GITLINT := $(TOOLS_BIN_DIR)/$(GITLINT_DIST_DIR)/$(GITLINT_BIN)-bin
 PROMTOOL=$(abspath $(TOOLS_BIN_DIR)/promtool)
 
 GO_GCFLAGS ?= -gcflags=all='-N -l'
-GO=GO111MODULE=on GOWORK=off GOFLAGS=-mod=vendor go
+ifeq ($(shell uname -s),Darwin)
+	CGO_LDFLAGS_ENV=CGO_LDFLAGS='-Wl,-w'
+endif
+GO=GO111MODULE=on GOWORK=off $(CGO_LDFLAGS_ENV) GOFLAGS='-mod=vendor' go
 GOWS=GO111MODULE=on GOWORK=$(shell pwd)/hack/workspace/go.work GOFLAGS=-mod=vendor go
 COMMIT_HASH ?= $(shell git rev-parse HEAD 2>/dev/null)
 VERSION_PKG=github.com/openshift/hypershift/support/supportedversion


### PR DESCRIPTION
## What this PR does / why we need it:
On macOS there are ld warnings when running with CGO that overwhelm the output and make it hard to see test results.

These additional flags suppress the warnings.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build configuration with a macOS-specific linker adjustment for native code builds, enhancing compilation reliability on macOS while keeping overall build behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->