### PR TITLE
[release-4.18] OCPBUGS-62756: Restart HCP on stale serving certs

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -16,6 +16,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"errors"
@@ -145,6 +146,9 @@ const (
 	etcdCheckRequeueInterval = 10 * time.Second
 
 	awsEndpointDeletionGracePeriod = 10 * time.Minute
+
+	previouslySyncedRestartDateAnnotation = "hypershift.openshift.io/previous-restart-date"
+	kasServingCertHashAnnotation          = "hypershift.openshift.io/kas-serving-cert-hash"
 )
 
 // NoopReconcile is just a default mutation function that does nothing.
@@ -1556,6 +1560,17 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
+	// Get release image version
+	var releaseImageVersion semver.Version
+	releaseInfo, err := r.lookupReleaseImage(ctx, hcluster, releaseProvider)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to lookup release image: %w", err)
+	}
+	releaseImageVersion, err = semver.Parse(releaseInfo.Version())
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to parse release image version: %w", err)
+	}
+
 	// Reconcile the HostedControlPlane
 	isAutoscalingNeeded, err := r.isAutoscalingNeeded(ctx, hcluster)
 	if err != nil {
@@ -1563,7 +1578,12 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 	}
 	hcp = controlplaneoperator.HostedControlPlane(controlPlaneNamespace.Name, hcluster.Name)
 	_, err = createOrUpdate(ctx, r.Client, hcp, func() error {
-		return reconcileHostedControlPlane(hcp, hcluster, isAutoscalingNeeded)
+		return reconcileHostedControlPlane(hcp, hcluster, isAutoscalingNeeded,
+			annotationsForCertRenewal(log,
+				hcp,
+				shouldCheckForStaleCerts(hcluster, releaseImageVersion),
+				r.kasServingCertHashFromSecret(ctx, hcp),
+				r.kasServingCertHashFromEndpoint(kasHostAndPortFromHCP(hcp))))
 	})
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile hostedcontrolplane: %w", err)
@@ -1712,17 +1732,6 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	// Get release image version
-	var releaseImageVersion semver.Version
-	releaseInfo, err := r.lookupReleaseImage(ctx, hcluster, releaseProvider)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to lookup release image: %w", err)
-	}
-	releaseImageVersion, err = semver.Parse(releaseInfo.Version())
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to parse release image version: %w", err)
-	}
-
 	if !controlPlaneOperatorManagesMachineApprover {
 		// Reconcile the machine approver.
 		if err = r.reconcileMachineApprover(ctx, createOrUpdate, hcluster, hcp, utilitiesImage, pullSecretBytes, releaseImageVersion, releaseProvider); err != nil {
@@ -1839,12 +1848,136 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 	return result, nil
 }
 
+// annotationsForCertRenewal returns a set of annotations to set based on the current state of the KAS
+// serving certificate. These could include the annotation to restart control plane pods.
+// It will always return an empty map whenever the HostedCluster should not be checked for
+// stale certs (see shouldCheckForStaleCerts)
+func annotationsForCertRenewal(
+	log logr.Logger,
+	hcp *hyperv1.HostedControlPlane,
+	shouldCheckForStaleCerts func() bool,
+	kasServingCertHashFromSecret func() (string, error),
+	kasServingCertHashFromEndpoint func() (string, error)) func() (map[string]string, error) {
+	return func() (map[string]string, error) {
+		if !shouldCheckForStaleCerts() {
+			return nil, nil
+		}
+
+		// The hash from the KAS serving secret is the source of truth for what
+		// certificate we should be using for KAS
+		// We can check whether we need to restart pods in one of 2 ways:
+		// 1. We have previously saved an annotation on the HCP that says which was the last
+		//    observed certificate hash. If they don't match, we need to restart.
+		// 2. We have not previously saved an annotation, and therefore we make a request
+		//    to the KAS endpoint to determine if the current secret matches what the KAS
+		//    pod is using as its serving cert. We then save the observed secret hash as an
+		//    annotation for next time. If they also don't match, we add the annotation to restart.
+		hashFromSecret, err := kasServingCertHashFromSecret()
+		if err != nil {
+			return nil, err
+		}
+
+		// The simplest check is to see if the hash of the KAS serving cert secret has changed
+		// since we last saw it.
+		if annotationServingCertHash := hcp.Annotations[kasServingCertHashAnnotation]; annotationServingCertHash != "" {
+			if annotationServingCertHash != hashFromSecret {
+				log.Info("WARNING: A change in the KAS server certificate hash detected. Setting the annotation to restart control plane workloads.")
+				return map[string]string{
+					kasServingCertHashAnnotation:  hashFromSecret,
+					hyperv1.RestartDateAnnotation: fmt.Sprintf("CertHash:%s", hashFromSecret),
+				}, nil
+			}
+			return nil, nil
+		}
+
+		// If we've never stored the kasServingCertHash, check the actual serving cert hash from the endpoint
+		// against the one from the secret
+		hashFromServerEndpoint, err := kasServingCertHashFromEndpoint()
+		if err != nil {
+			return nil, err
+		}
+		// If they match, we still need to store the hash for future comparisons
+		if hashFromServerEndpoint == hashFromSecret {
+			return map[string]string{
+				kasServingCertHashAnnotation: hashFromSecret,
+			}, nil
+		}
+		// If they don't match, we store the hash AND initiate a restart
+		log.Info("WARNING: The KAS endpoint server certificate does not match the serving certificate secret. Setting the annotation to restart control plane workloads.")
+		return map[string]string{
+			kasServingCertHashAnnotation:  hashFromSecret,
+			hyperv1.RestartDateAnnotation: fmt.Sprintf("CertHash:%s", hashFromSecret),
+		}, nil
+	}
+}
+
+func kasHostAndPortFromHCP(hcp *hyperv1.HostedControlPlane) string {
+	// NOTE: On IBM Cloud platform, the service port is different than the default. However, in that platform
+	// PKI is not managed by the CPO, therefore this check would never run. For simplicity, we only use the default
+	// port here.
+	return fmt.Sprintf("kube-apiserver.%s.svc:%d", hcp.Namespace, config.KASSVCPort)
+}
+
+func (r *HostedClusterReconciler) kasServingCertHashFromSecret(ctx context.Context, hcp *hyperv1.HostedControlPlane) func() (string, error) {
+	return func() (string, error) {
+		servingCertSecret := manifests.KASServingCertSecret(hcp.Namespace)
+		if err := r.Get(ctx, client.ObjectKeyFromObject(servingCertSecret), servingCertSecret); err != nil {
+			return "", err
+		}
+		if value := servingCertSecret.Data[corev1.TLSCertKey]; len(value) == 0 {
+			return "", fmt.Errorf("no value for KAS serving certificate in %s", client.ObjectKeyFromObject(servingCertSecret).String())
+		} else {
+			return hyperutil.HashSimple(value), nil
+		}
+	}
+}
+
+func (r *HostedClusterReconciler) kasServingCertHashFromEndpoint(kasHostAndPort string) func() (string, error) {
+	return func() (string, error) {
+		conn, err := tls.Dial("tcp", kasHostAndPort, &tls.Config{
+			InsecureSkipVerify: true,
+			ServerName:         "kubernetes",
+		})
+		if err != nil {
+			return "", fmt.Errorf("failed to dial %s: %w", kasHostAndPort, err)
+		}
+		defer conn.Close()
+		kasCerts := conn.ConnectionState().PeerCertificates
+		if len(kasCerts) == 0 {
+			return "", fmt.Errorf("no certificate found on KAS endpoint %s", kasHostAndPort)
+		}
+		pemBytes := certs.CertToPem(kasCerts[0])
+		return hyperutil.HashSimple(pemBytes), nil
+	}
+}
+
+// shouldCheckForStaleCerts returns true if a HostedCluster should be checked for stale certs
+// The following pre-conditions must be met:
+// - The HostedCluster must be managing its own PKI (the hyperv1.DisablePKIReconciliationAnnotation is not present)
+// - The HostedCluster has been available once
+// - The cluster version of the HostedCluster is < 4.19.0
+func shouldCheckForStaleCerts(hc *hyperv1.HostedCluster, hcVersion semver.Version) func() bool {
+	return func() bool {
+		if hc.Annotations[hcmetrics.HasBeenAvailableAnnotation] != "true" {
+			return false
+		}
+		if hc.Annotations[hyperv1.DisablePKIReconciliationAnnotation] == "true" {
+			return false
+		}
+		hcVersion.Pre = nil
+		hcVersion.Build = nil
+		return !hcVersion.GE(config.Version419)
+	}
+}
+
 // reconcileHostedControlPlane reconciles the given HostedControlPlane, which
 // will be mutated.
-func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hyperv1.HostedCluster, isAutoscalingNeeded bool) error {
-	hcp.Annotations = map[string]string{
-		HostedClusterAnnotation: client.ObjectKeyFromObject(hcluster).String(),
+func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hyperv1.HostedCluster, isAutoscalingNeeded bool, certRenewalAnnotations func() (map[string]string, error)) error {
+	if hcp.Annotations == nil {
+		hcp.Annotations = map[string]string{}
 	}
+
+	hcp.Annotations[HostedClusterAnnotation] = client.ObjectKeyFromObject(hcluster).String()
 
 	// These annotations are copied from the HostedCluster
 	mirroredAnnotations := []string{
@@ -1852,7 +1985,6 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 		hyperv1.OauthLoginURLOverrideAnnotation,
 		hyperv1.KonnectivityAgentImageAnnotation,
 		hyperv1.KonnectivityServerImageAnnotation,
-		hyperv1.RestartDateAnnotation,
 		hyperv1.ClusterAutoscalerImage,
 		hyperv1.IBMCloudKMSProviderImage,
 		hyperv1.AWSKMSProviderImage,
@@ -1899,9 +2031,30 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 		}
 	}
 
+	// Only set the restart date annotation if it has not been previously synced.
+	// This allows other values to be set on the HCP restart date annotation (for cert rotation) without
+	// causing a constant reconcile of the annotation value set on the HostedCluster.
+	if hcluster.Annotations[hyperv1.RestartDateAnnotation] != "" &&
+		hcp.Annotations[previouslySyncedRestartDateAnnotation] != hcluster.Annotations[hyperv1.RestartDateAnnotation] {
+		hcp.Annotations[previouslySyncedRestartDateAnnotation] = hcluster.Annotations[hyperv1.RestartDateAnnotation]
+		hcp.Annotations[hyperv1.RestartDateAnnotation] = hcluster.Annotations[hyperv1.RestartDateAnnotation]
+	}
+
+	// Determine which certRenewalAnnotations to set based on the current state of the KAS serving certificate.
+	// These could include an override of the RestartDateAnnotation
+	certAnnotations, err := certRenewalAnnotations()
+	if err != nil {
+		return err
+	}
+	for k, v := range certAnnotations {
+		hcp.Annotations[k] = v
+	}
+
 	// Set the DisableClusterAutoscalerAnnotation if autoscaling is not needed
 	if !isAutoscalingNeeded {
 		hcp.Annotations[hyperv1.DisableClusterAutoscalerAnnotation] = "true"
+	} else {
+		delete(hcp.Annotations, hyperv1.DisableClusterAutoscalerAnnotation)
 	}
 
 	if hcp.Labels == nil {
@@ -4119,6 +4272,29 @@ func enqueueHostedClustersFunc(metricsSet metrics.MetricsSet, operatorNamespace 
 				return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: name, Namespace: namespace}}}
 			}
 			return []reconcile.Request{}
