### PR TITLE
NO-JIRA: chore: pass COMMIT_HASH build arg to support git worktrees

### DIFF
--- a/Containerfile.cli
+++ b/Containerfile.cli
@@ -1,4 +1,5 @@
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
+ARG COMMIT_HASH
 
 WORKDIR /hypershift
 

--- a/Containerfile.control-plane
+++ b/Containerfile.control-plane
@@ -1,4 +1,5 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.25.7-1773318690 AS builder
+ARG COMMIT_HASH
 
 WORKDIR /hypershift
 

--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -1,4 +1,5 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.25.7-1773318690 AS builder
+ARG COMMIT_HASH
 
 WORKDIR /hypershift
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-4.23 AS builder
+ARG COMMIT_HASH
 
 WORKDIR /hypershift
 

--- a/Dockerfile.control-plane
+++ b/Dockerfile.control-plane
@@ -1,4 +1,5 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.23 AS builder
+ARG COMMIT_HASH
 
 WORKDIR /hypershift
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,6 +2,8 @@
 # The control-plane-operator should not be included in the Hypershift operator image because it is already part of the OpenShift payload.
 
 FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-4.23 AS builder
+ARG COMMIT_HASH
+
 WORKDIR /hypershift
 
 COPY . .

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,4 +1,5 @@
 FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.25-openshift-4.23 AS builder
+ARG COMMIT_HASH
 
 WORKDIR /hypershift
 

--- a/Makefile
+++ b/Makefile
@@ -539,7 +539,7 @@ staticcheck: $(STATICCHECK)
 # Build the docker image with official golang image
 .PHONY: docker-build
 docker-build:
-	${RUNTIME} build . -t ${IMG}
+	${RUNTIME} build --build-arg COMMIT_HASH=$(COMMIT_HASH) . -t ${IMG}
 
 # Push the docker image
 .PHONY: docker-push

--- a/hack/container-run.sh
+++ b/hack/container-run.sh
@@ -18,6 +18,6 @@ IMAGE=docker.io/openshift/origin-release:golang-1.16
 
 ENGINE=$(get_container_engine)
 
-ENGINE_CMD="${ENGINE} run --rm -v $(pwd):/go/src/github.com/openshift/hypershift:Z  -w /go/src/github.com/openshift/hypershift $IMAGE"
+ENGINE_CMD="${ENGINE} run --rm -e COMMIT_HASH=$(git rev-parse HEAD 2>/dev/null || true) -v $(pwd):/go/src/github.com/openshift/hypershift:Z  -w /go/src/github.com/openshift/hypershift $IMAGE"
 
 ${ENGINE_CMD} $*


### PR DESCRIPTION
## Summary

- Adds `ARG COMMIT_HASH` to all Dockerfiles/Containerfiles so the commit hash can be injected at build time
- Updates `make docker-build` to pass `--build-arg COMMIT_HASH=$(COMMIT_HASH)`, resolving the hash on the host where git works correctly
- Updates `hack/container-run.sh` to pass `-e COMMIT_HASH=` for the same reason

In a git worktree, `.git` is a file containing a pointer to the main repo's object store rather than a directory. When container builds copy this pointer file into the build context, `git rev-parse HEAD` inside the container fails silently, producing binaries with `<unknown>` version info. This was previously attempted via `.dockerignore` (#7944) but reverted (#8201) because CI needs `.git` inside the container. This approach instead resolves the hash on the host and passes it in — when no arg is provided (CI), the existing behavior is fully preserved.

## Test plan

- [x] From a git worktree, run `make docker-build` and verify the image has correct version info, not `<unknown>`
- [x] From a regular clone, run `make docker-build` and verify no regression


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build and run workflows now capture and propagate the current commit hash into images and running containers. Images produced for CLI, control plane, operator, e2e and dev builds include commit metadata, and container run commands set the COMMIT_HASH environment variable for improved artifact identification, troubleshooting and traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->