### PR TITLE
OCPBUGS-83751: add missing RBAC for webhook configurations

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -1483,6 +1483,11 @@ func (o HyperShiftOperatorClusterRole) Build() *rbacv1.ClusterRole {
 				ResourceNames: []string{hyperv1.GroupVersion.Group},
 			},
 			{
+				APIGroups: []string{"admissionregistration.k8s.io"},
+				Resources: []string{"mutatingwebhookconfigurations", "validatingwebhookconfigurations"},
+				Verbs:     []string{"get", "list", "watch", "update"},
+			},
+			{
 				APIGroups: []string{"certificates.k8s.io"},
 				Resources: []string{"certificatesigningrequests"},
 				Verbs:     []string{"get", "list", "watch"},

--- a/cmd/install/assets/hypershift_operator_test.go
+++ b/cmd/install/assets/hypershift_operator_test.go
@@ -9,6 +9,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -771,4 +772,30 @@ func TestHyperShiftOperatorDeployment_Build_WorkloadIdentityLabel(t *testing.T) 
 			}
 		})
 	}
+}
+
+func TestHyperShiftOperatorClusterRole_WebhookRBAC(t *testing.T) {
+	t.Parallel()
+	clusterRole := HyperShiftOperatorClusterRole{}.Build()
+
+	t.Run("When building the ClusterRole it should include cluster-scoped RBAC for webhook configurations", func(t *testing.T) {
+		t.Parallel()
+		g := NewGomegaWithT(t)
+		g.Expect(clusterRole.Rules).To(ContainElement(Equal(rbacv1.PolicyRule{
+			APIGroups: []string{"admissionregistration.k8s.io"},
+			Resources: []string{"mutatingwebhookconfigurations", "validatingwebhookconfigurations"},
+			Verbs:     []string{"get", "list", "watch", "update"},
+		})))
+	})
+
+	t.Run("When building the ClusterRole it should include scoped delete for validatingwebhookconfigurations", func(t *testing.T) {
+		t.Parallel()
+		g := NewGomegaWithT(t)
+		g.Expect(clusterRole.Rules).To(ContainElement(Equal(rbacv1.PolicyRule{
+			APIGroups:     []string{"admissionregistration.k8s.io"},
+			Resources:     []string{"validatingwebhookconfigurations"},
+			Verbs:         []string{"delete"},
+			ResourceNames: []string{hyperv1.GroupVersion.Group},
+		})))
+	})
 }


### PR DESCRIPTION
## Summary

- Add cluster-scoped RBAC rule for `mutatingwebhookconfigurations` and `validatingwebhookconfigurations` with `get`, `list`, `watch`, `update` verbs to the hypershift-operator `ClusterRole`
- The `webhookcerts` controller (PR #8174, [CNTRLPLANE-2207](https://redhat.atlassian.net/browse/CNTRLPLANE-2207)) uses `Client.Get()`/`Client.Update()` on these resources via the cached client, which triggers lazy informer creation requiring `list`/`watch` permissions at cluster scope
- Add unit tests verifying both the new cluster-scoped rule and the pre-existing scoped `delete` rule

## Bug

Closes https://issues.redhat.com/browse/OCPBUGS-83751

## Test plan

- [x] Unit tests pass (`go test -race ./cmd/install/assets/ -run TestHyperShiftOperatorClusterRole_WebhookRBAC`)
- [x] Build passes (`go build ./cmd/install/...`)
- [ ] Deploy with `hypershift install` and verify no reflector RBAC errors in operator logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for HyperShift operator webhook configuration permissions.

* **Chores**
  * Enhanced HyperShift operator role-based access control permissions to support webhook configuration management. Operator can now get, list, watch, and update mutating and validating webhook configurations as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->