### PR TITLE
OCPBUGS-83757: Remove network dependencies from unit tests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,6 +8,7 @@ ignore:
   - "hack/**"
   - "client/**"
   - "vendor/**"
+  - "support/thirdparty/**"
   - "docs/**"
   - "Makefile"
   - ".*/**"
@@ -19,6 +20,8 @@ ignore:
   # Generated mock files
   - "**/*_mock.go"
   - "**/*mock*.go"
+  # Test fakes and helpers
+  - "**/fake*/*.go"
   # Files containing only types, structs, or constants (no executable code)
   - "control-plane-operator/controllers/hostedcontrolplane/cloud/azure/providerconfig.go"
   - "control-plane-operator/controllers/hostedcontrolplane/ocm/config.go"
@@ -27,7 +30,6 @@ ignore:
   - "control-plane-operator/metrics-proxy/types.go"
   - "support/config/constants.go"
   - "support/config/types.go"
-  - "support/thirdparty/library-go/pkg/image/dockerv1client/types.go"
   - "support/awsapi/*.go"
   - "support/azureutil/constants.go"
   - "support/api/capi_types.go"

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/idp_convert_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/idp_convert_test.go
@@ -25,6 +25,15 @@ import (
 )
 
 func TestOpenIDProviderConversion(t *testing.T) {
+	// Pre-populate caches to avoid network calls to accounts.google.com and oauth2.googleapis.com.
+	openIDURLsCache.Set("https://accounts.google.com/.well-known/openid-configuration", &osinv1.OpenIDURLs{
+		Authorize: "https://accounts.google.com/o/oauth2/v2/auth",
+		Token:     "https://oauth2.googleapis.com/token",
+		UserInfo:  "https://openidconnect.googleapis.com/v1/userinfo",
+	}, openIDURLsTTL)
+	// Pre-populate the OIDC password grant check cache to avoid the token endpoint call.
+	oidcPasswordCheckCache.Set("1", false, oidcPasswordTTL)
+
 	// Define common inputs
 	groupsInput := []configv1.OpenIDClaim{"groups"}
 	volumeMountInfo := &IDPVolumeMountInfo{
@@ -37,8 +46,9 @@ func TestOpenIDProviderConversion(t *testing.T) {
 	const secretName = "secret1"
 	idpSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
-			Namespace: namespace,
+			Name:            secretName,
+			Namespace:       namespace,
+			ResourceVersion: "1",
 		},
 		Immutable: nil,
 		Data: map[string][]byte{

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/idp_convert_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/idp_convert_test.go
@@ -33,6 +33,10 @@ func TestOpenIDProviderConversion(t *testing.T) {
 	}, openIDURLsTTL)
 	// Pre-populate the OIDC password grant check cache to avoid the token endpoint call.
 	oidcPasswordCheckCache.Set("1", false, oidcPasswordTTL)
+	t.Cleanup(func() {
+		openIDURLsCache.Delete("https://accounts.google.com/.well-known/openid-configuration")
+		oidcPasswordCheckCache.Delete("1")
+	})
 
 	// Define common inputs
 	groupsInput := []configv1.OpenIDClaim{"groups"}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/deployment_test.go
@@ -21,7 +21,7 @@ import (
 
 // TestAdaptDeployment verifies that adaptDeployment produces a deterministic deployment
 // spec and does not perform live registry connectivity checks. This addresses OCPBUGS-60185
-// where non-deterministic results from LookupMappedImage/SeekOverride caused deployment
+// where non-deterministic results from LookupMappedImage/seekOverride caused deployment
 // flapping and pod restarts.
 func TestAdaptDeployment(t *testing.T) {
 	tests := []struct {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/idp_convert_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/idp_convert_test.go
@@ -25,6 +25,15 @@ import (
 )
 
 func TestOpenIDProviderConversion(t *testing.T) {
+	// Pre-populate caches to avoid network calls to accounts.google.com and oauth2.googleapis.com.
+	openIDURLsCache.Set("https://accounts.google.com/.well-known/openid-configuration", &osinv1.OpenIDURLs{
+		Authorize: "https://accounts.google.com/o/oauth2/v2/auth",
+		Token:     "https://oauth2.googleapis.com/token",
+		UserInfo:  "https://openidconnect.googleapis.com/v1/userinfo",
+	}, openIDURLsTTL)
+	// Pre-populate the OIDC password grant check cache to avoid the token endpoint call.
+	oidcPasswordCheckCache.Set("1", false, oidcPasswordTTL)
+
 	// Define common inputs
 	groupsInput := []configv1.OpenIDClaim{"groups"}
 	volumeMountInfo := &IDPVolumeMountInfo{
@@ -37,8 +46,9 @@ func TestOpenIDProviderConversion(t *testing.T) {
 	const secretName = "secret1"
 	idpSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
-			Namespace: namespace,
+			Name:            secretName,
+			Namespace:       namespace,
+			ResourceVersion: "1",
 		},
 		Immutable: nil,
 		Data: map[string][]byte{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/idp_convert_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/idp_convert_test.go
@@ -33,6 +33,10 @@ func TestOpenIDProviderConversion(t *testing.T) {
 	}, openIDURLsTTL)
 	// Pre-populate the OIDC password grant check cache to avoid the token endpoint call.
 	oidcPasswordCheckCache.Set("1", false, oidcPasswordTTL)
+	t.Cleanup(func() {
+		openIDURLsCache.Delete("https://accounts.google.com/.well-known/openid-configuration")
+		oidcPasswordCheckCache.Delete("1")
+	})
 
 	// Define common inputs
 	groupsInput := []configv1.OpenIDClaim{"groups"}

--- a/support/catalogs/images_test.go
+++ b/support/catalogs/images_test.go
@@ -433,11 +433,12 @@ func TestImageExistsFnGuestCluster(t *testing.T) {
 			pullSecret:     []byte("12345"),
 		},
 		{
-			name:           "Management cluster should fail when image not found",
-			olmcatalog:     hyperv1.ManagementOLMCatalogPlacement,
-			expectedExists: false,
-			expectedError:  true,
-			pullSecret:     []byte("12345"),
+			name:               "Management cluster should fail when image not found",
+			olmcatalog:         hyperv1.ManagementOLMCatalogPlacement,
+			expectedExists:     false,
+			expectedError:      true,
+			imageMetadataError: errors.New("image not found"),
+			pullSecret:         []byte("12345"),
 		},
 		{
 			name:               "Management cluster with manifest unknown error should return false",

--- a/support/catalogs/images_test.go
+++ b/support/catalogs/images_test.go
@@ -426,14 +426,14 @@ func TestImageExistsFnGuestCluster(t *testing.T) {
 		pullSecret         []byte
 	}{
 		{
-			name:           "Guest cluster should return true without checking image",
+			name:           "When using guest cluster placement it should return true without checking image",
 			olmcatalog:     hyperv1.GuestOLMCatalogPlacement,
 			expectedExists: true,
 			expectedError:  false,
 			pullSecret:     []byte("12345"),
 		},
 		{
-			name:               "Management cluster should fail when image not found",
+			name:               "When using management cluster placement and image is not found it should fail",
 			olmcatalog:         hyperv1.ManagementOLMCatalogPlacement,
 			expectedExists:     false,
 			expectedError:      true,
@@ -441,7 +441,7 @@ func TestImageExistsFnGuestCluster(t *testing.T) {
 			pullSecret:         []byte("12345"),
 		},
 		{
-			name:               "Management cluster with manifest unknown error should return false",
+			name:               "When using management cluster placement and manifest is unknown it should return false",
 			olmcatalog:         hyperv1.ManagementOLMCatalogPlacement,
 			expectedExists:     false,
 			expectedError:      false,
@@ -449,7 +449,7 @@ func TestImageExistsFnGuestCluster(t *testing.T) {
 			pullSecret:         []byte("12345"),
 		},
 		{
-			name:               "Management cluster with unauthorized error should return false",
+			name:               "When using management cluster placement and access is unauthorized it should return false",
 			olmcatalog:         hyperv1.ManagementOLMCatalogPlacement,
 			expectedExists:     false,
 			expectedError:      false,
@@ -457,7 +457,7 @@ func TestImageExistsFnGuestCluster(t *testing.T) {
 			pullSecret:         []byte("12345"),
 		},
 		{
-			name:           "Management cluster with successful image check should return true",
+			name:           "When using management cluster placement and image check succeeds it should return true",
 			olmcatalog:     hyperv1.ManagementOLMCatalogPlacement,
 			expectedExists: true,
 			expectedError:  false,

--- a/support/releaseinfo/registry_image_content_policies.go
+++ b/support/releaseinfo/registry_image_content_policies.go
@@ -5,11 +5,12 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/docker/distribution"
 	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/docker/distribution"
 )
 
 var _ ProviderWithOpenShiftImageRegistryOverrides = (*ProviderWithOpenShiftImageRegistryOverridesDecorator)(nil)

--- a/support/releaseinfo/registry_image_content_policies.go
+++ b/support/releaseinfo/registry_image_content_policies.go
@@ -5,7 +5,9 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/docker/distribution"
 	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
+	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -17,12 +19,21 @@ type ProviderWithOpenShiftImageRegistryOverridesDecorator struct {
 	OpenShiftImageRegistryOverrides map[string][]string
 	mirroredReleaseImage            string
 
+	// repoSetupFn is an injectable function for verifying mirror availability.
+	// When nil, defaults to registryclient.GetRepoSetup.
+	repoSetupFn func(ctx context.Context, imageRef string, pullSecret []byte) (distribution.Repository, *reference.DockerImageReference, error)
+
 	lock sync.Mutex
 }
 
 func (p *ProviderWithOpenShiftImageRegistryOverridesDecorator) Lookup(ctx context.Context, image string, pullSecret []byte) (*ReleaseImage, error) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
+
+	repoSetup := p.repoSetupFn
+	if repoSetup == nil {
+		repoSetup = registryclient.GetRepoSetup
+	}
 
 	logger := ctrl.LoggerFrom(ctx)
 
@@ -35,7 +46,7 @@ func (p *ProviderWithOpenShiftImageRegistryOverridesDecorator) Lookup(ctx contex
 				releaseImage, err := p.Delegate.Lookup(ctx, replacedImage, pullSecret)
 				if releaseImage != nil {
 					// Verify mirror image availability.
-					if _, _, err = registryclient.GetRepoSetup(ctx, replacedImage, pullSecret); err == nil {
+					if _, _, err = repoSetup(ctx, replacedImage, pullSecret); err == nil {
 						p.mirroredReleaseImage = replacedImage
 						return releaseImage, nil
 					}

--- a/support/releaseinfo/registry_image_content_policies_test.go
+++ b/support/releaseinfo/registry_image_content_policies_test.go
@@ -57,3 +57,41 @@ func TestProviderWithOpenShiftImageRegistryOverridesDecorator_Lookup(t *testing.
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(provider.GetMirroredReleaseImage()).To(Equal(mirroredReleaseImage))
 }
+
+func TestProviderWithOpenShiftImageRegistryOverridesDecorator_LookupWithNilRepoSetupFn(t *testing.T) {
+	g := NewWithT(t)
+
+	directImage := "quay.io/openshift-release-dev/ocp-release:4.16.13-x86_64"
+	releaseImage := &ReleaseImage{
+		ImageStream:    &imagev1.ImageStream{},
+		StreamMetadata: &CoreOSStreamMetadata{},
+	}
+
+	delegate := &RegistryMirrorProviderDecorator{
+		Delegate: &CachedProvider{
+			Inner: &RegistryClientProvider{},
+			Cache: map[string]*ReleaseImage{
+				directImage: releaseImage,
+			},
+		},
+		RegistryOverrides: map[string]string{},
+	}
+
+	// When repoSetupFn is nil it should default to registryclient.GetRepoSetup.
+	// Use an image that does not match any override so the default repoSetupFn
+	// is assigned but never called, avoiding real network calls.
+	provider := &ProviderWithOpenShiftImageRegistryOverridesDecorator{
+		Delegate: delegate,
+		OpenShiftImageRegistryOverrides: map[string][]string{
+			"no-match-source": {"no-match-mirror"},
+		},
+		// repoSetupFn intentionally nil to exercise the default fallback.
+		lock: sync.Mutex{},
+	}
+
+	pullSecret := []byte(`{"auths":{}}`)
+	result, err := provider.Lookup(t.Context(), directImage, pullSecret)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(releaseImage))
+	g.Expect(provider.GetMirroredReleaseImage()).To(BeEmpty())
+}

--- a/support/releaseinfo/registry_image_content_policies_test.go
+++ b/support/releaseinfo/registry_image_content_policies_test.go
@@ -1,13 +1,15 @@
 package releaseinfo
 
 import (
-	"os"
+	"context"
 	"sync"
 	"testing"
 
 	. "github.com/onsi/gomega"
 
+	"github.com/docker/distribution"
 	imagev1 "github.com/openshift/api/image/v1"
+	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
 )
 
 func TestProviderWithOpenShiftImageRegistryOverridesDecorator_Lookup(t *testing.T) {
@@ -34,17 +36,19 @@ func TestProviderWithOpenShiftImageRegistryOverridesDecorator_Lookup(t *testing.
 	provider := &ProviderWithOpenShiftImageRegistryOverridesDecorator{
 		Delegate: delegate,
 		OpenShiftImageRegistryOverrides: map[string][]string{
-			canonicalReleaseImage: []string{mirroredReleaseImage},
+			canonicalReleaseImage: {mirroredReleaseImage},
+		},
+		// Mock repoSetupFn to avoid real network calls for mirror verification.
+		repoSetupFn: func(ctx context.Context, imageRef string, pullSecret []byte) (distribution.Repository, *reference.DockerImageReference, error) {
+			ref, _ := reference.Parse(imageRef)
+			return nil, &ref, nil
 		},
 		lock: sync.Mutex{},
 	}
 
-	pullSecret, err := os.ReadFile("../../hack/dev/fakePullSecret.json")
-	if err != nil {
-		t.Fatalf("failed to read manifests file: %v", err)
-	}
+	pullSecret := []byte(`{"auths":{}}`)
 	// Call the Lookup method and validate GetMirroredReleaseImage.
-	_, err = provider.Lookup(t.Context(), canonicalReleaseImage, pullSecret)
+	_, err := provider.Lookup(t.Context(), canonicalReleaseImage, pullSecret)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(provider.GetMirroredReleaseImage()).To(Equal(mirroredReleaseImage))
 }

--- a/support/releaseinfo/registry_image_content_policies_test.go
+++ b/support/releaseinfo/registry_image_content_policies_test.go
@@ -7,9 +7,11 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"github.com/docker/distribution"
-	imagev1 "github.com/openshift/api/image/v1"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
+
+	imagev1 "github.com/openshift/api/image/v1"
+
+	"github.com/docker/distribution"
 )
 
 func TestProviderWithOpenShiftImageRegistryOverridesDecorator_Lookup(t *testing.T) {
@@ -40,7 +42,10 @@ func TestProviderWithOpenShiftImageRegistryOverridesDecorator_Lookup(t *testing.
 		},
 		// Mock repoSetupFn to avoid real network calls for mirror verification.
 		repoSetupFn: func(ctx context.Context, imageRef string, pullSecret []byte) (distribution.Repository, *reference.DockerImageReference, error) {
-			ref, _ := reference.Parse(imageRef)
+			ref, err := reference.Parse(imageRef)
+			if err != nil {
+				return nil, nil, err
+			}
 			return nil, &ref, nil
 		},
 		lock: sync.Mutex{},

--- a/support/releaseinfo/registryclient/client_test.go
+++ b/support/releaseinfo/registryclient/client_test.go
@@ -39,9 +39,8 @@ func (f *fakeRegistryClientImageMetadataProvider) ImageMetadata(ctx context.Cont
 }
 
 func (f *fakeRegistryClientImageMetadataProvider) GetManifest(ctx context.Context, imageRef string, pullSecret []byte) (distribution.Manifest, error) {
-	_, _, err := GetRepoSetup(ctx, imageRef, pullSecret)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve manifest %s: %w", imageRef, err)
+	if len(pullSecret) == 0 {
+		return nil, fmt.Errorf("empty pull secret")
 	}
 	return &fakeManifest{
 		f.mediaType,
@@ -49,11 +48,11 @@ func (f *fakeRegistryClientImageMetadataProvider) GetManifest(ctx context.Contex
 }
 
 func (f *fakeRegistryClientImageMetadataProvider) GetDigest(ctx context.Context, imageRef string, pullSecret []byte) (digest.Digest, *reference.DockerImageReference, error) {
-	var err error
-	_, f.ref, err = GetRepoSetup(ctx, imageRef, pullSecret)
+	ref, err := reference.Parse(imageRef)
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to retrieve manifest %s: %w", imageRef, err)
+		return "", nil, fmt.Errorf("failed to parse image reference %s: %w", imageRef, err)
 	}
+	f.ref = &ref
 	f.ref.ID = f.digest
 	return digest.Digest(f.digest), f.ref, nil
 }

--- a/support/util/fakeimagemetadataprovider/fakeimagemetadataprovider.go
+++ b/support/util/fakeimagemetadataprovider/fakeimagemetadataprovider.go
@@ -21,11 +21,14 @@ type FakeImageMetadataProvider interface {
 }
 
 func (f *FakeRegistryClientImageMetadataProvider) ImageMetadata(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, error) {
+	if f.Err != nil {
+		return nil, f.Err
+	}
 	return f.Result, nil
 }
 
 func (f *FakeManifest) References() []distribution.Descriptor { return []distribution.Descriptor{} }
-func (f *FakeManifest) Payload() (string, []byte, error)      { return f.MediaType, []byte{}, nil }
+func (f *FakeManifest) Payload() (string, []byte, error)      { return f.MediaType, []byte("{}"), nil }
 
 type FakeRegistryClientImageMetadataProvider struct {
 	MediaType string
@@ -33,18 +36,25 @@ type FakeRegistryClientImageMetadataProvider struct {
 	Manifest  FakeManifest
 	Digest    string
 	Ref       *reference.DockerImageReference
+	Err       error
 }
 type FakeManifest struct {
 	MediaType string
 }
 
 func (f *FakeRegistryClientImageMetadataProvider) GetManifest(ctx context.Context, imageRef string, pullSecret []byte) (distribution.Manifest, error) {
+	if f.Err != nil {
+		return nil, f.Err
+	}
 	return &FakeManifest{
 		f.MediaType,
 	}, nil
 }
 
 func (f *FakeRegistryClientImageMetadataProvider) GetDigest(ctx context.Context, imageRef string, pullSecret []byte) (digest.Digest, *reference.DockerImageReference, error) {
+	if f.Err != nil {
+		return "", nil, f.Err
+	}
 	ref, err := reference.Parse(imageRef)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to parse image reference %s: %w", imageRef, err)
@@ -55,10 +65,16 @@ func (f *FakeRegistryClientImageMetadataProvider) GetDigest(ctx context.Context,
 }
 
 func (f *FakeRegistryClientImageMetadataProvider) GetMetadata(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, []distribution.Descriptor, distribution.BlobStore, error) {
+	if f.Err != nil {
+		return nil, nil, nil, f.Err
+	}
 	return f.Result, []distribution.Descriptor{}, nil, nil
 }
 
 func (f *FakeRegistryClientImageMetadataProvider) GetOverride(ctx context.Context, imageRef string, pullSecret []byte) (*reference.DockerImageReference, error) {
+	if f.Err != nil {
+		return nil, f.Err
+	}
 	return f.Ref, nil
 }
 

--- a/support/util/fakeimagemetadataprovider/fakeimagemetadataprovider.go
+++ b/support/util/fakeimagemetadataprovider/fakeimagemetadataprovider.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
 
@@ -40,21 +39,17 @@ type FakeManifest struct {
 }
 
 func (f *FakeRegistryClientImageMetadataProvider) GetManifest(ctx context.Context, imageRef string, pullSecret []byte) (distribution.Manifest, error) {
-	_, _, err := registryclient.GetRepoSetup(ctx, imageRef, pullSecret)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve manifest %s: %w", imageRef, err)
-	}
 	return &FakeManifest{
 		f.MediaType,
 	}, nil
 }
 
 func (f *FakeRegistryClientImageMetadataProvider) GetDigest(ctx context.Context, imageRef string, pullSecret []byte) (digest.Digest, *reference.DockerImageReference, error) {
-	var err error
-	_, f.Ref, err = registryclient.GetRepoSetup(ctx, imageRef, pullSecret)
+	ref, err := reference.Parse(imageRef)
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to retrieve manifest %s: %w", imageRef, err)
+		return "", nil, fmt.Errorf("failed to parse image reference %s: %w", imageRef, err)
 	}
+	f.Ref = &ref
 	f.Ref.ID = f.Digest
 	return digest.Digest(f.Digest), f.Ref, nil
 }

--- a/support/util/imagemetadata.go
+++ b/support/util/imagemetadata.go
@@ -110,15 +110,17 @@ type ImageMetadataProvider interface {
 	GetOverride(ctx context.Context, imageRef string, pullSecret []byte) (*reference.DockerImageReference, error)
 }
 
-// MetadataGetter is a function that retrieves image metadata from a registry.
-type MetadataGetter func(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, []distribution.Descriptor, distribution.BlobStore, error)
-
 //go:generate ../../hack/tools/bin/mockgen -package=util -destination=imagemetadata_mock.go github.com/docker/distribution Repository,TagService,ManifestService
+
+// metadataGetterFn is a function that retrieves image metadata from a registry.
+type metadataGetterFn func(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, []distribution.Descriptor, distribution.BlobStore, error)
 
 type RegistryClientImageMetadataProvider struct {
 	OpenShiftImageRegistryOverrides map[string][]string
 	// repoSetupFn overrides GetRepoSetup for testing; nil means use the real implementation.
 	repoSetupFn func(ctx context.Context, imageRef string, pullSecret []byte) (distribution.Repository, *reference.DockerImageReference, error)
+	// metadataGetter overrides getMetadata for testing; nil means use the real implementation.
+	metadataGetter metadataGetterFn
 }
 
 func (r *RegistryClientImageMetadataProvider) getRepoSetup(ctx context.Context, imageRef string, pullSecret []byte) (distribution.Repository, *reference.DockerImageReference, error) {
@@ -126,6 +128,13 @@ func (r *RegistryClientImageMetadataProvider) getRepoSetup(ctx context.Context, 
 		return r.repoSetupFn(ctx, imageRef, pullSecret)
 	}
 	return GetRepoSetup(ctx, imageRef, pullSecret)
+}
+
+func (r *RegistryClientImageMetadataProvider) getMetadataGetter() metadataGetterFn {
+	if r.metadataGetter != nil {
+		return r.metadataGetter
+	}
+	return getMetadata
 }
 
 // ImageMetadata returns metadata for a given image using the given pull secret to authenticate.
@@ -138,7 +147,7 @@ func (r *RegistryClientImageMetadataProvider) ImageMetadata(ctx context.Context,
 	}
 
 	// Get the image repo info based the source/mirrors in the ICSPs/IDMSs
-	ref := SeekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret, nil)
+	ref := r.seekOverride(ctx, parsedImageRef, pullSecret)
 	refPullSpec := ref.String()
 
 	// Check the cache for the image
@@ -183,7 +192,7 @@ func (r *RegistryClientImageMetadataProvider) GetOverride(ctx context.Context, i
 		return nil, fmt.Errorf("failed to parse image reference %q: %w", imageRef, err)
 	}
 
-	ref = SeekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret, nil)
+	ref = r.seekOverride(ctx, parsedImageRef, pullSecret)
 
 	return ref, nil
 }
@@ -216,7 +225,7 @@ func (r *RegistryClientImageMetadataProvider) GetDigest(ctx context.Context, ima
 	}
 
 	// Get the image repo info based the source/mirrors in the ICSPs/IDMSs
-	ref = SeekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret, nil)
+	ref = r.seekOverride(ctx, parsedImageRef, pullSecret)
 	composedRef := ref.String()
 
 	// If the overridden image name is in the cache, return early
@@ -262,7 +271,7 @@ func (r *RegistryClientImageMetadataProvider) GetManifest(ctx context.Context, i
 	}
 
 	// Get the image repo info based the source/mirrors in the ICSPs/IDMSs
-	ref := SeekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret, nil)
+	ref := r.seekOverride(ctx, parsedImageRef, pullSecret)
 
 	// Check the cache for the image
 	if manifest, exists := manifestsCache.Get(ref.String()); exists {
@@ -298,7 +307,7 @@ func (r *RegistryClientImageMetadataProvider) GetMetadata(ctx context.Context, i
 	}
 
 	// Get the image repo info based the source/mirrors in the ICSPs/IDMSs
-	ref = SeekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret, nil)
+	ref = r.seekOverride(ctx, parsedImageRef, pullSecret)
 	composedRef := ref.String()
 
 	return getMetadata(ctx, composedRef, pullSecret)
@@ -524,12 +533,10 @@ func GetPayloadVersion(ctx context.Context, releaseImageProvider releaseinfo.Pro
 	return &version, nil
 }
 
-func SeekOverride(ctx context.Context, openshiftImageRegistryOverrides map[string][]string, parsedImageReference reference.DockerImageReference, pullSecret []byte, metadataGetter MetadataGetter) *reference.DockerImageReference {
-	if metadataGetter == nil {
-		metadataGetter = getMetadata
-	}
+func (r *RegistryClientImageMetadataProvider) seekOverride(ctx context.Context, parsedImageReference reference.DockerImageReference, pullSecret []byte) *reference.DockerImageReference {
+	getter := r.getMetadataGetter()
 	log := ctrl.LoggerFrom(ctx)
-	for source, mirrors := range openshiftImageRegistryOverrides {
+	for source, mirrors := range r.OpenShiftImageRegistryOverrides {
 		// Skip empty sources
 		if source == "" {
 			continue
@@ -560,7 +567,7 @@ func SeekOverride(ctx context.Context, openshiftImageRegistryOverrides map[strin
 
 				// Cache miss - verify mirror availability with 15s timeout
 				verifyCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
-				_, _, _, err = metadataGetter(verifyCtx, mirrorURL, pullSecret)
+				_, _, _, err = getter(verifyCtx, mirrorURL, pullSecret)
 				cancel()
 
 				if err == nil {

--- a/support/util/imagemetadata.go
+++ b/support/util/imagemetadata.go
@@ -110,6 +110,9 @@ type ImageMetadataProvider interface {
 	GetOverride(ctx context.Context, imageRef string, pullSecret []byte) (*reference.DockerImageReference, error)
 }
 
+// MetadataGetter is a function that retrieves image metadata from a registry.
+type MetadataGetter func(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, []distribution.Descriptor, distribution.BlobStore, error)
+
 //go:generate ../../hack/tools/bin/mockgen -package=util -destination=imagemetadata_mock.go github.com/docker/distribution Repository,TagService,ManifestService
 
 type RegistryClientImageMetadataProvider struct {
@@ -135,7 +138,7 @@ func (r *RegistryClientImageMetadataProvider) ImageMetadata(ctx context.Context,
 	}
 
 	// Get the image repo info based the source/mirrors in the ICSPs/IDMSs
-	ref := SeekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret)
+	ref := SeekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret, nil)
 	refPullSpec := ref.String()
 
 	// Check the cache for the image
@@ -180,7 +183,7 @@ func (r *RegistryClientImageMetadataProvider) GetOverride(ctx context.Context, i
 		return nil, fmt.Errorf("failed to parse image reference %q: %w", imageRef, err)
 	}
 
-	ref = SeekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret)
+	ref = SeekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret, nil)
 
 	return ref, nil
 }
@@ -213,7 +216,7 @@ func (r *RegistryClientImageMetadataProvider) GetDigest(ctx context.Context, ima
 	}
 
 	// Get the image repo info based the source/mirrors in the ICSPs/IDMSs
-	ref = SeekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret)
+	ref = SeekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret, nil)
 	composedRef := ref.String()
 
 	// If the overridden image name is in the cache, return early
@@ -259,7 +262,7 @@ func (r *RegistryClientImageMetadataProvider) GetManifest(ctx context.Context, i
 	}
 
 	// Get the image repo info based the source/mirrors in the ICSPs/IDMSs
-	ref := SeekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret)
+	ref := SeekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret, nil)
 
 	// Check the cache for the image
 	if manifest, exists := manifestsCache.Get(ref.String()); exists {
@@ -295,7 +298,7 @@ func (r *RegistryClientImageMetadataProvider) GetMetadata(ctx context.Context, i
 	}
 
 	// Get the image repo info based the source/mirrors in the ICSPs/IDMSs
-	ref = SeekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret)
+	ref = SeekOverride(ctx, r.OpenShiftImageRegistryOverrides, parsedImageRef, pullSecret, nil)
 	composedRef := ref.String()
 
 	return getMetadata(ctx, composedRef, pullSecret)
@@ -521,7 +524,10 @@ func GetPayloadVersion(ctx context.Context, releaseImageProvider releaseinfo.Pro
 	return &version, nil
 }
 
-func SeekOverride(ctx context.Context, openshiftImageRegistryOverrides map[string][]string, parsedImageReference reference.DockerImageReference, pullSecret []byte) *reference.DockerImageReference {
+func SeekOverride(ctx context.Context, openshiftImageRegistryOverrides map[string][]string, parsedImageReference reference.DockerImageReference, pullSecret []byte, metadataGetter MetadataGetter) *reference.DockerImageReference {
+	if metadataGetter == nil {
+		metadataGetter = getMetadata
+	}
 	log := ctrl.LoggerFrom(ctx)
 	for source, mirrors := range openshiftImageRegistryOverrides {
 		// Skip empty sources
@@ -554,7 +560,7 @@ func SeekOverride(ctx context.Context, openshiftImageRegistryOverrides map[strin
 
 				// Cache miss - verify mirror availability with 15s timeout
 				verifyCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
-				_, _, _, err = getMetadata(verifyCtx, mirrorURL, pullSecret)
+				_, _, _, err = metadataGetter(verifyCtx, mirrorURL, pullSecret)
 				cancel()
 
 				if err == nil {

--- a/support/util/imagemetadata_test.go
+++ b/support/util/imagemetadata_test.go
@@ -501,8 +501,8 @@ func TestSeekOverride(t *testing.T) {
 		},
 	}
 
-	// Mock MetadataGetter that always succeeds, avoiding real network calls.
-	fakeMetadataGetter := func(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, []distribution.Descriptor, distribution.BlobStore, error) {
+	// Mock metadataGetter that always succeeds, avoiding real network calls.
+	fakeGetter := func(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, []distribution.Descriptor, distribution.BlobStore, error) {
 		return &dockerv1client.DockerImageConfig{}, nil, nil, nil
 	}
 
@@ -511,7 +511,11 @@ func TestSeekOverride(t *testing.T) {
 			ctx := t.Context()
 			g := NewGomegaWithT(t)
 			pullSecret := []byte(`{"auths":{}}`)
-			imgRef := SeekOverride(ctx, tc.overrides, tc.imageRef, pullSecret, fakeMetadataGetter)
+			provider := &RegistryClientImageMetadataProvider{
+				OpenShiftImageRegistryOverrides: tc.overrides,
+				metadataGetter:                  fakeGetter,
+			}
+			imgRef := provider.seekOverride(ctx, tc.imageRef, pullSecret)
 			g.Expect(imgRef).To(Equal(tc.expectedImgRef), fmt.Sprintf("Expected image reference to be equal to: %v, \nbut got: %v", tc.expectedImgRef, imgRef))
 		})
 	}
@@ -938,8 +942,8 @@ func TestSeekOverrideWithCache(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Mock MetadataGetter that simulates an unavailable mirror, avoiding real network calls.
-	failingMetadataGetter := func(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, []distribution.Descriptor, distribution.BlobStore, error) {
+	// Mock metadataGetter that simulates an unavailable mirror, avoiding real network calls.
+	failingGetter := func(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, []distribution.Descriptor, distribution.BlobStore, error) {
 		return nil, nil, nil, fmt.Errorf("simulated mirror unavailable")
 	}
 
@@ -955,12 +959,17 @@ func TestSeekOverrideWithCache(t *testing.T) {
 			Tag:       "latest",
 		}
 
+		provider := &RegistryClientImageMetadataProvider{
+			OpenShiftImageRegistryOverrides: overrides,
+			metadataGetter:                  failingGetter,
+		}
+
 		// First call will attempt verification (which will fail via mock)
 		// and cache the result
-		result1 := SeekOverride(ctx, overrides, parsedRef, []byte(`{"auths":{}}`), failingMetadataGetter)
+		result1 := provider.seekOverride(ctx, parsedRef, []byte(`{"auths":{}}`))
 
 		// Second call should use cache and return same result without network call
-		result2 := SeekOverride(ctx, overrides, parsedRef, []byte(`{"auths":{}}`), failingMetadataGetter)
+		result2 := provider.seekOverride(ctx, parsedRef, []byte(`{"auths":{}}`))
 
 		g.Expect(result1).To(Equal(result2))
 
@@ -972,13 +981,6 @@ func TestSeekOverrideWithCache(t *testing.T) {
 	})
 
 	t.Run("cache respects different mirror URLs", func(t *testing.T) {
-		overrides1 := map[string][]string{
-			"quay.io": {"mirror1.example.com"},
-		}
-		overrides2 := map[string][]string{
-			"quay.io": {"mirror2.example.com"},
-		}
-
 		parsedRef := reference.DockerImageReference{
 			Registry:  "quay.io",
 			Namespace: "test",
@@ -987,10 +989,22 @@ func TestSeekOverrideWithCache(t *testing.T) {
 		}
 
 		// Test with first mirror
-		SeekOverride(ctx, overrides1, parsedRef, []byte(`{"auths":{}}`), failingMetadataGetter)
+		provider1 := &RegistryClientImageMetadataProvider{
+			OpenShiftImageRegistryOverrides: map[string][]string{
+				"quay.io": {"mirror1.example.com"},
+			},
+			metadataGetter: failingGetter,
+		}
+		provider1.seekOverride(ctx, parsedRef, []byte(`{"auths":{}}`))
 
 		// Test with second mirror
-		SeekOverride(ctx, overrides2, parsedRef, []byte(`{"auths":{}}`), failingMetadataGetter)
+		provider2 := &RegistryClientImageMetadataProvider{
+			OpenShiftImageRegistryOverrides: map[string][]string{
+				"quay.io": {"mirror2.example.com"},
+			},
+			metadataGetter: failingGetter,
+		}
+		provider2.seekOverride(ctx, parsedRef, []byte(`{"auths":{}}`))
 
 		// Both mirrors should be cached separately
 		pullSecret := []byte(`{"auths":{}}`)
@@ -1002,7 +1016,7 @@ func TestSeekOverrideWithCache(t *testing.T) {
 	})
 }
 
-func TestSeekOverrideTimeout(t *testing.T) {
+func TestSeekOverrideFallsBackWhenMirrorUnavailable(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	// Reset the global cache
@@ -1012,8 +1026,14 @@ func TestSeekOverrideTimeout(t *testing.T) {
 
 	ctx := context.Background()
 
-	overrides := map[string][]string{
-		"quay.io": {"nonexistent-mirror.invalid"},
+	provider := &RegistryClientImageMetadataProvider{
+		OpenShiftImageRegistryOverrides: map[string][]string{
+			"quay.io": {"nonexistent-mirror.invalid"},
+		},
+		// Mock metadataGetter that simulates an unavailable mirror, avoiding real network calls.
+		metadataGetter: func(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, []distribution.Descriptor, distribution.BlobStore, error) {
+			return nil, nil, nil, fmt.Errorf("simulated mirror unavailable")
+		},
 	}
 
 	parsedRef := reference.DockerImageReference{
@@ -1023,13 +1043,8 @@ func TestSeekOverrideTimeout(t *testing.T) {
 		Tag:       "latest",
 	}
 
-	// Mock MetadataGetter that simulates an unavailable mirror, avoiding real network calls.
-	failingMetadataGetter := func(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, []distribution.Descriptor, distribution.BlobStore, error) {
-		return nil, nil, nil, fmt.Errorf("simulated mirror unavailable")
-	}
-
 	// This should fail verification and fallback to original image
-	result := SeekOverride(ctx, overrides, parsedRef, []byte(`{"auths":{}}`), failingMetadataGetter)
+	result := provider.seekOverride(ctx, parsedRef, []byte(`{"auths":{}}`))
 
 	// Should return original reference since mirror is invalid
 	g.Expect(result.Registry).To(Equal("quay.io"))

--- a/support/util/imagemetadata_test.go
+++ b/support/util/imagemetadata_test.go
@@ -521,6 +521,31 @@ func TestSeekOverride(t *testing.T) {
 	}
 }
 
+func TestGetMetadataGetter(t *testing.T) {
+	t.Run("When metadataGetter is nil it should return the default getMetadata function", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		provider := &RegistryClientImageMetadataProvider{}
+
+		getter := provider.getMetadataGetter()
+		g.Expect(getter).ToNot(BeNil())
+	})
+
+	t.Run("When metadataGetter is set it should return the injected function", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		called := false
+		custom := func(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, []distribution.Descriptor, distribution.BlobStore, error) {
+			called = true
+			return nil, nil, nil, nil
+		}
+		provider := &RegistryClientImageMetadataProvider{metadataGetter: custom}
+
+		getter := provider.getMetadataGetter()
+		g.Expect(getter).ToNot(BeNil())
+		_, _, _, _ = getter(context.Background(), "", nil)
+		g.Expect(called).To(BeTrue())
+	})
+}
+
 func fakeOverrides() map[string][]string {
 	return map[string][]string{
 		"quay.io/openshift-release-dev/ocp-release": {

--- a/support/util/imagemetadata_test.go
+++ b/support/util/imagemetadata_test.go
@@ -3,12 +3,12 @@ package util
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
 	. "github.com/onsi/gomega"
 
+	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
 
 	"k8s.io/apimachinery/pkg/util/cache"
@@ -380,9 +380,9 @@ func TestSeekOverride(t *testing.T) {
 				Tag:       "4.15.0-rc.0-multi",
 			},
 			expectedImgRef: &reference.DockerImageReference{
-				Registry:  "quay.io",
+				Registry:  "myregistry1.io",
 				Name:      "ocp-release",
-				Namespace: "openshifttest",
+				Namespace: "openshift-release-dev",
 				Tag:       "4.15.0-rc.0-multi",
 			},
 		},
@@ -493,7 +493,7 @@ func TestSeekOverride(t *testing.T) {
 				ID:        "sha256:b272d47dded73ec8d9eb01a8e39cd62a453d2799c1785ecd538aa8cd15693bf0",
 			},
 			expectedImgRef: &reference.DockerImageReference{
-				Registry:  "quay.io",
+				Registry:  "myregistry1.io",
 				Name:      "ocp-release",
 				Namespace: "openshifttest",
 				ID:        "sha256:b272d47dded73ec8d9eb01a8e39cd62a453d2799c1785ecd538aa8cd15693bf0",
@@ -501,15 +501,17 @@ func TestSeekOverride(t *testing.T) {
 		},
 	}
 
+	// Mock MetadataGetter that always succeeds, avoiding real network calls.
+	fakeMetadataGetter := func(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, []distribution.Descriptor, distribution.BlobStore, error) {
+		return &dockerv1client.DockerImageConfig{}, nil, nil, nil
+	}
+
 	for _, tc := range testsCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := t.Context()
 			g := NewGomegaWithT(t)
-			pullSecret, err := os.ReadFile("../../hack/dev/fakePullSecret.json")
-			if err != nil {
-				t.Fatalf("failed to read manifests file: %v", err)
-			}
-			imgRef := SeekOverride(ctx, tc.overrides, tc.imageRef, pullSecret)
+			pullSecret := []byte(`{"auths":{}}`)
+			imgRef := SeekOverride(ctx, tc.overrides, tc.imageRef, pullSecret, fakeMetadataGetter)
 			g.Expect(imgRef).To(Equal(tc.expectedImgRef), fmt.Sprintf("Expected image reference to be equal to: %v, \nbut got: %v", tc.expectedImgRef, imgRef))
 		})
 	}
@@ -936,6 +938,11 @@ func TestSeekOverrideWithCache(t *testing.T) {
 
 	ctx := context.Background()
 
+	// Mock MetadataGetter that simulates an unavailable mirror, avoiding real network calls.
+	failingMetadataGetter := func(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, []distribution.Descriptor, distribution.BlobStore, error) {
+		return nil, nil, nil, fmt.Errorf("simulated mirror unavailable")
+	}
+
 	t.Run("cache prevents repeated network verification", func(t *testing.T) {
 		overrides := map[string][]string{
 			"quay.io": {"mirror.example.com"},
@@ -948,12 +955,12 @@ func TestSeekOverrideWithCache(t *testing.T) {
 			Tag:       "latest",
 		}
 
-		// First call will attempt network verification (which will likely fail for our test mirror)
+		// First call will attempt verification (which will fail via mock)
 		// and cache the result
-		result1 := SeekOverride(ctx, overrides, parsedRef, []byte(`{"auths":{}}`))
+		result1 := SeekOverride(ctx, overrides, parsedRef, []byte(`{"auths":{}}`), failingMetadataGetter)
 
 		// Second call should use cache and return same result without network call
-		result2 := SeekOverride(ctx, overrides, parsedRef, []byte(`{"auths":{}}`))
+		result2 := SeekOverride(ctx, overrides, parsedRef, []byte(`{"auths":{}}`), failingMetadataGetter)
 
 		g.Expect(result1).To(Equal(result2))
 
@@ -980,10 +987,10 @@ func TestSeekOverrideWithCache(t *testing.T) {
 		}
 
 		// Test with first mirror
-		SeekOverride(ctx, overrides1, parsedRef, []byte(`{"auths":{}}`))
+		SeekOverride(ctx, overrides1, parsedRef, []byte(`{"auths":{}}`), failingMetadataGetter)
 
 		// Test with second mirror
-		SeekOverride(ctx, overrides2, parsedRef, []byte(`{"auths":{}}`))
+		SeekOverride(ctx, overrides2, parsedRef, []byte(`{"auths":{}}`), failingMetadataGetter)
 
 		// Both mirrors should be cached separately
 		pullSecret := []byte(`{"auths":{}}`)
@@ -1016,8 +1023,13 @@ func TestSeekOverrideTimeout(t *testing.T) {
 		Tag:       "latest",
 	}
 
-	// This should timeout and fallback to original image
-	result := SeekOverride(ctx, overrides, parsedRef, []byte(`{"auths":{}}`))
+	// Mock MetadataGetter that simulates an unavailable mirror, avoiding real network calls.
+	failingMetadataGetter := func(ctx context.Context, imageRef string, pullSecret []byte) (*dockerv1client.DockerImageConfig, []distribution.Descriptor, distribution.BlobStore, error) {
+		return nil, nil, nil, fmt.Errorf("simulated mirror unavailable")
+	}
+
+	// This should fail verification and fallback to original image
+	result := SeekOverride(ctx, overrides, parsedRef, []byte(`{"auths":{}}`), failingMetadataGetter)
 
 	// Should return original reference since mirror is invalid
 	g.Expect(result.Registry).To(Equal("quay.io"))

--- a/support/util/util_test.go
+++ b/support/util/util_test.go
@@ -2,13 +2,19 @@ package util
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"unicode/utf8"
 
 	. "github.com/onsi/gomega"
 
+	"github.com/docker/distribution"
+	"github.com/opencontainers/go-digest"
+
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
+	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -562,33 +568,39 @@ func TestGetImageArchitecture(t *testing.T) {
 		name                  string
 		image                 string
 		pullSecretBytes       []byte
-		imageMetadataProvider *RegistryClientImageMetadataProvider
+		imageMetadataProvider ImageMetadataProvider
 		expectedArch          hyperv1.PayloadArchType
 		expectErr             bool
 	}{
 		{
-			name:                  "Bad pull secret, cache empty; err",
-			image:                 "quay.io/openshift-release-dev/ocp-release:4.16.11-ppc64le",
-			pullSecretBytes:       []byte(""),
-			imageMetadataProvider: &RegistryClientImageMetadataProvider{},
-			expectedArch:          "",
-			expectErr:             true,
+			name:            "When providing an empty pull secret it should return an error",
+			image:           "quay.io/openshift-release-dev/ocp-release:4.16.11-ppc64le",
+			pullSecretBytes: []byte(""),
+			imageMetadataProvider: &fakeImageMetadataProviderForTest{
+				err: fmt.Errorf("empty pull secret"),
+			},
+			expectedArch: "",
+			expectErr:    true,
 		},
 		{
-			name:                  "Get amd64 from amd64 image; no err",
-			image:                 "quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64",
-			pullSecretBytes:       pullSecretBytes,
-			imageMetadataProvider: &RegistryClientImageMetadataProvider{},
-			expectedArch:          hyperv1.AMD64,
-			expectErr:             false,
+			name:            "When resolving an amd64 image it should return AMD64",
+			image:           "quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64",
+			pullSecretBytes: pullSecretBytes,
+			imageMetadataProvider: &fakeImageMetadataProviderForTest{
+				result: &dockerv1client.DockerImageConfig{Architecture: "amd64"},
+			},
+			expectedArch: hyperv1.AMD64,
+			expectErr:    false,
 		},
 		{
-			name:                  "Get ppc64le from ppc64le image; no err",
-			image:                 "quay.io/openshift-release-dev/ocp-release:4.16.11-ppc64le",
-			pullSecretBytes:       pullSecretBytes,
-			imageMetadataProvider: &RegistryClientImageMetadataProvider{},
-			expectedArch:          hyperv1.PPC64LE,
-			expectErr:             false,
+			name:            "When resolving a ppc64le image it should return PPC64LE",
+			image:           "quay.io/openshift-release-dev/ocp-release:4.16.11-ppc64le",
+			pullSecretBytes: pullSecretBytes,
+			imageMetadataProvider: &fakeImageMetadataProviderForTest{
+				result: &dockerv1client.DockerImageConfig{Architecture: "ppc64le"},
+			},
+			expectedArch: hyperv1.PPC64LE,
+			expectErr:    false,
 		},
 	}
 
@@ -613,12 +625,12 @@ func TestDetermineHostedClusterPayloadArch(t *testing.T) {
 		name                  string
 		hc                    *hyperv1.HostedCluster
 		secret                *corev1.Secret
-		imageMetadataProvider *RegistryClientImageMetadataProvider
+		imageMetadataProvider ImageMetadataProvider
 		expectedPayloadType   hyperv1.PayloadArchType
 		expectErr             bool
 	}{
 		{
-			name: "Get amd64 from amd64 image; no err",
+			name: "When resolving an amd64 image it should return AMD64",
 			hc: &hyperv1.HostedCluster{
 				TypeMeta: metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{
@@ -641,12 +653,15 @@ func TestDetermineHostedClusterPayloadArch(t *testing.T) {
 					corev1.DockerConfigJsonKey: pullSecretBytes,
 				},
 			},
-			imageMetadataProvider: &RegistryClientImageMetadataProvider{},
-			expectedPayloadType:   hyperv1.AMD64,
-			expectErr:             false,
+			imageMetadataProvider: &fakeImageMetadataProviderForTest{
+				result:    &dockerv1client.DockerImageConfig{Architecture: "amd64"},
+				mediaType: "application/vnd.docker.distribution.manifest.v2+json",
+			},
+			expectedPayloadType: hyperv1.AMD64,
+			expectErr:           false,
 		},
 		{
-			name: "Get multi payload from multi image; no err",
+			name: "When resolving a multi-arch image it should return Multi",
 			hc: &hyperv1.HostedCluster{
 				TypeMeta: metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{
@@ -669,9 +684,12 @@ func TestDetermineHostedClusterPayloadArch(t *testing.T) {
 					corev1.DockerConfigJsonKey: pullSecretBytes,
 				},
 			},
-			imageMetadataProvider: &RegistryClientImageMetadataProvider{},
-			expectedPayloadType:   hyperv1.Multi,
-			expectErr:             false,
+			imageMetadataProvider: &fakeImageMetadataProviderForTest{
+				result:    &dockerv1client.DockerImageConfig{Architecture: "multi"},
+				mediaType: "application/vnd.docker.distribution.manifest.list.v2+json",
+			},
+			expectedPayloadType: hyperv1.Multi,
+			expectErr:           false,
 		},
 	}
 
@@ -692,6 +710,44 @@ func TestDetermineHostedClusterPayloadArch(t *testing.T) {
 			}
 		})
 	}
+}
+
+// fakeImageMetadataProviderForTest is a minimal ImageMetadataProvider for unit tests.
+type fakeImageMetadataProviderForTest struct {
+	result    *dockerv1client.DockerImageConfig
+	mediaType string
+	err       error
+}
+
+func (f *fakeImageMetadataProviderForTest) ImageMetadata(_ context.Context, _ string, _ []byte) (*dockerv1client.DockerImageConfig, error) {
+	return f.result, f.err
+}
+
+func (f *fakeImageMetadataProviderForTest) GetManifest(_ context.Context, _ string, _ []byte) (distribution.Manifest, error) {
+	return &fakeManifestForTest{mediaType: f.mediaType}, f.err
+}
+
+func (f *fakeImageMetadataProviderForTest) GetDigest(_ context.Context, imageRef string, _ []byte) (digest.Digest, *reference.DockerImageReference, error) {
+	ref, _ := reference.Parse(imageRef)
+	return "", &ref, f.err
+}
+
+func (f *fakeImageMetadataProviderForTest) GetMetadata(_ context.Context, _ string, _ []byte) (*dockerv1client.DockerImageConfig, []distribution.Descriptor, distribution.BlobStore, error) {
+	return f.result, nil, nil, f.err
+}
+
+func (f *fakeImageMetadataProviderForTest) GetOverride(_ context.Context, imageRef string, _ []byte) (*reference.DockerImageReference, error) {
+	ref, _ := reference.Parse(imageRef)
+	return &ref, f.err
+}
+
+type fakeManifestForTest struct {
+	mediaType string
+}
+
+func (f *fakeManifestForTest) References() []distribution.Descriptor { return nil }
+func (f *fakeManifestForTest) Payload() (string, []byte, error) {
+	return f.mediaType, []byte("{}"), nil
 }
 
 func TestIsIPv4CIDR(t *testing.T) {

--- a/support/util/util_test.go
+++ b/support/util/util_test.go
@@ -8,13 +8,10 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"github.com/docker/distribution"
-	"github.com/opencontainers/go-digest"
-
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
-	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
+	"github.com/openshift/hypershift/support/util/fakeimagemetadataprovider"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -576,8 +573,8 @@ func TestGetImageArchitecture(t *testing.T) {
 			name:            "When providing an empty pull secret it should return an error",
 			image:           "quay.io/openshift-release-dev/ocp-release:4.16.11-ppc64le",
 			pullSecretBytes: []byte(""),
-			imageMetadataProvider: &fakeImageMetadataProviderForTest{
-				err: fmt.Errorf("empty pull secret"),
+			imageMetadataProvider: &fakeimagemetadataprovider.FakeRegistryClientImageMetadataProvider{
+				Err: fmt.Errorf("empty pull secret"),
 			},
 			expectedArch: "",
 			expectErr:    true,
@@ -586,8 +583,8 @@ func TestGetImageArchitecture(t *testing.T) {
 			name:            "When resolving an amd64 image it should return AMD64",
 			image:           "quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64",
 			pullSecretBytes: pullSecretBytes,
-			imageMetadataProvider: &fakeImageMetadataProviderForTest{
-				result: &dockerv1client.DockerImageConfig{Architecture: "amd64"},
+			imageMetadataProvider: &fakeimagemetadataprovider.FakeRegistryClientImageMetadataProvider{
+				Result: &dockerv1client.DockerImageConfig{Architecture: "amd64"},
 			},
 			expectedArch: hyperv1.AMD64,
 			expectErr:    false,
@@ -596,8 +593,8 @@ func TestGetImageArchitecture(t *testing.T) {
 			name:            "When resolving a ppc64le image it should return PPC64LE",
 			image:           "quay.io/openshift-release-dev/ocp-release:4.16.11-ppc64le",
 			pullSecretBytes: pullSecretBytes,
-			imageMetadataProvider: &fakeImageMetadataProviderForTest{
-				result: &dockerv1client.DockerImageConfig{Architecture: "ppc64le"},
+			imageMetadataProvider: &fakeimagemetadataprovider.FakeRegistryClientImageMetadataProvider{
+				Result: &dockerv1client.DockerImageConfig{Architecture: "ppc64le"},
 			},
 			expectedArch: hyperv1.PPC64LE,
 			expectErr:    false,
@@ -653,9 +650,9 @@ func TestDetermineHostedClusterPayloadArch(t *testing.T) {
 					corev1.DockerConfigJsonKey: pullSecretBytes,
 				},
 			},
-			imageMetadataProvider: &fakeImageMetadataProviderForTest{
-				result:    &dockerv1client.DockerImageConfig{Architecture: "amd64"},
-				mediaType: "application/vnd.docker.distribution.manifest.v2+json",
+			imageMetadataProvider: &fakeimagemetadataprovider.FakeRegistryClientImageMetadataProvider{
+				Result:    &dockerv1client.DockerImageConfig{Architecture: "amd64"},
+				MediaType: "application/vnd.docker.distribution.manifest.v2+json",
 			},
 			expectedPayloadType: hyperv1.AMD64,
 			expectErr:           false,
@@ -684,9 +681,9 @@ func TestDetermineHostedClusterPayloadArch(t *testing.T) {
 					corev1.DockerConfigJsonKey: pullSecretBytes,
 				},
 			},
-			imageMetadataProvider: &fakeImageMetadataProviderForTest{
-				result:    &dockerv1client.DockerImageConfig{Architecture: "multi"},
-				mediaType: "application/vnd.docker.distribution.manifest.list.v2+json",
+			imageMetadataProvider: &fakeimagemetadataprovider.FakeRegistryClientImageMetadataProvider{
+				Result:    &dockerv1client.DockerImageConfig{Architecture: "multi"},
+				MediaType: "application/vnd.docker.distribution.manifest.list.v2+json",
 			},
 			expectedPayloadType: hyperv1.Multi,
 			expectErr:           false,
@@ -710,44 +707,6 @@ func TestDetermineHostedClusterPayloadArch(t *testing.T) {
 			}
 		})
 	}
-}
-
-// fakeImageMetadataProviderForTest is a minimal ImageMetadataProvider for unit tests.
-type fakeImageMetadataProviderForTest struct {
-	result    *dockerv1client.DockerImageConfig
-	mediaType string
-	err       error
-}
-
-func (f *fakeImageMetadataProviderForTest) ImageMetadata(_ context.Context, _ string, _ []byte) (*dockerv1client.DockerImageConfig, error) {
-	return f.result, f.err
-}
-
-func (f *fakeImageMetadataProviderForTest) GetManifest(_ context.Context, _ string, _ []byte) (distribution.Manifest, error) {
-	return &fakeManifestForTest{mediaType: f.mediaType}, f.err
-}
-
-func (f *fakeImageMetadataProviderForTest) GetDigest(_ context.Context, imageRef string, _ []byte) (digest.Digest, *reference.DockerImageReference, error) {
-	ref, _ := reference.Parse(imageRef)
-	return "", &ref, f.err
-}
-
-func (f *fakeImageMetadataProviderForTest) GetMetadata(_ context.Context, _ string, _ []byte) (*dockerv1client.DockerImageConfig, []distribution.Descriptor, distribution.BlobStore, error) {
-	return f.result, nil, nil, f.err
-}
-
-func (f *fakeImageMetadataProviderForTest) GetOverride(_ context.Context, imageRef string, _ []byte) (*reference.DockerImageReference, error) {
-	ref, _ := reference.Parse(imageRef)
-	return &ref, f.err
-}
-
-type fakeManifestForTest struct {
-	mediaType string
-}
-
-func (f *fakeManifestForTest) References() []distribution.Descriptor { return nil }
-func (f *fakeManifestForTest) Payload() (string, []byte, error) {
-	return f.mediaType, []byte("{}"), nil
 }
 
 func TestIsIPv4CIDR(t *testing.T) {


### PR DESCRIPTION
## Summary

- Remove network dependencies from unit tests so `make test` passes 100% with no network
- Add injectable `MetadataGetter` parameter to `SeekOverride` so tests can avoid real HTTP calls to container registries
- Remove `GetRepoSetup` calls from `registryclient` test fake and shared `FakeRegistryClientImageMetadataProvider` (affects ~20 test files)
- Add injectable `repoSetupFn` to `ProviderWithOpenShiftImageRegistryOverridesDecorator` for mirror verification
- Replace real `RegistryClientImageMetadataProvider` in `util_test.go` with a local fake
- Pre-populate OpenID discovery and password grant caches in oauth tests to avoid HTTP calls to `accounts.google.com`

## Details

Multiple unit tests made real HTTP calls to container registries (`quay.io`, `registry-1.docker.io`) and identity providers (`accounts.google.com`), causing test failures when the network was unavailable or slow. This was observed in CI:
https://github.com/openshift/hypershift/actions/runs/24573813584/job/71853756467?pr=8247

Jira: https://issues.redhat.com/browse/OCPBUGS-83757

## Test plan

- [x] `make test` passes 100% with no network connectivity
- [x] `make verify` passes (excluding git-clean check)
- [x] `go vet` passes on all modified packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved isolation and determinism by removing filesystem/network I/O, inlining test secrets, pre-populating caches, injecting mock behaviors, and updating expectations to match mirrored-image scenarios.

* **Refactor**
  * Made metadata retrieval and repo-verification checks injectable and converted standalone override logic into provider-scoped methods for controlled verification and testing.

* **Bug Fix**
  * Test fakes now fail fast on missing pull secrets and return clearer parse/failure responses to surface invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->