### PR TITLE
SREP-4438: refactor(karpenter): tidy Cincinnati version resolution

### DIFF
--- a/api/karpenter/v1beta1/karpenter_types.go
+++ b/api/karpenter/v1beta1/karpenter_types.go
@@ -270,7 +270,7 @@ type OpenshiftEC2NodeClassSpec struct {
 	// for nodes managed by this NodeClass. When set, the controller resolves this to a
 	// release image via the Cincinnati graph API. When not set, nodes use the control plane's
 	// release image.
-	// +kubebuilder:validation:XValidation:rule="self.matches('^(0|[1-9]\\\\d*)\\\\.(0|[1-9]\\\\d*)\\\\.(0|[1-9]\\\\d*)$')",message="version must be a valid semantic version (e.g., 4.20.1)"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^(0|[1-9]\\\\d*)\\\\.(0|[1-9]\\\\d*)\\\\.(0|[1-9]\\\\d*)(?:-((?:0|[1-9]\\\\d*|\\\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\\\.(?:0|[1-9]\\\\d*|\\\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\\\+([0-9a-zA-Z-]+(?:\\\\.[0-9a-zA-Z-]+)*))?$')",message="version must be a valid semantic version (e.g., 4.20.1)"
 	// +kubebuilder:validation:MinLength=5
 	// +kubebuilder:validation:MaxLength=64
 	// +optional

--- a/karpenter-operator/controllers/karpenter/assets/karpenter.hypershift.openshift.io_openshiftec2nodeclasses.yaml
+++ b/karpenter-operator/controllers/karpenter/assets/karpenter.hypershift.openshift.io_openshiftec2nodeclasses.yaml
@@ -461,7 +461,7 @@ spec:
                 type: string
                 x-kubernetes-validations:
                 - message: version must be a valid semantic version (e.g., 4.20.1)
-                  rule: self.matches('^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$')
+                  rule: self.matches('^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$')
             type: object
           status:
             description: status defines the observed state of the OpenshiftEC2NodeClass.

--- a/karpenter-operator/controllers/karpenterignition/karpenterignition_controller.go
+++ b/karpenter-operator/controllers/karpenterignition/karpenterignition_controller.go
@@ -347,18 +347,7 @@ func (r *KarpenterIgnitionReconciler) resolveReleaseImage(
 		return hcp.Spec.ReleaseImage, nil
 	}
 
-	nodeClassVersion, err := semver.Parse(version)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse OpenshiftEC2NodeClass version %q: %w", version, err)
-	}
-
-	// Derive the Cincinnati channel. Use the HCP channel if set, otherwise default to "stable-4.<minor>".
-	channel := hcp.Spec.Channel
-	if channel == "" {
-		channel = fmt.Sprintf("stable-%d.%d", nodeClassVersion.Major, nodeClassVersion.Minor)
-	}
-
-	resolved, err := r.VersionResolver.Resolve(ctx, version, channel)
+	resolved, err := r.VersionResolver.Resolve(ctx, version, hcp.Spec.Channel)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve version %q: %w", version, err)
 	}

--- a/support/releaseinfo/cincinnati_version_resolver.go
+++ b/support/releaseinfo/cincinnati_version_resolver.go
@@ -6,13 +6,19 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+
+	"github.com/blang/semver"
 )
 
 const (
 	defaultArch          = "multi"
-	defaultCincinnatiURL = "https://api.openshift.com/api/upgrades_info/v1/graph"
+	defaultCincinnatiURL = "https://api.openshift.com/api/upgrades_info/graph"
 	cacheTTL             = 10 * time.Minute
 )
 
