### PR TITLE
CNTRLPLANE-2078: add unit tests for AWS Route53 and IAM

### DIFF
--- a/cmd/infra/aws/destroy_iam_test.go
+++ b/cmd/infra/aws/destroy_iam_test.go
@@ -3,8 +3,9 @@ package aws
 import (
 	"context"
 	"errors"
-	"strings"
 	"testing"
+
+	. "github.com/onsi/gomega"
 
 	"github.com/openshift/hypershift/support/awsapi"
 
@@ -61,7 +62,7 @@ func TestDestroyOIDCRole(t *testing.T) {
 		{
 			name: "When the role does not exist it should return false without error",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+				m.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{RoleName: aws.String(roleName)}, gomock.Any()).
 					Return(nil, noSuchEntity())
 			},
 			expectRemoved: false,
@@ -69,59 +70,65 @@ func TestDestroyOIDCRole(t *testing.T) {
 		{
 			name: "When role exists with no policies it should delete it and return true",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil)
-				m.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.ListAttachedRolePoliciesOutput{}, nil)
-				m.EXPECT().ListRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.ListRolePoliciesOutput{PolicyNames: []string{}, IsTruncated: false}, nil)
-				m.EXPECT().DeleteRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.DeleteRoleOutput{}, nil)
+				gomock.InOrder(
+					m.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{RoleName: aws.String(roleName)}, gomock.Any()).
+						Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil),
+					m.EXPECT().ListAttachedRolePolicies(gomock.Any(), &iam.ListAttachedRolePoliciesInput{RoleName: aws.String(roleName)}, gomock.Any()).
+						Return(&iam.ListAttachedRolePoliciesOutput{}, nil),
+					m.EXPECT().ListRolePolicies(gomock.Any(), &iam.ListRolePoliciesInput{RoleName: aws.String(roleName)}, gomock.Any()).
+						Return(&iam.ListRolePoliciesOutput{PolicyNames: []string{}, IsTruncated: false}, nil),
+					m.EXPECT().DeleteRole(gomock.Any(), &iam.DeleteRoleInput{RoleName: aws.String(roleName)}, gomock.Any()).
+						Return(&iam.DeleteRoleOutput{}, nil),
+				)
 			},
 			expectRemoved: true,
 		},
 		{
 			name: "When role exists with managed and inline policies it should detach and delete all then delete the role",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil)
-				m.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.ListAttachedRolePoliciesOutput{
-						AttachedPolicies: []iamtypes.AttachedPolicy{
-							{PolicyArn: aws.String("arn:aws:iam::aws:policy/ManagedPolicy"), PolicyName: aws.String("ManagedPolicy")},
-						},
-					}, nil)
-				m.EXPECT().DetachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.DetachRolePolicyOutput{}, nil)
-				m.EXPECT().ListRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.ListRolePoliciesOutput{PolicyNames: []string{"inline-policy"}, IsTruncated: false}, nil)
-				m.EXPECT().DeleteRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.DeleteRolePolicyOutput{}, nil)
-				m.EXPECT().DeleteRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.DeleteRoleOutput{}, nil)
+				gomock.InOrder(
+					m.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{RoleName: aws.String(roleName)}, gomock.Any()).
+						Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil),
+					m.EXPECT().ListAttachedRolePolicies(gomock.Any(), &iam.ListAttachedRolePoliciesInput{RoleName: aws.String(roleName)}, gomock.Any()).
+						Return(&iam.ListAttachedRolePoliciesOutput{
+							AttachedPolicies: []iamtypes.AttachedPolicy{
+								{PolicyArn: aws.String("arn:aws:iam::aws:policy/ManagedPolicy"), PolicyName: aws.String("ManagedPolicy")},
+							},
+						}, nil),
+					m.EXPECT().DetachRolePolicy(gomock.Any(), &iam.DetachRolePolicyInput{RoleName: aws.String(roleName), PolicyArn: aws.String("arn:aws:iam::aws:policy/ManagedPolicy")}, gomock.Any()).
+						Return(&iam.DetachRolePolicyOutput{}, nil),
+					m.EXPECT().ListRolePolicies(gomock.Any(), &iam.ListRolePoliciesInput{RoleName: aws.String(roleName)}, gomock.Any()).
+						Return(&iam.ListRolePoliciesOutput{PolicyNames: []string{"inline-policy"}, IsTruncated: false}, nil),
+					m.EXPECT().DeleteRolePolicy(gomock.Any(), &iam.DeleteRolePolicyInput{RoleName: aws.String(roleName), PolicyName: aws.String("inline-policy")}, gomock.Any()).
+						Return(&iam.DeleteRolePolicyOutput{}, nil),
+					m.EXPECT().DeleteRole(gomock.Any(), &iam.DeleteRoleInput{RoleName: aws.String(roleName)}, gomock.Any()).
+						Return(&iam.DeleteRoleOutput{}, nil),
+				)
 			},
 			expectRemoved: true,
 		},
 		{
 			name: "When inline policy delete returns NoSuchEntityException it should ignore and continue",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil)
-				m.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.ListAttachedRolePoliciesOutput{}, nil)
-				m.EXPECT().ListRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.ListRolePoliciesOutput{PolicyNames: []string{"gone-policy"}, IsTruncated: false}, nil)
-				m.EXPECT().DeleteRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				m.EXPECT().DeleteRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.DeleteRoleOutput{}, nil)
+				gomock.InOrder(
+					m.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{RoleName: aws.String(roleName)}, gomock.Any()).
+						Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil),
+					m.EXPECT().ListAttachedRolePolicies(gomock.Any(), &iam.ListAttachedRolePoliciesInput{RoleName: aws.String(roleName)}, gomock.Any()).
+						Return(&iam.ListAttachedRolePoliciesOutput{}, nil),
+					m.EXPECT().ListRolePolicies(gomock.Any(), &iam.ListRolePoliciesInput{RoleName: aws.String(roleName)}, gomock.Any()).
+						Return(&iam.ListRolePoliciesOutput{PolicyNames: []string{"gone-policy"}, IsTruncated: false}, nil),
+					m.EXPECT().DeleteRolePolicy(gomock.Any(), &iam.DeleteRolePolicyInput{RoleName: aws.String(roleName), PolicyName: aws.String("gone-policy")}, gomock.Any()).
+						Return(nil, noSuchEntity()),
+					m.EXPECT().DeleteRole(gomock.Any(), &iam.DeleteRoleInput{RoleName: aws.String(roleName)}, gomock.Any()).
+						Return(&iam.DeleteRoleOutput{}, nil),
+				)
 			},
 			expectRemoved: true,
 		},
 		{
 			name: "When GetRole returns an API error it should return a wrapped error",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+				m.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{RoleName: aws.String(roleName)}, gomock.Any()).
 					Return(nil, errors.New("api error"))
 			},
 			expectError:   true,
@@ -130,10 +137,12 @@ func TestDestroyOIDCRole(t *testing.T) {
 		{
 			name: "When ListAttachedRolePolicies fails it should return the error",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil)
-				m.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("list policies failed"))
+				gomock.InOrder(
+					m.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{RoleName: aws.String(roleName)}, gomock.Any()).
+						Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil),
+					m.EXPECT().ListAttachedRolePolicies(gomock.Any(), &iam.ListAttachedRolePoliciesInput{RoleName: aws.String(roleName)}, gomock.Any()).
+						Return(nil, errors.New("list policies failed")),
+				)
 			},
 			expectError:   true,
 			errorContains: "failed to list attached policies",
@@ -141,16 +150,18 @@ func TestDestroyOIDCRole(t *testing.T) {
 		{
 			name: "When DetachRolePolicy fails it should return the error",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil)
-				m.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.ListAttachedRolePoliciesOutput{
-						AttachedPolicies: []iamtypes.AttachedPolicy{
-							{PolicyArn: aws.String("arn:aws:iam::aws:policy/ManagedPolicy"), PolicyName: aws.String("ManagedPolicy")},
-						},
-					}, nil)
-				m.EXPECT().DetachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("detach failed"))
+				gomock.InOrder(
+					m.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{RoleName: aws.String(roleName)}, gomock.Any()).
+						Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil),
+					m.EXPECT().ListAttachedRolePolicies(gomock.Any(), &iam.ListAttachedRolePoliciesInput{RoleName: aws.String(roleName)}, gomock.Any()).
+						Return(&iam.ListAttachedRolePoliciesOutput{
+							AttachedPolicies: []iamtypes.AttachedPolicy{
+								{PolicyArn: aws.String("arn:aws:iam::aws:policy/ManagedPolicy"), PolicyName: aws.String("ManagedPolicy")},
+							},
+						}, nil),
+					m.EXPECT().DetachRolePolicy(gomock.Any(), &iam.DetachRolePolicyInput{RoleName: aws.String(roleName), PolicyArn: aws.String("arn:aws:iam::aws:policy/ManagedPolicy")}, gomock.Any()).
+						Return(nil, errors.New("detach failed")),
+				)
 			},
 			expectError:   true,
 			errorContains: "failed to detach policy",
@@ -158,12 +169,14 @@ func TestDestroyOIDCRole(t *testing.T) {
 		{
 			name: "When ListRolePolicies fails it should return the error",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil)
-				m.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.ListAttachedRolePoliciesOutput{}, nil)
-				m.EXPECT().ListRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("list inline failed"))
+				gomock.InOrder(
+					m.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{RoleName: aws.String(roleName)}, gomock.Any()).
+						Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil),
+					m.EXPECT().ListAttachedRolePolicies(gomock.Any(), &iam.ListAttachedRolePoliciesInput{RoleName: aws.String(roleName)}, gomock.Any()).
+						Return(&iam.ListAttachedRolePoliciesOutput{}, nil),
+					m.EXPECT().ListRolePolicies(gomock.Any(), &iam.ListRolePoliciesInput{RoleName: aws.String(roleName)}, gomock.Any()).
+						Return(nil, errors.New("list inline failed")),
+				)
 			},
 			expectError:   true,
 			errorContains: "failed to list inline policies",
@@ -171,14 +184,16 @@ func TestDestroyOIDCRole(t *testing.T) {
 		{
 			name: "When DeleteRole fails it should return the error",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil)
-				m.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.ListAttachedRolePoliciesOutput{}, nil)
-				m.EXPECT().ListRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.ListRolePoliciesOutput{PolicyNames: []string{}, IsTruncated: false}, nil)
-				m.EXPECT().DeleteRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("delete role failed"))
+				gomock.InOrder(
+					m.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{RoleName: aws.String(roleName)}, gomock.Any()).
+						Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil),
+					m.EXPECT().ListAttachedRolePolicies(gomock.Any(), &iam.ListAttachedRolePoliciesInput{RoleName: aws.String(roleName)}, gomock.Any()).
+						Return(&iam.ListAttachedRolePoliciesOutput{}, nil),
+					m.EXPECT().ListRolePolicies(gomock.Any(), &iam.ListRolePoliciesInput{RoleName: aws.String(roleName)}, gomock.Any()).
+						Return(&iam.ListRolePoliciesOutput{PolicyNames: []string{}, IsTruncated: false}, nil),
+					m.EXPECT().DeleteRole(gomock.Any(), &iam.DeleteRoleInput{RoleName: aws.String(roleName)}, gomock.Any()).
+						Return(nil, errors.New("delete role failed")),
+				)
 			},
 			expectError:   true,
 			errorContains: "failed to delete role",
@@ -187,6 +202,7 @@ func TestDestroyOIDCRole(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 			ctrl := gomock.NewController(t)
 			mockIAM := awsapi.NewMockIAMAPI(ctrl)
 			tt.setupMock(mockIAM)
@@ -195,19 +211,13 @@ func TestDestroyOIDCRole(t *testing.T) {
 			removed, err := o.DestroyOIDCRole(context.Background(), mockIAM, "openshift-ingress")
 
 			if tt.expectError {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
-					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				g.Expect(err).To(HaveOccurred())
+				if tt.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tt.errorContains))
 				}
 			} else {
-				if err != nil {
-					t.Errorf("expected no error, got: %v", err)
-				}
-				if removed != tt.expectRemoved {
-					t.Errorf("expected removed=%v, got %v", tt.expectRemoved, removed)
-				}
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(removed).To(Equal(tt.expectRemoved))
 			}
 		})
 	}
