### PR TITLE
OCPBUGS-77040: Add AWS ISO domains to konnectivity IsCloudAPI

### DIFF
--- a/support/konnectivityproxy/dialer.go
+++ b/support/konnectivityproxy/dialer.go
@@ -457,6 +457,7 @@ func (kh *konnectivityHealth) isHealthy() bool {
 // actually end up proxying or not depends on the env for this binary.
 // DNS domains. The API list can be found below:
 // AWS: https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints
+// AWS ISO: https://docs.aws.amazon.com/general/latest/gr/aws-iso_region.html
 // AZURE: https://docs.microsoft.com/en-us/rest/api/azure/#how-to-call-azure-rest-apis-with-curl
 // IBMCLOUD: https://cloud.ibm.com/apidocs/iam-identity-token-api#endpoints
 func (p *konnectivityProxy) IsCloudAPI(host string) bool {
@@ -475,6 +476,9 @@ func (p *konnectivityProxy) IsCloudAPI(host string) bool {
 		return false
 	}
 	if strings.HasSuffix(host, ".amazonaws.com") ||
+		strings.HasSuffix(host, ".c2s.ic.gov") ||
+		strings.HasSuffix(host, ".hci.ic.gov") ||
+		strings.HasSuffix(host, ".sc2s.sgov.gov") ||
 		strings.HasSuffix(host, ".microsoftonline.com") ||
 		strings.HasSuffix(host, ".azure.com") ||
 		strings.HasSuffix(host, ".cloud.ibm.com") {

--- a/support/konnectivityproxy/dialer_test.go
+++ b/support/konnectivityproxy/dialer_test.go
@@ -306,6 +306,26 @@ func TestIsCloudAPI(t *testing.T) {
 			description: "IBM Cloud API endpoints should be detected",
 		},
 
+		// Valid AWS ISO cloud API hosts
+		{
+			name:        "When host is valid AWS ISO C2S API it should return true",
+			host:        "s3.c2s.ic.gov",
+			expected:    true,
+			description: "AWS ISO C2S endpoints should be detected",
+		},
+		{
+			name:        "When host is valid AWS ISO HCI API it should return true",
+			host:        "iam.hci.ic.gov",
+			expected:    true,
+			description: "AWS ISO HCI endpoints should be detected",
+		},
+		{
+			name:        "When host is valid AWS ISO-B SC2S API it should return true",
+			host:        "s3.sc2s.sgov.gov",
+			expected:    true,
+			description: "AWS ISO-B SC2S endpoints should be detected",
+		},
+
 		// False positive scenarios that were fixed
 		{
 			name:        "When host contains azure.com but is not azure.com it should return false",


### PR DESCRIPTION
## What this PR does / why we need it:

The konnectivity proxy's `IsCloudAPI` method was missing AWS ISO (classified) region domains from its cloud API detection list. This prevented the ingress operator from adding these domains to the `NO_PROXY` list, blocking direct (not proxied) communication with endpoints in those namespaces.

This PR adds three AWS ISO domain suffixes to the `IsCloudAPI` method:
- `.c2s.ic.gov` (AWS ISO / C2S)
- `.hci.ic.gov` (AWS ISO / HCI)
- `.sc2s.sgov.gov` (AWS ISO-B / SC2S)

## Which issue(s) this PR fixes:

Fixes OCPBUGS-77040

## Special notes for your reviewer:

The change is minimal and follows the existing pattern of `strings.HasSuffix` checks in `IsCloudAPI`. The three new domains are grouped together after the existing `.amazonaws.com` suffix check.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve OCPBUGS-77040`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for AWS ISO-specific cloud API domains: `.c2s.ic.gov`, `.hci.ic.gov`, and `.sc2s.sgov.gov`, enabling connectivity to isolated AWS regions.

* **Tests**
  * Added test cases validating proper recognition of the new AWS ISO-specific domains as cloud API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->