### PR TITLE
OCPBUGS-81631: fix(metrics): remove noisy vCPU log for non-AWS platforms

### DIFF
--- a/hypershift-operator/controllers/nodepool/metrics/metrics.go
+++ b/hypershift-operator/controllers/nodepool/metrics/metrics.go
@@ -285,7 +285,7 @@ func extractCPUFromInstanceTypeNameViaConfigMap(ctx context.Context, instanceTyp
 
 func (c *nodePoolsMetricsCollector) retrieveVCpusDetailsPerNode(ctx context.Context, nodePool *hyperv1.NodePool) (int32, error) {
 	if nodePool.Spec.Platform.Type != hyperv1.AWSPlatform {
-		ctrllog.Log.Info("cannot retrieve the number of vCPUs for " + nodePool.Name + " node pool as its platform is not supported (supported platforms: AWS)")
+		// vCPU counting only supported for AWS platform
 		return -1, errUnsupportedPlatform
 	}
 

--- a/hypershift-operator/controllers/nodepool/metrics/metrics_test.go
+++ b/hypershift-operator/controllers/nodepool/metrics/metrics_test.go
@@ -550,3 +550,85 @@ func TestErrorCache(t *testing.T) {
 		g.Expect(ec2CallCount).To(Equal(2), "EC2 API should be retried when its error was transient")
 	})
 }
+
+func TestVCpusCountForKubeVirtPlatform(t *testing.T) {
+	t.Run("When nodePool platform is KubeVirt, it should return -1 without logging", func(t *testing.T) {
+		hcluster := &hyperv1.HostedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "hc",
+				Namespace: "any",
+			},
+			Spec: hyperv1.HostedClusterSpec{
+				ClusterID: "id",
+				Platform: hyperv1.PlatformSpec{
+					Type: hyperv1.KubevirtPlatform,
+				},
+			},
+		}
+
+		nodePool := &hyperv1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "np",
+				Namespace: "any",
+			},
+			Spec: hyperv1.NodePoolSpec{
+				ClusterName: "hc",
+				Platform: hyperv1.NodePoolPlatform{
+					Type: hyperv1.KubevirtPlatform,
+				},
+			},
+			Status: hyperv1.NodePoolStatus{
+				Replicas: 2,
+			},
+		}
+
+		client := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(hcluster, nodePool).Build()
+
+		reg := prometheus.NewPedanticRegistry()
+		reg.MustRegister(createNodePoolsMetricsCollector(client, nil, clock.RealClock{}))
+
+		allMetricsValues, err := reg.Gather()
+		if err != nil {
+			t.Fatalf("gathering metrics failed: %v", err)
+		}
+
+		var vCpusCountMetricValue *dto.MetricFamily
+		var vCpusComputationErrorMetricValue *dto.MetricFamily
+
+		for _, metricValue := range allMetricsValues {
+			if metricValue != nil && metricValue.Name != nil {
+				switch *metricValue.Name {
+				case VCpusCountByHClusterMetricName:
+					vCpusCountMetricValue = metricValue
+				case VCpusComputationErrorByHClusterMetricName:
+					vCpusComputationErrorMetricValue = metricValue
+				}
+			}
+		}
+
+		// Verify vCPU count is -1 for KubeVirt platform
+		if vCpusCountMetricValue == nil || len(vCpusCountMetricValue.Metric) == 0 {
+			t.Fatal("expected vCPU count metric to be present")
+		}
+		actualVCpuCount := vCpusCountMetricValue.Metric[0].Gauge.GetValue()
+		if actualVCpuCount != -1 {
+			t.Errorf("expected vCPU count to be -1 for KubeVirt platform, got %v", actualVCpuCount)
+		}
+
+		// Verify error reason is "unsupported platform"
+		if vCpusComputationErrorMetricValue == nil || len(vCpusComputationErrorMetricValue.Metric) == 0 {
+			t.Fatal("expected vCPU computation error metric to be present")
+		}
+
+		foundReasonLabel := false
+		for _, label := range vCpusComputationErrorMetricValue.Metric[0].Label {
+			if label.GetName() == "reason" && label.GetValue() == "unsupported platform" {
+				foundReasonLabel = true
+				break
+			}
+		}
+		if !foundReasonLabel {
+			t.Error("expected error reason to be 'unsupported platform' for KubeVirt platform")
+		}
+	})
+}

