### PR TITLE
OCPBUGS-82166: fix etcd snapshot restore for etcd 3.6 and enforce restoreSnapshotURL immutability

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -1901,6 +1901,7 @@ type EtcdSpec struct {
 type ManagedEtcdSpec struct {
 	// storage specifies how etcd data is persisted.
 	// +required
+	// +kubebuilder:validation:XValidation:rule="has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)",message="restoreSnapshotURL cannot be added or removed after creation"
 	Storage ManagedEtcdStorageSpec `json:"storage"`
 
 	// backup defines the backup configuration for managed etcd, including
@@ -1952,6 +1953,7 @@ type ManagedEtcdStorageSpec struct {
 	// +kubebuilder:validation:MaxItems=1
 	// +kubebuilder:validation:items:MaxLength=1024
 	// +kubebuilder:validation:XValidation:rule="self.size() <= 1", message="RestoreSnapshotURL shouldn't contain more than 1 entry"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="restoreSnapshotURL is immutable"
 	RestoreSnapshotURL []string `json:"restoreSnapshotURL,omitempty"`
 }
 

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -2527,6 +2527,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2537,6 +2539,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -2654,6 +2654,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2664,6 +2666,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -2518,6 +2518,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2528,6 +2530,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -2518,6 +2518,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2528,6 +2530,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -2851,6 +2851,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2861,6 +2863,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -2991,6 +2991,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -3001,6 +3003,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -2972,6 +2972,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2982,6 +2984,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
@@ -2518,6 +2518,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2528,6 +2530,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -2583,6 +2583,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2593,6 +2595,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -2540,6 +2540,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2550,6 +2552,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -2536,6 +2536,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2546,6 +2548,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -2594,6 +2594,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2604,6 +2606,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -2518,6 +2518,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2528,6 +2530,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -2444,6 +2444,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2454,6 +2456,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -2573,6 +2573,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2583,6 +2585,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -2435,6 +2435,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2445,6 +2447,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -2435,6 +2435,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2445,6 +2447,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -2768,6 +2768,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2778,6 +2780,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -2908,6 +2908,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2918,6 +2920,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -2889,6 +2889,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2899,6 +2901,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
@@ -2435,6 +2435,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2445,6 +2447,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -2500,6 +2500,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2510,6 +2512,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -2457,6 +2457,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2467,6 +2469,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -2453,6 +2453,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2463,6 +2465,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -2511,6 +2511,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2521,6 +2523,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -2435,6 +2435,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2445,6 +2447,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.etcd.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.etcd.testsuite.yaml
@@ -1,0 +1,534 @@
+apiVersion: apiextensions.k8s.io/v1
+name: "HostedCluster etcd validation"
+crdName: hostedclusters.hypershift.openshift.io
+version: v1beta1
+tests:
+  onCreate:
+  - name: When restoreSnapshotURL contains more than 1 entry it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        etcd:
+          managementType: Managed
+          managed:
+            storage:
+              type: PersistentVolume
+              persistentVolume:
+                size: 8Gi
+              restoreSnapshotURL:
+              - "https://bucket.s3.amazonaws.com/snapshot1.db"
+              - "https://bucket.s3.amazonaws.com/snapshot2.db"
+        platform:
+          type: AWS
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    expectedError: "must have at most 1 item"
+
+  - name: When restoreSnapshotURL contains exactly 1 entry it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        etcd:
+          managementType: Managed
+          managed:
+            storage:
+              type: PersistentVolume
+              persistentVolume:
+                size: 8Gi
+              restoreSnapshotURL:
+              - "https://bucket.s3.amazonaws.com/snapshot.db"
+        platform:
+          type: AWS
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+
+  onUpdate:
+  - name: When restoreSnapshotURL is changed it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        etcd:
+          managementType: Managed
+          managed:
+            storage:
+              type: PersistentVolume
+              persistentVolume:
+                size: 8Gi
+              restoreSnapshotURL:
+              - "https://bucket.s3.amazonaws.com/snapshot-old.db"
+        platform:
+          type: AWS
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        etcd:
+          managementType: Managed
+          managed:
+            storage:
+              type: PersistentVolume
+              persistentVolume:
+                size: 8Gi
+              restoreSnapshotURL:
+              - "https://bucket.s3.amazonaws.com/snapshot-new.db"
+        platform:
+          type: AWS
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    expectedError: "restoreSnapshotURL is immutable"
+
+  - name: When restoreSnapshotURL is removed it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        etcd:
+          managementType: Managed
+          managed:
+            storage:
+              type: PersistentVolume
+              persistentVolume:
+                size: 8Gi
+              restoreSnapshotURL:
+              - "https://bucket.s3.amazonaws.com/snapshot.db"
+        platform:
+          type: AWS
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        etcd:
+          managementType: Managed
+          managed:
+            storage:
+              type: PersistentVolume
+              persistentVolume:
+                size: 8Gi
+              restoreSnapshotURL: []
+        platform:
+          type: AWS
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    expectedError: "restoreSnapshotURL is immutable"
+
+  - name: When restoreSnapshotURL is added after creation it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        etcd:
+          managementType: Managed
+          managed:
+            storage:
+              type: PersistentVolume
+              persistentVolume:
+                size: 8Gi
+        platform:
+          type: AWS
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        etcd:
+          managementType: Managed
+          managed:
+            storage:
+              type: PersistentVolume
+              persistentVolume:
+                size: 8Gi
+              restoreSnapshotURL:
+              - "https://bucket.s3.amazonaws.com/snapshot.db"
+        platform:
+          type: AWS
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    expectedError: "restoreSnapshotURL cannot be added or removed after creation"
+
+  - name: When restoreSnapshotURL is unchanged it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        etcd:
+          managementType: Managed
+          managed:
+            storage:
+              type: PersistentVolume
+              persistentVolume:
+                size: 8Gi
+              restoreSnapshotURL:
+              - "https://bucket.s3.amazonaws.com/snapshot.db"
+        platform:
+          type: AWS
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        etcd:
+          managementType: Managed
+          managed:
+            storage:
+              type: PersistentVolume
+              persistentVolume:
+                size: 8Gi
+              restoreSnapshotURL:
+              - "https://bucket.s3.amazonaws.com/snapshot.db"
+        platform:
+          type: AWS
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.16.0-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+
+  - name: When restoreSnapshotURL is not set and other fields are updated it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        etcd:
+          managementType: Managed
+          managed:
+            storage:
+              type: PersistentVolume
+              persistentVolume:
+                size: 8Gi
+        platform:
+          type: AWS
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        etcd:
+          managementType: Managed
+          managed:
+            storage:
+              type: PersistentVolume
+              persistentVolume:
+                size: 8Gi
+        platform:
+          type: AWS
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.16.0-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
@@ -3436,6 +3436,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -3446,6 +3448,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
@@ -3020,6 +3020,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -3030,6 +3032,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -3347,6 +3347,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -3357,6 +3359,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
@@ -3355,6 +3355,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -3365,6 +3367,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
@@ -2937,6 +2937,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -2947,6 +2949,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -3266,6 +3266,8 @@ spec:
                             - message: RestoreSnapshotURL shouldn't contain more than
                                 1 entry
                               rule: self.size() <= 1
+                            - message: restoreSnapshotURL is immutable
+                              rule: self == oldSelf
                           type:
                             description: |-
                               type is the kind of persistent storage implementation to use for etcd.
@@ -3276,6 +3278,10 @@ spec:
                         required:
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: restoreSnapshotURL cannot be added or removed after
+                            creation
+                          rule: has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)
                     required:
                     - storage
                     type: object

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/etcd-init.sh
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/etcd-init.sh
@@ -9,9 +9,24 @@ RESTORE_URL=${!RESTORE_URL_VAR}
 # and also when a pre-signed URL is expired.
 # In this case we get an XML file which can be detected with `file` so we show
 # the contents via the logs then exit with an error status
-curl -o /tmp/snapshot ${RESTORE_URL}
-file /tmp/snapshot | grep -q XML && cat /tmp/snapshot && exit 1
+curl -o /tmp/snapshot "${RESTORE_URL}"
+head -c 5 /tmp/snapshot | grep -q '<?xml' && cat /tmp/snapshot && exit 1
 
-# FIXME: etcdctl restore is deprecated but the etcd container doesn't have etcdutl
-env ETCDCTL_API=3 /usr/bin/etcdctl -w table snapshot status /tmp/snapshot
-env ETCDCTL_API=3 /usr/bin/etcdctl snapshot restore /tmp/snapshot --data-dir=/var/lib/data
+# etcd 3.6+ (OCP 4.21+) moved snapshot restore/status from etcdctl to etcdutl.
+# Restore to a staging directory first so a mid-write failure does not corrupt /var/lib/data.
+rm -rf /var/lib/restore
+if [ -x /usr/bin/etcdutl ]; then
+  echo "INFO: using etcdutl (etcd 3.6+)"
+  etcdutl snapshot status /tmp/snapshot -w table
+  etcdutl snapshot restore /tmp/snapshot --data-dir=/var/lib/restore
+elif [ -x /usr/bin/etcdctl ]; then
+  echo "INFO: using etcdctl (etcd 3.5.x)"
+  env ETCDCTL_API=3 /usr/bin/etcdctl -w table snapshot status /tmp/snapshot
+  env ETCDCTL_API=3 /usr/bin/etcdctl snapshot restore /tmp/snapshot --data-dir=/var/lib/restore
+else
+  echo "ERROR: neither etcdutl nor etcdctl found in the container image"
+  exit 1
+fi
+
+rm -rf /var/lib/data
+mv /var/lib/restore /var/lib/data

--- a/test/e2e/util/util_metrics_proxy.go
+++ b/test/e2e/util/util_metrics_proxy.go
@@ -185,7 +185,7 @@ func execInGuestPod(ctx context.Context, guestConfig *rest.Config, namespace, po
 // targetsAPIResponse wraps the Prometheus /api/v1/targets JSON envelope
 // around the upstream TargetsResult type.
 type targetsAPIResponse struct {
-	Status string                    `json:"status"`
+	Status string                     `json:"status"`
 	Data   prometheusv1.TargetsResult `json:"data"`
 }
 
@@ -198,4 +198,3 @@ type queryAPIResponse struct {
 		Result     model.Vector `json:"result"`
 	} `json:"data"`
 }
-

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -1901,6 +1901,7 @@ type EtcdSpec struct {
 type ManagedEtcdSpec struct {
 	// storage specifies how etcd data is persisted.
 	// +required
+	// +kubebuilder:validation:XValidation:rule="has(self.restoreSnapshotURL) == has(oldSelf.restoreSnapshotURL)",message="restoreSnapshotURL cannot be added or removed after creation"
 	Storage ManagedEtcdStorageSpec `json:"storage"`
 
 	// backup defines the backup configuration for managed etcd, including
@@ -1952,6 +1953,7 @@ type ManagedEtcdStorageSpec struct {
 	// +kubebuilder:validation:MaxItems=1
 	// +kubebuilder:validation:items:MaxLength=1024
 	// +kubebuilder:validation:XValidation:rule="self.size() <= 1", message="RestoreSnapshotURL shouldn't contain more than 1 entry"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="restoreSnapshotURL is immutable"
 	RestoreSnapshotURL []string `json:"restoreSnapshotURL,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
- Use `etcdutl` for snapshot restore/status on etcd 3.6+ (OCP 4.21+), falling back to `etcdctl` for older versions
- Add CEL validation rule (`self == oldSelf`) to enforce `restoreSnapshotURL` immutability at admission time, aligning with the existing API contract ("only when the etcd PV is empty")
- Add envtest CEL validation test suite for `restoreSnapshotURL` field constraints

## Changes
1. **etcd-init.sh**: etcdutl/etcdctl fallback with error when neither tool is available
2. **API**: CEL immutability rule on `restoreSnapshotURL` + regenerated CRDs
3. **Test suite**: envtest YAML-driven tests covering MaxItems enforcement, immutability on update (change/removal rejected), and allowed transitions (initial set, unchanged value, unrelated updates)

## Test plan
- [x] Verify etcd snapshot restore works on OCP 4.21 (etcd 3.6) with a valid pre-signed S3 URL
- [ ] Verify etcd snapshot restore works on OCP 4.18-4.20 (etcd 3.5.x)
- [ ] Verify day-2 modification of `restoreSnapshotURL` is rejected by CEL validation
- [x] Verify OADP restore workflow (plugin patches HC before CREATE) is not affected by CEL
- [x] envtest suite passes for `restoreSnapshotURL` CEL validation (`make test-envtest-kube`)

## Bug
https://redhat.atlassian.net/browse/OCPBUGS-82166

🤖 Generated with [Claude Code](https://claude.com/claude-code)