### PR TITLE
CNTRLPLANE-3207: feat(metrics): track AWS endpoint transition duration

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics.go
@@ -338,7 +338,7 @@ func (c *hostedClustersMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 			}
 
 			// transitionDurationMetric - aggregation
-			for _, conditionType := range []hyperv1.ConditionType{hyperv1.EtcdAvailable, hyperv1.InfrastructureReady, hyperv1.ExternalDNSReachable} {
+			for _, conditionType := range []hyperv1.ConditionType{hyperv1.EtcdAvailable, hyperv1.InfrastructureReady, hyperv1.ExternalDNSReachable, hyperv1.AWSEndpointServiceAvailable, hyperv1.AWSEndpointAvailable} {
 				condition := meta.FindStatusCondition(hcluster.Status.Conditions, string(conditionType))
 
 				if condition != nil && condition.Status == metav1.ConditionTrue {

--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
@@ -1280,6 +1280,137 @@ func TestHostedClusterAzureInfo(t *testing.T) {
 	}
 }
 
+func TestReportTransitionDurationForAWSEndpointConditions(t *testing.T) {
+	testCases := []struct {
+		name               string
+		conditions         []metav1.Condition
+		expectedConditions []string
+	}{
+		{
+			name:               "When no AWS endpoint conditions are set, no transition duration is recorded",
+			conditions:         nil,
+			expectedConditions: nil,
+		},
+		{
+			name: "When AWSEndpointServiceAvailable is true, it should be observed",
+			conditions: []metav1.Condition{
+				{
+					Type:               string(hyperv1.AWSEndpointServiceAvailable),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Time{Time: now.Add(2 * time.Minute)},
+				},
+			},
+			expectedConditions: []string{string(hyperv1.AWSEndpointServiceAvailable)},
+		},
+		{
+			name: "When AWSEndpointAvailable is true, it should be observed",
+			conditions: []metav1.Condition{
+				{
+					Type:               string(hyperv1.AWSEndpointAvailable),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Time{Time: now.Add(3 * time.Minute)},
+				},
+			},
+			expectedConditions: []string{string(hyperv1.AWSEndpointAvailable)},
+		},
+		{
+			name: "When both AWS endpoint conditions are true, both should be observed",
+			conditions: []metav1.Condition{
+				{
+					Type:               string(hyperv1.AWSEndpointServiceAvailable),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Time{Time: now.Add(2 * time.Minute)},
+				},
+				{
+					Type:               string(hyperv1.AWSEndpointAvailable),
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.Time{Time: now.Add(5 * time.Minute)},
+				},
+			},
+			expectedConditions: []string{
+				string(hyperv1.AWSEndpointServiceAvailable),
+				string(hyperv1.AWSEndpointAvailable),
+			},
+		},
+		{
+			name: "When AWSEndpointServiceAvailable is false, it should not be observed",
+			conditions: []metav1.Condition{
+				{
+					Type:               string(hyperv1.AWSEndpointServiceAvailable),
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.Time{Time: now.Add(2 * time.Minute)},
+				},
+			},
+			expectedConditions: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hcluster := &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "hc",
+					Namespace:         "any",
+					CreationTimestamp:  metav1.Time{Time: now},
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					ClusterID: "id",
+				},
+				Status: hyperv1.HostedClusterStatus{
+					Conditions: tc.conditions,
+				},
+			}
+
+			// Use a collect time after all transition times so observations fall in the window
+			collectTime := now.Add(10 * time.Minute)
+
+			reg := prometheus.NewPedanticRegistry()
+			reg.MustRegister(createHostedClustersMetricsCollector(
+				fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(hcluster).Build(),
+				clocktesting.NewFakeClock(collectTime),
+			))
+
+			result, err := reg.Gather()
+			if err != nil {
+				t.Fatalf("gathering metrics failed: %v", err)
+			}
+
+			metricFamily := findMetricValue(&result, TransitionDurationMetricName)
+			observedConditions := map[string]bool{}
+			if metricFamily != nil {
+				for _, m := range metricFamily.Metric {
+					for _, label := range m.Label {
+						if label.GetName() == "condition" && m.Histogram != nil && m.Histogram.GetSampleCount() > 0 {
+							observedConditions[label.GetValue()] = true
+						}
+					}
+				}
+			}
+
+			for _, expected := range tc.expectedConditions {
+				if !observedConditions[expected] {
+					t.Errorf("expected condition %q to be observed in transition duration metric, but it was not", expected)
+				}
+			}
+
+			// Verify no unexpected AWS endpoint conditions were observed
+			awsConditions := map[string]bool{
+				string(hyperv1.AWSEndpointServiceAvailable): true,
+				string(hyperv1.AWSEndpointAvailable):        true,
+			}
+			expectedSet := map[string]bool{}
+			for _, c := range tc.expectedConditions {
+				expectedSet[c] = true
+			}
+			for condition := range observedConditions {
+				if awsConditions[condition] && !expectedSet[condition] {
+					t.Errorf("unexpected AWS condition %q was observed in transition duration metric", condition)
+				}
+			}
+		})
+	}
+}
+
 func createCa(notBefore, notAfter time.Time) (*x509.Certificate, string, error) {
 	ca := &x509.Certificate{
 		SerialNumber: big.NewInt(2019),

--- a/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
+++ b/hypershift-operator/controllers/hostedcluster/metrics/metrics_test.go
@@ -1351,7 +1351,7 @@ func TestReportTransitionDurationForAWSEndpointConditions(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "hc",
 					Namespace:         "any",
-					CreationTimestamp:  metav1.Time{Time: now},
+					CreationTimestamp: metav1.Time{Time: now},
 				},
 				Spec: hyperv1.HostedClusterSpec{
 					ClusterID: "id",


### PR DESCRIPTION
## What this PR does / why we need it:

Add AWSEndpointServiceAvailable and AWSEndpointAvailable conditions to the existing `hypershift_hosted_cluster_transition_seconds` histogram. This enables fleet-wide observability of how long it takes for VPC Endpoint Services and VPC Endpoints to become ready after HostedCluster creation.

## Which issue(s) this PR fixes:
Fixes https://redhat.atlassian.net/browse/CNTRLPLANE-3207

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended hosted cluster metrics to include AWS-specific endpoint conditions for improved visibility into AWS infrastructure readiness.

* **Tests**
  * Added comprehensive test coverage validating that AWS endpoint service and availability conditions are correctly recorded in transition duration metrics, including scenarios where conditions are present or absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->