--- a/hypershift-operator/controllers/nodepool/metrics/metrics_test.go
+++ b/hypershift-operator/controllers/nodepool/metrics/metrics_test.go
@@ -96,6 +96,7 @@ func (c *Ec2ClientMock) DescribeInstanceTypes(ctx context.Context, input *ec2v2.
 func TestReportVCpusCountByHCluster(t *testing.T) {
 	testCases := []struct {
 		name      string
+		platform  hyperv1.PlatformType
 		npsParams []nodePoolParams
 		configMap *corev1.ConfigMap
 
@@ -229,10 +230,26 @@ func TestReportVCpusCountByHCluster(t *testing.T) {
 			expectedVCpusCount:            16,
 			expectedVCpusCountErrorReason: "",
 		},
+		{
+			name:     "When nodePool platform is KubeVirt, it should return -1 with unsupported platform error",
+			platform: hyperv1.KubevirtPlatform,
+			npsParams: []nodePoolParams{
+				{availableNodesCount: 2},
+			},
+			expectedVCpusCount:            -1,
+			expectedVCpusCountErrorReason: "unsupported platform",
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			platform := tc.platform
+			if platform == "" {
+				platform = hyperv1.AWSPlatform
+			}
+
 			hcluster := &hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "hc",
@@ -241,7 +258,7 @@ func TestReportVCpusCountByHCluster(t *testing.T) {
 				Spec: hyperv1.HostedClusterSpec{
 					ClusterID: "id",
 					Platform: hyperv1.PlatformSpec{
-						Type: hyperv1.AWSPlatform,
+						Type: platform,
 					},
 				},
 			}
@@ -263,15 +280,18 @@ func TestReportVCpusCountByHCluster(t *testing.T) {
 					Spec: hyperv1.NodePoolSpec{
 						ClusterName: "hc",
 						Platform: hyperv1.NodePoolPlatform{
-							Type: hyperv1.AWSPlatform,
-							AWS: &hyperv1.AWSNodePoolPlatform{
-								InstanceType: npParam.ec2InstanceType,
-							},
+							Type: platform,
 						},
 					},
 					Status: hyperv1.NodePoolStatus{
 						Replicas: npParam.availableNodesCount,
 					},
+				}
+
+				if platform == hyperv1.AWSPlatform {
+					nodePool.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{
+						InstanceType: npParam.ec2InstanceType,
+					}
 				}
 
 				clientBuilder = clientBuilder.WithObjects(nodePool)
@@ -281,9 +301,7 @@ func TestReportVCpusCountByHCluster(t *testing.T) {
 			reg.MustRegister(createNodePoolsMetricsCollector(clientBuilder.Build(), ec2MockedClient, clock.RealClock{}))
 
 			allMetricsValues, err := reg.Gather()
-			if err != nil {
-				t.Fatalf("gathering metrics failed: %v", err)
-			}
+			g.Expect(err).ToNot(HaveOccurred())
 
 			var vCpusCountMetricValue *dto.MetricFamily
 			var vCpusComputationErrorMetricValue *dto.MetricFamily
@@ -311,7 +329,7 @@ func TestReportVCpusCountByHCluster(t *testing.T) {
 					Name: ptr.To("namespace"), Value: ptr.To("any"),
 				},
 				{
-					Name: ptr.To("platform"), Value: ptr.To(string(hyperv1.AWSPlatform)),
+					Name: ptr.To("platform"), Value: ptr.To(string(platform)),
 				},
 			}
 
@@ -339,15 +357,8 @@ func TestReportVCpusCountByHCluster(t *testing.T) {
 				}
 			}
 
-			if diff := cmp.Diff(vCpusCountMetricValue, expectedVCpusCountMetricValue, ignoreUnexportedDto); diff != "" {
-				t.Errorf("result differs from actual: %s", diff)
-			}
-
-			if diff := cmp.Diff(vCpusComputationErrorMetricValue, expectedVCpusComputationErrorMetricValue, ignoreUnexportedDto); diff != "" {
-				t.Errorf("result differs from actual: %s, expected %+v, got %+v", diff,
-					expectedVCpusComputationErrorMetricValue,
-					vCpusComputationErrorMetricValue)
-			}
+			g.Expect(cmp.Diff(vCpusCountMetricValue, expectedVCpusCountMetricValue, ignoreUnexportedDto)).To(BeEmpty())
+			g.Expect(cmp.Diff(vCpusComputationErrorMetricValue, expectedVCpusComputationErrorMetricValue, ignoreUnexportedDto)).To(BeEmpty())
 		})
 	}
 }
