### PR TITLE
CNTRLPLANE-3146: fix(tekton): update control-plane-operator pipelines for release-4.21

### DIFF
--- a/.tekton/control-plane-operator-4-21-pull-request.yaml
+++ b/.tekton/control-plane-operator-4-21-pull-request.yaml
@@ -4,22 +4,23 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/hypershift?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push"
-      && target_branch == "main"
+      event == "pull_request"
+      && target_branch == "release-4.21"
       && ( "control-plane-operator/***".pathChanged() ||
            "support/***".pathChanged() ||
            ".tekton/control-plane-operator*".pathChanged() ||
            "/Containerfile.control-plane-operator".pathChanged() )
-    pipelinesascode.tekton.dev/pipeline: ".tekton/pipelines/common-operator-build.yaml"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: control-plane-operator
-    appstudio.openshift.io/component: control-plane-operator-main
+    appstudio.openshift.io/component: control-plane-operator-4-21
     pipelines.appstudio.openshift.io/type: build
-  name: control-plane-operator-main-on-push
+  name: control-plane-operator-4-21-on-pull-request
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -28,19 +29,31 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-main:{{revision}}
+    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
   - name: dockerfile
     value: /Containerfile.control-plane
   - name: path-context
     value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
   pipelineRef:
-    name: hypershift-common-operator-build
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/openshift/hypershift.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: .tekton/pipelines/common-operator-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-control-plane-operator-main
+    serviceAccountName: build-pipeline-control-plane-operator-4-21
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/control-plane-operator-4-21-push.yaml
+++ b/.tekton/control-plane-operator-4-21-push.yaml
@@ -4,24 +4,21 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/hypershift?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request"
-      && target_branch == "main"
+      event == "push"
+      && target_branch == "release-4.21"
       && ( "control-plane-operator/***".pathChanged() ||
            "support/***".pathChanged() ||
            ".tekton/control-plane-operator*".pathChanged() ||
            "/Containerfile.control-plane-operator".pathChanged() )
-    pipelinesascode.tekton.dev/pipeline: ".tekton/pipelines/common-operator-build.yaml"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: control-plane-operator
-    appstudio.openshift.io/component: control-plane-operator-main
+    appstudio.openshift.io/component: control-plane-operator-4-21
     pipelines.appstudio.openshift.io/type: build
-  name: control-plane-operator-main-on-pull-request
+  name: control-plane-operator-4-21-on-push
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -30,20 +27,30 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-main:on-pr-{{revision}}
-  - name: image-expires-after
-    value: 5d
+    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: /Containerfile.control-plane
   - name: path-context
     value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
   pipelineRef:
-    name: hypershift-common-operator-build
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/openshift/hypershift.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: .tekton/pipelines/common-operator-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-control-plane-operator-main
+    serviceAccountName: build-pipeline-control-plane-operator-4-21
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
## What this PR does / why we need it:

Updates the Tekton Pipelines as Code configuration for the control-plane-operator on the `release-4.21` branch:

- Renames pipeline files from `*-main-*` to `*-4-21-*` to match the release branch
- Updates `target_branch` CEL expressions from `main` to `release-4.21`
- Updates component names and service accounts from `*-main` to `*-4-21`
- Updates output image references to use `control-plane-operator-4-21`
- Switches `pipelineRef` from inline annotation to git resolver pointing at `main` branch
- Enables `build-source-image` and `hermetic` build params

## Which issue(s) this PR fixes:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.