### PR TITLE
ci: sync release branches to community fork

### DIFF
--- a/.github/workflows/sync-community-fork.yaml
+++ b/.github/workflows/sync-community-fork.yaml
@@ -2,7 +2,9 @@ name: Sync Community Fork
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'release-*'
 
 jobs:
   sync-community-fork:
@@ -20,4 +22,4 @@ jobs:
           token: ${{ secrets.COMMUNITY_FORK_TOKEN }}
       - run: |
           git remote add community https://github.com/hypershift-community/hypershift.git
-          git push community main
+          git push community ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

- Expand the community fork sync workflow to push release branches in addition to `main`
- Trigger now includes `release-*` branches; push target uses `github.ref_name` so whichever branch receives a push gets synced
- No hardcoded branch list or API queries needed — EOL branches simply stop receiving pushes

Ref: [CNTRLPLANE-3239](https://redhat.atlassian.net/browse/CNTRLPLANE-3239)

## Test plan

- [ ] Verify workflow triggers on push to `main` (existing behavior preserved)
- [ ] Verify workflow triggers on push to a `release-*` branch
- [ ] Verify `github.ref_name` resolves to the correct branch name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to broaden automatic sync capabilities. Workflow now triggers on pushes to both main and release branches. Git sync now dynamically pushes the triggering branch instead of always targeting the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->