### PR TITLE
OCPBUGS-83285: revert 5.0 supported version from release-4.22

### DIFF
--- a/support/supportedversion/version.go
+++ b/support/supportedversion/version.go
@@ -32,13 +32,9 @@ const (
 // NOTE: The .0 (z release) should be ignored. It's only here to support
 // semver parsing.
 var (
-	LatestSupportedVersion      = semver.MustParse("5.0.0")
+	LatestSupportedVersion      = semver.MustParse("4.22.0")
 	MinSupportedVersion         = semver.MustParse("4.14.0")
 	IBMCloudMinSupportedVersion = semver.MustParse("4.14.0")
-	// prevLatestSupportedMajor holds the value of the latest version before we updated to a new major.
-	// This value is only used internally to compute the list of supported versions when we have 2
-	// different major versions at the same time.
-	prevLatestSupportedMajor = semver.MustParse("4.23.0")
 )
 
 // ocpVersionToKubeVersion maps OCP versions to their corresponding Kubernetes versions.
@@ -85,21 +81,8 @@ func GetMinSupportedVersion(hc *hyperv1.HostedCluster) semver.Version {
 
 func Supported() []string {
 	versions := []string{trimVersion(LatestSupportedVersion.String())}
-	if LatestSupportedVersion.Major > MinSupportedVersion.Major {
-		// Include remaining minor versions of the latest major (e.g. 5.2 -> 5.1, 5.0)
-		for i := 0; i < int(LatestSupportedVersion.Minor); i++ {
-			versions = append(versions, trimVersion(subtractMinor(&LatestSupportedVersion, uint64(i+1)).String()))
-		}
-		// Bridge from the previous major's latest minor down to MinSupportedVersion
-		for i := int(prevLatestSupportedMajor.Minor); i >= int(MinSupportedVersion.Minor); i-- {
-			v := semver.Version{Major: prevLatestSupportedMajor.Major, Minor: uint64(i), Patch: 0}
-			versions = append(versions, trimVersion(v.String()))
-		}
-	} else {
-		// If no major change simply count minors backwards
-		for i := 0; i < int(LatestSupportedVersion.Minor-MinSupportedVersion.Minor); i++ {
-			versions = append(versions, trimVersion(subtractMinor(&LatestSupportedVersion, uint64(i+1)).String()))
-		}
+	for i := 0; i < int(LatestSupportedVersion.Minor-MinSupportedVersion.Minor); i++ {
+		versions = append(versions, trimVersion(subtractMinor(&LatestSupportedVersion, uint64(i+1)).String()))
 	}
 	return versions
 }

--- a/support/supportedversion/version_test.go
+++ b/support/supportedversion/version_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestSupportedVersions(t *testing.T) {
 	g := NewGomegaWithT(t)
-	g.Expect(Supported()).To(Equal([]string{"5.0", "4.23", "4.22", "4.21", "4.20", "4.19", "4.18", "4.17", "4.16", "4.15", "4.14"}))
+	g.Expect(Supported()).To(Equal([]string{"4.22", "4.21", "4.20", "4.19", "4.18", "4.17", "4.16", "4.15", "4.14"}))
 }
 
 func TestString(t *testing.T) {

--- a/test/e2e/util/version.go
+++ b/test/e2e/util/version.go
@@ -14,9 +14,7 @@ import (
 )
 
 var (
-	// y-stream versions supported by e2e in main
-	Version50  = semver.MustParse("5.0.0")
-	Version423 = semver.MustParse("4.23.0")
+	// y-stream versions supported by e2e in release-4.22
 	Version422 = semver.MustParse("4.22.0")
 	Version421 = semver.MustParse("4.21.0")
 	Version420 = semver.MustParse("4.20.0")
@@ -34,8 +32,6 @@ func init() {
 	// Ensure that the version constants are valid semver versions
 	// This is a compile-time check to ensure that the versions are valid
 	// semver versions.
-	_ = Version50
-	_ = Version423
 	_ = Version422
 	_ = Version421
 	_ = Version420


### PR DESCRIPTION
## Summary

- Reverts `LatestSupportedVersion` from `5.0.0` back to `4.22.0` on the `release-4.22` branch
- Removes `prevLatestSupportedMajor` variable and cross-major version logic in `Supported()` that were incorrectly cherry-picked from main via PR #8193
- Fixes unit tests and e2e version constants to match

## Context

PR https://github.com/openshift/hypershift/pull/8193 updated the latest supported version to 5.0 on main. When it was cherry-picked to `release-4.22`, it incorrectly brought along the 5.0 version bump and the cross-major version logic. On `release-4.22`, the latest supported version should remain `4.22.0`.

## Test plan

- [x] `go test ./support/supportedversion/...` passes
- [x] CodeRabbit review passes with no findings

Fixes: https://issues.redhat.com/browse/OCPBUGS-83285

🤖 Generated with [Claude Code](https://claude.com/claude-code)