@@ -25,6 +31,7 @@ type VersionResolver interface {
 
 type cacheEntry struct {
 	releaseImage string
+	channels     sets.Set[string]
 	expiry       time.Time
 }
 
@@ -63,65 +70,91 @@ type cincinnatiNode struct {
 // Resolve resolves an OpenShift version (e.g., "4.20.1") to a fully qualified
 // release image pullspec by querying the Cincinnati graph API with the given channel.
 func (r *CincinnatiVersionResolver) Resolve(ctx context.Context, version, channel string) (string, error) {
-	cacheKey := channel + "/" + version
+	// Derive the Cincinnati channel. Use the input channel if set, otherwise default to "fast-<major>.<minor>".
+	if channel == "" {
+		parsedVersion, err := semver.Parse(version)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse version %q: %w", version, err)
+		}
+		channel = fmt.Sprintf("fast-%d.%d", parsedVersion.Major, parsedVersion.Minor)
+	}
+
+	arch := defaultArch
+
+	cacheKey := arch + "/" + version
 
 	// Check cache
 	r.mu.RLock()
 	if entry, ok := r.cache[cacheKey]; ok && time.Now().Before(entry.expiry) {
 		r.mu.RUnlock()
+		if !entry.channels.Has(channel) {
+			return "", fmt.Errorf("%q not found in channel %q, although it is in %s", version, channel, strings.Join(sets.List(entry.channels), ", "))
+		}
 		return entry.releaseImage, nil
 	}
 	r.mu.RUnlock()
 
-	releaseImage, err := r.fetchVersion(ctx, version, channel)
+	entry, err := r.fetchVersion(ctx, version, channel, arch)
 	if err != nil {
 		return "", err
 	}
 
 	// Update cache
 	r.mu.Lock()
-	r.cache[cacheKey] = cacheEntry{
-		releaseImage: releaseImage,
-		expiry:       time.Now().Add(cacheTTL),
-	}
+	r.cache[cacheKey] = entry
 	r.mu.Unlock()
 
-	return releaseImage, nil
+	return entry.releaseImage, nil
 }
 
-func (r *CincinnatiVersionResolver) fetchVersion(ctx context.Context, version, channel string) (string, error) {
-	url := fmt.Sprintf("%s?channel=%s&arch=%s", r.baseURL, channel, defaultArch)
+func (r *CincinnatiVersionResolver) fetchVersion(ctx context.Context, version, channel, arch string) (cacheEntry, error) {
+	url := fmt.Sprintf("%s?channel=%s&arch=%s", r.baseURL, channel, arch)
+	entry := cacheEntry{}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to create request: %w", err)
+		return entry, fmt.Errorf("failed to create request: %w", err)
 	}
-	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Accept", "application/vnd.redhat.cincinnati.v1+json")
 
 	resp, err := r.client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("failed to query Cincinnati API: %w", err)
+		return entry, fmt.Errorf("failed to query Cincinnati API: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("cincinnati API returned status %d: %s", resp.StatusCode, string(body))
+		return entry, fmt.Errorf("cincinnati API returned status %d: %s", resp.StatusCode, string(body))
 	}
 
 	var graph cincinnatiGraph
 	if err := json.NewDecoder(resp.Body).Decode(&graph); err != nil {
-		return "", fmt.Errorf("failed to decode Cincinnati API response: %w", err)
+		return entry, fmt.Errorf("failed to decode Cincinnati API response: %w", err)
 	}
 
 	for _, node := range graph.Nodes {
 		if node.Version == version {
 			if node.Payload == "" {
-				return "", fmt.Errorf("empty payload for version %q in Cincinnati graph", version)
+				return entry, fmt.Errorf("empty payload for version %q in Cincinnati graph", version)
 			}
-			return node.Payload, nil
+			entry.expiry = time.Now().Add(cacheTTL)
+			entry.releaseImage = node.Payload
+			entry.channels = sets.New[string]()
+			channelsString := node.Metadata["io.openshift.upgrades.graph.release.channels"]
+			channels := strings.Split(channelsString, ",")
+			for _, ch := range channels {
+				if len(ch) > 0 {
+					entry.channels.Insert(ch)
+				}
+			}
+			if entry.channels.Len() == 0 {
+				klog.V(2).Infof("no non-empty, comma-delimited channels in io.openshift.upgrades.graph.release.channels for %q in %s: %q", version, req.URL, channelsString)
+				entry.channels.Insert(channel)
+			}
+			return entry, nil
 		}
 	}
 
-	return "", fmt.Errorf("version %q not found in Cincinnati graph for channel %q", version, channel)
+	return entry, fmt.Errorf("version %q not found in Cincinnati graph for channel %q", version, channel)
 }

--- a/support/releaseinfo/cincinnati_version_resolver_test.go
+++ b/support/releaseinfo/cincinnati_version_resolver_test.go
@@ -7,6 +7,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func TestCincinnatiVersionResolver_WhenValidResponse_ItShouldReturnReleaseImage(t *testing.T) {
@@ -169,8 +171,9 @@ func TestCincinnatiVersionResolver_WhenCacheIsExpired_ItShouldReQueryAPI(t *test
 
 	// Manually expire the cache
 	resolver.mu.Lock()
-	resolver.cache["stable-4.20/4.20.1"] = cacheEntry{
+	resolver.cache["multi/4.20.1"] = cacheEntry{
 		releaseImage: "quay.io/openshift-release-dev/ocp-release@sha256:abc123",
+		channels:     sets.New[string]("stable-4.20"),
 		expiry:       time.Now().Add(-1 * time.Minute),
 	}
 	resolver.mu.Unlock()

--- a/vendor/github.com/openshift/hypershift/api/karpenter/v1beta1/karpenter_types.go
+++ b/vendor/github.com/openshift/hypershift/api/karpenter/v1beta1/karpenter_types.go
@@ -270,7 +270,7 @@ type OpenshiftEC2NodeClassSpec struct {
 	// for nodes managed by this NodeClass. When set, the controller resolves this to a
 	// release image via the Cincinnati graph API. When not set, nodes use the control plane's
 	// release image.
-	// +kubebuilder:validation:XValidation:rule="self.matches('^(0|[1-9]\\\\d*)\\\\.(0|[1-9]\\\\d*)\\\\.(0|[1-9]\\\\d*)$')",message="version must be a valid semantic version (e.g., 4.20.1)"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^(0|[1-9]\\\\d*)\\\\.(0|[1-9]\\\\d*)\\\\.(0|[1-9]\\\\d*)(?:-((?:0|[1-9]\\\\d*|\\\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\\\.(?:0|[1-9]\\\\d*|\\\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\\\+([0-9a-zA-Z-]+(?:\\\\.[0-9a-zA-Z-]+)*))?$')",message="version must be a valid semantic version (e.g., 4.20.1)"
 	// +kubebuilder:validation:MinLength=5
 	// +kubebuilder:validation:MaxLength=64
 	// +optional


### PR DESCRIPTION
## What this PR does / why we need it:

- Update Cincinnati URL to drop /v1 and use content-negotiated media type (application/vnd.redhat.cincinnati.v1+json)
- Default channel to fast-<major>.<minor> (earliest GA channel) and push channel defaulting into CincinnatiVersionResolver
- Include architecture in cache key, remove channel from cache key (a version+arch release is unique regardless of channel)
- Parse channel membership from Cincinnati node metadata for cache hit validation
- Extend SemVer XValidation regex to allow prerelease and build metadata (e.g. 4.21.0-ec.3, nightlies)

Based on openshift/hypershift#7966 with fixes for compile errors (function signature, type qualifier, capitalization, trailing comma), a redundant map lookup, invalid CEL rule syntax, and a stale test cache key.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://redhat.atlassian.net/browse/SREP-4438

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced version validation to accept full semantic versioning formats, including pre-release and build metadata components (e.g., `v1.0.0-alpha+build123`).
  * Improved release information resolution with enhanced channel-aware caching and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->