### PR TITLE
NO-JIRA: control-plane-pki-operator: fix Event emission logic, format

### DIFF
--- a/control-plane-pki-operator/certificatesigningcontroller/certificatesigningcontroller.go
+++ b/control-plane-pki-operator/certificatesigningcontroller/certificatesigningcontroller.go
@@ -96,8 +96,8 @@ func (c *CertificateSigningController) syncCertificateSigningRequest(ctx context
 			syncContext.Recorder().Eventf("CertificateSigningRequestValid", "%q is valid", name)
 		}
 		_, err := c.kubeClient.CertificatesV1().CertificateSigningRequests().ApplyStatus(ctx, cfg, metav1.ApplyOptions{FieldManager: c.fieldManager})
-		if err != nil && validationErr == nil {
-			syncContext.Recorder().Eventf("CertificateSigningRequestFulfilled", "%q in %q is fulfilled", name)
+		if err == nil && validationErr == nil {
+			syncContext.Recorder().Eventf("CertificateSigningRequestFulfilled", "%q is fulfilled", name)
 		}
 		return err
 	}

--- a/control-plane-pki-operator/certificatesigningrequestapprovalcontroller/certificatesigningrequestapprovalcontroller.go
+++ b/control-plane-pki-operator/certificatesigningrequestapprovalcontroller/certificatesigningrequestapprovalcontroller.go
@@ -95,7 +95,7 @@ func (c *CertificateSigningRequestApprovalController) syncCertificateSigningRequ
 		return factory.SyntheticRequeueError
 	}
 	if csr != nil {
-		syncContext.Recorder().Eventf("CertificateSigningRequestApproved", "%q in is approved", csr.Name)
+		syncContext.Recorder().Eventf("CertificateSigningRequestApproved", "%q is approved", csr.Name)
 		_, err = c.kubeClient.CertificatesV1().CertificateSigningRequests().UpdateApproval(ctx, name, csr, metav1.UpdateOptions{})
 		return err
 	}


### PR DESCRIPTION
In the certificate signing controller, a mistaken `err != nil` meant that we were sending the CertificateSigningRequestFulfilled event in the wrong condition.

In the certificate signing request approval controller, a spurious `in` was left over from a previous version of this controller that emitted the namespace.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Fixed incorrect fulfillment event reporting for certificate signing requests — fulfillment events are now recorded only when the signing operation succeeds and validation passes.
* Corrected event message grammar in certificate signing request approvals so approval notifications display the proper message text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->