### PR TITLE
NO-JIRA: Add onboarding guide for new HCP team members

### DIFF
--- a/docs/content/contribute/run-hypershift-operator-locally.md
+++ b/docs/content/contribute/run-hypershift-operator-locally.md
@@ -37,7 +37,7 @@ To run the HyperShift Operator locally, follow these steps:
 
     `Default values are provided for HYPERSHIFT_REGION and HYPERSHIFT_BUCKET_NAME so Step #4 will function without requiring you to export any values.
 
-4. Install HyperShift in development mode which causes the operator deployment to be deployment scaled to zero so that it doesn't conflict with your local operator process (see [Prerequisites](../getting-started.md#prerequisites)):
+4. Install HyperShift in development mode which causes the operator deployment to be deployment scaled to zero so that it doesn't conflict with your local operator process (see [Prerequisites](../getting-started/quick-setup.md#prerequisites)):
   
 ```shell linenums="1"
   make hypershift-install-aws-dev

--- a/docs/content/getting-started/index.md
+++ b/docs/content/getting-started/index.md
@@ -1,0 +1,23 @@
+# Getting Started
+
+Welcome to HyperShift! Choose your path based on where you are:
+
+<div class="grid cards" markdown>
+
+-   :material-school:{ .lg .middle } **Onboarding Guide**
+
+    ---
+
+    New to the team? Start here for a structured learning path through HyperShift concepts, architecture, and codebase.
+
+    [:octicons-arrow-right-24: Start onboarding](onboarding/index.md)
+
+-   :material-rocket-launch:{ .lg .middle } **Quick Setup (AWS)**
+
+    ---
+
+    Ready to create your first hosted cluster? Follow the step-by-step setup guide for a self-managed AWS cluster.
+
+    [:octicons-arrow-right-24: Quick setup](quick-setup.md)
+
+</div>

--- a/docs/content/getting-started/onboarding/architecture.md
+++ b/docs/content/getting-started/onboarding/architecture.md
@@ -1,0 +1,233 @@
+# Architecture and Main Components
+
+## Overall Architecture
+
+> **See also**: [Controller Architecture](../../reference/controller-architecture.md) for detailed controller diagrams and resource dependency graphs.
+
+```mermaid
+graph TB
+    subgraph "Management Cluster"
+        subgraph "hypershift namespace"
+            HO_DEPLOY[HyperShift Operator]
+        end
+
+        subgraph "clusters namespace"
+            HC1[HostedCluster]
+            NP1[NodePool]
+        end
+
+        subgraph "clusters-my-cluster namespace"
+            HCP1[HostedControlPlane]
+            CPO1[control-plane-operator]
+            PKI1[PKI operator]
+            ETCD1[etcd]
+            KAS1[kube-apiserver]
+            KONN[konnectivity]
+            MORE1["KCM, scheduler, CVO,<br/>CCM, ignition, +30 more"]
+            CAPI_PROV[CAPI Provider]
+        end
+    end
+
+    subgraph "Guest Cluster"
+        KUBELET1[kubelet]
+        KONN_AGENT[konnectivity-agent]
+        WORKLOADS[User Workloads]
+    end
+
+    HO_DEPLOY -->|manages| HC1
+    HO_DEPLOY -->|manages| NP1
+    HO_DEPLOY -->|creates| HCP1
+    HO_DEPLOY -->|deploys| CPO1
+
+    CPO1 -->|reconciles| ETCD1
+    CPO1 -->|reconciles| KAS1
+    CPO1 -->|reconciles| MORE1
+
+    KONN -->|tunnel| KONN_AGENT
+    KAS1 -.->|API calls via tunnel| KUBELET1
+```
+
+> For the full detailed architecture diagram with all components, see [Controller Architecture](../../reference/controller-architecture.md).
+
+### Namespace Layout
+
+```mermaid
+graph LR
+    subgraph "Management Cluster Namespaces"
+        NS1["<b>hypershift</b><br/>HyperShift Operator"]
+        NS2["<b>clusters</b><br/>HostedCluster + NodePool CRs<br/>(user namespace)"]
+        NS3["<b>clusters-my-cluster</b><br/>Control Plane namespace"]
+        NS4["<b>clusters-another-cluster</b><br/>Another Control Plane"]
+    end
+
+    NS2 -->|HC controller creates| NS3
+    NS2 -->|HC controller creates| NS4
+```
+
+The namespace naming convention is implemented in `hypershift-operator/controllers/manifests/manifests.go`:
+```go
+func HostedControlPlaneNamespace(hostedClusterNamespace, hostedClusterName string) string {
+    return fmt.Sprintf("%s-%s", hostedClusterNamespace, strings.ReplaceAll(hostedClusterName, ".", "-"))
+}
+```
+
+!!! tip "Explore yourself"
+    Read `hypershift-operator/controllers/manifests/manifests.go` to see all the naming helpers used across the codebase.
+
+---
+
+## Main Components
+
+> **See also**: [Controller Architecture](../../reference/controller-architecture.md) for detailed controller diagrams, resource dependency graphs, and the Hosted Cluster Config Operator.
+
+### HyperShift Operator (HO)
+
+- **Entry point**: `hypershift-operator/main.go`
+- **Deployed in**: `hypershift` namespace as a Deployment
+
+Contains the main controllers:
+
+| Controller | Directory | Function | Read This First |
+|------------|-----------|----------|-----------------|
+| **HostedCluster** | `hypershift-operator/controllers/hostedcluster/` | Manages full HC lifecycle, creates CP namespace, deploys CPO | `hostedcluster_controller.go` (start at `Reconcile` method, ~line 337) |
+| **NodePool** | `hypershift-operator/controllers/nodepool/` | Manages CAPI Machines, ignition tokens, rolling upgrades | `nodepool_controller.go` (start at `Reconcile` method) |
+| **HostedClusterSizing** | `hypershift-operator/controllers/hostedclustersizing/` | Resource-based sizing decisions | `hostedclustersizing_controller.go` |
+| **Scheduler** | `hypershift-operator/controllers/scheduler/` | Schedules HCs on management cluster nodes | `scheduler.go` |
+| **SharedIngress** | `hypershift-operator/controllers/sharedingress/` | Shared ingress across multiple HCs | `sharedingress_controller.go` |
+
+!!! tip "Explore yourself"
+    The HostedCluster controller (`hostedcluster_controller.go`) is ~5200 lines. Don't try to read it all at once. Start with the `Reconcile` method and follow the function calls. Key sub-functions to look at:
+
+    - `reconcileHostedControlPlane()` (~line 2404) - how HC spec is translated to HCP
+    - `reconcileControlPlaneOperator()` - how the CPO deployment is created
+    - `reconcileCAPICluster()` (~line 2901) - how the CAPI Cluster CR is created
+    - `r.delete()` (~line 501) - the deletion flow
+
+### Control Plane Operator (CPO)
+
+- **Source**: `control-plane-operator/`
+- **Main controller**: `control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go` (~3200 lines)
+- **Deployed in**: each CP namespace (one CPO instance per hosted cluster)
+
+The CPO reads the `HostedControlPlane` resource and reconciles ~40 control plane components:
+
+```mermaid
+graph TD
+    HCP[HostedControlPlane CR] --> CPO[Control Plane Operator]
+
+    CPO --> PKI[PKI Operator]
+    CPO --> ETCD[etcd]
+    CPO --> FG[FeatureGate Generator]
+    CPO --> ROUTER[Router]
+
+    ETCD --> KAS[kube-apiserver]
+    FG --> KAS
+
+    KAS --> KCM[kube-controller-manager]
+    KAS --> SCHED[kube-scheduler]
+    KAS --> OAPI[openshift-apiserver]
+    KAS --> CVO[cluster-version-operator]
+    KAS --> CNO[cluster-network-operator]
+    KAS --> CCM[cloud-controller-manager]
+    KAS --> KONN[konnectivity]
+    KAS --> MORE["... +25 more components"]
+
+    style PKI fill:#e1f5fe
+    style ETCD fill:#e1f5fe
+    style FG fill:#e1f5fe
+    style ROUTER fill:#e1f5fe
+    style KAS fill:#fff3e0
+```
+
+> Light blue components have no KAS dependency. KAS (orange) is an implicit dependency for everything else. The full list includes oauth-server, oauth-apiserver, openshift-controller-manager, ingress-operator, dns-operator, machine-approver, config-operator, storage-operator, node-tuning-operator, and more.
+
+!!! tip "Explore yourself"
+    Look at the `registerComponents()` function (~line 236 in `hostedcontrolplane_controller.go`) to see the full list of registered components.
+
+    Then pick one simple component like `kube-scheduler` at `control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/` to understand the pattern.
+
+### CPOv2 Framework
+
+The declarative framework for defining control plane components. Each component uses a builder pattern:
+
+```go
+component.NewDeploymentComponent(name, opts).
+    WithAdaptFunction(adaptDeployment).           // Dynamic deployment mutations
+    WithPredicate(predicate).                      // Enable/disable the component
+    WithDependencies("etcd", "featuregate-generator"). // Block until deps are ready
+    WithManifestAdapter("config.yaml", ...).       // Adapt supporting manifests
+    InjectTokenMinterContainer(tokenOpts).         // Auto-inject token minter sidecar
+    InjectKonnectivityContainer(konnOpts).         // Auto-inject konnectivity proxy
+    RolloutOnConfigMapChange("my-config").          // Auto-rollout on config change
+    Build()
+```
+
+| File | What it does | Why you should read it |
+|------|-------------|----------------------|
+| `support/controlplane-component/controlplane-component.go` | Core reconcile logic, `ControlPlaneComponent` interface | Understand how components are reconciled (line 163, `Reconcile` method) |
+| `support/controlplane-component/builder.go` | Builder pattern for constructing components | Learn how to create a new component |
+| `support/controlplane-component/status.go` | Dependency checking, status conditions | Understand `checkDependencies` (line 50) and how `Available`/`RolloutComplete` conditions work |
+| `support/controlplane-component/workload.go` | Workload (Deployment/StatefulSet) reconciliation | See how deployments are created from asset manifests |
+
+Each component generates a `ControlPlaneComponent` CR with conditions:
+
+- `ControlPlaneComponentAvailable` - at least one pod is ready
+- `ControlPlaneComponentRolloutComplete` - all pods at the desired version
+
+!!! tip "Explore yourself"
+    Compare a simple component (`v2/kube_scheduler/`) with a complex one (`v2/kas/`) to see how the framework scales. Assets (YAML manifests) live in `v2/assets/<component>/`.
+
+### PKI Operator
+
+**Directory**: `control-plane-pki-operator/`
+
+Manages all PKI (certificates) for the hosted cluster:
+
+| Controller | Directory | Function |
+|------------|-----------|----------|
+| CertRotation | `certrotationcontroller/` | Rotates CAs and leaf certs using library-go |
+| CertificateSigning | `certificatesigningcontroller/` | Signs CSRs for break-glass access |
+| CSR Approval | `certificatesigningrequestapprovalcontroller/` | Auto-approves CSRs matching known signers |
+| CertRevocation | `certificaterevocationcontroller/` | Handles certificate revocation |
+| TargetConfig | `targetconfigcontroller/` | PKI target configuration |
+
+Supports two break-glass signers: **Customer** and **SRE**.
+
+!!! tip "Explore yourself"
+    Start with `control-plane-pki-operator/operator.go` to see how all sub-controllers are wired together. Then look at `certificates/` for signer definitions.
+
+### Ignition Server
+
+**Directory**: `ignition-server/`
+
+HTTPS server serving ignition configs to worker nodes during bootstrap:
+
+```mermaid
+sequenceDiagram
+    participant NPC as NodePool Controller
+    participant IS as Ignition Server
+    participant PS as PayloadStore
+    participant Node as Worker Node
+
+    NPC->>IS: Creates Token Secret<br/>(release, config, token UUID)
+    IS->>IS: TokenSecretReconciler<br/>detects new Secret
+    IS->>IS: LocalIgnitionProvider<br/>generates payload with MCO
+    IS->>PS: Stores payload<br/>keyed by token UUID
+
+    Note over Node: Cloud instance boots
+    Node->>IS: GET /ignition<br/>Header: token UUID
+    IS->>PS: Looks up payload by token
+    PS->>IS: Ignition JSON
+    IS->>Node: Responds with ignition config
+    Node->>Node: Applies ignition,<br/>starts kubelet,<br/>joins guest cluster
+```
+
+| File | What it does |
+|------|-------------|
+| `ignition-server/cmd/start.go` | HTTPS server setup, `/ignition` request handler |
+| `ignition-server/controllers/tokensecret_controller.go` | `TokenSecretReconciler`: watches token Secrets, generates payloads, rotates tokens |
+| `ignition-server/controllers/local_ignitionprovider.go` | `LocalIgnitionProvider`: extracts MCO binaries from release image, runs them to produce ignition JSON |
+| `ignition-server/controllers/cache.go` | `ExpiringCache`: in-memory TTL cache for payloads |
+
+!!! tip "Explore yourself"
+    Start with `ignition-server/cmd/start.go` to understand the HTTP handler, then follow the flow into `tokensecret_controller.go`.

--- a/docs/content/getting-started/onboarding/data-plane.md
+++ b/docs/content/getting-started/onboarding/data-plane.md
@@ -1,0 +1,134 @@
+# Data Plane and Node Management
+
+> **See also**: [NodePool Rollouts](../../reference/nodepool-rollouts.md) for in-depth rollout mechanics and update strategies.
+
+## NodePool - Key Fields
+
+| Field | Purpose | Look at |
+|-------|---------|---------|
+| `spec.clusterName` | Immutable reference to the HostedCluster | `api/hypershift/v1beta1/nodepool_types.go` |
+| `spec.release` | Release image (change triggers rollout, tagged `+rollout`) | Same file |
+| `spec.platform` | Platform-specific machine config (AMI, instance type, etc.) | `aws.go`, `azure.go`, `kubevirt.go` in the api dir |
+| `spec.replicas` / `spec.autoScaling` | Node count control | Same file |
+| `spec.management.upgradeType` | `Replace` (default) or `InPlace` | Same file |
+| `spec.management.autoRepair` | Enables MachineHealthCheck | Same file |
+| `spec.config` | ConfigMap refs with MachineConfig (change triggers rollout) | Same file |
+
+## Node Lifecycle
+
+```mermaid
+sequenceDiagram
+    participant NPC as NodePool Controller
+    participant CFG as ConfigGenerator
+    participant TOK as Token Manager
+    participant CAPI as ClusterAPI
+    participant Cloud as Cloud Provider
+    participant IGN as Ignition Server
+    participant Node as Worker Node
+    participant GC as Guest Cluster
+
+    NPC->>CFG: Compute config hash
+    CFG-->>NPC: hash = hashSimple(mcoConfig + version + ...)
+
+    NPC->>TOK: reconcileTokenSecret(hash)
+    TOK->>TOK: Creates token Secret in HCP ns<br/>(token UUID, release, config)
+    TOK->>TOK: Creates userdata Secret<br/>(ignition stub with URL + token)
+
+    NPC->>CAPI: Creates/updates MachineDeployment
+    Note over CAPI: Spec.Template.Bootstrap.DataSecretName<br/>= userdata secret name
+
+    CAPI->>CAPI: Creates MachineSet
+    CAPI->>CAPI: Creates Machine(s)
+    CAPI->>Cloud: Provisions instance<br/>(EC2, Azure VM, KubeVirt VM)
+
+    Cloud->>Node: Instance boots with userdata
+    Node->>IGN: GET /ignition<br/>Authorization: token UUID
+    IGN->>IGN: Looks up payload in cache
+    IGN-->>Node: Full ignition JSON
+
+    Node->>Node: Applies ignition config
+    Node->>Node: Starts kubelet
+    Node->>GC: Joins the guest cluster
+
+    Note over NPC: machine-approver approves node CSR
+```
+
+!!! tip "Explore yourself"
+    The NodePool controller is split across several files. Read them in this order:
+
+    1. `hypershift-operator/controllers/nodepool/nodepool_controller.go` - Main reconciler entry point, condition checks
+    2. `hypershift-operator/controllers/nodepool/config.go` - `ConfigGenerator`: how config hash is computed for rollout detection
+    3. `hypershift-operator/controllers/nodepool/token.go` - `Token`: token Secret and userdata Secret lifecycle
+    4. `hypershift-operator/controllers/nodepool/capi.go` - `CAPI`: MachineDeployment, MachineSet, MachineHealthCheck, MachineTemplate creation
+
+## ClusterAPI Integration
+
+```mermaid
+graph TD
+    NP[NodePool] -->|creates| MD[MachineDeployment]
+    NP -->|creates| MT[PlatformMachineTemplate<br/><i>e.g., AWSMachineTemplate</i>]
+    NP -->|creates| MHC[MachineHealthCheck]
+
+    MD -->|CAPI creates| MS[MachineSet]
+    MS -->|CAPI creates| M1[Machine 1]
+    MS -->|CAPI creates| M2[Machine 2]
+    MS -->|CAPI creates| MN[Machine N]
+
+    M1 -->|infra provider creates| I1[EC2 Instance / Azure VM / KubeVirt VM]
+
+    MT -.->|referenced by| MD
+    MHC -.->|monitors| M1
+    MHC -.->|monitors| M2
+
+    subgraph "CP Namespace (clusters-my-cluster)"
+        MD
+        MS
+        M1
+        M2
+        MN
+        MT
+        MHC
+    end
+```
+
+**Rollout detection**: `ConfigGenerator.Hash()` produces a new hash when config or version changes. New hash = new Secrets = new `DataSecretName` on MachineDeployment = CAPI rolling update.
+
+!!! tip "Explore yourself"
+    Platform-specific machine template builders:
+
+    - `hypershift-operator/controllers/nodepool/aws.go` - `awsMachineTemplateSpec()`: AMI resolution, instance type, root volume, security groups
+    - `hypershift-operator/controllers/nodepool/azure.go` - Azure VM config
+    - `hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go` - KubeVirt VM config
+    - `hypershift-operator/controllers/nodepool/agent.go` - Agent/bare-metal label selectors
+    - `hypershift-operator/controllers/nodepool/gcp.go` - GCP machine config
+    - `hypershift-operator/controllers/nodepool/openstack.go` - OpenStack config
+
+## Auto-scaling
+
+> **See also**: [Resource-Based Control Plane Autoscaling](../../how-to/resource-based-control-plane-autoscaling.md) for detailed autoscaling configuration.
+
+- **Manual**: `nodePool.spec.replicas` propagates to `MachineDeployment.Spec.Replicas`
+- **Cluster Autoscaler**: `nodePool.spec.autoScaling.min/max` becomes CAPI annotations on MachineDeployment
+- **Scale-from-zero** (AWS only): capacity annotations (`vCPU`, `memoryMb`, `GPU`) in `hypershift-operator/controllers/nodepool/scale_from_zero.go`
+- **Karpenter** (alternative): provisions nodes directly based on pending pods, bypassing MachineDeployments. See `karpenter-operator/controllers/`
+
+!!! tip "Explore yourself"
+    Karpenter integration files:
+
+    - `karpenter-operator/controllers/karpenter/karpenter_controller.go` - Main reconciler
+    - `karpenter-operator/controllers/karpenterignition/karpenterignition_controller.go` - Ignition for Karpenter nodes
+    - `api/karpenter/v1beta1/` - HyperShift Karpenter API types
+
+## Auto-repair
+
+```mermaid
+flowchart LR
+    MHC[MachineHealthCheck] -->|detects NodeReady=False<br/>for 8-16 min| UNHEALTHY[Machine marked<br/>unhealthy]
+    UNHEALTHY -->|MaxUnhealthy=2<br/>prevents cascade| DELETE[Deletes Machine]
+    DELETE -->|CAPI| NEW[Creates replacement<br/>Machine]
+```
+
+!!! tip "Explore yourself"
+    MHC creation is in `hypershift-operator/controllers/nodepool/capi.go`, function `reconcileMachineHealthCheck()` (~line 649). Note the different timeouts for cloud (8 min) vs Agent/None (16 min) platforms.
+
+---