@@ -230,87 +240,100 @@ func TestDestroyWorkerInstanceProfile(t *testing.T) {
 		{
 			name: "When no instance profile or worker roles exist it should return nil",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				// existingInstanceProfile
-				m.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				// existingRole for standard role
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				// existingRole for ROSA role
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
+				gomock.InOrder(
+					// existingInstanceProfile
+					m.EXPECT().GetInstanceProfile(gomock.Any(), &iam.GetInstanceProfileInput{InstanceProfileName: aws.String(profileName)}, gomock.Any()).
+						Return(nil, noSuchEntity()),
+					// existingRole for standard role
+					m.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{RoleName: aws.String(standardRole)}, gomock.Any()).
+						Return(nil, noSuchEntity()),
+					// existingRole for ROSA role
+					m.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{RoleName: aws.String(rosaRole)}, gomock.Any()).
+						Return(nil, noSuchEntity()),
+				)
 			},
 		},
 		{
 			name: "When instance profile with a role exists it should remove the role and delete the profile",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.GetInstanceProfileOutput{
-						InstanceProfile: testInstanceProfile(profileName,
-							iamtypes.Role{RoleName: aws.String("worker-role")},
-						),
-					}, nil)
-				m.EXPECT().RemoveRoleFromInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.RemoveRoleFromInstanceProfileOutput{}, nil)
-				m.EXPECT().DeleteInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.DeleteInstanceProfileOutput{}, nil)
-				// standard role and ROSA role not found
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity()).Times(2)
+				gomock.InOrder(
+					m.EXPECT().GetInstanceProfile(gomock.Any(), &iam.GetInstanceProfileInput{InstanceProfileName: aws.String(profileName)}, gomock.Any()).
+						Return(&iam.GetInstanceProfileOutput{
+							InstanceProfile: testInstanceProfile(profileName,
+								iamtypes.Role{RoleName: aws.String("worker-role")},
+							),
+						}, nil),
+					m.EXPECT().RemoveRoleFromInstanceProfile(gomock.Any(), &iam.RemoveRoleFromInstanceProfileInput{
+						InstanceProfileName: aws.String(profileName),
+						RoleName:            aws.String("worker-role"),
+					}, gomock.Any()).
+						Return(&iam.RemoveRoleFromInstanceProfileOutput{}, nil),
+					m.EXPECT().DeleteInstanceProfile(gomock.Any(), &iam.DeleteInstanceProfileInput{InstanceProfileName: aws.String(profileName)}, gomock.Any()).
+						Return(&iam.DeleteInstanceProfileOutput{}, nil),
+					// standard role and ROSA role not found
+					m.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{RoleName: aws.String(standardRole)}, gomock.Any()).
+						Return(nil, noSuchEntity()),
+					m.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{RoleName: aws.String(rosaRole)}, gomock.Any()).
+						Return(nil, noSuchEntity()),
+				)
 			},
 		},
 		{
 			name: "When standard worker role exists with an inline policy it should delete the policy and the role",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				// no instance profile
-				m.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				// standard role exists
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.GetRoleOutput{Role: testRole(standardRole)}, nil)
-				// policy exists
-				m.EXPECT().GetRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.GetRolePolicyOutput{
-						RoleName:   aws.String(standardRole),
-						PolicyName: aws.String(standardPolicy),
-					}, nil)
-				m.EXPECT().DeleteRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.DeleteRolePolicyOutput{}, nil)
-				m.EXPECT().DeleteRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.DeleteRoleOutput{}, nil)
-				// ROSA role not found
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
+				gomock.InOrder(
+					// no instance profile
+					m.EXPECT().GetInstanceProfile(gomock.Any(), &iam.GetInstanceProfileInput{InstanceProfileName: aws.String(profileName)}, gomock.Any()).
+						Return(nil, noSuchEntity()),
+					// standard role exists
+					m.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{RoleName: aws.String(standardRole)}, gomock.Any()).
+						Return(&iam.GetRoleOutput{Role: testRole(standardRole)}, nil),
+					// policy exists
+					m.EXPECT().GetRolePolicy(gomock.Any(), &iam.GetRolePolicyInput{RoleName: aws.String(standardRole), PolicyName: aws.String(standardPolicy)}, gomock.Any()).
+						Return(&iam.GetRolePolicyOutput{
+							RoleName:   aws.String(standardRole),
+							PolicyName: aws.String(standardPolicy),
+						}, nil),
+					m.EXPECT().DeleteRolePolicy(gomock.Any(), &iam.DeleteRolePolicyInput{PolicyName: aws.String(standardPolicy), RoleName: aws.String(standardRole)}, gomock.Any()).
+						Return(&iam.DeleteRolePolicyOutput{}, nil),
+					m.EXPECT().DeleteRole(gomock.Any(), &iam.DeleteRoleInput{RoleName: aws.String(standardRole)}, gomock.Any()).
+						Return(&iam.DeleteRoleOutput{}, nil),
+					// ROSA role not found
+					m.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{RoleName: aws.String(rosaRole)}, gomock.Any()).
+						Return(nil, noSuchEntity()),
+				)
 			},
 		},
 		{
 			name: "When ROSA worker role exists with a managed policy it should detach the policy and delete the role",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				// no instance profile
-				m.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				// standard role not found
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				// ROSA role exists
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.GetRoleOutput{Role: testRole(rosaRole)}, nil)
-				m.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.ListAttachedRolePoliciesOutput{
-						AttachedPolicies: []iamtypes.AttachedPolicy{
-							{PolicyArn: aws.String("arn:aws:iam::aws:policy/ROSAPolicy"), PolicyName: aws.String("ROSAPolicy")},
-						},
-					}, nil)
-				m.EXPECT().DetachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.DetachRolePolicyOutput{}, nil)
-				m.EXPECT().DeleteRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.DeleteRoleOutput{}, nil)
+				gomock.InOrder(
+					// no instance profile
+					m.EXPECT().GetInstanceProfile(gomock.Any(), &iam.GetInstanceProfileInput{InstanceProfileName: aws.String(profileName)}, gomock.Any()).
+						Return(nil, noSuchEntity()),
+					// standard role not found
+					m.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{RoleName: aws.String(standardRole)}, gomock.Any()).
+						Return(nil, noSuchEntity()),
+					// ROSA role exists
+					m.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{RoleName: aws.String(rosaRole)}, gomock.Any()).
+						Return(&iam.GetRoleOutput{Role: testRole(rosaRole)}, nil),
+					m.EXPECT().ListAttachedRolePolicies(gomock.Any(), &iam.ListAttachedRolePoliciesInput{RoleName: aws.String(rosaRole)}, gomock.Any()).
+						Return(&iam.ListAttachedRolePoliciesOutput{
+							AttachedPolicies: []iamtypes.AttachedPolicy{
+								{PolicyArn: aws.String("arn:aws:iam::aws:policy/ROSAPolicy"), PolicyName: aws.String("ROSAPolicy")},
+							},
+						}, nil),
+					m.EXPECT().DetachRolePolicy(gomock.Any(), &iam.DetachRolePolicyInput{PolicyArn: aws.String("arn:aws:iam::aws:policy/ROSAPolicy"), RoleName: aws.String(rosaRole)}, gomock.Any()).
+						Return(&iam.DetachRolePolicyOutput{}, nil),
+					m.EXPECT().DeleteRole(gomock.Any(), &iam.DeleteRoleInput{RoleName: aws.String(rosaRole)}, gomock.Any()).
+						Return(&iam.DeleteRoleOutput{}, nil),
+				)
 			},
 		},
 		{
 			name: "When GetInstanceProfile returns an API error it should return the error",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+				m.EXPECT().GetInstanceProfile(gomock.Any(), &iam.GetInstanceProfileInput{InstanceProfileName: aws.String(profileName)}, gomock.Any()).
 					Return(nil, errors.New("api error"))
 			},
 			expectError:   true,
@@ -319,14 +342,19 @@ func TestDestroyWorkerInstanceProfile(t *testing.T) {
 		{
 			name: "When RemoveRoleFromInstanceProfile fails it should return the error",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.GetInstanceProfileOutput{
-						InstanceProfile: testInstanceProfile(profileName,
-							iamtypes.Role{RoleName: aws.String("worker-role")},
-						),
-					}, nil)
-				m.EXPECT().RemoveRoleFromInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("remove failed"))
+				gomock.InOrder(
+					m.EXPECT().GetInstanceProfile(gomock.Any(), &iam.GetInstanceProfileInput{InstanceProfileName: aws.String(profileName)}, gomock.Any()).
+						Return(&iam.GetInstanceProfileOutput{
+							InstanceProfile: testInstanceProfile(profileName,
+								iamtypes.Role{RoleName: aws.String("worker-role")},
+							),
+						}, nil),
+					m.EXPECT().RemoveRoleFromInstanceProfile(gomock.Any(), &iam.RemoveRoleFromInstanceProfileInput{
+						InstanceProfileName: aws.String(profileName),
+						RoleName:            aws.String("worker-role"),
+					}, gomock.Any()).
+						Return(nil, errors.New("remove failed")),
+				)
 			},
 			expectError:   true,
 			errorContains: "cannot remove role",
@@ -335,6 +363,7 @@ func TestDestroyWorkerInstanceProfile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 			ctrl := gomock.NewController(t)
 			mockIAM := awsapi.NewMockIAMAPI(ctrl)
 			tt.setupMock(mockIAM)
@@ -343,16 +372,12 @@ func TestDestroyWorkerInstanceProfile(t *testing.T) {
 			err := o.DestroyWorkerInstanceProfile(context.Background(), mockIAM)
 
 			if tt.expectError {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
-					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				g.Expect(err).To(HaveOccurred())
+				if tt.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tt.errorContains))
 				}
 			} else {
-				if err != nil {
-					t.Errorf("expected no error, got: %v", err)
-				}
+				g.Expect(err).NotTo(HaveOccurred())
 			}
 		})
 	}
@@ -363,6 +388,10 @@ func TestDestroyOIDCResources(t *testing.T) {
 	const matchingARN = "arn:aws:iam::123456789012:oidc-provider/s3.example.com/" + testInfraID
 	const otherARN = "arn:aws:iam::123456789012:oidc-provider/s3.example.com/other-infra"
 
+	// DestroyOIDCResources calls GetRole for: shared-role + 9 individual component roles.
+	// When shared-role is not found (removed=false), all 9 individual roles are also checked.
+	const totalRoleChecks = 10
+
 	tests := []struct {
 		name          string
 		setupMock     func(*awsapi.MockIAMAPI)
@@ -372,53 +401,59 @@ func TestDestroyOIDCResources(t *testing.T) {
 		{
 			name: "When OIDC provider matches infraID and shared role exists it should delete the provider and return early",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.ListOpenIDConnectProvidersOutput{
-						OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{
-							{Arn: aws.String(matchingARN)},
-						},
-					}, nil)
-				m.EXPECT().DeleteOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.DeleteOpenIDConnectProviderOutput{}, nil)
-				// DestroyOIDCRole("shared-role") → role found → early return
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.GetRoleOutput{Role: testRole(testInfraID + "-shared-role")}, nil)
-				m.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.ListAttachedRolePoliciesOutput{}, nil)
-				m.EXPECT().ListRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.ListRolePoliciesOutput{IsTruncated: false}, nil)
-				m.EXPECT().DeleteRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.DeleteRoleOutput{}, nil)
+				gomock.InOrder(
+					m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.ListOpenIDConnectProvidersOutput{
+							OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{
+								{Arn: aws.String(matchingARN)},
+							},
+						}, nil),
+					m.EXPECT().DeleteOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.DeleteOpenIDConnectProviderOutput{}, nil),
+					// DestroyOIDCRole("shared-role") → role found → early return
+					m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.GetRoleOutput{Role: testRole(testInfraID + "-shared-role")}, nil),
+					m.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.ListAttachedRolePoliciesOutput{}, nil),
+					m.EXPECT().ListRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.ListRolePoliciesOutput{IsTruncated: false}, nil),
+					m.EXPECT().DeleteRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.DeleteRoleOutput{}, nil),
+				)
 			},
 		},
 		{
 			name: "When OIDC provider ARN does not match infraID it should skip deletion and proceed with role cleanup",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.ListOpenIDConnectProvidersOutput{
-						OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{
-							{Arn: aws.String(otherARN)},
-						},
-					}, nil)
-				// All role lookups return not found — covers shared-role + 9 component roles
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity()).AnyTimes()
+				gomock.InOrder(
+					m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.ListOpenIDConnectProvidersOutput{
+							OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{
+								{Arn: aws.String(otherARN)},
+							},
+						}, nil),
+					// shared-role + 9 component roles, all not found
+					m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, noSuchEntity()).Times(totalRoleChecks),
+				)
 			},
 		},
 		{
 			name: "When DeleteOpenIDConnectProvider returns NoSuchEntityException it should ignore and continue",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.ListOpenIDConnectProvidersOutput{
-						OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{
-							{Arn: aws.String(matchingARN)},
-						},
-					}, nil)
-				m.EXPECT().DeleteOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				// continues to role cleanup; all roles not found
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity()).AnyTimes()
+				gomock.InOrder(
+					m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.ListOpenIDConnectProvidersOutput{
+							OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{
+								{Arn: aws.String(matchingARN)},
+							},
+						}, nil),
+					m.EXPECT().DeleteOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, noSuchEntity()),
+					// continues to role cleanup; shared-role + 9 component roles all not found
+					m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, noSuchEntity()).Times(totalRoleChecks),
+				)
 			},
 		},
 		{
@@ -433,14 +468,16 @@ func TestDestroyOIDCResources(t *testing.T) {
 		{
 			name: "When DeleteOpenIDConnectProvider fails with a non-NSE error it should return the error",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.ListOpenIDConnectProvidersOutput{
-						OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{
-							{Arn: aws.String(matchingARN)},
-						},
-					}, nil)
-				m.EXPECT().DeleteOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("permission denied"))
+				gomock.InOrder(
+					m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.ListOpenIDConnectProvidersOutput{
+							OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{
+								{Arn: aws.String(matchingARN)},
+							},
+						}, nil),
+					m.EXPECT().DeleteOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, errors.New("permission denied")),
+				)
 			},
 			expectError:   true,
 			errorContains: "permission denied",
