### PR TITLE
NO-JIRA: docs: add local development workflow references to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,27 @@ bin/hypershift install --development # Install in development mode
 bin/hypershift-operator run          # Run operator locally
 ```
 
+## Local Development Environment
+
+For detailed instructions on local development workflows including:
+- Building custom operator images
+- Installing HyperShift with custom images
+- Creating and managing hosted clusters
+- Running E2E tests
+- Iteration workflows
+
+See the comprehensive guides in:
+- **[HACKING.md](./HACKING.md)** - General development how-to guides
+- **[.claude/skills/dev/](./.claude/skills/dev/)** - Step-by-step development skills for specific tasks:
+  - `build-ho-image` - Building HyperShift operator images
+  - `build-cpo-image` - Building control plane operator images
+  - `install-ho-aws` - Installing HyperShift on AWS
+  - `create-hc-aws` - Creating hosted clusters
+  - `e2e-run-aws` - Running and iterating on E2E tests
+  - `destroy-hc-aws` - Cleaning up hosted clusters
+
+These skills include environment setup, prerequisites, troubleshooting, and iteration workflows.
+
 ## Testing Strategy
 
 ### Unit Tests

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -2227,6 +2227,19 @@ func EnsureKubeAPIDNSNameCustomCert(t *testing.T, ctx context.Context, mgmtClien
 			customApiServerHost = fmt.Sprintf("api-custom-cert-%s.%s", entryHostedCluster.Spec.InfraID, serviceDomain)
 		}
 
+		// For AWS, use ExternalDNSDomain if set, otherwise fall back to BaseDomain for local development
+		if entryHostedCluster.Spec.Platform.Type == hyperv1.AWSPlatform {
+			if clusterOpts.ExternalDNSDomain != "" {
+				serviceDomain = clusterOpts.ExternalDNSDomain
+				customApiServerHost = fmt.Sprintf("api-custom-cert-%s.%s", entryHostedCluster.Spec.InfraID, serviceDomain)
+			} else if clusterOpts.BaseDomain != "" {
+				// Use base domain for local development environments where external-dns is not available
+				serviceDomain = clusterOpts.BaseDomain
+				customApiServerHost = fmt.Sprintf("api-custom-cert-%s.%s", entryHostedCluster.Spec.InfraID, serviceDomain)
+				t.Logf("Using base domain for custom cert DNS: %s", serviceDomain)
+			}
+		}
+
 		g := NewWithT(t)
 		if !hyperutil.IsPublicHC(entryHostedCluster) {
 			return


### PR DESCRIPTION
Updates AGENTS.md to reference existing comprehensive development guides instead of duplicating documentation.

Changes:
- AGENTS.md:
* Add "Local Development Environment" section with references to:
  - HACKING.md for general development workflows
  - .claude/skills/dev/ for step-by-step development tasks
* List available skills: build-ho-image, build-cpo-image, install-ho-aws, create-hc-aws, e2e-run-aws, destroy-hc-aws

This avoids documentation duplication and points developers to the detailed guides that include environment setup, prerequisites, troubleshooting, and iteration workflows.

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.