### PR TITLE
CNTRLPLANE-3182: gate PR CI on author association or ok-to-test label

### DIFF
--- a/.github/workflows/authorize-pr.yaml
+++ b/.github/workflows/authorize-pr.yaml
@@ -1,0 +1,44 @@
+name: Authorize PR
+
+on:
+  workflow_call:
+    outputs:
+      authorized:
+        description: Whether the PR is authorized to run CI
+        value: ${{ jobs.authorize.outputs.authorized }}
+
+jobs:
+  authorize:
+    name: Authorize
+    runs-on: arc-runner-set
+    timeout-minutes: 1
+    outputs:
+      authorized: ${{ steps.check.outputs.authorized }}
+    steps:
+      - name: Check PR authorization
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Non-PR events (push, workflow_dispatch) are always authorized
+            if (context.eventName !== 'pull_request') {
+              core.setOutput('authorized', 'true');
+              return;
+            }
+
+            const pr = context.payload.pull_request;
+            const trusted = ['MEMBER', 'COLLABORATOR', 'OWNER'];
+            if (trusted.includes(pr.author_association)) {
+              console.log(`Author is ${pr.author_association}, authorized`);
+              core.setOutput('authorized', 'true');
+              return;
+            }
+
+            if (pr.labels.some(l => l.name === 'ok-to-test')) {
+              console.log('ok-to-test label present, authorized');
+              core.setOutput('authorized', 'true');
+              return;
+            }
+
+            core.setOutput('authorized', 'false');
+            core.warning('PR author is not an org member and ok-to-test label is missing. A maintainer must add the ok-to-test label to run CI.');

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -5,8 +5,13 @@ on:
     branches: [main]
 
 jobs:
+  authorize:
+    uses: ./.github/workflows/authorize-pr.yaml
+
   codespell:
     name: Codespell
+    needs: [authorize]
+    if: needs.authorize.outputs.authorized == 'true'
     runs-on: arc-runner-set
     timeout-minutes: 10
     steps:

--- a/.github/workflows/cpo-container-sync.yaml
+++ b/.github/workflows/cpo-container-sync.yaml
@@ -5,8 +5,13 @@ on:
     branches: [main]
 
 jobs:
+  authorize:
+    uses: ./.github/workflows/authorize-pr.yaml
+
   cpo-container-sync:
     name: CPO Container Sync
+    needs: [authorize]
+    if: needs.authorize.outputs.authorized == 'true'
     runs-on: arc-runner-set
     timeout-minutes: 10
     steps:

--- a/.github/workflows/envtest-kube.yaml
+++ b/.github/workflows/envtest-kube.yaml
@@ -16,8 +16,13 @@ on:
   workflow_dispatch: {}
 
 jobs:
+  authorize:
+    uses: ./.github/workflows/authorize-pr.yaml
+
   envtest-kube:
     name: Envtest Vanilla Kube ${{ matrix.version }}
+    needs: [authorize]
+    if: needs.authorize.outputs.authorized == 'true'
     runs-on: arc-runner-set
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/envtest-ocp.yaml
+++ b/.github/workflows/envtest-ocp.yaml
@@ -16,8 +16,13 @@ on:
   workflow_dispatch: {}
 
 jobs:
+  authorize:
+    uses: ./.github/workflows/authorize-pr.yaml
+
   envtest-ocp:
     name: Envtest OCP (K8s ${{ matrix.version }})
+    needs: [authorize]
+    if: needs.authorize.outputs.authorized == 'true'
     runs-on: arc-runner-set
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/gitlint.yaml
+++ b/.github/workflows/gitlint.yaml
@@ -5,8 +5,13 @@ on:
     branches: [main]
 
 jobs:
+  authorize:
+    uses: ./.github/workflows/authorize-pr.yaml
+
   gitlint:
     name: Gitlint
+    needs: [authorize]
+    if: needs.authorize.outputs.authorized == 'true'
     runs-on: arc-runner-set
     timeout-minutes: 10
     steps:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,8 +5,13 @@ on:
     branches: [main]
 
 jobs:
+  authorize:
+    uses: ./.github/workflows/authorize-pr.yaml
+
   lint:
     name: Lint
+    needs: [authorize]
+    if: needs.authorize.outputs.authorized == 'true'
     runs-on: arc-runner-set
     timeout-minutes: 60
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,8 +8,13 @@ on:
   workflow_dispatch: {}
 
 jobs:
+  authorize:
+    uses: ./.github/workflows/authorize-pr.yaml
+
   test:
     name: Unit Tests
+    needs: [authorize]
+    if: needs.authorize.outputs.authorized == 'true'
     runs-on: arc-runner-set
     timeout-minutes: 30
     steps:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -5,8 +5,13 @@ on:
     branches: [main]
 
 jobs:
+  authorize:
+    uses: ./.github/workflows/authorize-pr.yaml
+
   verify:
     name: Verify
+    needs: [authorize]
+    if: needs.authorize.outputs.authorized == 'true'
     runs-on: arc-runner-set
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
## What this PR does / why we need it:

Adds authorization gating to all GitHub Actions workflows triggered by `pull_request` to prevent
resource abuse from external contributors on our self-hosted `arc-runner-set` runners.

A new reusable `authorize-pr.yaml` workflow checks whether:
1. The event is non-PR (push, workflow_dispatch) → always authorized
2. The PR author is an org `MEMBER`, `COLLABORATOR`, or `OWNER` → authorized
3. The PR has the `ok-to-test` label → authorized
4. Otherwise → job is skipped with a warning

All 8 PR-triggered workflows (`codespell`, `cpo-container-sync`, `envtest-kube`, `envtest-ocp`,
`gitlint`, `lint`, `test`, `verify`) now depend on this authorization check.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-3182](https://redhat.atlassian.net/browse/CNTRLPLANE-3182)

## Special notes for your reviewer:

- The `authorize` job is ultra-lightweight (1 min timeout, no checkout, just a JS script)
- `sync-community-fork.yaml` was not modified as it only triggers on `push` to main
- `docs-preview.yaml` uses `pull_request_target` and has its own security concerns tracked separately

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.