### PR TITLE
OTA-1764: feat(cvo): add TLS cipher suites and minimum version flags

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -76,6 +76,8 @@ spec:
         - --serving-key-file=/etc/kubernetes/certs/server/tls.key
         - --hypershift=true
         - --v=4
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - cluster-version-operator
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -76,6 +76,8 @@ spec:
         - --serving-key-file=/etc/kubernetes/certs/server/tls.key
         - --hypershift=true
         - --v=4
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - cluster-version-operator
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -76,6 +76,8 @@ spec:
         - --serving-key-file=/etc/kubernetes/certs/server/tls.key
         - --hypershift=true
         - --v=4
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - cluster-version-operator
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -76,6 +76,8 @@ spec:
         - --serving-key-file=/etc/kubernetes/certs/server/tls.key
         - --hypershift=true
         - --v=4
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - cluster-version-operator
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -76,6 +76,8 @@ spec:
         - --serving-key-file=/etc/kubernetes/certs/server/tls.key
         - --hypershift=true
         - --v=4
+        - --tls-min-version=VersionTLS12
+        - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         command:
         - cluster-version-operator
         env:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment.go
@@ -109,10 +109,11 @@ func (cvo *clusterVersionOperator) adaptDeployment(cpContext component.WorkloadC
 			Value: dataPlaneReleaseImage,
 		})
 
