### PR TITLE
OCPBUGS-77529: clean stale mock files before make generate function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,8 +169,10 @@ $(MOCKGEN): ${TOOLS_DIR}/go.mod
 	cd $(TOOLS_DIR); $(GO) build -tags=tools -o $(BIN_DIR)/mockgen go.uber.org/mock/mockgen
 
 
-#.PHONY: generate
+.PHONY: generate
 generate: $(MOCKGEN)
+	@echo "Cleaning stale mock files..."
+	git clean -fx -- '*_mock.go'
 	$(GO) generate ./...
 
 # Compile all tests


### PR DESCRIPTION

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:
This PR Deletes all *_mock.go files before running go generate to prevent issues when switching branches with different interface definitions.

Mock files are gitignored and can persist across branch switches, causing compilation errors if interfaces have changed between branches.


## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
 Fixes  : https://redhat.atlassian.net/browse/OCPBUGS-77529

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build process enhancement: the generation step now pre-cleans stale generated mock files before running, reducing leftover artifacts and improving reliability of code generation and builds.
  * Build metadata tweak: the generation target is explicitly marked as phony to ensure consistent invocation and avoid accidental skips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->