@@ -548,87 +559,5 @@ func TestErrorCache(t *testing.T) {
 		collector.Collect(ch)
 		close(ch)
 		g.Expect(ec2CallCount).To(Equal(2), "EC2 API should be retried when its error was transient")
-	})
-}
-
-func TestVCpusCountForKubeVirtPlatform(t *testing.T) {
-	t.Run("When nodePool platform is KubeVirt, it should return -1 without logging", func(t *testing.T) {
-		hcluster := &hyperv1.HostedCluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "hc",
-				Namespace: "any",
-			},
-			Spec: hyperv1.HostedClusterSpec{
-				ClusterID: "id",
-				Platform: hyperv1.PlatformSpec{
-					Type: hyperv1.KubevirtPlatform,
-				},
-			},
-		}
-
-		nodePool := &hyperv1.NodePool{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "np",
-				Namespace: "any",
-			},
-			Spec: hyperv1.NodePoolSpec{
-				ClusterName: "hc",
-				Platform: hyperv1.NodePoolPlatform{
-					Type: hyperv1.KubevirtPlatform,
-				},
-			},
-			Status: hyperv1.NodePoolStatus{
-				Replicas: 2,
-			},
-		}
-
-		client := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(hcluster, nodePool).Build()
-
-		reg := prometheus.NewPedanticRegistry()
-		reg.MustRegister(createNodePoolsMetricsCollector(client, nil, clock.RealClock{}))
-
-		allMetricsValues, err := reg.Gather()
-		if err != nil {
-			t.Fatalf("gathering metrics failed: %v", err)
-		}
-
-		var vCpusCountMetricValue *dto.MetricFamily
-		var vCpusComputationErrorMetricValue *dto.MetricFamily
-
-		for _, metricValue := range allMetricsValues {
-			if metricValue != nil && metricValue.Name != nil {
-				switch *metricValue.Name {
-				case VCpusCountByHClusterMetricName:
-					vCpusCountMetricValue = metricValue
-				case VCpusComputationErrorByHClusterMetricName:
-					vCpusComputationErrorMetricValue = metricValue
-				}
-			}
-		}
-
-		// Verify vCPU count is -1 for KubeVirt platform
-		if vCpusCountMetricValue == nil || len(vCpusCountMetricValue.Metric) == 0 {
-			t.Fatal("expected vCPU count metric to be present")
-		}
-		actualVCpuCount := vCpusCountMetricValue.Metric[0].Gauge.GetValue()
-		if actualVCpuCount != -1 {
-			t.Errorf("expected vCPU count to be -1 for KubeVirt platform, got %v", actualVCpuCount)
-		}
-
-		// Verify error reason is "unsupported platform"
-		if vCpusComputationErrorMetricValue == nil || len(vCpusComputationErrorMetricValue.Metric) == 0 {
-			t.Fatal("expected vCPU computation error metric to be present")
-		}
-
-		foundReasonLabel := false
-		for _, label := range vCpusComputationErrorMetricValue.Metric[0].Label {
-			if label.GetName() == "reason" && label.GetValue() == "unsupported platform" {
-				foundReasonLabel = true
-				break
-			}
-		}
-		if !foundReasonLabel {
-			t.Error("expected error reason to be 'unsupported platform' for KubeVirt platform")
-		}
 	})
 }


### PR DESCRIPTION
## What this PR does / why we need it:

- The vCPU metrics collector logged an Info message for every non-AWS nodepool on every collection cycle, creating excessive log spam. vCPU counting is AWS-only by design, and the metric              `hypershift_cluster_vcpus_computation_error` already captures this with reason='unsupported platform'. 

- Example log generated during every log collection cycle:
`2025-11-22T17:16:31.752587014Z {"level":"info","ts":"2025-11-22T17:16:31Z","msg":"cannot retrieve the number of vCPUs for oscpgpu node pool as its plaform is not supported (supported platforms: AWS)"}`

- Removing this excess log from inside the hypershift operator pod would keep the logs more clean and easy to analyze.

## Which issue(s) this PR fixes:
Fixes  [OCPBUGS-81631](https://redhat.atlassian.net/browse/OCPBUGS-81631)

## Special notes for your reviewer:
- This removes the log while preserving all behavior and metrics.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test coverage for metrics reporting to include KubeVirt platform validation
  * Modernized test assertion patterns for improved code quality and reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->