### PR TITLE
OCPBUGS-83389: fix(supportedversion): normalize OCP 5.x versions for skew and release validation

### DIFF
--- a/cmd/nodepool/core/create_test.go
+++ b/cmd/nodepool/core/create_test.go
@@ -189,7 +189,7 @@ func TestValidMinorVersionCompatibility(t *testing.T) {
 			controlPlaneVersion:  "4.18.0",
 			nodePoolReleaseImage: "quay.io/openshift-release-dev/ocp-release:5.0.0-x86_64",
 			nodePoolVersion:      "5.0.0",
-			expectedError:        "NodePool major version 5 must match HostedCluster major version 4",
+			expectedError:        "NodePool version 5.0.0 cannot be higher than the HostedCluster version 4.18.0",
 		},
 	}
 

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -669,12 +669,13 @@ func (r *NodePoolReconciler) getReleaseImage(ctx context.Context, hostedCluster 
 		return nil, err
 	}
 
-	var currentVersionParsed semver.Version
+	var currentVersionParsed *semver.Version
 	if currentVersion != "" {
-		currentVersionParsed, err = semver.Parse(currentVersion)
+		parsed, err := semver.Parse(currentVersion)
 		if err != nil {
 			return nil, err
 		}
+		currentVersionParsed = &parsed
 	}
 
 	minSupportedVersion := supportedversion.GetMinSupportedVersion(hostedCluster)
@@ -684,7 +685,7 @@ func (r *NodePoolReconciler) getReleaseImage(ctx context.Context, hostedCluster 
 		return nil, err
 	}
 
