### PR TITLE
OCPBUGS-84011: fix(karpenter): watch VAP resources to reconcile on deletion

### DIFF
--- a/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller.go
+++ b/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller.go
@@ -101,22 +101,8 @@ func (r *EC2NodeClassReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 			},
 		)).
 		Watches(&awskarpenterv1.EC2NodeClass{}, &handler.EnqueueRequestForObject{}).
-		Watches(&admissionv1.ValidatingAdmissionPolicy{}, handler.EnqueueRequestsFromMapFunc(
-			func(ctx context.Context, o client.Object) []ctrl.Request {
-				if o.GetName() != "karpenter.ec2nodeclass.hypershift.io" {
-					return nil
-				}
-				return r.mapToOpenShiftEC2NodeClasses(ctx, o)
-			},
-		)).
-		Watches(&admissionv1.ValidatingAdmissionPolicyBinding{}, handler.EnqueueRequestsFromMapFunc(
-			func(ctx context.Context, o client.Object) []ctrl.Request {
-				if o.GetName() != "karpenter-binding.ec2nodeclass.hypershift.io" {
-					return nil
-				}
-				return r.mapToOpenShiftEC2NodeClasses(ctx, o)
-			},
-		)).
+		Watches(&admissionv1.ValidatingAdmissionPolicy{}, handler.EnqueueRequestsFromMapFunc(r.mapVAPToOpenShiftEC2NodeClasses)).
+		Watches(&admissionv1.ValidatingAdmissionPolicyBinding{}, handler.EnqueueRequestsFromMapFunc(r.mapVAPBindingToOpenShiftEC2NodeClasses)).
 		// Watch secrets in the management cluster and reconcile all ec2nodeclasses
 		WatchesRawSource(source.Kind[client.Object](managementCluster.GetCache(), &corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.mapToOpenShiftEC2NodeClasses),
@@ -688,6 +674,20 @@ func (r *EC2NodeClassReconciler) hcpAnnotationPredicate() predicate.Predicate {
 		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
 		GenericFunc: func(e event.GenericEvent) bool { return false },
 	}
+}
+
+func (r *EC2NodeClassReconciler) mapVAPToOpenShiftEC2NodeClasses(ctx context.Context, o client.Object) []ctrl.Request {
+	if o.GetName() != "karpenter.ec2nodeclass.hypershift.io" {
+		return nil
+	}
+	return r.mapToOpenShiftEC2NodeClasses(ctx, o)
+}
+
+func (r *EC2NodeClassReconciler) mapVAPBindingToOpenShiftEC2NodeClasses(ctx context.Context, o client.Object) []ctrl.Request {
+	if o.GetName() != "karpenter-binding.ec2nodeclass.hypershift.io" {
+		return nil
+	}
+	return r.mapToOpenShiftEC2NodeClasses(ctx, o)
 }
 
 // mapToOpenShiftEC2NodeClasses maps a request to all OpenshiftEC2NodeClass resources

--- a/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller.go
+++ b/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller.go
@@ -101,6 +101,22 @@ func (r *EC2NodeClassReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 			},
 		)).
 		Watches(&awskarpenterv1.EC2NodeClass{}, &handler.EnqueueRequestForObject{}).
+		Watches(&admissionv1.ValidatingAdmissionPolicy{}, handler.EnqueueRequestsFromMapFunc(
+			func(ctx context.Context, o client.Object) []ctrl.Request {
+				if o.GetName() != "karpenter.ec2nodeclass.hypershift.io" {
+					return nil
+				}
+				return r.mapToOpenShiftEC2NodeClasses(ctx, o)
+			},
+		)).
+		Watches(&admissionv1.ValidatingAdmissionPolicyBinding{}, handler.EnqueueRequestsFromMapFunc(
+			func(ctx context.Context, o client.Object) []ctrl.Request {
+				if o.GetName() != "karpenter-binding.ec2nodeclass.hypershift.io" {
+					return nil
+				}
+				return r.mapToOpenShiftEC2NodeClasses(ctx, o)
+			},
+		)).
 		// Watch secrets in the management cluster and reconcile all ec2nodeclasses
 		WatchesRawSource(source.Kind[client.Object](managementCluster.GetCache(), &corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.mapToOpenShiftEC2NodeClasses),

--- a/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller_test.go
+++ b/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller_test.go
@@ -19,7 +19,9 @@ import (
 
 	awskarpenterv1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
 
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1489,4 +1491,49 @@ func TestReconcileKarpenterSubnetsConfigMap(t *testing.T) {
 			g.Expect(subnetIDs).To(ConsistOf(tc.expectedSubnets))
 		})
 	}
