### PR TITLE
CNTRLPLANE-3260: ci: harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -87,3 +87,16 @@ updates:
       misc-dependencies:
         patterns:
           - "*"
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "01:00"
+      timezone: "Etc/UTC"
+    commit-message:
+      prefix: "ci(deps)"
+    labels:
+      - "area/ci-tooling"
+      - "ok-to-test"

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -2,7 +2,12 @@ name: Codespell
 
 on:
   pull_request:
-    branches: [main, release-4.22]
+    branches:
+      - main
+      - release-4.22
+
+permissions:
+  contents: read
 
 jobs:
   codespell:
@@ -10,5 +15,7 @@ jobs:
     runs-on: arc-runner-set
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - run: make verify-codespell

--- a/.github/workflows/cpo-container-sync.yaml
+++ b/.github/workflows/cpo-container-sync.yaml
@@ -2,7 +2,12 @@ name: CPO Container Sync
 
 on:
   pull_request:
-    branches: [main, release-4.22]
+    branches:
+      - main
+      - release-4.22
+
+permissions:
+  contents: read
 
 jobs:
   cpo-container-sync:
@@ -10,5 +15,7 @@ jobs:
     runs-on: arc-runner-set
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - run: make cpo-container-sync

--- a/.github/workflows/docs-preview.yaml
+++ b/.github/workflows/docs-preview.yaml
@@ -2,7 +2,9 @@ name: Docs Preview
 
 on:
   pull_request_target:
-    branches: [main, release-4.22]
+    branches:
+      - main
+      - release-4.22
     paths:
       - 'docs/**'
 
@@ -17,21 +19,20 @@ jobs:
     timeout-minutes: 10
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-python@v5
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.x'
-        env:
-          PIP_CACHE_DIR: ${{ runner.temp }}/.pip-cache
-      - run: pip install -r docs/requirements.txt
+          pip-install: '-r docs/requirements.txt'
         env:
           PIP_CACHE_DIR: ${{ runner.temp }}/.pip-cache
       - name: Build documentation
         run: mkdocs build --strict
         working-directory: docs
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docs-site
           path: docs/site
@@ -46,11 +47,11 @@ jobs:
       name: docs-preview
       url: https://pr-${{ github.event.pull_request.number }}.hypershift.pages.dev
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: docs-site
           path: site
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '20'
         env:
@@ -58,7 +59,7 @@ jobs:
       - name: Deploy to Cloudflare Pages
         env:
           npm_config_cache: ${{ runner.temp }}/.npm
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/envtest-kube.yaml
+++ b/.github/workflows/envtest-kube.yaml
@@ -2,22 +2,55 @@ name: Envtest Vanilla Kube API Validation
 
 on:
   push:
-    branches: [main, release-4.22]
-    paths:
-      - 'api/**'
-      - 'test/envtest/**'
-      - 'cmd/install/assets/crds/hypershift-operator/tests/**'
+    branches:
+      - main
+      - release-4.22
   pull_request:
