### PR TITLE
CNTRLPLANE-3214: add envtest suites for HCPEtcdBackup CRD validation

### DIFF
--- a/cmd/install/assets/crds/hypershift-operator/tests/hcpetcdbackups.hypershift.openshift.io/techpreview.hcpetcdbackups.immutability.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/hcpetcdbackups.hypershift.openshift.io/techpreview.hcpetcdbackups.immutability.testsuite.yaml
@@ -1,0 +1,308 @@
+apiVersion: apiextensions.k8s.io/v1
+name: "HCPEtcdBackup immutability"
+crdName: hcpetcdbackups.hypershift.openshift.io
+featureGates:
+  - HCPEtcdBackup
+version: v1beta1
+tests:
+  onUpdate:
+  # --- Spec-level immutability (self == oldSelf) ---
+  - name: When S3 spec storage is changed it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: different-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+    expectedError: "HCPEtcdBackupSpec is immutable"
+
+  - name: When AzureBlob spec storage is changed it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: different-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+    expectedError: "HCPEtcdBackupSpec is immutable"
+
+  - name: When S3 keyPrefix is changed it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/different-prefix
+            credentials:
+              name: aws-credentials
+    expectedError: "HCPEtcdBackupSpec is immutable"
+
+  - name: When S3 credentials name is changed it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: different-credentials
+    expectedError: "HCPEtcdBackupSpec is immutable"
+
+  - name: When kmsKeyARN is added after creation it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+            kmsKeyARN: "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+    expectedError: "HCPEtcdBackupSpec is immutable"
+
+  - name: When encryptionKeyURL is added after creation it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+            encryptionKeyURL: "https://my-vault.vault.azure.net/keys/my-key/abc123"
+    expectedError: "HCPEtcdBackupSpec is immutable"
+
+  - name: When storageType is changed from S3 to AzureBlob it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+    expectedError: "HCPEtcdBackupSpec is immutable"
+
+  # --- Spec unchanged should pass ---
+  - name: When S3 spec is unchanged on update it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+
+  - name: When AzureBlob spec is unchanged on update it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+
+  - name: When S3 spec with kmsKeyARN is unchanged on update it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+            kmsKeyARN: "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+            kmsKeyARN: "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+
+  - name: When AzureBlob spec with encryptionKeyURL is unchanged on update it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+            encryptionKeyURL: "https://my-vault.vault.azure.net/keys/my-key/abc123"
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+            encryptionKeyURL: "https://my-vault.vault.azure.net/keys/my-key/abc123"

