### PR TITLE
CNTRLPLANE-3203: Add autoscaling documentation for self-managed Azure

### DIFF
--- a/docs/content/how-to/autoscaling.md
+++ b/docs/content/how-to/autoscaling.md
@@ -1,0 +1,153 @@
+# Autoscaling
+
+This guide covers configuring node pool and cluster autoscaling for HostedClusters. Autoscaling automatically adjusts the number of worker nodes based on workload demands.
+
+## Node Pool Autoscaling
+
+Node pool autoscaling enables individual NodePools to automatically scale between a minimum and maximum number of nodes based on pending pod resource requests.
+
+### Enable Autoscaling on a NodePool
+
+To enable autoscaling, set `spec.autoScaling` and remove `spec.replicas`:
+
+```bash
+oc patch nodepool -n <HOSTED_CLUSTER_NAMESPACE> <NODEPOOL_NAME> --type merge -p '{
+  "spec": {
+    "replicas": null,
+    "autoScaling": {
+      "min": 1,
+      "max": 5
+    }
+  }
+}'
+```
+
+| Field | Description |
+|-------|-------------|
+| `min` | Minimum number of nodes to maintain. Must be >= 0 and <= `max`. See note below about platform restrictions. |
+| `max` | Maximum number of nodes the autoscaler can scale to. Must be >= 1 and >= `min`. |
+
+!!! note
+    `autoScaling` and `replicas` are mutually exclusive. When enabling autoscaling, `replicas` must be set to `null`.
+
+!!! note
+    Scale-from-zero (`min: 0`) is only supported on the AWS platform. All other platforms require `min` >= 1.
+
+### Verify Autoscaling is Enabled
+
+Check the `AutoscalingEnabled` condition on the NodePool:
+
+```bash
+oc get nodepool -n <HOSTED_CLUSTER_NAMESPACE> <NODEPOOL_NAME> -o jsonpath='{.status.conditions[?(@.type=="AutoscalingEnabled")].status}'
+```
+
+The output should be `True`.
+
+### Disable Autoscaling
+
+To disable autoscaling and return to a fixed replica count:
+
+```bash
+oc patch nodepool -n <HOSTED_CLUSTER_NAMESPACE> <NODEPOOL_NAME> --type merge -p '{
+  "spec": {
+    "autoScaling": null,
+    "replicas": 2
+  }
+}'
+```
+
+## Cluster Autoscaling
+
+Cluster autoscaling configures global autoscaling behavior that applies to all NodePools in a HostedCluster. This includes scale-down policies, node group balancing, and expander strategies.
+
+### Configure Cluster Autoscaling
+
+Set `spec.autoscaling` on the HostedCluster:
+
+```bash
+oc patch hostedcluster -n <HOSTED_CLUSTER_NAMESPACE> <HOSTED_CLUSTER_NAME> --type merge -p '{
+  "spec": {
+    "autoscaling": {
+      "scaling": "ScaleUpAndScaleDown",
+      "maxNodesTotal": 10,
+      "expanders": ["LeastWaste"],
+      "scaleDown": {
+        "delayAfterAddSeconds": 300,
+        "unneededDurationSeconds": 600,
+        "utilizationThresholdPercent": 50
+      }
+    }
+  }
+}'
+```
+
+### Configuration Reference
+
+#### Scaling Behavior
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `scaling` | string | `ScaleUpAndScaleDown` | `ScaleUpOnly` or `ScaleUpAndScaleDown`. Controls whether the autoscaler can scale down nodes. |
+| `maxNodesTotal` | int | unlimited | Maximum total nodes across all NodePools. The autoscaler will not scale beyond this limit. |
+| `maxPodGracePeriod` | int | 600 | Maximum seconds to wait for graceful pod termination before scaling down. |
+| `maxNodeProvisionTime` | string | 15m | Maximum time to wait for a node to provision, in Go duration format (e.g., `15m`, `20m`). |
+| `podPriorityThreshold` | int | -10 | Pods with priority below this threshold won't trigger scale-up. |
+
+!!! note
+    Defaults listed in the configuration reference tables represent the cluster autoscaler's effective behavior when the field is omitted. The only API-enforced default is `scaling`, which defaults to `ScaleUpAndScaleDown`.
+
+#### Expanders
+
+Expanders control how the autoscaler selects which NodePool to scale when multiple NodePools can satisfy pending pods. Set via `spec.autoscaling.expanders`:
+
+| Expander | Description |
+|----------|-------------|
+| `LeastWaste` | Selects the NodePool with the least idle CPU and memory after scaling. |
+| `Priority` | Selects the NodePool with the highest user-defined priority. |
+| `Random` | Selects a NodePool randomly. |
+
+Default: `[Priority, LeastWaste]`. Up to 3 expanders can be specified in priority order.
+
+!!! note
+    The `Priority` expander uses a ConfigMap named `cluster-autoscaler-priority-expander` in the `kube-system` namespace of the guest cluster to determine NodePool priorities. The ConfigMap maps integer priorities to node group name patterns (regex). Higher values mean higher priority. See the [upstream documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/expander/priority/readme.md) for details on the ConfigMap format.
+
+#### Scale Down Configuration
+
+The `scaleDown` field is only valid when `scaling` is set to `ScaleUpAndScaleDown`:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `delayAfterAddSeconds` | int | 600 | Seconds to wait after scale-up before evaluating scale-down. |
+| `delayAfterDeleteSeconds` | int | 0 | Seconds to wait after node deletion before evaluating scale-down. |
+| `delayAfterFailureSeconds` | int | 180 | Seconds to wait after a failed scale-down before retrying. |
+| `unneededDurationSeconds` | int | 600 | How long a node must be unneeded before it is eligible for removal. |
+| `utilizationThresholdPercent` | int | 50 | Nodes with utilization below this percentage are candidates for removal. 0 means only completely idle nodes; 100 means any node can be removed. |
+
+#### Node Group Balancing
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `balancingIgnoredLabels` | []string | [] | Labels the autoscaler should ignore when comparing node groups for balancing. Platform-specific labels are added automatically. |
+| `maxFreeDifferenceRatioPercent` | int | 10 | Maximum allowed difference in free resources between node groups to be considered similar for balancing. 0 = exact match required; 100 = any difference allowed. |
+
+## How It Works
+
+1. When a pod cannot be scheduled due to insufficient resources, the cluster autoscaler identifies NodePools with autoscaling enabled that can satisfy the pod's requirements.
+2. The autoscaler selects a NodePool based on the configured expander strategy and triggers a scale-up by increasing the NodePool's replica count.
+3. HyperShift provisions new platform-specific machine instances for the NodePool and the new nodes join the guest cluster.
+4. When `scaling` is set to `ScaleUpAndScaleDown`, the autoscaler monitors node utilization. Nodes that remain underutilized (below `utilizationThresholdPercent`) for longer than `unneededDurationSeconds` are removed.
+
+## Monitoring
+
+Check the current state of autoscaling:
+
+```bash
+# View NodePool autoscaling status
+oc get nodepools -n <HOSTED_CLUSTER_NAMESPACE> -o wide
+
+# Check autoscaler deployment in the control plane namespace
+oc get deployment cluster-autoscaler -n <HOSTED_CLUSTER_NAMESPACE>-<HOSTED_CLUSTER_NAME>
+
+# View autoscaler logs
+oc logs deployment/cluster-autoscaler -n <HOSTED_CLUSTER_NAMESPACE>-<HOSTED_CLUSTER_NAME>
+```

