### PR TITLE
OCPBUGS-82301: fix(catalogs): use semver comparison for catalog version cap to handle OCP 5.0

### DIFF
--- a/support/catalogs/images.go
+++ b/support/catalogs/images.go
@@ -169,11 +169,15 @@ func computeCatalogImages(releaseVersion func() (*semver.Version, error), imageE
 		"redhat-operators":    "",
 	}
 
+	maxCatalogVersion := semver.Version{Major: 4, Minor: 21}
 	for catalog := range catalogs {
 		catalogVersion := *version
-		// Start at 4.21 until the 4.22 catalog images works properly
-		if catalogVersion.Minor > 21 {
-			catalogVersion.Minor = 21
+		// Cap catalog version to the latest known-good catalog images.
+		// Use semver comparison to correctly handle the 4.x to 5.0 major version boundary.
+		catalogMajorMinor := semver.Version{Major: catalogVersion.Major, Minor: catalogVersion.Minor}
+		if catalogMajorMinor.GT(maxCatalogVersion) {
+			catalogVersion.Major = maxCatalogVersion.Major
+			catalogVersion.Minor = maxCatalogVersion.Minor
 		}
 		for i := range supportedVersions {
 			for _, registry := range registries {

--- a/support/catalogs/images_test.go
+++ b/support/catalogs/images_test.go
@@ -140,6 +140,70 @@ func TestComputeCatalogImages(t *testing.T) {
 			},
 		},
 		{
+			name:           "When version is 5.0, it should be capped to 4.21 catalog images",
+			releaseVersion: semver.MustParse("5.0.0"),
+			existingImages: []string{
+				"registry.redhat.io/redhat/certified-operator-index:v4.21",
+				"registry.redhat.io/redhat/community-operator-index:v4.21",
+				"registry.redhat.io/redhat/redhat-marketplace-index:v4.21",
+				"registry.redhat.io/redhat/redhat-operator-index:v4.21",
+			},
+			expected: map[string]string{
+				"certified-operators": "registry.redhat.io/redhat/certified-operator-index:v4.21",
+				"community-operators": "registry.redhat.io/redhat/community-operator-index:v4.21",
+				"redhat-marketplace":  "registry.redhat.io/redhat/redhat-marketplace-index:v4.21",
+				"redhat-operators":    "registry.redhat.io/redhat/redhat-operator-index:v4.21",
+			},
+		},
+		{
+			name:           "When version is 5.0 nightly, it should be capped to 4.21 catalog images",
+			releaseVersion: semver.MustParse("5.0.0-0.nightly-multi-2026-04-07-214955"),
+			existingImages: []string{
+				"registry.redhat.io/redhat/certified-operator-index:v4.21",
+				"registry.redhat.io/redhat/community-operator-index:v4.21",
+				"registry.redhat.io/redhat/redhat-marketplace-index:v4.21",
+				"registry.redhat.io/redhat/redhat-operator-index:v4.21",
+			},
+			expected: map[string]string{
+				"certified-operators": "registry.redhat.io/redhat/certified-operator-index:v4.21",
+				"community-operators": "registry.redhat.io/redhat/community-operator-index:v4.21",
+				"redhat-marketplace":  "registry.redhat.io/redhat/redhat-marketplace-index:v4.21",
+				"redhat-operators":    "registry.redhat.io/redhat/redhat-operator-index:v4.21",
+			},
+		},
+		{
+			name:           "When version is 5.0 and 4.21 not available, it should fall back to earlier versions",
+			releaseVersion: semver.MustParse("5.0.0"),
+			existingImages: []string{
+				"registry.redhat.io/redhat/certified-operator-index:v4.19",
+				"registry.redhat.io/redhat/community-operator-index:v4.19",
+				"registry.redhat.io/redhat/redhat-marketplace-index:v4.19",
+				"registry.redhat.io/redhat/redhat-operator-index:v4.19",
+			},
+			expected: map[string]string{
+				"certified-operators": "registry.redhat.io/redhat/certified-operator-index:v4.19",
+				"community-operators": "registry.redhat.io/redhat/community-operator-index:v4.19",
+				"redhat-marketplace":  "registry.redhat.io/redhat/redhat-marketplace-index:v4.19",
+				"redhat-operators":    "registry.redhat.io/redhat/redhat-operator-index:v4.19",
+			},
+		},
+		{
+			name:           "When version is 4.22, it should be capped to 4.21 catalog images",
+			releaseVersion: semver.MustParse("4.22.0"),
+			existingImages: []string{
+				"registry.redhat.io/redhat/certified-operator-index:v4.21",
+				"registry.redhat.io/redhat/community-operator-index:v4.21",
+				"registry.redhat.io/redhat/redhat-marketplace-index:v4.21",
+				"registry.redhat.io/redhat/redhat-operator-index:v4.21",
+			},
+			expected: map[string]string{
+				"certified-operators": "registry.redhat.io/redhat/certified-operator-index:v4.21",
+				"community-operators": "registry.redhat.io/redhat/community-operator-index:v4.21",
+				"redhat-marketplace":  "registry.redhat.io/redhat/redhat-marketplace-index:v4.21",
+				"redhat-operators":    "registry.redhat.io/redhat/redhat-operator-index:v4.21",
+			},
+		},
+		{
 			name:           "overrides with root registry only",
 			releaseVersion: semver.MustParse("4.19.0"),
 			existingImages: []string{


### PR DESCRIPTION
## What this PR does / why we need it:

The `computeCatalogImages()` function in `support/catalogs/images.go` uses a minor-only version comparison (`catalogVersion.Minor > 21`) to cap the catalog image version. This fails for OCP 5.0 where `Minor=0`:

1. The version cap does not apply (`0 > 21` is false), so the code tries to resolve `v5.0` catalog images that don't exist
2. Decrementing `Minor` from 0 causes a `uint64` underflow to `18446744073709551615`, generating nonsensical image tags

This is the same class of bug fixed in #8182 for the ignition-server version checks.

**Fix:**
- Replace `catalogVersion.Minor > 21` with `semver.Version.GT()` for proper major+minor comparison that handles the 4.x → 5.0 boundary
- When capping, set both `Major` and `Minor` so 5.0 is correctly mapped to 4.21 catalog images

## Which issue(s) this PR fixes:

Fixes OCPBUGS-82301

## Special notes for your reviewer:

**Impact:** Without this fix, all OCP 5.0 hosted clusters fail to resolve OLM catalog images, causing 15/65 e2e tests to fail with:
```
Available=False: ComponentsNotAvailable(Waiting for components: certified-operators-catalog, community-operators-catalog, redhat-operators-catalog, redhat-marketplace-catalog)
```

**Failing CI job investigated:** https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-hypershift-release-5.0-periodics-e2e-aks/2042165259266953216

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed catalog image version handling to properly cap newer release versions (5.0.0, 4.22.0) to use compatible catalog images (v4.21), ensuring fallback to available images when expected versions are not present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->