@@ -449,6 +486,7 @@ func TestDestroyOIDCResources(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 			ctrl := gomock.NewController(t)
 			mockIAM := awsapi.NewMockIAMAPI(ctrl)
 			tt.setupMock(mockIAM)
@@ -457,22 +495,23 @@ func TestDestroyOIDCResources(t *testing.T) {
 			err := o.DestroyOIDCResources(context.Background(), mockIAM)
 
 			if tt.expectError {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
-					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				g.Expect(err).To(HaveOccurred())
+				if tt.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tt.errorContains))
 				}
 			} else {
-				if err != nil {
-					t.Errorf("expected no error, got: %v", err)
-				}
+				g.Expect(err).NotTo(HaveOccurred())
 			}
 		})
 	}
 }
 
 func TestDestroySharedVPCRoles(t *testing.T) {
+	const (
+		ingressRoleName = testInfraID + "-shared-vpc-ingress"
+		cpRoleName      = testInfraID + "-shared-vpc-control-plane"
+	)
+
 	tests := []struct {
 		name                  string
 		privateZonesInCluster bool
@@ -486,25 +525,23 @@ func TestDestroySharedVPCRoles(t *testing.T) {
 			privateZonesInCluster: false,
 			setupIAMMock:          func(_ *awsapi.MockIAMAPI) {},
 			setupVPCOwnerMock: func(m *awsapi.MockIAMAPI) {
-				// ingress role not found on vpcOwner
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				// control-plane role not found on vpcOwner
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
+				gomock.InOrder(
+					m.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{RoleName: aws.String(ingressRoleName)}, gomock.Any()).
+						Return(nil, noSuchEntity()),
+					m.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{RoleName: aws.String(cpRoleName)}, gomock.Any()).
+						Return(nil, noSuchEntity()),
+				)
 			},
 		},
 		{
 			name:                  "When PrivateZonesInClusterAccount is true ingress role should use iamClient",
 			privateZonesInCluster: true,
 			setupIAMMock: func(m *awsapi.MockIAMAPI) {
-				// ingress role not found on iamClient
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+				m.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{RoleName: aws.String(ingressRoleName)}, gomock.Any()).
 					Return(nil, noSuchEntity())
 			},
 			setupVPCOwnerMock: func(m *awsapi.MockIAMAPI) {
-				// control-plane role not found on vpcOwner
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+				m.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{RoleName: aws.String(cpRoleName)}, gomock.Any()).
 					Return(nil, noSuchEntity())
 			},
 		},
@@ -513,7 +550,7 @@ func TestDestroySharedVPCRoles(t *testing.T) {
 			privateZonesInCluster: false,
 			setupIAMMock:          func(_ *awsapi.MockIAMAPI) {},
 			setupVPCOwnerMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+				m.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{RoleName: aws.String(ingressRoleName)}, gomock.Any()).
 					Return(nil, errors.New("api error"))
 			},
 			expectError:   true,
@@ -524,12 +561,12 @@ func TestDestroySharedVPCRoles(t *testing.T) {
 			privateZonesInCluster: false,
 			setupIAMMock:          func(_ *awsapi.MockIAMAPI) {},
 			setupVPCOwnerMock: func(m *awsapi.MockIAMAPI) {
-				// ingress role not found
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				// control-plane role returns API error
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("api error"))
+				gomock.InOrder(
+					m.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{RoleName: aws.String(ingressRoleName)}, gomock.Any()).
+						Return(nil, noSuchEntity()),
+					m.EXPECT().GetRole(gomock.Any(), &iam.GetRoleInput{RoleName: aws.String(cpRoleName)}, gomock.Any()).
+						Return(nil, errors.New("api error")),
+				)
 			},
 			expectError:   true,
 			errorContains: "cannot check for existing role",
@@ -538,6 +575,7 @@ func TestDestroySharedVPCRoles(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 			ctrl := gomock.NewController(t)
 			mockIAM := awsapi.NewMockIAMAPI(ctrl)
 			mockVPCOwner := awsapi.NewMockIAMAPI(ctrl)
@@ -552,16 +590,12 @@ func TestDestroySharedVPCRoles(t *testing.T) {
 			err := o.DestroySharedVPCRoles(context.Background(), mockIAM, mockVPCOwner)
 
 			if tt.expectError {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
-					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				g.Expect(err).To(HaveOccurred())
+				if tt.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tt.errorContains))
 				}
 			} else {
-				if err != nil {
-					t.Errorf("expected no error, got: %v", err)
-				}
+				g.Expect(err).NotTo(HaveOccurred())
 			}
 		})
 	}

--- a/cmd/infra/aws/destroy_iam_test.go
+++ b/cmd/infra/aws/destroy_iam_test.go
@@ -1,0 +1,568 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/openshift/hypershift/support/awsapi"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+
+	"github.com/go-logr/logr"
+	"go.uber.org/mock/gomock"
+)
+
+const testInfraID = "test-infra"
+
+// noSuchEntity returns an IAM NoSuchEntityException for use in mock error responses.
+func noSuchEntity() *iamtypes.NoSuchEntityException {
+	return &iamtypes.NoSuchEntityException{Message: aws.String("no such entity")}
+}
+
+// testRole returns an iamtypes.Role for use in mock GetRole responses.
+func testRole(name string) *iamtypes.Role {
+	return &iamtypes.Role{
+		RoleName: aws.String(name),
+		Arn:      aws.String("arn:aws:iam::123456789012:role/" + name),
+	}
+}
+
+// testInstanceProfile returns an iamtypes.InstanceProfile for use in mock responses.
+func testInstanceProfile(name string, roles ...iamtypes.Role) *iamtypes.InstanceProfile {
+	return &iamtypes.InstanceProfile{
+		InstanceProfileName: aws.String(name),
+		Roles:               roles,
+	}
+}
+
+// destroyIAMOptions returns a DestroyIAMOptions with the shared test infraID.
+func destroyIAMOptions() *DestroyIAMOptions {
+	return &DestroyIAMOptions{
+		InfraID: testInfraID,
+		Log:     logr.Discard(),
+	}
+}
+
+func TestDestroyOIDCRole(t *testing.T) {
+	// roleName produced by the function under test: "<infraID>-<name>"
+	const roleName = testInfraID + "-openshift-ingress"
+
+	tests := []struct {
+		name          string
+		setupMock     func(*awsapi.MockIAMAPI)
+		expectRemoved bool
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "When the role does not exist it should return false without error",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+			},
+			expectRemoved: false,
+		},
+		{
+			name: "When role exists with no policies it should delete it and return true",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil)
+				m.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.ListAttachedRolePoliciesOutput{}, nil)
+				m.EXPECT().ListRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.ListRolePoliciesOutput{PolicyNames: []string{}, IsTruncated: false}, nil)
+				m.EXPECT().DeleteRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.DeleteRoleOutput{}, nil)
+			},
+			expectRemoved: true,
+		},
+		{
+			name: "When role exists with managed and inline policies it should detach and delete all then delete the role",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil)
+				m.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.ListAttachedRolePoliciesOutput{
+						AttachedPolicies: []iamtypes.AttachedPolicy{
+							{PolicyArn: aws.String("arn:aws:iam::aws:policy/ManagedPolicy"), PolicyName: aws.String("ManagedPolicy")},
+						},
+					}, nil)
+				m.EXPECT().DetachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.DetachRolePolicyOutput{}, nil)
+				m.EXPECT().ListRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.ListRolePoliciesOutput{PolicyNames: []string{"inline-policy"}, IsTruncated: false}, nil)
+				m.EXPECT().DeleteRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.DeleteRolePolicyOutput{}, nil)
+				m.EXPECT().DeleteRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.DeleteRoleOutput{}, nil)
+			},
+			expectRemoved: true,
+		},
+		{
+			name: "When inline policy delete returns NoSuchEntityException it should ignore and continue",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil)
+				m.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.ListAttachedRolePoliciesOutput{}, nil)
+				m.EXPECT().ListRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.ListRolePoliciesOutput{PolicyNames: []string{"gone-policy"}, IsTruncated: false}, nil)
+				m.EXPECT().DeleteRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				m.EXPECT().DeleteRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.DeleteRoleOutput{}, nil)
+			},
+			expectRemoved: true,
+		},
+		{
+			name: "When GetRole returns an API error it should return a wrapped error",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("api error"))
+			},
+			expectError:   true,
+			errorContains: "cannot check for existing role",
+		},
+		{
+			name: "When ListAttachedRolePolicies fails it should return the error",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil)
+				m.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("list policies failed"))
+			},
+			expectError:   true,
+			errorContains: "failed to list attached policies",
+		},
+		{
+			name: "When DetachRolePolicy fails it should return the error",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil)
+				m.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.ListAttachedRolePoliciesOutput{
+						AttachedPolicies: []iamtypes.AttachedPolicy{
+							{PolicyArn: aws.String("arn:aws:iam::aws:policy/ManagedPolicy"), PolicyName: aws.String("ManagedPolicy")},
+						},
+					}, nil)
+				m.EXPECT().DetachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("detach failed"))
+			},
+			expectError:   true,
+			errorContains: "failed to detach policy",
+		},
+		{
+			name: "When ListRolePolicies fails it should return the error",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil)
+				m.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.ListAttachedRolePoliciesOutput{}, nil)
+				m.EXPECT().ListRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("list inline failed"))
+			},
+			expectError:   true,
+			errorContains: "failed to list inline policies",
+		},
+		{
+			name: "When DeleteRole fails it should return the error",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil)
+				m.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.ListAttachedRolePoliciesOutput{}, nil)
+				m.EXPECT().ListRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.ListRolePoliciesOutput{PolicyNames: []string{}, IsTruncated: false}, nil)
+				m.EXPECT().DeleteRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("delete role failed"))
+			},
+			expectError:   true,
+			errorContains: "failed to delete role",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockIAM := awsapi.NewMockIAMAPI(ctrl)
+			tt.setupMock(mockIAM)
+
+			o := destroyIAMOptions()
+			removed, err := o.DestroyOIDCRole(context.Background(), mockIAM, "openshift-ingress")
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+				if removed != tt.expectRemoved {
+					t.Errorf("expected removed=%v, got %v", tt.expectRemoved, removed)
+				}
+			}
+		})
+	}
+}
+
+func TestDestroyWorkerInstanceProfile(t *testing.T) {
+	const (
+		profileName    = testInfraID + "-worker"
+		standardRole   = testInfraID + "-worker-role"
+		standardPolicy = testInfraID + "-worker-policy"
+		rosaRole       = testInfraID + "-worker-" + ROSAWorkerRoleNameSuffix
+	)
+
+	tests := []struct {
+		name          string
+		setupMock     func(*awsapi.MockIAMAPI)
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "When no instance profile or worker roles exist it should return nil",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				// existingInstanceProfile
+				m.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				// existingRole for standard role
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				// existingRole for ROSA role
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+			},
+		},
+		{
+			name: "When instance profile with a role exists it should remove the role and delete the profile",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.GetInstanceProfileOutput{
+						InstanceProfile: testInstanceProfile(profileName,
+							iamtypes.Role{RoleName: aws.String("worker-role")},
+						),
+					}, nil)
+				m.EXPECT().RemoveRoleFromInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.RemoveRoleFromInstanceProfileOutput{}, nil)
+				m.EXPECT().DeleteInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.DeleteInstanceProfileOutput{}, nil)
+				// standard role and ROSA role not found
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity()).Times(2)
+			},
+		},
+		{
+			name: "When standard worker role exists with an inline policy it should delete the policy and the role",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				// no instance profile
+				m.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				// standard role exists
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.GetRoleOutput{Role: testRole(standardRole)}, nil)
+				// policy exists
+				m.EXPECT().GetRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.GetRolePolicyOutput{
+						RoleName:   aws.String(standardRole),
+						PolicyName: aws.String(standardPolicy),
+					}, nil)
+				m.EXPECT().DeleteRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.DeleteRolePolicyOutput{}, nil)
+				m.EXPECT().DeleteRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.DeleteRoleOutput{}, nil)
+				// ROSA role not found
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+			},
+		},
+		{
+			name: "When ROSA worker role exists with a managed policy it should detach the policy and delete the role",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				// no instance profile
+				m.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				// standard role not found
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				// ROSA role exists
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.GetRoleOutput{Role: testRole(rosaRole)}, nil)
+				m.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.ListAttachedRolePoliciesOutput{
+						AttachedPolicies: []iamtypes.AttachedPolicy{
+							{PolicyArn: aws.String("arn:aws:iam::aws:policy/ROSAPolicy"), PolicyName: aws.String("ROSAPolicy")},
+						},
+					}, nil)
+				m.EXPECT().DetachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.DetachRolePolicyOutput{}, nil)
+				m.EXPECT().DeleteRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.DeleteRoleOutput{}, nil)
+			},
+		},
+		{
+			name: "When GetInstanceProfile returns an API error it should return the error",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("api error"))
+			},
+			expectError:   true,
+			errorContains: "cannot check for existing instance profile",
+		},
+		{
+			name: "When RemoveRoleFromInstanceProfile fails it should return the error",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.GetInstanceProfileOutput{
+						InstanceProfile: testInstanceProfile(profileName,
+							iamtypes.Role{RoleName: aws.String("worker-role")},
+						),
+					}, nil)
+				m.EXPECT().RemoveRoleFromInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("remove failed"))
+			},
+			expectError:   true,
+			errorContains: "cannot remove role",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockIAM := awsapi.NewMockIAMAPI(ctrl)
+			tt.setupMock(mockIAM)
+
+			o := destroyIAMOptions()
+			err := o.DestroyWorkerInstanceProfile(context.Background(), mockIAM)
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestDestroyOIDCResources(t *testing.T) {
+	// OIDC provider ARN whose last path segment matches testInfraID
+	const matchingARN = "arn:aws:iam::123456789012:oidc-provider/s3.example.com/" + testInfraID
+	const otherARN = "arn:aws:iam::123456789012:oidc-provider/s3.example.com/other-infra"
+
+	tests := []struct {
+		name          string
+		setupMock     func(*awsapi.MockIAMAPI)
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "When OIDC provider matches infraID and shared role exists it should delete the provider and return early",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.ListOpenIDConnectProvidersOutput{
+						OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{
+							{Arn: aws.String(matchingARN)},
+						},
+					}, nil)
+				m.EXPECT().DeleteOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.DeleteOpenIDConnectProviderOutput{}, nil)
+				// DestroyOIDCRole("shared-role") → role found → early return
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.GetRoleOutput{Role: testRole(testInfraID + "-shared-role")}, nil)
+				m.EXPECT().ListAttachedRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.ListAttachedRolePoliciesOutput{}, nil)
+				m.EXPECT().ListRolePolicies(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.ListRolePoliciesOutput{IsTruncated: false}, nil)
+				m.EXPECT().DeleteRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.DeleteRoleOutput{}, nil)
+			},
+		},
+		{
+			name: "When OIDC provider ARN does not match infraID it should skip deletion and proceed with role cleanup",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.ListOpenIDConnectProvidersOutput{
+						OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{
+							{Arn: aws.String(otherARN)},
+						},
+					}, nil)
+				// All role lookups return not found — covers shared-role + 9 component roles
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity()).AnyTimes()
+			},
+		},
+		{
+			name: "When DeleteOpenIDConnectProvider returns NoSuchEntityException it should ignore and continue",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.ListOpenIDConnectProvidersOutput{
+						OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{
+							{Arn: aws.String(matchingARN)},
+						},
+					}, nil)
+				m.EXPECT().DeleteOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				// continues to role cleanup; all roles not found
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity()).AnyTimes()
+			},
+		},
+		{
+			name: "When ListOpenIDConnectProviders fails it should return the error",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("api error"))
+			},
+			expectError:   true,
+			errorContains: "api error",
+		},
+		{
+			name: "When DeleteOpenIDConnectProvider fails with a non-NSE error it should return the error",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.ListOpenIDConnectProvidersOutput{
+						OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{
+							{Arn: aws.String(matchingARN)},
+						},
+					}, nil)
+				m.EXPECT().DeleteOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("permission denied"))
+			},
+			expectError:   true,
+			errorContains: "permission denied",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockIAM := awsapi.NewMockIAMAPI(ctrl)
+			tt.setupMock(mockIAM)
+
+			o := destroyIAMOptions()
+			err := o.DestroyOIDCResources(context.Background(), mockIAM)
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestDestroySharedVPCRoles(t *testing.T) {
+	tests := []struct {
+		name                  string
+		privateZonesInCluster bool
+		setupIAMMock          func(*awsapi.MockIAMAPI)
+		setupVPCOwnerMock     func(*awsapi.MockIAMAPI)
+		expectError           bool
+		errorContains         string
+	}{
+		{
+			name:                  "When PrivateZonesInClusterAccount is false ingress role should use vpcOwnerClient",
+			privateZonesInCluster: false,
+			setupIAMMock:          func(_ *awsapi.MockIAMAPI) {},
+			setupVPCOwnerMock: func(m *awsapi.MockIAMAPI) {
+				// ingress role not found on vpcOwner
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				// control-plane role not found on vpcOwner
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+			},
+		},
+		{
+			name:                  "When PrivateZonesInClusterAccount is true ingress role should use iamClient",
+			privateZonesInCluster: true,
+			setupIAMMock: func(m *awsapi.MockIAMAPI) {
+				// ingress role not found on iamClient
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+			},
+			setupVPCOwnerMock: func(m *awsapi.MockIAMAPI) {
+				// control-plane role not found on vpcOwner
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+			},
+		},
+		{
+			name:                  "When destroying the ingress role fails it should return the error",
+			privateZonesInCluster: false,
+			setupIAMMock:          func(_ *awsapi.MockIAMAPI) {},
+			setupVPCOwnerMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("api error"))
+			},
+			expectError:   true,
+			errorContains: "cannot check for existing role",
+		},
+		{
+			name:                  "When destroying the control-plane role fails it should return the error",
+			privateZonesInCluster: false,
+			setupIAMMock:          func(_ *awsapi.MockIAMAPI) {},
+			setupVPCOwnerMock: func(m *awsapi.MockIAMAPI) {
+				// ingress role not found
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				// control-plane role returns API error
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("api error"))
+			},
+			expectError:   true,
+			errorContains: "cannot check for existing role",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockIAM := awsapi.NewMockIAMAPI(ctrl)
+			mockVPCOwner := awsapi.NewMockIAMAPI(ctrl)
+			tt.setupIAMMock(mockIAM)
+			tt.setupVPCOwnerMock(mockVPCOwner)
+
+			o := &DestroyIAMOptions{
+				InfraID:                      testInfraID,
+				Log:                          logr.Discard(),
+				PrivateZonesInClusterAccount: tt.privateZonesInCluster,
+			}
+			err := o.DestroySharedVPCRoles(context.Background(), mockIAM, mockVPCOwner)
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/cmd/infra/aws/iam_test.go
+++ b/cmd/infra/aws/iam_test.go
@@ -3,8 +3,9 @@ package aws
 import (
 	"context"
 	"errors"
-	"strings"
 	"testing"
+
+	. "github.com/onsi/gomega"
 
 	"github.com/openshift/hypershift/support/awsapi"
 
@@ -53,13 +54,15 @@ func TestCreateRole(t *testing.T) {
 		{
 			name: "When role does not exist it should create it and return new ARN",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.CreateRoleOutput{Role: &iamtypes.Role{
-						RoleName: aws.String(roleName),
-						Arn:      aws.String(roleARN),
-					}}, nil)
+				gomock.InOrder(
+					m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, noSuchEntity()),
+					m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.CreateRoleOutput{Role: &iamtypes.Role{
+							RoleName: aws.String(roleName),
+							Arn:      aws.String(roleARN),
+						}}, nil),
+				)
 			},
 			expectARN: roleARN,
 		},