-		if tlsMinVersion := config.MinTLSVersion(configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
+		tlsProfile := configuration.GetTLSSecurityProfile()
+		if tlsMinVersion := config.MinTLSVersion(tlsProfile); tlsMinVersion != "" {
 			c.Args = append(c.Args, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
 		}
-		if cipherSuites := config.CipherSuites(configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
+		if cipherSuites := config.CipherSuites(tlsProfile); len(cipherSuites) != 0 {
 			c.Args = append(c.Args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
 		}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment.go
@@ -102,11 +102,19 @@ func (cvo *clusterVersionOperator) adaptDeployment(cpContext component.WorkloadC
 		})
 	})
 
+	configuration := cpContext.HCP.Spec.Configuration
 	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		podspec.UpsertEnvVar(c, corev1.EnvVar{
 			Name:  "RELEASE_IMAGE",
 			Value: dataPlaneReleaseImage,
 		})
+
+		if tlsMinVersion := config.MinTLSVersion(configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
+			c.Args = append(c.Args, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
+		}
+		if cipherSuites := config.CipherSuites(configuration.GetTLSSecurityProfile()); len(cipherSuites) != 0 {
+			c.Args = append(c.Args, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(cipherSuites, ",")))
+		}
 
 		if updateService := cpContext.HCP.Spec.UpdateService; updateService != "" {
 			c.Args = append(c.Args, "--update-service", string(updateService))

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment_test.go
@@ -369,6 +369,25 @@ func TestAdaptDeployment(t *testing.T) {
 			expectedTLSMinVersion: "--tls-min-version=VersionTLS13",
 			expectedCipherSuites:  "--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
 		},
+		{
+			name: "When TLS profile type is Modern, it should set min version to TLS 1.3 and not add cipher suites flag",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-hcp", Namespace: "test-ns"},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.AWSPlatform},
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							TLSSecurityProfile: &configv1.TLSSecurityProfile{
+								Type:   configv1.TLSProfileModernType,
+								Modern: &configv1.ModernTLSProfile{},
+							},
+						},
+					},
+				},
+			},
+			expectedTLSMinVersion: "--tls-min-version=VersionTLS13",
+			expectedCipherSuites:  "",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment_test.go
@@ -1,16 +1,27 @@
 package cvo
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
+	"github.com/openshift/hypershift/support/api"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
+	"github.com/openshift/hypershift/support/util/fakeimagemetadataprovider"
 
 	configv1 "github.com/openshift/api/config/v1"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestPreparePayloadScript(t *testing.T) {
@@ -197,4 +208,197 @@ func extractResourceNames(objects []client.Object) []string {
 		names = append(names, obj.GetName())
 	}
 	return names
+}
+
+func createTestContext(hcp *hyperv1.HostedControlPlane) component.WorkloadContext {
+	pullSecret := common.PullSecret(hcp.Namespace)
+	pullSecret.Data = map[string][]byte{
+		corev1.DockerConfigJsonKey: []byte(`{"auths":{"test.registry":{"auth":"dGVzdDp0ZXN0"}}}`),
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(api.Scheme).
+		WithObjects(pullSecret).
+		Build()
+
+	fakeImageProvider := &fakeimagemetadataprovider.FakeRegistryClientImageMetadataProvider{
+		Digest: "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+	}
+
+	if hcp.Spec.ReleaseImage == "" {
+		hcp.Spec.ReleaseImage = "quay.io/openshift-release-dev/ocp-release:4.18.0-x86_64"
+	}
+
+	return component.WorkloadContext{
+		Context:               context.Background(),
+		Client:                fakeClient,
+		HCP:                   hcp,
+		ImageMetadataProvider: fakeImageProvider,
+	}
+}
+
+func TestAdaptDeployment(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                  string
+		hcp                   *hyperv1.HostedControlPlane
+		expectedTLSMinVersion string
+		expectedCipherSuites  string
+	}{
+		{
+			name: "When TLS profile has empty cipher suites list, it should not add tls-cipher-suites flag",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-hcp", Namespace: "test-ns"},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.AWSPlatform},
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							TLSSecurityProfile: &configv1.TLSSecurityProfile{
+								Type: configv1.TLSProfileCustomType,
+								Custom: &configv1.CustomTLSProfile{
+									TLSProfileSpec: configv1.TLSProfileSpec{
+										Ciphers:       []string{},
+										MinTLSVersion: configv1.VersionTLS12,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedTLSMinVersion: "--tls-min-version=VersionTLS12",
+			expectedCipherSuites:  "",
+		},
+		{
+			name: "When TLS profile has empty MinTLSVersion, it should not add tls-min-version flag",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-hcp", Namespace: "test-ns"},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.AWSPlatform},
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							TLSSecurityProfile: &configv1.TLSSecurityProfile{
+								Type: configv1.TLSProfileCustomType,
+								Custom: &configv1.CustomTLSProfile{
+									TLSProfileSpec: configv1.TLSProfileSpec{
+										Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+										MinTLSVersion: "",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedTLSMinVersion: "",
+			expectedCipherSuites:  "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+		},
+		{
+			name: "When TLS profile has both fields empty, it should not add any TLS flags",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-hcp", Namespace: "test-ns"},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.AWSPlatform},
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							TLSSecurityProfile: &configv1.TLSSecurityProfile{
+								Type: configv1.TLSProfileCustomType,
+								Custom: &configv1.CustomTLSProfile{
+									TLSProfileSpec: configv1.TLSProfileSpec{
+										Ciphers:       []string{},
+										MinTLSVersion: "",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedTLSMinVersion: "",
+			expectedCipherSuites:  "",
+		},
+		{
+			name: "When TLS profile has both fields set and a single cipher suite, it should add both flags and a single cipher",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-hcp", Namespace: "test-ns"},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.AWSPlatform},
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							TLSSecurityProfile: &configv1.TLSSecurityProfile{
+								Type: configv1.TLSProfileCustomType,
+								Custom: &configv1.CustomTLSProfile{
+									TLSProfileSpec: configv1.TLSProfileSpec{
+										Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256"},
+										MinTLSVersion: configv1.VersionTLS12,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedTLSMinVersion: "--tls-min-version=VersionTLS12",
+			expectedCipherSuites:  "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+		},
+		{
+			name: "When TLS profile has both fields set and multiple cipher suites, it should add both flags and a comma-separated cipher list",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-hcp", Namespace: "test-ns"},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.AWSPlatform},
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							TLSSecurityProfile: &configv1.TLSSecurityProfile{
+								Type: configv1.TLSProfileCustomType,
+								Custom: &configv1.CustomTLSProfile{
+									TLSProfileSpec: configv1.TLSProfileSpec{
+										Ciphers: []string{
+											"ECDHE-ECDSA-AES128-GCM-SHA256",
+											"ECDHE-RSA-AES256-GCM-SHA384",
+										},
+										MinTLSVersion: configv1.VersionTLS13,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedTLSMinVersion: "--tls-min-version=VersionTLS13",
+			expectedCipherSuites:  "--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			deployment, err := assets.LoadDeploymentManifest(ComponentName)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			cpContext := createTestContext(tc.hcp)
+
+			cvo := &clusterVersionOperator{}
+			err = cvo.adaptDeployment(cpContext, deployment)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+			g.Expect(container).ToNot(BeNil())
+
+			if tc.expectedTLSMinVersion != "" {
+				g.Expect(container.Args).To(ContainElement(tc.expectedTLSMinVersion))
+			} else {
+				g.Expect(container.Args).ToNot(ContainElement(ContainSubstring("--tls-min-version")))
+			}
+
+			if tc.expectedCipherSuites != "" {
+				g.Expect(container.Args).To(ContainElement(tc.expectedCipherSuites))
+			} else {
+				g.Expect(container.Args).ToNot(ContainElement(ContainSubstring("--tls-cipher-suites")))
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

Add new flags to the hosted CVO to comply with the [centralized TLS configuration in HyperShift](https://github.com/openshift/enhancements/blob/master/enhancements/security/centralized-tls-config.md#hypershift--hosted-control-planes). These flags are to override the CVO's internal TLS profile, which is used for its metrics server. The flags were added with https://github.com/openshift/cluster-version-operator/pull/1338.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes #[OTA-1764](https://redhat.atlassian.net/browse/OTA-1764)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced hosted control plane deployment TLS configuration by honoring the specified minimum TLS version and TLS cipher suites.
  * Ensures the correct TLS CLI arguments are applied (including modern TLS profile behavior).

* **Tests**
  * Added table-driven test coverage to verify TLS-related deployment arguments are added or omitted correctly for different TLS configuration combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->