### PR TITLE
CNTRLPLANE-3233: ci(gha): add release-4.22 branch to GitHub Actions workflows

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -2,7 +2,7 @@ name: Codespell
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, release-4.22]
 
 jobs:
   codespell:

--- a/.github/workflows/cpo-container-sync.yaml
+++ b/.github/workflows/cpo-container-sync.yaml
@@ -2,7 +2,7 @@ name: CPO Container Sync
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, release-4.22]
 
 jobs:
   cpo-container-sync:

--- a/.github/workflows/docs-preview.yaml
+++ b/.github/workflows/docs-preview.yaml
@@ -2,7 +2,7 @@ name: Docs Preview
 
 on:
   pull_request_target:
-    branches: [main]
+    branches: [main, release-4.22]
     paths:
       - 'docs/**'
 

--- a/.github/workflows/envtest-kube.yaml
+++ b/.github/workflows/envtest-kube.yaml
@@ -2,13 +2,13 @@ name: Envtest Vanilla Kube API Validation
 
 on:
   push:
-    branches: [main]
+    branches: [main, release-4.22]
     paths:
       - 'api/**'
       - 'test/envtest/**'
       - 'cmd/install/assets/crds/hypershift-operator/tests/**'
   pull_request:
-    branches: [main]
+    branches: [main, release-4.22]
     paths:
       - 'api/**'
       - 'test/envtest/**'

--- a/.github/workflows/envtest-ocp.yaml
+++ b/.github/workflows/envtest-ocp.yaml
@@ -2,13 +2,13 @@ name: Envtest OCP API Validation
 
 on:
   push:
-    branches: [main]
+    branches: [main, release-4.22]
     paths:
       - 'api/**'
       - 'test/envtest/**'
       - 'cmd/install/assets/crds/hypershift-operator/tests/**'
   pull_request:
-    branches: [main]
+    branches: [main, release-4.22]
     paths:
       - 'api/**'
       - 'test/envtest/**'

--- a/.github/workflows/gitlint.yaml
+++ b/.github/workflows/gitlint.yaml
@@ -2,7 +2,7 @@ name: Gitlint
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, release-4.22]
 
 jobs:
   gitlint:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, release-4.22]
 
 jobs:
   lint:
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - run: git fetch origin main:main
+      - run: git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
       - name: Use pre-built lint tools
         run: |
           if [ -d /opt/lint-tools ]; then

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,9 +2,9 @@ name: Unit Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, release-4.22]
   pull_request:
-    branches: [main]
+    branches: [main, release-4.22]
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -2,7 +2,7 @@ name: Verify
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, release-4.22]
 
 jobs:
   verify:


### PR DESCRIPTION
## Summary

- Add `release-4.22` to the branch triggers for all applicable GitHub Actions workflows so PRs targeting that branch get the same CI checks as `main`
- Replace hardcoded `git fetch origin main:main` in lint workflow with dynamic `github.base_ref` reference
- `sync-community-fork.yaml` excluded (only relevant for main)

**Updated workflows:** codespell, cpo-container-sync, docs-preview, envtest-kube, envtest-ocp, gitlint, lint, test, verify

Resolves: [CNTRLPLANE-3233](https://issues.redhat.com/browse/CNTRLPLANE-3233)

## Test plan

- [ ] Verify GHA workflows trigger on PRs targeting `release-4.22`
- [ ] Verify lint job correctly fetches the base branch ref

🤖 Generated with [Claude Code](https://claude.com/claude-code)