### PR TITLE
OCPBUGS-78539: revert temporary crash toleration for dns-operator

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -134,11 +134,9 @@ var (
 		"network-node-identity": 1,
 		// temporary workaround for https://issues.redhat.com/browse/CNV-76520
 		"kubevirt-cloud-controller-manager": 2,
-		// Allow 5 restarts for dns-operator due to new RBAC rollout out by CVO trailing dns-operator rollout
-		// https://redhat.atlassian.net/browse/OCPBUGS-78539
-		// https://redhat.atlassian.net/browse/NE-2500
-		// Can be removed after https://github.com/openshift/cluster-dns-operator/pull/458 is accepted into payload
-		"dns-operator": 5,
+		// Allow 1 restart for token-minter sidecar race condition: https://issues.redhat.com/browse/GCP-441
+		// TODO(GCP-447): Remove this toleration once token-minter is injected as a native sidecar init container.
+		"gcp-cloud-controller-manager": 1,
 	}
 )
 


### PR DESCRIPTION
## Summary

- Reverts the temporary e2e crash toleration for `dns-operator` added in #7978
- The toleration was a temporary workaround while waiting for the updated `cluster-dns-operator` manifests to reach the OCP payload in nightly builds
- The fix has now landed in the payload, so the toleration is no longer needed

## References
- https://redhat.atlassian.net/browse/OCPBUGS-78539
- Reverts #7978

## Test plan
- [ ] Verify e2e tests pass without the dns-operator crash toleration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal tolerance configurations for pod restart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->