### PR TITLE
CNTRLPLANE-3197: add release-4.22 branch to renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,8 @@
         "release-4.18",
         "release-4.19",
         "release-4.20",
-        "release-4.21"
+        "release-4.21",
+        "release-4.22"
     ],
     "tekton": {
         "branchConcurrentLimit": 10,
@@ -45,7 +46,8 @@
                 "release-4.18",
                 "release-4.19",
                 "release-4.20",
-                "release-4.21"
+                "release-4.21",
+                "release-4.22"
             ],
             "matchUpdateTypes": [
                 "patch"


### PR DESCRIPTION
## Summary
Add release-4.22 branch to Renovate configuration to enable security-only Go dependency updates.

## Changes
- Add `release-4.22` to `baseBranchPatterns` 
- Add `release-4.22` to `matchBaseBranches` in packageRules

## Fixes
- [CNTRLPLANE-3197](https://issues.redhat.com/browse/CNTRLPLANE-3197)