### PR TITLE
docs: update for controlPlaneVersion CP/DP version tracking

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -205,8 +205,8 @@ namespace and when ready it will look similar to the following:
 
 ```
 oc get --namespace clusters hostedclusters
-NAME      VERSION   KUBECONFIG                 PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
-example   4.12.0    example-admin-kubeconfig   Completed   True        False         The hosted control plane is available
+NAME      VERSION   CP VERSION   KUBECONFIG                 PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
+example   4.12.0    4.12.0       example-admin-kubeconfig   Completed   True        False         The hosted control plane is available
 
 oc get nodepools --namespace clusters
 NAME                 CLUSTER   DESIRED NODES   CURRENT NODES   AUTOSCALING   AUTOREPAIR   VERSION   UPDATINGVERSION   UPDATINGCONFIG   MESSAGE

--- a/docs/content/how-to/automated-machine-management/nodepool-lifecycle.md
+++ b/docs/content/how-to/automated-machine-management/nodepool-lifecycle.md
@@ -22,7 +22,7 @@ For a comprehensive reference on what triggers a rollout, upgrade strategies, ro
 
 ### Upgrading to a new OCP version
 
-These upgrades can be triggered via changing the `spec.release.image` of the NodePool. Note that you should only upgrade NodePools to the current version of the Hosted Control Plane.
+These upgrades can be triggered via changing the `spec.release.image` of the NodePool. Note that you should only upgrade NodePools to the current version of the Hosted Control Plane. You can check the control plane rollout status via `status.controlPlaneVersion` on the HostedCluster to determine which versions are currently active. See [Control Plane Version Status](../../how-to/upgrades.md#control-plane-version-status) for details.
 
 ### Adding a new MachineConfig
 

--- a/docs/content/how-to/kubevirt/create-kubevirt-cluster.md
+++ b/docs/content/how-to/kubevirt/create-kubevirt-cluster.md
@@ -126,8 +126,8 @@ reflects what a fully provisioned HostedCluster object looks like.
 
 oc get --namespace clusters hostedclusters
 
-NAME            VERSION   KUBECONFIG                       PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
-example         4.14.0    example-admin-kubeconfig         Completed  True        False         The hosted control plane is available
+NAME            VERSION   CP VERSION   KUBECONFIG                       PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
+example         4.14.0    4.14.0       example-admin-kubeconfig         Completed  True        False         The hosted control plane is available
 ```
 
 ## Accessing the HostedCluster