--- a/docs/content/how-to/azure/autoscaling-self-managed.md
+++ b/docs/content/how-to/azure/autoscaling-self-managed.md
@@ -1,0 +1,68 @@
+# Autoscaling for Self-Managed Azure HostedClusters
+
+This guide covers configuring autoscaling for self-managed Azure HostedClusters. For the full autoscaling configuration reference, see the [Autoscaling](../autoscaling.md) guide.
+
+## Prerequisites
+
+- A self-managed Azure HostedCluster created following the [Create a Self-Managed Azure HostedCluster](create-self-managed-azure-cluster.md) guide
+- `oc` or `kubectl` CLI with access to the management cluster
+
+## Example: Full Autoscaling Configuration
+
+This example configures a HostedCluster with two Azure NodePools balanced by the autoscaler:
+
+```yaml
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  name: my-cluster
+  namespace: clusters
+spec:
+  autoscaling:
+    scaling: ScaleUpAndScaleDown
+    maxNodesTotal: 12
+    expanders:
+      - Random
+    scaleDown:
+      delayAfterAddSeconds: 300
+      unneededDurationSeconds: 600
+      utilizationThresholdPercent: 50
+    balancingIgnoredLabels:
+      - "custom.label/environment"
+    maxFreeDifferenceRatioPercent: 70
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: NodePool
+metadata:
+  name: my-cluster-nodepool-1
+  namespace: clusters
+spec:
+  clusterName: my-cluster
+  autoScaling:
+    min: 1
+    max: 6
+  platform:
+    azure:
+      vmSize: Standard_D4s_v3
+      # ... other required fields (image, osDisk) omitted for brevity
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: NodePool
+metadata:
+  name: my-cluster-nodepool-2
+  namespace: clusters
+spec:
+  clusterName: my-cluster
+  autoScaling:
+    min: 1
+    max: 6
+  platform:
+    azure:
+      vmSize: Standard_D4s_v3
+      # ... other required fields (image, osDisk) omitted for brevity
+```
+
+## Azure-Specific Details
+
+- HyperShift provisions individual Azure Virtual Machines via CAPZ when scaling up NodePools.
+- Scale-from-zero (`autoScaling.min: 0`) is not supported on Azure. The minimum must be >= 1.

