### PR TITLE
NO-JIRA: revert: remove .git/ from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git/
 bin/
 hack/tools/bin/
 contrib/


### PR DESCRIPTION
## Summary
- Reverts #7944 which added `.git/` to `.dockerignore`
- The `.git/` directory is needed during container builds so the build process can embed the correct server-version info
- Without it the hypershift-operator reports version as `<unknown>` in logs and in `configmap -n hypershift supported-versions`

## Test plan
- [ ] Verify hypershift-operator logs show correct version instead of `<unknown>`
- [ ] Verify `supported-versions` configmap has correct `server-version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to include Git metadata in container builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->