### PR TITLE
NO_JIRA: ci(gha): add release-4.23 branch to unit test workflow (expect verify-workflows PASS)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - release-4.22
+      - release-4.23
   pull_request:
     branches:
       - main
       - release-4.22
+      - release-4.23
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
## Summary

- Test PR to verify the `verify-workflows` presubmit from [openshift/release#77164](https://github.com/openshift/release/pull/77164)
- This branch is based on current `main` and **intentionally modifies** a GHA workflow file (`.github/workflows/test.yaml`)
- The `ci/prow/verify-workflows` check should **PASS** on this PR because the workflow change is intentional (hash differs from both main and merge-base)

## Changes

- Added `release-4.23` to the push and pull_request branch filters in the unit test workflow

## Expected behavior

The `verify-workflows` presubmit should detect that the workflow file was intentionally modified and pass.

## Test plan

- [ ] Verify `ci/prow/verify-workflows` passes on this PR
- [ ] Close PR after verification (do not merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal testing infrastructure to support additional release branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->