### PR TITLE
NO-JIRA: fix(e2e): handle uint64 underflow in karpenter version computation for 5.x

### DIFF
--- a/support/supportedversion/version.go
+++ b/support/supportedversion/version.go
@@ -416,6 +416,21 @@ func denormalizeFromV4(minor uint64) (major, displayMinor uint64) {
 	return 4, minor
 }
 
+// PreviousMinorVersion returns the OpenShift version that is n minor releases
+// before v, correctly handling the 5.0 == 4.23 version bridge.
+// For example, PreviousMinorVersion(5.0.0, 2) returns (4, 21).
+func PreviousMinorVersion(v semver.Version, n uint64) (major, minor uint64, err error) {
+	normalized, err := normalizeToV4(v)
+	if err != nil {
+		return 0, 0, err
+	}
+	if normalized.Minor < n {
+		return 0, 0, fmt.Errorf("cannot go back %d minor versions from %s (normalized minor %d)", n, v, normalized.Minor)
+	}
+	major, minor = denormalizeFromV4(normalized.Minor - n)
+	return major, minor, nil
+}
+
 // ValidateVersionSkew validates the version skew between HostedCluster and NodePool versions.
 // Returns nil if the version skew is supported, otherwise returns a descriptive error.
 // All 4.y versions support n-3 version skew (e.g., 4.18 HostedCluster supports NodePools running 4.17, 4.16, and 4.15).

--- a/support/supportedversion/version_test.go
+++ b/support/supportedversion/version_test.go
@@ -582,6 +582,78 @@ func TestDenormalizeFromV4(t *testing.T) {
 	}
 }
 
