### PR TITLE
OCPBUGS-83538: fix(metrics-proxy): resolve ports from pods instead of deployments

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/metrics_proxy/scrape_config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/metrics_proxy/scrape_config.go
@@ -8,9 +8,10 @@ import (
 	metricsproxybin "github.com/openshift/hypershift/control-plane-operator/metrics-proxy"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
@@ -60,6 +61,10 @@ func adaptScrapeConfig(cpContext component.WorkloadContext, cm *corev1.ConfigMap
 			log.V(4).Info("skipping ServiceMonitor: service not found", "serviceMonitor", sm.Name, "error", err)
 			continue
 		}
+		if len(podSelector) == 0 {
+			log.V(4).Info("skipping ServiceMonitor: service has no pod selector", "serviceMonitor", sm.Name, "service", serviceName)
+			continue
+		}
 
 		portRef := ep.Port
 		if portRef == "" && ep.TargetPort != nil {
@@ -70,7 +75,7 @@ func adaptScrapeConfig(cpContext component.WorkloadContext, cm *corev1.ConfigMap
 			continue
 		}
 
-		port, err := resolveServicePort(cpContext, namespace, serviceName, portRef)
+		port, err := resolveServicePort(cpContext, namespace, serviceName, portRef, podSelector)
 		if err != nil {
 			log.V(4).Info("skipping ServiceMonitor: port not resolvable", "serviceMonitor", sm.Name, "port", portRef, "error", err)
 			continue
@@ -134,9 +139,13 @@ func adaptScrapeConfig(cpContext component.WorkloadContext, cm *corev1.ConfigMap
 			continue
 		}
 
-		// Resolve the port number from the component's Deployment.
-		// The PodMonitor name matches the component name by CPOv2 convention.
-		port, err := resolveDeploymentPort(cpContext, namespace, pm.Name, portName)
+		// Resolve the port number from a Pod matching the PodMonitor's selector.
+		podSelector, err := metav1.LabelSelectorAsSelector(&pm.Spec.Selector)
+		if err != nil {
+			log.V(4).Info("skipping PodMonitor: invalid selector", "podMonitor", pm.Name, "error", err)
+			continue
+		}
+		port, err := resolvePodPort(cpContext, namespace, podSelector, portName)
 		if err != nil {
 			log.V(4).Info("skipping PodMonitor: port not resolvable", "podMonitor", pm.Name, "port", portName, "error", err)
 			continue
@@ -239,8 +248,10 @@ func findServiceForMonitor(cpContext component.WorkloadContext, namespace, smNam
 }
 
 // resolveServicePort reads a Service and resolves a named port to a numeric
-// port value.
-func resolveServicePort(cpContext component.WorkloadContext, namespace, serviceName, portName string) (int32, error) {
+// container port value. If the Service's targetPort is numeric it is returned
+// directly. If the targetPort is a named port, it is resolved from a Pod
+// matched by the Service's selector.
+func resolveServicePort(cpContext component.WorkloadContext, namespace, serviceName, portName string, podSelector map[string]string) (int32, error) {
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -256,6 +267,11 @@ func resolveServicePort(cpContext component.WorkloadContext, namespace, serviceN
 			if p.TargetPort.IntValue() > 0 {
 				return int32(p.TargetPort.IntValue()), nil
 			}
+			// targetPort is a named port, resolve from a Pod.
+			if p.TargetPort.Type == intstr.String && p.TargetPort.StrVal != "" {
+				return resolvePodPort(cpContext, namespace, labels.SelectorFromSet(podSelector), p.TargetPort.StrVal)
+			}
+			// No targetPort set; Kubernetes defaults it to the port value.
 			return p.Port, nil
 		}
 	}
@@ -280,22 +296,28 @@ func populateMetricsLabelsFromAnnotations(comp *metricsproxybin.ComponentFileCon
 	}
 }
 
-// resolveDeploymentPort reads a Deployment and resolves a named container port
-// to a numeric port value. It searches all containers for a port matching the
-// given name.
-func resolveDeploymentPort(cpContext component.WorkloadContext, namespace, deploymentName, portName string) (int32, error) {
-	deploy := &appsv1.Deployment{}
-	if err := cpContext.Client.Get(cpContext, client.ObjectKey{Namespace: namespace, Name: deploymentName}, deploy); err != nil {
-		return 0, fmt.Errorf("failed to get deployment %s: %w", deploymentName, err)
+// resolvePodPort finds a Pod matching the given selector and resolves a named
+// container port to a numeric port value. It scans all matching pods so that
+// a port can still be resolved during rollouts when different pod revisions coexist.
+func resolvePodPort(cpContext component.WorkloadContext, namespace string, selector labels.Selector, portName string) (int32, error) {
+	podList := &corev1.PodList{}
+	if err := cpContext.Client.List(cpContext, podList, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: selector}); err != nil {
+		return 0, fmt.Errorf("failed to list pods with selector %s: %w", selector, err)
 	}
 
-	for _, container := range deploy.Spec.Template.Spec.Containers {
-		for _, p := range container.Ports {
-			if p.Name == portName {
-				return p.ContainerPort, nil
+	if len(podList.Items) == 0 {
+		return 0, fmt.Errorf("no pods found with selector %s", selector)
+	}
+
+	for i := range podList.Items {
+		for _, container := range podList.Items[i].Spec.Containers {
+			for _, p := range container.Ports {
+				if p.Name == portName {
+					return p.ContainerPort, nil
+				}
 			}
 		}
 	}
 
-	return 0, fmt.Errorf("port %q not found on deployment %s", portName, deploymentName)
+	return 0, fmt.Errorf("port %q not found on pods with selector %s", portName, selector)
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/metrics_proxy/scrape_config_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/metrics_proxy/scrape_config_test.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	metricsproxybin "github.com/openshift/hypershift/control-plane-operator/metrics-proxy"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -75,6 +77,10 @@ func newServiceMonitor(name, namespace, svcLabel, portOrTargetPort, scheme, serv
 }
 
 func newService(name, namespace, appLabel, portName string, portNum int32) *corev1.Service {
+	return newServiceWithTargetPort(name, namespace, appLabel, portName, portNum, intstr.FromInt32(portNum))
+}
+
+func newServiceWithTargetPort(name, namespace, appLabel, portName string, portNum int32, targetPort intstr.IntOrString) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -84,7 +90,7 @@ func newService(name, namespace, appLabel, portName string, portNum int32) *core
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{"app": appLabel},
 			Ports: []corev1.ServicePort{
-				{Name: portName, Port: portNum, TargetPort: intstr.FromInt32(portNum)},
+				{Name: portName, Port: portNum, TargetPort: targetPort},
 			},
 		},
 	}
@@ -112,25 +118,23 @@ func newPodMonitor(name, namespace, portName, scheme string, tlsCfg *prometheuso
 	}
 }
 
-func newDeployment(name, namespace, portName string, portNum int32) *appsv1.Deployment {
-	return &appsv1.Deployment{
+func newPod(name, namespace, portName string, portNum int32) *corev1.Pod {
+	return newPodWithLabels(name, namespace, portName, portNum, map[string]string{"app": name})
+}
+
+func newPodWithLabels(name, namespace, portName string, portNum int32, labels map[string]string) *corev1.Pod {
+	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Labels:    labels,
 		},
-		Spec: appsv1.DeploymentSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"app": name},
-			},
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: name,
-							Ports: []corev1.ContainerPort{
-								{Name: portName, ContainerPort: portNum},
-							},
-						},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: name,
+					Ports: []corev1.ContainerPort{
+						{Name: portName, ContainerPort: portNum},
 					},
 				},
 			},
@@ -148,6 +152,7 @@ func findComponent(components []metricsproxybin.ComponentFileConfig, name string
 }
 
 func TestAdaptScrapeConfig(t *testing.T) {
+	g := NewGomegaWithT(t)
 	t.Parallel()
 
 	namespace := "clusters-test-hosted"
@@ -193,7 +198,7 @@ func TestAdaptScrapeConfig(t *testing.T) {
 
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
+
 	_ = prometheusoperatorv1.AddToScheme(scheme)
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(allObjects...).Build()
 
@@ -215,104 +220,61 @@ func TestAdaptScrapeConfig(t *testing.T) {
 		},
 	}
 
-	if err := adaptScrapeConfig(cpContext, cm); err != nil {
-		t.Fatalf("adaptScrapeConfig() returned error: %v", err)
-	}
-
-	configData, ok := cm.Data["config.yaml"]
-	if !ok {
-		t.Fatal("config.yaml key missing from ConfigMap data")
-	}
+	g.Expect(adaptScrapeConfig(cpContext, cm)).To(Succeed())
+	g.Expect(cm.Data).To(HaveKey("config.yaml"))
 
 	var cfg metricsproxybin.FileConfig
-	if err := yaml.Unmarshal([]byte(configData), &cfg); err != nil {
-		t.Fatalf("failed to unmarshal config YAML: %v", err)
-	}
+	g.Expect(yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &cfg)).To(Succeed())
 
 	t.Run("When all ServiceMonitors and services exist, it should include all 10 components", func(t *testing.T) {
+		g := NewGomegaWithT(t)
 		t.Parallel()
-		if len(cfg.Components) != 10 {
-			t.Errorf("expected 10 components, got %d", len(cfg.Components))
-		}
+		g.Expect(cfg.Components).To(HaveLen(10))
 	})
 
 	t.Run("When endpoint resolver config is generated, it should have correct URL and CA", func(t *testing.T) {
+		g := NewGomegaWithT(t)
 		t.Parallel()
-		expectedURL := "https://endpoint-resolver." + namespace + ".svc"
-		if cfg.EndpointResolver.URL != expectedURL {
-			t.Errorf("expected endpoint resolver URL %q, got %q", expectedURL, cfg.EndpointResolver.URL)
-		}
-		if cfg.EndpointResolver.CAFile != endpointResolverCA {
-			t.Errorf("expected endpoint resolver CA %q, got %q", endpointResolverCA, cfg.EndpointResolver.CAFile)
-		}
+		g.Expect(cfg.EndpointResolver.URL).To(Equal("https://endpoint-resolver." + namespace + ".svc"))
+		g.Expect(cfg.EndpointResolver.CAFile).To(Equal(endpointResolverCA))
 	})
 
 	t.Run("When kube-apiserver config is generated, it should have correct port, certs and selector", func(t *testing.T) {
+		g := NewGomegaWithT(t)
 		t.Parallel()
 		kas, ok := findComponent(cfg.Components, "kube-apiserver")
-		if !ok {
-			t.Fatal("kube-apiserver not found in components")
-		}
-		if kas.MetricsPort != 6443 {
-			t.Errorf("expected kube-apiserver port 6443, got %d", kas.MetricsPort)
-		}
-		expectedCA := certBasePath + "/root-ca/ca.crt"
-		if kas.CAFile != expectedCA {
-			t.Errorf("expected CA file %q, got %q", expectedCA, kas.CAFile)
-		}
-		expectedCert := certBasePath + "/metrics-client/tls.crt"
-		if kas.CertFile != expectedCert {
-			t.Errorf("expected cert file %q, got %q", expectedCert, kas.CertFile)
-		}
-		if kas.Selector == nil || kas.Selector["app"] != "kube-apiserver" {
-			t.Errorf("expected selector {app: kube-apiserver}, got %v", kas.Selector)
-		}
+		g.Expect(ok).To(BeTrue(), "kube-apiserver not found in components")
+		g.Expect(kas.MetricsPort).To(Equal(int32(6443)))
+		g.Expect(kas.CAFile).To(Equal(certBasePath + "/root-ca/ca.crt"))
+		g.Expect(kas.CertFile).To(Equal(certBasePath + "/metrics-client/tls.crt"))
+		g.Expect(kas.Selector).To(HaveKeyWithValue("app", "kube-apiserver"))
 	})
 
 	t.Run("When etcd config is generated, it should use etcd-specific certs", func(t *testing.T) {
+		g := NewGomegaWithT(t)
 		t.Parallel()
 		etcd, ok := findComponent(cfg.Components, "etcd")
-		if !ok {
-			t.Fatal("etcd not found in components")
-		}
-		expectedCA := certBasePath + "/etcd-ca/ca.crt"
-		if etcd.CAFile != expectedCA {
-			t.Errorf("expected etcd CA file %q, got %q", expectedCA, etcd.CAFile)
-		}
-		expectedCert := certBasePath + "/etcd-metrics-client-tls/etcd-client.crt"
-		if etcd.CertFile != expectedCert {
-			t.Errorf("expected etcd cert file %q, got %q", expectedCert, etcd.CertFile)
-		}
-		expectedKey := certBasePath + "/etcd-metrics-client-tls/etcd-client.key"
-		if etcd.KeyFile != expectedKey {
-			t.Errorf("expected etcd key file %q, got %q", expectedKey, etcd.KeyFile)
-		}
+		g.Expect(ok).To(BeTrue(), "etcd not found in components")
+		g.Expect(etcd.CAFile).To(Equal(certBasePath + "/etcd-ca/ca.crt"))
+		g.Expect(etcd.CertFile).To(Equal(certBasePath + "/etcd-metrics-client-tls/etcd-client.crt"))
+		g.Expect(etcd.KeyFile).To(Equal(certBasePath + "/etcd-metrics-client-tls/etcd-client.key"))
 	})
 
 	t.Run("When CVO config is generated, it should have no client cert", func(t *testing.T) {
+		g := NewGomegaWithT(t)
 		t.Parallel()
 		cvo, ok := findComponent(cfg.Components, "cluster-version-operator")
-		if !ok {
-			t.Fatal("cluster-version-operator not found in components")
-		}
-		if cvo.CertFile != "" {
-			t.Errorf("expected empty cert file for CVO, got %q", cvo.CertFile)
-		}
-		if cvo.KeyFile != "" {
-			t.Errorf("expected empty key file for CVO, got %q", cvo.KeyFile)
-		}
+		g.Expect(ok).To(BeTrue(), "cluster-version-operator not found in components")
+		g.Expect(cvo.CertFile).To(BeEmpty())
+		g.Expect(cvo.KeyFile).To(BeEmpty())
 	})
 
 	t.Run("When NTO config is generated, it should include namespace in serverName", func(t *testing.T) {
+		g := NewGomegaWithT(t)
 		t.Parallel()
 		nto, ok := findComponent(cfg.Components, "node-tuning-operator")
-		if !ok {
-			t.Fatal("node-tuning-operator not found in components")
-		}
-		expectedServerName := "node-tuning-operator." + namespace + ".svc"
-		if nto.TLSServerName != expectedServerName {
-			t.Errorf("expected NTO server name %q, got %q", expectedServerName, nto.TLSServerName)
-		}
+		g.Expect(ok).To(BeTrue(), "node-tuning-operator not found in components")
+		g.Expect(nto.TLSServerName).To(Equal("node-tuning-operator." + namespace + ".svc"))
 	})
 }
 
@@ -333,7 +295,7 @@ func TestAdaptScrapeConfigMissingService(t *testing.T) {
 
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
+
 	_ = prometheusoperatorv1.AddToScheme(scheme)
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
 
@@ -351,26 +313,21 @@ func TestAdaptScrapeConfigMissingService(t *testing.T) {
 	cm := &corev1.ConfigMap{}
 
 	t.Run("When some services are missing, it should skip missing components without error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
 		t.Parallel()
-		if err := adaptScrapeConfig(cpContext, cm); err != nil {
-			t.Fatalf("adaptScrapeConfig() returned error: %v", err)
-		}
+		g.Expect(adaptScrapeConfig(cpContext, cm)).To(Succeed())
 
 		var cfg metricsproxybin.FileConfig
-		if err := yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &cfg); err != nil {
-			t.Fatalf("failed to unmarshal config YAML: %v", err)
-		}
+		g.Expect(yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &cfg)).To(Succeed())
 
-		if len(cfg.Components) != 1 {
-			t.Errorf("expected 1 component, got %d", len(cfg.Components))
-		}
-		if _, ok := findComponent(cfg.Components, "kube-apiserver"); !ok {
-			t.Error("expected kube-apiserver to be present")
-		}
+		g.Expect(cfg.Components).To(HaveLen(1))
+		_, ok := findComponent(cfg.Components, "kube-apiserver")
+		g.Expect(ok).To(BeTrue(), "expected kube-apiserver to be present")
 	})
 }
 
 func TestAdaptScrapeConfigWithPodMonitors(t *testing.T) {
+	g := NewGomegaWithT(t)
 	t.Parallel()
 
 	namespace := "clusters-test-hosted"
@@ -395,22 +352,22 @@ func TestAdaptScrapeConfigWithPodMonitors(t *testing.T) {
 		}),
 	}
 