--- a/docs/content/how-to/azure/self-managed-azure-index.md
+++ b/docs/content/how-to/azure/self-managed-azure-index.md
@@ -172,6 +172,7 @@ Begin your self-managed Azure HyperShift deployment by following the guides in o
 2. **[Setup Azure Management Cluster for HyperShift](setup-management-cluster.md)** - Install HyperShift operator (with or without External DNS)
 3. **[Create a Self-Managed Azure HostedCluster](create-self-managed-azure-cluster.md)** - Deploy your first hosted cluster
 4. **[Deploy Azure Private Clusters](deploy-azure-private-clusters.md)** (Optional) - Configure private endpoint access with Azure Private Link
+5. **[Autoscaling](autoscaling-self-managed.md)** - Configure node pool and cluster autoscaling
 
 Each guide includes sections for both DNS approaches - simply follow the sections that match your choice.
 

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -4563,6 +4563,165 @@ After these steps, you will see how the (in the AWS case) instances will be term
 
 ---
 
+## Source: docs/content/how-to/autoscaling.md
+
+# Autoscaling
+
+This guide covers configuring node pool and cluster autoscaling for HostedClusters. Autoscaling automatically adjusts the number of worker nodes based on workload demands.
+
+## Node Pool Autoscaling
+
+Node pool autoscaling enables individual NodePools to automatically scale between a minimum and maximum number of nodes based on pending pod resource requests.
+
+### Enable Autoscaling on a NodePool
+
+To enable autoscaling, set `spec.autoScaling` and remove `spec.replicas`:
+
+```bash
+oc patch nodepool -n <HOSTED_CLUSTER_NAMESPACE> <NODEPOOL_NAME> --type merge -p '{
+  "spec": {
+    "replicas": null,
+    "autoScaling": {
+      "min": 1,
+      "max": 5
+    }
+  }
+}'
+```
+
+| Field | Description |
+|-------|-------------|
+| `min` | Minimum number of nodes to maintain. Must be >= 0 and <= `max`. See note below about platform restrictions. |
+| `max` | Maximum number of nodes the autoscaler can scale to. Must be >= 1 and >= `min`. |
+
+!!! note
+    `autoScaling` and `replicas` are mutually exclusive. When enabling autoscaling, `replicas` must be set to `null`.
+
+!!! note
+    Scale-from-zero (`min: 0`) is only supported on the AWS platform. All other platforms require `min` >= 1.
+
+### Verify Autoscaling is Enabled
+
+Check the `AutoscalingEnabled` condition on the NodePool:
+
+```bash
+oc get nodepool -n <HOSTED_CLUSTER_NAMESPACE> <NODEPOOL_NAME> -o jsonpath='{.status.conditions[?(@.type=="AutoscalingEnabled")].status}'
+```
+
+The output should be `True`.
+
+### Disable Autoscaling
+
+To disable autoscaling and return to a fixed replica count:
+
+```bash
+oc patch nodepool -n <HOSTED_CLUSTER_NAMESPACE> <NODEPOOL_NAME> --type merge -p '{
+  "spec": {
+    "autoScaling": null,
+    "replicas": 2
+  }
+}'
+```
+
+## Cluster Autoscaling
+
+Cluster autoscaling configures global autoscaling behavior that applies to all NodePools in a HostedCluster. This includes scale-down policies, node group balancing, and expander strategies.
+
+### Configure Cluster Autoscaling
+
+Set `spec.autoscaling` on the HostedCluster:
+
+```bash
+oc patch hostedcluster -n <HOSTED_CLUSTER_NAMESPACE> <HOSTED_CLUSTER_NAME> --type merge -p '{
+  "spec": {
+    "autoscaling": {
+      "scaling": "ScaleUpAndScaleDown",
+      "maxNodesTotal": 10,
+      "expanders": ["LeastWaste"],
+      "scaleDown": {
+        "delayAfterAddSeconds": 300,
+        "unneededDurationSeconds": 600,
+        "utilizationThresholdPercent": 50
+      }
+    }
+  }
+}'
+```
+
+### Configuration Reference
+
+#### Scaling Behavior
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `scaling` | string | `ScaleUpAndScaleDown` | `ScaleUpOnly` or `ScaleUpAndScaleDown`. Controls whether the autoscaler can scale down nodes. |
+| `maxNodesTotal` | int | unlimited | Maximum total nodes across all NodePools. The autoscaler will not scale beyond this limit. |
+| `maxPodGracePeriod` | int | 600 | Maximum seconds to wait for graceful pod termination before scaling down. |
+| `maxNodeProvisionTime` | string | 15m | Maximum time to wait for a node to provision, in Go duration format (e.g., `15m`, `20m`). |
+| `podPriorityThreshold` | int | -10 | Pods with priority below this threshold won't trigger scale-up. |
+
+!!! note
+    Defaults listed in the configuration reference tables represent the cluster autoscaler's effective behavior when the field is omitted. The only API-enforced default is `scaling`, which defaults to `ScaleUpAndScaleDown`.
+
+#### Expanders
+
+Expanders control how the autoscaler selects which NodePool to scale when multiple NodePools can satisfy pending pods. Set via `spec.autoscaling.expanders`:
+
+| Expander | Description |
+|----------|-------------|
+| `LeastWaste` | Selects the NodePool with the least idle CPU and memory after scaling. |
+| `Priority` | Selects the NodePool with the highest user-defined priority. |
+| `Random` | Selects a NodePool randomly. |
+
+Default: `[Priority, LeastWaste]`. Up to 3 expanders can be specified in priority order.
+
+!!! note
+    The `Priority` expander uses a ConfigMap named `cluster-autoscaler-priority-expander` in the `kube-system` namespace of the guest cluster to determine NodePool priorities. The ConfigMap maps integer priorities to node group name patterns (regex). Higher values mean higher priority. See the upstream documentation for details on the ConfigMap format.
+
+#### Scale Down Configuration
+
+The `scaleDown` field is only valid when `scaling` is set to `ScaleUpAndScaleDown`:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `delayAfterAddSeconds` | int | 600 | Seconds to wait after scale-up before evaluating scale-down. |
+| `delayAfterDeleteSeconds` | int | 0 | Seconds to wait after node deletion before evaluating scale-down. |
+| `delayAfterFailureSeconds` | int | 180 | Seconds to wait after a failed scale-down before retrying. |
+| `unneededDurationSeconds` | int | 600 | How long a node must be unneeded before it is eligible for removal. |
+| `utilizationThresholdPercent` | int | 50 | Nodes with utilization below this percentage are candidates for removal. 0 means only completely idle nodes; 100 means any node can be removed. |
+
+#### Node Group Balancing
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `balancingIgnoredLabels` | []string | [] | Labels the autoscaler should ignore when comparing node groups for balancing. Platform-specific labels are added automatically. |
+| `maxFreeDifferenceRatioPercent` | int | 10 | Maximum allowed difference in free resources between node groups to be considered similar for balancing. 0 = exact match required; 100 = any difference allowed. |
+
+## How It Works
+
+1. When a pod cannot be scheduled due to insufficient resources, the cluster autoscaler identifies NodePools with autoscaling enabled that can satisfy the pod's requirements.
+2. The autoscaler selects a NodePool based on the configured expander strategy and triggers a scale-up by increasing the NodePool's replica count.
+3. HyperShift provisions new platform-specific machine instances for the NodePool and the new nodes join the guest cluster.
+4. When `scaling` is set to `ScaleUpAndScaleDown`, the autoscaler monitors node utilization. Nodes that remain underutilized (below `utilizationThresholdPercent`) for longer than `unneededDurationSeconds` are removed.
+
+## Monitoring
+
+Check the current state of autoscaling:
+
+```bash
+# View NodePool autoscaling status
+oc get nodepools -n <HOSTED_CLUSTER_NAMESPACE> -o wide
+
+# Check autoscaler deployment in the control plane namespace
+oc get deployment cluster-autoscaler -n <HOSTED_CLUSTER_NAMESPACE>-<HOSTED_CLUSTER_NAME>
+
+# View autoscaler logs
+oc logs deployment/cluster-autoscaler -n <HOSTED_CLUSTER_NAMESPACE>-<HOSTED_CLUSTER_NAME>
+```
+
+
+---
+
 ## Source: docs/content/how-to/aws/create-aws-hosted-cluster-arm-workers.md
 
 ---