--- a/docs/content/getting-started/onboarding/development.md
+++ b/docs/content/getting-started/onboarding/development.md
@@ -1,0 +1,253 @@
+# APIs, Code Structure, and Development
+
+## Multi-Module Structure
+
+```mermaid
+graph TD
+    subgraph "Root Module: github.com/openshift/hypershift"
+        ROOT_MOD[go.mod]
+        OPERATORS[hypershift-operator/<br/>control-plane-operator/<br/>karpenter-operator/]
+        SUPPORT[support/]
+        CMD[cmd/]
+        VENDOR[vendor/<br/><i>DO NOT modify directly</i>]
+    end
+
+    subgraph "API Module: github.com/openshift/hypershift/api"
+        API_MOD[api/go.mod]
+        API_TYPES[api/hypershift/v1beta1/<br/>api/scheduling/v1alpha1/<br/>api/certificates/v1alpha1/<br/>api/karpenter/v1beta1/]
+        API_VENDOR[api/vendor/]
+    end
+
+    OPERATORS -->|consumes via vendor| API_TYPES
+
+    style VENDOR fill:#ffcdd2
+    style API_VENDOR fill:#ffcdd2
+```
+
+> **GOLDEN RULE**: After any change in `api/`, run `make update`. This runs: `api-deps` -> `workspace-sync` -> `deps` -> `api` -> `api-docs` -> `clients` -> `docs-aggregate`.
+
+!!! tip "Explore yourself"
+    - `api/go.mod` - the separate module definition
+    - `api/CLAUDE.md` - API backward compatibility rules (critical reading!)
+    - `hack/workspace/go.work` - Go workspace for local development across both modules
+
+## Main API Types
+
+```mermaid
+classDiagram
+    class HostedCluster {
+        +HostedClusterSpec spec
+        +HostedClusterStatus status
+        namespace: user namespace
+        scope: user-facing
+    }
+
+    class HostedControlPlane {
+        +HostedControlPlaneSpec spec
+        +HostedControlPlaneStatus status
+        namespace: CP namespace
+        scope: internal
+    }
+
+    class NodePool {
+        +NodePoolSpec spec
+        +NodePoolStatus status
+        namespace: user namespace
+        scope: user-facing
+    }
+
+    class ControlPlaneComponent {
+        +conditions: Available, RolloutComplete
+        namespace: CP namespace
+        scope: internal
+    }
+
+    HostedCluster "1" --> "1" HostedControlPlane : HC controller creates
+    HostedCluster "1" --> "*" NodePool : clusterName reference
+    HostedControlPlane "1" --> "*" ControlPlaneComponent : CPO creates
+
+    NodePool --> MachineDeployment : CAPI
+    MachineDeployment --> MachineSet : CAPI
+    MachineSet --> Machine : CAPI
+```
+
+!!! tip "Explore yourself"
+    Key API files to read:
+
+    - `api/hypershift/v1beta1/hostedcluster_types.go` - Start here. HostedClusterSpec (~line 529), HostedClusterStatus (~line 2105)
+    - `api/hypershift/v1beta1/hosted_controlplane.go` - HCP spec (~line 44) mirrors HC spec
+    - `api/hypershift/v1beta1/nodepool_types.go` - NodePoolSpec, note the `+rollout` tags
+    - `api/hypershift/v1beta1/controlplanecomponent_types.go` - CPOv2 status tracking
+    - `api/hypershift/v1beta1/etcdbackup_types.go` - Example of a feature-gated type
+    - `api/hypershift/v1beta1/groupversion_info.go` - API group registration
+
+## Feature Gates
+
+Feature gates control which API fields and CRD types are available:
+
+```go
+// Example: gated field
+// +openshift:enable:FeatureGate=AutoNodeKarpenter
+AutoNode *AutoNode `json:"autoNode,omitempty"`
+```
+
+!!! tip "Explore yourself"
+    Feature gate definitions are in `api/hypershift/v1beta1/featuregates/`:
+
+    - `featureGate-Hypershift-Default.yaml` - Default feature set
+    - `featureGate-Hypershift-TechPreviewNoUpgrade.yaml` - TechPreview set
+    - Per-gate CRD fragments are generated in `api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/`
+
+## Key Annotations
+
+Some important annotations you'll encounter (defined in `api/hypershift/v1beta1/hostedcluster_types.go`, lines 29-449):
+
+| Annotation | Purpose |
+|-----------|---------|
+| `hypershift.openshift.io/control-plane-operator-image` | Override CPO image (dev/e2e) |
+| `hypershift.openshift.io/restart-date` | Triggers rolling restart of all components |
+| `hypershift.openshift.io/force-upgrade-to` | Force upgrade even if CVO says not upgradeable |
+| `hypershift.openshift.io/disable-pki-reconciliation` | Stops PKI cert regeneration |
+| `resource-request-override.hypershift.openshift.io/<deploy>.<container>` | Override resource requests per container |
+| `hypershift.openshift.io/topology` | `dedicated-request-serving-components` for dedicated nodes |
+| `hypershift.openshift.io/cleanup-cloud-resources` | Controls cloud resource cleanup on deletion |
+
+!!! tip "Explore yourself"
+    Read the annotation constants block at the top of `hostedcluster_types.go` (lines 29-449). Each has a comment explaining its purpose.
+
+---
+
+## Development Workflow
+
+> **See also**: [Run Tests](../../contribute/run-tests.md), [Run HyperShift Operator Locally](../../contribute/run-hypershift-operator-locally.md), and [Develop In-Cluster](../../contribute/develop_in_cluster.md) for detailed development setup guides.
+
+### Essential Commands
+
+```bash
+# Build
+make build                    # All binaries
+make hypershift               # CLI only
+make hypershift-operator      # HO only
+make control-plane-operator   # CPO only
+
+# Test
+make test                     # Unit tests with race detection
+make e2e                      # Build E2E test binaries
+
+# Code quality
+make verify                   # Full verification (BEFORE PR) - includes generate, fmt, vet, lint, codespell, gitlint
+make lint                     # golangci-lint
+make lint-fix                 # Auto-fix linting
+make fmt                      # Format
+make vet                      # go vet
+
+# API and generation
+make update                   # Full update after api/ changes
+make api                      # Only regenerate CRDs
+make generate                 # go generate
+make clients                  # Update generated clients
+```
+
+### Workflow for API Changes
+
+```mermaid
+flowchart TD
+    A[Edit types in api/hypershift/v1beta1/] --> B[make update]
+    B --> C[make verify]
+    C --> D{Changed a field type?}
+    D -->|Yes| E[Add serialization compatibility test<br/>in *_types_test.go]
+    D -->|No| F[make test]
+    E --> F
+    F --> G[Create PR]
+```
+
+!!! tip "Explore yourself"
+    Look at `api/hypershift/v1beta1/nodepool_types_test.go` for the serialization compatibility test pattern. It defines an N-1 struct and verifies JSON round-trip compatibility.
+
+### Running Locally
+
+```bash
+# Install HyperShift in development mode
+make hypershift-install-aws-dev
+
+# Run operator locally
+make run-operator-locally-aws-dev
+
+# Or manually
+bin/hypershift install --development
+bin/hypershift-operator run
+```
+
+!!! tip "Explore yourself"
+    The CLI is built from `main.go` at the repo root. Subcommands are in `cmd/`:
+
+    - `cmd/cluster/` - `create cluster` and `destroy cluster` commands
+    - `cmd/nodepool/` - `create nodepool` and `destroy nodepool`
+    - `cmd/install/` - `install` command and CRD assets
+    - `cmd/infra/` - `create infra` commands per platform
+    - `cmd/install/assets/hypershift-operator/` - Final CRD YAML files
+
+---
+
+## Common Development Patterns
+
+### Upsert Pattern
+
+`support/upsert/upsert.go` wraps `controllerutil.CreateOrUpdate` to prevent reconciliation loops by copying server-defaulted fields.
+
+```go
+// Typical usage in a reconciler
+result, err := r.createOrUpdate(ctx, r.client, deployment, func() error {
+    // mutate deployment here
+    return nil
+})
+```
+
+!!! tip "Explore yourself"
+    Read `support/upsert/upsert.go` to understand the loop detection mechanism. The `CreateOrUpdateProvider` interface is injected into controllers via `SetupWithManager`.
+
+### Controller Structure
+
+```go
+type MyReconciler struct {
+    client         crclient.Client
+    createOrUpdate upsert.CreateOrUpdateFN
+}
+
+func (r *MyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+    // 1. Fetch resource
+    // 2. Handle deletion
+    // 3. Add finalizer
+    // 4. Reconcile sub-resources
+    // 5. Update status
+}
+```
+
+!!! tip "Explore yourself"
+    Compare how different controllers are set up:
+
+    - `hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go` - Large, complex controller
+    - `hypershift-operator/controllers/hostedclustersizing/hostedclustersizing_controller.go` - Simpler controller
+    - `control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go` - CPO main controller
+
+### Test Conventions
+
+- Use **Gherkin syntax** for test names: `"When ... it should ..."`
+- Use **gomega** for assertions
+- Unit tests live alongside source files
+- E2E tests in `test/e2e/`
+- Integration tests in `test/integration/`
+
+!!! tip "Explore yourself"
+    - `test/e2e/` - E2E tests covering cluster lifecycle, nodepool operations, upgrades
+    - `test/integration/` - Integration tests for controller behavior
+    - Any `*_test.go` file alongside the source for unit test examples
+
+### API Backward Compatibility
+
+Rules from `api/CLAUDE.md`:
+
+- Every API type change must be safe for **N+1 (forward)** and **N-1 (rollback)** compatibility
+- Changing a value type to a pointer (e.g., `int32` to `*int32`) requires `omitempty`
+- Never remove or rename fields
+- Always add serialization compatibility tests when modifying field types