--- a/docs/content/how-to/kubevirt/ingress-and-dns.md
+++ b/docs/content/how-to/kubevirt/ingress-and-dns.md
@@ -71,8 +71,8 @@ This time, the HostedCluster will not finish the deployment (will remain in `Par
 ```shell linenums="1"
 oc get --namespace clusters hostedclusters
 
-NAME            VERSION   KUBECONFIG                       PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
-example                   example-admin-kubeconfig         Partial    True        False         The hosted control plane is available
+NAME            VERSION   CP VERSION   KUBECONFIG                       PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
+example                                example-admin-kubeconfig         Partial    True        False         The hosted control plane is available
 ```
 
 If we access the HostedCluster this is what we will see:
@@ -168,8 +168,8 @@ Now that we fixed the ingress, we should see our HostedCluster progress moved fr
 ```shell linenums="1"
 oc get --namespace clusters hostedclusters
 
-NAME            VERSION   KUBECONFIG                       PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
-example         4.14.0    example-admin-kubeconfig         Completed   True        False         The hosted control plane is available
+NAME            VERSION   CP VERSION   KUBECONFIG                       PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
+example         4.14.0    4.14.0       example-admin-kubeconfig         Completed   True        False         The hosted control plane is available
 ```
 
 ## Optional MetalLB Configuration Steps

--- a/docs/content/how-to/none/create-none-cluster.md
+++ b/docs/content/how-to/none/create-none-cluster.md
@@ -405,8 +405,8 @@ version             False       True          3h46m   Unable to apply 4.9.17: so
 
 ~~~sh
 oc get hostedcluster -n clusters hosted0
-NAME      VERSION   KUBECONFIG                 PROGRESS    AVAILABLE   REASON
-hosted0   4.9.17    hosted0-admin-kubeconfig   Completed   True        HostedClusterAsExpected
+NAME      VERSION   CP VERSION   KUBECONFIG                 PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
+hosted0   4.9.17    4.9.17       hosted0-admin-kubeconfig   Completed   True        False         HostedClusterAsExpected
 
 KUBECONFIG=./hosted0-kubeconfig oc get co
 NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE

--- a/docs/content/how-to/openstack/hostedcluster.md
+++ b/docs/content/how-to/openstack/hostedcluster.md
@@ -176,8 +176,8 @@ To know whether the HostedCluster is healthy, you can verify with this command:
 ```shell
 oc get --namespace clusters hostedclusters
 
-NAME            VERSION   KUBECONFIG                       PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
-example         4.17.0    example-admin-kubeconfig         Completed  True        False         The hosted control plane is available
+NAME            VERSION   CP VERSION   KUBECONFIG                       PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
+example         4.17.0    4.17.0       example-admin-kubeconfig         Completed  True        False         The hosted control plane is available
 ```
 
 ## Scaling an existing NodePool

--- a/docs/content/how-to/upgrades.md
+++ b/docs/content/how-to/upgrades.md
@@ -3,30 +3,111 @@ HyperShift enables the decoupling of upgrades between the Control Plane and Node
 
 This allows there to be two separate procedures a [Cluster Service Provider](../reference/concepts-and-personas.md#personas) can take, giving them flexibility to manage the different components separately.
 
-Control Plane upgrades are driven by the HostedCluster, while Node upgrades are driven by its respective NodePool. Both the HostedCluster and NodePool expose a `.release` field where the OCP release image can be specified.
+Control Plane upgrades are driven by the HostedCluster, while Node upgrades are driven by its respective NodePool. Both the HostedCluster and NodePool expose a `.spec.release` field where the OCP release image can be specified.
 
-For a cluster to keep fully operational during an upgrade process, Control Plane and Nodes upgrades need to be orchestrated while satisfying [Kubernetes version skew policy](https://kubernetes.io/releases/version-skew-policy/) at any time. The supported OCP versions are dictated by the running HyperShift Operator [see here](../reference/versioning-support.md) for more details on versioning.
+For a cluster to remain fully operational during an upgrade process, Control Plane and Node upgrades need to be orchestrated while satisfying [Kubernetes version skew policy](https://kubernetes.io/releases/version-skew-policy/) at any time. The supported OCP versions are dictated by the running HyperShift Operator [see here](../reference/versioning-support.md) for more details on versioning.
 
 ## HostedCluster
 `.spec.release` dictates the version of the Control Plane.
 
 The HostedCluster propagates the intended `.spec.release` to the `HostedControlPlane.spec.release` and runs the appropriate Control Plane Operator version.
 
-The HostedControlPlane orchestrates the rollout of the new version of the Control Plane components along with any OCP component in the data plane through the new version of the [cluster version operator (CVO)](https://github.com/openshift/cluster-version-operator). This includes resources like:
+The upgrade is carried out by two operators working on different sides:
 
-- the CVO itself
-- cluster network operator (CNO)
-- cluster ingress operator
-- manifests for the kube API-server (KAS), scheduler, and manager
-- machine approver
-- autoscaler
-- infra resources needed to enable ingress for control plane endpoints (KAS, ignition, konnectivity, etc.)
+- The **Control Plane Operator (CPO)** deploys management-side control plane components into the HCP namespace on the management cluster. These are represented by `ControlPlaneComponent` custom resources and include components like kube-apiserver, etcd, kube-controller-manager, kube-scheduler, and openshift-apiserver.
+- The **[Cluster Version Operator (CVO)](https://github.com/openshift/cluster-version-operator)** also runs in the HCP namespace on the management cluster but manages the data-plane rollout -applying the OCP payload to the hosted cluster for data-plane components like OVN pods and console. Their rollout depends on NodePool compute availability.
 
-The CVO also applies the payload for the `CLUSTER_PROFILE": "ibm-cloud-managed` into the hosted cluster.
+Traditionally, in standalone OCP, the CVO has been the sole source of truth for upgrades. In HyperShift, the responsibility is split between CPO and CVO. This split enabled the flexibility and speed the HyperShift project needed for the CPO to support the management/guest cluster topology and the multiple customizations needed for manifests that otherwise would have needed to be segregated in the payload.
 
-Traditionally, in standalone OCP, the CVO has been the sole source of truth for upgrades. In HyperShift, the responsibility is currently split between CPO and CVO. This enabled the flexibility and speed the HyperShift project needed for the CPO to support the management/guest cluster topology and the multiple customizations needed for manifests that otherwise would have needed to be segregated in the payload.
+HyperShift exposes available upgrades in `HostedCluster.Status` by bubbling up the status of the `ClusterVersion` resource inside the hosted cluster. While HCP is authoritative over upgrades, it does honour the CVO's `ClusterVersionUpgradeable` condition at a higher layer: z-stream upgrades are allowed regardless, but y-stream upgrades are blocked unless overridden via the `hypershift.openshift.io/force-upgrade-to` annotation on the HostedCluster. Some of the builtin CVO features like recommendations and allowed upgrade paths are not directly surfaced, but the underlying information is still available in the `HostedCluster.Status` field for consumers to read.
 
-HyperShift exposes available upgrades in HostedCluster.Status by bubbling up the status of the ClusterVersion resource inside a hosted cluster. This info is purely informational and doesn't determine upgradability, which is dictated by the `.spec.release` input in practice. This does result in the loss of some of the builtin features and guardrails from CVO like recommendations, allowed upgrade paths, risks, etc. However, this information is still available in the HostedCluster.Status field for consumers to read.
+### Understanding Version Tracking: Control Plane vs Data Plane
+
+When `.spec.release` is updated on a HostedCluster, two separate rollouts happen on two different sides:
+
+- **Control plane (CP)** -management-side components represented by `ControlPlaneComponent` resources in the HCP namespace (kube-apiserver, etcd, kube-controller-manager, kube-scheduler, openshift-apiserver, etc.). Deployed by the CPO. These typically complete first.
+- **Data plane (DP)** -workloads running on guest cluster worker nodes (OVN pods, console, etc.). Managed by the CVO (which itself runs in the HCP namespace). Their rollout depends on NodePool compute availability.
+
+These rollouts complete independently. The control plane can finish while the data plane is still progressing -or may even complete when no worker nodes exist at all (zero-compute clusters). Tracking them separately enables service providers to confirm CVE patches are applied to management-side components, track upgrade completion for fleet-management decisions, and compute NodePool version skew -all without waiting for the data-plane rollout to finish.
+
+!!! warning "Known limitation"
+
+    Some management-side components (notably OVN) currently have data-plane dependencies that can block the control plane version from reaching `Completed`. This means `controlPlaneVersion` may remain `Partial` due to data-plane issues even though the control plane components themselves are ready. This limitation is being actively resolved -each component is responsible for removing its own data-plane dependencies so that its management-side rollout can complete independently.
+
+When `ControlPlaneReleaseImage` is set on the HostedControlPlane spec, the control plane and data plane may use different release images. In this case, `controlPlaneVersion.desired` and `version.desired` will show different versions -this is expected and reflects the intentional split.
+
+HyperShift tracks each rollout separately in the HostedCluster status:
+
+| Status field | Tracks | Managed by | Shown as |
+|---|---|---|---|
+| `status.version` | Data-plane rollout | CVO | `VERSION` and `PROGRESS` columns |
+| `status.controlPlaneVersion` | Control-plane rollout | CPO | `CP VERSION` column |
+
+Both fields contain a `history` list where the newest entry is first, with state `Completed` or `Partial`.
+
+### Control Plane Version Status
+
+The `status.controlPlaneVersion` field exists on both `HostedCluster` and `HostedControlPlane`.
+
+!!! note
+
+    This field is populated by the control plane operator once it begins reconciling. It will be absent from the resource status on newly created clusters until the first reconciliation completes, and on clusters managed by older operator versions that do not support this field.
+
+The field contains:
+
+- **`desired`** -a release object describing what the control plane is reconciling towards. It contains:
+    - `version`: the semantic version string (e.g. "4.18.5").
+    - `image`: the release image pullspec.
+- **`history`** -a list of version transitions (newest first, minimum 1 entry when present, capped at 100). Each entry has:
+    - `state`: `Completed` (all `ControlPlaneComponent` resources report the target version) or `Partial` (rollout not yet fully applied).
+    - `startedTime`: when the rollout started.
+    - `completionTime`: when the rollout finished (only set for `Completed` entries).
+    - `version`: the semantic version string (e.g. "4.18.5").
+    - `image`: the release image pullspec.
+- **`observedGeneration`** -reports which generation of the `HostedControlPlane` spec is being synced. On the `HostedCluster`, this value is propagated from the underlying `HostedControlPlane`.
+
+#### Understanding the `Partial` State
+
+A `Partial` state means the rollout has not yet fully completed -one or more `ControlPlaneComponent` resources have not reached the target version. This can indicate either an in-progress rollout or a stalled one. To distinguish the two:
+
+- Check the `HostedControlPlane` conditions (e.g. `Progressing`, `Degraded`) for signals about whether the rollout is still making progress or has encountered errors.
+- A rollout that remains `Partial` for an extended period without progress in component conditions likely requires operator investigation.
+
+If `.spec.release` is changed back to a previous version (rollback), a new history entry is prepended for the rollback target, and the previously `Partial` entry remains in history.
+
+### Monitoring Upgrade Progress
+
+The `HostedCluster` printer columns surface both CP and DP version status:
+
+```
+oc get --namespace clusters hostedclusters
+NAME    VERSION   CP VERSION   KUBECONFIG                 PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
+my-hc   4.18.5    4.18.5       my-hc-admin-kubeconfig     Completed   True        False         The hosted control plane is available
+```
+
+| Column | What it shows |
+|---|---|
+| `VERSION` | Most recent completed data-plane version (from CVO) |
+| `CP VERSION` | Most recent completed control-plane version (from CPO) |
+| `PROGRESS` | Data-plane rollout state (latest entry) |
+
+During an in-progress upgrade, `CP VERSION` may already show the new version while `VERSION` still reflects the previous one -this is normal and means the control plane finished first.
+
+On newly created clusters, both `CP VERSION` and `VERSION` will be blank until their respective rollouts complete. The `Available` condition can be `True` before version columns are populated -`Available` reflects API server readiness, not full rollout completion.
+
+With `-o wide`, two additional columns appear:
+
+- `CP Progress` (Control Plane): the state of the latest control-plane history entry.
+- `DP Progress` (Data Plane): the state of the latest data-plane history entry.
+
+### Use Cases
+
+- **CVE verification**: Confirm that a security patch has been applied to all management-side control plane components by checking `status.controlPlaneVersion.history[0].state == "Completed"`, without waiting for the full data-plane rollout to finish.
+- **Upgrade completion tracking**: Track control plane upgrade completion independently from the data plane, enabling fleet-management decisions like marking y-stream end-of-support or z-stream forced upgrades as done.
+- **Zero-compute clusters**: Upgrade a HostedCluster control plane even when no NodePools exist or all are scaled to zero -in this scenario, the CVO cannot complete its rollout but the control plane version status still reflects the management-side rollout.
+- **NodePool version skew computation**: Use the control plane version history to determine which NodePool versions are allowed under the [version skew policy](../reference/versioning-support.md#hostedcluster-and-nodepool-version-compatibility), including during multi-step or failed upgrades where multiple versions may be in flight.
+
+See [NodePool Lifecycle](./automated-machine-management/nodepool-lifecycle.md) for details on triggering NodePool upgrades.
 
 ## NodePools
 `.spec.release` dictates the version of any particular NodePool.

--- a/docs/content/labs/Dual/hostedcluster/hostedcluster.md
+++ b/docs/content/labs/Dual/hostedcluster/hostedcluster.md
@@ -247,8 +247,8 @@ packageserver-67c87d4d4f-kl7qh                        2/2     Running   0       
 And this is how the HostedCluster looks like:
 
 ```bash
-NAMESPACE   NAME         VERSION   KUBECONFIG                PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
-clusters    hosted-dual            hosted-admin-kubeconfig   Partial    True 	      False         The hosted control plane is available
+NAMESPACE   NAME         VERSION   CP VERSION   KUBECONFIG                PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
+clusters    hosted-dual                        hosted-admin-kubeconfig   Partial    True 	      False         The hosted control plane is available
 ```
 
 After some time, we will have almost all the pieces in place, and the Control Plane operator awaits for the worker nodes to join the cluster. To achieve this, we need to create some more objects. Let's discuss the `InfraEnv` and the `BareMetalHost` in the following sections.

--- a/docs/content/labs/IPv4/hostedcluster/hostedcluster.md
+++ b/docs/content/labs/IPv4/hostedcluster/hostedcluster.md
@@ -243,8 +243,8 @@ packageserver-67c87d4d4f-kl7qh                        2/2     Running   0       
 And this is how the HostedCluster looks like:
 
 ```bash
-NAMESPACE   NAME         VERSION   KUBECONFIG                PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
-clusters    hosted-ipv4            hosted-admin-kubeconfig   Partial    True 	      False         The hosted control plane is available
+NAMESPACE   NAME         VERSION   CP VERSION   KUBECONFIG                PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
+clusters    hosted-ipv4                        hosted-admin-kubeconfig   Partial    True 	      False         The hosted control plane is available
 ```
 
 After some time, we will have almost all the pieces in place, and the Control Plane operator awaits for the worker nodes to join the cluster. To achieve this, we need to create some more objects. Let's discuss the `InfraEnv` and the `BareMetalHost` in the following sections.

--- a/docs/content/labs/IPv6/hostedcluster/hostedcluster.md
+++ b/docs/content/labs/IPv6/hostedcluster/hostedcluster.md
@@ -246,8 +246,8 @@ packageserver-67c87d4d4f-kl7qh                        2/2     Running   0       
 And this is how the HostedCluster looks like:
 
 ```bash
-NAMESPACE   NAME         VERSION   KUBECONFIG                PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
-clusters    hosted-ipv6            hosted-admin-kubeconfig   Partial    True 	      False         The hosted control plane is available
+NAMESPACE   NAME         VERSION   CP VERSION   KUBECONFIG                PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
+clusters    hosted-ipv6                        hosted-admin-kubeconfig   Partial    True 	      False         The hosted control plane is available
 ```
 
 After some time, we will have almost all the pieces in place, and the Control Plane operator awaits for the worker nodes to join the cluster. To achieve this, we need to create some more objects. Let's discuss the `InfraEnv` and the `BareMetalHost` in the following sections.

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -1159,8 +1159,8 @@ namespace and when ready it will look similar to the following:
 
 ```
 oc get --namespace clusters hostedclusters
-NAME      VERSION   KUBECONFIG                 PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
-example   4.12.0    example-admin-kubeconfig   Completed   True        False         The hosted control plane is available
+NAME      VERSION   CP VERSION   KUBECONFIG                 PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
+example   4.12.0    4.12.0       example-admin-kubeconfig   Completed   True        False         The hosted control plane is available
 
 oc get nodepools --namespace clusters
 NAME                 CLUSTER   DESIRED NODES   CURRENT NODES   AUTOSCALING   AUTOREPAIR   VERSION   UPDATINGVERSION   UPDATINGCONFIG   MESSAGE
@@ -3887,7 +3887,7 @@ For a comprehensive reference on what triggers a rollout, upgrade strategies, ro
 
 ### Upgrading to a new OCP version
 
-These upgrades can be triggered via changing the `spec.release.image` of the NodePool. Note that you should only upgrade NodePools to the current version of the Hosted Control Plane.
+These upgrades can be triggered via changing the `spec.release.image` of the NodePool. Note that you should only upgrade NodePools to the current version of the Hosted Control Plane. You can check the control plane rollout status via `status.controlPlaneVersion` on the HostedCluster to determine which versions are currently active. See Control Plane Version Status for details.
 
 ### Adding a new MachineConfig
 
@@ -17010,8 +17010,8 @@ reflects what a fully provisioned HostedCluster object looks like.
 
 oc get --namespace clusters hostedclusters
 
-NAME            VERSION   KUBECONFIG                       PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
-example         4.14.0    example-admin-kubeconfig         Completed  True        False         The hosted control plane is available
+NAME            VERSION   CP VERSION   KUBECONFIG                       PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
+example         4.14.0    4.14.0       example-admin-kubeconfig         Completed  True        False         The hosted control plane is available
 ```
 
 ## Accessing the HostedCluster
@@ -17869,8 +17869,8 @@ This time, the HostedCluster will not finish the deployment (will remain in `Par
 ```shell linenums="1"
 oc get --namespace clusters hostedclusters
 
-NAME            VERSION   KUBECONFIG                       PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
-example                   example-admin-kubeconfig         Partial    True        False         The hosted control plane is available
+NAME            VERSION   CP VERSION   KUBECONFIG                       PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
+example                                example-admin-kubeconfig         Partial    True        False         The hosted control plane is available
 ```
 
 If we access the HostedCluster this is what we will see:
@@ -17966,8 +17966,8 @@ Now that we fixed the ingress, we should see our HostedCluster progress moved fr
 ```shell linenums="1"
 oc get --namespace clusters hostedclusters
 
-NAME            VERSION   KUBECONFIG                       PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
-example         4.14.0    example-admin-kubeconfig         Completed   True        False         The hosted control plane is available
+NAME            VERSION   CP VERSION   KUBECONFIG                       PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
+example         4.14.0    4.14.0       example-admin-kubeconfig         Completed   True        False         The hosted control plane is available
 ```
 
 ## Optional MetalLB Configuration Steps
@@ -18630,8 +18630,8 @@ version             False       True          3h46m   Unable to apply 4.9.17: so
 
 ~~~sh
 oc get hostedcluster -n clusters hosted0
-NAME      VERSION   KUBECONFIG                 PROGRESS    AVAILABLE   REASON
-hosted0   4.9.17    hosted0-admin-kubeconfig   Completed   True        HostedClusterAsExpected
+NAME      VERSION   CP VERSION   KUBECONFIG                 PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
+hosted0   4.9.17    4.9.17       hosted0-admin-kubeconfig   Completed   True        False         HostedClusterAsExpected
 
 KUBECONFIG=./hosted0-kubeconfig oc get co
 NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
@@ -19933,8 +19933,8 @@ To know whether the HostedCluster is healthy, you can verify with this command:
 ```shell
 oc get --namespace clusters hostedclusters
 
-NAME            VERSION   KUBECONFIG                       PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
-example         4.17.0    example-admin-kubeconfig         Completed  True        False         The hosted control plane is available
+NAME            VERSION   CP VERSION   KUBECONFIG                       PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
+example         4.17.0    4.17.0       example-admin-kubeconfig         Completed  True        False         The hosted control plane is available
 ```
 
 ## Scaling an existing NodePool
@@ -22324,30 +22324,111 @@ HyperShift enables the decoupling of upgrades between the Control Plane and Node
 
 This allows there to be two separate procedures a Cluster Service Provider can take, giving them flexibility to manage the different components separately.
 
-Control Plane upgrades are driven by the HostedCluster, while Node upgrades are driven by its respective NodePool. Both the HostedCluster and NodePool expose a `.release` field where the OCP release image can be specified.
+Control Plane upgrades are driven by the HostedCluster, while Node upgrades are driven by its respective NodePool. Both the HostedCluster and NodePool expose a `.spec.release` field where the OCP release image can be specified.
 
-For a cluster to keep fully operational during an upgrade process, Control Plane and Nodes upgrades need to be orchestrated while satisfying Kubernetes version skew policy at any time. The supported OCP versions are dictated by the running HyperShift Operator see here for more details on versioning.
+For a cluster to remain fully operational during an upgrade process, Control Plane and Node upgrades need to be orchestrated while satisfying Kubernetes version skew policy at any time. The supported OCP versions are dictated by the running HyperShift Operator see here for more details on versioning.
 
 ## HostedCluster
 `.spec.release` dictates the version of the Control Plane.
 
 The HostedCluster propagates the intended `.spec.release` to the `HostedControlPlane.spec.release` and runs the appropriate Control Plane Operator version.
 
-The HostedControlPlane orchestrates the rollout of the new version of the Control Plane components along with any OCP component in the data plane through the new version of the cluster version operator (CVO). This includes resources like:
+The upgrade is carried out by two operators working on different sides:
 
-- the CVO itself
-- cluster network operator (CNO)
-- cluster ingress operator
-- manifests for the kube API-server (KAS), scheduler, and manager
-- machine approver
-- autoscaler
-- infra resources needed to enable ingress for control plane endpoints (KAS, ignition, konnectivity, etc.)
+- The **Control Plane Operator (CPO)** deploys management-side control plane components into the HCP namespace on the management cluster. These are represented by `ControlPlaneComponent` custom resources and include components like kube-apiserver, etcd, kube-controller-manager, kube-scheduler, and openshift-apiserver.
+- The **Cluster Version Operator (CVO)** also runs in the HCP namespace on the management cluster but manages the data-plane rollout -applying the OCP payload to the hosted cluster for data-plane components like OVN pods and console. Their rollout depends on NodePool compute availability.
 
-The CVO also applies the payload for the `CLUSTER_PROFILE": "ibm-cloud-managed` into the hosted cluster.
+Traditionally, in standalone OCP, the CVO has been the sole source of truth for upgrades. In HyperShift, the responsibility is split between CPO and CVO. This split enabled the flexibility and speed the HyperShift project needed for the CPO to support the management/guest cluster topology and the multiple customizations needed for manifests that otherwise would have needed to be segregated in the payload.
 
-Traditionally, in standalone OCP, the CVO has been the sole source of truth for upgrades. In HyperShift, the responsibility is currently split between CPO and CVO. This enabled the flexibility and speed the HyperShift project needed for the CPO to support the management/guest cluster topology and the multiple customizations needed for manifests that otherwise would have needed to be segregated in the payload.
+HyperShift exposes available upgrades in `HostedCluster.Status` by bubbling up the status of the `ClusterVersion` resource inside the hosted cluster. While HCP is authoritative over upgrades, it does honour the CVO's `ClusterVersionUpgradeable` condition at a higher layer: z-stream upgrades are allowed regardless, but y-stream upgrades are blocked unless overridden via the `hypershift.openshift.io/force-upgrade-to` annotation on the HostedCluster. Some of the builtin CVO features like recommendations and allowed upgrade paths are not directly surfaced, but the underlying information is still available in the `HostedCluster.Status` field for consumers to read.
 
-HyperShift exposes available upgrades in HostedCluster.Status by bubbling up the status of the ClusterVersion resource inside a hosted cluster. This info is purely informational and doesn't determine upgradability, which is dictated by the `.spec.release` input in practice. This does result in the loss of some of the builtin features and guardrails from CVO like recommendations, allowed upgrade paths, risks, etc. However, this information is still available in the HostedCluster.Status field for consumers to read.
+### Understanding Version Tracking: Control Plane vs Data Plane
+
+When `.spec.release` is updated on a HostedCluster, two separate rollouts happen on two different sides:
+
+- **Control plane (CP)** -management-side components represented by `ControlPlaneComponent` resources in the HCP namespace (kube-apiserver, etcd, kube-controller-manager, kube-scheduler, openshift-apiserver, etc.). Deployed by the CPO. These typically complete first.
+- **Data plane (DP)** -workloads running on guest cluster worker nodes (OVN pods, console, etc.). Managed by the CVO (which itself runs in the HCP namespace). Their rollout depends on NodePool compute availability.
+
+These rollouts complete independently. The control plane can finish while the data plane is still progressing -or may even complete when no worker nodes exist at all (zero-compute clusters). Tracking them separately enables service providers to confirm CVE patches are applied to management-side components, track upgrade completion for fleet-management decisions, and compute NodePool version skew -all without waiting for the data-plane rollout to finish.
+
+!!! warning "Known limitation"
+
+    Some management-side components (notably OVN) currently have data-plane dependencies that can block the control plane version from reaching `Completed`. This means `controlPlaneVersion` may remain `Partial` due to data-plane issues even though the control plane components themselves are ready. This limitation is being actively resolved -each component is responsible for removing its own data-plane dependencies so that its management-side rollout can complete independently.
+
+When `ControlPlaneReleaseImage` is set on the HostedControlPlane spec, the control plane and data plane may use different release images. In this case, `controlPlaneVersion.desired` and `version.desired` will show different versions -this is expected and reflects the intentional split.
+
+HyperShift tracks each rollout separately in the HostedCluster status:
+
+| Status field | Tracks | Managed by | Shown as |
+|---|---|---|---|
+| `status.version` | Data-plane rollout | CVO | `VERSION` and `PROGRESS` columns |
+| `status.controlPlaneVersion` | Control-plane rollout | CPO | `CP VERSION` column |
+
+Both fields contain a `history` list where the newest entry is first, with state `Completed` or `Partial`.
+
+### Control Plane Version Status
+
+The `status.controlPlaneVersion` field exists on both `HostedCluster` and `HostedControlPlane`.
+
+!!! note
+
+    This field is populated by the control plane operator once it begins reconciling. It will be absent from the resource status on newly created clusters until the first reconciliation completes, and on clusters managed by older operator versions that do not support this field.
+
+The field contains:
+
+- **`desired`** -a release object describing what the control plane is reconciling towards. It contains:
+    - `version`: the semantic version string (e.g. "4.18.5").
+    - `image`: the release image pullspec.
+- **`history`** -a list of version transitions (newest first, minimum 1 entry when present, capped at 100). Each entry has:
+    - `state`: `Completed` (all `ControlPlaneComponent` resources report the target version) or `Partial` (rollout not yet fully applied).
+    - `startedTime`: when the rollout started.
+    - `completionTime`: when the rollout finished (only set for `Completed` entries).
+    - `version`: the semantic version string (e.g. "4.18.5").
+    - `image`: the release image pullspec.
+- **`observedGeneration`** -reports which generation of the `HostedControlPlane` spec is being synced. On the `HostedCluster`, this value is propagated from the underlying `HostedControlPlane`.
+
+#### Understanding the `Partial` State
+
+A `Partial` state means the rollout has not yet fully completed -one or more `ControlPlaneComponent` resources have not reached the target version. This can indicate either an in-progress rollout or a stalled one. To distinguish the two:
+
+- Check the `HostedControlPlane` conditions (e.g. `Progressing`, `Degraded`) for signals about whether the rollout is still making progress or has encountered errors.
+- A rollout that remains `Partial` for an extended period without progress in component conditions likely requires operator investigation.
+
+If `.spec.release` is changed back to a previous version (rollback), a new history entry is prepended for the rollback target, and the previously `Partial` entry remains in history.
+
+### Monitoring Upgrade Progress
+
+The `HostedCluster` printer columns surface both CP and DP version status:
+
+```
+oc get --namespace clusters hostedclusters
+NAME    VERSION   CP VERSION   KUBECONFIG                 PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
+my-hc   4.18.5    4.18.5       my-hc-admin-kubeconfig     Completed   True        False         The hosted control plane is available
+```
+
+| Column | What it shows |
+|---|---|
+| `VERSION` | Most recent completed data-plane version (from CVO) |
+| `CP VERSION` | Most recent completed control-plane version (from CPO) |
+| `PROGRESS` | Data-plane rollout state (latest entry) |
+
+During an in-progress upgrade, `CP VERSION` may already show the new version while `VERSION` still reflects the previous one -this is normal and means the control plane finished first.
+
+On newly created clusters, both `CP VERSION` and `VERSION` will be blank until their respective rollouts complete. The `Available` condition can be `True` before version columns are populated -`Available` reflects API server readiness, not full rollout completion.
+
+With `-o wide`, two additional columns appear:
+
+- `CP Progress` (Control Plane): the state of the latest control-plane history entry.
+- `DP Progress` (Data Plane): the state of the latest data-plane history entry.
+
+### Use Cases
+
+- **CVE verification**: Confirm that a security patch has been applied to all management-side control plane components by checking `status.controlPlaneVersion.history[0].state == "Completed"`, without waiting for the full data-plane rollout to finish.
+- **Upgrade completion tracking**: Track control plane upgrade completion independently from the data plane, enabling fleet-management decisions like marking y-stream end-of-support or z-stream forced upgrades as done.
+- **Zero-compute clusters**: Upgrade a HostedCluster control plane even when no NodePools exist or all are scaled to zero -in this scenario, the CVO cannot complete its rollout but the control plane version status still reflects the management-side rollout.
+- **NodePool version skew computation**: Use the control plane version history to determine which NodePool versions are allowed under the version skew policy, including during multi-step or failed upgrades where multiple versions may be in flight.
+
+See NodePool Lifecycle for details on triggering NodePool upgrades.
 
 ## NodePools
 `.spec.release` dictates the version of any particular NodePool.
@@ -22889,8 +22970,8 @@ packageserver-67c87d4d4f-kl7qh                        2/2     Running   0       
 And this is how the HostedCluster looks like:
 
 ```bash
-NAMESPACE   NAME         VERSION   KUBECONFIG                PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
-clusters    hosted-dual            hosted-admin-kubeconfig   Partial    True 	      False         The hosted control plane is available
+NAMESPACE   NAME         VERSION   CP VERSION   KUBECONFIG                PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
+clusters    hosted-dual                        hosted-admin-kubeconfig   Partial    True 	      False         The hosted control plane is available
 ```
 
 After some time, we will have almost all the pieces in place, and the Control Plane operator awaits for the worker nodes to join the cluster. To achieve this, we need to create some more objects. Let's discuss the `InfraEnv` and the `BareMetalHost` in the following sections.
@@ -24559,8 +24640,8 @@ packageserver-67c87d4d4f-kl7qh                        2/2     Running   0       
 And this is how the HostedCluster looks like:
 
 ```bash
-NAMESPACE   NAME         VERSION   KUBECONFIG                PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
-clusters    hosted-ipv4            hosted-admin-kubeconfig   Partial    True 	      False         The hosted control plane is available
+NAMESPACE   NAME         VERSION   CP VERSION   KUBECONFIG                PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
+clusters    hosted-ipv4                        hosted-admin-kubeconfig   Partial    True 	      False         The hosted control plane is available
 ```
 
 After some time, we will have almost all the pieces in place, and the Control Plane operator awaits for the worker nodes to join the cluster. To achieve this, we need to create some more objects. Let's discuss the `InfraEnv` and the `BareMetalHost` in the following sections.
@@ -26213,8 +26294,8 @@ packageserver-67c87d4d4f-kl7qh                        2/2     Running   0       
 And this is how the HostedCluster looks like:
 
 ```bash
-NAMESPACE   NAME         VERSION   KUBECONFIG                PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
-clusters    hosted-ipv6            hosted-admin-kubeconfig   Partial    True 	      False         The hosted control plane is available
+NAMESPACE   NAME         VERSION   CP VERSION   KUBECONFIG                PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
+clusters    hosted-ipv6                        hosted-admin-kubeconfig   Partial    True 	      False         The hosted control plane is available
 ```
 
 After some time, we will have almost all the pieces in place, and the Control Plane operator awaits for the worker nodes to join the cluster. To achieve this, we need to create some more objects. Let's discuss the `InfraEnv` and the `BareMetalHost` in the following sections.
@@ -50508,7 +50589,9 @@ When a rollout is triggered, the controller follows this sequence:
 
 ### Monitoring Rollout Progress
 
-You can monitor rollout progress through the following NodePool conditions:
+NodePool rollouts track *data-plane* node updates. For *control-plane* rollout status, see `status.controlPlaneVersion` on the HostedCluster, which can be used to determine which NodePool versions are allowed under the version skew policy.
+
+You can monitor NodePool rollout progress through the following conditions:
 
 | Condition | Meaning |
 |-----------|---------|
@@ -51025,6 +51108,8 @@ against your KUBECONFIG. Running the `hcp version --commit-only` will show the c
 ## HostedCluster and NodePool Version Compatibility
 
 HyperShift validates version compatibility between HostedClusters and their NodePools. While the system reports version incompatibilities, existing NodePools with unsupported version skews will continue to operate without guarantees of stability or support.
+
+The `status.controlPlaneVersion` field on both `HostedCluster` and `HostedControlPlane` tracks the rollout state of management-side control plane components independently from the data-plane version reported by CVO. This can be used to verify the control plane has completed its upgrade before initiating NodePool upgrades or to compute version skew between the control plane and NodePools. See Upgrades for details.
 
 ### Version Skew Policy
 

--- a/docs/content/reference/nodepool-rollouts.md
+++ b/docs/content/reference/nodepool-rollouts.md
@@ -153,7 +153,9 @@ When a rollout is triggered, the controller follows this sequence:
 
 ### Monitoring Rollout Progress
 
-You can monitor rollout progress through the following NodePool conditions:
+NodePool rollouts track *data-plane* node updates. For *control-plane* rollout status, see [`status.controlPlaneVersion`](../how-to/upgrades.md#control-plane-version-status) on the HostedCluster, which can be used to determine which NodePool versions are allowed under the version skew policy.
+
+You can monitor NodePool rollout progress through the following conditions:
 
 | Condition | Meaning |
 |-----------|---------|

--- a/docs/content/reference/versioning-support.md
+++ b/docs/content/reference/versioning-support.md
@@ -141,6 +141,8 @@ against your KUBECONFIG. Running the `hcp version --commit-only` will show the c
 
 HyperShift validates version compatibility between HostedClusters and their NodePools. While the system reports version incompatibilities, existing NodePools with unsupported version skews will continue to operate without guarantees of stability or support.
 
+The `status.controlPlaneVersion` field on both `HostedCluster` and `HostedControlPlane` tracks the rollout state of management-side control plane components independently from the data-plane version reported by CVO. This can be used to verify the control plane has completed its upgrade before initiating NodePool upgrades or to compute version skew between the control plane and NodePools. See [Upgrades](../how-to/upgrades.md#control-plane-version-status) for details.
+
 ### Version Skew Policy
 
 The following rules apply to NodePool version compatibility:


### PR DESCRIPTION
## Summary
- Add CP vs DP version tracking conceptual framing and use cases to the upgrades page, aligned with the [controlPlaneVersion enhancement](https://github.com/openshift/enhancements/blob/master/enhancements/hypershift/hypershift-control-plane-version-status.md)
- Document `status.controlPlaneVersion` field, `Partial` state semantics, and monitoring columns
- Add known limitation warning for OVN data-plane dependencies blocking CP completion
- Update all `oc get hostedclusters` examples across 12 docs files to include the `CP VERSION` column
- Add cross-references from nodepool-lifecycle, nodepool-rollouts, and versioning-support docs
- Fix pre-existing issues: CPO/CVO component attribution, `.release` → `.spec.release`, stale column layouts

## Test plan
- [ ] Verify docs render correctly via `make serve-containerized` in `docs/`
- [ ] Check all updated pages for correct column layout in kubectl examples
- [ ] Verify cross-reference links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a CP VERSION column to HostedCluster example outputs and adjusted displayed status columns (including replacing REASON with PROGRESSING and MESSAGE in examples).
  * Expanded upgrade docs to describe separate control-plane vs data-plane version tracking, Partial/Completed semantics, and use cases (monitoring, CVE checks, zero-compute).
  * Added guidance to check controlPlaneVersion on HostedCluster when planning NodePool upgrades and clarified NodePool version-skew guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->