### PR TITLE
CNTRLPLANE-3215: fix envtest GHA workflow path filters for CRD test suites

### DIFF
--- a/.github/workflows/envtest-kube.yaml
+++ b/.github/workflows/envtest-kube.yaml
@@ -6,13 +6,13 @@ on:
     paths:
       - 'api/**'
       - 'test/envtest/**'
-      - 'cmd/install/assets/hypershift-operator/tests/**'
+      - 'cmd/install/assets/crds/hypershift-operator/tests/**'
   pull_request:
     branches: [main]
     paths:
       - 'api/**'
       - 'test/envtest/**'
-      - 'cmd/install/assets/hypershift-operator/tests/**'
+      - 'cmd/install/assets/crds/hypershift-operator/tests/**'
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/envtest-ocp.yaml
+++ b/.github/workflows/envtest-ocp.yaml
@@ -6,13 +6,13 @@ on:
     paths:
       - 'api/**'
       - 'test/envtest/**'
-      - 'cmd/install/assets/hypershift-operator/tests/**'
+      - 'cmd/install/assets/crds/hypershift-operator/tests/**'
   pull_request:
     branches: [main]
     paths:
       - 'api/**'
       - 'test/envtest/**'
-      - 'cmd/install/assets/hypershift-operator/tests/**'
+      - 'cmd/install/assets/crds/hypershift-operator/tests/**'
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes the path filters in the envtest GitHub Actions workflows (`envtest-kube.yaml` and `envtest-ocp.yaml`).

The workflows were configured to trigger on changes to `cmd/install/assets/hypershift-operator/tests/**`, but the actual CRD test suite files live under `cmd/install/assets/crds/hypershift-operator/tests/**` (missing the `crds/` path segment). This caused the envtest workflows to never trigger when CRD test suites were added or modified — as seen in PR #8199.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-3215](https://redhat.atlassian.net/browse/CNTRLPLANE-3215)

## Special notes for your reviewer:

The fix is a simple path correction in both workflow files — adding the missing `crds/` directory segment to the path filter.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow triggers to monitor test asset changes from a reorganized location, ensuring automated testing runs appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->