### PR TITLE
CNTRLPLANE-3216: Add codecov.yml validation to make verify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,8 +130,16 @@ verify-git-clean:
 	$(eval STATUS = $(shell git status -s))
 	$(if $(strip $(STATUS)),$(error untracked files detected: ${STATUS}))
 
+.PHONY: verify-codecov
+verify-codecov: ## Validate codecov.yml against Codecov's API.
+	@curl --silent --show-error \
+		--connect-timeout 5 --max-time 30 \
+		--retry 3 --retry-all-errors --retry-delay 1 \
+		--data-binary @codecov.yml https://codecov.io/validate \
+		| tee /dev/stderr | grep -q "^Valid!"
+
 .PHONY: verify-parallel
-verify-parallel: verify-codespell lint cpo-container-sync run-gitlint
+verify-parallel: verify-codespell verify-codecov lint cpo-container-sync run-gitlint
 
 .PHONY: verify
 verify: generate update staticcheck fmt vet


### PR DESCRIPTION
## What this PR does / why we need it:

Adds a `verify-codecov` Make target that validates `codecov.yml` against Codecov's validation API (`https://codecov.io/validate`) and includes it in the `verify-parallel` target so it runs as part of `make verify`.

This catches invalid codecov configuration during development and CI rather than after merge.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-3216](https://redhat.atlassian.net/browse/CNTRLPLANE-3216)

## Special notes for your reviewer:

The validation uses the documented Codecov approach: `cat codecov.yml | curl --data-binary @- https://codecov.io/validate`

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened the verification workflow by adding an automated validation step for Codecov configuration as part of the parallel verification process. This helps catch misconfigured coverage settings earlier, reduces CI failures related to coverage configuration, and improves reliability of pre-merge checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->