-	return ReleaseImage, supportedversion.IsValidReleaseVersion(&wantedVersion, &currentVersionParsed, hostedClusterVersion, &minSupportedVersion, hostedCluster.Spec.Networking.NetworkType, hostedCluster.Spec.Platform.Type)
+	return ReleaseImage, supportedversion.IsValidReleaseVersion(&wantedVersion, currentVersionParsed, hostedClusterVersion, &minSupportedVersion, hostedCluster.Spec.Networking.NetworkType, hostedCluster.Spec.Platform.Type)
 }
 
 func (r *NodePoolReconciler) getHostedClusterVersion(ctx context.Context, hostedCluster *hyperv1.HostedCluster, pullSecretBytes []byte) (*semver.Version, error) {

--- a/support/supportedversion/version.go
+++ b/support/supportedversion/version.go
@@ -15,7 +15,6 @@ import (
 	"github.com/openshift/hypershift/support/config"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/ptr"
 
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -53,10 +52,16 @@ var ocpVersionToKubeVersion = map[string]semver.Version{
 	"4.20.0": semver.MustParse("1.33.0"),
 	"4.21.0": semver.MustParse("1.34.0"),
 	"4.22.0": semver.MustParse("1.35.0"),
+	"4.23.0": semver.MustParse("1.36.0"),
 }
 
 func GetKubeVersionForSupportedVersion(supportedVersion semver.Version) (*semver.Version, error) {
-	kubeVersion, ok := ocpVersionToKubeVersion[supportedVersion.String()]
+	normalized, err := normalizeToV4(supportedVersion)
+	if err != nil {
+		return nil, err
+	}
+	lookupKey := semver.Version{Major: normalized.Major, Minor: normalized.Minor}
+	kubeVersion, ok := ocpVersionToKubeVersion[lookupKey.String()]
 	if !ok {
 		return nil, fmt.Errorf("unknown supported version %q", supportedVersion.String())
 	}
@@ -110,48 +115,77 @@ func trimVersion(version string) string {
 
 func subtractMinor(version *semver.Version, count uint64) *semver.Version {
 	result := *version
-	result.Minor = maxInt64(0, result.Minor-count)
+	if result.Minor >= count {
+		result.Minor -= count
+	} else {
+		result.Minor = 0
+	}
 	return &result
 }
 
-func maxInt64(a, b uint64) uint64 {
-	if a > b {
-		return a
-	}
-	return b
-}
+// Version thresholds used by IsValidReleaseVersion, parsed once at package init.
+var (
+	minReleaseVersion = semver.MustParse("4.8.0")
+	sdnMaxVersion     = semver.MustParse("4.10.0")
+)
 
 func IsValidReleaseVersion(version, currentVersion, maxSupportedVersion, minSupportedVersion *semver.Version, networkType hyperv1.NetworkType, platformType hyperv1.PlatformType) error {
-	if maxSupportedVersion.GT(LatestSupportedVersion) {
-		maxSupportedVersion = ptr.To(LatestSupportedVersion)
+	// Normalize all versions to 4.x for consistent comparison across the 4.x/5.x boundary.
+	normalizedVersion, err := normalizeToV4(*version)
+	if err != nil {
+		return err
+	}
+	normalizedMax, err := normalizeToV4(*maxSupportedVersion)
+	if err != nil {
+		return err
+	}
+	normalizedMin, err := normalizeToV4(*minSupportedVersion)
+	if err != nil {
+		return err
+	}
+	normalizedLatest, err := normalizeToV4(LatestSupportedVersion)
+	if err != nil {
+		return err
 	}
 
-	if version.LT(semver.MustParse("4.8.0")) {
+	displayMax := maxSupportedVersion
+	if normalizedMax.GT(normalizedLatest) {
+		normalizedMax = normalizedLatest
+		displayMax = &LatestSupportedVersion
+	}
+
+	if normalizedVersion.LT(minReleaseVersion) {
 		return fmt.Errorf("releases before 4.8 are not supported. Attempting to use: %q", version)
 	}
 
-	if currentVersion != nil && currentVersion.Minor > version.Minor {
-		return fmt.Errorf("y-stream downgrade from %q to %q is not supported", currentVersion, version)
+	if currentVersion != nil {
+		normalizedCurrent, err := normalizeToV4(*currentVersion)
+		if err != nil {
+			return err
+		}
+		if normalizedCurrent.Minor > normalizedVersion.Minor {
+			return fmt.Errorf("y-stream downgrade from %q to %q is not supported", currentVersion, version)
+		}
+
+		if networkType == hyperv1.OpenShiftSDN && normalizedCurrent.Minor < normalizedVersion.Minor {
+			return fmt.Errorf("y-stream upgrade from %q to %q is not for OpenShiftSDN", currentVersion, version)
+		}
 	}
 
-	if networkType == hyperv1.OpenShiftSDN && currentVersion != nil && currentVersion.Minor < version.Minor {
-		return fmt.Errorf("y-stream upgrade from %q to %q is not for OpenShiftSDN", currentVersion, version)
-	}
-
-	versionMinorOnly := &semver.Version{Major: version.Major, Minor: version.Minor}
-	if networkType == hyperv1.OpenShiftSDN && currentVersion == nil && versionMinorOnly.GT(semver.MustParse("4.10.0")) && platformType != hyperv1.PowerVSPlatform {
+	normalizedVersionMinorOnly := semver.Version{Major: 4, Minor: normalizedVersion.Minor}
+	if networkType == hyperv1.OpenShiftSDN && currentVersion == nil && normalizedVersionMinorOnly.GT(sdnMaxVersion) && platformType != hyperv1.PowerVSPlatform {
 		return fmt.Errorf("cannot use OpenShiftSDN with OCP version %q > 4.10", version)
 	}
 
-	if networkType == hyperv1.OVNKubernetes && currentVersion == nil && versionMinorOnly.LTE(semver.MustParse("4.10.0")) {
+	if networkType == hyperv1.OVNKubernetes && currentVersion == nil && normalizedVersionMinorOnly.LTE(sdnMaxVersion) {
 		return fmt.Errorf("cannot use OVNKubernetes with OCP version %q < 4.11", version)
 	}
 
-	if (version.Major == maxSupportedVersion.Major && version.Minor > maxSupportedVersion.Minor) || version.Major > maxSupportedVersion.Major {
-		return fmt.Errorf("the latest version supported is: %q. Attempting to use: %q", maxSupportedVersion, version)
+	if normalizedVersion.Minor > normalizedMax.Minor {
+		return fmt.Errorf("the latest version supported is: %q. Attempting to use: %q", displayMax, version)
 	}
 
-	if (version.Major == minSupportedVersion.Major && version.Minor < minSupportedVersion.Minor) || version.Major < minSupportedVersion.Major {
+	if normalizedVersion.Minor < normalizedMin.Minor {
 		return fmt.Errorf("the minimum version supported for platform %s is: %q. Attempting to use: %q", string(platformType), minSupportedVersion, version)
 	}
 
@@ -218,9 +252,16 @@ func getArchFromStream(releaseStream string) string {
 func LookupLatestSupportedRelease(ctx context.Context, hc *hyperv1.HostedCluster) (string, error) {
 	minSupportedVersion := GetMinSupportedVersion(hc)
 
+	// Normalize LatestSupportedVersion to 4.x so the filter range is correct
+	// even when LatestSupportedVersion is 5.x (e.g. 5.0 -> 4.23).
+	normalizedLatest, err := normalizeToV4(LatestSupportedVersion)
+	if err != nil {
+		return "", fmt.Errorf("failed to normalize latest supported version: %w", err)
+	}
+
 	prefix := "https://multi.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable-multi/latest"
 	filter := fmt.Sprintf("in=>4.%d.%d+<+4.%d.0-a",
-		minSupportedVersion.Minor, minSupportedVersion.Patch, LatestSupportedVersion.Minor+1)
+		minSupportedVersion.Minor, minSupportedVersion.Patch, normalizedLatest.Minor+1)
 
 	releaseURL := fmt.Sprintf("%s?%s", prefix, filter)
 
@@ -340,35 +381,72 @@ type ocpTags struct {
 	Tags []ocpVersion `json:"tags"`
 }
 
+// v5MinorOffset is the 4.x minor version that corresponds to 5.0.
+// OCP 5.0 is equivalent to OCP 4.23 (dual versioning), so 5.x maps to 4.(v5MinorOffset+x).
+const v5MinorOffset uint64 = 23
+
+// normalizeToV4 converts a version to the 4.x numbering scheme for comparison.
+// OCP 5.0 is equivalent to OCP 4.23, so 5.x maps to 4.(23+x).
+// Versions already in the 4.x series are returned unchanged.
+// NOTE: Only handles Major 4 and 5. If a future major version (e.g., 6.x) is
+// introduced, this function must be updated to include the new mapping.
+func normalizeToV4(v semver.Version) (semver.Version, error) {
+	switch v.Major {
+	case 4:
+		return v, nil
+	case 5:
+		return semver.Version{
+			Major: 4,
+			Minor: v.Minor + v5MinorOffset,
+			Patch: v.Patch,
+			Pre:   v.Pre,
+			Build: v.Build,
+		}, nil
+	default:
+		return semver.Version{}, fmt.Errorf("unsupported major version %d; only 4.x and 5.x are supported", v.Major)
+	}
+}
+
+// denormalizeFromV4 converts a normalized 4.x minor version back to the display version.
+// Minor versions >= v5MinorOffset are mapped to 5.x; lower values remain 4.x.
+func denormalizeFromV4(minor uint64) (major, displayMinor uint64) {
+	if minor >= v5MinorOffset {
+		return 5, minor - v5MinorOffset
+	}
+	return 4, minor
+}
+
 // ValidateVersionSkew validates the version skew between HostedCluster and NodePool versions.
 // Returns nil if the version skew is supported, otherwise returns a descriptive error.
 // All 4.y versions support n-3 version skew (e.g., 4.18 HostedCluster supports NodePools running 4.17, 4.16, and 4.15).
+// OCP 5.0 is equivalent to 4.23, so cross-major-version skew is handled via normalization.
 func ValidateVersionSkew(hostedClusterVersion, nodePoolVersion *semver.Version) error {
-	// Reject mismatched major versions
-	if nodePoolVersion.Major != hostedClusterVersion.Major {
-		return fmt.Errorf("NodePool major version %d must match HostedCluster major version %d",
-			nodePoolVersion.Major, hostedClusterVersion.Major)
+	// Normalize versions to 4.x equivalents for comparison.
+	// OCP 5.0 == 4.23 (dual versioning), so cross-major-version skew
+	// (e.g., HC=5.0, NP=4.22) is valid within the n-3 skew policy.
+	normalizedHC, err := normalizeToV4(*hostedClusterVersion)
+	if err != nil {
+		return err
+	}
+	normalizedNP, err := normalizeToV4(*nodePoolVersion)
+	if err != nil {
+		return err
 	}
 
-	if nodePoolVersion.GT(*hostedClusterVersion) {
+	if normalizedNP.GT(normalizedHC) {
 		return fmt.Errorf("NodePool version %s cannot be higher than the HostedCluster version %s",
 			nodePoolVersion, hostedClusterVersion)
 	}
 
-	versionDiff := int(hostedClusterVersion.Minor) - int(nodePoolVersion.Minor)
+	versionDiff := int(normalizedHC.Minor) - int(normalizedNP.Minor)
 	maxAllowedDiff := 3
 
 	if versionDiff > maxAllowedDiff {
-		// Compute minSupportedMinor with explicit conditional
-		var minSupportedMinor int
-		if int(hostedClusterVersion.Minor)-maxAllowedDiff < 0 {
-			minSupportedMinor = 0
-		} else {
-			minSupportedMinor = int(hostedClusterVersion.Minor) - maxAllowedDiff
-		}
+		minSupportedMinor := max(int(normalizedHC.Minor)-maxAllowedDiff, 0)
+		minMajor, minMinor := denormalizeFromV4(uint64(minSupportedMinor))
 		return fmt.Errorf("NodePool minor version %d.%d is less than %d.%d, which is the minimum NodePool version compatible with the %d.%d HostedCluster",
 			nodePoolVersion.Major, nodePoolVersion.Minor,
-			hostedClusterVersion.Major, minSupportedMinor,
+			minMajor, minMinor,
 			hostedClusterVersion.Major, hostedClusterVersion.Minor)
 	}
 

--- a/support/supportedversion/version_test.go
+++ b/support/supportedversion/version_test.go
@@ -65,6 +65,11 @@ func TestGetKubeVersionForSupportedVersion(t *testing.T) {
 			expectedKubeVer: "1.34.0",
 		},
 		{
+			name:            "When OCP 5.0 is provided, it should normalize to 4.23 and return Kubernetes 1.36",
+			ocpVersion:      "5.0.0",
+			expectedKubeVer: "1.36.0",
+		},
+		{
 			name:       "When an unmapped OCP version is provided it should return an error",
 			ocpVersion: "4.99.0",
 			expectErr:  true,
@@ -235,6 +240,51 @@ func TestIsValidReleaseVersion(t *testing.T) {
 			networkType:            hyperv1.OpenShiftSDN,
 			expectError:            false,
 			platform:               hyperv1.PowerVSPlatform,
+		},
+		{
+			name:                   "When version is 5.0 (equivalent to 4.23), it should be valid",
+			currentVersion:         v("4.22.0"),
+			nextVersion:            v("5.0.0"),
+			latestVersionSupported: v("5.0.0"),
+			minVersionSupported:    v("4.14.0"),
+			expectError:            false,
+			platform:               hyperv1.AWSPlatform,
+		},
+		{
+			name:                   "When version is 4.23 (equivalent to 5.0), it should be valid",
+			currentVersion:         v("4.22.0"),
+			nextVersion:            v("4.23.0"),
+			latestVersionSupported: v("5.0.0"),
+			minVersionSupported:    v("4.14.0"),
+			expectError:            false,
+			platform:               hyperv1.AWSPlatform,
+		},
+		{
+			name:                   "When version is 5.0 with pre-release tag, it should be valid",
+			currentVersion:         v("4.22.0"),
+			nextVersion:            v("5.0.0-nightly-something"),
+			latestVersionSupported: v("5.0.0"),
+			minVersionSupported:    v("4.14.0"),
+			expectError:            false,
+			platform:               hyperv1.AWSPlatform,
+		},
+		{
+			name:                   "When maxSupportedVersion is clamped below LatestSupportedVersion, it should reject higher versions",
+			currentVersion:         v("4.18.0"),
+			nextVersion:            v("4.20.0"),
+			latestVersionSupported: v("4.19.0"),
+			minVersionSupported:    v("4.14.0"),
+			expectError:            true,
+			platform:               hyperv1.AWSPlatform,
+		},
+		{
+			name:                   "When version has unsupported major 6, it should return error",
+			currentVersion:         nil,
+			nextVersion:            v("6.0.0"),
+			latestVersionSupported: v("5.0.0"),
+			minVersionSupported:    v("4.14.0"),
+			expectError:            true,
+			platform:               hyperv1.AWSPlatform,
 		},
 	}
 
@@ -421,7 +471,119 @@ func TestGetSupportedOCPVersions(t *testing.T) {
 	}
 }
 
+func TestNormalizeToV4(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name      string
+		input     string
+		expected  string
+		expectErr bool
+	}{
+		{
+			name:     "When version is 4.x, it should be returned unchanged",
+			input:    "4.22.0",
+			expected: "4.22.0",
+		},
+		{
+			name:     "When version is 5.0, it should normalize to 4.23",
+			input:    "5.0.0",
+			expected: "4.23.0",
+		},
+		{
+			name:     "When version is 5.1, it should normalize to 4.24",
+			input:    "5.1.0",
+			expected: "4.24.0",
+		},
+		{
+			name:     "When version has patch level, it should be preserved",
+			input:    "5.0.7",
+			expected: "4.23.7",
+		},
+		{
+			name:     "When version has pre-release metadata, it should be preserved",
+			input:    "5.0.0-nightly",
+			expected: "4.23.0-nightly",
+		},
+		{
+			name:     "When version is 4.14, it should be returned unchanged",
+			input:    "4.14.0",
+			expected: "4.14.0",
+		},
+		{
+			name:      "When version has unsupported major 6, it should return error",
+			input:     "6.0.0",
+			expectErr: true,
+		},
+		{
+			name:      "When version has unsupported major 3, it should return error",
+			input:     "3.11.0",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			input := semver.MustParse(tc.input)
+			result, err := normalizeToV4(input)
+			if tc.expectErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(result.String()).To(Equal(tc.expected))
+			}
+		})
+	}
+}
+
+func TestDenormalizeFromV4(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name          string
+		minor         uint64
+		expectedMajor uint64
+		expectedMinor uint64
+	}{
+		{
+			name:          "When minor is 0, it should return 4.0",
+			minor:         0,
+			expectedMajor: 4,
+			expectedMinor: 0,
+		},
+		{
+			name:          "When minor is 22, it should return 4.22",
+			minor:         22,
+			expectedMajor: 4,
+			expectedMinor: 22,
+		},
+		{
+			name:          "When minor is 23, it should return 5.0",
+			minor:         23,
+			expectedMajor: 5,
+			expectedMinor: 0,
+		},
+		{
+			name:          "When minor is 24, it should return 5.1",
+			minor:         24,
+			expectedMajor: 5,
+			expectedMinor: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			major, minor := denormalizeFromV4(tc.minor)
+			g.Expect(major).To(Equal(tc.expectedMajor))
+			g.Expect(minor).To(Equal(tc.expectedMinor))
+		})
+	}
+}
+
 func TestValidateVersionSkew(t *testing.T) {
+	t.Parallel()
 	v := func(str string) *semver.Version {
 		result := semver.MustParse(str)
 		return &result
@@ -491,17 +653,93 @@ func TestValidateVersionSkew(t *testing.T) {
 			nodePoolVersion:      v("4.18.0"),
 			expectError:          false,
 		},
+		// Cross-major-version tests (5.0 == 4.23 dual versioning)
+		{
+			name:                 "When HC is 5.0 and NP is 4.22 (n-1 across major boundary), it should pass validation",
+			hostedClusterVersion: v("5.0.0"),
+			nodePoolVersion:      v("4.22.0"),
+			expectError:          false,
+		},
+		{
+			name:                 "When HC is 5.0 and NP is 4.21 (n-2 across major boundary), it should pass validation",
+			hostedClusterVersion: v("5.0.0"),
+			nodePoolVersion:      v("4.21.0"),
+			expectError:          false,
+		},
+		{
+			name:                 "When HC is 5.0 and NP is 4.20 (n-3 across major boundary), it should pass validation",
+			hostedClusterVersion: v("5.0.0"),
+			nodePoolVersion:      v("4.20.0"),
+			expectError:          false,
+		},
+		{
+			name:                 "When HC is 5.0 and NP is 4.19 (exceeds n-3 across major boundary), it should return error",
+			hostedClusterVersion: v("5.0.0"),
+			nodePoolVersion:      v("4.19.0"),
+			expectError:          true,
+			expectedErrSubstr:    "is less than 4.20, which is the minimum NodePool version compatible with the 5.0 HostedCluster",
+		},
+		{
+			name:                 "When HC is 5.0 and NP is 5.0 (same version), it should pass validation",
+			hostedClusterVersion: v("5.0.0"),
+			nodePoolVersion:      v("5.0.0"),
+			expectError:          false,
+		},
+		{
+			name:                 "When HC is 5.0 and NP is 4.23 (equivalent versions), it should pass validation",
+			hostedClusterVersion: v("5.0.0"),
+			nodePoolVersion:      v("4.23.0"),
+			expectError:          false,
+		},
+		{
+			name:                 "When HC is 4.23 and NP is 5.0 (equivalent versions), it should pass validation",
+			hostedClusterVersion: v("4.23.0"),
+			nodePoolVersion:      v("5.0.0"),
+			expectError:          false,
+		},
+		{
+			name:                 "When HC is 4.23 and NP is 4.22 (n-1 with 4.23), it should pass validation",
+			hostedClusterVersion: v("4.23.0"),
+			nodePoolVersion:      v("4.22.0"),
+			expectError:          false,
+		},
+		{
+			name:                 "When HC is 5.0 and NP is 5.1 (NP higher than HC), it should return error",
+			hostedClusterVersion: v("5.0.0"),
+			nodePoolVersion:      v("5.1.0"),
+			expectError:          true,
+			expectedErrSubstr:    "cannot be higher than the HostedCluster version",
+		},
+		{
+			name:                 "When HC is 5.1 and NP is 4.21 (n-3 boundary with 5.1), it should pass validation",
+			hostedClusterVersion: v("5.1.0"),
+			nodePoolVersion:      v("4.21.0"),
+			expectError:          false,
+		},
+		{
+			name:                 "When HC is 5.1 and NP is 4.20 (exceeds n-3 with 5.1), it should return error",
+			hostedClusterVersion: v("5.1.0"),
+			nodePoolVersion:      v("4.20.0"),
+			expectError:          true,
+			expectedErrSubstr:    "is less than 4.21, which is the minimum NodePool version compatible with the 5.1 HostedCluster",
+		},
+		{
+			name:                 "When HC is 5.0.3 and NP is 4.22.7 (patch-level across major boundary), it should pass validation",
+			hostedClusterVersion: v("5.0.3"),
+			nodePoolVersion:      v("4.22.7"),
+			expectError:          false,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			t.Parallel()
+			g := NewWithT(t)
 
 			err := ValidateVersionSkew(tc.hostedClusterVersion, tc.nodePoolVersion)
 
 			if tc.expectError {
-				g.Expect(err).To(HaveOccurred())
-				g.Expect(err.Error()).To(ContainSubstring(tc.expectedErrSubstr))
+				g.Expect(err).To(MatchError(ContainSubstring(tc.expectedErrSubstr)))
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 			}


### PR DESCRIPTION
## What this PR does / why we need it:

OCP 5.0 is equivalent to OCP 4.23 (dual versioning). `ValidateVersionSkew` rejects cross-major-version skew (e.g., HC=5.0 with NP=4.22) because it compares major versions directly, and `IsValidReleaseVersion` rejects 5.x releases when bounds are expressed in 4.x.

This PR adds `normalizeToV4`/`denormalizeFromV4` helpers that map 5.x → 4.(23+x) before comparison and back for error messages. Both `ValidateVersionSkew` and `IsValidReleaseVersion` now use normalization so the n-3 skew policy and release bounds work correctly across the 4.x/5.x boundary.

## Which issue(s) this PR fixes:

Fixes https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/77738/rehearse-77738-pull-ci-openshift-hypershift-main-e2e-aws/2043772424360562688

`TestNodePoolPrevReleaseN1` fails with:
```
SupportedVersionSkew=True, got SupportedVersionSkew=False: UnsupportedSkew(NodePool major version 4 must match HostedCluster major version 5)
```

## Special notes for your reviewer:

- `normalizeToV4` maps 5.x → 4.(23+x); `denormalizeFromV4` converts back for error messages
- The `v5MinorOffset` constant (23) encodes the 5.0 == 4.23 mapping
- `IsValidReleaseVersion` is also normalized to handle 5.x release images against 4.x bounds

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Version validation now normalizes certain 5.x releases into 4.x equivalents for range and skew checks, relaxes strict major-mismatch rejection between HostedCluster and NodePool, and yields clearer, more specific version-compare and "latest supported" messages; validations also handle absent/current-version cases more consistently.

* **Tests**
  * Added and expanded tests for normalization/denormalization, cross-major and patch/pre-release scenarios; updated assertions and expected error-message text to match clarified messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->