+}
+
+func TestReconcileVAPRecreatesDeletedResources(t *testing.T) {
+	g := NewWithT(t)
+
+	guestClient := fake.NewClientBuilder().
+		WithScheme(hyperapi.Scheme).
+		Build()
+
+	r := &EC2NodeClassReconciler{
+		guestClient:            guestClient,
+		CreateOrUpdateProvider: upsert.New(false),
+	}
+
+	ctx := context.Background()
+	vapKey := client.ObjectKey{Name: "karpenter.ec2nodeclass.hypershift.io"}
+	bindingKey := client.ObjectKey{Name: "karpenter-binding.ec2nodeclass.hypershift.io"}
+
+	// When reconcileVAP is called it should create the VAP and binding
+	g.Expect(r.reconcileVAP(ctx)).To(Succeed())
+
+	vap := &admissionv1.ValidatingAdmissionPolicy{}
+	g.Expect(guestClient.Get(ctx, vapKey, vap)).To(Succeed())
+
+	binding := &admissionv1.ValidatingAdmissionPolicyBinding{}
+	g.Expect(guestClient.Get(ctx, bindingKey, binding)).To(Succeed())
+	g.Expect(binding.Spec.PolicyName).To(Equal(vapKey.Name))
+
+	// When the VAP and binding are deleted and reconcileVAP is called again it should recreate them
+	g.Expect(guestClient.Delete(ctx, vap)).To(Succeed())
+	g.Expect(guestClient.Delete(ctx, binding)).To(Succeed())
+
+	g.Expect(apierrors.IsNotFound(guestClient.Get(ctx, vapKey, vap))).To(BeTrue())
+	g.Expect(apierrors.IsNotFound(guestClient.Get(ctx, bindingKey, binding))).To(BeTrue())
+
+	g.Expect(r.reconcileVAP(ctx)).To(Succeed())
+
+	recreatedVAP := &admissionv1.ValidatingAdmissionPolicy{}
+	g.Expect(guestClient.Get(ctx, vapKey, recreatedVAP)).To(Succeed())
+	g.Expect(recreatedVAP.Spec.Validations).To(HaveLen(1))
+
+	recreatedBinding := &admissionv1.ValidatingAdmissionPolicyBinding{}
+	g.Expect(guestClient.Get(ctx, bindingKey, recreatedBinding)).To(Succeed())
+	g.Expect(recreatedBinding.Spec.PolicyName).To(Equal(vapKey.Name))
+	g.Expect(recreatedBinding.Spec.ValidationActions).To(ContainElement(admissionv1.Deny))
 }

--- a/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller_test.go
+++ b/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller_test.go
@@ -21,7 +21,6 @@ import (
 
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1493,47 +1492,108 @@ func TestReconcileKarpenterSubnetsConfigMap(t *testing.T) {
 	}
 }
 
-func TestReconcileVAPRecreatesDeletedResources(t *testing.T) {
-	g := NewWithT(t)
-
-	guestClient := fake.NewClientBuilder().
-		WithScheme(hyperapi.Scheme).
-		Build()
-
-	r := &EC2NodeClassReconciler{
-		guestClient:            guestClient,
-		CreateOrUpdateProvider: upsert.New(false),
+func TestMapVAPToOpenShiftEC2NodeClasses(t *testing.T) {
+	testCases := []struct {
+		name             string
+		vapName          string
+		nodeClasses      []client.Object
+		expectedRequests int
+	}{
+		{
+			name:    "When the VAP matches the expected name it should enqueue all OpenshiftEC2NodeClasses",
+			vapName: "karpenter.ec2nodeclass.hypershift.io",
+			nodeClasses: []client.Object{
+				&hyperkarpenterv1.OpenshiftEC2NodeClass{ObjectMeta: metav1.ObjectMeta{Name: "nc-1"}},
+				&hyperkarpenterv1.OpenshiftEC2NodeClass{ObjectMeta: metav1.ObjectMeta{Name: "nc-2"}},
+			},
+			expectedRequests: 2,
+		},
+		{
+			name:    "When the VAP name does not match it should not enqueue any requests",
+			vapName: "unrelated-policy",
+			nodeClasses: []client.Object{
+				&hyperkarpenterv1.OpenshiftEC2NodeClass{ObjectMeta: metav1.ObjectMeta{Name: "nc-1"}},
+			},
+			expectedRequests: 0,
+		},
+		{
+			name:             "When the VAP matches but no OpenshiftEC2NodeClasses exist it should return empty",
+			vapName:          "karpenter.ec2nodeclass.hypershift.io",
+			nodeClasses:      []client.Object{},
+			expectedRequests: 0,
+		},
 	}
 
-	ctx := context.Background()
-	vapKey := client.ObjectKey{Name: "karpenter.ec2nodeclass.hypershift.io"}
-	bindingKey := client.ObjectKey{Name: "karpenter-binding.ec2nodeclass.hypershift.io"}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 
-	// When reconcileVAP is called it should create the VAP and binding
-	g.Expect(r.reconcileVAP(ctx)).To(Succeed())
+			guestClient := fake.NewClientBuilder().
+				WithScheme(hyperapi.Scheme).
+				WithObjects(tc.nodeClasses...).
+				Build()
 
-	vap := &admissionv1.ValidatingAdmissionPolicy{}
-	g.Expect(guestClient.Get(ctx, vapKey, vap)).To(Succeed())
+			r := &EC2NodeClassReconciler{guestClient: guestClient}
 
-	binding := &admissionv1.ValidatingAdmissionPolicyBinding{}
-	g.Expect(guestClient.Get(ctx, bindingKey, binding)).To(Succeed())
-	g.Expect(binding.Spec.PolicyName).To(Equal(vapKey.Name))
+			vap := &admissionv1.ValidatingAdmissionPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: tc.vapName},
+			}
 
-	// When the VAP and binding are deleted and reconcileVAP is called again it should recreate them
-	g.Expect(guestClient.Delete(ctx, vap)).To(Succeed())
-	g.Expect(guestClient.Delete(ctx, binding)).To(Succeed())
+			requests := r.mapVAPToOpenShiftEC2NodeClasses(context.Background(), vap)
+			g.Expect(requests).To(HaveLen(tc.expectedRequests))
+		})
+	}
+}
 
