### PR TITLE
CNTRLPLANE-3065: docs: add Agentic Software Development Life Cycle page

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -9,3 +9,4 @@ userA
 ser
 MIs
 AfterAll
+SME

--- a/docs/content/how-to/agentic-sdlc.md
+++ b/docs/content/how-to/agentic-sdlc.md
@@ -1,0 +1,273 @@
+---
+title: Agentic Software Development Life Cycle
+---
+
+# Agentic Software Development Life Cycle
+
+The HyperShift team operates an **Agentic Software Development Life Cycle (ASDLC)**. A framework that decouples distributed consumption of reusable agentic building blocks (skills, slash commands, sub-agents, knowledge bases) from the systems that orchestrate agent execution and LLM inference at scale.
+
+This separation enables flexible implementation choices: the same building blocks power local Claude Code (or other agents) sessions that can run on a developer's laptop, centralized Prow CI jobs, ambient agents, long-running cluster workloads, etc.
+
+```mermaid
+graph TB
+    subgraph "Building Blocks Layer"
+        direction LR
+        SK["Skills & Slash Commands — /jira:solve, /code-review:pr, ..."]
+        AG["Sub-agents — HCP SMEs, Explore, Plan"]
+        KB["Knowledge Bases — CLAUDE.md, AGENTS.md, Rules"]
+        HK["Hooks & Plugins — Pre-commit, CI integration"]
+    end
+
+    subgraph "Orchestration / Execution Layer"
+        subgraph Local["Local (Dev Laptop)"]
+            direction LR
+            L_CC["Claude Code CLI"]
+            L_BM["Bot Minter"]
+        end
+        subgraph Centralized["Centralized (Shared Infra)"]
+            direction LR
+            C_PJ["Prow Jobs"]
+            C_AM["Ambient"]
+        end
+    end
+
+    SK --> Local
+    AG --> Local
+    KB --> Local
+    HK --> Local
+    SK --> Centralized
+    AG --> Centralized
+    KB --> Centralized
+    HK --> Centralized
+
+    style SK fill:#e8f4fd,stroke:#1a73e8
+    style AG fill:#e8f4fd,stroke:#1a73e8
+    style KB fill:#e8f4fd,stroke:#1a73e8
+    style HK fill:#e8f4fd,stroke:#1a73e8
+    style L_CC fill:#fce8e6,stroke:#d93025
+    style L_BM fill:#fce8e6,stroke:#d93025
+    style C_PJ fill:#fce8e6,stroke:#d93025
+    style C_AM fill:#fce8e6,stroke:#d93025
+```
+
+
+
+---
+
+## Phases of ASDLC
+
+### Phase 1 — Discovery
+
+The discovery phase focuses on understanding the problem space, designing the solution, and refining scope into actionable work items.
+
+```mermaid
+flowchart LR
+    subgraph "Architecture Design"
+        A1["Interactive Claude session: discuss design and implementation"] --> A2["HCP SME sub-agents: cloud-provider, control-plane, data-plane, api, architect"]
+        A2 --> A3["Create RFC or enhancement proposal"]
+    end
+
+    subgraph "Scope Refinement"
+        B1["/jira:create — Create Jira issues"] --> B2["/jira:generate-test-plan — Generate test plan from Jira"]
+        B1 --> B3["/utils:generate-test-plan — Generate test plan from PRs"]
+        B1 --> B4["Obra superpowers"]
+    end
+
+    A3 --> B1
+```
+
+
+
+#### Architecture Design
+
+
+| Activity          | Building Block                                 | Description                                                                                                              |
+| ----------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Design discussion | Claude Code / Other Agents interactive session | Discuss design and implementation plans with Agents in a conversational session                                          |
+| Domain expertise  | HCP SME sub-agents                             | Leverage specialized agents: `cloud-provider-sme`, `control-plane-sme`, `data-plane-sme`, `api-sme`, `hcp-architect-sme` |
+| Proposal creation | RFC / Enhancement                              | Create a formal enhancement or RFC document capturing the agreed design                                                  |
+
+
+#### Scope Refinement
+
+
+| Activity             | Building Block              | Description                                                      |
+| -------------------- | --------------------------- | ---------------------------------------------------------------- |
+| Issue creation       | `/jira:create`              | Create well-structured Jira issues (stories, bugs, tasks, epics) |
+| Test planning (Jira) | `/jira:generate-test-plan`  | Generate test steps from a Jira issue                            |
+| Test planning (PRs)  | `/utils:generate-test-plan` | Generate test steps for one or more related PRs                  |
+
+
+---
+
+### Phase 2 — Delivery
+
+The delivery phase covers implementation, review, and quality assurance — each supported by agentic workflows.
+
+```mermaid
+flowchart LR
+    subgraph "Implementation"
+        C1["/jira:solve"]
+        C2["Bot minter"]
+    end
+
+    subgraph "Code Review"
+        D1["CodeRabbit — automated review"] --> D3["Address feedback"]
+        D2["/code-review:pr — /code-review:pre-commit-review"] --> D3
+        D3 --> D4["/utils:address-reviews"]
+    end
+
+    subgraph "QE & Testing"
+        E2["/ci:analyze-prow-job-test-failure"]
+        E3["/agentic-qe test-plan"]
+    end
+
+    C1 --> D1
+    C2 --> D1
+    D4 --> E2
+```
+
+
+
+#### Implementation
+
+
+| Activity        | Building Block | Description                                                         |
+| --------------- | -------------- | ------------------------------------------------------------------- |
+| Code generation | `/jira:solve`  | Analyze a Jira issue and create a pull request with a proposed fix  |
+| Code generation | Bot minter     | GitHub App-based agents that create and manage PRs programmatically |
+
+
+#### Code Review
+
+
+| Activity          | Building Block                      | Description                                           |
+| ----------------- | ----------------------------------- | ----------------------------------------------------- |
+| Automated review  | [CodeRabbit](https://coderabbit.ai) | AI-powered code review bot running on every PR        |
+| On-demand review  | `/code-review:pr`                   | Trigger a full PR review with language-aware analysis |
+| Pre-commit review | `/code-review:pre-commit-review`    | Review staged changes before committing               |
+| Address feedback  | `/utils:address-reviews`            | Automatically address PR review comments              |
+
+
+#### QE & Testing
+
+
+| Activity                | Building Block                      | Description                                                     |
+| ----------------------- | ----------------------------------- | --------------------------------------------------------------- |
+| CI failure analysis     | `/ci:analyze-prow-job-test-failure` | Analyze test failures from Prow CI job artifacts                |
+| Agentic QE              | `/agentic-qe test-plan`             | Execute test plans with agentic workflows                       |
+| Presubmit auto-analysis | Prow presubmits                     | CI jobs automatically trigger failure analysis on test failures |
+
+
+---
+
+## Modes of Agentic Workflows
+
+A mode describes where/how execution happens. Building blocks can be executed in different modes depending on the use case:
+
+```mermaid
+graph LR
+    subgraph "Local"
+        L1["Developer laptop — Claude Code CLI"]
+    end
+
+    subgraph "Centralized"
+        P1["Prow periodic jobs"]
+        P2["Prow presubmit jobs"]
+        AM1["Ambient agents"]
+        LR1["Long-running agents — prebuilt binaries as cluster workloads"]
+    end
+
+    L1 -.- BB["Shared — Building Blocks"]
+    P1 -.- BB
+    P2 -.- BB
+    AM1 -.- BB
+    LR1 -.- BB
+
+    style BB fill:#e8f5e9,stroke:#34a853
+```
+
+
+
+### Local
+
+Building blocks executed by developers on their laptops using Claude Code CLI, Bot-Minter, others... This is the most interactive mode where removing ambiguity might need several iterations. Ideal for design discussions, exploratory work, and ad-hoc tasks.
+
+Before publishing a code artifact for human review, developers are expected to levereage building blocks for local code review and agentic qe
+
+### Centralized
+
+Building blocks run and driven by central infrastructure tools. These run on schedule, in response to events, or continuously as cluster workloads: Prow Jobs, Ambient, Cluster workloads... Ideal for repetitive tasks or concise work items.
+
+#### Hands-off Delivery
+
+```mermaid
+flowchart TD
+    A["Jira item labeled with issue-for-agent"] --> B["Periodic Job picks from backlog"]
+    B --> C["Agent generates code, reviews, addresses and creates PR"]
+    C --> D["Agent review on published PR"]
+    D --> E["Human review"]
+    E --> F["/address-pr-review"]
+    F --> E
+    E --> G["Human lgtm"]
+    G --> H["/agentic-qe"]
+    H --> I["Presubmit e2e runs"]
+    I --> J["Auto-analysis on failures"]
+    J -->|"Failures found"| F
+    I -->|"Pass"| K["Merge"]
+```
+
+
+
+For details on the current centralized jobs, see [AI-Assisted CI Jobs](https://hypershift.pages.dev/how-to/ci/ai-assisted-ci-jobs/).
+
+---
+
+## Monitoring
+
+### Dashboards
+
+[Agent execution metrics, token usage, and cost tracking](https://dashboard-jira-agent-dashboard.apps.jira-agent-scraper.brcox.hypershift.devcluster.openshift.com/)
+
+### Slack Integration
+
+
+| Channel               | Purpose                                         |
+| --------------------- | ----------------------------------------------- |
+| `@ship-help`          | AI-assisted triage and routing of help requests |
+| `#project-hypershift` | General team channel                            |
+
+
+Building blocks integrate with Slack for notifications, status updates, and interactive assistance.
+
+---
+
+## Principles
+
+- **Reuse drives self-improvement** — Every execution of a building block generates signal (successes, failures, review feedback) that feeds back into refining the building blocks themselves.
+- **Raise the quality floor** — Agentic workflows must enforce consistent code patterns, code review, test generation, and CI analysis on every change, raising the baseline quality across all contributions.
+- **Compounding returns** — Better building block specifications produce better output, which produces better input data for the next iteration. The system improves itself over time.
+
+---
+
+## Getting Started
+
+=== "For developers"
+
+    1. Install [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code/getting-started)
+    2. Clone the HyperShift repository
+    3. Install plugins:
+
+    ```bash
+    /plugin marketplace add openshift-eng/ai-helpers
+    /plugin install jira@ai-helpers
+    /plugin install utils@ai-helpers
+    /plugin install ci@ai-helpers
+    /plugin install code-review@ai-helpers
+    ```
+
+=== "For CI integration"
+
+    1. See [AI-Assisted CI Jobs](https://hypershift.pages.dev/how-to/ci/ai-assisted-ci-jobs/) for existing Prow job setup
+    2. Label Jira issues with `issue-for-agent` to submit them for processing
+

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -3181,6 +3181,285 @@ In order for Cilium connectivity test pods to run on OpenShift, a simple custom 
 
 ---
 
+## Source: docs/content/how-to/agentic-sdlc.md
+
+---
+title: Agentic Software Development Life Cycle
+---
+
+# Agentic Software Development Life Cycle
+
+The HyperShift team operates an **Agentic Software Development Life Cycle (ASDLC)**. A framework that decouples distributed consumption of reusable agentic building blocks (skills, slash commands, sub-agents, knowledge bases) from the systems that orchestrate agent execution and LLM inference at scale.
+
+This separation enables flexible implementation choices: the same building blocks power local Claude Code (or other agents) sessions that can run on a developer's laptop, centralized Prow CI jobs, ambient agents, long-running cluster workloads, etc.
+
+```mermaid
+graph TB
+    subgraph "Building Blocks Layer"
+        direction LR
+        SK["Skills & Slash Commands — /jira:solve, /code-review:pr, ..."]
+        AG["Sub-agents — HCP SMEs, Explore, Plan"]
+        KB["Knowledge Bases — CLAUDE.md, AGENTS.md, Rules"]
+        HK["Hooks & Plugins — Pre-commit, CI integration"]
+    end
+
+    subgraph "Orchestration / Execution Layer"
+        subgraph Local["Local (Dev Laptop)"]
+            direction LR
+            L_CC["Claude Code CLI"]
+            L_BM["Bot Minter"]
+        end
+        subgraph Centralized["Centralized (Shared Infra)"]
+            direction LR
+            C_PJ["Prow Jobs"]
+            C_AM["Ambient"]
+        end
+    end
+
+    SK --> Local
+    AG --> Local
+    KB --> Local
+    HK --> Local
+    SK --> Centralized
+    AG --> Centralized
+    KB --> Centralized
+    HK --> Centralized
+
+    style SK fill:#e8f4fd,stroke:#1a73e8
+    style AG fill:#e8f4fd,stroke:#1a73e8
+    style KB fill:#e8f4fd,stroke:#1a73e8
+    style HK fill:#e8f4fd,stroke:#1a73e8
+    style L_CC fill:#fce8e6,stroke:#d93025
+    style L_BM fill:#fce8e6,stroke:#d93025
+    style C_PJ fill:#fce8e6,stroke:#d93025
+    style C_AM fill:#fce8e6,stroke:#d93025
+```
+
+
+
+---
+
+## Phases of ASDLC
+
+### Phase 1 — Discovery
+
+The discovery phase focuses on understanding the problem space, designing the solution, and refining scope into actionable work items.
+
+```mermaid
+flowchart LR
+    subgraph "Architecture Design"
+        A1["Interactive Claude session: discuss design and implementation"] --> A2["HCP SME sub-agents: cloud-provider, control-plane, data-plane, api, architect"]
+        A2 --> A3["Create RFC or enhancement proposal"]
+    end
+
+    subgraph "Scope Refinement"
+        B1["/jira:create — Create Jira issues"] --> B2["/jira:generate-test-plan — Generate test plan from Jira"]
+        B1 --> B3["/utils:generate-test-plan — Generate test plan from PRs"]
+        B1 --> B4["Obra superpowers"]
+    end
+
+    A3 --> B1
+```
+
+
+
+#### Architecture Design
+
+
+| Activity          | Building Block                                 | Description                                                                                                              |
+| ----------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Design discussion | Claude Code / Other Agents interactive session | Discuss design and implementation plans with Agents in a conversational session                                          |
+| Domain expertise  | HCP SME sub-agents                             | Leverage specialized agents: `cloud-provider-sme`, `control-plane-sme`, `data-plane-sme`, `api-sme`, `hcp-architect-sme` |
+| Proposal creation | RFC / Enhancement                              | Create a formal enhancement or RFC document capturing the agreed design                                                  |
+
+
+#### Scope Refinement
+
+
+| Activity             | Building Block              | Description                                                      |
+| -------------------- | --------------------------- | ---------------------------------------------------------------- |
+| Issue creation       | `/jira:create`              | Create well-structured Jira issues (stories, bugs, tasks, epics) |
+| Test planning (Jira) | `/jira:generate-test-plan`  | Generate test steps from a Jira issue                            |
+| Test planning (PRs)  | `/utils:generate-test-plan` | Generate test steps for one or more related PRs                  |
+
+
+---
+
+### Phase 2 — Delivery
+
+The delivery phase covers implementation, review, and quality assurance — each supported by agentic workflows.
+
+```mermaid
+flowchart LR
+    subgraph "Implementation"
+        C1["/jira:solve"]
+        C2["Bot minter"]
+    end
+
+    subgraph "Code Review"
+        D1["CodeRabbit — automated review"] --> D3["Address feedback"]
+        D2["/code-review:pr — /code-review:pre-commit-review"] --> D3
+        D3 --> D4["/utils:address-reviews"]
+    end
+
+    subgraph "QE & Testing"
+        E2["/ci:analyze-prow-job-test-failure"]
+        E3["/agentic-qe test-plan"]
+    end
+
+    C1 --> D1
+    C2 --> D1
+    D4 --> E2
+```
+
+
+
+#### Implementation
+
+
+| Activity        | Building Block | Description                                                         |
+| --------------- | -------------- | ------------------------------------------------------------------- |
+| Code generation | `/jira:solve`  | Analyze a Jira issue and create a pull request with a proposed fix  |
+| Code generation | Bot minter     | GitHub App-based agents that create and manage PRs programmatically |
+
+
+#### Code Review
+
+
+| Activity          | Building Block                      | Description                                           |
+| ----------------- | ----------------------------------- | ----------------------------------------------------- |
+| Automated review  | CodeRabbit | AI-powered code review bot running on every PR        |
+| On-demand review  | `/code-review:pr`                   | Trigger a full PR review with language-aware analysis |
+| Pre-commit review | `/code-review:pre-commit-review`    | Review staged changes before committing               |
+| Address feedback  | `/utils:address-reviews`            | Automatically address PR review comments              |
+
+
+#### QE & Testing
+
+
+| Activity                | Building Block                      | Description                                                     |
+| ----------------------- | ----------------------------------- | --------------------------------------------------------------- |
+| CI failure analysis     | `/ci:analyze-prow-job-test-failure` | Analyze test failures from Prow CI job artifacts                |
+| Agentic QE              | `/agentic-qe test-plan`             | Execute test plans with agentic workflows                       |
+| Presubmit auto-analysis | Prow presubmits                     | CI jobs automatically trigger failure analysis on test failures |
+
+
+---
+
+## Modes of Agentic Workflows
+
+A mode describes where/how execution happens. Building blocks can be executed in different modes depending on the use case:
+
+```mermaid
+graph LR
+    subgraph "Local"
+        L1["Developer laptop — Claude Code CLI"]
+    end
+
+    subgraph "Centralized"
+        P1["Prow periodic jobs"]
+        P2["Prow presubmit jobs"]
+        AM1["Ambient agents"]
+        LR1["Long-running agents — prebuilt binaries as cluster workloads"]
+    end
+
+    L1 -.- BB["Shared — Building Blocks"]
+    P1 -.- BB
+    P2 -.- BB
+    AM1 -.- BB
+    LR1 -.- BB
+
+    style BB fill:#e8f5e9,stroke:#34a853
+```
+
+
+
+### Local
+
+Building blocks executed by developers on their laptops using Claude Code CLI, Bot-Minter, others... This is the most interactive mode where removing ambiguity might need several iterations. Ideal for design discussions, exploratory work, and ad-hoc tasks.
+
+Before publishing a code artifact for human review, developers are expected to levereage building blocks for local code review and agentic qe
+
+### Centralized
+
+Building blocks run and driven by central infrastructure tools. These run on schedule, in response to events, or continuously as cluster workloads: Prow Jobs, Ambient, Cluster workloads... Ideal for repetitive tasks or concise work items.
+
+#### Hands-off Delivery
+
+```mermaid
+flowchart TD
+    A["Jira item labeled with issue-for-agent"] --> B["Periodic Job picks from backlog"]
+    B --> C["Agent generates code, reviews, addresses and creates PR"]
+    C --> D["Agent review on published PR"]
+    D --> E["Human review"]
+    E --> F["/address-pr-review"]
+    F --> E
+    E --> G["Human lgtm"]
+    G --> H["/agentic-qe"]
+    H --> I["Presubmit e2e runs"]
+    I --> J["Auto-analysis on failures"]
+    J -->|"Failures found"| F
+    I -->|"Pass"| K["Merge"]
+```
+
+
+
+For details on the current centralized jobs, see AI-Assisted CI Jobs.
+
+---
+
+## Monitoring
+
+### Dashboards
+
+Agent execution metrics, token usage, and cost tracking
+
+### Slack Integration
+
+
+| Channel               | Purpose                                         |
+| --------------------- | ----------------------------------------------- |
+| `@ship-help`          | AI-assisted triage and routing of help requests |
+| `#project-hypershift` | General team channel                            |
+
+
+Building blocks integrate with Slack for notifications, status updates, and interactive assistance.
+
+---
+
+## Principles
+
+- **Reuse drives self-improvement** — Every execution of a building block generates signal (successes, failures, review feedback) that feeds back into refining the building blocks themselves.
+- **Raise the quality floor** — Agentic workflows must enforce consistent code patterns, code review, test generation, and CI analysis on every change, raising the baseline quality across all contributions.
+- **Compounding returns** — Better building block specifications produce better output, which produces better input data for the next iteration. The system improves itself over time.
+
+---
+
+## Getting Started
+
+=== "For developers"
+
+    1. Install Claude Code CLI
+    2. Clone the HyperShift repository
+    3. Install plugins:
+
+    ```bash
+    /plugin marketplace add openshift-eng/ai-helpers
+    /plugin install jira@ai-helpers
+    /plugin install utils@ai-helpers
+    /plugin install ci@ai-helpers
+    /plugin install code-review@ai-helpers
+    ```
+
+=== "For CI integration"
+
+    1. See AI-Assisted CI Jobs for existing Prow job setup
+    2. Label Jira issues with `issue-for-agent` to submit them for processing
+
+
+
+---
+
 ## Source: docs/content/how-to/audit-log-persistence.md
 
 # Audit Log Persistence

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
     - how-to/common/exposing-services-from-hcp.md
     - how-to/common/multi-arch-on-hcp.md
     - 'Global Pull Secret': how-to/common/global-pull-secret.md
+  - 'Agentic SDLC': how-to/agentic-sdlc.md
   - 'CI':
     - how-to/ci/checking-ci.md
     - how-to/ci/ci-infrastructure.md


### PR DESCRIPTION
## Summary
- Adds a new how-to page documenting the HyperShift team's Agentic Software Development Life Cycle (ASDLC) framework
- Covers building blocks layer, orchestration/execution modes (local vs centralized), discovery and delivery phases, autonomous delivery workflow, monitoring, and principles
- Adds the page to mkdocs navigation under How-to guides

## Test plan
- [ ] Verify docs build: `cd docs && mkdocs build`
- [ ] Preview rendered page at the docs preview URL from the CI job
- [ ] Verify all Mermaid diagrams render correctly
- [ ] Verify internal and external links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new guide describing HyperShift's Agentic SDLC: layered architecture, discovery and delivery phases, hands-off delivery lifecycle, execution modes, monitoring, principles, and developer/CI getting-started steps.
* **Chores**
  * Added navigation entry for the new guide.
  * Updated spell-ignore configuration to skip the token SME.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->