+func TestPreviousMinorVersion(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name          string
+		version       semver.Version
+		n             uint64
+		expectedMajor uint64
+		expectedMinor uint64
+		expectError   bool
+		errSubstr     string
+	}{
+		{
+			name:          "When subtracting within 4.x, it should return the correct 4.x version",
+			version:       semver.MustParse("4.20.0"),
+			n:             2,
+			expectedMajor: 4,
+			expectedMinor: 18,
+		},
+		{
+			name:          "When crossing the 5.x to 4.x bridge, it should denormalize correctly",
+			version:       semver.MustParse("5.0.0"),
+			n:             2,
+			expectedMajor: 4,
+			expectedMinor: 21,
+		},
+		{
+			name:          "When staying within 5.x, it should return the correct 5.x version",
+			version:       semver.MustParse("5.2.0"),
+			n:             1,
+			expectedMajor: 5,
+			expectedMinor: 1,
+		},
+		{
+			name:          "When n is 0, it should return the same version",
+			version:       semver.MustParse("4.18.0"),
+			n:             0,
+			expectedMajor: 4,
+			expectedMinor: 18,
+		},
+		{
+			name:        "When n exceeds the normalized minor, it should return an underflow error",
+			version:     semver.MustParse("4.1.0"),
+			n:           5,
+			expectError: true,
+			errSubstr:   "cannot go back",
+		},
+		{
+			name:        "When major version is unsupported, it should return a normalization error",
+			version:     semver.MustParse("6.0.0"),
+			n:           1,
+			expectError: true,
+			errSubstr:   "unsupported major version",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			major, minor, err := PreviousMinorVersion(tc.version, tc.n)
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tc.errSubstr))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(major).To(Equal(tc.expectedMajor))
+				g.Expect(minor).To(Equal(tc.expectedMinor))
+			}
+		})
+	}
+}
+
 func TestValidateVersionSkew(t *testing.T) {
 	t.Parallel()
 	v := func(str string) *semver.Version {

--- a/test/e2e/karpenter_test.go
+++ b/test/e2e/karpenter_test.go
@@ -26,6 +26,7 @@ import (
 	karpenterassets "github.com/openshift/hypershift/karpenter-operator/controllers/karpenter/assets"
 	karpenterutil "github.com/openshift/hypershift/support/karpenter"
 	"github.com/openshift/hypershift/support/releaseinfo"
+	"github.com/openshift/hypershift/support/supportedversion"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	dto "github.com/prometheus/client_model/go"
 	appsv1 "k8s.io/api/apps/v1"
@@ -209,7 +210,7 @@ func testARM64Provisioning(ctx context.Context, guestClient crclient.Client, hos
 
 		armNodeLabels := map[string]string{
 			karpenterv1.NodePoolLabelKey: armNodePool.Name,
-			"kubernetes.io/arch":    "arm64",
+			"kubernetes.io/arch":         "arm64",
 		}
 
 		nodes := e2eutil.WaitForReadyNodesByLabels(t, ctx, guestClient, hostedCluster.Spec.Platform.Type, 1, armNodeLabels)
@@ -378,10 +379,12 @@ func testNodeClassVersionField(ctx context.Context, mgtClient, guestClient crcli
 		)
 		t.Log("Default OpenshiftEC2NodeClass has correct version status")
 
-		// Use previous minor version (e.g., 4.21.0 for CP 4.22.x) to test a genuinely different version.
-		nodeClassVersion := fmt.Sprintf("%d.%d.0", cpVersion.Major, cpVersion.Minor-1)
+		// Use a previous minor version (n-2) to test a genuinely different version.
+		prevMajor, prevMinor, err := supportedversion.PreviousMinorVersion(cpVersion, 2)
+		g.Expect(err).NotTo(HaveOccurred())
+		nodeClassVersion := fmt.Sprintf("%d.%d.0", prevMajor, prevMinor)
 
-		// Create a custom OpenshiftEC2NodeClass with the version field set to the previous minor.
+		// Create a custom OpenshiftEC2NodeClass with the version field set to the n-2 previous minor version.
 		nc := &hyperkarpenterv1.OpenshiftEC2NodeClass{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "version-test",
@@ -568,12 +571,14 @@ func testNodeClassVersionField(ctx context.Context, mgtClient, guestClient crcli
 		g.Expect(guestClient.Delete(ctx, testNodePool)).To(Succeed())
 
 		// Verify that a version exceeding the allowed n-3 skew sets SupportedVersionSkew=False.
-		skewMinor := cpVersion.Minor - 4
-		if skewMinor <= 14 {
-			t.Logf("Skipping version-skew check: computed skew version 4.%d.0 would be at or below MinSupportedVersion (4.14.0)", skewMinor)
+		skewMajor, skewMinor, err := supportedversion.PreviousMinorVersion(cpVersion, 4)
+		if err != nil {
+			t.Fatalf("Cannot compute n-4 skew version: %v", err)
+		} else if skewMajor == 4 && skewMinor <= 14 {
+			t.Skipf("Skipping version-skew check: computed skew version %d.%d.0 would be at or below MinSupportedVersion (4.14.0)", skewMajor, skewMinor)
 		} else {
 			skewPatch := 1 // There are cases where x.y.0 doesn't exist, so arbitrarily stick with x.y.1 for test consistency
-			skewVersion := fmt.Sprintf("%d.%d.%d", cpVersion.Major, skewMinor, skewPatch)
+			skewVersion := fmt.Sprintf("%d.%d.%d", skewMajor, skewMinor, skewPatch)
 
 			skewNC := &hyperkarpenterv1.OpenshiftEC2NodeClass{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## What this PR does / why we need it:

Add PreviousMinorVersion to the supportedversion package, reusing the existing normalizeToV4/denormalizeFromV4 helpers to safely compute previous minor versions across the 5.0 == 4.23 bridge. This fixes a uint64 underflow when the CI release stream uses 5.0.x (minor=0), where cpVersion.Minor-1 wraps to MaxUint64.

Also makes the test use n-2 since we could be at a branching date, and (e.g., 5.0 n-1 == 4.22) which is not in stable or fast channel yet.

## Which issue(s) this PR fixes:
Fixes None

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved provisioning tests to compute previous-minor Kubernetes versions, tighten version-skew checks with error-aware skipping/failing, and broaden node-class version scenarios.
  * Added unit tests covering previous-minor computation across normal, boundary and error cases.
* **Chores**
  * Introduced a reusable helper for previous-minor version calculations and applied minor formatting/spacing cleanups in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->