### PR TITLE
OCPBUGS-79530: fix(ignition-server): retry-on-conflict when annotating token secret

### DIFF
--- a/ignition-server/cmd/start.go
+++ b/ignition-server/cmd/start.go
@@ -22,12 +22,10 @@ import (
 	"github.com/openshift/hypershift/support/util"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/util/retry"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -276,13 +274,13 @@ func run(ctx context.Context, opts Options) error {
 		// Annotate tokenSecret so NodePool controller can set a conditions based on it.
 		// Use retry-on-conflict because the TokenSecretReconciler (running in the same
 		// process) may concurrently patch the token secret with payload data, bumping
-		// the resourceVersion and causing a conflict on our Update.
-		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			if err := mgr.GetClient().Get(ctx, client.ObjectKeyFromObject(tokenSecret), tokenSecret); err != nil {
-				return err
+		// the resourceVersion and causing a conflict.
+		if err := util.UpdateObject(ctx, mgr.GetClient(), tokenSecret, func() error {
+			if tokenSecret.Annotations == nil {
+				tokenSecret.Annotations = make(map[string]string)
 			}
 			tokenSecret.Annotations[TokenSecretIgnitionReachedAnnotation] = "True"
-			return mgr.GetClient().Update(ctx, tokenSecret)
+			return nil
 		}); err != nil {
 			log.Printf("Failed to annotate tokenSecret %q with ignition-reached: %s", tokenSecret.Name, err)
 		}

--- a/ignition-server/cmd/start.go
+++ b/ignition-server/cmd/start.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openshift/hypershift/support/util"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/util/retry"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -273,13 +274,17 @@ func run(ctx context.Context, opts Options) error {
 		getRequestsPerNodePool.WithLabelValues(r.Header.Get("NodePool")).Inc()
 
 		// Annotate tokenSecret so NodePool controller can set a conditions based on it.
-		if err := mgr.GetClient().Get(ctx, client.ObjectKeyFromObject(tokenSecret), tokenSecret); err != nil {
-			log.Printf("Failed to get tokenSecret resource: %q: %s", client.ObjectKeyFromObject(tokenSecret).String(), err)
-		} else {
-			tokenSecret.Annotations[TokenSecretIgnitionReachedAnnotation] = "True"
-			if err := mgr.GetClient().Update(ctx, tokenSecret); err != nil {
-				log.Printf("Failed to update tokenSecret: %q: %s", tokenSecret.Name, err)
+		// Use retry-on-conflict because the TokenSecretReconciler (running in the same
+		// process) may concurrently patch the token secret with payload data, bumping
+		// the resourceVersion and causing a conflict on our Update.
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			if err := mgr.GetClient().Get(ctx, client.ObjectKeyFromObject(tokenSecret), tokenSecret); err != nil {
+				return err
 			}
+			tokenSecret.Annotations[TokenSecretIgnitionReachedAnnotation] = "True"
+			return mgr.GetClient().Update(ctx, tokenSecret)
+		}); err != nil {
+			log.Printf("Failed to annotate tokenSecret %q with ignition-reached: %s", tokenSecret.Name, err)
 		}
 	})
 	mux.HandleFunc("/healthz", func(http.ResponseWriter, *http.Request) {})


### PR DESCRIPTION
## Summary

- Add retry-on-conflict to the ignition server's annotation update of the token secret with `ignition-reached=True`
- The current `Get` + `Update` without retry is susceptible to conflicts from the `TokenSecretReconciler` which runs in the same process and may concurrently patch the same secret
- This improves determinism particularly for InPlace upgrade NodePools which contact the ignition endpoint exactly once

## Context

While investigating a `TestNodePoolInPlaceUpgrade` e2e timeout where `ReachedIgnitionEndpoint` stayed `False`, we identified a potential race window in the ignition server:

1. The `TokenSecretReconciler` generates the payload, stores it in the in-memory `payloadStore`, then patches the token secret with payload data (compressed payload for InPlace, reason/message for all types)
2. Between `payloadStore.Set()` and `Patch()`, the HTTP handler can serve the payload to the node and attempt to annotate the secret with `ignition-reached=True`
3. If the reconciler's `Patch` completes first, the handler's `Update` could fail with a stale `resourceVersion`
4. The error is logged but not retried, potentially losing the annotation

We could not definitively confirm this race caused the specific failure — the ignition server logs were scrubbed from the CI artifacts. However, the code path is objectively fragile: a fire-and-forget `Get` + `Update` on a resource that multiple actors modify concurrently.

InPlace NodePools are more susceptible because:
- The reconciler writes compressed payload data into the secret (always a real Patch)
- Nodes contact the ignition endpoint exactly once (no reboots give retry opportunities)
- Replace/Rolling nodes contact it multiple times, giving more chances to succeed

## Fix

Wrap the `Get` + `Update` in `retry.RetryOnConflict` so a fresh `Get` is performed on conflict, picking up the new `resourceVersion` and succeeding on retry.

## Test plan

- [ ] `TestNodePoolInPlaceUpgrade` e2e test passes
- [ ] Existing ignition server unit tests pass
- [ ] Verify `ReachedIgnitionEndpoint` condition transitions to `True` for InPlace NodePools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of server token annotation updates under concurrent conditions by adding a retry-on-conflict update path.
  * Always initializes token annotations before setting the "ignition reached" flag to avoid nil-related failures.
  * Consolidated failure logging for annotation operations to produce clearer, less noisy error output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->