+		}
+		// Watch for KAS serving certificate Secret changes (for cert renewal)
+		if secret, isSecret := obj.(*corev1.Secret); isSecret {
+			if secret.Name == manifests.KASServingCertSecret("").Name {
+				for _, ownerRef := range secret.OwnerReferences {
+					if ownerRef.Kind == "HostedControlPlane" {
+						hcp := &hyperv1.HostedControlPlane{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: secret.Namespace,
+								Name:      ownerRef.Name,
+							},
+						}
+						if err := c.Get(ctx, client.ObjectKeyFromObject(hcp), hcp); err != nil {
+							log.Error(err, "failed to get hcp")
+							return []reconcile.Request{}
+						}
+						if hcAnnotation := hcp.Annotations[HostedClusterAnnotation]; hcAnnotation != "" {
+							return []reconcile.Request{{NamespacedName: hyperutil.ParseNamespacedName(hcAnnotation)}}
+						}
+						return []reconcile.Request{}
+					}
+				}
+			}
 		}
 
 		var hostedClusterName string

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -58,6 +58,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/blang/semver"
 )
 
 var (
@@ -308,7 +310,7 @@ func TestReconcileHostedControlPlaneUpgrades(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			updated := test.ControlPlane.DeepCopy()
-			err := reconcileHostedControlPlane(updated, &test.Cluster, true)
+			err := reconcileHostedControlPlane(updated, &test.Cluster, true, func() (map[string]string, error) { return nil, nil })
 			if err != nil {
 				t.Error(err)
 			}
@@ -440,7 +442,7 @@ func TestReconcileHostedControlPlaneAPINetwork(t *testing.T) {
 			hostedCluster := &hyperv1.HostedCluster{}
 			hostedCluster.Spec.Networking.APIServer = test.networking
 			hostedControlPlane := &hyperv1.HostedControlPlane{}
-			err := reconcileHostedControlPlane(hostedControlPlane, hostedCluster, true)
+			err := reconcileHostedControlPlane(hostedControlPlane, hostedCluster, true, func() (map[string]string, error) { return nil, nil })
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -498,11 +500,293 @@ func TestReconcileHostedControlPlaneConfiguration(t *testing.T) {
 			hostedControlPlane := &hyperv1.HostedControlPlane{}
 			g := NewGomegaWithT(t)
 
-			err := reconcileHostedControlPlane(hostedControlPlane, hostedCluster, true)
+			err := reconcileHostedControlPlane(hostedControlPlane, hostedCluster, true, func() (map[string]string, error) { return nil, nil })
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// DeepEqual to check that all ClusterConfiguration fields are deep copied to HostedControlPlane
 			g.Expect(hostedControlPlane.Spec.Configuration).To(BeEquivalentTo(test.configuration))
+		})
+	}
+}
+
+func TestReconcileHostedControlPlaneAutoscalingNeeded(t *testing.T) {
+	tests := []struct {
+		name                     string
+		autoscalingNeeded        bool
+		existingHCPAnnotations   map[string]string
+		expectedHCPAnnotations   map[string]string
+		unexpectedHCPAnnotations []string
+	}{
+		{
+			name:                   "Autoscaling not needed, no annotation set",
+			autoscalingNeeded:      false,
+			existingHCPAnnotations: nil,
+			expectedHCPAnnotations: map[string]string{
+				hyperv1.DisableClusterAutoscalerAnnotation: "true",
+			},
+		},
+		{
+			name:                     "Autoscaling needed, no annotation set",
+			autoscalingNeeded:        true,
+			existingHCPAnnotations:   nil,
+			unexpectedHCPAnnotations: []string{hyperv1.DisableClusterAutoscalerAnnotation},
+		},
+		{
+			name:              "Autoscaling not needed, annotation set",
+			autoscalingNeeded: false,
+			existingHCPAnnotations: map[string]string{
+				hyperv1.DisableClusterAutoscalerAnnotation: "true",
+			},
+			expectedHCPAnnotations: map[string]string{
+				hyperv1.DisableClusterAutoscalerAnnotation: "true",
+			},
+		},
+		{
+			name:              "Autoscaling needed, annotation set",
+			autoscalingNeeded: true,
+			existingHCPAnnotations: map[string]string{
+				hyperv1.DisableClusterAutoscalerAnnotation: "true",
+			},
+			unexpectedHCPAnnotations: []string{hyperv1.DisableClusterAutoscalerAnnotation},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			hc := &hyperv1.HostedCluster{}
+			hcp := &hyperv1.HostedControlPlane{}
+			hcp.Annotations = test.existingHCPAnnotations
+			err := reconcileHostedControlPlane(hcp, hc, test.autoscalingNeeded, func() (map[string]string, error) { return nil, nil })
+			g.Expect(err).ToNot(HaveOccurred())
+			for k, v := range test.expectedHCPAnnotations {
+				g.Expect(hcp.Annotations).To(HaveKeyWithValue(k, v))
+			}
+			for _, k := range test.unexpectedHCPAnnotations {
+				g.Expect(hcp.Annotations).ToNot(HaveKey(k))
+			}
+		})
+	}
+}
+
+func TestReconcileHostedControlPlaneRestartAnnotation(t *testing.T) {
+	tests := []struct {
+		name                     string
+		hcAnnotations            map[string]string
+		existingHCPAnnotations   map[string]string
+		expectedHCPAnnotations   map[string]string
+		unexpectedHCPAnnotations []string
+	}{
+		{
+			name:                   "No annotation set",
+			hcAnnotations:          nil,
+			existingHCPAnnotations: nil,
+			expectedHCPAnnotations: nil,
+			unexpectedHCPAnnotations: []string{
+				hyperv1.RestartDateAnnotation,
+				previouslySyncedRestartDateAnnotation,
+			},
+		},
+		{
+			name: "Newly set restart annotation",
+			hcAnnotations: map[string]string{
+				hyperv1.RestartDateAnnotation: "01012024",
+			},
+			existingHCPAnnotations: nil,
+			expectedHCPAnnotations: map[string]string{
+				hyperv1.RestartDateAnnotation:         "01012024",
+				previouslySyncedRestartDateAnnotation: "01012024",
+			},
+		},
+		{
+			name: "Existing restart annotation (different value)",
+			hcAnnotations: map[string]string{
+				hyperv1.RestartDateAnnotation: "05012024",
+			},
+			existingHCPAnnotations: map[string]string{
+				hyperv1.RestartDateAnnotation:         "01012024",
+				previouslySyncedRestartDateAnnotation: "01012024",
+			},
+			expectedHCPAnnotations: map[string]string{
+				hyperv1.RestartDateAnnotation:         "05012024",
+				previouslySyncedRestartDateAnnotation: "05012024",
+			},
+		},
+		{
+			name: "Previously applied restart annotation, different actual value",
+			hcAnnotations: map[string]string{
+				hyperv1.RestartDateAnnotation: "01012024",
+			},
+			existingHCPAnnotations: map[string]string{
+				hyperv1.RestartDateAnnotation:         "some other value",
+				previouslySyncedRestartDateAnnotation: "01012024",
+			},
+			expectedHCPAnnotations: map[string]string{
+				hyperv1.RestartDateAnnotation:         "some other value",
+				previouslySyncedRestartDateAnnotation: "01012024",
+			},
+		},
+		{
+			name: "Previously applied restart annotation, new value",
+			hcAnnotations: map[string]string{
+				hyperv1.RestartDateAnnotation: "05012024",
+			},
+			existingHCPAnnotations: map[string]string{
+				hyperv1.RestartDateAnnotation:         "some other value",
+				previouslySyncedRestartDateAnnotation: "01012024",
+			},
+			expectedHCPAnnotations: map[string]string{
+				hyperv1.RestartDateAnnotation:         "05012024",
+				previouslySyncedRestartDateAnnotation: "05012024",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			hc := &hyperv1.HostedCluster{}
+			hcp := &hyperv1.HostedControlPlane{}
+			hc.Annotations = test.hcAnnotations
+			hcp.Annotations = test.existingHCPAnnotations
+			err := reconcileHostedControlPlane(hcp, hc, true, func() (map[string]string, error) { return nil, nil })
+			g.Expect(err).ToNot(HaveOccurred())
+			for k, v := range test.expectedHCPAnnotations {
+				g.Expect(hcp.Annotations).To(HaveKeyWithValue(k, v))
+			}
+			for _, k := range test.unexpectedHCPAnnotations {
+				g.Expect(hcp.Annotations).ToNot(HaveKey(k))
+			}
+		})
+	}
+}
+
+func TestAnnotationsForCertRenewal(t *testing.T) {
+	tests := []struct {
+		name             string
+		shouldSkip       bool
+		hcpAnnotations   map[string]string
+		hashFromSecret   string
+		hashFromEndpoint string
+		expected         map[string]string
+	}{
+		{
+			name:             "should not check",
+			shouldSkip:       true,
+			hashFromSecret:   "12345",
+			hashFromEndpoint: "67890",
+			expected:         nil,
+		},
+		{
+			name:             "no existing hash annotation on hcp, endpoint hash matches",
+			hashFromSecret:   "12345",
+			hashFromEndpoint: "12345",
+			expected: map[string]string{
+				kasServingCertHashAnnotation: "12345",
+			},
+		},
+		{
+			name:             "no existing hash annotation on hcp, endpoint hash does not match",
+			hashFromSecret:   "12345",
+			hashFromEndpoint: "67890",
+			expected: map[string]string{
+				kasServingCertHashAnnotation:  "12345",
+				hyperv1.RestartDateAnnotation: "CertHash:12345",
+			},
+		},
+		{
+			name:           "existing hash annotation, secret hash matches",
+			hashFromSecret: "12345",
+			hcpAnnotations: map[string]string{
+				kasServingCertHashAnnotation: "12345",
+			},
+			expected: nil,
+		},
+		{
+			name:           "existing hash annotation, secret hash does not match",
+			hashFromSecret: "67890",
+			hcpAnnotations: map[string]string{
+				kasServingCertHashAnnotation: "12345",
+			},
+			expected: map[string]string{
+				kasServingCertHashAnnotation:  "67890",
+				hyperv1.RestartDateAnnotation: "CertHash:67890",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			hcp := &hyperv1.HostedControlPlane{}
+			hcp.Annotations = test.hcpAnnotations
+			fn := annotationsForCertRenewal(
+				ctrl.Log,
+				hcp,
+				func() bool { return !test.shouldSkip },
+				func() (string, error) { return test.hashFromSecret, nil },
+				func() (string, error) { return test.hashFromEndpoint, nil },
+			)
+			result, err := fn()
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(result).To(Equal(test.expected))
+		})
+	}
+}
+
+func TestShouldCheckForStaleCerts(t *testing.T) {
+	tests := []struct {
+		name           string
+		hcAnnotations  map[string]string
+		hcVersion      string
+		expectedResult bool
+	}{
+		{
+			name: "version older than 4.19",
+			hcAnnotations: map[string]string{
+				hcmetrics.HasBeenAvailableAnnotation: "true",
+			},
+			hcVersion:      "4.18.7",
+			expectedResult: true,
+		},
+		{
+			name: "ci version with 4.19",
+			hcAnnotations: map[string]string{
+				hcmetrics.HasBeenAvailableAnnotation: "true",
+			},
+			hcVersion:      "4.19.0-0.ci-2025-02-03-120046",
+			expectedResult: false,
+		},
+		{
+			name: "4.20",
+			hcAnnotations: map[string]string{
+				hcmetrics.HasBeenAvailableAnnotation: "true",
+			},
+			hcVersion:      "4.20.0",
+			expectedResult: false,
+		},
+		{
+			name:           "version older than 4.19, never been available",
+			hcAnnotations:  nil,
+			hcVersion:      "4.17.4",
+			expectedResult: false,
+		},
+		{
+			name: "version older than 4.19, has been available, does not reconcile pki",
+			hcAnnotations: map[string]string{
+				hcmetrics.HasBeenAvailableAnnotation:       "true",
+				hyperv1.DisablePKIReconciliationAnnotation: "true",
+			},
+			hcVersion:      "4.16.20",
+			expectedResult: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			hc := &hyperv1.HostedCluster{}
+			hc.Annotations = test.hcAnnotations
+			fn := shouldCheckForStaleCerts(hc, semver.MustParse(test.hcVersion))
+			result := fn()
+			g.Expect(result).To(Equal(test.expectedResult))
 		})
 	}
 }