@@ -75,10 +78,12 @@ func TestCreateRole(t *testing.T) {
 		{
 			name: "When CreateRole fails it should return the error",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("create failed"))
+				gomock.InOrder(
+					m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, noSuchEntity()),
+					m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, errors.New("create failed")),
+				)
 			},
 			expectError:   true,
 			errorContains: "create failed",
@@ -87,6 +92,7 @@ func TestCreateRole(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 			ctrl := gomock.NewController(t)
 			mockIAM := awsapi.NewMockIAMAPI(ctrl)
 			tt.setupMock(mockIAM)
@@ -95,19 +101,13 @@ func TestCreateRole(t *testing.T) {
 			arn, err := o.CreateRole(context.Background(), mockIAM, logr.Discard())
 
 			if tt.expectError {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
-					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				g.Expect(err).To(HaveOccurred())
+				if tt.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tt.errorContains))
 				}
 			} else {
-				if err != nil {
-					t.Errorf("expected no error, got: %v", err)
-				}
-				if arn != tt.expectARN {
-					t.Errorf("expected ARN %q, got %q", tt.expectARN, arn)
-				}
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(arn).To(Equal(tt.expectARN))
 			}
 		})
 	}
@@ -130,48 +130,56 @@ func TestCreateRoleWithInlinePolicy(t *testing.T) {
 		{
 			name: "When role does not exist it should create it and put inline policy",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.CreateRoleOutput{Role: testRole(roleName)}, nil)
-				m.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.PutRolePolicyOutput{}, nil)
+				gomock.InOrder(
+					m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, noSuchEntity()),
+					m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.CreateRoleOutput{Role: testRole(roleName)}, nil),
+					m.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.PutRolePolicyOutput{}, nil),
+				)
 			},
-			expectARN: "arn:aws:iam::123456789012:role/" + roleName,
+			expectARN: roleARN,
 		},
 		{
 			name: "When role already exists it should skip creation and still put inline policy",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil)
-				m.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.PutRolePolicyOutput{}, nil)
+				gomock.InOrder(
+					m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil),
+					m.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.PutRolePolicyOutput{}, nil),
+				)
 			},
-			expectARN: "arn:aws:iam::123456789012:role/" + roleName,
+			expectARN: roleARN,
 		},
 		{
 			name:        "When AllowAssume is true it should also put the assume role inline policy",
 			allowAssume: true,
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.CreateRoleOutput{Role: testRole(roleName)}, nil)
-				// inline permissions policy + assume policy
-				m.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.PutRolePolicyOutput{}, nil).Times(2)
+				gomock.InOrder(
+					m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, noSuchEntity()),
+					m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.CreateRoleOutput{Role: testRole(roleName)}, nil),
+					// inline permissions policy + assume policy
+					m.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.PutRolePolicyOutput{}, nil).Times(2),
+				)
 			},
-			expectARN: "arn:aws:iam::123456789012:role/" + roleName,
+			expectARN: roleARN,
 		},
 		{
 			name: "When PutRolePolicy fails it should return the error",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.CreateRoleOutput{Role: testRole(roleName)}, nil)
-				m.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("put policy failed"))
+				gomock.InOrder(
+					m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, noSuchEntity()),
+					m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.CreateRoleOutput{Role: testRole(roleName)}, nil),
+					m.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, errors.New("put policy failed")),
+				)
 			},
 			expectError:   true,
 			errorContains: "put policy failed",
@@ -180,6 +188,7 @@ func TestCreateRoleWithInlinePolicy(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 			ctrl := gomock.NewController(t)
 			mockIAM := awsapi.NewMockIAMAPI(ctrl)
 			tt.setupMock(mockIAM)
@@ -193,19 +202,13 @@ func TestCreateRoleWithInlinePolicy(t *testing.T) {
 			arn, err := o.CreateRoleWithInlinePolicy(context.Background(), mockIAM, logr.Discard())
 
 			if tt.expectError {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
-					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				g.Expect(err).To(HaveOccurred())
+				if tt.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tt.errorContains))
 				}
 			} else {
-				if err != nil {
-					t.Errorf("expected no error, got: %v", err)
-				}
-				if arn != tt.expectARN {
-					t.Errorf("expected ARN %q, got %q", tt.expectARN, arn)
-				}
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(arn).To(Equal(tt.expectARN))
 			}
 		})
 	}
@@ -228,12 +231,14 @@ func TestCreateRoleWithManagedPolicy(t *testing.T) {
 		{
 			name: "When role does not exist it should create it and attach managed policy",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.CreateRoleOutput{Role: testRole(roleName)}, nil)
-				m.EXPECT().AttachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.AttachRolePolicyOutput{}, nil)
+				gomock.InOrder(
+					m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, noSuchEntity()),
+					m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.CreateRoleOutput{Role: testRole(roleName)}, nil),
+					m.EXPECT().AttachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.AttachRolePolicyOutput{}, nil),
+				)
 			},
 			expectARN: "arn:aws:iam::123456789012:role/" + roleName,
 		},
@@ -241,36 +246,42 @@ func TestCreateRoleWithManagedPolicy(t *testing.T) {
 			name:        "When AllowAssume is true it should also put the assume role inline policy",
 			allowAssume: true,
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.CreateRoleOutput{Role: testRole(roleName)}, nil)
-				m.EXPECT().AttachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.AttachRolePolicyOutput{}, nil)
-				m.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.PutRolePolicyOutput{}, nil)
+				gomock.InOrder(
+					m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, noSuchEntity()),
+					m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.CreateRoleOutput{Role: testRole(roleName)}, nil),
+					m.EXPECT().AttachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.AttachRolePolicyOutput{}, nil),
+					m.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.PutRolePolicyOutput{}, nil),
+				)
 			},
 			expectARN: "arn:aws:iam::123456789012:role/" + roleName,
 		},
 		{
 			name: "When role already exists it should skip creation and attach managed policy",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil)
-				m.EXPECT().AttachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.AttachRolePolicyOutput{}, nil)
+				gomock.InOrder(
+					m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil),
+					m.EXPECT().AttachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.AttachRolePolicyOutput{}, nil),
+				)
 			},
 			expectARN: "arn:aws:iam::123456789012:role/" + roleName,
 		},
 		{
 			name: "When AttachRolePolicy fails it should return the error",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.CreateRoleOutput{Role: testRole(roleName)}, nil)
-				m.EXPECT().AttachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("attach failed"))
+				gomock.InOrder(
+					m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, noSuchEntity()),
+					m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.CreateRoleOutput{Role: testRole(roleName)}, nil),
+					m.EXPECT().AttachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, errors.New("attach failed")),
+				)
 			},
 			expectError:   true,
 			errorContains: "attach failed",
@@ -279,6 +290,7 @@ func TestCreateRoleWithManagedPolicy(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 			ctrl := gomock.NewController(t)
 			mockIAM := awsapi.NewMockIAMAPI(ctrl)
 			tt.setupMock(mockIAM)
@@ -291,19 +303,13 @@ func TestCreateRoleWithManagedPolicy(t *testing.T) {
 			arn, err := o.CreateRoleWithManagedPolicy(context.Background(), mockIAM, managedPolicyARN, logr.Discard())
 
 			if tt.expectError {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
-					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				g.Expect(err).To(HaveOccurred())
+				if tt.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tt.errorContains))
 				}
 			} else {
-				if err != nil {
-					t.Errorf("expected no error, got: %v", err)
-				}
-				if arn != tt.expectARN {
-					t.Errorf("expected ARN %q, got %q", tt.expectARN, arn)
-				}
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(arn).To(Equal(tt.expectARN))
 			}
 		})
 	}
