### PR TITLE
OCPBUGS-79471: fix(test): reduce e2e autorepair flakes from unhealthy node conditions

### DIFF
--- a/test/e2e/nodepool_autorepair_test.go
+++ b/test/e2e/nodepool_autorepair_test.go
@@ -61,12 +61,12 @@ func (ar *NodePoolAutoRepairTest) Run(t *testing.T, nodePool hyperv1.NodePool, n
 	g := NewWithT(t)
 
 	// Terminate one of the machines belonging to the cluster
-	t.Log("Terminating AWS Instance with a autorepair NodePool")
+	t.Log("Terminating AWS Instance with an autorepair NodePool")
 	nodeToReplace := nodes[0].Name
 	awsSpec := nodes[0].Spec.ProviderID
 	g.Expect(len(awsSpec)).NotTo(BeZero())
 	instanceID := awsSpec[strings.LastIndex(awsSpec, "/")+1:]
-	t.Logf("Terminating AWS instance: %s", instanceID)
+	t.Logf("Terminating AWS instance: %s (node: %s)", instanceID, nodeToReplace)
 	ec2client := ec2Client(ar.clusterOpts.AWSPlatform.Credentials.AWSCredentialsFile, ar.clusterOpts.AWSPlatform.Region)
 	_, err := ec2client.TerminateInstances(ar.ctx, &ec2.TerminateInstancesInput{
 		InstanceIds: []string{instanceID},
@@ -92,6 +92,28 @@ func (ar *NodePoolAutoRepairTest) Run(t *testing.T, nodePool hyperv1.NodePool, n
 				}
 				return true, fmt.Sprintf("node %s replaced", nodeToReplace), nil
 			},
+		),
+		// Ensure replacement nodes are free of kubelet pressure conditions
+		// (MemoryPressure, DiskPressure, PIDPressure). A replacement node
+		// can be NodeReady=True but still have pressure conditions, which
+		// causes CAPI to set MachineNodeHealthyCondition=False
+		// (NodeConditionsFailed). This makes the NodePool's AllNodesHealthy
+		// condition False and fails validateNodePoolConditions downstream.
+		// By checking pressure conditions here, we wait for the replacement
+		// node to be fully healthy before proceeding.
+		e2eutil.WithPredicates(
+			e2eutil.ConditionPredicate[*corev1.Node](e2eutil.Condition{
+				Type:   string(corev1.NodeMemoryPressure),
+				Status: metav1.ConditionFalse,
+			}),
+			e2eutil.ConditionPredicate[*corev1.Node](e2eutil.Condition{
+				Type:   string(corev1.NodeDiskPressure),
+				Status: metav1.ConditionFalse,
+			}),
+			e2eutil.ConditionPredicate[*corev1.Node](e2eutil.Condition{
+				Type:   string(corev1.NodePIDPressure),
+				Status: metav1.ConditionFalse,
+			}),
 		),
 	)
 }

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -407,5 +407,6 @@ func validateNodePoolConditions(t *testing.T, ctx context.Context, client crclie
 			return nodePool, err
 		},
 		predicates, e2eutil.WithoutConditionDump(), e2eutil.WithTimeout(20*time.Minute),
+		e2eutil.WithInterval(15*time.Second), // Reduce polling frequency from 3s default to prevent client rate limiting
 	)
 }


### PR DESCRIPTION
## What this PR does / why we need it:
## Summary
- Add per-node kubelet health predicates (`MemoryPressure=False`,
  `DiskPressure=False`, `PIDPressure=False`) to the autorepair test's
  `WaitForReadyNodesByNodePool` call, ensuring the replacement node is
  fully healthy before proceeding
- Add `WithInterval(15s)` to `validateNodePoolConditions` to reduce
  API server polling and eliminate client rate limiter errors

## Problem
- The `TestNodePoolAutoRepair` e2e test flakes when a replacement node
comes up `NodeReady=True` but with kubelet pressure conditions. CAPI
sets `MachineNodeHealthyCondition=False` (`NodeConditionsFailed`),
which propagates to `AllNodesHealthy=False` on the NodePool.
`validateNodePoolConditions` then times out after 20 minutes.

- Additionally, `validateNodePoolConditions` polls every 3s (default),
generating ~400 API GETs over 20 min, triggering client rate limiter
errors.

## Root cause
- `WaitForReadyNodesByNodePool` only verified `NodeReady=True` and did
not check kubelet health conditions. The test passed at ~7 min with an
unhealthy node, leaving `validateNodePoolConditions` to discover the
problem with insufficient time for the node to stabilize.

## Design decisions
- **Reused `ConditionPredicate`/`WithPredicates`** instead of custom
  helpers — the framework already logs predicate failures, giving
  specific diagnostics (e.g., `wanted MemoryPressure=False, got True`)
- **Kept original collection predicates unchanged** — the built-in
  count predicate in `WaitForNReadyNodesWithOptions` already ensures
  the old node is fully removed
- **15s polling interval** matches the pattern in
  `WaitForNodePoolConfigUpdateComplete` (15-20s with explicit comments
  about rate limiting)
- **No stabilization window (`Consistently`)** — `validateNodePoolConditions`
  already serves as a 20-min post-`Run()` stabilization check
- **No direct Machine condition check** — would require management
  client access in the test interface; node-level pressure checks are
  functionally equivalent to what CAPI evaluates
## Which issue(s) this PR fixes:

Fixes [OCPBUGS-79471](https://redhat.atlassian.net/browse/OCPBUGS-79471)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced node pool autorepair test with improved logging including AWS instance IDs for better diagnostics.
  * Added validation for kubelet pressure conditions to ensure proper node health verification.
  * Optimized node pool status polling to reduce test execution overhead while maintaining reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->