--- a/hypershift-operator/controllers/manifests/manifests.go
+++ b/hypershift-operator/controllers/manifests/manifests.go
@@ -112,3 +112,12 @@ func OpenShiftTrustedCABundleForNamespace(namespace string) *corev1.ConfigMap {
 		},
 	}
 }
+
+func KASServingCertSecret(namespace string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "kas-server-crt",
+		},
+	}
+}

--- a/support/config/constants.go
+++ b/support/config/constants.go
@@ -1,5 +1,7 @@
 package config
 
+import "github.com/blang/semver"
+
 const (
 	// NeedManagementKASAccessLabel is used by network policies
 	// to prevent any pod which doesn't contain the label from accessing the management cluster KAS.
@@ -87,4 +89,8 @@ const (
 	ManagedAzureNetworkSecretStoreProviderClassName       = "managed-azure-network"
 	ManagedAzureNodePoolMgmtSecretProviderClassName       = "managed-azure-nodepool-management"
 	ManagedAzureNodePoolMgmtSecretStoreVolumeName         = "nodepool-management-cert"
+)
+
+var (
+	Version419 = semver.MustParse("4.19.0")
 )


### PR DESCRIPTION
## What this PR does / why we need it:

This PR contains a back port of https://github.com/openshift/hypershift/pull/5601. Unfortunately the original diff does not apply without conflicts on top of `release-4.18` so I had to do some adjustments.

## Notes for validation

I have tried to create an end-to-end test to validate this one but merging it directly on a release branch does not make the test part of the suite. I have received feedback that tests on hypershift are per-release and that is why the new test does not run. Taking that into account I have raised https://github.com/openshift/hypershift/pull/8294, that puts the test on the `main` branch.

For sake of manual validation, this is how to reproduce the bug that this PR if fixing:

1. Create a `HostedCluster` with annotations for a short certificate expiration time:

```    
hypershift.openshift.io/certificate-validity: "1h"    
hypershift.openshift.io/certificate-renewal: "0.3"
```

2. Wait for initial certificates to expire

Cluster becomes degraded, apiservices in hosted cluster API become unavailable. To test this, obtain a kubeconfig for the hosted cluster and list apiservices:

```
$ oc get apiservices
```

API services that are external to the kube-apiserver appear as unavailable.