@@ -328,32 +334,36 @@ func TestCreateOIDCProvider(t *testing.T) {
 		{
 			name: "When no existing provider matches it should create and return the new ARN",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.ListOpenIDConnectProvidersOutput{
-						OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{},
-					}, nil)
-				m.EXPECT().CreateOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.CreateOpenIDConnectProviderOutput{
-						OpenIDConnectProviderArn: aws.String(newARN),
-					}, nil)
+				gomock.InOrder(
+					m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.ListOpenIDConnectProvidersOutput{
+							OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{},
+						}, nil),
+					m.EXPECT().CreateOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.CreateOpenIDConnectProviderOutput{
+							OpenIDConnectProviderArn: aws.String(newARN),
+						}, nil),
+				)
 			},
 			expectARN: newARN,
 		},
 		{
 			name: "When an existing provider matches the issuer URL it should delete it then create a new one",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.ListOpenIDConnectProvidersOutput{
-						OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{
-							{Arn: aws.String(matchingARN)},
-						},
-					}, nil)
-				m.EXPECT().DeleteOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.DeleteOpenIDConnectProviderOutput{}, nil)
-				m.EXPECT().CreateOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.CreateOpenIDConnectProviderOutput{
-						OpenIDConnectProviderArn: aws.String(newARN),
-					}, nil)
+				gomock.InOrder(
+					m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.ListOpenIDConnectProvidersOutput{
+							OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{
+								{Arn: aws.String(matchingARN)},
+							},
+						}, nil),
+					m.EXPECT().DeleteOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.DeleteOpenIDConnectProviderOutput{}, nil),
+					m.EXPECT().CreateOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.CreateOpenIDConnectProviderOutput{
+							OpenIDConnectProviderArn: aws.String(newARN),
+						}, nil),
+				)
 			},
 			expectARN: newARN,
 		},
@@ -369,14 +379,16 @@ func TestCreateOIDCProvider(t *testing.T) {
 		{
 			name: "When DeleteOpenIDConnectProvider fails it should return the error",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.ListOpenIDConnectProvidersOutput{
-						OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{
-							{Arn: aws.String(matchingARN)},
-						},
-					}, nil)
-				m.EXPECT().DeleteOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("delete failed"))
+				gomock.InOrder(
+					m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.ListOpenIDConnectProvidersOutput{
+							OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{
+								{Arn: aws.String(matchingARN)},
+							},
+						}, nil),
+					m.EXPECT().DeleteOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, errors.New("delete failed")),
+				)
 			},
 			expectError:   true,
 			errorContains: "delete failed",
@@ -384,10 +396,12 @@ func TestCreateOIDCProvider(t *testing.T) {
 		{
 			name: "When CreateOpenIDConnectProvider fails it should return the error",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.ListOpenIDConnectProvidersOutput{}, nil)
-				m.EXPECT().CreateOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("create failed"))
+				gomock.InOrder(
+					m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.ListOpenIDConnectProvidersOutput{}, nil),
+					m.EXPECT().CreateOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, errors.New("create failed")),
+				)
 			},
 			expectError:   true,
 			errorContains: "create failed",
@@ -396,6 +410,7 @@ func TestCreateOIDCProvider(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 			ctrl := gomock.NewController(t)
 			mockIAM := awsapi.NewMockIAMAPI(ctrl)
 			tt.setupMock(mockIAM)
@@ -404,19 +419,13 @@ func TestCreateOIDCProvider(t *testing.T) {
 			arn, err := o.CreateOIDCProvider(context.Background(), mockIAM, logr.Discard())
 
 			if tt.expectError {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
-					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				g.Expect(err).To(HaveOccurred())
+				if tt.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tt.errorContains))
 				}
 			} else {
-				if err != nil {
-					t.Errorf("expected no error, got: %v", err)
-				}
-				if arn != tt.expectARN {
-					t.Errorf("expected ARN %q, got %q", tt.expectARN, arn)
-				}
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(arn).To(Equal(tt.expectARN))
 			}
 		})
 	}
@@ -438,80 +447,88 @@ func TestCreateWorkerInstanceProfile(t *testing.T) {
 		{
 			name: "When role and profile do not exist it should create both and put inline policy",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				// existingRole → not found → CreateRole
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.CreateRoleOutput{Role: testRole(standardRoleName)}, nil)
-				// existingInstanceProfile → not found → CreateInstanceProfile
-				m.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				m.EXPECT().CreateInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.CreateInstanceProfileOutput{
-						InstanceProfile: testInstanceProfile(profileName), // no roles yet
-					}, nil)
-				// role not yet in profile → AddRoleToInstanceProfile
-				m.EXPECT().AddRoleToInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.AddRoleToInstanceProfileOutput{}, nil)
-				// existingRolePolicy → not found → PutRolePolicy
-				m.EXPECT().GetRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				m.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.PutRolePolicyOutput{}, nil)
+				gomock.InOrder(
+					// existingRole → not found → CreateRole
+					m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, noSuchEntity()),
+					m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.CreateRoleOutput{Role: testRole(standardRoleName)}, nil),
+					// existingInstanceProfile → not found → CreateInstanceProfile
+					m.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, noSuchEntity()),
+					m.EXPECT().CreateInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.CreateInstanceProfileOutput{
+							InstanceProfile: testInstanceProfile(profileName), // no roles yet
+						}, nil),
+					// role not yet in profile → AddRoleToInstanceProfile
+					m.EXPECT().AddRoleToInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.AddRoleToInstanceProfileOutput{}, nil),
+					// existingRolePolicy → not found → PutRolePolicy
+					m.EXPECT().GetRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, noSuchEntity()),
+					m.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.PutRolePolicyOutput{}, nil),
+				)
 			},
 		},
 		{
 			name: "When role and profile already exist and role is already in profile it should skip all creates",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				// role exists
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.GetRoleOutput{Role: testRole(standardRoleName)}, nil)
-				// profile exists and already has the role
-				m.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.GetInstanceProfileOutput{
-						InstanceProfile: testInstanceProfile(profileName,
-							iamtypes.Role{RoleName: aws.String(standardRoleName)},
-						),
-					}, nil)
-				// policy exists
-				m.EXPECT().GetRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.GetRolePolicyOutput{
-						PolicyName: aws.String(policyName),
-						RoleName:   aws.String(standardRoleName),
-					}, nil)
+				gomock.InOrder(
+					// role exists
+					m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.GetRoleOutput{Role: testRole(standardRoleName)}, nil),
+					// profile exists and already has the role
+					m.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.GetInstanceProfileOutput{
+							InstanceProfile: testInstanceProfile(profileName,
+								iamtypes.Role{RoleName: aws.String(standardRoleName)},
+							),
+						}, nil),
+					// policy exists
+					m.EXPECT().GetRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.GetRolePolicyOutput{
+							PolicyName: aws.String(policyName),
+							RoleName:   aws.String(standardRoleName),
+						}, nil),
+				)
 			},
 		},
 		{
 			name:                   "When UseROSAManagedPolicies is true it should use ROSA role name and attach managed policy",
 			useROSAManagedPolicies: true,
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				// existingRole for ROSA role name → not found → CreateRole
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.CreateRoleOutput{Role: testRole(rosaRoleName)}, nil)
-				// existingInstanceProfile → not found → CreateInstanceProfile
-				m.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				m.EXPECT().CreateInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.CreateInstanceProfileOutput{
-						InstanceProfile: testInstanceProfile(profileName),
-					}, nil)
-				// role not in profile → AddRoleToInstanceProfile
-				m.EXPECT().AddRoleToInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.AddRoleToInstanceProfileOutput{}, nil)
-				// ROSA path: AttachRolePolicy instead of PutRolePolicy
-				m.EXPECT().AttachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.AttachRolePolicyOutput{}, nil)
+				gomock.InOrder(
+					// existingRole for ROSA role name → not found → CreateRole
+					m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, noSuchEntity()),
+					m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.CreateRoleOutput{Role: testRole(rosaRoleName)}, nil),
+					// existingInstanceProfile → not found → CreateInstanceProfile
+					m.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, noSuchEntity()),
+					m.EXPECT().CreateInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.CreateInstanceProfileOutput{
+							InstanceProfile: testInstanceProfile(profileName),
+						}, nil),
+					// role not in profile → AddRoleToInstanceProfile
+					m.EXPECT().AddRoleToInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.AddRoleToInstanceProfileOutput{}, nil),
+					// ROSA path: AttachRolePolicy instead of PutRolePolicy
+					m.EXPECT().AttachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.AttachRolePolicyOutput{}, nil),
+				)
 			},
 		},
 		{
 			name: "When CreateRole fails it should return the error",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("create role failed"))
+				gomock.InOrder(
+					m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, noSuchEntity()),
+					m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, errors.New("create role failed")),
+				)
 			},
 			expectError:   true,
 			errorContains: "cannot create worker role",
@@ -519,14 +536,16 @@ func TestCreateWorkerInstanceProfile(t *testing.T) {
 		{
 			name: "When CreateInstanceProfile fails it should return the error",
 			setupMock: func(m *awsapi.MockIAMAPI) {
-				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(&iam.CreateRoleOutput{Role: testRole(standardRoleName)}, nil)
-				m.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, noSuchEntity())
-				m.EXPECT().CreateInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("create profile failed"))
+				gomock.InOrder(
+					m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, noSuchEntity()),
+					m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.CreateRoleOutput{Role: testRole(standardRoleName)}, nil),
+					m.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, noSuchEntity()),
+					m.EXPECT().CreateInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil, errors.New("create profile failed")),
+				)
 			},
 			expectError:   true,
 			errorContains: "cannot create instance profile",
@@ -535,6 +554,7 @@ func TestCreateWorkerInstanceProfile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 			ctrl := gomock.NewController(t)
 			mockIAM := awsapi.NewMockIAMAPI(ctrl)
 			tt.setupMock(mockIAM)
@@ -546,16 +566,12 @@ func TestCreateWorkerInstanceProfile(t *testing.T) {
 			err := o.CreateWorkerInstanceProfile(context.Background(), mockIAM, profileName, logr.Discard())
 
 			if tt.expectError {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
-					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				g.Expect(err).To(HaveOccurred())
+				if tt.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tt.errorContains))
 				}
 			} else {
-				if err != nil {
-					t.Errorf("expected no error, got: %v", err)
-				}
+				g.Expect(err).NotTo(HaveOccurred())
 			}
 		})
 	}
@@ -581,10 +597,9 @@ func TestEnsureHostedZonePrefix(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 			got := ensureHostedZonePrefix(tt.input)
-			if got != tt.expectOut {
-				t.Errorf("expected %q, got %q", tt.expectOut, got)
-			}
+			g.Expect(got).To(Equal(tt.expectOut))
 		})
 	}
 }

