### PR TITLE
OCPBUGS-83790: change Azure workload identity webhook FailurePolicy from Fail to Ignore

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/azure_workload_identity_webhook_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/azure_workload_identity_webhook_test.go
@@ -71,7 +71,7 @@ func TestReconcileAzureIdentityWebhook(t *testing.T) {
 			wh := webhook.Webhooks[0]
 			g.Expect(wh.Name).To(Equal("pod-identity-webhook.azure.mutate.io"))
 			g.Expect(wh.AdmissionReviewVersions).To(Equal([]string{"v1", "v1beta1"}))
-			g.Expect(*wh.FailurePolicy).To(Equal(admissionregistrationv1.Fail))
+			g.Expect(*wh.FailurePolicy).To(Equal(admissionregistrationv1.Ignore))
 			g.Expect(*wh.MatchPolicy).To(Equal(admissionregistrationv1.Equivalent))
 			g.Expect(*wh.ReinvocationPolicy).To(Equal(admissionregistrationv1.IfNeededReinvocationPolicy))
 			g.Expect(*wh.SideEffects).To(Equal(admissionregistrationv1.SideEffectClassNone))

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -2594,7 +2594,7 @@ func (r *reconciler) reconcileAzureIdentityWebhook(ctx context.Context) []error 
 		errs = append(errs, fmt.Errorf("failed to reconcile %T %s: %w", clusterRoleBinding, clusterRoleBinding.Name, err))
 	}
 
-	failFailurePolicy := admissionregistrationv1.Fail
+	ignoreFailurePolicy := admissionregistrationv1.Ignore
 	sideEffectsNone := admissionregistrationv1.SideEffectClassNone
 	matchEquivalent := admissionregistrationv1.Equivalent
 	reinvocationIfNeeded := admissionregistrationv1.IfNeededReinvocationPolicy
@@ -2607,7 +2607,7 @@ func (r *reconciler) reconcileAzureIdentityWebhook(ctx context.Context) []error 
 				CABundle: []byte(r.rootCA),
 				URL:      ptr.To("https://127.0.0.1:9443/mutate-v1-pod"),
 			},
-			FailurePolicy:      &failFailurePolicy,
+			FailurePolicy:      &ignoreFailurePolicy,
 			MatchPolicy:        &matchEquivalent,
 			ReinvocationPolicy: &reinvocationIfNeeded,
 			ObjectSelector: &metav1.LabelSelector{


### PR DESCRIPTION
## What this PR does / why we need it:

Changes the Azure workload identity `MutatingWebhookConfiguration` `FailurePolicy` from `Fail` to `Ignore`, matching the pattern already used by the AWS pod identity webhook.

The `e2e-azure-self-managed` presubmit has had a ~43% pass rate over the past 24 hours (3/7). Two of the three failures show the same pattern: `EnsureNoCrashingPods` detecting single restarts of `openshift-oauth-apiserver` and `router` during bootstrap across most hosted clusters. This is Azure-only — no other platform is seeing `EnsureNoCrashingPods` failures.

The most likely cause is a race condition during bootstrap. The Azure workload identity webhook is deployed as a sidecar in the KAS pod and waits for KAS `/version` before starting. Meanwhile, the HCCO registers the `MutatingWebhookConfiguration` in the guest cluster as soon as it can talk to KAS. With `FailurePolicy: Fail`, any pod creation matching `azure.workload.identity/use: "true"` during this window would be rejected, potentially causing downstream component restarts.

We were unable to confirm this definitively — the test framework only logs `restartCount > 0` without capturing exit codes or termination reasons. However, the code structure supports this hypothesis:
- The webhook sidecar intentionally delays startup until KAS is serving (`deployment.go:41-54`)
- The webhook uses `FailurePolicy: Fail` while the equivalent AWS webhook uses `Ignore`
- The `ObjectSelector` targets pods with the `azure.workload.identity/use` label
- Failures are Azure-specific, consistent with an Azure-only component in the admission path

Pods that miss the mutation during the startup window will be re-created by their controllers once the webhook is ready. Note that there is a brief window where pods could run without Azure workload identity tokens injected — operators managing these pods should naturally retry on authentication failures.

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/OCPBUGS-83790

## Special notes for your reviewer:

The AWS pod identity webhook already uses `FailurePolicy: Ignore` here: [`resources.go:2534`](https://github.com/openshift/hypershift/blob/5c06422c7d0d2e8b3f50701f8e15abda5ec9526c/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go#L2534)

A follow-up PR to convert the webhook to a native sidecar init container (using the existing `NativeSidecarContainersEnabled` pattern from `token-minter-container.go`) would provide a more architecturally correct solution by guaranteeing the webhook is ready before KAS starts serving.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.