### PR TITLE
OCPBUGS-83604: fix(kubevirt): filter link-local addresses from EndpointSlice endpoints

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/machine/machine.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/machine/machine.go
@@ -126,6 +126,10 @@ func (r *reconciler) reconcileKubevirtPassthroughService(ctx context.Context, hc
 			if err != nil {
 				return fmt.Errorf("parsing machine address (%s) in machine %s: %w", machineAddress.Address, machine.Name, err)
 			}
+			if parsedAddr.IsLinkLocalUnicast() {
+				log.Info("Skipping link-local address for EndpointSlice", "address", machineAddress.Address, "machine", machine.Name)
+				continue
+			}
 			if parsedAddr.Is4() {
 				ipv4MachineAddresses = append(ipv4MachineAddresses, machineAddress.Address)
 			} else {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/machine/machine_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/machine/machine_test.go
@@ -383,6 +383,45 @@ func TestReconcileDefaultIngressEndpoints(t *testing.T) {
 	_ = kubevirtv1.AddToScheme(scheme.Scheme)
 	_ = discoveryv1.AddToScheme(scheme.Scheme)
 	_ = corev1.AddToScheme(scheme.Scheme)
+	machinesWithLinkLocalAddresses := []capiv1.Machine{
+		{
+			TypeMeta:   machineTypeMeta,
+			ObjectMeta: worker1Meta,
+			Spec: capiv1.MachineSpec{
+				InfrastructureRef: corev1.ObjectReference{
+					Name: vmWorker1Meta.Name,
+				},
+			},
+			Status: capiv1.MachineStatus{
+				Phase: string(capiv1.MachinePhaseRunning),
+				Addresses: []capiv1.MachineAddress{
+					{Type: capiv1.MachineInternalIP, Address: "192.168.1.3"},
+					{Type: capiv1.MachineInternalIP, Address: "169.254.0.2"},
+					{Type: capiv1.MachineInternalIP, Address: "2001:db8:a0b:12f0::3"},
+					{Type: capiv1.MachineInternalIP, Address: "fe80::1"},
+				},
+			},
+		},
+		{
+			TypeMeta:   machineTypeMeta,
+			ObjectMeta: worker2Meta,
+			Spec: capiv1.MachineSpec{
+				InfrastructureRef: corev1.ObjectReference{
+					Name: vmWorker2Meta.Name,
+				},
+			},
+			Status: capiv1.MachineStatus{
+				Phase: string(capiv1.MachinePhaseRunning),
+				Addresses: []capiv1.MachineAddress{
+					{Type: capiv1.MachineInternalIP, Address: "192.168.1.4"},
+					{Type: capiv1.MachineInternalIP, Address: "169.254.169.254"},
+					{Type: capiv1.MachineInternalIP, Address: "2001:db8:a0b:12f0::4"},
+					{Type: capiv1.MachineInternalIP, Address: "fe80::dead:beef"},
+				},
+			},
+		},
+	}
+
 	testCases := []struct {
 		name                          string
 		machines                      []capiv1.Machine
@@ -435,6 +474,24 @@ func TestReconcileDefaultIngressEndpoints(t *testing.T) {
 				defaultIngressEndpointSliceIPv4(pairOfDualStackRunningMachines[1], pairOfVirtualMachines[1], readyAndServing(false, false)),
 				defaultIngressEndpointSliceIPv6(pairOfDualStackRunningMachines[0], pairOfVirtualMachines[0], readyAndServing(true, true)),
 				defaultIngressEndpointSliceIPv6(pairOfDualStackRunningMachines[1], pairOfVirtualMachines[1], readyAndServing(false, false)),
+			},
+			hcp: kubevirtHCP,
+		},
+		{
+			name:             "When machines have link-local addresses it should filter them from EndpointSlice endpoints",
+			machines:         machinesWithLinkLocalAddresses,
+			virtualMachines:  pairOfVirtualMachines,
+			services:         []corev1.Service{defaultIngressService, kccmService},
+			expectedServices: []corev1.Service{defaultIngressService, kccmService},
+			expectedIngressEndpointSlices: []discoveryv1.EndpointSlice{
+				defaultIngressEndpointSliceIPv4(machinesWithLinkLocalAddresses[0], pairOfVirtualMachines[0]),
+				defaultIngressEndpointSliceIPv4(machinesWithLinkLocalAddresses[1], pairOfVirtualMachines[1]),
+				defaultIngressEndpointSliceIPv6(machinesWithLinkLocalAddresses[0], pairOfVirtualMachines[0]),
+				defaultIngressEndpointSliceIPv6(machinesWithLinkLocalAddresses[1], pairOfVirtualMachines[1]),
+				kccmEndpointSliceIPv4(machinesWithLinkLocalAddresses[0], pairOfVirtualMachines[0]),
+				kccmEndpointSliceIPv4(machinesWithLinkLocalAddresses[1], pairOfVirtualMachines[1]),
+				kccmEndpointSliceIPv6(machinesWithLinkLocalAddresses[0], pairOfVirtualMachines[0]),
+				kccmEndpointSliceIPv6(machinesWithLinkLocalAddresses[1], pairOfVirtualMachines[1]),
 			},
 			hcp: kubevirtHCP,
 		},


### PR DESCRIPTION
### Summary

The HCCO machine controller fails to create EndpointSlices for KubeVirt guest LoadBalancer shadow services on Kubernetes 1.33+ clusters. This is because link-local addresses (`169.254.0.0/16`, `fe80::/10`) reported in `Machine.Status.Addresses` are now rejected by EndpointSlice validation.

### Problem

KubeVirt VMs can report link-local addresses (e.g. `169.254.0.2`, `fe80::1`) as `InternalIP` entries in `Machine.Status.Addresses`. The `reconcileKubevirtPassthroughService` function collected **all** `InternalIP` addresses without filtering and placed them into EndpointSlice endpoints.

Kubernetes 1.33 introduced validation that rejects link-local addresses in EndpointSlices, causing errors like:

```
EndpointSlice "default-ingress-passthrough-service-...-ipv4" is invalid:
  endpoints[0].addresses[1]: Invalid value: "169.254.0.2":
    may not be in the link-local range (169.254.0.0/16, fe80::/10)
```

Because the reconciler returns early on error, the failure on the ingress passthrough service also prevented processing of any subsequent KCCM shadow services.

### Fix

Filter out link-local addresses using `netip.Addr.IsLinkLocalUnicast()` (which covers both IPv4 `169.254.0.0/16` and IPv6 `fe80::/10`) before populating EndpointSlice endpoints. Filtered addresses are logged for observability.

### Test plan

- [x] Added unit test: "When machines have link-local addresses it should filter them from EndpointSlice endpoints"
  - Machines carry a mix of routable (`192.168.1.x`, `2001:db8::x`) and link-local (`169.254.0.2`, `169.254.169.254`, `fe80::1`, `fe80::dead:beef`) addresses
  - Verifies only routable addresses appear in the resulting EndpointSlices
  - Covers both ingress passthrough and KCCM service EndpointSlices
- [x] All existing tests continue to pass

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://redhat.atlassian.net/browse/OCPBUGS-83604

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed KubeVirt passthrough to properly filter out link-local IP addresses when constructing EndpointSlice endpoints, ensuring only routable addresses are exposed.

* **Tests**
  * Added test coverage validating correct endpoint filtering for machines with mixed link-local and standard IP addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->