--- a/docs/content/getting-started/onboarding/index.md
+++ b/docs/content/getting-started/onboarding/index.md
@@ -1,0 +1,108 @@
+# HyperShift / Hosted Control Planes (HCP) - Onboarding Guide
+
+!!! note "How this guide relates to other docs"
+    This is a **curated learning path** — it provides a structured narrative to help newcomers build a mental model of HyperShift step by step. It intentionally summarizes topics that are covered in more detail in dedicated reference pages. Where applicable, "See also" links point you to the authoritative source for deeper reading. This guide is not a replacement for those docs.
+
+---
+
+## Tips for New Team Members
+
+1. **Start with the CRDs**: Understanding `HostedCluster`, `HostedControlPlane`, and `NodePool` is 80% of the work
+2. **Follow the data flow**: HC -> HCP -> Components. NP -> CAPI -> Cloud -> Node
+3. **Conditions are your friend**: Always check `.status.conditions` to understand what's happening
+4. **`make verify` before pushing**: Always
+5. **The CP namespace is where the magic happens**: `kubectl get pods -n clusters-<name>` shows you everything
+6. **Read the tests**: Unit tests and E2E tests are the best living documentation
+7. **Use `hypershift dump`**: The diagnostic tool at `cmd/dump/` captures full cluster state for debugging
+8. **Don't read 5000-line files end-to-end**: Follow function calls from the `Reconcile` entry point
+9. **The API module is separate**: Remember to run `make update` after any change in `api/`
+10. **Ask about invariants**: When in doubt about a design decision, check if it violates any of the [architectural invariants](reference.md#architectural-invariants)
+
+---
+
+## Recommended Learning Path
+
+```mermaid
+graph TD
+    subgraph "Week 1-2: Foundations"
+        S1A[Read this guide end-to-end]
+        S1B[Install HyperShift locally<br/><code>make hypershift-install-aws-dev</code>]
+        S1C[Create a test HostedCluster<br/><code>bin/hypershift create cluster</code>]
+        S1D[Explore the CRDs:<br/>HostedCluster, HCP, NodePool<br/><i>Read the API type files</i>]
+        S1E[Observe pods in the<br/>CP namespace with kubectl]
+    end
+
+    subgraph "Week 3-4: Architecture"
+        S2A[Read hostedcluster_controller.go<br/>Understand the reconcile loop]
+        S2B[Read hostedcontrolplane_controller.go<br/>Understand how the CPO<br/>deploys components]
+        S2C[Read nodepool_controller.go<br/>Understand the node flow]
+        S2D[Study the CPOv2 framework<br/>support/controlplane-component/]
+        S2E[Read a simple v2 component<br/>e.g., kube-scheduler]
+    end
+
+    subgraph "Week 5-6: Deep Dive"
+        S3A[Study the Platform interface<br/>and one implementation<br/>e.g., AWS or KubeVirt]
+        S3B[Understand the ignition flow<br/>Token -> Ignition Server -> Node]
+        S3C[Study PKI and certificates]
+        S3D[Make a real change:<br/>bug fix or small feature]
+        S3E[Run make verify<br/>and create your first PR]
+    end
+
+    subgraph "Week 7+: Specialization"
+        S4A[Choose area of focus:<br/>- Control Plane<br/>- Data Plane / NodePool<br/>- Platform specific<br/>- API Design]
+        S4B[Read E2E tests<br/>test/e2e/]
+        S4C[Contribute features<br/>and PR reviews]
+    end
+
+    S1A --> S1B --> S1C --> S1D --> S1E
+    S1E --> S2A
+    S2A --> S2B --> S2C --> S2D --> S2E
+    S2E --> S3A
+    S3A --> S3B --> S3C --> S3D --> S3E
+    S3E --> S4A --> S4B --> S4C
+```
+
+### Suggested Reading Order for Code
+
+For each area, follow this order to build understanding incrementally:
+
+**Control Plane path:**
+
+1. `api/hypershift/v1beta1/hostedcluster_types.go` (skim the Spec, focus on key fields)
+2. `api/hypershift/v1beta1/hosted_controlplane.go` (note the similarity to HC)
+3. `hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go` (`Reconcile` method only)
+4. `control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go` (`Reconcile` and `registerComponents`)
+5. `support/controlplane-component/controlplane-component.go` (core framework)
+6. `control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/` (simple component)
+
+**Data Plane path:**
+
+1. `api/hypershift/v1beta1/nodepool_types.go`
+2. `hypershift-operator/controllers/nodepool/nodepool_controller.go` (`Reconcile` entry point)
+3. `hypershift-operator/controllers/nodepool/config.go` (hash-based rollout)
+4. `hypershift-operator/controllers/nodepool/token.go` (ignition tokens)
+5. `hypershift-operator/controllers/nodepool/capi.go` (CAPI resource creation)
+6. `ignition-server/cmd/start.go` (how nodes fetch their config)
+
+**Platform path (pick one):**
+
+1. `hypershift-operator/controllers/hostedcluster/internal/platform/platform.go` (interface)
+2. `hypershift-operator/controllers/hostedcluster/internal/platform/<your-platform>/` (implementation)
+3. `hypershift-operator/controllers/nodepool/<your-platform>.go` (machine template)
+4. `control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/<your-platform>/` (CCM)
+5. `api/hypershift/v1beta1/<your-platform>.go` (API types)
+
+---
+
+## Guide Contents
+
+| Section | What you'll learn |
+|---------|------------------|
+| [What is HyperShift?](what-is-hypershift.md) | The problem HyperShift solves and how it works |
+| [Key Concepts](key-concepts.md) | Core resources, glossary, and terminology |
+| [Architecture](architecture.md) | Overall architecture, namespace layout, and main components |
+| [Cluster Lifecycle](lifecycle.md) | Creation, upgrades, deletion, and the CPO reconciliation flow |
+| [Data Plane](data-plane.md) | NodePool management, node lifecycle, ClusterAPI, auto-scaling |
+| [Cloud Platforms](platforms.md) | Supported platforms, comparison, and infrastructure details |
+| [Development](development.md) | APIs, code structure, development workflow, and patterns |
+| [Reference](reference.md) | Architectural invariants and key file reference |

--- a/docs/content/getting-started/onboarding/key-concepts.md
+++ b/docs/content/getting-started/onboarding/key-concepts.md
@@ -1,0 +1,67 @@
+# Key Concepts
+
+> **See also**: [Concepts and Personas](../../reference/concepts-and-personas.md) for detailed persona definitions (Service Provider, Consumer, Instance Admin) and [Controller Architecture](../../reference/controller-architecture.md) for detailed controller diagrams and resource dependency graphs.
+
+```mermaid
+graph TD
+    subgraph "Management Cluster"
+        HC[HostedCluster<br/><i>namespace: clusters</i>]
+        NP[NodePool<br/><i>namespace: clusters</i>]
+
+        subgraph "CP Namespace: clusters-my-cluster"
+            HCP[HostedControlPlane]
+            CPO[Control Plane Operator]
+            ETCD[etcd]
+            KAS[kube-apiserver]
+            KCM[kube-controller-manager]
+            SCHED[kube-scheduler]
+            OAPI[openshift-apiserver]
+            PKI[PKI Operator]
+            IGN[Ignition Server]
+        end
+
+        HO[HyperShift Operator<br/><i>namespace: hypershift</i>]
+    end
+
+    subgraph "Guest Cluster - Data Plane"
+        W1[Worker Node 1]
+        W2[Worker Node 2]
+        W3[Worker Node N]
+    end
+
+    HO -->|manages| HC
+    HO -->|manages| NP
+    HO -->|creates| HCP
+    HO -->|deploys| CPO
+    CPO -->|manages| ETCD
+    CPO -->|manages| KAS
+    CPO -->|manages| KCM
+    CPO -->|manages| SCHED
+    CPO -->|manages| OAPI
+    CPO -->|manages| PKI
+    CPO -->|manages| IGN
+
+    KAS -.->|konnectivity tunnel| W1
+    KAS -.->|konnectivity tunnel| W2
+    KAS -.->|konnectivity tunnel| W3
+    IGN -.->|ignition configs| W1
+    IGN -.->|ignition configs| W2
+    IGN -.->|ignition configs| W3
+```
+
+## Glossary
+
+> For full persona and concept definitions, see [Concepts and Personas](../../reference/concepts-and-personas.md).
+
+| Term | Description | Start Reading Here |
+|------|-------------|-------------------|
+| **Management Cluster** | The OpenShift/K8s cluster where HyperShift operators run and where control plane pods live | `hypershift-operator/main.go` |
+| **Guest Cluster** (Hosted Cluster) | The cluster end users consume. Only has worker nodes | - |
+| **HostedCluster (HC)** | User-facing CRD declaring the intent to create a cluster. Lives in the user's namespace | `api/hypershift/v1beta1/hostedcluster_types.go` |
+| **HostedControlPlane (HCP)** | Internal CRD created by the HC controller. Lives in the control plane namespace. The CPO reads it to know what to deploy | `api/hypershift/v1beta1/hosted_controlplane.go` |
+| **NodePool (NP)** | User-facing CRD defining a scalable set of worker nodes. References a HostedCluster | `api/hypershift/v1beta1/nodepool_types.go` |
+| **Control Plane Namespace** | Namespace (`{hc-ns}-{hc-name}`) where all control plane components live | `hypershift-operator/controllers/manifests/manifests.go` |
+| **HyperShift Operator (HO)** | Main operator managing HostedClusters and NodePools | `hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go` |
+| **Control Plane Operator (CPO)** | Runs inside each CP namespace and manages all control plane components | `control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go` |
+| **PKI Operator** | Certificate operator handling rotation and signing | `control-plane-pki-operator/operator.go` |
+| **Ignition Server** | HTTPS server that serves ignition configs to worker nodes during bootstrap | `ignition-server/cmd/start.go` |

--- a/docs/content/getting-started/onboarding/lifecycle.md
+++ b/docs/content/getting-started/onboarding/lifecycle.md
@@ -1,0 +1,197 @@
+# Cluster Lifecycle and Control Plane
+
+---
+
+## HostedCluster Lifecycle
+
+### Creation
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant HC as HostedCluster
+    participant HO as HyperShift Operator
+    participant CPNS as CP Namespace
+    participant CPO as Control Plane Operator
+    participant CAPI as ClusterAPI
+    participant NP as NodePool
+    participant Cloud as Cloud Provider
+
+    User->>HC: Creates HostedCluster CR
+    HO->>HC: Watch & Reconcile
+    HO->>HO: Validates release image, config
+    HO->>CPNS: Creates namespace<br/>{hc-ns}-{hc-name}
+    HO->>CPNS: Copies secrets<br/>(pull-secret, SSH, encryption)
+    HO->>CPNS: Creates HostedControlPlane CR
+    HO->>CPNS: Deploys CPO Deployment
+    HO->>CPNS: Deploys CAPI Manager + Provider
+    HO->>CPNS: Configures NetworkPolicies
+
+    CPO->>CPO: Reads HCP, resolves release image
+    CPO->>CPNS: Deploys etcd StatefulSet
+    CPO->>CPNS: Deploys kube-apiserver
+    CPO->>CPNS: Deploys +30 components
+    CPO->>HC: Reports status via HCP
+
+    HO->>HC: Copies kubeconfig to user namespace
+
+    User->>NP: Creates NodePool CR
+    HO->>NP: Watch & Reconcile
+    HO->>CPNS: Creates Token + UserData Secrets
+    HO->>CAPI: Creates MachineDeployment + MachineTemplate
+    CAPI->>Cloud: Provisions instances
+    Cloud-->>CPNS: Nodes boot, fetch ignition
+    Cloud-->>HC: Nodes join the guest cluster
+```
+
+!!! tip "Explore yourself"
+    Follow the creation flow step by step in `hostedcluster_controller.go`:
+
+    1. `Reconcile()` (~line 337) - entry point
+    2. `reconcileHostedControlPlane()` (~line 2404) - HCP creation
+    3. `reconcileControlPlaneOperator()` - CPO deployment
+    4. `reconcileCAPIManager()` - CAPI deployment
+    5. Network policies: `hypershift-operator/controllers/hostedcluster/network_policies.go`
+
+### Steady State
+
+- The CPO continuously reconciles all components against the HCP spec
+- The PKI operator rotates certificates automatically
+- The NodePool controller manages auto-repair and scaling
+- Status flow: `CPO -> HCP status -> HO -> HC status`
+
+### Upgrade
+
+> **See also**: [Upgrades](../../how-to/upgrades.md) for detailed upgrade procedures and version skew policies.
+
+Control plane and data plane upgrades are **decoupled**:
+
+```mermaid
+graph LR
+    subgraph "Control Plane Upgrade"
+        A[Change HC.spec.release] --> B[HO updates HCP]
+        B --> C[CPO deploys new versions<br/>of components]
+    end
+
+    subgraph "Data Plane Upgrade"
+        D[Change NP.spec.release] --> E[New config hash]
+        E --> F[New token/userdata Secrets]
+        F --> G[CAPI rolling update<br/>of MachineDeployment]
+    end
+
+    A -.->|independent| D
+```
+
+- `controlPlaneRelease`: allows patching management-side components without touching the data plane
+- NodePool releases can be updated independently (within N-2 y-stream skew)
+
+### Deletion
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant HO as HyperShift Operator
+    participant CAPI as ClusterAPI
+    participant Cloud as Cloud Provider
+
+    User->>HO: Delete HostedCluster
+    HO->>CAPI: Deletes Machines, MachineDeployments
+    CAPI->>Cloud: Terminates instances
+    HO->>HO: Deletes HCP, waits for CPO cleanup
+    HO->>Cloud: Cleans up cloud resources<br/>(LBs, DNS, SGs, endpoints)
+    HO->>HO: Cleans up cluster-wide RBAC
+    HO->>HO: Removes finalizer
+    Note over HO: Supports grace period via<br/>hypershift.openshift.io/destroy-grace-period
+```
+
+!!! tip "Explore yourself"
+    The deletion flow starts at `r.delete()` (~line 501 in `hostedcluster_controller.go`). Notice the `CloudResourcesDestroyed` and `HostedClusterDestroyed` conditions.
+
+---
+
+## Control Plane in Detail
+
+### CPO Reconciliation Flow
+
+> **See also**: [Controller Architecture](../../reference/controller-architecture.md) for the full controller dependency graph and reconciliation details.
+
+```mermaid
+flowchart TD
+    START[Reconcile HCP] --> FETCH[Fetch HostedControlPlane]
+    FETCH --> DEL{Deletion?}
+    DEL -->|Yes| CLEANUP[Cleanup cloud resources<br/>Remove finalizer]
+    DEL -->|No| FIN[Add finalizer]
+    FIN --> VALIDATE[Validate configuration]
+    VALIDATE --> ETCD_STATUS[Check etcd status]
+    ETCD_STATUS --> KMS[Validate KMS config]
+    KMS --> KAS_STATUS[Check KAS availability]
+    KAS_STATUS --> INFRA[Setup infrastructure status<br/>endpoints, DNS, routes]
+    INFRA --> IGNITION_CFG[Reconcile ignition configs]
+    IGNITION_CFG --> OAUTH_PWD[Reconcile kubeadmin password]
+    OAUTH_PWD --> CONTEXT[Build ControlPlaneContext]
+    CONTEXT --> COMPONENTS[Iterate registered components]
+
+    subgraph "Component Loop"
+        COMPONENTS --> C1[Component.Reconcile]
+        C1 --> PRED{Predicate<br/>passes?}
+        PRED -->|No| DELETE_RES[Delete component resources]
+        PRED -->|Yes| DEPS{Dependencies<br/>ready?}
+        DEPS -->|No| WAIT[Skip, requeue]
+        DEPS -->|Yes| RECONCILE[Reconcile manifests<br/>+ workload]
+        RECONCILE --> STATUS_CR[Update ControlPlaneComponent CR]
+    end
+```
+
+!!! tip "Explore yourself"
+    In `hostedcontrolplane_controller.go`, the component iteration loop is at ~line 1232:
+
+    ```go
+    for _, c := range r.components {
+        r.Log.Info("Reconciling component", "component_name", c.Name())
+        if err := c.Reconcile(cpContext); err != nil {
+            errs = append(errs, err)
+        }
+    }
+    ```
+
+### Component Dependencies
+
+```mermaid
+graph TD
+    PKI[PKI Operator] --> |no deps| READY1((Ready))
+    ETCD[etcd] --> |no deps| READY2((Ready))
+    FG[FeatureGate Generator] --> |no deps| READY3((Ready))
+    ROUTER[Router] --> |no deps| READY4((Ready))
+
+    READY2 --> KAS[kube-apiserver]
+    READY3 --> KAS
+
+    KAS --> |implicit dependency| KCM[kube-controller-manager]
+    KAS --> |implicit dependency| SCHED[kube-scheduler]
+    KAS --> |implicit dependency| OAPI[openshift-apiserver]
+    KAS --> |implicit dependency| CVO[CVO]
+    KAS --> |implicit dependency| ALL["All other<br/>components (~30)"]
+
+    style PKI fill:#c8e6c9
+    style ETCD fill:#c8e6c9
+    style FG fill:#c8e6c9
+    style ROUTER fill:#c8e6c9
+    style KAS fill:#ffcc80
+```
+
+KAS is an implicit dependency for all components **except**: etcd, featuregate-generator, control-plane-operator, cluster-api, capi-provider, karpenter, and router.
+
+### Status Propagation
+
+```mermaid
+graph LR
+    CPC[ControlPlaneComponent CRs<br/><i>per-component</i><br/>Available / RolloutComplete] --> HCP_STATUS[HCP Status<br/>Conditions:<br/>EtcdAvailable<br/>KubeAPIServerAvailable<br/>ValidConfiguration]
+    HCP_STATUS --> HC_STATUS[HC Status<br/>Conditions:<br/>Available<br/>Progressing<br/>Degraded]
+
+    HC_STATUS --> USER[Visible to the user]
+```
+
+!!! tip "Explore yourself"
+    - HC conditions are defined in `api/hypershift/v1beta1/hostedcluster_conditions.go`
+    - NP conditions are in `api/hypershift/v1beta1/nodepool_conditions.go`
+    - The CPOv2 status logic is in `support/controlplane-component/status.go`

--- a/docs/content/getting-started/onboarding/platforms.md
+++ b/docs/content/getting-started/onboarding/platforms.md
@@ -1,0 +1,268 @@
+# Supported Cloud Platforms
+
+> **See also**: [Multi-Platform Support](../../reference/multi-platform-support.md) for the full support matrix across HostedCluster, NodePool, and management cluster platform combinations.
+
+HyperShift supports multiple infrastructure platforms. Each platform implements the same `Platform` interface but brings its own CAPI provider, credential model, and networking primitives. Some platforms are generally available while others are behind feature gates.
+
+```mermaid
+graph TD
+    subgraph "Cloud Providers"
+        subgraph "AWS"
+            AWS_SM["AWS Self-Managed"]
+            AWS_M["AWS Managed<br/><i>ROSA HCP</i>"]
+        end
+
+        subgraph "Azure"
+            AZ_SM["Azure Self-Managed"]
+            AZ_M["Azure Managed<br/><i>ARO HCP</i>"]
+        end
+
+        subgraph "GCP"
+            GCP_SM["GCP Self-Managed<br/><i>Feature-gated</i>"]
+            GCP_M["GCP Managed<br/><i>GCP HCP</i>"]
+        end
+    end
+
+    subgraph "Virtualization"
+        KV["KubeVirt<br/><i>VMs on K8s</i>"]
+    end
+
+    subgraph "Bare Metal"
+        AG["Agent<br/><i>Bare-metal</i>"]
+    end
+
+    subgraph "Other"
+        OS["OpenStack<br/><i>Feature-gated</i>"]
+        IBM["IBM Cloud<br/><i>PowerVS</i>"]
+    end
+
+    style AWS_SM fill:#f96,stroke:#333
+    style AWS_M fill:#f96,stroke:#333
+    style AZ_SM fill:#69f,stroke:#333
+    style AZ_M fill:#69f,stroke:#333
+    style GCP_SM fill:#6c6,stroke:#333
+    style GCP_M fill:#6c6,stroke:#333
+    style KV fill:#c6f,stroke:#333
+    style AG fill:#a65,stroke:#333
+    style OS fill:#f66,stroke:#333
+    style IBM fill:#999,stroke:#333
+```
+
+---
+
+## Platform Interface
+
+Every platform must implement the `Platform` interface defined in `hypershift-operator/controllers/hostedcluster/internal/platform/platform.go`. The HyperShift Operator uses this interface to abstract away cloud-specific details during HostedCluster reconciliation.
+
+```go
+type Platform interface {
+    // ReconcileCAPIInfraCR creates/updates the platform-specific CAPI infrastructure CR
+    // that will be referenced by the CAPI Cluster CR.
+    ReconcileCAPIInfraCR(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
+        hcluster *hyperv1.HostedCluster, controlPlaneNamespace string,
+        apiEndpoint hyperv1.APIEndpoint) (client.Object, error)
+
+    // CAPIProviderDeploymentSpec returns the DeploymentSpec for the CAPI provider
+    // with platform-specific volumes, secrets, and containers.
+    CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster,
+        hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error)
+
+    // ReconcileCredentials copies cloud credentials from the HostedCluster namespace
+    // into the control plane namespace for the CPO to consume.
+    ReconcileCredentials(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
+        hcluster *hyperv1.HostedCluster, controlPlaneNamespace string) error
+
+    // ReconcileSecretEncryption copies KMS-related resources into the control plane
+    // namespace (if the platform supports KMS).
+    ReconcileSecretEncryption(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
+        hcluster *hyperv1.HostedCluster, controlPlaneNamespace string) error
+
+    // CAPIProviderPolicyRules returns additional RBAC PolicyRules required by the
+    // CAPI provider to manage platform resources. Return nil if none are needed.
+    CAPIProviderPolicyRules() []rbacv1.PolicyRule
+
+    // DeleteCredentials cleans up platform credential resources so they don't leak
+    // when a HostedCluster is deleted.
+    DeleteCredentials(ctx context.Context, c client.Client,
+        hcluster *hyperv1.HostedCluster, controlPlaneNamespace string) error
+}
+```
+
+The `GetPlatform()` function in the same file uses a `switch` on `hcluster.Spec.Platform.Type` to instantiate the correct implementation (AWS, Azure, GCP, KubeVirt, Agent, etc.).
+
+---
+
+## Platform Comparison
+
+| Aspect | AWS (Self-Managed) | AWS (ROSA HCP) | Azure (Self-Managed) | Azure (ARO HCP) | GCP (GCP HCP) | KubeVirt | Agent |
+|--------|-------------------|----------------|---------------------|-----------------|---------------|----------|-------|
+| **Managed service** | No | Yes | No | Yes | Yes | No | No |
+| **CAPI Provider** | CAPA | CAPA | CAPZ | CAPZ | CAPG | - | - |
+| **Identity** | STS / IRSA | STS / IRSA | Workload Identity | Workload Identity | Workload Identity | N/A | N/A |
+| **KMS** | AWS KMS | AWS KMS | Azure Key Vault | Azure Key Vault | GCP KMS | N/A | N/A |
+| **Private connectivity** | AWS PrivateLink | AWS PrivateLink | Azure Private Link Service | Azure Private Link Service | Private Service Connect | N/A | N/A |
+| **Infra provisioning** | EC2/VPC | EC2/VPC | VMs/VNet | VMs/VNet | GCE/VPC | KubeVirt VMs | BareMetalHost |
+| **Cloud Controller Manager** | aws-ccm | aws-ccm | azure-ccm | azure-ccm | gcp-ccm | kubevirt-ccm | N/A |
+
+!!! tip "Explore yourself"
+    Browse the platform implementation directories to see how each platform implements the interface:
+
+    - `hypershift-operator/controllers/hostedcluster/internal/platform/aws/`
+    - `hypershift-operator/controllers/hostedcluster/internal/platform/azure/`
+    - `hypershift-operator/controllers/hostedcluster/internal/platform/gcp/`
+    - `hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/`
+    - `hypershift-operator/controllers/hostedcluster/internal/platform/agent/`
+    - `hypershift-operator/controllers/hostedcluster/internal/platform/openstack/`
+    - `hypershift-operator/controllers/hostedcluster/internal/platform/powervs/`
+
+---
+
+## AWS Infrastructure
+
+AWS is the most mature platform. Both self-managed and managed (ROSA HCP) deployments use the same underlying infrastructure primitives.
+
+```mermaid
+graph TD
+    subgraph "Management Cluster VPC"
+        HO[HyperShift Operator]
+
+        subgraph "CP Namespace"
+            KAS[kube-apiserver]
+            NLB[Network Load Balancer<br/><i>API endpoint</i>]
+            CAPA[CAPA Controller]
+        end
+    end
+
+    subgraph "Guest Cluster VPC"
+        subgraph "Public Subnets"
+            IGW[Internet Gateway]
+            NATGW[NAT Gateway]
+        end
+        subgraph "Private Subnets"
+            W1[Worker EC2<br/>Subnet AZ-a]
+            W2[Worker EC2<br/>Subnet AZ-b]
+            W3[Worker EC2<br/>Subnet AZ-c]
+        end
+    end
+
+    HO -->|creates| NLB
+    NLB --> KAS
+    CAPA -->|provisions| W1
+    CAPA -->|provisions| W2
+    CAPA -->|provisions| W3
+    W1 & W2 & W3 -->|egress via| NATGW
+    NATGW --> IGW
+
+    style NLB fill:#f96,stroke:#333
+    style KAS fill:#69f,stroke:#333
+```
+
+The guest cluster VPC contains public subnets (with an Internet Gateway and NAT Gateway for outbound traffic) and private subnets where worker EC2 instances run. The CAPI AWS provider (CAPA) manages the machine lifecycle. The kube-apiserver is fronted by a Network Load Balancer for external access.
+
+---
+
+## AWS PrivateLink
+
+For private clusters on AWS, HyperShift uses AWS PrivateLink to expose the kube-apiserver without traversing the public internet. The CPO runs a dedicated controller that manages the PrivateLink endpoint service and VPC endpoint:
+
+- **Source**: `control-plane-operator/controllers/awsprivatelink/`
+- The management cluster creates a VPC Endpoint Service backed by the kube-apiserver NLB
+- Consumers create a VPC Endpoint in their VPC that connects through PrivateLink
+- DNS is configured so the API server hostname resolves to the private endpoint
+
+This model is critical for ROSA HCP where the control plane runs in a service account VPC that the customer never sees directly.
+
+---
+
+## KubeVirt Nested Virtualization
+
+KubeVirt is unique because it runs guest cluster worker nodes as virtual machines on an existing Kubernetes cluster, creating a nested architecture:
+
+```mermaid
+graph TD
+    subgraph "Infrastructure Cluster (OCP with KubeVirt)"
+        KV_OP[KubeVirt Operator]
+        subgraph "Management Cluster Layer"
+            HO[HyperShift Operator]
+            subgraph "CP Namespace"
+                CPO_KV[CPO]
+                KAS_KV[kube-apiserver]
+            end
+        end
+
+        subgraph "KubeVirt VMs"
+            VM1[VM: Worker 1<br/><i>runs as a Pod</i>]
+            VM2[VM: Worker 2<br/><i>runs as a Pod</i>]
+            VM3[VM: Worker N<br/><i>runs as a Pod</i>]
+        end
+    end
+
+    KV_OP -->|manages VMs| VM1 & VM2 & VM3
+    HO -->|creates HC| CPO_KV
+    CPO_KV -->|manages| KAS_KV
+    KAS_KV -.->|konnectivity| VM1 & VM2 & VM3
+
+    style VM1 fill:#c6f,stroke:#333
+    style VM2 fill:#c6f,stroke:#333
+    style VM3 fill:#c6f,stroke:#333
+```
+
+Key differences from cloud platforms:
+
+- **No CAPI provider**: KubeVirt manages VMs directly through the KubeVirt API
+- **No cloud credentials**: The infrastructure cluster already has everything needed
+- **Nested networking**: Guest cluster pods run inside VMs that run inside pods on the infra cluster
+- **Shared infrastructure**: The management cluster, control plane, and worker VMs all share the same underlying cluster
+
+---
+
+## Cloud Controller Managers
+
+Each cloud platform has a Cloud Controller Manager (CCM) that runs in the control plane namespace. The CCM is responsible for:
+
+- Initializing nodes with cloud-specific metadata (zone, instance type, addresses)
+- Managing cloud load balancers for Services of type `LoadBalancer`
+- Handling node lifecycle (detecting when cloud instances are terminated)
+
+Platform-specific CCM implementations are registered as CPO v2 components:
+
+- `control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/aws/`
+- `control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/`
+- `control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/gcp/`
+- `control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/kubevirt/`
+- `control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/`
+- `control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/powervs/`
+
+Each CCM component adapts a `cloud-provider-<platform>` binary with the appropriate cloud configuration file, credentials, and feature gates for the hosted cluster.
+
+---
+
+## Credential Management Pattern
+
+Cloud credentials flow from the user-facing HostedCluster resource into the control plane namespace where they are consumed by the CAPI provider, CCM, and other platform-aware components:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant HC as HostedCluster
+    participant HO as HyperShift Operator
+    participant CPN as CP Namespace
+    participant CAPI as CAPI Provider
+    participant CCM as Cloud Controller Manager
+
+    User->>HC: Creates HC with cloud credentials<br/>(Secret references in spec.platform)
+    HO->>HO: platform.ReconcileCredentials()
+    HO->>CPN: Copies credential Secrets<br/>into control plane namespace
+    HO->>HO: platform.ReconcileSecretEncryption()
+    HO->>CPN: Copies KMS Secrets<br/>(if platform supports KMS)
+    CPN->>CAPI: Mounts credentials as volumes
+    CPN->>CCM: Mounts cloud config + credentials
+```
+
+The cloud configuration file that the CCM and other components consume is generated per-platform:
+
+- **AWS**: `control-plane-operator/controllers/hostedcontrolplane/cloud/aws/providerconfig.go`
+- **Azure**: `control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go`
+- **OpenStack**: `control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/providerconfig.go`
+
+These files build the `cloud.conf` (or equivalent) that gets mounted into the CCM, KCM, and other components that need to interact with the cloud API.

--- a/docs/content/getting-started/onboarding/reference.md
+++ b/docs/content/getting-started/onboarding/reference.md
@@ -1,0 +1,126 @@
+# Architectural Invariants and Key File Reference
+
+## Architectural Invariants
+
+> **See also**: [Goals and Design Invariants](../../reference/goals-and-design-invariants.md) for the authoritative list of project goals and invariants.
+
+These are the design rules that should inform **every decision**:
+
+1. **Unidirectional communication**: Management cluster -> hosted cluster, never the reverse. All communication originates from within the CP namespace.
+
+2. **Pristine workers**: Compute nodes run only user workloads + minimal agents (kubelet, konnectivity-agent, CNI). No control plane logic.
+
+3. **No mutable CRDs/CRs exposed**: The hosted cluster should not expose mutable resources that could interfere with HyperShift-managed features.
+
+4. **Data plane changes do not trigger management-side lifecycle actions**: Prevents cascading failures.
+
+5. **No user credential management**: HyperShift components do not own credentials; they copy and use them, but ownership remains with the user.
+
+6. **Namespace isolation**: Each CP namespace is isolated via NetworkPolicies and Linux container primitives. See `hypershift-operator/controllers/hostedcluster/network_policies.go`.
+
+7. **Decoupled upgrade signals**: Management-side and data-plane components upgrade independently via `controlPlaneRelease`.
+
+8. **CPO backward compatibility**: The HO may deploy older CPO versions. Changes to the HO must consider impact on older CPOs. The HO checks CPO image labels before enabling features (e.g., `controlPlanePKIOperatorSignsCSRs`, `useRestrictedPSA`, `defaultToControlPlaneV2`).
+
+---
+
+## Key File Reference
+
+### APIs
+
+| File | Contents | Priority |
+|------|----------|----------|
+| `api/hypershift/v1beta1/hostedcluster_types.go` | HostedCluster spec/status, platform configs, constants, annotations | Must read |
+| `api/hypershift/v1beta1/hostedcluster_conditions.go` | HC condition type constants | Must read |
+| `api/hypershift/v1beta1/hosted_controlplane.go` | HostedControlPlane spec/status | Must read |
+| `api/hypershift/v1beta1/nodepool_types.go` | NodePool spec/status | Must read |
+| `api/hypershift/v1beta1/nodepool_conditions.go` | NP condition type constants | Must read |
+| `api/hypershift/v1beta1/aws.go` | AWS types (`AWSPlatformSpec`, `AWSRolesRef`) | Read for AWS work |
+| `api/hypershift/v1beta1/azure.go` | Azure types | Read for Azure work |
+| `api/hypershift/v1beta1/kubevirt.go` | KubeVirt types | Read for KubeVirt work |
+| `api/hypershift/v1beta1/controlplanecomponent_types.go` | CPOv2 ControlPlaneComponent CR | Good to know |
+| `api/hypershift/v1beta1/etcdbackup_types.go` | Feature-gated type example | Good to know |
+| `api/hypershift/v1beta1/groupversion_info.go` | API group registration | Reference |
+| `api/CLAUDE.md` | API compatibility rules | Must read |
+
+### HO Controllers
+
+| File | Contents | Priority |
+|------|----------|----------|
+| `hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go` | HC Reconciler (~5200 lines) | Must read (selectively) |
+| `hypershift-operator/controllers/hostedcluster/network_policies.go` | Namespace isolation NetworkPolicies | Good to know |
+| `hypershift-operator/controllers/nodepool/nodepool_controller.go` | NP Reconciler main entry | Must read |
+| `hypershift-operator/controllers/nodepool/config.go` | ConfigGenerator, rollout hash | Must read |
+| `hypershift-operator/controllers/nodepool/token.go` | Token and UserData Secrets | Must read |
+| `hypershift-operator/controllers/nodepool/capi.go` | MachineDeployment, MHC, templates | Must read |
+| `hypershift-operator/controllers/nodepool/aws.go` | AWS MachineTemplate builder | Read for AWS work |
+| `hypershift-operator/controllers/nodepool/azure.go` | Azure MachineTemplate builder | Read for Azure work |
+| `hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go` | KubeVirt MachineTemplate builder | Read for KubeVirt work |
+| `hypershift-operator/controllers/nodepool/conditions.go` | SetStatusCondition helpers | Reference |
+| `hypershift-operator/controllers/nodepool/version.go` | NodesInfo aggregation from CAPI Machines | Reference |
+| `hypershift-operator/controllers/nodepool/scale_from_zero.go` | Scale-from-zero annotation management | Reference |
+| `hypershift-operator/controllers/manifests/manifests.go` | Namespace naming, resource naming helpers | Reference |
+
+### CPO Controllers
+
+| File | Contents | Priority |
+|------|----------|----------|
+| `control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go` | HCP Reconciler (~3200 lines) | Must read (selectively) |
+| `control-plane-operator/controllers/hostedcontrolplane/v2/kas/` | kube-apiserver component (complex example) | Good to know |
+| `control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/` | kube-scheduler component (simple example) | Must read |
+| `control-plane-operator/controllers/hostedcontrolplane/v2/etcd/` | etcd component | Good to know |
+| `control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/` | CAPI manager component | Reference |
+| `control-plane-operator/controllers/hostedcontrolplane/v2/capi_provider/` | CAPI provider component | Reference |
+| `control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/` | Per-platform CCMs | Read per platform |
+| `control-plane-operator/controllers/hostedcontrolplane/v2/assets/` | YAML manifests for all components | Reference |
+
+### Framework and Support
+
+| File | Contents | Priority |
+|------|----------|----------|
+| `support/controlplane-component/controlplane-component.go` | CPOv2 framework core | Must read |
+| `support/controlplane-component/builder.go` | Builder pattern for components | Must read |
+| `support/controlplane-component/status.go` | Status logic, dependency checking | Must read |
+| `support/controlplane-component/workload.go` | Workload reconciliation | Good to know |
+| `support/upsert/upsert.go` | CreateOrUpdate wrapper | Must read |
+
+### Platform Implementations
+
+| File | Contents | Priority |
+|------|----------|----------|
+| `hypershift-operator/controllers/hostedcluster/internal/platform/platform.go` | Platform interface definition | Must read |
+| `hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go` | AWS platform impl | Read for AWS |
+| `hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go` | Azure platform impl | Read for Azure |
+| `hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go` | KubeVirt platform impl | Read for KubeVirt |
+| `hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go` | Agent platform impl | Read for Agent |
+
+### PKI and Ignition
+
+| File | Contents | Priority |
+|------|----------|----------|
+| `control-plane-pki-operator/operator.go` | PKI operator wiring | Good to know |
+| `control-plane-pki-operator/certrotationcontroller/` | Certificate rotation | Reference |
+| `control-plane-pki-operator/certificatesigningcontroller/` | CSR signing | Reference |
+| `ignition-server/cmd/start.go` | Ignition HTTPS server | Good to know |
+| `ignition-server/controllers/tokensecret_controller.go` | Token reconciler | Good to know |
+| `ignition-server/controllers/local_ignitionprovider.go` | MCO binary execution | Reference |
+
+### CLI and Infrastructure
+
+| File | Contents | Priority |
+|------|----------|----------|
+| `main.go` | CLI entry point | Reference |
+| `cmd/cluster/` | create/destroy cluster commands | Reference |
+| `cmd/nodepool/` | create/destroy nodepool commands | Reference |
+| `cmd/install/` | install command, CRD assets | Reference |
+| `cmd/infra/aws/create.go` | AWS infra CLI (`CreateInfra()`) | Read for AWS |
+| `cmd/infra/aws/iam.go` | AWS IAM roles and OIDC | Read for AWS |
+| `cmd/infra/azure/` | Azure infra CLI | Read for Azure |
+
+### Tests
+
+| File | Contents | Priority |
+|------|----------|----------|
+| `test/e2e/` | E2E tests (cluster lifecycle, nodepool, upgrades) | Browse for context |
+| `test/integration/` | Integration tests (controller behavior) | Browse for context |
+| `api/hypershift/v1beta1/nodepool_types_test.go` | Serialization compatibility test example | Must read for API changes |

--- a/docs/content/getting-started/onboarding/what-is-hypershift.md
+++ b/docs/content/getting-started/onboarding/what-is-hypershift.md
@@ -1,0 +1,62 @@
+# What is HyperShift?
+
+HyperShift is an OpenShift middleware that **decouples the control plane from the data plane** (worker nodes), allowing control planes to run as workloads on a central **management cluster**.
+
+## The Problem it Solves
+
+In standalone OpenShift, every cluster runs its own control plane (etcd, kube-apiserver, controllers) on dedicated master nodes. This creates:
+
+- **Resource overhead**: 3+ master nodes per cluster just for the control plane
+- **Provisioning time**: 30-45 minutes including bootstrap
+- **Distributed operations**: each control plane is independently operated
+
+## How HyperShift Solves It
+
+**Standalone OpenShift** — each cluster embeds its own control plane on dedicated master nodes:
+
+```mermaid
+graph LR
+    subgraph "Standalone Cluster 1"
+        M1[Control Plane<br/>Masters x3]
+        W1[Workers 1..N]
+        M1 --> W1
+    end
+
+    subgraph "Standalone Cluster 2"
+        M2[Control Plane<br/>Masters x3]
+        W2[Workers 1..N]
+        M2 --> W2
+    end
+
+    subgraph "Standalone Cluster 3"
+        M3[Control Plane<br/>Masters x3]
+        W3[Workers 1..N]
+        M3 --> W3
+    end
+```
+
+Each standalone cluster is **self-contained** — it embeds its own control plane on dedicated master nodes. There is no shared management layer; every cluster independently operates its own etcd, API server, and controllers.
+
+**HyperShift Model** — a single management cluster hosts all control planes as pods:
+
+```mermaid
+graph LR
+    subgraph "Management Cluster"
+        D[Management Cluster]
+        D --> E[HCP 1 - Pods]
+        D --> F[HCP 2 - Pods]
+        D --> G[HCP 3 - Pods]
+    end
+
+    E -.-> H[Workers 1..N]
+    F -.-> I[Workers 1..N]
+    G -.-> J[Workers 1..N]
+```
+
+| Aspect | Standalone OpenShift | HyperShift (HCP) |
+|--------|---------------------|-------------------|
+| Control plane location | Dedicated master nodes inside the cluster | Pods on a management cluster |
+| Master nodes | 3+ required | Zero; only worker nodes in the guest cluster |
+| Provisioning time | 30-45 minutes | ~10-15 minutes |
+| Control plane isolation | Physical/VM | Namespace + NetworkPolicies |
+| Upgrade model | Single upgrade for CP + workers | Independent upgrades for CP vs data plane |

--- a/docs/content/getting-started/quick-setup.md
+++ b/docs/content/getting-started/quick-setup.md
@@ -106,7 +106,7 @@ Create a new hosted cluster, specifying the domain of the public zone provided i
 
 The HyperShift CLI uses AWS STS (Security Token Service) for authentication. You need:
 
-1. An IAM role with the [required permissions](./reference/infrastructure/aws.md) to create cluster infrastructure
+1. An IAM role with the [required permissions](../reference/infrastructure/aws.md) to create cluster infrastructure
 2. Temporary STS credentials to authenticate
 
 Create an IAM role using the HyperShift CLI. The `--aws-creds` flag points to the credentials file for your
@@ -264,7 +264,7 @@ oc scale nodepool/$NODEPOOL_NAME \
 
 !!! note
 
-    See the [Scale Down](./how-to/automated-machine-management/nodepool-lifecycle.md#scale-down) section of the [NodePool lifecycle page](./how-to/automated-machine-management/nodepool-lifecycle.md) for more details when scaling down NodePools.
+    See the [Scale Down](../how-to/automated-machine-management/nodepool-lifecycle.md#scale-down) section of the [NodePool lifecycle page](../how-to/automated-machine-management/nodepool-lifecycle.md) for more details when scaling down NodePools.
 
 ## Delete a Hosted Cluster
 To delete a Hosted Cluster:

--- a/docs/content/how-to/aws/deploy-aws-private-clusters.md
+++ b/docs/content/how-to/aws/deploy-aws-private-clusters.md
@@ -15,7 +15,7 @@ through the process of configuring HyperShift for private cluster support on AWS
 
 To enable private hosted clusters, HyperShift must be installed with private
 cluster support. This guide assumes you have performed all the
-[Getting started guide prerequisites](../../getting-started.md#prerequisites). The
+[Getting started guide prerequisites](../../getting-started/quick-setup.md#prerequisites). The
 following steps will reference elements of the steps you already performed.
 
 1. Create the private cluster IAM policy document.
@@ -128,7 +128,7 @@ following steps will reference elements of the steps you already performed.
 
     !!! note
 
-        Even if you already installed HyperShift using the [Getting started guide](../../getting-started.md), you
+        Even if you already installed HyperShift using the [Getting started guide](../../getting-started/quick-setup.md), you
         can safely run `hypershift install` again with private cluster support to update the existing installation.
 
     !!! important

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -10,7 +10,7 @@ cross cloud with strong separation of concerns between management and workloads.
 Clusters are fully compliant [OpenShift Container Platform](https://www.redhat.com/en/technologies/cloud-computing/openshift/container-platform) (OCP)
 clusters and are compatible with standard OCP and Kubernetes toolchains.
 
-[Quick start](getting-started.md){ .md-button .md-button--primary }
+[Quick start](getting-started/quick-setup.md){ .md-button .md-button--primary }
 [Contribute](contribute/){ .md-button }
 
 ![Overview](images/high-level-overview.png)

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -1084,7 +1084,1538 @@ title: Run tests
 
 ---
 
-## Source: docs/content/getting-started.md
+## Source: docs/content/getting-started/index.md
+
+# Getting Started
+
+Welcome to HyperShift! Choose your path based on where you are:
+
+<div class="grid cards" markdown>
+
+-   :material-school:{ .lg .middle } **Onboarding Guide**
+
+    ---
+
+    New to the team? Start here for a structured learning path through HyperShift concepts, architecture, and codebase.
+
+    :octicons-arrow-right-24: Start onboarding
+
+-   :material-rocket-launch:{ .lg .middle } **Quick Setup (AWS)**
+
+    ---
+
+    Ready to create your first hosted cluster? Follow the step-by-step setup guide for a self-managed AWS cluster.
+
+    :octicons-arrow-right-24: Quick setup
+
+</div>
+
+
+---
+
+## Source: docs/content/getting-started/onboarding/architecture.md
+
+# Architecture and Main Components
+
+## Overall Architecture
+
+> **See also**: Controller Architecture for detailed controller diagrams and resource dependency graphs.
+
+```mermaid
+graph TB
+    subgraph "Management Cluster"
+        subgraph "hypershift namespace"
+            HO_DEPLOY[HyperShift Operator]
+        end
+
+        subgraph "clusters namespace"
+            HC1[HostedCluster]
+            NP1[NodePool]
+        end
+
+        subgraph "clusters-my-cluster namespace"
+            HCP1[HostedControlPlane]
+            CPO1[control-plane-operator]
+            PKI1[PKI operator]
+            ETCD1[etcd]
+            KAS1[kube-apiserver]
+            KONN[konnectivity]
+            MORE1["KCM, scheduler, CVO,<br/>CCM, ignition, +30 more"]
+            CAPI_PROV[CAPI Provider]
+        end
+    end
+
+    subgraph "Guest Cluster"
+        KUBELET1[kubelet]
+        KONN_AGENT[konnectivity-agent]
+        WORKLOADS[User Workloads]
+    end
+
+    HO_DEPLOY -->|manages| HC1
+    HO_DEPLOY -->|manages| NP1
+    HO_DEPLOY -->|creates| HCP1
+    HO_DEPLOY -->|deploys| CPO1
+
+    CPO1 -->|reconciles| ETCD1
+    CPO1 -->|reconciles| KAS1
+    CPO1 -->|reconciles| MORE1
+
+    KONN -->|tunnel| KONN_AGENT
+    KAS1 -.->|API calls via tunnel| KUBELET1
+```
+
+> For the full detailed architecture diagram with all components, see Controller Architecture.
+
+### Namespace Layout
+
+```mermaid
+graph LR
+    subgraph "Management Cluster Namespaces"
+        NS1["<b>hypershift</b><br/>HyperShift Operator"]
+        NS2["<b>clusters</b><br/>HostedCluster + NodePool CRs<br/>(user namespace)"]
+        NS3["<b>clusters-my-cluster</b><br/>Control Plane namespace"]
+        NS4["<b>clusters-another-cluster</b><br/>Another Control Plane"]
+    end
+
+    NS2 -->|HC controller creates| NS3
+    NS2 -->|HC controller creates| NS4
+```
+
+The namespace naming convention is implemented in `hypershift-operator/controllers/manifests/manifests.go`:
+```go
+func HostedControlPlaneNamespace(hostedClusterNamespace, hostedClusterName string) string {
+    return fmt.Sprintf("%s-%s", hostedClusterNamespace, strings.ReplaceAll(hostedClusterName, ".", "-"))
+}
+```
+
+!!! tip "Explore yourself"
+    Read `hypershift-operator/controllers/manifests/manifests.go` to see all the naming helpers used across the codebase.
+
+---
+
+## Main Components
+
+> **See also**: Controller Architecture for detailed controller diagrams, resource dependency graphs, and the Hosted Cluster Config Operator.
+
+### HyperShift Operator (HO)
+
+- **Entry point**: `hypershift-operator/main.go`
+- **Deployed in**: `hypershift` namespace as a Deployment
+
+Contains the main controllers:
+
+| Controller | Directory | Function | Read This First |
+|------------|-----------|----------|-----------------|
+| **HostedCluster** | `hypershift-operator/controllers/hostedcluster/` | Manages full HC lifecycle, creates CP namespace, deploys CPO | `hostedcluster_controller.go` (start at `Reconcile` method, ~line 337) |
+| **NodePool** | `hypershift-operator/controllers/nodepool/` | Manages CAPI Machines, ignition tokens, rolling upgrades | `nodepool_controller.go` (start at `Reconcile` method) |
+| **HostedClusterSizing** | `hypershift-operator/controllers/hostedclustersizing/` | Resource-based sizing decisions | `hostedclustersizing_controller.go` |
+| **Scheduler** | `hypershift-operator/controllers/scheduler/` | Schedules HCs on management cluster nodes | `scheduler.go` |
+| **SharedIngress** | `hypershift-operator/controllers/sharedingress/` | Shared ingress across multiple HCs | `sharedingress_controller.go` |
+
+!!! tip "Explore yourself"
+    The HostedCluster controller (`hostedcluster_controller.go`) is ~5200 lines. Don't try to read it all at once. Start with the `Reconcile` method and follow the function calls. Key sub-functions to look at:
+
+    - `reconcileHostedControlPlane()` (~line 2404) - how HC spec is translated to HCP
+    - `reconcileControlPlaneOperator()` - how the CPO deployment is created
+    - `reconcileCAPICluster()` (~line 2901) - how the CAPI Cluster CR is created
+    - `r.delete()` (~line 501) - the deletion flow
+
+### Control Plane Operator (CPO)
+
+- **Source**: `control-plane-operator/`
+- **Main controller**: `control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go` (~3200 lines)
+- **Deployed in**: each CP namespace (one CPO instance per hosted cluster)
+
+The CPO reads the `HostedControlPlane` resource and reconciles ~40 control plane components:
+
+```mermaid
+graph TD
+    HCP[HostedControlPlane CR] --> CPO[Control Plane Operator]
+
+    CPO --> PKI[PKI Operator]
+    CPO --> ETCD[etcd]
+    CPO --> FG[FeatureGate Generator]
+    CPO --> ROUTER[Router]
+
+    ETCD --> KAS[kube-apiserver]
+    FG --> KAS
+
+    KAS --> KCM[kube-controller-manager]
+    KAS --> SCHED[kube-scheduler]
+    KAS --> OAPI[openshift-apiserver]
+    KAS --> CVO[cluster-version-operator]
+    KAS --> CNO[cluster-network-operator]
+    KAS --> CCM[cloud-controller-manager]
+    KAS --> KONN[konnectivity]
+    KAS --> MORE["... +25 more components"]
+
+    style PKI fill:#e1f5fe
+    style ETCD fill:#e1f5fe
+    style FG fill:#e1f5fe
+    style ROUTER fill:#e1f5fe
+    style KAS fill:#fff3e0
+```
+
+> Light blue components have no KAS dependency. KAS (orange) is an implicit dependency for everything else. The full list includes oauth-server, oauth-apiserver, openshift-controller-manager, ingress-operator, dns-operator, machine-approver, config-operator, storage-operator, node-tuning-operator, and more.
+
+!!! tip "Explore yourself"
+    Look at the `registerComponents()` function (~line 236 in `hostedcontrolplane_controller.go`) to see the full list of registered components.
+
+    Then pick one simple component like `kube-scheduler` at `control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/` to understand the pattern.
+
+### CPOv2 Framework
+
+The declarative framework for defining control plane components. Each component uses a builder pattern:
+
+```go
+component.NewDeploymentComponent(name, opts).
+    WithAdaptFunction(adaptDeployment).           // Dynamic deployment mutations
+    WithPredicate(predicate).                      // Enable/disable the component
+    WithDependencies("etcd", "featuregate-generator"). // Block until deps are ready
+    WithManifestAdapter("config.yaml", ...).       // Adapt supporting manifests
+    InjectTokenMinterContainer(tokenOpts).         // Auto-inject token minter sidecar
+    InjectKonnectivityContainer(konnOpts).         // Auto-inject konnectivity proxy
+    RolloutOnConfigMapChange("my-config").          // Auto-rollout on config change
+    Build()
+```
+
+| File | What it does | Why you should read it |
+|------|-------------|----------------------|
+| `support/controlplane-component/controlplane-component.go` | Core reconcile logic, `ControlPlaneComponent` interface | Understand how components are reconciled (line 163, `Reconcile` method) |
+| `support/controlplane-component/builder.go` | Builder pattern for constructing components | Learn how to create a new component |
+| `support/controlplane-component/status.go` | Dependency checking, status conditions | Understand `checkDependencies` (line 50) and how `Available`/`RolloutComplete` conditions work |
+| `support/controlplane-component/workload.go` | Workload (Deployment/StatefulSet) reconciliation | See how deployments are created from asset manifests |
+
+Each component generates a `ControlPlaneComponent` CR with conditions:
+
+- `ControlPlaneComponentAvailable` - at least one pod is ready
+- `ControlPlaneComponentRolloutComplete` - all pods at the desired version
+
+!!! tip "Explore yourself"
+    Compare a simple component (`v2/kube_scheduler/`) with a complex one (`v2/kas/`) to see how the framework scales. Assets (YAML manifests) live in `v2/assets/<component>/`.
+
+### PKI Operator
+
+**Directory**: `control-plane-pki-operator/`
+
+Manages all PKI (certificates) for the hosted cluster:
+
+| Controller | Directory | Function |
+|------------|-----------|----------|
+| CertRotation | `certrotationcontroller/` | Rotates CAs and leaf certs using library-go |
+| CertificateSigning | `certificatesigningcontroller/` | Signs CSRs for break-glass access |
+| CSR Approval | `certificatesigningrequestapprovalcontroller/` | Auto-approves CSRs matching known signers |
+| CertRevocation | `certificaterevocationcontroller/` | Handles certificate revocation |
+| TargetConfig | `targetconfigcontroller/` | PKI target configuration |
+
+Supports two break-glass signers: **Customer** and **SRE**.
+
+!!! tip "Explore yourself"
+    Start with `control-plane-pki-operator/operator.go` to see how all sub-controllers are wired together. Then look at `certificates/` for signer definitions.
+
+### Ignition Server
+
+**Directory**: `ignition-server/`
+
+HTTPS server serving ignition configs to worker nodes during bootstrap:
+
+```mermaid
+sequenceDiagram
+    participant NPC as NodePool Controller
+    participant IS as Ignition Server
+    participant PS as PayloadStore
+    participant Node as Worker Node
+
+    NPC->>IS: Creates Token Secret<br/>(release, config, token UUID)
+    IS->>IS: TokenSecretReconciler<br/>detects new Secret
+    IS->>IS: LocalIgnitionProvider<br/>generates payload with MCO
+    IS->>PS: Stores payload<br/>keyed by token UUID
+
+    Note over Node: Cloud instance boots
+    Node->>IS: GET /ignition<br/>Header: token UUID
+    IS->>PS: Looks up payload by token
+    PS->>IS: Ignition JSON
+    IS->>Node: Responds with ignition config
+    Node->>Node: Applies ignition,<br/>starts kubelet,<br/>joins guest cluster
+```
+
+| File | What it does |
+|------|-------------|
+| `ignition-server/cmd/start.go` | HTTPS server setup, `/ignition` request handler |
+| `ignition-server/controllers/tokensecret_controller.go` | `TokenSecretReconciler`: watches token Secrets, generates payloads, rotates tokens |
+| `ignition-server/controllers/local_ignitionprovider.go` | `LocalIgnitionProvider`: extracts MCO binaries from release image, runs them to produce ignition JSON |
+| `ignition-server/controllers/cache.go` | `ExpiringCache`: in-memory TTL cache for payloads |
+
+!!! tip "Explore yourself"
+    Start with `ignition-server/cmd/start.go` to understand the HTTP handler, then follow the flow into `tokensecret_controller.go`.
+
+
+---
+
+## Source: docs/content/getting-started/onboarding/data-plane.md
+
+# Data Plane and Node Management
+
+> **See also**: NodePool Rollouts for in-depth rollout mechanics and update strategies.
+
+## NodePool - Key Fields
+
+| Field | Purpose | Look at |
+|-------|---------|---------|
+| `spec.clusterName` | Immutable reference to the HostedCluster | `api/hypershift/v1beta1/nodepool_types.go` |
+| `spec.release` | Release image (change triggers rollout, tagged `+rollout`) | Same file |
+| `spec.platform` | Platform-specific machine config (AMI, instance type, etc.) | `aws.go`, `azure.go`, `kubevirt.go` in the api dir |
+| `spec.replicas` / `spec.autoScaling` | Node count control | Same file |
+| `spec.management.upgradeType` | `Replace` (default) or `InPlace` | Same file |
+| `spec.management.autoRepair` | Enables MachineHealthCheck | Same file |
+| `spec.config` | ConfigMap refs with MachineConfig (change triggers rollout) | Same file |
+
+## Node Lifecycle
+
+```mermaid
+sequenceDiagram
+    participant NPC as NodePool Controller
+    participant CFG as ConfigGenerator
+    participant TOK as Token Manager
+    participant CAPI as ClusterAPI
+    participant Cloud as Cloud Provider
+    participant IGN as Ignition Server
+    participant Node as Worker Node
+    participant GC as Guest Cluster
+
+    NPC->>CFG: Compute config hash
+    CFG-->>NPC: hash = hashSimple(mcoConfig + version + ...)
+
+    NPC->>TOK: reconcileTokenSecret(hash)
+    TOK->>TOK: Creates token Secret in HCP ns<br/>(token UUID, release, config)
+    TOK->>TOK: Creates userdata Secret<br/>(ignition stub with URL + token)
+
+    NPC->>CAPI: Creates/updates MachineDeployment
+    Note over CAPI: Spec.Template.Bootstrap.DataSecretName<br/>= userdata secret name
+
+    CAPI->>CAPI: Creates MachineSet
+    CAPI->>CAPI: Creates Machine(s)
+    CAPI->>Cloud: Provisions instance<br/>(EC2, Azure VM, KubeVirt VM)
+
+    Cloud->>Node: Instance boots with userdata
+    Node->>IGN: GET /ignition<br/>Authorization: token UUID
+    IGN->>IGN: Looks up payload in cache
+    IGN-->>Node: Full ignition JSON
+
+    Node->>Node: Applies ignition config
+    Node->>Node: Starts kubelet
+    Node->>GC: Joins the guest cluster
+
+    Note over NPC: machine-approver approves node CSR
+```
+
+!!! tip "Explore yourself"
+    The NodePool controller is split across several files. Read them in this order:
+
+    1. `hypershift-operator/controllers/nodepool/nodepool_controller.go` - Main reconciler entry point, condition checks
+    2. `hypershift-operator/controllers/nodepool/config.go` - `ConfigGenerator`: how config hash is computed for rollout detection
+    3. `hypershift-operator/controllers/nodepool/token.go` - `Token`: token Secret and userdata Secret lifecycle
+    4. `hypershift-operator/controllers/nodepool/capi.go` - `CAPI`: MachineDeployment, MachineSet, MachineHealthCheck, MachineTemplate creation
+
+## ClusterAPI Integration
+
+```mermaid
+graph TD
+    NP[NodePool] -->|creates| MD[MachineDeployment]
+    NP -->|creates| MT[PlatformMachineTemplate<br/><i>e.g., AWSMachineTemplate</i>]
+    NP -->|creates| MHC[MachineHealthCheck]
+
+    MD -->|CAPI creates| MS[MachineSet]
+    MS -->|CAPI creates| M1[Machine 1]
+    MS -->|CAPI creates| M2[Machine 2]
+    MS -->|CAPI creates| MN[Machine N]
+
+    M1 -->|infra provider creates| I1[EC2 Instance / Azure VM / KubeVirt VM]
+
+    MT -.->|referenced by| MD
+    MHC -.->|monitors| M1
+    MHC -.->|monitors| M2
+
+    subgraph "CP Namespace (clusters-my-cluster)"
+        MD
+        MS
+        M1
+        M2
+        MN
+        MT
+        MHC
+    end
+```
+
+**Rollout detection**: `ConfigGenerator.Hash()` produces a new hash when config or version changes. New hash = new Secrets = new `DataSecretName` on MachineDeployment = CAPI rolling update.
+
+!!! tip "Explore yourself"
+    Platform-specific machine template builders:
+
+    - `hypershift-operator/controllers/nodepool/aws.go` - `awsMachineTemplateSpec()`: AMI resolution, instance type, root volume, security groups
+    - `hypershift-operator/controllers/nodepool/azure.go` - Azure VM config
+    - `hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go` - KubeVirt VM config
+    - `hypershift-operator/controllers/nodepool/agent.go` - Agent/bare-metal label selectors
+    - `hypershift-operator/controllers/nodepool/gcp.go` - GCP machine config
+    - `hypershift-operator/controllers/nodepool/openstack.go` - OpenStack config
+
+## Auto-scaling
+
+> **See also**: Resource-Based Control Plane Autoscaling for detailed autoscaling configuration.
+
+- **Manual**: `nodePool.spec.replicas` propagates to `MachineDeployment.Spec.Replicas`
+- **Cluster Autoscaler**: `nodePool.spec.autoScaling.min/max` becomes CAPI annotations on MachineDeployment
+- **Scale-from-zero** (AWS only): capacity annotations (`vCPU`, `memoryMb`, `GPU`) in `hypershift-operator/controllers/nodepool/scale_from_zero.go`
+- **Karpenter** (alternative): provisions nodes directly based on pending pods, bypassing MachineDeployments. See `karpenter-operator/controllers/`
+
+!!! tip "Explore yourself"
+    Karpenter integration files:
+
+    - `karpenter-operator/controllers/karpenter/karpenter_controller.go` - Main reconciler
+    - `karpenter-operator/controllers/karpenterignition/karpenterignition_controller.go` - Ignition for Karpenter nodes
+    - `api/karpenter/v1beta1/` - HyperShift Karpenter API types
+
+## Auto-repair
+
+```mermaid
+flowchart LR
+    MHC[MachineHealthCheck] -->|detects NodeReady=False<br/>for 8-16 min| UNHEALTHY[Machine marked<br/>unhealthy]
+    UNHEALTHY -->|MaxUnhealthy=2<br/>prevents cascade| DELETE[Deletes Machine]
+    DELETE -->|CAPI| NEW[Creates replacement<br/>Machine]
+```
+
+!!! tip "Explore yourself"
+    MHC creation is in `hypershift-operator/controllers/nodepool/capi.go`, function `reconcileMachineHealthCheck()` (~line 649). Note the different timeouts for cloud (8 min) vs Agent/None (16 min) platforms.
+
+---
+
+
+---
+
+## Source: docs/content/getting-started/onboarding/development.md
+
+# APIs, Code Structure, and Development
+
+## Multi-Module Structure
+
+```mermaid
+graph TD
+    subgraph "Root Module: github.com/openshift/hypershift"
+        ROOT_MOD[go.mod]
+        OPERATORS[hypershift-operator/<br/>control-plane-operator/<br/>karpenter-operator/]
+        SUPPORT[support/]
+        CMD[cmd/]
+        VENDOR[vendor/<br/><i>DO NOT modify directly</i>]
+    end
+
+    subgraph "API Module: github.com/openshift/hypershift/api"
+        API_MOD[api/go.mod]
+        API_TYPES[api/hypershift/v1beta1/<br/>api/scheduling/v1alpha1/<br/>api/certificates/v1alpha1/<br/>api/karpenter/v1beta1/]
+        API_VENDOR[api/vendor/]
+    end
+
+    OPERATORS -->|consumes via vendor| API_TYPES
+
+    style VENDOR fill:#ffcdd2
+    style API_VENDOR fill:#ffcdd2
+```
+
+> **GOLDEN RULE**: After any change in `api/`, run `make update`. This runs: `api-deps` -> `workspace-sync` -> `deps` -> `api` -> `api-docs` -> `clients` -> `docs-aggregate`.
+
+!!! tip "Explore yourself"
+    - `api/go.mod` - the separate module definition
+    - `api/CLAUDE.md` - API backward compatibility rules (critical reading!)
+    - `hack/workspace/go.work` - Go workspace for local development across both modules
+
+## Main API Types
+
+```mermaid
+classDiagram
+    class HostedCluster {
+        +HostedClusterSpec spec
+        +HostedClusterStatus status
+        namespace: user namespace
+        scope: user-facing
+    }
+
+    class HostedControlPlane {
+        +HostedControlPlaneSpec spec
+        +HostedControlPlaneStatus status
+        namespace: CP namespace
+        scope: internal
+    }
+
+    class NodePool {
+        +NodePoolSpec spec
+        +NodePoolStatus status
+        namespace: user namespace
+        scope: user-facing
+    }
+
+    class ControlPlaneComponent {
+        +conditions: Available, RolloutComplete
+        namespace: CP namespace
+        scope: internal
+    }
+
+    HostedCluster "1" --> "1" HostedControlPlane : HC controller creates
+    HostedCluster "1" --> "*" NodePool : clusterName reference
+    HostedControlPlane "1" --> "*" ControlPlaneComponent : CPO creates
+
+    NodePool --> MachineDeployment : CAPI
+    MachineDeployment --> MachineSet : CAPI
+    MachineSet --> Machine : CAPI
+```
+
+!!! tip "Explore yourself"
+    Key API files to read:
+
+    - `api/hypershift/v1beta1/hostedcluster_types.go` - Start here. HostedClusterSpec (~line 529), HostedClusterStatus (~line 2105)
+    - `api/hypershift/v1beta1/hosted_controlplane.go` - HCP spec (~line 44) mirrors HC spec
+    - `api/hypershift/v1beta1/nodepool_types.go` - NodePoolSpec, note the `+rollout` tags
+    - `api/hypershift/v1beta1/controlplanecomponent_types.go` - CPOv2 status tracking
+    - `api/hypershift/v1beta1/etcdbackup_types.go` - Example of a feature-gated type
+    - `api/hypershift/v1beta1/groupversion_info.go` - API group registration
+
+## Feature Gates
+
+Feature gates control which API fields and CRD types are available:
+
+```go
+// Example: gated field
+// +openshift:enable:FeatureGate=AutoNodeKarpenter
+AutoNode *AutoNode `json:"autoNode,omitempty"`
+```
+
+!!! tip "Explore yourself"
+    Feature gate definitions are in `api/hypershift/v1beta1/featuregates/`:
+
+    - `featureGate-Hypershift-Default.yaml` - Default feature set
+    - `featureGate-Hypershift-TechPreviewNoUpgrade.yaml` - TechPreview set
+    - Per-gate CRD fragments are generated in `api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/`
+
+## Key Annotations
+
+Some important annotations you'll encounter (defined in `api/hypershift/v1beta1/hostedcluster_types.go`, lines 29-449):
+
+| Annotation | Purpose |
+|-----------|---------|
+| `hypershift.openshift.io/control-plane-operator-image` | Override CPO image (dev/e2e) |
+| `hypershift.openshift.io/restart-date` | Triggers rolling restart of all components |
+| `hypershift.openshift.io/force-upgrade-to` | Force upgrade even if CVO says not upgradeable |
+| `hypershift.openshift.io/disable-pki-reconciliation` | Stops PKI cert regeneration |
+| `resource-request-override.hypershift.openshift.io/<deploy>.<container>` | Override resource requests per container |
+| `hypershift.openshift.io/topology` | `dedicated-request-serving-components` for dedicated nodes |
+| `hypershift.openshift.io/cleanup-cloud-resources` | Controls cloud resource cleanup on deletion |
+
+!!! tip "Explore yourself"
+    Read the annotation constants block at the top of `hostedcluster_types.go` (lines 29-449). Each has a comment explaining its purpose.
+
+---
+
+## Development Workflow
+
+> **See also**: Run Tests, Run HyperShift Operator Locally, and Develop In-Cluster for detailed development setup guides.
+
+### Essential Commands
+
+```bash
+# Build
+make build                    # All binaries
+make hypershift               # CLI only
+make hypershift-operator      # HO only
+make control-plane-operator   # CPO only
+
+# Test
+make test                     # Unit tests with race detection
+make e2e                      # Build E2E test binaries
+
+# Code quality
+make verify                   # Full verification (BEFORE PR) - includes generate, fmt, vet, lint, codespell, gitlint
+make lint                     # golangci-lint
+make lint-fix                 # Auto-fix linting
+make fmt                      # Format
+make vet                      # go vet
+
+# API and generation
+make update                   # Full update after api/ changes
+make api                      # Only regenerate CRDs
+make generate                 # go generate
+make clients                  # Update generated clients
+```
+
+### Workflow for API Changes
+
+```mermaid
+flowchart TD
+    A[Edit types in api/hypershift/v1beta1/] --> B[make update]
+    B --> C[make verify]
+    C --> D{Changed a field type?}
+    D -->|Yes| E[Add serialization compatibility test<br/>in *_types_test.go]
+    D -->|No| F[make test]
+    E --> F
+    F --> G[Create PR]
+```
+
+!!! tip "Explore yourself"
+    Look at `api/hypershift/v1beta1/nodepool_types_test.go` for the serialization compatibility test pattern. It defines an N-1 struct and verifies JSON round-trip compatibility.
+
+### Running Locally
+
+```bash
+# Install HyperShift in development mode
+make hypershift-install-aws-dev
+
+# Run operator locally
+make run-operator-locally-aws-dev
+
+# Or manually
+bin/hypershift install --development
+bin/hypershift-operator run
+```
+
+!!! tip "Explore yourself"
+    The CLI is built from `main.go` at the repo root. Subcommands are in `cmd/`:
+
+    - `cmd/cluster/` - `create cluster` and `destroy cluster` commands
+    - `cmd/nodepool/` - `create nodepool` and `destroy nodepool`
+    - `cmd/install/` - `install` command and CRD assets
+    - `cmd/infra/` - `create infra` commands per platform
+    - `cmd/install/assets/hypershift-operator/` - Final CRD YAML files
+
+---
+
+## Common Development Patterns
+
+### Upsert Pattern
+
+`support/upsert/upsert.go` wraps `controllerutil.CreateOrUpdate` to prevent reconciliation loops by copying server-defaulted fields.
+
+```go
+// Typical usage in a reconciler
+result, err := r.createOrUpdate(ctx, r.client, deployment, func() error {
+    // mutate deployment here
+    return nil
+})
+```
+
+!!! tip "Explore yourself"
+    Read `support/upsert/upsert.go` to understand the loop detection mechanism. The `CreateOrUpdateProvider` interface is injected into controllers via `SetupWithManager`.
+
+### Controller Structure
+
+```go
+type MyReconciler struct {
+    client         crclient.Client
+    createOrUpdate upsert.CreateOrUpdateFN
+}
+
+func (r *MyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+    // 1. Fetch resource
+    // 2. Handle deletion
+    // 3. Add finalizer
+    // 4. Reconcile sub-resources
+    // 5. Update status
+}
+```
+
+!!! tip "Explore yourself"
+    Compare how different controllers are set up:
+
+    - `hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go` - Large, complex controller
+    - `hypershift-operator/controllers/hostedclustersizing/hostedclustersizing_controller.go` - Simpler controller
+    - `control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go` - CPO main controller
+
+### Test Conventions
+
+- Use **Gherkin syntax** for test names: `"When ... it should ..."`
+- Use **gomega** for assertions
+- Unit tests live alongside source files
+- E2E tests in `test/e2e/`
+- Integration tests in `test/integration/`
+
+!!! tip "Explore yourself"
+    - `test/e2e/` - E2E tests covering cluster lifecycle, nodepool operations, upgrades
+    - `test/integration/` - Integration tests for controller behavior
+    - Any `*_test.go` file alongside the source for unit test examples
+
+### API Backward Compatibility
+
+Rules from `api/CLAUDE.md`:
+
+- Every API type change must be safe for **N+1 (forward)** and **N-1 (rollback)** compatibility
+- Changing a value type to a pointer (e.g., `int32` to `*int32`) requires `omitempty`
+- Never remove or rename fields
+- Always add serialization compatibility tests when modifying field types
+
+
+---
+
+## Source: docs/content/getting-started/onboarding/index.md
+
+# HyperShift / Hosted Control Planes (HCP) - Onboarding Guide
+
+!!! note "How this guide relates to other docs"
+    This is a **curated learning path** — it provides a structured narrative to help newcomers build a mental model of HyperShift step by step. It intentionally summarizes topics that are covered in more detail in dedicated reference pages. Where applicable, "See also" links point you to the authoritative source for deeper reading. This guide is not a replacement for those docs.
+
+---
+
+## Tips for New Team Members
+
+1. **Start with the CRDs**: Understanding `HostedCluster`, `HostedControlPlane`, and `NodePool` is 80% of the work
+2. **Follow the data flow**: HC -> HCP -> Components. NP -> CAPI -> Cloud -> Node
+3. **Conditions are your friend**: Always check `.status.conditions` to understand what's happening
+4. **`make verify` before pushing**: Always
+5. **The CP namespace is where the magic happens**: `kubectl get pods -n clusters-<name>` shows you everything
+6. **Read the tests**: Unit tests and E2E tests are the best living documentation
+7. **Use `hypershift dump`**: The diagnostic tool at `cmd/dump/` captures full cluster state for debugging
+8. **Don't read 5000-line files end-to-end**: Follow function calls from the `Reconcile` entry point
+9. **The API module is separate**: Remember to run `make update` after any change in `api/`
+10. **Ask about invariants**: When in doubt about a design decision, check if it violates any of the architectural invariants
+
+---
+
+## Recommended Learning Path
+
+```mermaid
+graph TD
+    subgraph "Week 1-2: Foundations"
+        S1A[Read this guide end-to-end]
+        S1B[Install HyperShift locally<br/><code>make hypershift-install-aws-dev</code>]
+        S1C[Create a test HostedCluster<br/><code>bin/hypershift create cluster</code>]
+        S1D[Explore the CRDs:<br/>HostedCluster, HCP, NodePool<br/><i>Read the API type files</i>]
+        S1E[Observe pods in the<br/>CP namespace with kubectl]
+    end
+
+    subgraph "Week 3-4: Architecture"
+        S2A[Read hostedcluster_controller.go<br/>Understand the reconcile loop]
+        S2B[Read hostedcontrolplane_controller.go<br/>Understand how the CPO<br/>deploys components]
+        S2C[Read nodepool_controller.go<br/>Understand the node flow]
+        S2D[Study the CPOv2 framework<br/>support/controlplane-component/]
+        S2E[Read a simple v2 component<br/>e.g., kube-scheduler]
+    end
+
+    subgraph "Week 5-6: Deep Dive"
+        S3A[Study the Platform interface<br/>and one implementation<br/>e.g., AWS or KubeVirt]
+        S3B[Understand the ignition flow<br/>Token -> Ignition Server -> Node]
+        S3C[Study PKI and certificates]
+        S3D[Make a real change:<br/>bug fix or small feature]
+        S3E[Run make verify<br/>and create your first PR]
+    end
+
+    subgraph "Week 7+: Specialization"
+        S4A[Choose area of focus:<br/>- Control Plane<br/>- Data Plane / NodePool<br/>- Platform specific<br/>- API Design]
+        S4B[Read E2E tests<br/>test/e2e/]
+        S4C[Contribute features<br/>and PR reviews]
+    end
+
+    S1A --> S1B --> S1C --> S1D --> S1E
+    S1E --> S2A
+    S2A --> S2B --> S2C --> S2D --> S2E
+    S2E --> S3A
+    S3A --> S3B --> S3C --> S3D --> S3E
+    S3E --> S4A --> S4B --> S4C
+```
+
+### Suggested Reading Order for Code
+
+For each area, follow this order to build understanding incrementally:
+
+**Control Plane path:**
+
+1. `api/hypershift/v1beta1/hostedcluster_types.go` (skim the Spec, focus on key fields)
+2. `api/hypershift/v1beta1/hosted_controlplane.go` (note the similarity to HC)
+3. `hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go` (`Reconcile` method only)
+4. `control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go` (`Reconcile` and `registerComponents`)
+5. `support/controlplane-component/controlplane-component.go` (core framework)
+6. `control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/` (simple component)
+
+**Data Plane path:**
+
+1. `api/hypershift/v1beta1/nodepool_types.go`
+2. `hypershift-operator/controllers/nodepool/nodepool_controller.go` (`Reconcile` entry point)
+3. `hypershift-operator/controllers/nodepool/config.go` (hash-based rollout)
+4. `hypershift-operator/controllers/nodepool/token.go` (ignition tokens)
+5. `hypershift-operator/controllers/nodepool/capi.go` (CAPI resource creation)
+6. `ignition-server/cmd/start.go` (how nodes fetch their config)
+
+**Platform path (pick one):**
+
+1. `hypershift-operator/controllers/hostedcluster/internal/platform/platform.go` (interface)
+2. `hypershift-operator/controllers/hostedcluster/internal/platform/<your-platform>/` (implementation)
+3. `hypershift-operator/controllers/nodepool/<your-platform>.go` (machine template)
+4. `control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/<your-platform>/` (CCM)
+5. `api/hypershift/v1beta1/<your-platform>.go` (API types)
+
+---
+
+## Guide Contents
+
+| Section | What you'll learn |
+|---------|------------------|
+| What is HyperShift? | The problem HyperShift solves and how it works |
+| Key Concepts | Core resources, glossary, and terminology |
+| Architecture | Overall architecture, namespace layout, and main components |
+| Cluster Lifecycle | Creation, upgrades, deletion, and the CPO reconciliation flow |
+| Data Plane | NodePool management, node lifecycle, ClusterAPI, auto-scaling |
+| Cloud Platforms | Supported platforms, comparison, and infrastructure details |
+| Development | APIs, code structure, development workflow, and patterns |
+| Reference | Architectural invariants and key file reference |
+
+
+---
+
+## Source: docs/content/getting-started/onboarding/key-concepts.md
+
+# Key Concepts
+
+> **See also**: Concepts and Personas for detailed persona definitions (Service Provider, Consumer, Instance Admin) and Controller Architecture for detailed controller diagrams and resource dependency graphs.
+
+```mermaid
+graph TD
+    subgraph "Management Cluster"
+        HC[HostedCluster<br/><i>namespace: clusters</i>]
+        NP[NodePool<br/><i>namespace: clusters</i>]
+
+        subgraph "CP Namespace: clusters-my-cluster"
+            HCP[HostedControlPlane]
+            CPO[Control Plane Operator]
+            ETCD[etcd]
+            KAS[kube-apiserver]
+            KCM[kube-controller-manager]
+            SCHED[kube-scheduler]
+            OAPI[openshift-apiserver]
+            PKI[PKI Operator]
+            IGN[Ignition Server]
+        end
+
+        HO[HyperShift Operator<br/><i>namespace: hypershift</i>]
+    end
+
+    subgraph "Guest Cluster - Data Plane"
+        W1[Worker Node 1]
+        W2[Worker Node 2]
+        W3[Worker Node N]
+    end
+
+    HO -->|manages| HC
+    HO -->|manages| NP
+    HO -->|creates| HCP
+    HO -->|deploys| CPO
+    CPO -->|manages| ETCD
+    CPO -->|manages| KAS
+    CPO -->|manages| KCM
+    CPO -->|manages| SCHED
+    CPO -->|manages| OAPI
+    CPO -->|manages| PKI
+    CPO -->|manages| IGN
+
+    KAS -.->|konnectivity tunnel| W1
+    KAS -.->|konnectivity tunnel| W2
+    KAS -.->|konnectivity tunnel| W3
+    IGN -.->|ignition configs| W1
+    IGN -.->|ignition configs| W2
+    IGN -.->|ignition configs| W3
+```
+
+## Glossary
+
+> For full persona and concept definitions, see Concepts and Personas.
+
+| Term | Description | Start Reading Here |
+|------|-------------|-------------------|
+| **Management Cluster** | The OpenShift/K8s cluster where HyperShift operators run and where control plane pods live | `hypershift-operator/main.go` |
+| **Guest Cluster** (Hosted Cluster) | The cluster end users consume. Only has worker nodes | - |
+| **HostedCluster (HC)** | User-facing CRD declaring the intent to create a cluster. Lives in the user's namespace | `api/hypershift/v1beta1/hostedcluster_types.go` |
+| **HostedControlPlane (HCP)** | Internal CRD created by the HC controller. Lives in the control plane namespace. The CPO reads it to know what to deploy | `api/hypershift/v1beta1/hosted_controlplane.go` |
+| **NodePool (NP)** | User-facing CRD defining a scalable set of worker nodes. References a HostedCluster | `api/hypershift/v1beta1/nodepool_types.go` |
+| **Control Plane Namespace** | Namespace (`{hc-ns}-{hc-name}`) where all control plane components live | `hypershift-operator/controllers/manifests/manifests.go` |
+| **HyperShift Operator (HO)** | Main operator managing HostedClusters and NodePools | `hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go` |
+| **Control Plane Operator (CPO)** | Runs inside each CP namespace and manages all control plane components | `control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go` |
+| **PKI Operator** | Certificate operator handling rotation and signing | `control-plane-pki-operator/operator.go` |
+| **Ignition Server** | HTTPS server that serves ignition configs to worker nodes during bootstrap | `ignition-server/cmd/start.go` |
+
+
+---
+
+## Source: docs/content/getting-started/onboarding/lifecycle.md
+
+# Cluster Lifecycle and Control Plane
+
+---
+
+## HostedCluster Lifecycle
+
+### Creation
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant HC as HostedCluster
+    participant HO as HyperShift Operator
+    participant CPNS as CP Namespace
+    participant CPO as Control Plane Operator
+    participant CAPI as ClusterAPI
+    participant NP as NodePool
+    participant Cloud as Cloud Provider
+
+    User->>HC: Creates HostedCluster CR
+    HO->>HC: Watch & Reconcile
+    HO->>HO: Validates release image, config
+    HO->>CPNS: Creates namespace<br/>{hc-ns}-{hc-name}
+    HO->>CPNS: Copies secrets<br/>(pull-secret, SSH, encryption)
+    HO->>CPNS: Creates HostedControlPlane CR
+    HO->>CPNS: Deploys CPO Deployment
+    HO->>CPNS: Deploys CAPI Manager + Provider
+    HO->>CPNS: Configures NetworkPolicies
+
+    CPO->>CPO: Reads HCP, resolves release image
+    CPO->>CPNS: Deploys etcd StatefulSet
+    CPO->>CPNS: Deploys kube-apiserver
+    CPO->>CPNS: Deploys +30 components
+    CPO->>HC: Reports status via HCP
+
+    HO->>HC: Copies kubeconfig to user namespace
+
+    User->>NP: Creates NodePool CR
+    HO->>NP: Watch & Reconcile
+    HO->>CPNS: Creates Token + UserData Secrets
+    HO->>CAPI: Creates MachineDeployment + MachineTemplate
+    CAPI->>Cloud: Provisions instances
+    Cloud-->>CPNS: Nodes boot, fetch ignition
+    Cloud-->>HC: Nodes join the guest cluster
+```
+
+!!! tip "Explore yourself"
+    Follow the creation flow step by step in `hostedcluster_controller.go`:
+
+    1. `Reconcile()` (~line 337) - entry point
+    2. `reconcileHostedControlPlane()` (~line 2404) - HCP creation
+    3. `reconcileControlPlaneOperator()` - CPO deployment
+    4. `reconcileCAPIManager()` - CAPI deployment
+    5. Network policies: `hypershift-operator/controllers/hostedcluster/network_policies.go`
+
+### Steady State
+
+- The CPO continuously reconciles all components against the HCP spec
+- The PKI operator rotates certificates automatically
+- The NodePool controller manages auto-repair and scaling
+- Status flow: `CPO -> HCP status -> HO -> HC status`
+
+### Upgrade
+
+> **See also**: Upgrades for detailed upgrade procedures and version skew policies.
+
+Control plane and data plane upgrades are **decoupled**:
+
+```mermaid
+graph LR
+    subgraph "Control Plane Upgrade"
+        A[Change HC.spec.release] --> B[HO updates HCP]
+        B --> C[CPO deploys new versions<br/>of components]
+    end
+
+    subgraph "Data Plane Upgrade"
+        D[Change NP.spec.release] --> E[New config hash]
+        E --> F[New token/userdata Secrets]
+        F --> G[CAPI rolling update<br/>of MachineDeployment]
+    end
+
+    A -.->|independent| D
+```
+
+- `controlPlaneRelease`: allows patching management-side components without touching the data plane
+- NodePool releases can be updated independently (within N-2 y-stream skew)
+
+### Deletion
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant HO as HyperShift Operator
+    participant CAPI as ClusterAPI
+    participant Cloud as Cloud Provider
+
+    User->>HO: Delete HostedCluster
+    HO->>CAPI: Deletes Machines, MachineDeployments
+    CAPI->>Cloud: Terminates instances
+    HO->>HO: Deletes HCP, waits for CPO cleanup
+    HO->>Cloud: Cleans up cloud resources<br/>(LBs, DNS, SGs, endpoints)
+    HO->>HO: Cleans up cluster-wide RBAC
+    HO->>HO: Removes finalizer
+    Note over HO: Supports grace period via<br/>hypershift.openshift.io/destroy-grace-period
+```
+
+!!! tip "Explore yourself"
+    The deletion flow starts at `r.delete()` (~line 501 in `hostedcluster_controller.go`). Notice the `CloudResourcesDestroyed` and `HostedClusterDestroyed` conditions.
+
+---
+
+## Control Plane in Detail
+
+### CPO Reconciliation Flow
+
+> **See also**: Controller Architecture for the full controller dependency graph and reconciliation details.
+
+```mermaid
+flowchart TD
+    START[Reconcile HCP] --> FETCH[Fetch HostedControlPlane]
+    FETCH --> DEL{Deletion?}
+    DEL -->|Yes| CLEANUP[Cleanup cloud resources<br/>Remove finalizer]
+    DEL -->|No| FIN[Add finalizer]
+    FIN --> VALIDATE[Validate configuration]
+    VALIDATE --> ETCD_STATUS[Check etcd status]
+    ETCD_STATUS --> KMS[Validate KMS config]
+    KMS --> KAS_STATUS[Check KAS availability]
+    KAS_STATUS --> INFRA[Setup infrastructure status<br/>endpoints, DNS, routes]
+    INFRA --> IGNITION_CFG[Reconcile ignition configs]
+    IGNITION_CFG --> OAUTH_PWD[Reconcile kubeadmin password]
+    OAUTH_PWD --> CONTEXT[Build ControlPlaneContext]
+    CONTEXT --> COMPONENTS[Iterate registered components]
+
+    subgraph "Component Loop"
+        COMPONENTS --> C1[Component.Reconcile]
+        C1 --> PRED{Predicate<br/>passes?}
+        PRED -->|No| DELETE_RES[Delete component resources]
+        PRED -->|Yes| DEPS{Dependencies<br/>ready?}
+        DEPS -->|No| WAIT[Skip, requeue]
+        DEPS -->|Yes| RECONCILE[Reconcile manifests<br/>+ workload]
+        RECONCILE --> STATUS_CR[Update ControlPlaneComponent CR]
+    end
+```
+
+!!! tip "Explore yourself"
+    In `hostedcontrolplane_controller.go`, the component iteration loop is at ~line 1232:
+
+    ```go
+    for _, c := range r.components {
+        r.Log.Info("Reconciling component", "component_name", c.Name())
+        if err := c.Reconcile(cpContext); err != nil {
+            errs = append(errs, err)
+        }
+    }
+    ```
+
+### Component Dependencies
+
+```mermaid
+graph TD
+    PKI[PKI Operator] --> |no deps| READY1((Ready))
+    ETCD[etcd] --> |no deps| READY2((Ready))
+    FG[FeatureGate Generator] --> |no deps| READY3((Ready))
+    ROUTER[Router] --> |no deps| READY4((Ready))
+
+    READY2 --> KAS[kube-apiserver]
+    READY3 --> KAS
+
+    KAS --> |implicit dependency| KCM[kube-controller-manager]
+    KAS --> |implicit dependency| SCHED[kube-scheduler]
+    KAS --> |implicit dependency| OAPI[openshift-apiserver]
+    KAS --> |implicit dependency| CVO[CVO]
+    KAS --> |implicit dependency| ALL["All other<br/>components (~30)"]
+
+    style PKI fill:#c8e6c9
+    style ETCD fill:#c8e6c9
+    style FG fill:#c8e6c9
+    style ROUTER fill:#c8e6c9
+    style KAS fill:#ffcc80
+```
+
+KAS is an implicit dependency for all components **except**: etcd, featuregate-generator, control-plane-operator, cluster-api, capi-provider, karpenter, and router.
+
+### Status Propagation
+
+```mermaid
+graph LR
+    CPC[ControlPlaneComponent CRs<br/><i>per-component</i><br/>Available / RolloutComplete] --> HCP_STATUS[HCP Status<br/>Conditions:<br/>EtcdAvailable<br/>KubeAPIServerAvailable<br/>ValidConfiguration]
+    HCP_STATUS --> HC_STATUS[HC Status<br/>Conditions:<br/>Available<br/>Progressing<br/>Degraded]
+
+    HC_STATUS --> USER[Visible to the user]
+```
+
+!!! tip "Explore yourself"
+    - HC conditions are defined in `api/hypershift/v1beta1/hostedcluster_conditions.go`
+    - NP conditions are in `api/hypershift/v1beta1/nodepool_conditions.go`
+    - The CPOv2 status logic is in `support/controlplane-component/status.go`
+
+
+---
+
+## Source: docs/content/getting-started/onboarding/platforms.md
+
+# Supported Cloud Platforms
+
+> **See also**: Multi-Platform Support for the full support matrix across HostedCluster, NodePool, and management cluster platform combinations.
+
+HyperShift supports multiple infrastructure platforms. Each platform implements the same `Platform` interface but brings its own CAPI provider, credential model, and networking primitives. Some platforms are generally available while others are behind feature gates.
+
+```mermaid
+graph TD
+    subgraph "Cloud Providers"
+        subgraph "AWS"
+            AWS_SM["AWS Self-Managed"]
+            AWS_M["AWS Managed<br/><i>ROSA HCP</i>"]
+        end
+
+        subgraph "Azure"
+            AZ_SM["Azure Self-Managed"]
+            AZ_M["Azure Managed<br/><i>ARO HCP</i>"]
+        end
+
+        subgraph "GCP"
+            GCP_SM["GCP Self-Managed<br/><i>Feature-gated</i>"]
+            GCP_M["GCP Managed<br/><i>GCP HCP</i>"]
+        end
+    end
+
+    subgraph "Virtualization"
+        KV["KubeVirt<br/><i>VMs on K8s</i>"]
+    end
+
+    subgraph "Bare Metal"
+        AG["Agent<br/><i>Bare-metal</i>"]
+    end
+
+    subgraph "Other"
+        OS["OpenStack<br/><i>Feature-gated</i>"]
+        IBM["IBM Cloud<br/><i>PowerVS</i>"]
+    end
+
+    style AWS_SM fill:#f96,stroke:#333
+    style AWS_M fill:#f96,stroke:#333
+    style AZ_SM fill:#69f,stroke:#333
+    style AZ_M fill:#69f,stroke:#333
+    style GCP_SM fill:#6c6,stroke:#333
+    style GCP_M fill:#6c6,stroke:#333
+    style KV fill:#c6f,stroke:#333
+    style AG fill:#a65,stroke:#333
+    style OS fill:#f66,stroke:#333
+    style IBM fill:#999,stroke:#333
+```
+
+---
+
+## Platform Interface
+
+Every platform must implement the `Platform` interface defined in `hypershift-operator/controllers/hostedcluster/internal/platform/platform.go`. The HyperShift Operator uses this interface to abstract away cloud-specific details during HostedCluster reconciliation.
+
+```go
+type Platform interface {
+    // ReconcileCAPIInfraCR creates/updates the platform-specific CAPI infrastructure CR
+    // that will be referenced by the CAPI Cluster CR.
+    ReconcileCAPIInfraCR(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
+        hcluster *hyperv1.HostedCluster, controlPlaneNamespace string,
+        apiEndpoint hyperv1.APIEndpoint) (client.Object, error)
+
+    // CAPIProviderDeploymentSpec returns the DeploymentSpec for the CAPI provider
+    // with platform-specific volumes, secrets, and containers.
+    CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster,
+        hcp *hyperv1.HostedControlPlane) (*appsv1.DeploymentSpec, error)
+
+    // ReconcileCredentials copies cloud credentials from the HostedCluster namespace
+    // into the control plane namespace for the CPO to consume.
+    ReconcileCredentials(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
+        hcluster *hyperv1.HostedCluster, controlPlaneNamespace string) error
+
+    // ReconcileSecretEncryption copies KMS-related resources into the control plane
+    // namespace (if the platform supports KMS).
+    ReconcileSecretEncryption(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
+        hcluster *hyperv1.HostedCluster, controlPlaneNamespace string) error
+
+    // CAPIProviderPolicyRules returns additional RBAC PolicyRules required by the
+    // CAPI provider to manage platform resources. Return nil if none are needed.
+    CAPIProviderPolicyRules() []rbacv1.PolicyRule
+
+    // DeleteCredentials cleans up platform credential resources so they don't leak
+    // when a HostedCluster is deleted.
+    DeleteCredentials(ctx context.Context, c client.Client,
+        hcluster *hyperv1.HostedCluster, controlPlaneNamespace string) error
+}
+```
+
+The `GetPlatform()` function in the same file uses a `switch` on `hcluster.Spec.Platform.Type` to instantiate the correct implementation (AWS, Azure, GCP, KubeVirt, Agent, etc.).
+
+---
+
+## Platform Comparison
+
+| Aspect | AWS (Self-Managed) | AWS (ROSA HCP) | Azure (Self-Managed) | Azure (ARO HCP) | GCP (GCP HCP) | KubeVirt | Agent |
+|--------|-------------------|----------------|---------------------|-----------------|---------------|----------|-------|
+| **Managed service** | No | Yes | No | Yes | Yes | No | No |
+| **CAPI Provider** | CAPA | CAPA | CAPZ | CAPZ | CAPG | - | - |
+| **Identity** | STS / IRSA | STS / IRSA | Workload Identity | Workload Identity | Workload Identity | N/A | N/A |
+| **KMS** | AWS KMS | AWS KMS | Azure Key Vault | Azure Key Vault | GCP KMS | N/A | N/A |
+| **Private connectivity** | AWS PrivateLink | AWS PrivateLink | Azure Private Link Service | Azure Private Link Service | Private Service Connect | N/A | N/A |
+| **Infra provisioning** | EC2/VPC | EC2/VPC | VMs/VNet | VMs/VNet | GCE/VPC | KubeVirt VMs | BareMetalHost |
+| **Cloud Controller Manager** | aws-ccm | aws-ccm | azure-ccm | azure-ccm | gcp-ccm | kubevirt-ccm | N/A |
+
+!!! tip "Explore yourself"
+    Browse the platform implementation directories to see how each platform implements the interface:
+
+    - `hypershift-operator/controllers/hostedcluster/internal/platform/aws/`
+    - `hypershift-operator/controllers/hostedcluster/internal/platform/azure/`
+    - `hypershift-operator/controllers/hostedcluster/internal/platform/gcp/`
+    - `hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/`
+    - `hypershift-operator/controllers/hostedcluster/internal/platform/agent/`
+    - `hypershift-operator/controllers/hostedcluster/internal/platform/openstack/`
+    - `hypershift-operator/controllers/hostedcluster/internal/platform/powervs/`
+
+---
+
+## AWS Infrastructure
+
+AWS is the most mature platform. Both self-managed and managed (ROSA HCP) deployments use the same underlying infrastructure primitives.
+
+```mermaid
+graph TD
+    subgraph "Management Cluster VPC"
+        HO[HyperShift Operator]
+
+        subgraph "CP Namespace"
+            KAS[kube-apiserver]
+            NLB[Network Load Balancer<br/><i>API endpoint</i>]
+            CAPA[CAPA Controller]
+        end
+    end
+
+    subgraph "Guest Cluster VPC"
+        subgraph "Public Subnets"
+            IGW[Internet Gateway]
+            NATGW[NAT Gateway]
+        end
+        subgraph "Private Subnets"
+            W1[Worker EC2<br/>Subnet AZ-a]
+            W2[Worker EC2<br/>Subnet AZ-b]
+            W3[Worker EC2<br/>Subnet AZ-c]
+        end
+    end
+
+    HO -->|creates| NLB
+    NLB --> KAS
+    CAPA -->|provisions| W1
+    CAPA -->|provisions| W2
+    CAPA -->|provisions| W3
+    W1 & W2 & W3 -->|egress via| NATGW
+    NATGW --> IGW
+
+    style NLB fill:#f96,stroke:#333
+    style KAS fill:#69f,stroke:#333
+```
+
+The guest cluster VPC contains public subnets (with an Internet Gateway and NAT Gateway for outbound traffic) and private subnets where worker EC2 instances run. The CAPI AWS provider (CAPA) manages the machine lifecycle. The kube-apiserver is fronted by a Network Load Balancer for external access.
+
+---
+
+## AWS PrivateLink
+
+For private clusters on AWS, HyperShift uses AWS PrivateLink to expose the kube-apiserver without traversing the public internet. The CPO runs a dedicated controller that manages the PrivateLink endpoint service and VPC endpoint:
+
+- **Source**: `control-plane-operator/controllers/awsprivatelink/`
+- The management cluster creates a VPC Endpoint Service backed by the kube-apiserver NLB
+- Consumers create a VPC Endpoint in their VPC that connects through PrivateLink
+- DNS is configured so the API server hostname resolves to the private endpoint
+
+This model is critical for ROSA HCP where the control plane runs in a service account VPC that the customer never sees directly.
+
+---
+
+## KubeVirt Nested Virtualization
+
+KubeVirt is unique because it runs guest cluster worker nodes as virtual machines on an existing Kubernetes cluster, creating a nested architecture:
+
+```mermaid
+graph TD
+    subgraph "Infrastructure Cluster (OCP with KubeVirt)"
+        KV_OP[KubeVirt Operator]
+        subgraph "Management Cluster Layer"
+            HO[HyperShift Operator]
+            subgraph "CP Namespace"
+                CPO_KV[CPO]
+                KAS_KV[kube-apiserver]
+            end
+        end
+
+        subgraph "KubeVirt VMs"
+            VM1[VM: Worker 1<br/><i>runs as a Pod</i>]
+            VM2[VM: Worker 2<br/><i>runs as a Pod</i>]
+            VM3[VM: Worker N<br/><i>runs as a Pod</i>]
+        end
+    end
+
+    KV_OP -->|manages VMs| VM1 & VM2 & VM3
+    HO -->|creates HC| CPO_KV
+    CPO_KV -->|manages| KAS_KV
+    KAS_KV -.->|konnectivity| VM1 & VM2 & VM3
+
+    style VM1 fill:#c6f,stroke:#333
+    style VM2 fill:#c6f,stroke:#333
+    style VM3 fill:#c6f,stroke:#333
+```
+
+Key differences from cloud platforms:
+
+- **No CAPI provider**: KubeVirt manages VMs directly through the KubeVirt API
+- **No cloud credentials**: The infrastructure cluster already has everything needed
+- **Nested networking**: Guest cluster pods run inside VMs that run inside pods on the infra cluster
+- **Shared infrastructure**: The management cluster, control plane, and worker VMs all share the same underlying cluster
+
+---
+
+## Cloud Controller Managers
+
+Each cloud platform has a Cloud Controller Manager (CCM) that runs in the control plane namespace. The CCM is responsible for:
+
+- Initializing nodes with cloud-specific metadata (zone, instance type, addresses)
+- Managing cloud load balancers for Services of type `LoadBalancer`
+- Handling node lifecycle (detecting when cloud instances are terminated)
+
+Platform-specific CCM implementations are registered as CPO v2 components:
+
+- `control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/aws/`
+- `control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/`
+- `control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/gcp/`
+- `control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/kubevirt/`
+- `control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/`
+- `control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/powervs/`
+
+Each CCM component adapts a `cloud-provider-<platform>` binary with the appropriate cloud configuration file, credentials, and feature gates for the hosted cluster.
+
+---
+
+## Credential Management Pattern
+
+Cloud credentials flow from the user-facing HostedCluster resource into the control plane namespace where they are consumed by the CAPI provider, CCM, and other platform-aware components:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant HC as HostedCluster
+    participant HO as HyperShift Operator
+    participant CPN as CP Namespace
+    participant CAPI as CAPI Provider
+    participant CCM as Cloud Controller Manager
+
+    User->>HC: Creates HC with cloud credentials<br/>(Secret references in spec.platform)
+    HO->>HO: platform.ReconcileCredentials()
+    HO->>CPN: Copies credential Secrets<br/>into control plane namespace
+    HO->>HO: platform.ReconcileSecretEncryption()
+    HO->>CPN: Copies KMS Secrets<br/>(if platform supports KMS)
+    CPN->>CAPI: Mounts credentials as volumes
+    CPN->>CCM: Mounts cloud config + credentials
+```
+
+The cloud configuration file that the CCM and other components consume is generated per-platform:
+
+- **AWS**: `control-plane-operator/controllers/hostedcontrolplane/cloud/aws/providerconfig.go`
+- **Azure**: `control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go`
+- **OpenStack**: `control-plane-operator/controllers/hostedcontrolplane/cloud/openstack/providerconfig.go`
+
+These files build the `cloud.conf` (or equivalent) that gets mounted into the CCM, KCM, and other components that need to interact with the cloud API.
+
+
+---
+
+## Source: docs/content/getting-started/onboarding/reference.md
+
+# Architectural Invariants and Key File Reference
+
+## Architectural Invariants
+
+> **See also**: Goals and Design Invariants for the authoritative list of project goals and invariants.
+
+These are the design rules that should inform **every decision**:
+
+1. **Unidirectional communication**: Management cluster -> hosted cluster, never the reverse. All communication originates from within the CP namespace.
+
+2. **Pristine workers**: Compute nodes run only user workloads + minimal agents (kubelet, konnectivity-agent, CNI). No control plane logic.
+
+3. **No mutable CRDs/CRs exposed**: The hosted cluster should not expose mutable resources that could interfere with HyperShift-managed features.
+
+4. **Data plane changes do not trigger management-side lifecycle actions**: Prevents cascading failures.
+
+5. **No user credential management**: HyperShift components do not own credentials; they copy and use them, but ownership remains with the user.
+
+6. **Namespace isolation**: Each CP namespace is isolated via NetworkPolicies and Linux container primitives. See `hypershift-operator/controllers/hostedcluster/network_policies.go`.
+
+7. **Decoupled upgrade signals**: Management-side and data-plane components upgrade independently via `controlPlaneRelease`.
+
+8. **CPO backward compatibility**: The HO may deploy older CPO versions. Changes to the HO must consider impact on older CPOs. The HO checks CPO image labels before enabling features (e.g., `controlPlanePKIOperatorSignsCSRs`, `useRestrictedPSA`, `defaultToControlPlaneV2`).
+
+---
+
+## Key File Reference
+
+### APIs
+
+| File | Contents | Priority |
+|------|----------|----------|
+| `api/hypershift/v1beta1/hostedcluster_types.go` | HostedCluster spec/status, platform configs, constants, annotations | Must read |
+| `api/hypershift/v1beta1/hostedcluster_conditions.go` | HC condition type constants | Must read |
+| `api/hypershift/v1beta1/hosted_controlplane.go` | HostedControlPlane spec/status | Must read |
+| `api/hypershift/v1beta1/nodepool_types.go` | NodePool spec/status | Must read |
+| `api/hypershift/v1beta1/nodepool_conditions.go` | NP condition type constants | Must read |
+| `api/hypershift/v1beta1/aws.go` | AWS types (`AWSPlatformSpec`, `AWSRolesRef`) | Read for AWS work |
+| `api/hypershift/v1beta1/azure.go` | Azure types | Read for Azure work |
+| `api/hypershift/v1beta1/kubevirt.go` | KubeVirt types | Read for KubeVirt work |
+| `api/hypershift/v1beta1/controlplanecomponent_types.go` | CPOv2 ControlPlaneComponent CR | Good to know |
+| `api/hypershift/v1beta1/etcdbackup_types.go` | Feature-gated type example | Good to know |
+| `api/hypershift/v1beta1/groupversion_info.go` | API group registration | Reference |
+| `api/CLAUDE.md` | API compatibility rules | Must read |
+
+### HO Controllers
+
+| File | Contents | Priority |
+|------|----------|----------|
+| `hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go` | HC Reconciler (~5200 lines) | Must read (selectively) |
+| `hypershift-operator/controllers/hostedcluster/network_policies.go` | Namespace isolation NetworkPolicies | Good to know |
+| `hypershift-operator/controllers/nodepool/nodepool_controller.go` | NP Reconciler main entry | Must read |
+| `hypershift-operator/controllers/nodepool/config.go` | ConfigGenerator, rollout hash | Must read |
+| `hypershift-operator/controllers/nodepool/token.go` | Token and UserData Secrets | Must read |
+| `hypershift-operator/controllers/nodepool/capi.go` | MachineDeployment, MHC, templates | Must read |
+| `hypershift-operator/controllers/nodepool/aws.go` | AWS MachineTemplate builder | Read for AWS work |
+| `hypershift-operator/controllers/nodepool/azure.go` | Azure MachineTemplate builder | Read for Azure work |
+| `hypershift-operator/controllers/nodepool/kubevirt/kubevirt.go` | KubeVirt MachineTemplate builder | Read for KubeVirt work |
+| `hypershift-operator/controllers/nodepool/conditions.go` | SetStatusCondition helpers | Reference |
+| `hypershift-operator/controllers/nodepool/version.go` | NodesInfo aggregation from CAPI Machines | Reference |
+| `hypershift-operator/controllers/nodepool/scale_from_zero.go` | Scale-from-zero annotation management | Reference |
+| `hypershift-operator/controllers/manifests/manifests.go` | Namespace naming, resource naming helpers | Reference |
+
+### CPO Controllers
+
+| File | Contents | Priority |
+|------|----------|----------|
+| `control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go` | HCP Reconciler (~3200 lines) | Must read (selectively) |
+| `control-plane-operator/controllers/hostedcontrolplane/v2/kas/` | kube-apiserver component (complex example) | Good to know |
+| `control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/` | kube-scheduler component (simple example) | Must read |
+| `control-plane-operator/controllers/hostedcontrolplane/v2/etcd/` | etcd component | Good to know |
+| `control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/` | CAPI manager component | Reference |
+| `control-plane-operator/controllers/hostedcontrolplane/v2/capi_provider/` | CAPI provider component | Reference |
+| `control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/` | Per-platform CCMs | Read per platform |
+| `control-plane-operator/controllers/hostedcontrolplane/v2/assets/` | YAML manifests for all components | Reference |
+
+### Framework and Support
+
+| File | Contents | Priority |
+|------|----------|----------|
+| `support/controlplane-component/controlplane-component.go` | CPOv2 framework core | Must read |
+| `support/controlplane-component/builder.go` | Builder pattern for components | Must read |
+| `support/controlplane-component/status.go` | Status logic, dependency checking | Must read |
+| `support/controlplane-component/workload.go` | Workload reconciliation | Good to know |
+| `support/upsert/upsert.go` | CreateOrUpdate wrapper | Must read |
+
+### Platform Implementations
+
+| File | Contents | Priority |
+|------|----------|----------|
+| `hypershift-operator/controllers/hostedcluster/internal/platform/platform.go` | Platform interface definition | Must read |
+| `hypershift-operator/controllers/hostedcluster/internal/platform/aws/aws.go` | AWS platform impl | Read for AWS |
+| `hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go` | Azure platform impl | Read for Azure |
+| `hypershift-operator/controllers/hostedcluster/internal/platform/kubevirt/kubevirt.go` | KubeVirt platform impl | Read for KubeVirt |
+| `hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go` | Agent platform impl | Read for Agent |
+
+### PKI and Ignition
+
+| File | Contents | Priority |
+|------|----------|----------|
+| `control-plane-pki-operator/operator.go` | PKI operator wiring | Good to know |
+| `control-plane-pki-operator/certrotationcontroller/` | Certificate rotation | Reference |
+| `control-plane-pki-operator/certificatesigningcontroller/` | CSR signing | Reference |
+| `ignition-server/cmd/start.go` | Ignition HTTPS server | Good to know |
+| `ignition-server/controllers/tokensecret_controller.go` | Token reconciler | Good to know |
+| `ignition-server/controllers/local_ignitionprovider.go` | MCO binary execution | Reference |
+
+### CLI and Infrastructure
+
+| File | Contents | Priority |
+|------|----------|----------|
+| `main.go` | CLI entry point | Reference |
+| `cmd/cluster/` | create/destroy cluster commands | Reference |
+| `cmd/nodepool/` | create/destroy nodepool commands | Reference |
+| `cmd/install/` | install command, CRD assets | Reference |
+| `cmd/infra/aws/create.go` | AWS infra CLI (`CreateInfra()`) | Read for AWS |
+| `cmd/infra/aws/iam.go` | AWS IAM roles and OIDC | Read for AWS |
+| `cmd/infra/azure/` | Azure infra CLI | Read for Azure |
+
+### Tests
+
+| File | Contents | Priority |
+|------|----------|----------|
+| `test/e2e/` | E2E tests (cluster lifecycle, nodepool, upgrades) | Browse for context |
+| `test/integration/` | Integration tests (controller behavior) | Browse for context |
+| `api/hypershift/v1beta1/nodepool_types_test.go` | Serialization compatibility test example | Must read for API changes |
+
+
+---
+
+## Source: docs/content/getting-started/onboarding/what-is-hypershift.md
+
+# What is HyperShift?
+
+HyperShift is an OpenShift middleware that **decouples the control plane from the data plane** (worker nodes), allowing control planes to run as workloads on a central **management cluster**.
+
+## The Problem it Solves
+
+In standalone OpenShift, every cluster runs its own control plane (etcd, kube-apiserver, controllers) on dedicated master nodes. This creates:
+
+- **Resource overhead**: 3+ master nodes per cluster just for the control plane
+- **Provisioning time**: 30-45 minutes including bootstrap
+- **Distributed operations**: each control plane is independently operated
+
+## How HyperShift Solves It
+
+**Standalone OpenShift** — each cluster embeds its own control plane on dedicated master nodes:
+
+```mermaid
+graph LR
+    subgraph "Standalone Cluster 1"
+        M1[Control Plane<br/>Masters x3]
+        W1[Workers 1..N]
+        M1 --> W1
+    end
+
+    subgraph "Standalone Cluster 2"
+        M2[Control Plane<br/>Masters x3]
+        W2[Workers 1..N]
+        M2 --> W2
+    end
+
+    subgraph "Standalone Cluster 3"
+        M3[Control Plane<br/>Masters x3]
+        W3[Workers 1..N]
+        M3 --> W3
+    end
+```
+
+Each standalone cluster is **self-contained** — it embeds its own control plane on dedicated master nodes. There is no shared management layer; every cluster independently operates its own etcd, API server, and controllers.
+
+**HyperShift Model** — a single management cluster hosts all control planes as pods:
+
+```mermaid
+graph LR
+    subgraph "Management Cluster"
+        D[Management Cluster]
+        D --> E[HCP 1 - Pods]
+        D --> F[HCP 2 - Pods]
+        D --> G[HCP 3 - Pods]
+    end
+
+    E -.-> H[Workers 1..N]
+    F -.-> I[Workers 1..N]
+    G -.-> J[Workers 1..N]
+```
+
+| Aspect | Standalone OpenShift | HyperShift (HCP) |
+|--------|---------------------|-------------------|
+| Control plane location | Dedicated master nodes inside the cluster | Pods on a management cluster |
+| Master nodes | 3+ required | Zero; only worker nodes in the guest cluster |
+| Provisioning time | 30-45 minutes | ~10-15 minutes |
+| Control plane isolation | Physical/VM | Namespace + NetworkPolicies |
+| Upgrade model | Single upgrade for CP + workers | Independent upgrades for CP vs data plane |
+
+
+---
+
+## Source: docs/content/getting-started/quick-setup.md
 
 ---
 title: Getting started

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -9,6 +9,7 @@ plugins:
 - search
 - mermaid2:
     version: 11.2.0