-    branches: [main, release-4.22]
-    paths:
-      - 'api/**'
-      - 'test/envtest/**'
-      - 'cmd/install/assets/crds/hypershift-operator/tests/**'
+    branches:
+      - main
+      - release-4.22
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: arc-runner-set
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Check for relevant file changes
+        id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CREATED: ${{ github.event.created }}
+          PR_DIFF_REF: origin/${{ github.base_ref }}...HEAD
+          PUSH_DIFF_REF: ${{ github.event.before }}..HEAD
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] || [ "$CREATED" = "true" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          ref="$PUSH_DIFF_REF"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            ref="$PR_DIFF_REF"
+          fi
+          if git diff --name-only "$ref" | grep -qE '^(api/|test/envtest/|cmd/install/assets/crds/hypershift-operator/tests/|\.github/workflows/envtest-kube\.yaml$)'; then
+            echo "should_run=true"
+          else
+            echo "should_run=false"
+          fi >> "$GITHUB_OUTPUT"
+
   envtest-kube:
     name: Envtest Vanilla Kube ${{ matrix.version }}
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
     runs-on: arc-runner-set
     timeout-minutes: 15
     strategy:
@@ -25,5 +58,31 @@ jobs:
       matrix:
         version: ["1.31.0", "1.32.0", "1.33.0", "1.34.0", "1.35.0"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - run: make test-envtest-kube ENVTEST_KUBE_VERSIONS="${{ matrix.version }}"
+
+  conclusion:
+    name: Conclusion
+    needs:
+      - changes
+      - envtest-kube
+    if: always()
+    runs-on: arc-runner-set
+    steps:
+      - name: Aggregate results
+        run: |
+          changes_result="${{ needs.changes.result }}"
+          envtest_result="${{ needs.envtest-kube.result }}"
+          if [ "$changes_result" != "success" ]; then
+            echo "Change detection failed: $changes_result"
+            exit 1
+          fi
+          if [ "$envtest_result" = "success" ] || [ "$envtest_result" = "skipped" ]; then
+            echo "All envtest jobs passed or were skipped"
+            exit 0
+          else
+            echo "Envtest jobs failed: $envtest_result"
+            exit 1
+          fi

--- a/.github/workflows/envtest-ocp.yaml
+++ b/.github/workflows/envtest-ocp.yaml
@@ -2,22 +2,55 @@ name: Envtest OCP API Validation
 
 on:
   push:
-    branches: [main, release-4.22]
-    paths:
-      - 'api/**'
-      - 'test/envtest/**'
-      - 'cmd/install/assets/crds/hypershift-operator/tests/**'
+    branches:
+      - main
+      - release-4.22
   pull_request:
-    branches: [main, release-4.22]
-    paths:
-      - 'api/**'
-      - 'test/envtest/**'
-      - 'cmd/install/assets/crds/hypershift-operator/tests/**'
+    branches:
+      - main
+      - release-4.22
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: arc-runner-set
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Check for relevant file changes
+        id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CREATED: ${{ github.event.created }}
+          PR_DIFF_REF: origin/${{ github.base_ref }}...HEAD
+          PUSH_DIFF_REF: ${{ github.event.before }}..HEAD
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] || [ "$CREATED" = "true" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          ref="$PUSH_DIFF_REF"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            ref="$PR_DIFF_REF"
+          fi
+          if git diff --name-only "$ref" | grep -qE '^(api/|test/envtest/|cmd/install/assets/crds/hypershift-operator/tests/|\.github/workflows/envtest-ocp\.yaml$)'; then
+            echo "should_run=true"
+          else
+            echo "should_run=false"
+          fi >> "$GITHUB_OUTPUT"
+
   envtest-ocp:
     name: Envtest OCP (K8s ${{ matrix.version }})
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
     runs-on: arc-runner-set
     timeout-minutes: 15
     strategy:
@@ -26,5 +59,31 @@ jobs:
         # OCP 4.17=1.30, 4.18=1.31, 4.19=1.32, 4.20=1.33, 4.21=1.34, 4.22=1.35
         version: ["1.30.3", "1.31.2", "1.32.1", "1.33.2", "1.34.1", "1.35.1"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - run: make test-envtest-ocp ENVTEST_OCP_K8S_VERSIONS="${{ matrix.version }}"
+
+  conclusion:
+    name: Conclusion
+    needs:
+      - changes
+      - envtest-ocp
+    if: always()
+    runs-on: arc-runner-set
+    steps:
+      - name: Aggregate results
+        run: |
+          changes_result="${{ needs.changes.result }}"
+          envtest_result="${{ needs.envtest-ocp.result }}"
+          if [ "$changes_result" != "success" ]; then
+            echo "Change detection failed: $changes_result"
+            exit 1
+          fi
+          if [ "$envtest_result" = "success" ] || [ "$envtest_result" = "skipped" ]; then
+            echo "All envtest jobs passed or were skipped"
+            exit 0
+          else
+            echo "Envtest jobs failed: $envtest_result"
+            exit 1
+          fi

--- a/.github/workflows/gitlint.yaml
+++ b/.github/workflows/gitlint.yaml
@@ -2,7 +2,12 @@ name: Gitlint
 
 on:
   pull_request:
-    branches: [main, release-4.22]
+    branches:
+      - main
+      - release-4.22
+
+permissions:
+  contents: read
 
 jobs:
   gitlint:
@@ -10,9 +15,10 @@ jobs:
     runs-on: arc-runner-set
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - run: make run-gitlint
         env:
           PULL_BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,7 +2,12 @@ name: Lint
 
 on:
   pull_request:
-    branches: [main, release-4.22]
+    branches:
+      - main
+      - release-4.22
+
+permissions:
+  contents: read
 
 jobs:
   lint:
@@ -10,7 +15,7 @@ jobs:
     runs-on: arc-runner-set
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - run: git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}

--- a/.github/workflows/sync-community-fork.yaml
+++ b/.github/workflows/sync-community-fork.yaml
@@ -2,7 +2,11 @@ name: Sync Community Fork
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+
+permissions:
+  contents: read
 
 jobs:
   sync-community-fork:
@@ -14,7 +18,7 @@ jobs:
       # is configured with it for all github.com requests. This allows the push
       # to the community fork to authenticate correctly instead of using the
       # default GITHUB_TOKEN (which only has access to the source repo).
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ secrets.COMMUNITY_FORK_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,10 +2,17 @@ name: Unit Tests
 
 on:
   push:
-    branches: [main, release-4.22]
+    branches:
+      - main
+      - release-4.22
   pull_request:
-    branches: [main, release-4.22]
+    branches:
+      - main
+      - release-4.22
   workflow_dispatch: {}
+
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -13,9 +20,10 @@ jobs:
     runs-on: arc-runner-set
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Check for non-contrib changes
         id: changes
         run: |
@@ -33,7 +41,7 @@ jobs:
         run: make test
       - if: steps.changes.outputs.run_tests == 'true'
         name: Upload to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         env:
           HOME: /tmp
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -2,7 +2,12 @@ name: Verify
 
 on:
   pull_request:
-    branches: [main, release-4.22]
+    branches:
+      - main
+      - release-4.22
+
+permissions:
+  contents: read
 
 jobs:
   verify:
@@ -10,7 +15,9 @@ jobs:
     runs-on: arc-runner-set
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - run: make generate update
       - run: |
           git update-index --refresh


### PR DESCRIPTION
## Summary

- **SHA-pin all actions at latest versions** — pins every action to an immutable 40-char commit SHA with a version comment; pinned at current latest releases (checkout v6.0.2, setup-python v6.2.0, upload-artifact v7.0.1, download-artifact v8.0.1, setup-node v6.3.0, codecov-action v6.0.0, wrangler-action v3.14.1), preventing tag-mutation supply-chain attacks; adds `github-actions` ecosystem to Dependabot to keep pins current automatically
- **Explicit minimal permissions** — adds `permissions: contents: read` to all workflows lacking a permissions block, following least-privilege; `docs-preview.yaml` already had correct permissions
- **Disable credential persistence** — adds `persist-credentials: false` to all `actions/checkout` steps except `sync-community-fork.yaml`, which requires credentials for its `git push` to the community fork
- **Stable conclusion jobs for matrix workflows** — `envtest-kube.yaml` and `envtest-ocp.yaml` gain a `changes` job (using event-appropriate git diff ranges) and a `Conclusion` job that aggregates matrix results under a fixed check name, enabling reliable branch protection configuration; the `Conclusion` job depends on both `changes` and the matrix job so change-detection failures are never silently hidden; path filtering moves inside the workflow so the conclusion job always runs
- **Housekeeping** — multi-line branch lists throughout for consistency; `docs-preview.yaml` pip install uses setup-python's native `pip-install` input (supported in v6.2.0+)

## Change detection diff ranges

The envtest `changes` job uses event-appropriate ranges to ensure all commits are considered:

| Event | Range | Variable |
|-------|-------|----------|
| `pull_request` | `origin/<base>...HEAD` | `PR_DIFF_REF` |
| `push` | `<before>..HEAD` | `PUSH_DIFF_REF` |
| `workflow_dispatch` | always runs | — |

## Required checks (for branch protection configuration)

| Workflow | Stable check name |
|----------|------------------|
| `codespell.yaml` | `Codespell / Codespell` |
| `cpo-container-sync.yaml` | `CPO Container Sync / CPO Container Sync` |
| `gitlint.yaml` | `Gitlint / Gitlint` |
| `lint.yaml` | `Lint / Lint` |
| `verify.yaml` | `Verify / Verify` |
| `test.yaml` | `Unit Tests / Unit Tests` |
| `envtest-kube.yaml` | `Envtest Vanilla Kube API Validation / Conclusion` |
| `envtest-ocp.yaml` | `Envtest OCP API Validation / Conclusion` |

`docs-preview.yaml` and `sync-community-fork.yaml` are not required checks.

## Test plan

- [x] All 10 workflow checks trigger and pass on this PR
- [x] For envtest workflows: verify `Conclusion` job runs and passes when no API files are changed (matrix skipped, conclusion shows `skipped` → passes)
- [x] Confirm Dependabot picks up the `github-actions` ecosystem after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a weekly Dependabot update entry for GitHub Actions with standardized commit message prefix and labels.
  * Standardized workflow branch filters and added workflow-level read-only permissions.
  * Pinned action versions for more reproducible runs and disabled credential persistence for improved checkout security.
  * Introduced change-detection gating and conclusion jobs to avoid unnecessary test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->