### PR TITLE
CNTRLPLANE-2511: refactor(cpo): move OAuth internal LB annotation into ReconcileService

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/infra/infra.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/infra.go
@@ -346,26 +346,11 @@ func (r *Reconciler) reconcileOAuthServerService(ctx context.Context, hcp *hyper
 	p := oauth.NewOAuthServiceParams(hcp)
 	oauthServerService := manifests.OauthServerService(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r.Client, oauthServerService, func() error {
-		if err := oauth.ReconcileService(oauthServerService, p.OwnerRef, serviceStrategy, hcp.Spec.Platform.Type); err != nil {
-			return err
-		}
-		// For private Azure topology, annotate the OAuth service as an internal LB
-		if serviceStrategy.Type == hyperv1.LoadBalancer && hcp.Spec.Platform.Type == hyperv1.AzurePlatform && !util.IsPublicHCP(hcp) {
-			if oauthServerService.Annotations == nil {
-				oauthServerService.Annotations = map[string]string{}
-			}
-			oauthServerService.Annotations[hyperazureutil.InternalLoadBalancerAnnotation] = hyperazureutil.InternalLoadBalancerValue
-		}
-		return nil
+		return oauth.ReconcileService(oauthServerService, p.OwnerRef, serviceStrategy, hcp.Spec.Platform.Type, util.IsPrivateHCP(hcp))
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile OAuth service: %w", err)
 	}
-	switch serviceStrategy.Type {
-	case hyperv1.LoadBalancer:
-		return nil
-	case hyperv1.Route:
-		// Continue with Route reconciliation below
-	default:
+	if serviceStrategy.Type != hyperv1.Route {
 		return nil
 	}
 	oauthExternalPublicRoute := manifests.OauthServerExternalPublicRoute(hcp.Namespace)

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/service.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	azureutil "github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/config"
 
 	routev1 "github.com/openshift/api/route/v1"
@@ -26,7 +27,7 @@ var (
 	}
 )
 
-func ReconcileService(svc *corev1.Service, ownerRef config.OwnerRef, strategy *hyperv1.ServicePublishingStrategy, platformType hyperv1.PlatformType) error {
+func ReconcileService(svc *corev1.Service, ownerRef config.OwnerRef, strategy *hyperv1.ServicePublishingStrategy, platformType hyperv1.PlatformType, isPrivate bool) error {
 	ownerRef.ApplyTo(svc)
 	if svc.Spec.Selector == nil {
 		svc.Spec.Selector = oauthServerLabels
@@ -64,11 +65,16 @@ func ReconcileService(svc *corev1.Service, ownerRef config.OwnerRef, strategy *h
 		// the management cluster's KAS on the shared Azure internal load balancer.
 		// The target port remains 6443 as that is what the OAuth server pod listens on.
 		portSpec.Port = int32(RouteExternalPort)
+		if svc.Annotations == nil {
+			svc.Annotations = map[string]string{}
+		}
 		if strategy.LoadBalancer != nil && strategy.LoadBalancer.Hostname != "" {
-			if svc.Annotations == nil {
-				svc.Annotations = map[string]string{}
-			}
 			svc.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = strategy.LoadBalancer.Hostname
+		}
+		if isPrivate {
+			svc.Annotations[azureutil.InternalLoadBalancerAnnotation] = azureutil.InternalLoadBalancerValue
+		} else {
+			delete(svc.Annotations, azureutil.InternalLoadBalancerAnnotation)
 		}
 	default:
 		return fmt.Errorf("invalid publishing strategy for OAuth service: %s", strategy.Type)

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/service_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/service_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+	supportazureutil "github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/config"
 
 	routev1 "github.com/openshift/api/route/v1"
@@ -19,12 +20,14 @@ import (
 
 func TestOauthServiceReconcile(t *testing.T) {
 	testCases := []struct {
-		name     string
-		platform v1beta1.PlatformType
-		strategy v1beta1.ServicePublishingStrategy
-		svc_in   corev1.Service
-		svc_out  corev1.Service
-		err      error
+		name              string
+		platform          v1beta1.PlatformType
+		strategy          v1beta1.ServicePublishingStrategy
+		isPrivate         bool
+		svc_in            corev1.Service
+		svc_out           corev1.Service
+		absentAnnotations []string
+		err               error
 	}{
 		{
 			name:     "When IBM Cloud platform uses NodePort strategy with a port, it should populate the NodePort from the strategy",
@@ -105,7 +108,7 @@ func TestOauthServiceReconcile(t *testing.T) {
 			err:      fmt.Errorf("LoadBalancer publishing strategy for OAuth service is only supported on self-managed Azure, got platform: AWS"),
 		},
 		{
-			name:     "When Azure platform uses LoadBalancer strategy, it should set service type to LoadBalancer with port 443 and target port 6443",
+			name:     "When public Azure platform uses LoadBalancer strategy, it should set service type to LoadBalancer without the internal LB annotation",
 			platform: v1beta1.AzurePlatform,
 			strategy: v1beta1.ServicePublishingStrategy{Type: v1beta1.LoadBalancer},
 			svc_in:   corev1.Service{},
@@ -119,7 +122,8 @@ func TestOauthServiceReconcile(t *testing.T) {
 					},
 				},
 			}},
-			err: nil,
+			absentAnnotations: []string{supportazureutil.InternalLoadBalancerAnnotation},
+			err:               nil,
 		},
 		{
 			name:     "When Azure platform uses LoadBalancer strategy with hostname, it should set the ExternalDNS annotation",
@@ -150,11 +154,66 @@ func TestOauthServiceReconcile(t *testing.T) {
 			},
 			err: nil,
 		},
+		{
+			name:      "When private Azure platform uses LoadBalancer strategy, it should set the internal LB annotation",
+			platform:  v1beta1.AzurePlatform,
+			isPrivate: true,
+			strategy: v1beta1.ServicePublishingStrategy{
+				Type: v1beta1.LoadBalancer,
+				LoadBalancer: &v1beta1.LoadBalancerPublishingStrategy{
+					Hostname: "oauth-mycluster.example.com",
+				},
+			},
+			svc_in: corev1.Service{},
+			svc_out: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						v1beta1.ExternalDNSHostnameAnnotation:           "oauth-mycluster.example.com",
+						supportazureutil.InternalLoadBalancerAnnotation: supportazureutil.InternalLoadBalancerValue,
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeLoadBalancer,
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.IntOrString{IntVal: 6443},
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			name:     "When public Azure LB service has a stale internal LB annotation, it should remove it",
+			platform: v1beta1.AzurePlatform,
+			strategy: v1beta1.ServicePublishingStrategy{Type: v1beta1.LoadBalancer},
+			svc_in: corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						supportazureutil.InternalLoadBalancerAnnotation: supportazureutil.InternalLoadBalancerValue,
+					},
+				},
+			},
+			svc_out: corev1.Service{Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Ports: []corev1.ServicePort{
+					{
+						Protocol:   corev1.ProtocolTCP,
+						Port:       443,
+						TargetPort: intstr.IntOrString{IntVal: 6443},
+					},
+				},
+			}},
+			absentAnnotations: []string{supportazureutil.InternalLoadBalancerAnnotation},
+			err:               nil,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			err := ReconcileService(&tc.svc_in, config.OwnerRef{}, &tc.strategy, tc.platform)
+			err := ReconcileService(&tc.svc_in, config.OwnerRef{}, &tc.strategy, tc.platform, tc.isPrivate)
 
 			if tc.err == nil {
 				g.Expect(err).ToNot(HaveOccurred())
@@ -162,6 +221,9 @@ func TestOauthServiceReconcile(t *testing.T) {
 				g.Expect(tc.svc_in.Spec.Ports).To(Equal(tc.svc_out.Spec.Ports))
 				for k, v := range tc.svc_out.Annotations {
 					g.Expect(tc.svc_in.Annotations).To(HaveKeyWithValue(k, v))
+				}
+				for _, k := range tc.absentAnnotations {
+					g.Expect(tc.svc_in.Annotations).ToNot(HaveKey(k))
 				}
 			} else {
 				g.Expect(err).To(HaveOccurred())
@@ -246,6 +308,28 @@ func TestReconcileServiceStatus(t *testing.T) {
 			expectedPort:    0,
 			expectedMessage: "OAuth LoadBalancer not yet provisioned; 5m since creation",
 		},
+		{
+			name: "When LoadBalancer ingress has neither hostname nor IP, it should return a message indicating blank ingress",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.NewTime(time.Now().Add(-3 * time.Minute)),
+				},
+				Status: corev1.ServiceStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{
+							{},
+						},
+					},
+				},
+			},
+			route: &routev1.Route{},
+			strategy: &v1beta1.ServicePublishingStrategy{
+				Type: v1beta1.LoadBalancer,
+			},
+			expectedHost:    "",
+			expectedPort:    0,
+			expectedMessage: "OAuth LoadBalancer ingress has no hostname or IP",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -260,7 +344,7 @@ func TestReconcileServiceStatus(t *testing.T) {
 			g.Expect(host).To(Equal(tc.expectedHost))
 			g.Expect(port).To(Equal(tc.expectedPort))
 			if tc.expectedMessage != "" {
-				g.Expect(message).To(ContainSubstring("OAuth LoadBalancer not yet provisioned"))
+				g.Expect(message).To(ContainSubstring(tc.expectedMessage))
 			} else {
 				g.Expect(message).To(BeEmpty())
 			}


### PR DESCRIPTION
## What this PR does / why we need it:

Addresses review feedback from @muraee on #8149:

1. **Moves the Azure internal LoadBalancer annotation** (`service.beta.kubernetes.io/azure-load-balancer-internal`) from `infra.go` into `oauth.ReconcileService()`, co-locating all OAuth service configuration in one place. This follows the same pattern used by `kas.ReconcileService()`.

2. **Reverts the unnecessary `switch` refactor** on the strategy type check back to the original `if serviceStrategy.Type != hyperv1.Route` form, since the switch didn't change behavior.

3. **Adds behavioral unit tests** for the new `isPrivate` parameter:
   - Public Azure LB does NOT set the internal LB annotation (negative assertion)
   - Private Azure LB sets the internal LB annotation
   - Blank LoadBalancer ingress (neither hostname nor IP) returns appropriate message

## Which issue(s) this PR fixes:

Fixes #8149 (review feedback)

## Special notes for your reviewer:

Follow-up to #8149. The `ReconcileService` function gains an `isPrivate bool` parameter so the ILB annotation logic can live alongside all other service configuration rather than being split across `infra.go` and `oauth/service.go`.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * OAuth service reconciliation now correctly applies or removes Azure internal load balancer annotations based on private vs. public hosted control planes, and consistently sets hostname annotations when provided.
* **Tests**
  * Expanded OAuth service tests for Azure: private/public LB scenarios, removal of stale internal annotations, and additional service status edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->