-	deployments := []runtime.Object{
-		newDeployment("cluster-autoscaler", namespace, "metrics", 8085),
-		newDeployment("control-plane-operator", namespace, "metrics", 8080),
-		newDeployment("hosted-cluster-config-operator", namespace, "metrics", 8080),
-		newDeployment("ignition-server", namespace, "metrics", 8080),
-		newDeployment("ingress-operator", namespace, "metrics", 60000),
-		newDeployment("karpenter", namespace, "metrics", 8080),
-		newDeployment("karpenter-operator", namespace, "metrics", 8080),
-		newDeployment("cluster-image-registry-operator", namespace, "metrics", 60000),
+	pods := []runtime.Object{
+		newPod("cluster-autoscaler", namespace, "metrics", 8085),
+		newPod("control-plane-operator", namespace, "metrics", 8080),
+		newPod("hosted-cluster-config-operator", namespace, "metrics", 8080),
+		newPod("ignition-server", namespace, "metrics", 8080),
+		newPod("ingress-operator", namespace, "metrics", 60000),
+		newPod("karpenter", namespace, "metrics", 8080),
+		newPod("karpenter-operator", namespace, "metrics", 8080),
+		newPod("cluster-image-registry-operator", namespace, "metrics", 60000),
 	}
 
-	allObjects := append(podMonitors, deployments...)
+	allObjects := append(podMonitors, pods...)
 
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
+
 	_ = prometheusoperatorv1.AddToScheme(scheme)
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(allObjects...).Build()
 
@@ -426,80 +383,47 @@ func TestAdaptScrapeConfigWithPodMonitors(t *testing.T) {
 	}
 
 	cm := &corev1.ConfigMap{}
-	if err := adaptScrapeConfig(cpContext, cm); err != nil {
-		t.Fatalf("adaptScrapeConfig() returned error: %v", err)
-	}
+	g.Expect(adaptScrapeConfig(cpContext, cm)).To(Succeed())
 
 	var cfg metricsproxybin.FileConfig
-	if err := yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &cfg); err != nil {
-		t.Fatalf("failed to unmarshal config YAML: %v", err)
-	}
+	g.Expect(yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &cfg)).To(Succeed())
 