--- a/cmd/infra/aws/iam_test.go
+++ b/cmd/infra/aws/iam_test.go
@@ -1,0 +1,590 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/openshift/hypershift/support/awsapi"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+
+	"github.com/go-logr/logr"
+	"go.uber.org/mock/gomock"
+)
+
+const testIssuerURL = "https://s3.example.com/" + testInfraID
+
+// createIAMOptions returns a CreateIAMOptions with shared test defaults.
+func createIAMOptions() *CreateIAMOptions {
+	return &CreateIAMOptions{
+		InfraID:   testInfraID,
+		IssuerURL: testIssuerURL,
+	}
+}
+
+func TestCreateRole(t *testing.T) {
+	const (
+		roleName = "test-role"
+		roleARN  = "arn:aws:iam::123456789012:role/" + roleName
+	)
+
+	tests := []struct {
+		name          string
+		setupMock     func(*awsapi.MockIAMAPI)
+		expectARN     string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "When role already exists it should return existing ARN without calling CreateRole",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.GetRoleOutput{Role: &iamtypes.Role{
+						RoleName: aws.String(roleName),
+						Arn:      aws.String(roleARN),
+					}}, nil)
+			},
+			expectARN: roleARN,
+		},
+		{
+			name: "When role does not exist it should create it and return new ARN",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.CreateRoleOutput{Role: &iamtypes.Role{
+						RoleName: aws.String(roleName),
+						Arn:      aws.String(roleARN),
+					}}, nil)
+			},
+			expectARN: roleARN,
+		},
+		{
+			name: "When GetRole returns an API error it should return the error",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("api error"))
+			},
+			expectError:   true,
+			errorContains: "api error",
+		},
+		{
+			name: "When CreateRole fails it should return the error",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("create failed"))
+			},
+			expectError:   true,
+			errorContains: "create failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockIAM := awsapi.NewMockIAMAPI(ctrl)
+			tt.setupMock(mockIAM)
+
+			o := &CreateIAMRoleOptions{RoleName: roleName, TrustPolicy: "{}"}
+			arn, err := o.CreateRole(context.Background(), mockIAM, logr.Discard())
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+				if arn != tt.expectARN {
+					t.Errorf("expected ARN %q, got %q", tt.expectARN, arn)
+				}
+			}
+		})
+	}
+}
+
+func TestCreateRoleWithInlinePolicy(t *testing.T) {
+	const (
+		roleName = "test-role"
+		roleARN  = "arn:aws:iam::123456789012:role/" + roleName
+	)
+
+	tests := []struct {
+		name          string
+		allowAssume   bool
+		setupMock     func(*awsapi.MockIAMAPI)
+		expectARN     string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "When role does not exist it should create it and put inline policy",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.CreateRoleOutput{Role: testRole(roleName)}, nil)
+				m.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.PutRolePolicyOutput{}, nil)
+			},
+			expectARN: "arn:aws:iam::123456789012:role/" + roleName,
+		},
+		{
+			name: "When role already exists it should skip creation and still put inline policy",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil)
+				m.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.PutRolePolicyOutput{}, nil)
+			},
+			expectARN: "arn:aws:iam::123456789012:role/" + roleName,
+		},
+		{
+			name:        "When AllowAssume is true it should also put the assume role inline policy",
+			allowAssume: true,
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.CreateRoleOutput{Role: testRole(roleName)}, nil)
+				// inline permissions policy + assume policy
+				m.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.PutRolePolicyOutput{}, nil).Times(2)
+			},
+			expectARN: "arn:aws:iam::123456789012:role/" + roleName,
+		},
+		{
+			name: "When PutRolePolicy fails it should return the error",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.CreateRoleOutput{Role: testRole(roleName)}, nil)
+				m.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("put policy failed"))
+			},
+			expectError:   true,
+			errorContains: "put policy failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockIAM := awsapi.NewMockIAMAPI(ctrl)
+			tt.setupMock(mockIAM)
+
+			o := &CreateIAMRoleOptions{
+				RoleName:          roleName,
+				TrustPolicy:       "{}",
+				PermissionsPolicy: "{}",
+				AllowAssume:       tt.allowAssume,
+			}
+			arn, err := o.CreateRoleWithInlinePolicy(context.Background(), mockIAM, logr.Discard())
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+				if arn != tt.expectARN {
+					t.Errorf("expected ARN %q, got %q", tt.expectARN, arn)
+				}
+			}
+		})
+	}
+}
+
+func TestCreateRoleWithManagedPolicy(t *testing.T) {
+	const (
+		roleName         = "test-role"
+		managedPolicyARN = "arn:aws:iam::aws:policy/ManagedTestPolicy"
+	)
+
+	tests := []struct {
+		name          string
+		allowAssume   bool
+		setupMock     func(*awsapi.MockIAMAPI)
+		expectARN     string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "When role does not exist it should create it and attach managed policy",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.CreateRoleOutput{Role: testRole(roleName)}, nil)
+				m.EXPECT().AttachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.AttachRolePolicyOutput{}, nil)
+			},
+			expectARN: "arn:aws:iam::123456789012:role/" + roleName,
+		},
+		{
+			name:        "When AllowAssume is true it should also put the assume role inline policy",
+			allowAssume: true,
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.CreateRoleOutput{Role: testRole(roleName)}, nil)
+				m.EXPECT().AttachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.AttachRolePolicyOutput{}, nil)
+				m.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.PutRolePolicyOutput{}, nil)
+			},
+			expectARN: "arn:aws:iam::123456789012:role/" + roleName,
+		},
+		{
+			name: "When role already exists it should skip creation and attach managed policy",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.GetRoleOutput{Role: testRole(roleName)}, nil)
+				m.EXPECT().AttachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.AttachRolePolicyOutput{}, nil)
+			},
+			expectARN: "arn:aws:iam::123456789012:role/" + roleName,
+		},
+		{
+			name: "When AttachRolePolicy fails it should return the error",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.CreateRoleOutput{Role: testRole(roleName)}, nil)
+				m.EXPECT().AttachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("attach failed"))
+			},
+			expectError:   true,
+			errorContains: "attach failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockIAM := awsapi.NewMockIAMAPI(ctrl)
+			tt.setupMock(mockIAM)
+
+			o := &CreateIAMRoleOptions{
+				RoleName:    roleName,
+				TrustPolicy: "{}",
+				AllowAssume: tt.allowAssume,
+			}
+			arn, err := o.CreateRoleWithManagedPolicy(context.Background(), mockIAM, managedPolicyARN, logr.Discard())
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+				if arn != tt.expectARN {
+					t.Errorf("expected ARN %q, got %q", tt.expectARN, arn)
+				}
+			}
+		})
+	}
+}
+
+func TestCreateOIDCProvider(t *testing.T) {
+	// providerName is the URL without "https://" prefix — used for ARN matching.
+	const (
+		providerName = "s3.example.com/" + testInfraID
+		// matchingARN contains providerName so the production code treats it as existing.
+		matchingARN = "arn:aws:iam::123456789012:oidc-provider/" + providerName
+		newARN      = "arn:aws:iam::123456789012:oidc-provider/" + providerName + "-new"
+	)
+
+	tests := []struct {
+		name          string
+		setupMock     func(*awsapi.MockIAMAPI)
+		expectARN     string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "When no existing provider matches it should create and return the new ARN",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.ListOpenIDConnectProvidersOutput{
+						OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{},
+					}, nil)
+				m.EXPECT().CreateOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.CreateOpenIDConnectProviderOutput{
+						OpenIDConnectProviderArn: aws.String(newARN),
+					}, nil)
+			},
+			expectARN: newARN,
+		},
+		{
+			name: "When an existing provider matches the issuer URL it should delete it then create a new one",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.ListOpenIDConnectProvidersOutput{
+						OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{
+							{Arn: aws.String(matchingARN)},
+						},
+					}, nil)
+				m.EXPECT().DeleteOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.DeleteOpenIDConnectProviderOutput{}, nil)
+				m.EXPECT().CreateOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.CreateOpenIDConnectProviderOutput{
+						OpenIDConnectProviderArn: aws.String(newARN),
+					}, nil)
+			},
+			expectARN: newARN,
+		},
+		{
+			name: "When ListOpenIDConnectProviders fails it should return the error",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("api error"))
+			},
+			expectError:   true,
+			errorContains: "api error",
+		},
+		{
+			name: "When DeleteOpenIDConnectProvider fails it should return the error",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.ListOpenIDConnectProvidersOutput{
+						OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{
+							{Arn: aws.String(matchingARN)},
+						},
+					}, nil)
+				m.EXPECT().DeleteOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("delete failed"))
+			},
+			expectError:   true,
+			errorContains: "delete failed",
+		},
+		{
+			name: "When CreateOpenIDConnectProvider fails it should return the error",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.ListOpenIDConnectProvidersOutput{}, nil)
+				m.EXPECT().CreateOpenIDConnectProvider(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("create failed"))
+			},
+			expectError:   true,
+			errorContains: "create failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockIAM := awsapi.NewMockIAMAPI(ctrl)
+			tt.setupMock(mockIAM)
+
+			o := createIAMOptions()
+			arn, err := o.CreateOIDCProvider(context.Background(), mockIAM, logr.Discard())
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+				if arn != tt.expectARN {
+					t.Errorf("expected ARN %q, got %q", tt.expectARN, arn)
+				}
+			}
+		})
+	}
+}
+
+func TestCreateWorkerInstanceProfile(t *testing.T) {
+	const profileName = testInfraID + "-worker"
+	const standardRoleName = profileName + "-role"
+	const policyName = profileName + "-policy"
+	const rosaRoleName = profileName + "-" + ROSAWorkerRoleNameSuffix
+
+	tests := []struct {
+		name                   string
+		useROSAManagedPolicies bool
+		setupMock              func(*awsapi.MockIAMAPI)
+		expectError            bool
+		errorContains          string
+	}{
+		{
+			name: "When role and profile do not exist it should create both and put inline policy",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				// existingRole → not found → CreateRole
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.CreateRoleOutput{Role: testRole(standardRoleName)}, nil)
+				// existingInstanceProfile → not found → CreateInstanceProfile
+				m.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				m.EXPECT().CreateInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.CreateInstanceProfileOutput{
+						InstanceProfile: testInstanceProfile(profileName), // no roles yet
+					}, nil)
+				// role not yet in profile → AddRoleToInstanceProfile
+				m.EXPECT().AddRoleToInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.AddRoleToInstanceProfileOutput{}, nil)
+				// existingRolePolicy → not found → PutRolePolicy
+				m.EXPECT().GetRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				m.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.PutRolePolicyOutput{}, nil)
+			},
+		},
+		{
+			name: "When role and profile already exist and role is already in profile it should skip all creates",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				// role exists
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.GetRoleOutput{Role: testRole(standardRoleName)}, nil)
+				// profile exists and already has the role
+				m.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.GetInstanceProfileOutput{
+						InstanceProfile: testInstanceProfile(profileName,
+							iamtypes.Role{RoleName: aws.String(standardRoleName)},
+						),
+					}, nil)
+				// policy exists
+				m.EXPECT().GetRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.GetRolePolicyOutput{
+						PolicyName: aws.String(policyName),
+						RoleName:   aws.String(standardRoleName),
+					}, nil)
+			},
+		},
+		{
+			name:                   "When UseROSAManagedPolicies is true it should use ROSA role name and attach managed policy",
+			useROSAManagedPolicies: true,
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				// existingRole for ROSA role name → not found → CreateRole
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.CreateRoleOutput{Role: testRole(rosaRoleName)}, nil)
+				// existingInstanceProfile → not found → CreateInstanceProfile
+				m.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				m.EXPECT().CreateInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.CreateInstanceProfileOutput{
+						InstanceProfile: testInstanceProfile(profileName),
+					}, nil)
+				// role not in profile → AddRoleToInstanceProfile
+				m.EXPECT().AddRoleToInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.AddRoleToInstanceProfileOutput{}, nil)
+				// ROSA path: AttachRolePolicy instead of PutRolePolicy
+				m.EXPECT().AttachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.AttachRolePolicyOutput{}, nil)
+			},
+		},
+		{
+			name: "When CreateRole fails it should return the error",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("create role failed"))
+			},
+			expectError:   true,
+			errorContains: "cannot create worker role",
+		},
+		{
+			name: "When CreateInstanceProfile fails it should return the error",
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.CreateRoleOutput{Role: testRole(standardRoleName)}, nil)
+				m.EXPECT().GetInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, noSuchEntity())
+				m.EXPECT().CreateInstanceProfile(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("create profile failed"))
+			},
+			expectError:   true,
+			errorContains: "cannot create instance profile",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockIAM := awsapi.NewMockIAMAPI(ctrl)
+			tt.setupMock(mockIAM)
+
+			o := &CreateIAMOptions{
+				InfraID:                testInfraID,
+				UseROSAManagedPolicies: tt.useROSAManagedPolicies,
+			}
+			err := o.CreateWorkerInstanceProfile(context.Background(), mockIAM, profileName, logr.Discard())
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestEnsureHostedZonePrefix(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		expectOut string
+	}{
+		{
+			name:      "When hostedZone lacks prefix it should prepend hostedzone/",
+			input:     "Z1234567890ABC",
+			expectOut: "hostedzone/Z1234567890ABC",
+		},
+		{
+			name:      "When hostedZone already has prefix it should return it unchanged",
+			input:     "hostedzone/Z1234567890ABC",
+			expectOut: "hostedzone/Z1234567890ABC",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ensureHostedZonePrefix(tt.input)
+			if got != tt.expectOut {
+				t.Errorf("expected %q, got %q", tt.expectOut, got)
+			}
+		})
+	}
+}

