### PR TITLE
OCPBUGS-83410: fix, cno, skip cloud-network-config-controller check on non-cloud platforms

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cno/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cno/component.go
@@ -109,6 +109,20 @@ type operand struct {
 	ReleaseImageKey string
 }
 
+// platformHasCloudNetworkConfigController returns true for platforms where the
+// cluster-network-operator deploys a cloud-network-config-controller.
+// This controller manages cloud-specific network configurations (e.g. EgressIP)
+// and requires cloud API credentials. Non-cloud platforms (KubeVirt, Agent, etc.)
+// do not have this deployment.
+func platformHasCloudNetworkConfigController(platformType hyperv1.PlatformType) bool {
+	switch platformType {
+	case hyperv1.AWSPlatform, hyperv1.AzurePlatform, hyperv1.GCPPlatform, hyperv1.OpenStackPlatform:
+		return true
+	default:
+		return false
+	}
+}
+
 func checkOperandsRolloutStatus(cpContext component.WorkloadContext) (bool, error) {
 	var operandsDeploymentsList []operand
 
@@ -125,11 +139,17 @@ func checkOperandsRolloutStatus(cpContext component.WorkloadContext) (bool, erro
 				ContainerName:   "approver",
 				ReleaseImageKey: "ovn-kubernetes",
 			},
-			{
+		}
+
+		// cloud-network-config-controller is only deployed by CNO on cloud platforms
+		// that have cloud APIs for network management (AWS, Azure, GCP, OpenStack).
+		// Non-cloud platforms like KubeVirt, Agent, None, etc. do not have this deployment.
+		if platformHasCloudNetworkConfigController(cpContext.HCP.Spec.Platform.Type) {
+			operandsDeploymentsList = append(operandsDeploymentsList, operand{
 				DeploymentName:  "cloud-network-config-controller",
 				ContainerName:   "controller",
 				ReleaseImageKey: "cloud-network-config-controller",
-			},
+			})
 		}
 	}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cno/component_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cno/component_test.go
@@ -1,0 +1,71 @@
+package cno
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+)
+
+func TestPlatformHasCloudNetworkConfigController(t *testing.T) {
+	tests := []struct {
+		name         string
+		platformType hyperv1.PlatformType
+		expected     bool
+	}{
+		{
+			name:         "When platform is AWS it should have cloud-network-config-controller",
+			platformType: hyperv1.AWSPlatform,
+			expected:     true,
+		},
+		{
+			name:         "When platform is Azure it should have cloud-network-config-controller",
+			platformType: hyperv1.AzurePlatform,
+			expected:     true,
+		},
+		{
+			name:         "When platform is GCP it should have cloud-network-config-controller",
+			platformType: hyperv1.GCPPlatform,
+			expected:     true,
+		},
+		{
+			name:         "When platform is OpenStack it should have cloud-network-config-controller",
+			platformType: hyperv1.OpenStackPlatform,
+			expected:     true,
+		},
+		{
+			name:         "When platform is KubeVirt it should not have cloud-network-config-controller",
+			platformType: hyperv1.KubevirtPlatform,
+			expected:     false,
+		},
+		{
+			name:         "When platform is Agent it should not have cloud-network-config-controller",
+			platformType: hyperv1.AgentPlatform,
+			expected:     false,
+		},
+		{
+			name:         "When platform is None it should not have cloud-network-config-controller",
+			platformType: hyperv1.NonePlatform,
+			expected:     false,
+		},
+		{
+			name:         "When platform is IBMCloud it should not have cloud-network-config-controller",
+			platformType: hyperv1.IBMCloudPlatform,
+			expected:     false,
+		},
+		{
+			name:         "When platform is PowerVS it should not have cloud-network-config-controller",
+			platformType: hyperv1.PowerVSPlatform,
+			expected:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result := platformHasCloudNetworkConfigController(tt.platformType)
+			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it:

The `checkOperandsRolloutStatus` function in the CNO ControlPlaneComponent unconditionally expects the `cloud-network-config-controller` deployment to exist when `NetworkType` is `OVNKubernetes`. However, this deployment is only created by CNO on cloud platforms (AWS, Azure, GCP, OpenStack) that have cloud APIs for network management.

On non-cloud platforms like **KubeVirt**, Agent, None, IBMCloud, and PowerVS, CNO never creates this deployment. This causes the CNO ControlPlaneComponent's `RolloutComplete` condition to be permanently `False` with reason `WaitingForOperands`:

```
status:
  conditions:
  - type: RolloutComplete
    status: "False"
    reason: WaitingForOperands
    message: 'failed to get deployment cloud-network-config-controller:
              Deployment.apps "cloud-network-config-controller" not found'
```

This blocks `controlPlaneVersion` from reaching `Completed`, causing all e2e tests to time out on KubeVirt (and potentially other non-cloud platforms).

This PR adds a platform check so `cloud-network-config-controller` is only expected on platforms that actually deploy it (AWS, Azure, GCP, OpenStack).

## Which issue(s) this PR fixes:

Fixes KubeVirt e2e test failures caused by `controlPlaneVersion` stuck at `Partial` — see [openshift/cluster-api-provider-kubevirt#415](https://github.com/openshift/cluster-api-provider-kubevirt/pull/415) and [prow job](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-api-provider-kubevirt/415/pull-ci-openshift-cluster-api-provider-kubevirt-main-e2e-hypershift-kubevirt/2042132391526404096).

## Special notes for your reviewer:

The bug was introduced in 59c5143166 ("feat: monitor operands rollout status for cno, storage and snapshotcontroller"). A later fix (1f4b7c931b) addressed the `NetworkType == Other` case but missed the platform dimension.

The `cloud-network-config-controller` manages cloud-specific network configurations (e.g. EgressIP association/disassociation via cloud APIs). Platforms without cloud APIs simply don't have this deployment — CNO itself decides not to create it based on the infrastructure platform type.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud network configuration controller is now enabled only on supported cloud platforms (AWS, Azure, GCP, OpenStack), preventing activation and rollout checks on unsupported platforms.

* **Tests**
  * Added unit tests validating the controller is active on supported platforms and inactive on others, increasing confidence in platform-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->