### PR TITLE
NO-JIRA: fix(test): set 1h time limit on e2e capacity reservations

### DIFF
--- a/test/e2e/util/aws.go
+++ b/test/e2e/util/aws.go
@@ -361,7 +361,8 @@ func CreateCapacityReservation(ctx context.Context, awsCreds, awsRegion, instanc
 		AvailabilityZone:      awsv2.String(availabilityZone),
 		InstanceCount:         awsv2.Int32(instanceCount),
 		InstanceMatchCriteria: ec2types.InstanceMatchCriteriaTargeted,
-		EndDateType:           ec2types.EndDateTypeUnlimited,
+		EndDateType:           ec2types.EndDateTypeLimited,
+		EndDate:               awsv2.Time(time.Now().Add(1 * time.Hour)),
 	})
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to create capacity reservation: %w", err)

--- a/test/e2e/util/aws.go
+++ b/test/e2e/util/aws.go
@@ -362,7 +362,7 @@ func CreateCapacityReservation(ctx context.Context, awsCreds, awsRegion, instanc
 		InstanceCount:         awsv2.Int32(instanceCount),
 		InstanceMatchCriteria: ec2types.InstanceMatchCriteriaTargeted,
 		EndDateType:           ec2types.EndDateTypeLimited,
-		EndDate:               awsv2.Time(time.Now().Add(1 * time.Hour)),
+		EndDate:               awsv2.Time(time.Now().Add(2 * time.Hour)),
 	})
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to create capacity reservation: %w", err)


### PR DESCRIPTION
## Summary

- Capacity reservations in e2e tests were created with `EndDateType: unlimited`, meaning if test cleanup fails (e.g. crash/timeout), the reservation lives forever and incurs cost.
- Changed to `EndDateType: limited` with a 1-hour expiry as a safety net. The cleanup function still cancels them immediately on success.

## Test plan

- [ ] Verify `make test` passes
- [ ] Verify e2e karpenter capacity reservation tests still work with the time-limited reservation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated EC2 capacity reservation test to use a limited-duration reservation (expires after two hours) instead of an unlimited-duration reservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->