### PR TITLE
OCPBUGS-78832: control-plane-operator/controllers/hostedcontrolplane/v2/cvo: Consume include.release.openshift.io/hypershift-bootstrap annotation

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -137,12 +137,6 @@ spec:
           rm -f /var/payload/manifests/*_deployment.yaml
           rm -f /var/payload/manifests/*_servicemonitor.yaml
           cp -R /release-manifests /var/payload/
-          for file in $(find /var/payload/manifests/ -name "*.yaml"); do
-              IFS=',' read -ra feature_sets <<< "$(cat $file | grep "release.openshift.io/feature-set:" | awk '{print $2}')"
-              if [[ "${#feature_sets[@]}" -gt 0 ]] && ! [[ " ${feature_sets[*]} " =~ "Default" ]]; then
-                  rm -vf $file
-              fi
-          done
           rm -f /var/payload/release-manifests/0000_50_olm_00-pprof-config.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_00-pprof-rbac.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_00-pprof-secret.yaml
@@ -306,13 +300,11 @@ spec:
           cat > /tmp/clusterversion.json <<EOF
           ${CLUSTER_VERSION_JSON}
           EOF
-          oc get ns openshift-config &> /dev/null || oc create ns openshift-config
-          oc get ns openshift-config-managed &> /dev/null || oc create ns openshift-config-managed
-          oc apply -f /var/payload/manifests/0000_00_cluster-version-operator_01_clusterversions*
-          oc apply -f /tmp/clusterversion.json
-          while true; do
+          echo 'Deciding whether bootstrap resources need to be applied...'
+          ls -l $(grep -rl 'include.release.openshift.io/bootstrap-cluster-version-operator: .*hypershift' /var/payload/manifests) /tmp/clusterversion.json
+          while test -z "$(oc get -o jsonpath='{.status.history[0].version}' clusterversions.config.openshift.io version)"; do
             echo "Applying CVO bootstrap manifests..."
-            if oc apply -f /var/payload/manifests; then
+            if oc apply $(grep -rl 'include.release.openshift.io/bootstrap-cluster-version-operator: .*hypershift' /var/payload/manifests | sed 's/^/-f /') -f /tmp/clusterversion.json; then
               echo "Bootstrap manifests applied successfully."
               break
             fi

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -148,12 +148,6 @@ spec:
           rm -f /var/payload/manifests/*_deployment.yaml
           rm -f /var/payload/manifests/*_servicemonitor.yaml
           cp -R /release-manifests /var/payload/
-          for file in $(find /var/payload/manifests/ -name "*.yaml"); do
-              IFS=',' read -ra feature_sets <<< "$(cat $file | grep "release.openshift.io/feature-set:" | awk '{print $2}')"
-              if [[ "${#feature_sets[@]}" -gt 0 ]] && ! [[ " ${feature_sets[*]} " =~ "TechPreviewNoUpgrade" ]]; then
-                  rm -vf $file
-              fi
-          done
           rm -f /var/payload/release-manifests/0000_50_olm_00-pprof-config.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_00-pprof-rbac.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_00-pprof-secret.yaml
@@ -323,13 +317,11 @@ spec:
           cat > /tmp/clusterversion.json <<EOF
           ${CLUSTER_VERSION_JSON}
           EOF
-          oc get ns openshift-config &> /dev/null || oc create ns openshift-config
-          oc get ns openshift-config-managed &> /dev/null || oc create ns openshift-config-managed
-          oc apply -f /var/payload/manifests/0000_00_cluster-version-operator_01_clusterversions*
-          oc apply -f /tmp/clusterversion.json
-          while true; do
+          echo 'Deciding whether bootstrap resources need to be applied...'
+          ls -l $(grep -rl 'include.release.openshift.io/bootstrap-cluster-version-operator: .*hypershift' /var/payload/manifests) /tmp/clusterversion.json
+          while test -z "$(oc get -o jsonpath='{.status.history[0].version}' clusterversions.config.openshift.io version)"; do
             echo "Applying CVO bootstrap manifests..."
-            if oc apply -f /var/payload/manifests; then
+            if oc apply $(grep -rl 'include.release.openshift.io/bootstrap-cluster-version-operator: .*hypershift' /var/payload/manifests | sed 's/^/-f /') -f /tmp/clusterversion.json; then
               echo "Bootstrap manifests applied successfully."
               break
             fi

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -137,12 +137,6 @@ spec:
           rm -f /var/payload/manifests/*_deployment.yaml
           rm -f /var/payload/manifests/*_servicemonitor.yaml
           cp -R /release-manifests /var/payload/
-          for file in $(find /var/payload/manifests/ -name "*.yaml"); do
-              IFS=',' read -ra feature_sets <<< "$(cat $file | grep "release.openshift.io/feature-set:" | awk '{print $2}')"
-              if [[ "${#feature_sets[@]}" -gt 0 ]] && ! [[ " ${feature_sets[*]} " =~ "Default" ]]; then
-                  rm -vf $file
-              fi
-          done
           rm -f /var/payload/release-manifests/0000_50_olm_00-pprof-config.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_00-pprof-rbac.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_00-pprof-secret.yaml
@@ -243,13 +237,11 @@ spec:
           cat > /tmp/clusterversion.json <<EOF
           ${CLUSTER_VERSION_JSON}
           EOF
-          oc get ns openshift-config &> /dev/null || oc create ns openshift-config
-          oc get ns openshift-config-managed &> /dev/null || oc create ns openshift-config-managed
-          oc apply -f /var/payload/manifests/0000_00_cluster-version-operator_01_clusterversions*
-          oc apply -f /tmp/clusterversion.json
-          while true; do
+          echo 'Deciding whether bootstrap resources need to be applied...'
+          ls -l $(grep -rl 'include.release.openshift.io/bootstrap-cluster-version-operator: .*hypershift' /var/payload/manifests) /tmp/clusterversion.json
+          while test -z "$(oc get -o jsonpath='{.status.history[0].version}' clusterversions.config.openshift.io version)"; do
             echo "Applying CVO bootstrap manifests..."
-            if oc apply -f /var/payload/manifests; then
+            if oc apply $(grep -rl 'include.release.openshift.io/bootstrap-cluster-version-operator: .*hypershift' /var/payload/manifests | sed 's/^/-f /') -f /tmp/clusterversion.json; then
               echo "Bootstrap manifests applied successfully."
               break
             fi

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -137,12 +137,6 @@ spec:
           rm -f /var/payload/manifests/*_deployment.yaml
           rm -f /var/payload/manifests/*_servicemonitor.yaml
           cp -R /release-manifests /var/payload/
-          for file in $(find /var/payload/manifests/ -name "*.yaml"); do
-              IFS=',' read -ra feature_sets <<< "$(cat $file | grep "release.openshift.io/feature-set:" | awk '{print $2}')"
-              if [[ "${#feature_sets[@]}" -gt 0 ]] && ! [[ " ${feature_sets[*]} " =~ "TechPreviewNoUpgrade" ]]; then
-                  rm -vf $file
-              fi
-          done
           rm -f /var/payload/release-manifests/0000_50_olm_00-pprof-config.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_00-pprof-rbac.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_00-pprof-secret.yaml
@@ -306,13 +300,11 @@ spec:
           cat > /tmp/clusterversion.json <<EOF
           ${CLUSTER_VERSION_JSON}
           EOF
-          oc get ns openshift-config &> /dev/null || oc create ns openshift-config
-          oc get ns openshift-config-managed &> /dev/null || oc create ns openshift-config-managed
-          oc apply -f /var/payload/manifests/0000_00_cluster-version-operator_01_clusterversions*
-          oc apply -f /tmp/clusterversion.json
-          while true; do
+          echo 'Deciding whether bootstrap resources need to be applied...'
+          ls -l $(grep -rl 'include.release.openshift.io/bootstrap-cluster-version-operator: .*hypershift' /var/payload/manifests) /tmp/clusterversion.json
+          while test -z "$(oc get -o jsonpath='{.status.history[0].version}' clusterversions.config.openshift.io version)"; do
             echo "Applying CVO bootstrap manifests..."
-            if oc apply -f /var/payload/manifests; then
+            if oc apply $(grep -rl 'include.release.openshift.io/bootstrap-cluster-version-operator: .*hypershift' /var/payload/manifests | sed 's/^/-f /') -f /tmp/clusterversion.json; then
               echo "Bootstrap manifests applied successfully."
               break
             fi

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -137,12 +137,6 @@ spec:
           rm -f /var/payload/manifests/*_deployment.yaml
           rm -f /var/payload/manifests/*_servicemonitor.yaml
           cp -R /release-manifests /var/payload/
-          for file in $(find /var/payload/manifests/ -name "*.yaml"); do
-              IFS=',' read -ra feature_sets <<< "$(cat $file | grep "release.openshift.io/feature-set:" | awk '{print $2}')"
-              if [[ "${#feature_sets[@]}" -gt 0 ]] && ! [[ " ${feature_sets[*]} " =~ "Default" ]]; then
-                  rm -vf $file
-              fi
-          done
           rm -f /var/payload/release-manifests/0000_50_olm_00-pprof-config.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_00-pprof-rbac.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_00-pprof-secret.yaml
@@ -306,13 +300,11 @@ spec:
           cat > /tmp/clusterversion.json <<EOF
           ${CLUSTER_VERSION_JSON}
           EOF
-          oc get ns openshift-config &> /dev/null || oc create ns openshift-config
-          oc get ns openshift-config-managed &> /dev/null || oc create ns openshift-config-managed
-          oc apply -f /var/payload/manifests/0000_00_cluster-version-operator_01_clusterversions*
-          oc apply -f /tmp/clusterversion.json
-          while true; do
+          echo 'Deciding whether bootstrap resources need to be applied...'
+          ls -l $(grep -rl 'include.release.openshift.io/bootstrap-cluster-version-operator: .*hypershift' /var/payload/manifests) /tmp/clusterversion.json
+          while test -z "$(oc get -o jsonpath='{.status.history[0].version}' clusterversions.config.openshift.io version)"; do
             echo "Applying CVO bootstrap manifests..."
-            if oc apply -f /var/payload/manifests; then
+            if oc apply $(grep -rl 'include.release.openshift.io/bootstrap-cluster-version-operator: .*hypershift' /var/payload/manifests | sed 's/^/-f /') -f /tmp/clusterversion.json; then
               echo "Bootstrap manifests applied successfully."
               break
             fi

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-version-operator/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-version-operator/deployment.yaml
@@ -91,13 +91,11 @@ spec:
           cat > /tmp/clusterversion.json <<EOF
           ${CLUSTER_VERSION_JSON}
           EOF
-          oc get ns openshift-config &> /dev/null || oc create ns openshift-config
-          oc get ns openshift-config-managed &> /dev/null || oc create ns openshift-config-managed
-          oc apply -f /var/payload/manifests/0000_00_cluster-version-operator_01_clusterversions*
-          oc apply -f /tmp/clusterversion.json
-          while true; do
+          echo 'Deciding whether bootstrap resources need to be applied...'
+          ls -l $(grep -rl 'include.release.openshift.io/bootstrap-cluster-version-operator: .*hypershift' /var/payload/manifests) /tmp/clusterversion.json
+          while test -z "$(oc get -o jsonpath='{.status.history[0].version}' clusterversions.config.openshift.io version)"; do
             echo "Applying CVO bootstrap manifests..."
-            if oc apply -f /var/payload/manifests; then
+            if oc apply $(grep -rl 'include.release.openshift.io/bootstrap-cluster-version-operator: .*hypershift' /var/payload/manifests | sed 's/^/-f /') -f /tmp/clusterversion.json; then
               echo "Bootstrap manifests applied successfully."
               break
             fi

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment.go
@@ -204,18 +204,6 @@ func preparePayloadScript(platformType hyperv1.PlatformType, oauthEnabled bool, 
 		fmt.Sprintf("cp -R /release-manifests %s/", payloadDir),
 	)
 
-	// NOTE: We would need to leverage part of the manifest.Include logic (https://github.com/openshift/library-go/blob/0064ad7bd060b9fd52f7840972c1d3e72186d0f0/pkg/manifest/manifest.go#L190-L196)
-	// to properly evaluate which CVO manifests to select based on featureset.
-	// We only have access to bash, so we must filter based on the feature-set annotation in the manifests manually.
-	// Any file that has a feature-set annotation must have a value that matches the current feature set else it is removed.
-	// Files that do not have a feature-set annotation are included unconditionally.
-	stmts = append(stmts, fmt.Sprintf(`for file in $(find %s/manifests/ -name "*.yaml"); do
-    IFS=',' read -ra feature_sets <<< "$(cat $file | grep "release.openshift.io/feature-set:" | awk '{print $2}')"
-    if [[ "${#feature_sets[@]}" -gt 0 ]] && ! [[ " ${feature_sets[*]} " =~ "%s" ]]; then
-        rm -vf $file
-    fi
-done`, payloadDir, featureSet))
-
 	for _, manifest := range manifestsToOmit {
 		if platformType == hyperv1.IBMCloudPlatform || platformType == hyperv1.PowerVSPlatform {
 			if manifest == "0000_50_cluster-storage-operator_10_deployment-ibm-cloud-managed.yaml" || manifest == "0000_50_cluster-csi-snapshot-controller-operator_07_deployment-ibm-cloud-managed.yaml" {


### PR DESCRIPTION
## What this PR does / why we need it:

The cluster-version operator has a [complicated][1] [system][2] for deciding whether a given release-image manifest should be managed in the current cluster.  Implementing that system here, or even using `library-go` and remembering to vendor-bump here, both seem like an annoying maintenance load.

We could use [the CVO's render command][4] like [the standalone installer][3], but that logic is fairly complicated because it needs to generate all the artifacts necessary for bootstrap MachineConfig rendering, or the production machine-config operator will complain about MachineConfigPools requesting `rendered-...` MachineConfig that don't exist.

All we actually need out of the bootstrap container are the resources that the cluster-version operator needs to launch and run, which are labeled with the `grep` target since openshift/cluster-version-operator#1352.  That avoids installing anything the cluster doesn't actually need here by mistake.  Once the production CVO container starts, it will apply the remaining resources that the cluster actually needs.

I'm also dropping the `openshift-config` and `openshift-config-managed` Namespace creation.  They are from a30db71271 (#5125), but that commit doesn't explain why they were added or hint at where they lived before (if anywhere).  I would expect the cluster-version operator to be able to create those Namespaces from the release-image manifests when they are needed, as with other cluster resources.

[1]: https://github.com/openshift/enhancements/blob/2b38513b8661632f08e64f4acc3b856e842f8669/dev-guide/cluster-version-operator/dev/operators.md#manifest-inclusion-annotations
[2]: https://github.com/openshift/library-go/blob/ac826d10cb4081fe3034b027863c08953d95f602/pkg/manifest/manifest.go#L296-L376
[3]: https://github.com/openshift/installer/blob/a300d8c0e9d9d566a85740244a7da74d3d63e23c/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template#L189-L216
[4]: https://github.com/openshift/cluster-version-operator/blob/eaf28f5165bde27435b0f0c9a69458677034a58d/pkg/payload/render.go

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.