### PR TITLE
OCPBUGS-83585: Wait for CRD removal in GenerateCRDInstallTest to fix flaky envtest

### DIFF
--- a/test/envtest/generator.go
+++ b/test/envtest/generator.go
@@ -17,6 +17,7 @@ import (
 	crdassets "github.com/openshift/hypershift/cmd/install/assets/crds"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
@@ -208,9 +209,10 @@ func GenerateTestSuite(suiteSpec SuiteSpec) {
 				Expect(envtest.UninstallCRDs(cfg, envtest.CRDInstallOptions{
 					CRDs: []*apiextensionsv1.CustomResourceDefinition{crd},
 				})).ToNot(HaveOccurred())
-				Eventually(func() error {
-					return k8sClient.Get(ctx, client.ObjectKeyFromObject(crd), crd)
-				}, "30s").ShouldNot(Succeed())
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(crd), &apiextensionsv1.CustomResourceDefinition{})
+					return apierrors.IsNotFound(err)
+				}, "30s", "1s").Should(BeTrue(), fmt.Sprintf("CRD %s should be fully removed", crd.Name))
 			})
 
 			generateOnCreateTable(suiteSpec.Tests.OnCreate)
@@ -246,10 +248,19 @@ func GenerateCRDInstallTest(featureSet string) {
 		Expect(crds).To(HaveLen(len(allCRDs)), "all CRDs should have been installed")
 		Expect(envtest.WaitForCRDs(cfg, crds, envtest.CRDInstallOptions{})).To(Succeed())
 
-		// Uninstall after validation.
+		// Uninstall after validation and wait for full removal so that
+		// subsequent per-suite tests do not hit a stale CRD that is still
+		// being deleted by the API server.
 		Expect(envtest.UninstallCRDs(cfg, envtest.CRDInstallOptions{
 			CRDs: crds,
 		})).ToNot(HaveOccurred())
+		for _, crd := range crds {
+			key := client.ObjectKeyFromObject(crd)
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, &apiextensionsv1.CustomResourceDefinition{})
+				return apierrors.IsNotFound(err)
+			}, "30s", "1s").Should(BeTrue(), fmt.Sprintf("CRD %s should be fully removed", crd.Name))
+		}
 	})
 }
 


### PR DESCRIPTION
## What this PR does / why we need it

`GenerateCRDInstallTest` uninstalls all CRDs after validation but does **not** wait for the API server to fully remove them. When individual per-suite tests start immediately after, they find a stale CRD in a transitional/deletion state, causing `WaitForCRDs` to timeout with `context deadline exceeded`.

This adds a wait-for-removal loop after `UninstallCRDs` in `GenerateCRDInstallTest`, matching the pattern already used in `GenerateTestSuite`'s `AfterEach`.

### Root Cause

The execution order in `suite_test.go` is:

1. `GenerateCRDInstallTest("Default")` — installs Default CRDs
2. `GenerateCRDInstallTest("TechPreviewNoUpgrade")` — installs **all** TechPreviewNoUpgrade CRDs (including `hcpetcdbackups`), uninstalls **without waiting**
3. Individual test suites start — the `hcpetcdbackups` CustomNoUpgrade variant hits the stale CRD

The flakiness depends on how fast the API server finalizes CRD deletion, which varies by K8s version and CI load:
- On main: failed on K8s 1.31.0 ([run 24473624963](https://github.com/openshift/hypershift/actions/runs/24473624963))
- On PR #8223: failed on K8s 1.35.0 ([run 24513124942](https://github.com/openshift/hypershift/actions/runs/24513124942/job/71649529435))

## Which issue(s) this PR fixes

Fixes https://issues.redhat.com/browse/OCPBUGS-83585

## Checklist
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved CRD uninstall verification in the test suite: tests now actively wait (with retries) for each custom resource definition to be fully removed, confirming cleanup within a 30-second window. This reduces test flakiness by preventing leftover CRDs from affecting subsequent test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->