### PR TITLE
CNTRLPLANE-2946: Move AWS NLB annotation inside LoadBalancer strategy block

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/infra/infra_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/infra_test.go
@@ -1338,6 +1338,7 @@ func TestReconcileAPIServerService(t *testing.T) {
 				kasPublicService(func(s *corev1.Service) {
 					s.Spec.Type = corev1.ServiceTypeClusterIP
 					delete(s.Annotations, "external-dns.alpha.kubernetes.io/hostname")
+					delete(s.Annotations, "service.beta.kubernetes.io/aws-load-balancer-type")
 				}),
 				kasPrivateService(withCrossZoneAnnotation),
 			},

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/infra_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/infra_test.go
@@ -1356,6 +1356,7 @@ func TestReconcileAPIServerService(t *testing.T) {
 				kasPublicService(func(s *corev1.Service) {
 					s.Spec.Type = corev1.ServiceTypeClusterIP
 					delete(s.Annotations, "external-dns.alpha.kubernetes.io/hostname")
+					delete(s.Annotations, "service.beta.kubernetes.io/aws-load-balancer-type")
 				}),
 			},
 			expectedRoutes: []routev1.Route{
@@ -1377,6 +1378,7 @@ func TestReconcileAPIServerService(t *testing.T) {
 				kasPublicService(func(s *corev1.Service) {
 					s.Spec.Type = corev1.ServiceTypeClusterIP
 					delete(s.Annotations, "external-dns.alpha.kubernetes.io/hostname")
+					delete(s.Annotations, "service.beta.kubernetes.io/aws-load-balancer-type")
 				}),
 			},
 			expectedRoutes: []routev1.Route{
@@ -1398,6 +1400,7 @@ func TestReconcileAPIServerService(t *testing.T) {
 				kasPublicService(func(s *corev1.Service) {
 					s.Spec.Type = corev1.ServiceTypeClusterIP
 					delete(s.Annotations, "external-dns.alpha.kubernetes.io/hostname")
+					delete(s.Annotations, "service.beta.kubernetes.io/aws-load-balancer-type")
 				}),
 			},
 			expectedRoutes: []routev1.Route{

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_AWS_Private_KAS_LoadBalancer.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_AWS_Private_KAS_LoadBalancer.yaml
@@ -97,8 +97,6 @@ services:
     status:
       loadBalancer: {}
   - metadata:
-      annotations:
-        service.beta.kubernetes.io/aws-load-balancer-type: nlb
       labels:
         app: kube-apiserver
         hypershift.openshift.io/control-plane-component: kube-apiserver

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_AWS_Private_Route.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_AWS_Private_Route.yaml
@@ -144,8 +144,6 @@ services:
     status:
       loadBalancer: {}
   - metadata:
-      annotations:
-        service.beta.kubernetes.io/aws-load-balancer-type: nlb
       labels:
         app: kube-apiserver
         hypershift.openshift.io/control-plane-component: kube-apiserver

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_AWS_PublicAndPrivate_Route.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_AWS_PublicAndPrivate_Route.yaml
@@ -140,8 +140,6 @@ services:
     status:
       loadBalancer: {}
   - metadata:
-      annotations:
-        service.beta.kubernetes.io/aws-load-balancer-type: nlb
       labels:
         app: kube-apiserver
         hypershift.openshift.io/control-plane-component: kube-apiserver

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_AWS_Public_Route.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_AWS_Public_Route.yaml
@@ -116,8 +116,6 @@ services:
     status:
       loadBalancer: {}
   - metadata:
-      annotations:
-        service.beta.kubernetes.io/aws-load-balancer-type: nlb
       labels:
         app: kube-apiserver
         hypershift.openshift.io/control-plane-component: kube-apiserver

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -62,11 +62,15 @@ func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingSt
 	if svc.Annotations == nil {
 		svc.Annotations = map[string]string{}
 	}
-	if hcp.Spec.Platform.Type == hyperv1.AWSPlatform {
-		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
-	}
+
 	switch strategy.Type {
 	case hyperv1.LoadBalancer:
+		// Apply AWS NLB annotation only for LoadBalancer services.
+		// Previously this was set unconditionally, but it is only relevant
+		// when the service type is LoadBalancer.
+		if hcp.Spec.Platform.Type == hyperv1.AWSPlatform {
+			svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
+		}
 		if isPublic {
 			svc.Spec.Type = corev1.ServiceTypeLoadBalancer
 			if strategy.LoadBalancer != nil && strategy.LoadBalancer.Hostname != "" {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -21,6 +21,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+const AWSNLBAnnotation = "service.beta.kubernetes.io/aws-load-balancer-type"
+
 func kasLabels() map[string]string {
 	return map[string]string{
 		"app":                              "kube-apiserver",
@@ -65,14 +67,14 @@ func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingSt
 
 	// Remove stale AWS NLB annotation before reconciling.
 	// It will be re-added only when the service is actually a LoadBalancer.
-	delete(svc.Annotations, "service.beta.kubernetes.io/aws-load-balancer-type")
+	delete(svc.Annotations, AWSNLBAnnotation)
 
 	switch strategy.Type {
 	case hyperv1.LoadBalancer:
 		if isPublic {
 			svc.Spec.Type = corev1.ServiceTypeLoadBalancer
 			if hcp.Spec.Platform.Type == hyperv1.AWSPlatform {
-				svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
+				svc.Annotations[AWSNLBAnnotation] = "nlb"
 			}
 			if strategy.LoadBalancer != nil && strategy.LoadBalancer.Hostname != "" {
 				svc.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = strategy.LoadBalancer.Hostname
@@ -216,7 +218,7 @@ func ReconcilePrivateService(svc *corev1.Service, hcp *hyperv1.HostedControlPlan
 	default:
 		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"] = "true"
 		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-internal"] = "true"
-		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
+		svc.Annotations[AWSNLBAnnotation] = "nlb"
 	}
 	svc.Spec.Ports[0] = portSpec
 	return nil

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -63,16 +63,17 @@ func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingSt
 		svc.Annotations = map[string]string{}
 	}
 
+	// Remove stale AWS NLB annotation before reconciling.
+	// It will be re-added only when the service is actually a LoadBalancer.
+	delete(svc.Annotations, "service.beta.kubernetes.io/aws-load-balancer-type")
+
 	switch strategy.Type {
 	case hyperv1.LoadBalancer:
-		// Apply AWS NLB annotation only for LoadBalancer services.
-		// Previously this was set unconditionally, but it is only relevant
-		// when the service type is LoadBalancer.
-		if hcp.Spec.Platform.Type == hyperv1.AWSPlatform {
-			svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
-		}
 		if isPublic {
 			svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+			if hcp.Spec.Platform.Type == hyperv1.AWSPlatform {
+				svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
+			}
 			if strategy.LoadBalancer != nil && strategy.LoadBalancer.Hostname != "" {
 				svc.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = strategy.LoadBalancer.Hostname
 			}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service_test.go
@@ -181,7 +181,7 @@ func TestReconcilePrivateService(t *testing.T) {
 	azureILBAnnotation := azureutil.InternalLoadBalancerAnnotation
 	awsCrossZoneAnnotation := "service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"
 	awsInternalAnnotation := "service.beta.kubernetes.io/aws-load-balancer-internal"
-	awsNLBAnnotation := "service.beta.kubernetes.io/aws-load-balancer-type"
+	awsNLBAnnotation := AWSNLBAnnotation
 
 	testCases := []struct {
 		name                    string


### PR DESCRIPTION
## What this PR does / why we need it:

Moves the AWS NLB annotation (`service.beta.kubernetes.io/aws-load-balancer-type=nlb`)
inside the `LoadBalancer` strategy block in KAS service reconciliation.

Previously, the annotation was applied unconditionally, even when the service
strategy was not `LoadBalancer`, where it had no effect.

This change ensures the annotation is only applied when relevant and also
removes any stale annotation to maintain correct reconciliation behavior.

## Which issue(s) this PR fixes:

https://redhat.atlassian.net/browse/CNTRLPLANE-2946

## Special notes for your reviewer:

This aligns AWS behavior with the Azure annotation fix in #7821.

Also ensures proper reconciliation by removing stale annotations when not applicable.

## Checklist:

* [x] Subject and description added to both, commit and PR.
* [ ] Relevant issues have been referenced.
* [ ] This change includes docs.
* [ ] This change includes unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Remove stale AWS NLB annotation before evaluating publishing strategy; re-apply the NLB annotation only for public LoadBalancer services on AWS.

* **Tests**
  * Updated service tests and expectations to explicitly verify removal of the AWS NLB annotation when hostname annotations are removed (private/Route strategies and related transitions).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->