--- a/cmd/infra/aws/route53_test.go
+++ b/cmd/infra/aws/route53_test.go
@@ -1,0 +1,565 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/openshift/hypershift/support/awsapi"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+
+	"github.com/go-logr/logr"
+	"go.uber.org/mock/gomock"
+)
+
+// cancelledCtx returns a pre-canceled context. Used to prevent
+// retryRoute53WithBackoff from sleeping between retries in error test cases.
+func cancelledCtx() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return ctx
+}
+
+const (
+	testZoneName   = "internal.example.com"
+	testBaseDomain = "example.com"
+	testCluster    = "mycluster"
+	testVPCID      = "vpc-12345"
+	testInitialVPC = "vpc-initial"
+	// validSOAValue is a 7-field SOA record value as required by setSOAMinimum.
+	validSOAValue = "ns-1.awsdns-1.org. hostmaster.example.com. 1 7200 900 1209600 86400"
+)
+
+// soaRecordFor returns a mock ListResourceRecordSets response containing a
+// single SOA record for the given zone name.
+func soaRecordFor(name string) *route53.ListResourceRecordSetsOutput {
+	return &route53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: []route53types.ResourceRecordSet{
+			{
+				Name: aws.String(name + "."),
+				Type: route53types.RRTypeSoa,
+				ResourceRecords: []route53types.ResourceRecord{
+					{Value: aws.String(validSOAValue)},
+				},
+			},
+		},
+	}
+}
+
+// publicZonePage returns a single-page ListHostedZones response with one public zone.
+func publicZonePage(id, name string) *route53.ListHostedZonesOutput {
+	return &route53.ListHostedZonesOutput{
+		HostedZones: []route53types.HostedZone{
+			{
+				Id:     aws.String("/hostedzone/" + id),
+				Name:   aws.String(name + "."),
+				Config: &route53types.HostedZoneConfig{PrivateZone: false},
+			},
+		},
+	}
+}
+
+// privateZonePage returns a single-page ListHostedZones response with one private zone.
+func privateZonePage(id, name string) *route53.ListHostedZonesOutput {
+	return &route53.ListHostedZonesOutput{
+		HostedZones: []route53types.HostedZone{
+			{
+				Id:     aws.String("/hostedzone/" + id),
+				Name:   aws.String(name + "."),
+				Config: &route53types.HostedZoneConfig{PrivateZone: true},
+			},
+		},
+	}
+}
+
+// emptyZonePage returns a single-page ListHostedZones response with no zones.
+func emptyZonePage() *route53.ListHostedZonesOutput {
+	return &route53.ListHostedZonesOutput{HostedZones: []route53types.HostedZone{}}
+}
+
+func TestLookupPublicZone(t *testing.T) {
+	tests := []struct {
+		name        string
+		baseDomain  string
+		redact      bool
+		setupMock   func(*awsapi.MockROUTE53API)
+		expectID    string
+		expectError bool
+		useCtx      func() context.Context
+	}{
+		{
+			name:       "When the public zone exists it should return its ID",
+			baseDomain: testBaseDomain,
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListHostedZones(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(publicZonePage("PUBZONE", testBaseDomain), nil)
+			},
+			expectID: "PUBZONE",
+		},
+		{
+			name:       "When the zone API call fails it should return an error",
+			baseDomain: testBaseDomain,
+			useCtx:     cancelledCtx,
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListHostedZones(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("api error"))
+			},
+			expectError: true,
+		},
+		{
+			name:       "When redact is true and zone lookup fails it should return error without logging the domain",
+			baseDomain: "secret.example.com",
+			redact:     true,
+			useCtx:     cancelledCtx,
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListHostedZones(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("api error"))
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockR53 := awsapi.NewMockROUTE53API(ctrl)
+			tt.setupMock(mockR53)
+
+			ctx := context.Background()
+			if tt.useCtx != nil {
+				ctx = tt.useCtx()
+			}
+
+			o := &CreateInfraOptions{BaseDomain: tt.baseDomain, RedactBaseDomain: tt.redact}
+			id, err := o.LookupPublicZone(ctx, logr.Discard(), mockR53)
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+				if id != tt.expectID {
+					t.Errorf("expected zone ID %q, got %q", tt.expectID, id)
+				}
+			}
+		})
+	}
+}
+
+func TestCreatePrivateZone(t *testing.T) {
+	tests := []struct {
+		name              string
+		zoneName          string
+		vpcID             string
+		authorizeAssoc    bool
+		initialVPC        string
+		setupMock         func(*awsapi.MockROUTE53API)
+		setupVPCOwnerMock func(*awsapi.MockROUTE53API)
+		expectID          string
+		expectError       bool
+		errorContains     string
+		useCtx            func() context.Context
+	}{
+		{
+			name:     "When the private zone already exists it should update the SOA minimum and return its ID",
+			zoneName: testZoneName,
+			vpcID:    testVPCID,
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				// LookupZone finds the existing zone
+				m.EXPECT().ListHostedZones(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(privateZonePage("EXISTZONE", testZoneName), nil)
+				// setSOAMinimum: findRecord + update
+				m.EXPECT().ListResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(soaRecordFor(testZoneName), nil)
+				m.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&route53.ChangeResourceRecordSetsOutput{}, nil)
+			},
+			setupVPCOwnerMock: func(_ *awsapi.MockROUTE53API) {},
+			expectID:          "EXISTZONE",
+		},
+		{
+			name:     "When the private zone does not exist it should create it and return the new ID",
+			zoneName: testZoneName,
+			vpcID:    testVPCID,
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				// LookupZone finds no zone
+				m.EXPECT().ListHostedZones(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(emptyZonePage(), nil)
+				// CreateHostedZone
+				m.EXPECT().CreateHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&route53.CreateHostedZoneOutput{
+						HostedZone: &route53types.HostedZone{
+							Id:   aws.String("/hostedzone/NEWZONE"),
+							Name: aws.String(testZoneName + "."),
+						},
+					}, nil)
+				// setSOAMinimum: findRecord + update
+				m.EXPECT().ListResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(soaRecordFor(testZoneName), nil)
+				m.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&route53.ChangeResourceRecordSetsOutput{}, nil)
+			},
+			setupVPCOwnerMock: func(_ *awsapi.MockROUTE53API) {},
+			expectID:          "NEWZONE",
+		},
+		{
+			name:           "When authorizeAssociation is true it should wire cross-account VPC association and return the ID",
+			zoneName:       testZoneName,
+			vpcID:          testVPCID,
+			authorizeAssoc: true,
+			initialVPC:     testInitialVPC,
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListHostedZones(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(emptyZonePage(), nil)
+				m.EXPECT().CreateHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&route53.CreateHostedZoneOutput{
+						HostedZone: &route53types.HostedZone{
+							Id:   aws.String("/hostedzone/AUTHZONE"),
+							Name: aws.String(testZoneName + "."),
+						},
+					}, nil)
+				m.EXPECT().ListResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(soaRecordFor(testZoneName), nil)
+				m.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&route53.ChangeResourceRecordSetsOutput{}, nil)
+				m.EXPECT().CreateVPCAssociationAuthorization(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&route53.CreateVPCAssociationAuthorizationOutput{}, nil)
+				m.EXPECT().DisassociateVPCFromHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&route53.DisassociateVPCFromHostedZoneOutput{}, nil)
+			},
+			setupVPCOwnerMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().AssociateVPCWithHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&route53.AssociateVPCWithHostedZoneOutput{}, nil)
+			},
+			expectID: "AUTHZONE",
+		},
+		{
+			name:     "When CreateHostedZone fails it should return a wrapped error",
+			zoneName: testZoneName,
+			vpcID:    testVPCID,
+			useCtx:   cancelledCtx,
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListHostedZones(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(emptyZonePage(), nil)
+				m.EXPECT().CreateHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("create failed"))
+			},
+			setupVPCOwnerMock: func(_ *awsapi.MockROUTE53API) {},
+			expectError:       true,
+			errorContains:     "failed to create hosted zone",
+		},
+		{
+			name:     "When setSOAMinimum fails on an existing zone it should return an error",
+			zoneName: testZoneName,
+			vpcID:    testVPCID,
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListHostedZones(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(privateZonePage("EXISTZONE", testZoneName), nil)
+				// setSOAMinimum → findRecord fails
+				m.EXPECT().ListResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("records error"))
+			},
+			setupVPCOwnerMock: func(_ *awsapi.MockROUTE53API) {},
+			expectError:       true,
+			errorContains:     "records error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockR53 := awsapi.NewMockROUTE53API(ctrl)
+			mockVPCOwner := awsapi.NewMockROUTE53API(ctrl)
+			tt.setupMock(mockR53)
+			tt.setupVPCOwnerMock(mockVPCOwner)
+
+			ctx := context.Background()
+			if tt.useCtx != nil {
+				ctx = tt.useCtx()
+			}
+
+			o := &CreateInfraOptions{Region: "us-east-1"}
+			id, err := o.CreatePrivateZone(ctx, logr.Discard(), mockR53, tt.zoneName, tt.vpcID, tt.authorizeAssoc, mockVPCOwner, tt.initialVPC)
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+				if id != tt.expectID {
+					t.Errorf("expected zone ID %q, got %q", tt.expectID, id)
+				}
+			}
+		})
+	}
+}
+
+func TestCleanupPublicZone(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMock     func(*awsapi.MockROUTE53API)
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "When zone and wildcard record exist it should delete the record and return nil",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListHostedZones(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(publicZonePage("PUBZONE", testBaseDomain), nil)
+				m.EXPECT().ListResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&route53.ListResourceRecordSetsOutput{
+						ResourceRecordSets: []route53types.ResourceRecordSet{
+							{
+								Name: aws.String("*.apps." + testCluster + "." + testBaseDomain + "."),
+								Type: route53types.RRTypeA,
+							},
+						},
+					}, nil)
+				m.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&route53.ChangeResourceRecordSetsOutput{}, nil)
+			},
+		},
+		{
+			name: "When the zone is not found it should return nil as a no-op",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListHostedZones(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(emptyZonePage(), nil)
+			},
+		},
+		{
+			name: "When the wildcard record is not found it should ignore the error and return nil",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListHostedZones(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(publicZonePage("PUBZONE", testBaseDomain), nil)
+				m.EXPECT().ListResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&route53.ListResourceRecordSetsOutput{
+						ResourceRecordSets: []route53types.ResourceRecordSet{},
+					}, nil)
+			},
+		},
+		{
+			name: "When ChangeResourceRecordSets fails with a non-404 error it should return the error",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListHostedZones(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(publicZonePage("PUBZONE", testBaseDomain), nil)
+				m.EXPECT().ListResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&route53.ListResourceRecordSetsOutput{
+						ResourceRecordSets: []route53types.ResourceRecordSet{
+							{
+								Name: aws.String("*.apps." + testCluster + "." + testBaseDomain + "."),
+								Type: route53types.RRTypeA,
+							},
+						},
+					}, nil)
+				m.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("permission denied"))
+			},
+			expectError:   true,
+			errorContains: "failed to delete wildcard record",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockR53 := awsapi.NewMockROUTE53API(ctrl)
+			tt.setupMock(mockR53)
+
+			o := &DestroyInfraOptions{
+				BaseDomain: testBaseDomain,
+				Name:       testCluster,
+				Log:        logr.Discard(),
+			}
+			err := o.CleanupPublicZone(context.Background(), mockR53)
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestDestroyDNS(t *testing.T) {
+	tests := []struct {
+		name           string
+		setupMock      func(*awsapi.MockROUTE53API)
+		expectErrCount int
+	}{
+		{
+			name: "When zone exists but wildcard record is absent it should return no errors",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListHostedZones(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(publicZonePage("PUBZONE", testBaseDomain), nil)
+				// wildcard record not found — CleanupPublicZone treats this as a no-op
+				m.EXPECT().ListResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&route53.ListResourceRecordSetsOutput{
+						ResourceRecordSets: []route53types.ResourceRecordSet{},
+					}, nil)
+			},
+			expectErrCount: 0,
+		},
+		{
+			name: "When CleanupPublicZone fails it should return the error",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListHostedZones(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(publicZonePage("PUBZONE", testBaseDomain), nil)
+				m.EXPECT().ListResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&route53.ListResourceRecordSetsOutput{
+						ResourceRecordSets: []route53types.ResourceRecordSet{
+							{
+								Name: aws.String("*.apps." + testCluster + "." + testBaseDomain + "."),
+								Type: route53types.RRTypeA,
+							},
+						},
+					}, nil)
+				m.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("permission denied"))
+			},
+			expectErrCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockR53 := awsapi.NewMockROUTE53API(ctrl)
+			tt.setupMock(mockR53)
+
+			o := &DestroyInfraOptions{
+				BaseDomain: testBaseDomain,
+				Name:       testCluster,
+				Log:        logr.Discard(),
+			}
+			errs := o.DestroyDNS(context.Background(), mockR53)
+
+			nonNilErrs := 0
+			for _, e := range errs {
+				if e != nil {
+					nonNilErrs++
+				}
+			}
+			if nonNilErrs != tt.expectErrCount {
+				t.Errorf("expected %d errors, got %d: %v", tt.expectErrCount, nonNilErrs, errs)
+			}
+		})
+	}
+}
+
+func TestDestroyPrivateZones(t *testing.T) {
+	tests := []struct {
+		name           string
+		setupListMock  func(*awsapi.MockROUTE53API)
+		setupRecsMock  func(*awsapi.MockROUTE53API)
+		expectErrCount int
+		useCtx         func() context.Context
+	}{
+		{
+			name: "When private zones exist it should delete them and return no errors",
+			setupListMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListHostedZonesByVPC(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&route53.ListHostedZonesByVPCOutput{
+						HostedZoneSummaries: []route53types.HostedZoneSummary{
+							{
+								HostedZoneId: aws.String("/hostedzone/PRIVZONE"),
+								Name:         aws.String(testZoneName + "."),
+							},
+						},
+					}, nil)
+			},
+			setupRecsMock: func(m *awsapi.MockROUTE53API) {
+				// deleteRecords: no deletable records
+				m.EXPECT().ListResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&route53.ListResourceRecordSetsOutput{
+						ResourceRecordSets: []route53types.ResourceRecordSet{},
+					}, nil)
+				m.EXPECT().DeleteHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&route53.DeleteHostedZoneOutput{}, nil)
+			},
+			expectErrCount: 0,
+		},
+		{
+			name: "When no private zones exist it should return no errors",
+			setupListMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListHostedZonesByVPC(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&route53.ListHostedZonesByVPCOutput{
+						HostedZoneSummaries: []route53types.HostedZoneSummary{},
+					}, nil)
+			},
+			setupRecsMock:  func(_ *awsapi.MockROUTE53API) {},
+			expectErrCount: 0,
+		},
+		{
+			name:   "When ListHostedZonesByVPC fails it should return the error",
+			useCtx: cancelledCtx,
+			setupListMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListHostedZonesByVPC(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("list failed"))
+			},
+			setupRecsMock:  func(_ *awsapi.MockROUTE53API) {},
+			expectErrCount: 1,
+		},
+		{
+			name: "When deleteZone fails it should return the error",
+			setupListMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListHostedZonesByVPC(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&route53.ListHostedZonesByVPCOutput{
+						HostedZoneSummaries: []route53types.HostedZoneSummary{
+							{
+								HostedZoneId: aws.String("/hostedzone/PRIVZONE"),
+								Name:         aws.String(testZoneName + "."),
+							},
+						},
+					}, nil)
+			},
+			setupRecsMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errors.New("records error"))
+			},
+			expectErrCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockListClient := awsapi.NewMockROUTE53API(ctrl)
+			mockRecsClient := awsapi.NewMockROUTE53API(ctrl)
+			tt.setupListMock(mockListClient)
+			tt.setupRecsMock(mockRecsClient)
+
+			ctx := context.Background()
+			if tt.useCtx != nil {
+				ctx = tt.useCtx()
+			}
+
+			o := &DestroyInfraOptions{Region: "us-east-1", Log: logr.Discard()}
+			errs := o.DestroyPrivateZones(ctx, mockListClient, mockRecsClient, testVPCID)
+
+			if len(errs) != tt.expectErrCount {
+				t.Errorf("expected %d errors, got %d: %v", tt.expectErrCount, len(errs), errs)
+			}
+		})
+	}
+}