--- a/cmd/install/assets/crds/hypershift-operator/tests/hcpetcdbackups.hypershift.openshift.io/techpreview.hcpetcdbackups.status.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/hcpetcdbackups.hypershift.openshift.io/techpreview.hcpetcdbackups.status.testsuite.yaml
@@ -1,0 +1,333 @@
+apiVersion: apiextensions.k8s.io/v1
+name: "HCPEtcdBackup status validation"
+crdName: hcpetcdbackups.hypershift.openshift.io
+featureGates:
+  - HCPEtcdBackup
+version: v1beta1
+tests:
+  onUpdate:
+  # --- snapshotURL validation ---
+  - name: When snapshotURL has invalid scheme it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+      status:
+        snapshotURL: "http://bucket.s3.amazonaws.com/snapshot.db"
+        conditions:
+        - type: BackupCompleted
+          status: "True"
+          reason: BackupSucceeded
+          message: Backup completed
+          lastTransitionTime: "2024-01-01T00:00:00Z"
+    expectedStatusError: "snapshotURL must be a valid URL with scheme https or s3"
+
+  - name: When snapshotURL has valid https scheme it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+      status:
+        snapshotURL: "https://bucket.s3.amazonaws.com/snapshot.db"
+        conditions:
+        - type: BackupCompleted
+          status: "True"
+          reason: BackupSucceeded
+          message: Backup completed
+          lastTransitionTime: "2024-01-01T00:00:00Z"
+
+  - name: When snapshotURL has valid s3 scheme it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+      status:
+        snapshotURL: "s3://my-backup-bucket/backups/etcd/snapshot.db"
+        conditions:
+        - type: BackupCompleted
+          status: "True"
+          reason: BackupSucceeded
+          message: Backup completed
+          lastTransitionTime: "2024-01-01T00:00:00Z"
+
+  # --- encryptionMetadata validation ---
+  - name: When encryptionMetadata has both aws and azure it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+      status:
+        conditions:
+        - type: BackupCompleted
+          status: "True"
+          reason: BackupSucceeded
+          message: Backup completed
+          lastTransitionTime: "2024-01-01T00:00:00Z"
+        encryptionMetadata:
+          aws:
+            kmsKeyARN: "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+          azure:
+            encryptionKeyURL: "https://my-vault.vault.azure.net/keys/my-key/abc123"
+    expectedStatusError: "must have at most 1 item"
+
+  - name: When encryptionMetadata is empty it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+      status:
+        conditions:
+        - type: BackupCompleted
+          status: "True"
+          reason: BackupSucceeded
+          message: Backup completed
+          lastTransitionTime: "2024-01-01T00:00:00Z"
+        encryptionMetadata: {}
+    expectedStatusError: "should have at least 1 properties"
+
+  - name: When encryptionMetadata has only aws it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+      status:
+        conditions:
+        - type: BackupCompleted
+          status: "True"
+          reason: BackupSucceeded
+          message: Backup completed
+          lastTransitionTime: "2024-01-01T00:00:00Z"
+        encryptionMetadata:
+          aws:
+            kmsKeyARN: "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+
+  - name: When encryptionMetadata has only azure it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+      status:
+        conditions:
+        - type: BackupCompleted
+          status: "True"
+          reason: BackupSucceeded
+          message: Backup completed
+          lastTransitionTime: "2024-01-01T00:00:00Z"
+        encryptionMetadata:
+          azure:
+            encryptionKeyURL: "https://my-vault.vault.azure.net/keys/my-key/abc123"
+
+  # --- encryptionMetadata field format validation ---
+  - name: When encryptionMetadata aws kmsKeyARN has invalid format it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+      status:
+        conditions:
+        - type: BackupCompleted
+          status: "True"
+          reason: BackupSucceeded
+          message: Backup completed
+          lastTransitionTime: "2024-01-01T00:00:00Z"
+        encryptionMetadata:
+          aws:
+            kmsKeyARN: "not-a-valid-arn"
+    expectedStatusError: "kmsKeyARN must be a valid AWS KMS key ARN"
+
+  - name: When encryptionMetadata azure encryptionKeyURL has invalid format it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+      status:
+        conditions:
+        - type: BackupCompleted
+          status: "True"
+          reason: BackupSucceeded
+          message: Backup completed
+          lastTransitionTime: "2024-01-01T00:00:00Z"
+        encryptionMetadata:
+          azure:
+            encryptionKeyURL: "not-a-valid-url"
+    expectedStatusError: "encryptionKeyURL must be a valid Azure Key Vault HTTPS URL"