-	g.Expect(apierrors.IsNotFound(guestClient.Get(ctx, vapKey, vap))).To(BeTrue())
-	g.Expect(apierrors.IsNotFound(guestClient.Get(ctx, bindingKey, binding))).To(BeTrue())
+func TestMapVAPBindingToOpenShiftEC2NodeClasses(t *testing.T) {
+	testCases := []struct {
+		name             string
+		bindingName      string
+		nodeClasses      []client.Object
+		expectedRequests int
+	}{
+		{
+			name:        "When the VAPBinding matches the expected name it should enqueue all OpenshiftEC2NodeClasses",
+			bindingName: "karpenter-binding.ec2nodeclass.hypershift.io",
+			nodeClasses: []client.Object{
+				&hyperkarpenterv1.OpenshiftEC2NodeClass{ObjectMeta: metav1.ObjectMeta{Name: "nc-1"}},
+				&hyperkarpenterv1.OpenshiftEC2NodeClass{ObjectMeta: metav1.ObjectMeta{Name: "nc-2"}},
+			},
+			expectedRequests: 2,
+		},
+		{
+			name:        "When the VAPBinding name does not match it should not enqueue any requests",
+			bindingName: "unrelated-binding",
+			nodeClasses: []client.Object{
+				&hyperkarpenterv1.OpenshiftEC2NodeClass{ObjectMeta: metav1.ObjectMeta{Name: "nc-1"}},
+			},
+			expectedRequests: 0,
+		},
+		{
+			name:             "When the VAPBinding matches but no OpenshiftEC2NodeClasses exist it should return empty",
+			bindingName:      "karpenter-binding.ec2nodeclass.hypershift.io",
+			nodeClasses:      []client.Object{},
+			expectedRequests: 0,
+		},
+	}
 
-	g.Expect(r.reconcileVAP(ctx)).To(Succeed())
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
 
-	recreatedVAP := &admissionv1.ValidatingAdmissionPolicy{}
-	g.Expect(guestClient.Get(ctx, vapKey, recreatedVAP)).To(Succeed())
-	g.Expect(recreatedVAP.Spec.Validations).To(HaveLen(1))
+			guestClient := fake.NewClientBuilder().
+				WithScheme(hyperapi.Scheme).
+				WithObjects(tc.nodeClasses...).
+				Build()
 
-	recreatedBinding := &admissionv1.ValidatingAdmissionPolicyBinding{}
-	g.Expect(guestClient.Get(ctx, bindingKey, recreatedBinding)).To(Succeed())
-	g.Expect(recreatedBinding.Spec.PolicyName).To(Equal(vapKey.Name))
-	g.Expect(recreatedBinding.Spec.ValidationActions).To(ContainElement(admissionv1.Deny))
+			r := &EC2NodeClassReconciler{guestClient: guestClient}
+
+			binding := &admissionv1.ValidatingAdmissionPolicyBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: tc.bindingName},
+			}
+
+			requests := r.mapVAPBindingToOpenShiftEC2NodeClasses(context.Background(), binding)
+			g.Expect(requests).To(HaveLen(tc.expectedRequests))
+		})
+	}
 }


### PR DESCRIPTION
## What this PR does / why we need it:

The EC2NodeClass controller creates a ValidatingAdmissionPolicy and binding on the guest cluster but did not watch those resources. If they were deleted externally, the controller would not detect the deletion and recreate them until an unrelated watched resource changed.

Add watches for ValidatingAdmissionPolicy and
ValidatingAdmissionPolicyBinding filtered to the karpenter-managed resources so that deletion triggers immediate reconciliation.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes OCPBUGS-84011

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admission policy and binding changes in guest clusters now also trigger synchronization of EC2 node class configuration across hosted clusters.

* **Tests**
  * Added unit tests verifying that admission policy and binding events correctly map to and enqueue reconciliation for existing EC2 node classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->