--- a/cmd/infra/aws/route53_test.go
+++ b/cmd/infra/aws/route53_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	"github.com/openshift/hypershift/support/awsapi"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -13,6 +15,7 @@ import (
 	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
 
 	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
 	"go.uber.org/mock/gomock"
 )
 
@@ -125,6 +128,7 @@ func TestLookupPublicZone(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 			ctrl := gomock.NewController(t)
 			mockR53 := awsapi.NewMockROUTE53API(ctrl)
 			tt.setupMock(mockR53)
@@ -134,20 +138,24 @@ func TestLookupPublicZone(t *testing.T) {
 				ctx = tt.useCtx()
 			}
 
+			var logBuf strings.Builder
+			logger := funcr.New(func(prefix, args string) {
+				logBuf.WriteString(prefix + args + "\n")
+			}, funcr.Options{})
+
 			o := &CreateInfraOptions{BaseDomain: tt.baseDomain, RedactBaseDomain: tt.redact}
-			id, err := o.LookupPublicZone(ctx, logr.Discard(), mockR53)
+			id, err := o.LookupPublicZone(ctx, logger, mockR53)
 
 			if tt.expectError {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
+				g.Expect(err).To(HaveOccurred())
 			} else {
-				if err != nil {
-					t.Errorf("expected no error, got: %v", err)
-				}
-				if id != tt.expectID {
-					t.Errorf("expected zone ID %q, got %q", tt.expectID, id)
-				}
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(id).To(Equal(tt.expectID))
+			}
+
+			if tt.redact {
+				g.Expect(err.Error()).NotTo(ContainSubstring(tt.baseDomain))
+				g.Expect(logBuf.String()).NotTo(ContainSubstring(tt.baseDomain))
 			}
 		})
 	}
@@ -403,9 +411,10 @@ func TestCleanupPublicZone(t *testing.T) {
 
 func TestDestroyDNS(t *testing.T) {
 	tests := []struct {
-		name           string
-		setupMock      func(*awsapi.MockROUTE53API)
-		expectErrCount int
+		name          string
+		setupMock     func(*awsapi.MockROUTE53API)
+		expectError   bool
+		errorContains string
 	}{
 		{
 			name: "When zone exists but wildcard record is absent it should return no errors",
@@ -418,7 +427,6 @@ func TestDestroyDNS(t *testing.T) {
 						ResourceRecordSets: []route53types.ResourceRecordSet{},
 					}, nil)
 			},
-			expectErrCount: 0,
 		},
 		{
 			name: "When CleanupPublicZone fails it should return the error",
@@ -437,12 +445,14 @@ func TestDestroyDNS(t *testing.T) {
 				m.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, errors.New("permission denied"))
 			},
-			expectErrCount: 1,
+			expectError:   true,
+			errorContains: "failed to delete wildcard record",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 			ctrl := gomock.NewController(t)
 			mockR53 := awsapi.NewMockROUTE53API(ctrl)
 			tt.setupMock(mockR53)
@@ -454,14 +464,13 @@ func TestDestroyDNS(t *testing.T) {
 			}
 			errs := o.DestroyDNS(context.Background(), mockR53)
 
-			nonNilErrs := 0
-			for _, e := range errs {
-				if e != nil {
-					nonNilErrs++
+			if tt.expectError {
+				g.Expect(errs).To(ContainElement(HaveOccurred()))
+				if tt.errorContains != "" {
+					g.Expect(errs).To(ContainElement(MatchError(ContainSubstring(tt.errorContains))))
 				}
-			}
-			if nonNilErrs != tt.expectErrCount {
-				t.Errorf("expected %d errors, got %d: %v", tt.expectErrCount, nonNilErrs, errs)
+			} else {
+				g.Expect(errs).To(HaveEach(BeNil()))
 			}
 		})
 	}
@@ -469,11 +478,12 @@ func TestDestroyDNS(t *testing.T) {
 
 func TestDestroyPrivateZones(t *testing.T) {
 	tests := []struct {
-		name           string
-		setupListMock  func(*awsapi.MockROUTE53API)
-		setupRecsMock  func(*awsapi.MockROUTE53API)
-		expectErrCount int
-		useCtx         func() context.Context
+		name          string
+		setupListMock func(*awsapi.MockROUTE53API)
+		setupRecsMock func(*awsapi.MockROUTE53API)
+		expectError   bool
+		errorContains string
+		useCtx        func() context.Context
 	}{
 		{
 			name: "When private zones exist it should delete them and return no errors",
@@ -497,7 +507,6 @@ func TestDestroyPrivateZones(t *testing.T) {
 				m.EXPECT().DeleteHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(&route53.DeleteHostedZoneOutput{}, nil)
 			},
-			expectErrCount: 0,
 		},
 		{
 			name: "When no private zones exist it should return no errors",
@@ -507,8 +516,7 @@ func TestDestroyPrivateZones(t *testing.T) {
 						HostedZoneSummaries: []route53types.HostedZoneSummary{},
 					}, nil)
 			},
-			setupRecsMock:  func(_ *awsapi.MockROUTE53API) {},
-			expectErrCount: 0,
+			setupRecsMock: func(_ *awsapi.MockROUTE53API) {},
 		},
 		{
 			name:   "When ListHostedZonesByVPC fails it should return the error",
@@ -517,8 +525,9 @@ func TestDestroyPrivateZones(t *testing.T) {
 				m.EXPECT().ListHostedZonesByVPC(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, errors.New("list failed"))
 			},
-			setupRecsMock:  func(_ *awsapi.MockROUTE53API) {},
-			expectErrCount: 1,
+			setupRecsMock: func(_ *awsapi.MockROUTE53API) {},
+			expectError:   true,
+			errorContains: "failed to list hosted zones for vpc",
 		},
 		{
 			name: "When deleteZone fails it should return the error",
@@ -537,12 +546,14 @@ func TestDestroyPrivateZones(t *testing.T) {
 				m.EXPECT().ListResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, errors.New("records error"))
 			},
-			expectErrCount: 1,
+			expectError:   true,
+			errorContains: "failed to delete private hosted zones for vpc",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 			ctrl := gomock.NewController(t)
 			mockListClient := awsapi.NewMockROUTE53API(ctrl)
 			mockRecsClient := awsapi.NewMockROUTE53API(ctrl)
@@ -557,8 +568,13 @@ func TestDestroyPrivateZones(t *testing.T) {
 			o := &DestroyInfraOptions{Region: "us-east-1", Log: logr.Discard()}
 			errs := o.DestroyPrivateZones(ctx, mockListClient, mockRecsClient, testVPCID)
 
-			if len(errs) != tt.expectErrCount {
-				t.Errorf("expected %d errors, got %d: %v", tt.expectErrCount, len(errs), errs)
+			if tt.expectError {
+				g.Expect(errs).To(ContainElement(HaveOccurred()))
+				if tt.errorContains != "" {
+					g.Expect(errs).To(ContainElement(MatchError(ContainSubstring(tt.errorContains))))
+				}
+			} else {
+				g.Expect(errs).To(BeEmpty())
 			}
 		})
 	}

--- a/control-plane-operator/controllers/awsprivatelink/route53_test.go
+++ b/control-plane-operator/controllers/awsprivatelink/route53_test.go
@@ -1,0 +1,261 @@
+package awsprivatelink
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/openshift/hypershift/support/awsapi"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+	"github.com/aws/smithy-go"
+
+	"go.uber.org/mock/gomock"
+)
+
+// testAPIError implements smithy.APIError for testing.
+type testAPIError struct {
+	code string
+}
+
+func (e *testAPIError) Error() string                 { return e.code }
+func (e *testAPIError) ErrorCode() string             { return e.code }
+func (e *testAPIError) ErrorMessage() string          { return e.code }
+func (e *testAPIError) ErrorFault() smithy.ErrorFault { return smithy.FaultUnknown }
+
+func TestFindRecord(t *testing.T) {
+	const (
+		recordName = "test.example.com"
+		recordType = route53types.RRTypeA
+	)
+
+	tests := []struct {
+		name          string
+		setupMock     func(*awsapi.MockROUTE53API)
+		expectNil     bool
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "When record exists with matching name and type it should return the record set",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.ListResourceRecordSetsOutput{
+						ResourceRecordSets: []route53types.ResourceRecordSet{
+							{
+								Name: aws.String("test.example.com."),
+								Type: route53types.RRTypeA,
+							},
+						},
+					}, nil,
+				)
+			},
+		},
+		{
+			name: "When no records are returned it should return nil without error",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.ListResourceRecordSetsOutput{
+						ResourceRecordSets: []route53types.ResourceRecordSet{},
+					}, nil,
+				)
+			},
+			expectNil: true,
+		},
+		{
+			name: "When returned record name does not match it should return nil without error",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.ListResourceRecordSetsOutput{
+						ResourceRecordSets: []route53types.ResourceRecordSet{
+							{
+								Name: aws.String("other.example.com."),
+								Type: route53types.RRTypeA,
+							},
+						},
+					}, nil,
+				)
+			},
+			expectNil: true,
+		},
+		{
+			name: "When returned record type does not match it should return nil without error",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.ListResourceRecordSetsOutput{
+						ResourceRecordSets: []route53types.ResourceRecordSet{
+							{
+								Name: aws.String("test.example.com."),
+								Type: route53types.RRTypeCname,
+							},
+						},
+					}, nil,
+				)
+			},
+			expectNil: true,
+		},
+		{
+			name: "When API returns an error it should propagate the error",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					nil, errors.New("api error"),
+				)
+			},
+			expectNil:     true,
+			expectError:   true,
+			errorContains: "api error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockR53 := awsapi.NewMockROUTE53API(ctrl)
+			tt.setupMock(mockR53)
+
+			result, err := FindRecord(context.Background(), mockR53, "ZONE123", recordName, recordType)
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+			}
+			if tt.expectNil && result != nil {
+				t.Errorf("expected nil result, got: %+v", result)
+			}
+			if !tt.expectNil && !tt.expectError && result == nil {
+				t.Error("expected non-nil result, got nil")
+			}
+		})
+	}
+}
+
+func TestCreateRecord(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMock     func(*awsapi.MockROUTE53API)
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "When ChangeResourceRecordSets succeeds it should return nil",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.ChangeResourceRecordSetsOutput{}, nil,
+				)
+			},
+			expectError: false,
+		},
+		{
+			name: "When API returns a smithy error it should return the error code as the error message",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					nil, &testAPIError{code: "NoSuchHostedZone"},
+				)
+			},
+			expectError:   true,
+			errorContains: "NoSuchHostedZone",
+		},
+		{
+			name: "When API returns a non-smithy error it should propagate the original error",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					nil, errors.New("network error"),
+				)
+			},
+			expectError:   true,
+			errorContains: "network error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockR53 := awsapi.NewMockROUTE53API(ctrl)
+			tt.setupMock(mockR53)
+
+			err := CreateRecord(context.Background(), mockR53, "ZONE123", "test.example.com", "10.0.0.1", route53types.RRTypeA)
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestDeleteRecord(t *testing.T) {
+	record := &route53types.ResourceRecordSet{
+		Name: aws.String("test.example.com."),
+		Type: route53types.RRTypeA,
+		TTL:  aws.Int64(300),
+	}
+
+	tests := []struct {
+		name          string
+		setupMock     func(*awsapi.MockROUTE53API)
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "When ChangeResourceRecordSets succeeds it should return nil",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.ChangeResourceRecordSetsOutput{}, nil,
+				)
+			},
+			expectError: false,
+		},
+		{
+			name: "When ChangeResourceRecordSets fails it should propagate the error",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					nil, errors.New("delete failed"),
+				)
+			},
+			expectError:   true,
+			errorContains: "delete failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockR53 := awsapi.NewMockROUTE53API(ctrl)
+			tt.setupMock(mockR53)
+
+			err := DeleteRecord(context.Background(), mockR53, "ZONE123", record)
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:
add unit tests for AWS Route53 and IAM

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes [CNTRLPLANE-2056](https://redhat.atlassian.net/browse/CNTRLPLANE-2056)

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive Route53 tests for public/private hosted zone lookup, SOA updates, wildcard record cleanup, DNS destroy semantics, and aggregated error handling.
  * Added private-link Route53 tests for record find/create/delete behaviors and API-error propagation.
  * Added extensive IAM tests covering role and instance-profile create/destroy flows, policy attach/detach, OIDC provider handling, shared VPC role teardown, and related error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->