--- a/cmd/install/assets/crds/hypershift-operator/tests/hcpetcdbackups.hypershift.openshift.io/techpreview.hcpetcdbackups.validation.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/hcpetcdbackups.hypershift.openshift.io/techpreview.hcpetcdbackups.validation.testsuite.yaml
@@ -1,0 +1,423 @@
+apiVersion: apiextensions.k8s.io/v1
+name: "HCPEtcdBackup validation"
+crdName: hcpetcdbackups.hypershift.openshift.io
+featureGates:
+  - HCPEtcdBackup
+version: v1beta1
+tests:
+  onCreate:
+  # --- Valid configurations ---
+  - name: When a valid S3 backup is created it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+
+  - name: When a valid S3 backup with kmsKeyARN is created it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+            kmsKeyARN: "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+
+  - name: When a valid AzureBlob backup is created it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+
+  - name: When a valid AzureBlob backup with encryptionKeyURL is created it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+            encryptionKeyURL: "https://my-vault.vault.azure.net/keys/my-key/abc123"
+
+  # --- Storage type union discrimination ---
+  - name: When storageType is S3 but azureBlob is provided it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+    expectedError: "s3 configuration is required when storageType is S3, and forbidden otherwise"
+
+  - name: When storageType is AzureBlob but s3 is provided it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+    expectedError: "azureBlob configuration is required when storageType is AzureBlob, and forbidden otherwise"
+
+  - name: When storageType is invalid it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: GCS
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+    expectedError: 'Unsupported value: "GCS"'
+
+  # --- S3 bucket validation ---
+  - name: When S3 bucket name is too short it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: ab
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+    expectedError: "spec.storage.s3.bucket in body should be at least 3 chars long"
+
+  - name: When S3 bucket name exceeds max length it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+    expectedError: "spec.storage.s3.bucket: Too long"
+
+  - name: When S3 bucket name has uppercase characters it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: MyBucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+    expectedError: "bucket must consist of lowercase letters, numbers, hyphens, and periods, and must start and end with a letter or number"
+
+  - name: When S3 bucket name has consecutive periods it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my..bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+    expectedError: "bucket must not contain consecutive periods"
+
+  # --- S3 region validation ---
+  - name: When S3 region has uppercase characters it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: US-EAST-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+    expectedError: "region must consist of lowercase letters, digits, and hyphens, must start with a letter and end with an alphanumeric character"
+
+  - name: When S3 region has consecutive hyphens it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us--east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+    expectedError: "region must not contain consecutive hyphens"
+
+  # --- S3 keyPrefix validation ---
+  - name: When S3 keyPrefix has invalid characters it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: "backups/etcd snapshot"
+            credentials:
+              name: aws-credentials
+    expectedError: "keyPrefix must consist of safe S3 key characters"
+
+  # --- S3 kmsKeyARN validation ---
+  - name: When S3 kmsKeyARN has invalid format it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: aws-credentials
+            kmsKeyARN: "not-a-valid-arn"
+    expectedError: "kmsKeyARN must be a valid AWS KMS key ARN"
+
+  # --- AzureBlob container validation ---
+  - name: When AzureBlob container name is too short it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: ab
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+    expectedError: "spec.storage.azureBlob.container in body should be at least 3 chars long"
+
+  - name: When AzureBlob container name has uppercase characters it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: MyContainer
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+    expectedError: "container must consist of lowercase letters, numbers, and hyphens, and must start and end with a letter or number"
+
+  - name: When AzureBlob container name has consecutive hyphens it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my--container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+    expectedError: "container must not contain consecutive hyphens"
+
+  # --- AzureBlob storageAccount validation ---
+  - name: When AzureBlob container name exceeds max length it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+    expectedError: "spec.storage.azureBlob.container: Too long"
+
+  - name: When AzureBlob storageAccount exceeds max length it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: abcdefghijklmnopqrstuvwxy
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+    expectedError: "spec.storage.azureBlob.storageAccount: Too long"
+
+  - name: When AzureBlob storageAccount is too short it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: ab
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+    expectedError: "spec.storage.azureBlob.storageAccount in body should be at least 3 chars long"
+
+  - name: When AzureBlob storageAccount has hyphens it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: my-storage-account
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+    expectedError: "storageAccount must consist of lowercase letters and numbers only"
+
+  - name: When AzureBlob storageAccount has uppercase characters it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: MyStorageAccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+    expectedError: "storageAccount must consist of lowercase letters and numbers only"
+
+  # --- AzureBlob keyPrefix validation ---
+  - name: When AzureBlob keyPrefix has invalid characters it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: "backups/etcd snapshot"
+            credentials:
+              name: azure-credentials
+    expectedError: "keyPrefix must consist of alphanumeric characters, forward slashes, hyphens, underscores, and periods"
+
+  # --- AzureBlob encryptionKeyURL validation ---
+  - name: When AzureBlob encryptionKeyURL has invalid format it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: azure-credentials
+            encryptionKeyURL: "not-a-valid-url"
+    expectedError: "encryptionKeyURL must be a valid Azure Key Vault HTTPS URL"
+
+  # --- SecretReference name validation ---
+  - name: When S3 credentials name has invalid characters it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: S3
+          s3:
+            bucket: my-backup-bucket
+            region: us-east-1
+            keyPrefix: backups/etcd
+            credentials:
+              name: "INVALID_NAME!"
+    expectedError: "name must consist only of lowercase alphanumeric characters, hyphens, and periods"
+
+  - name: When AzureBlob credentials name has invalid characters it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HCPEtcdBackup
+      spec:
+        storage:
+          storageType: AzureBlob
+          azureBlob:
+            container: my-backup-container
+            storageAccount: mystorageaccount
+            keyPrefix: backups/etcd
+            credentials:
+              name: "INVALID_NAME!"
+    expectedError: "name must consist only of lowercase alphanumeric characters, hyphens, and periods"

