### PR TITLE
OCPBUGS-78988: bump go to v1.25

### DIFF
--- a/Dockerfile.github-actions-runner
+++ b/Dockerfile.github-actions-runner
@@ -14,7 +14,7 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH
-ARG GO_VERSION=1.25.3
+ARG GO_VERSION=1.25.8
 RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" | tar -C /usr/local -xz
 
 RUN OCP_ARCH=$([ "$TARGETARCH" = "amd64" ] && echo "x86_64" || echo "aarch64") && \

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/hypershift/api
 
-go 1.25.3
+go 1.25.8
 
 require (
 	github.com/aws/karpenter-provider-aws v1.8.6

--- a/contrib/aws-tag-lb-service-webhook/Dockerfile
+++ b/contrib/aws-tag-lb-service-webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24
+FROM golang:1.25
 
 # Set the working directory inside the container
 WORKDIR /app

--- a/contrib/gomaxprocs-webhook/Dockerfile
+++ b/contrib/gomaxprocs-webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.23 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-4.23 AS builder
 WORKDIR /workspace
 
 # Force module mode and leverage Go module caching

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/hypershift
 
-go 1.25.3
+go 1.25.8
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0

--- a/hack/workspace/go.work
+++ b/hack/workspace/go.work
@@ -1,4 +1,4 @@
-go 1.25.3
+go 1.25.8
 
 use (
 	./hypershift

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1135,7 +1135,7 @@ github.com/openshift/cluster-node-tuning-operator/pkg/performanceprofile/control
 ## explicit; go 1.12
 github.com/openshift/custom-resource-status/conditions/v1
 # github.com/openshift/hypershift/api v0.0.0-20240604072534-cd2d5291e2b7 => ./api
-## explicit; go 1.25.3
+## explicit; go 1.25.8
 github.com/openshift/hypershift/api/auditlogpersistence
 github.com/openshift/hypershift/api/auditlogpersistence/v1alpha1
 github.com/openshift/hypershift/api/certificates


### PR DESCRIPTION
## What this PR does / why we need it:

bump all go references to v1.25. when possible make sure we are using v1.25.8 as it has some security improvements over v1.25.3.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain to 1.25.8 across build infrastructure and container images to align tooling and improve build stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->