### PR TITLE
CNTRLPLANE-3255: enable CodeRabbit reviews on draft PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,8 @@
 inheritance: true
 language: en-US
 reviews:
+  auto_review:
+    drafts: true
   profile: chill
   high_level_summary: true
   collapse_walkthrough: true


### PR DESCRIPTION
## What this PR does / why we need it:

Enables CodeRabbit to run reviews on draft PRs by adding `auto_review.drafts: true` to `.coderabbit.yaml`. Currently CodeRabbit skips draft PRs, which means developers don't get early AI review feedback while work is still in progress.

Reference: [CodeRabbit YAML Configuration - auto_review.drafts](https://docs.coderabbit.ai/getting-started/yaml-configuration)

## Which issue(s) this PR fixes:

Fixes https://redhat.atlassian.net/browse/CNTRLPLANE-3255

## Special notes for your reviewer:

None

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code review configuration to enable automatic review generation for draft items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->