-	t.Run("When all PodMonitors and deployments exist, it should include all 8 PodMonitor components", func(t *testing.T) {
+	t.Run("When all PodMonitors and pods exist, it should include all 8 PodMonitor components", func(t *testing.T) {
+		g := NewGomegaWithT(t)
 		t.Parallel()
-		if len(cfg.Components) != 8 {
-			t.Errorf("expected 8 components, got %d", len(cfg.Components))
-		}
+		g.Expect(cfg.Components).To(HaveLen(8))
 	})
 
 	t.Run("When cluster-autoscaler config is generated, it should have correct port, scheme and selector", func(t *testing.T) {
+		g := NewGomegaWithT(t)
 		t.Parallel()
 		ca, ok := findComponent(cfg.Components, "cluster-autoscaler")
-		if !ok {
-			t.Fatal("cluster-autoscaler not found in components")
-		}
-		if ca.MetricsPort != 8085 {
-			t.Errorf("expected cluster-autoscaler port 8085, got %d", ca.MetricsPort)
-		}
-		if ca.MetricsScheme != "http" {
-			t.Errorf("expected scheme http, got %q", ca.MetricsScheme)
-		}
-		if ca.Selector == nil || ca.Selector["app"] != "cluster-autoscaler" {
-			t.Errorf("expected selector {app: cluster-autoscaler}, got %v", ca.Selector)
-		}
+		g.Expect(ok).To(BeTrue(), "cluster-autoscaler not found in components")
+		g.Expect(ca.MetricsPort).To(Equal(int32(8085)))
+		g.Expect(ca.MetricsScheme).To(Equal("http"))
+		g.Expect(ca.Selector).To(HaveKeyWithValue("app", "cluster-autoscaler"))
 	})
 
 	t.Run("When cluster-image-registry-operator config is generated, it should have TLS CA", func(t *testing.T) {
+		g := NewGomegaWithT(t)
 		t.Parallel()
 		ciro, ok := findComponent(cfg.Components, "cluster-image-registry-operator")
-		if !ok {
-			t.Fatal("cluster-image-registry-operator not found in components")
-		}
-		if ciro.MetricsPort != 60000 {
-			t.Errorf("expected port 60000, got %d", ciro.MetricsPort)
-		}
-		if ciro.MetricsScheme != "https" {
-			t.Errorf("expected scheme https, got %q", ciro.MetricsScheme)
-		}
-		expectedCA := certBasePath + "/root-ca/ca.crt"
-		if ciro.CAFile != expectedCA {
-			t.Errorf("expected CA file %q, got %q", expectedCA, ciro.CAFile)
-		}
-		// No client cert for this component.
-		if ciro.CertFile != "" {
-			t.Errorf("expected empty cert file, got %q", ciro.CertFile)
-		}
-		if ciro.KeyFile != "" {
-			t.Errorf("expected empty key file, got %q", ciro.KeyFile)
-		}
-		expectedServerName := "cluster-image-registry-operator." + namespace + ".svc"
-		if ciro.TLSServerName != expectedServerName {
-			t.Errorf("expected server name %q, got %q", expectedServerName, ciro.TLSServerName)
-		}
+		g.Expect(ok).To(BeTrue(), "cluster-image-registry-operator not found in components")
+		g.Expect(ciro.MetricsPort).To(Equal(int32(60000)))
+		g.Expect(ciro.MetricsScheme).To(Equal("https"))
+		g.Expect(ciro.CAFile).To(Equal(certBasePath + "/root-ca/ca.crt"))
+		g.Expect(ciro.CertFile).To(BeEmpty())
+		g.Expect(ciro.KeyFile).To(BeEmpty())
+		g.Expect(ciro.TLSServerName).To(Equal("cluster-image-registry-operator." + namespace + ".svc"))
 	})
 
 	t.Run("When PodMonitor without TLS is generated, it should have no TLS fields", func(t *testing.T) {
+		g := NewGomegaWithT(t)
 		t.Parallel()
 		cpo, ok := findComponent(cfg.Components, "control-plane-operator")
-		if !ok {
-			t.Fatal("control-plane-operator not found in components")
-		}
-		if cpo.CAFile != "" {
-			t.Errorf("expected empty CA file, got %q", cpo.CAFile)
-		}
-		if cpo.TLSServerName != "" {
-			t.Errorf("expected empty server name, got %q", cpo.TLSServerName)
-		}
+		g.Expect(ok).To(BeTrue(), "control-plane-operator not found in components")
+		g.Expect(cpo.CAFile).To(BeEmpty())
+		g.Expect(cpo.TLSServerName).To(BeEmpty())
 	})
 }
 
@@ -513,14 +437,14 @@ func TestAdaptScrapeConfigMixedMonitors(t *testing.T) {
 		newServiceMonitor("kube-apiserver", namespace, "kube-apiserver", "client", "https", "kube-apiserver",
 			"root-ca", "ca.crt", "metrics-client", "tls.crt", "metrics-client", "tls.key"),
 		newService("kube-apiserver", namespace, "kube-apiserver", "client", 6443),
-		// One PodMonitor with its Deployment.
+		// One PodMonitor with its Pod.
 		newPodMonitor("cluster-autoscaler", namespace, "metrics", "http", nil),
-		newDeployment("cluster-autoscaler", namespace, "metrics", 8085),
+		newPod("cluster-autoscaler", namespace, "metrics", 8085),
 	}
 
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
+
 	_ = prometheusoperatorv1.AddToScheme(scheme)
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
 
@@ -536,42 +460,143 @@ func TestAdaptScrapeConfigMixedMonitors(t *testing.T) {
 	}
 
 	cm := &corev1.ConfigMap{}
-	if err := adaptScrapeConfig(cpContext, cm); err != nil {
-		t.Fatalf("adaptScrapeConfig() returned error: %v", err)
-	}
+	g := NewGomegaWithT(t)
+	g.Expect(adaptScrapeConfig(cpContext, cm)).To(Succeed())
 
 	var cfg metricsproxybin.FileConfig
-	if err := yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &cfg); err != nil {
-		t.Fatalf("failed to unmarshal config YAML: %v", err)
-	}
+	g.Expect(yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &cfg)).To(Succeed())
 
 	t.Run("When both ServiceMonitor and PodMonitor components exist, it should include both", func(t *testing.T) {
+		g := NewGomegaWithT(t)
 		t.Parallel()
-		if len(cfg.Components) != 2 {
-			t.Errorf("expected 2 components, got %d", len(cfg.Components))
-		}
-		if _, ok := findComponent(cfg.Components, "kube-apiserver"); !ok {
-			t.Error("expected kube-apiserver to be present")
-		}
-		if _, ok := findComponent(cfg.Components, "cluster-autoscaler"); !ok {
-			t.Error("expected cluster-autoscaler to be present")
-		}
+		g.Expect(cfg.Components).To(HaveLen(2))
+		_, ok := findComponent(cfg.Components, "kube-apiserver")
+		g.Expect(ok).To(BeTrue(), "expected kube-apiserver to be present")
+		_, ok = findComponent(cfg.Components, "cluster-autoscaler")
+		g.Expect(ok).To(BeTrue(), "expected cluster-autoscaler to be present")
 	})
 }
 