+    javascript: https://unpkg.com/mermaid@11.2.0/dist/mermaid.min.js
 - glightbox:
     touchNavigation: true
     loop: false
@@ -25,12 +26,14 @@ docs_dir: content
 repo_url: https://github.com/openshift/hypershift
 edit_uri: edit/main/docs/content
 repo_name: openshift/hypershift
-extra_javascript:
-  - https://unpkg.com/mermaid@11.2.0/dist/mermaid.min.js
 markdown_extensions:
 - toc:
     toc_depth: "2-3"
 - attr_list:
+- md_in_html:
+- pymdownx.emoji:
+    emoji_index: !!python/name:material.extensions.emoji.twemoji
+    emoji_generator: !!python/name:material.extensions.emoji.to_svg
 - pymdownx.highlight
 - pymdownx.inlinehilite
 - pymdownx.superfences:
@@ -55,7 +58,19 @@ extra_css:
   - custom.css
 nav:
 - Home: index.md
-- 'Getting started': getting-started.md
+- 'Getting Started':
+  - getting-started/index.md
+  - 'Quick Setup (AWS)': getting-started/quick-setup.md
+  - 'Onboarding Guide':
+    - getting-started/onboarding/index.md
+    - 'What is HyperShift?': getting-started/onboarding/what-is-hypershift.md
+    - 'Key Concepts': getting-started/onboarding/key-concepts.md
+    - 'Architecture': getting-started/onboarding/architecture.md
+    - 'Cluster Lifecycle': getting-started/onboarding/lifecycle.md
+    - 'Data Plane': getting-started/onboarding/data-plane.md
+    - 'Cloud Platforms': getting-started/onboarding/platforms.md
+    - 'Development': getting-started/onboarding/development.md
+    - 'Reference': getting-started/onboarding/reference.md
 - 'How-to guides':
   - how-to/index.md
   - 'Agentic SDLC': how-to/agentic-sdlc.md


### PR DESCRIPTION
## Summary

- Adds a comprehensive onboarding guide (`docs/content/reference/onboarding-guide.md`) covering HyperShift architecture, control plane and data plane internals, supported platforms, APIs, development workflow, and a recommended learning path
- Includes Mermaid diagrams for visual understanding of component interactions, lifecycle flows, and dependency graphs
- Provides direct code file references throughout so newcomers can self-guide their exploration of the codebase
- Adds the guide to the mkdocs nav under the Reference section and regenerates aggregated docs

## Test plan

- [ ] Verify the onboarding guide renders correctly in mkdocs (`cd docs && mkdocs serve`)
- [ ] Verify all Mermaid diagrams render properly
- [ ] Verify file path references in the guide point to existing files
- [ ] Review content accuracy with team members

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Onboarding Guide covering HyperShift/Hosted Control Plane architecture, core concepts, control-plane vs data-plane lifecycles, component model, and platform-specific notes (including KubeVirt).
  * Documented NodePool/data-plane lifecycle, upgrade/delete flows, and operator responsibilities.
  * Included development workflows, recommended reading order, API/compatibility guidelines, and updated site navigation to include the new guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->