@@ -7832,6 +7991,80 @@ This command creates a new job in that namespace and eventually will report the 
 
 ---
 
+## Source: docs/content/how-to/azure/autoscaling-self-managed.md
+
+# Autoscaling for Self-Managed Azure HostedClusters
+
+This guide covers configuring autoscaling for self-managed Azure HostedClusters. For the full autoscaling configuration reference, see the Autoscaling guide.
+
+## Prerequisites
+
+- A self-managed Azure HostedCluster created following the Create a Self-Managed Azure HostedCluster guide
+- `oc` or `kubectl` CLI with access to the management cluster
+
+## Example: Full Autoscaling Configuration
+
+This example configures a HostedCluster with two Azure NodePools balanced by the autoscaler:
+
+```yaml
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  name: my-cluster
+  namespace: clusters
+spec:
+  autoscaling:
+    scaling: ScaleUpAndScaleDown
+    maxNodesTotal: 12
+    expanders:
+      - Random
+    scaleDown:
+      delayAfterAddSeconds: 300
+      unneededDurationSeconds: 600
+      utilizationThresholdPercent: 50
+    balancingIgnoredLabels:
+      - "custom.label/environment"
+    maxFreeDifferenceRatioPercent: 70
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: NodePool
+metadata:
+  name: my-cluster-nodepool-1
+  namespace: clusters
+spec:
+  clusterName: my-cluster
+  autoScaling:
+    min: 1
+    max: 6
+  platform:
+    azure:
+      vmSize: Standard_D4s_v3
+      # ... other required fields (image, osDisk) omitted for brevity
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: NodePool
+metadata:
+  name: my-cluster-nodepool-2
+  namespace: clusters
+spec:
+  clusterName: my-cluster
+  autoScaling:
+    min: 1
+    max: 6
+  platform:
+    azure:
+      vmSize: Standard_D4s_v3
+      # ... other required fields (image, osDisk) omitted for brevity
+```
+
+## Azure-Specific Details
+
+- HyperShift provisions individual Azure Virtual Machines via CAPZ when scaling up NodePools.
+- Scale-from-zero (`autoScaling.min: 0`) is not supported on Azure. The minimum must be >= 1.
+
+
+---
+
 ## Source: docs/content/how-to/azure/azure-workload-identity-setup.md
 
 # Azure Workload Identity Setup for Self-Managed Clusters