--- a/test/envtest/generator.go
+++ b/test/envtest/generator.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -190,7 +191,9 @@ func GenerateTestSuite(suiteSpec SuiteSpec) {
 				Expect(crds).To(HaveLen(1), "Only one CRD should have been installed")
 				crd = crds[0]
 
-				Expect(envtest.WaitForCRDs(cfg, crds, envtest.CRDInstallOptions{})).To(Succeed())
+				Expect(envtest.WaitForCRDs(cfg, crds, envtest.CRDInstallOptions{
+					MaxTime: 30 * time.Second,
+				})).To(Succeed())
 			})
 
 			AfterEach(func() {


### PR DESCRIPTION
## Summary

- Add comprehensive CRD validation test suites for the HCPEtcdBackup API under `cmd/install/assets/crds/hypershift-operator/tests/hcpetcdbackups.hypershift.openshift.io/`
- Covers all CEL validation rules: storage union discrimination, field format regex, enum validation, spec immutability, status field validation, and encryption metadata constraints
- Tests run against both TechPreviewNoUpgrade and CustomNoUpgrade CRD variants via the envtest harness, filtered by `featureGates: [HCPEtcdBackup]`
- Fix flaky `WaitForCRDs` timeout in the envtest framework (10s → 30s) to prevent `context deadline exceeded` failures in CI

## Details

Three test suite files:

| File | Tests | Coverage |
|------|-------|----------|
| `validation.testsuite.yaml` | 27 onCreate | Storage union, field regex (bucket, region, keyPrefix, kmsKeyARN, container, storageAccount, encryptionKeyURL), enum, MaxLength boundaries (bucket/63, container/63, storageAccount/24), SecretReference |
| `immutability.testsuite.yaml` | 11 onUpdate | Spec `self == oldSelf`: bucket/container/keyPrefix/credentials mutations, storageType change, encryption key additions, unchanged-spec pass |
| `status.testsuite.yaml` | 9 onUpdate | snapshotURL scheme validation, encryptionMetadata MinProperties/MaxProperties, encryption metadata field format |

Closes: [CNTRLPLANE-3214](https://issues.redhat.com/browse/CNTRLPLANE-3214)
Follow-up from: https://github.com/openshift/hypershift/pull/8179#discussion_r3060277697

## Test plan

- [x] `make test-envtest-kube` — all specs pass across K8s 1.31–1.35
- [x] `make test-envtest-kube ENVTEST_KUBE_VERSIONS="1.35.0"` — 3 consecutive runs without flakiness
- [ ] CI envtest jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)