### PR TITLE
OCPBUGS-79502: Bump e2e AWS instance types to accommodate AutoSizingReserved

### DIFF
--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -45,7 +45,7 @@ func TestAutoscaling(t *testing.T) {
 
 			// Set instance type to m5.xlarge for autoscaling tests to increase node capacity
 			if nodepool.Spec.Platform.AWS != nil {
-				nodepool.Spec.Platform.AWS.InstanceType = "m5.xlarge"
+				nodepool.Spec.Platform.AWS.InstanceType = "m5.2xlarge"
 			}
 
 			if additionalNP == nil {
@@ -68,7 +68,7 @@ func TestAutoscaling(t *testing.T) {
 
 				// Also set m5.xlarge for the additional NodePool
 				if additionalNP.Spec.Platform.AWS != nil {
-					additionalNP.Spec.Platform.AWS.InstanceType = "m5.xlarge"
+					additionalNP.Spec.Platform.AWS.InstanceType = "m5.2xlarge"
 				}
 			}
 		}

--- a/test/e2e/nodepool_rolling_upgrade_test.go
+++ b/test/e2e/nodepool_rolling_upgrade_test.go
@@ -74,7 +74,7 @@ func (k *RollingUpgradeTest) BuildNodePoolManifest(defaultNodepool hyperv1.NodeP
 	nodePool.Spec.Replicas = &twoReplicas
 	switch globalOpts.Platform {
 	case hyperv1.AWSPlatform:
-		nodePool.Spec.Platform.AWS.InstanceType = "m5.large"
+		nodePool.Spec.Platform.AWS.InstanceType = "m5.xlarge"
 	case hyperv1.AzurePlatform:
 		nodePool.Spec.Platform.Azure.VMSize = "Standard_D2s_v3"
 	}
@@ -90,7 +90,7 @@ func (k *RollingUpgradeTest) Run(t *testing.T, nodePool hyperv1.NodePool, nodes 
 	var vmSize string
 	switch globalOpts.Platform {
 	case hyperv1.AWSPlatform:
-		instanceType = "m5.xlarge"
+		instanceType = "m5.2xlarge"
 	case hyperv1.AzurePlatform:
 		vmSize = "Standard_D4s_v5"
 	}

--- a/test/e2e/util/requestserving.go
+++ b/test/e2e/util/requestserving.go
@@ -82,6 +82,10 @@ func SetupReqServingClusterNodePools(ctx context.Context, t *testing.T, kubeconf
 				Effect: corev1.TaintEffectNoSchedule,
 			},
 		}
+		// Ensure we use m5.xlarge for sufficient memory
+		if np.Spec.Platform.AWS != nil {
+			np.Spec.Platform.AWS.InstanceType = "m5.xlarge"
+		}
 	}
 
 	prepareNonReqServingNodePool := func(np *hyperv1.NodePool) {
@@ -94,6 +98,10 @@ func SetupReqServingClusterNodePools(ctx context.Context, t *testing.T, kubeconf
 		np.Spec.AutoScaling = nil
 		np.Spec.NodeLabels = map[string]string{
 			"hypershift.openshift.io/control-plane": "true",
+		}
+		// Ensure we use m5.xlarge for sufficient memory
+		if np.Spec.Platform.AWS != nil {
+			np.Spec.Platform.AWS.InstanceType = "m5.xlarge"
 		}
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it:
AutoSizingReserved was enabled by default in OCP 4.21 (openshift/machine-config-operator#5390), which dynamically reserves system memory based on node size. On the m5.xlarge and m5.large instances used by Hypershift e2e tests, this increases system-reserved memory enough to prevent platform pods from scheduling, causing Cluster Operator degradation and test failures.

This PR bumps the instance types to the next size up to provide sufficient allocatable memory for all platform pods with AutoSizingReserved enabled.

## Which issue(s) this PR fixes:
Fixes OCPBUGS-79502

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.