@@ -10620,6 +10853,7 @@ Begin your self-managed Azure HyperShift deployment by following the guides in o
 2. **Setup Azure Management Cluster for HyperShift** - Install HyperShift operator (with or without External DNS)
 3. **Create a Self-Managed Azure HostedCluster** - Deploy your first hosted cluster
 4. **Deploy Azure Private Clusters** (Optional) - Configure private endpoint access with Azure Private Link
+5. **Autoscaling** - Configure node pool and cluster autoscaling
 
 Each guide includes sections for both DNS approaches - simply follow the sections that match your choice.
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
     - how-to/automated-machine-management/node-tuning.md
     - how-to/automated-machine-management/nodepool-lifecycle.md
     - how-to/automated-machine-management/scale-to-zero-dataplane.md
+  - how-to/autoscaling.md
   - 'CI':
     - 'AI-Assisted CI Jobs': how-to/ci/ai-assisted-ci-jobs.md
     - how-to/ci/ci-infrastructure.md
@@ -140,6 +141,7 @@ nav:
         - how-to/azure/scheduler.md
       - 'Self-managed Azure':
         - how-to/azure/self-managed-azure-index.md
+        - how-to/azure/autoscaling-self-managed.md
         - how-to/azure/azure-workload-identity-setup.md
         - how-to/azure/create-self-managed-azure-cluster.md
         - how-to/azure/create-iam-separately.md


### PR DESCRIPTION
## Summary
- Add documentation for node pool and cluster autoscaling on self-managed Azure HostedClusters
- Covers NodePool `autoScaling` (min/max), HostedCluster `autoscaling` (scale-down, expanders, balancing), monitoring, and limitations
- Add nav entry in mkdocs.yml and link from the self-managed Azure index page

## Context
Autoscaling is validated in CI via `TestAutoscaling` on the `e2e-azure-self-managed` job ([PR #77597](https://github.com/openshift/release/pull/77597)), but no user-facing documentation existed for configuring it on self-managed Azure.

## Test plan
- [ ] Verify docs render correctly with `mkdocs serve`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive how-to guides for NodePool and cluster autoscaling for self-managed Azure HostedClusters.
  * Described modes, global/node limits, expander strategies, scale-down settings, and node-group balancing.
  * Clarified Azure-specific behavior, including that scale-from-zero is unsupported (NodePool min ≥ 1).
  * Included end-to-end YAML examples, verification steps, operational notes, and updated site navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->