-func TestAdaptScrapeConfigPodMonitorMissingDeployment(t *testing.T) {
+func TestAdaptScrapeConfigNamedTargetPort(t *testing.T) {
+	g := NewGomegaWithT(t)
+	t.Parallel()
+
+	namespace := "clusters-test-hosted"
+
+	objects := []runtime.Object{
+		// Service with a named targetPort that differs from the service port.
+		newServiceWithTargetPort("kube-apiserver", namespace, "kube-apiserver", "client", 443, intstr.FromString("https")),
+		newServiceMonitor("kube-apiserver", namespace, "kube-apiserver", "client", "https", "kube-apiserver",
+			"root-ca", "ca.crt", "metrics-client", "tls.crt", "metrics-client", "tls.key"),
+		// Pod with the named container port "https" on 6443.
+		newPod("kube-apiserver", namespace, "https", 6443),
+	}
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	_ = prometheusoperatorv1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
+
+	cpContext := component.WorkloadContext{
+		Context: context.Background(),
+		Client:  fakeClient,
+		HCP: &hyperv1.HostedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "test",
+			},
+		},
+	}
+
+	cm := &corev1.ConfigMap{}
+	g.Expect(adaptScrapeConfig(cpContext, cm)).To(Succeed())
+
+	var cfg metricsproxybin.FileConfig
+	g.Expect(yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &cfg)).To(Succeed())
+
+	t.Run("When service has a named targetPort, it should resolve the port from the pod", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		t.Parallel()
+		kas, ok := findComponent(cfg.Components, "kube-apiserver")
+		g.Expect(ok).To(BeTrue(), "kube-apiserver not found in components")
+		g.Expect(kas.MetricsPort).To(Equal(int32(6443)))
+	})
+}
+
+func TestAdaptScrapeConfigPodMonitorNameMismatch(t *testing.T) {
+	g := NewGomegaWithT(t)
+	t.Parallel()
+
+	namespace := "clusters-test-hosted"
+
+	// Regression test: the PodMonitor name differs from the pod label value.
+	// This mirrors the real control-plane-operator case where the PodMonitor YAML
+	// has name: controlplane-operator but the pod label is name: control-plane-operator.
+	objects := []runtime.Object{
+		&prometheusoperatorv1.PodMonitor{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "controlplane-operator",
+				Namespace: namespace,
+			},
+			Spec: prometheusoperatorv1.PodMonitorSpec{
+				PodMetricsEndpoints: []prometheusoperatorv1.PodMetricsEndpoint{
+					{Port: ptr.To("metrics"), Scheme: (*prometheusoperatorv1.Scheme)(ptr.To("http"))},
+				},
+				Selector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"name": "control-plane-operator"},
+				},
+			},
+		},
+		newPodWithLabels("control-plane-operator", namespace, "metrics", 8080,
+			map[string]string{"name": "control-plane-operator"}),
+	}
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	_ = prometheusoperatorv1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
+
+	cpContext := component.WorkloadContext{
+		Context: context.Background(),
+		Client:  fakeClient,
+		HCP: &hyperv1.HostedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "test",
+			},
+		},
+	}
+
+	cm := &corev1.ConfigMap{}
+	g.Expect(adaptScrapeConfig(cpContext, cm)).To(Succeed())
+
+	var cfg metricsproxybin.FileConfig
+	g.Expect(yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &cfg)).To(Succeed())
+
+	t.Run("When PodMonitor name differs from pod label, it should still resolve via selector", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		t.Parallel()
+		cpo, ok := findComponent(cfg.Components, "controlplane-operator")
+		g.Expect(ok).To(BeTrue(), "controlplane-operator not found in components")
+		g.Expect(cpo.MetricsPort).To(Equal(int32(8080)))
+	})
+}
+
+func TestAdaptScrapeConfigPodMonitorMissingPod(t *testing.T) {
 	t.Parallel()
 
 	namespace := "clusters-test-hosted"
 
 	objects := []runtime.Object{
 		newPodMonitor("cluster-autoscaler", namespace, "metrics", "http", nil),
-		// No deployment — should be skipped.
+		// No pod — should be skipped.
 	}
 
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
+
 	_ = prometheusoperatorv1.AddToScheme(scheme)
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
 
@@ -588,19 +613,97 @@ func TestAdaptScrapeConfigPodMonitorMissingDeployment(t *testing.T) {
 
 	cm := &corev1.ConfigMap{}
 
-	t.Run("When PodMonitor deployment is missing, it should skip without error", func(t *testing.T) {
+	t.Run("When PodMonitor pod is missing, it should skip without error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
 		t.Parallel()
-		if err := adaptScrapeConfig(cpContext, cm); err != nil {
-			t.Fatalf("adaptScrapeConfig() returned error: %v", err)
-		}
+		g.Expect(adaptScrapeConfig(cpContext, cm)).To(Succeed())
 
 		var cfg metricsproxybin.FileConfig
-		if err := yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &cfg); err != nil {
-			t.Fatalf("failed to unmarshal config YAML: %v", err)
-		}
-
-		if len(cfg.Components) != 0 {
-			t.Errorf("expected 0 components, got %d", len(cfg.Components))
-		}
+		g.Expect(yaml.Unmarshal([]byte(cm.Data["config.yaml"]), &cfg)).To(Succeed())
+		g.Expect(cfg.Components).To(BeEmpty())
 	})
+}
+
+func TestResolvePodPort(t *testing.T) {
+	t.Parallel()
+
+	namespace := "test-ns"
+
+	tests := []struct {
+		name        string
+		pods        []runtime.Object
+		selector    map[string]string
+		portName    string
+		expectedErr bool
+		expected    int32
+	}{
+		{
+			name: "When a pod has the named port, it should resolve the port number",
+			pods: []runtime.Object{
+				newPodWithLabels("my-pod", namespace, "https", 6443, map[string]string{"app": "kas"}),
+			},
+			selector: map[string]string{"app": "kas"},
+			portName: "https",
+			expected: 6443,
+		},
+		{
+			name: "When no pods match the selector, it should return an error",
+			pods: []runtime.Object{
+				newPodWithLabels("my-pod", namespace, "https", 6443, map[string]string{"app": "other"}),
+			},
+			selector:    map[string]string{"app": "kas"},
+			portName:    "https",
+			expectedErr: true,
+		},
+		{
+			name: "When the port name does not match, it should return an error",
+			pods: []runtime.Object{
+				newPodWithLabels("my-pod", namespace, "metrics", 8080, map[string]string{"app": "kas"}),
+			},
+			selector:    map[string]string{"app": "kas"},
+			portName:    "https",
+			expectedErr: true,
+		},
+		{
+			name:        "When no pods exist, it should return an error",
+			pods:        nil,
+			selector:    map[string]string{"app": "kas"},
+			portName:    "https",
+			expectedErr: true,
+		},
+		{
+			name: "When multiple pods exist during rollout, it should resolve from the first match",
+			pods: []runtime.Object{
+				newPodWithLabels("pod-old", namespace, "https", 6443, map[string]string{"app": "kas"}),
+				newPodWithLabels("pod-new", namespace, "https", 6443, map[string]string{"app": "kas"}),
+			},
+			selector: map[string]string{"app": "kas"},
+			portName: "https",
+			expected: 6443,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			t.Parallel()
+
+			scheme := runtime.NewScheme()
+			_ = corev1.AddToScheme(scheme)
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tt.pods...).Build()
+
+			cpContext := component.WorkloadContext{
+				Context: context.Background(),
+				Client:  fakeClient,
+			}
+
+			port, err := resolvePodPort(cpContext, namespace, labels.SelectorFromSet(tt.selector), tt.portName)
+			if tt.expectedErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(port).To(Equal(tt.expected))
+			}
+		})
+	}
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -896,6 +896,9 @@ func (r *reconciler) reconcileMetricsForwarder(ctx context.Context, hcp *hyperv1
 	if _, disabled := hcp.Annotations[hyperv1.DisableMonitoringServices]; disabled {
 		return util.DeleteAllIfNeeded(ctx, r.client, deployment, cm, servingCA, podMonitor)
 	}
+	if _, enabled := hcp.Annotations[hyperv1.EnableMetricsForwarding]; !enabled {
+		return util.DeleteAllIfNeeded(ctx, r.client, deployment, cm, servingCA, podMonitor)
+	}
 
 	route := &routev1.Route{}
 	if err := r.cpClient.Get(ctx, types.NamespacedName{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -94,6 +94,10 @@ var initialObjects = []client.Object{
 	fakeOperatorHub(),
 	manifests.KASConnectionCheckerDeployment(),
 	manifests.KASConnectionCheckerServiceAccount(),
+	manifests.MetricsForwarderDeployment(),
+	manifests.MetricsForwarderConfigMap(),
+	manifests.MetricsForwarderServingCA(),
+	manifests.MetricsForwarderPodMonitor(),
 }
 
 func shouldNotError(key client.ObjectKey) bool {
@@ -2959,6 +2963,81 @@ func Test_reconciler_reconcileKASConnectionCheckerDeployment(t *testing.T) {
 
 			if tt.validate != nil {
 				tt.validate(t, r.client)
+			}
+		})
+	}
+}
+
+func TestReconcileMetricsForwarder(t *testing.T) {
+	tests := []struct {
+		name            string
+		annotations     map[string]string
+		existingObjects []client.Object
+		expectCleanup   bool
+	}{
+		{
+			name:        "When EnableMetricsForwarding is not set, it should delete existing resources",
+			annotations: map[string]string{},
+			existingObjects: []client.Object{
+				manifests.MetricsForwarderDeployment(),
+				manifests.MetricsForwarderConfigMap(),
+				manifests.MetricsForwarderServingCA(),
+				manifests.MetricsForwarderPodMonitor(),
+			},
+			expectCleanup: true,
+		},
+		{
+			name:        "When DisableMonitoringServices is set, it should delete existing resources",
+			annotations: map[string]string{hyperv1.DisableMonitoringServices: "true"},
+			existingObjects: []client.Object{
+				manifests.MetricsForwarderDeployment(),
+				manifests.MetricsForwarderConfigMap(),
+				manifests.MetricsForwarderServingCA(),
+				manifests.MetricsForwarderPodMonitor(),
+			},
+			expectCleanup: true,
+		},
+		{
+			name:            "When EnableMetricsForwarding is not set and no resources exist, it should succeed",
+			annotations:     map[string]string{},
+			existingObjects: nil,
+			expectCleanup:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			guestClient := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(tt.existingObjects...).Build()
+			r := &reconciler{
+				client:                 guestClient,
+				CreateOrUpdateProvider: &simpleCreateOrUpdater{},
+			}
+
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test",
+					Namespace:   "test-ns",
+					Annotations: tt.annotations,
+				},
+			}
+
+			err := r.reconcileMetricsForwarder(t.Context(), hcp, nil)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			if tt.expectCleanup {
+				deployment := manifests.MetricsForwarderDeployment()
+				g.Expect(apierrors.IsNotFound(guestClient.Get(t.Context(), client.ObjectKeyFromObject(deployment), deployment))).To(BeTrue(), "deployment should be deleted")
+
+				cm := manifests.MetricsForwarderConfigMap()
+				g.Expect(apierrors.IsNotFound(guestClient.Get(t.Context(), client.ObjectKeyFromObject(cm), cm))).To(BeTrue(), "configmap should be deleted")
+
+				servingCA := manifests.MetricsForwarderServingCA()
+				g.Expect(apierrors.IsNotFound(guestClient.Get(t.Context(), client.ObjectKeyFromObject(servingCA), servingCA))).To(BeTrue(), "serving CA should be deleted")
+
+				podMonitor := manifests.MetricsForwarderPodMonitor()
+				g.Expect(apierrors.IsNotFound(guestClient.Get(t.Context(), client.ObjectKeyFromObject(podMonitor), podMonitor))).To(BeTrue(), "pod monitor should be deleted")
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- **PodMonitor port resolution**: `resolveDeploymentPort` used the PodMonitor's name to look up a Deployment by convention (`pm.Name == deployment name`). This broke for the control-plane-operator because its PodMonitor YAML has `name: controlplane-operator` while the Deployment is named `control-plane-operator`, causing the CPO metric to be silently omitted from the metrics-proxy-config configmap. Replaced with `resolvePodPort` which uses the PodMonitor's full label selector (`metav1.LabelSelectorAsSelector`) to find matching Pods directly, scanning all pods for rollout resilience.
- **ServiceMonitor named targetPort**: When a Service's `targetPort` is a named port (string) rather than a number, `resolveServicePort` incorrectly fell back to the Service's `port` field. Now resolves the named targetPort from matching Pods using the Service's selector.
- **HCCO guest resource cleanup**: When the `EnableMetricsForwarding` annotation is removed, the CPO deletes the metrics-proxy Route. The HCCO then gets NotFound on the route lookup and silently returns without cleaning up guest cluster resources (deployment, configmap, serving CA, pod monitor). Added an explicit check so guest resources are deleted when forwarding is not enabled.

## Test plan
- [x] Existing scrape config unit tests pass
- [x] New `TestAdaptScrapeConfigNamedTargetPort` test verifies named targetPort resolution from pods
- [x] New `TestAdaptScrapeConfigPodMonitorNameMismatch` regression test for the CPO name mismatch
- [ ] Verify on a running cluster that the control-plane-operator metric appears in the metrics-proxy-config configmap
- [ ] Verify removing `EnableMetricsForwarding` annotation cleans up guest resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics forwarding now requires an explicit cluster annotation; when absent, related monitoring resources are removed.

* **Bug Fixes**
  * More reliable port detection for services with named target ports and for monitors that select pods by labels; clearer failure when no matching pods or ports exist.

* **Refactor**
  * Port resolution now derives ports from matching pods and selectors rather than previous deployment-template lookup.

* **Tests**
  * Added and updated tests for pod-based resolution, named target-port resolution, selector mismatches, deletion behavior, and mixed-monitor scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->