### PR TITLE
CNTRLPLANE-3259: Add sdminonne, clebs, and Nirshal to core-reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -27,6 +27,9 @@ aliases:
     - cblecker
     - jparrill
     - devguyio
+    - sdminonne
+    - clebs
+    - Nirshal
   karpenter-approvers:
     - elmiko
     - enxebre


### PR DESCRIPTION
## What this PR does / why we need it:

Adds sdminonne, clebs, and Nirshal to the `core-reviewers` alias in OWNERS_ALIASES.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-3259](https://redhat.atlassian.net/browse/CNTRLPLANE-3259)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core team reviewer configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->