### PR TITLE
NO-JIRA: docs: add jira:ready-to-solve to agentic SDLC workflow

### DIFF
--- a/docs/content/how-to/agentic-sdlc.md
+++ b/docs/content/how-to/agentic-sdlc.md
@@ -68,7 +68,8 @@ flowchart LR
     end
 
     subgraph "Scope Refinement"
-        B1["/jira:create — Create Jira issues"] --> B2["/jira:generate-test-plan — Generate test plan from Jira"]
+        B1["/jira:create — Create Jira issues"] --> B5["/jira:ready-to-solve — Validate readiness for agent"]
+        B1 --> B2["/jira:generate-test-plan — Generate test plan from Jira"]
         B1 --> B3["/utils:generate-test-plan — Generate test plan from PRs"]
         B1 --> B4["Obra superpowers"]
     end
@@ -94,6 +95,7 @@ flowchart LR
 | Activity             | Building Block              | Description                                                      |
 | -------------------- | --------------------------- | ---------------------------------------------------------------- |
 | Issue creation       | `/jira:create`              | Create well-structured Jira issues (stories, bugs, tasks, epics) |
+| Readiness validation | `/jira:ready-to-solve`      | Validate a Jira issue is well-groomed and ready for `/jira:solve` |
 | Test planning (Jira) | `/jira:generate-test-plan`  | Generate test steps from a Jira issue                            |
 | Test planning (PRs)  | `/utils:generate-test-plan` | Generate test steps for one or more related PRs                  |
 
@@ -203,7 +205,8 @@ Building blocks run and driven by central infrastructure tools. These run on sch
 
 ```mermaid
 flowchart TD
-    A["Jira item labeled with issue-for-agent"] --> B["Periodic Job picks from backlog"]
+    A["Jira item labeled with issue-for-agent"] --> A2["/jira:ready-to-solve validates readiness"]
+    A2 --> B["Periodic Job picks from backlog"]
     B --> C["Agent generates code, reviews, addresses and creates PR"]
     C --> D["Agent review on published PR"]
     D --> E["Human review"]

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -3264,7 +3264,8 @@ flowchart LR
     end
 
     subgraph "Scope Refinement"
-        B1["/jira:create — Create Jira issues"] --> B2["/jira:generate-test-plan — Generate test plan from Jira"]
+        B1["/jira:create — Create Jira issues"] --> B5["/jira:ready-to-solve — Validate readiness for agent"]
+        B1 --> B2["/jira:generate-test-plan — Generate test plan from Jira"]
         B1 --> B3["/utils:generate-test-plan — Generate test plan from PRs"]
         B1 --> B4["Obra superpowers"]
     end
@@ -3290,6 +3291,7 @@ flowchart LR
 | Activity             | Building Block              | Description                                                      |
 | -------------------- | --------------------------- | ---------------------------------------------------------------- |
 | Issue creation       | `/jira:create`              | Create well-structured Jira issues (stories, bugs, tasks, epics) |
+| Readiness validation | `/jira:ready-to-solve`      | Validate a Jira issue is well-groomed and ready for `/jira:solve` |
 | Test planning (Jira) | `/jira:generate-test-plan`  | Generate test steps from a Jira issue                            |
 | Test planning (PRs)  | `/utils:generate-test-plan` | Generate test steps for one or more related PRs                  |
 
@@ -3399,7 +3401,8 @@ Building blocks run and driven by central infrastructure tools. These run on sch
 
 ```mermaid
 flowchart TD
-    A["Jira item labeled with issue-for-agent"] --> B["Periodic Job picks from backlog"]
+    A["Jira item labeled with issue-for-agent"] --> A2["/jira:ready-to-solve validates readiness"]
+    A2 --> B["Periodic Job picks from backlog"]
     B --> C["Agent generates code, reviews, addresses and creates PR"]
     C --> D["Agent review on published PR"]
     D --> E["Human review"]


### PR DESCRIPTION
## Summary

- Add `/jira:ready-to-solve` to the Phase 1 Discovery diagram and Scope Refinement table as a readiness validation step after `/jira:create`
- Add `/jira:ready-to-solve` to the Hands-off Delivery flowchart between the `issue-for-agent` label and periodic job pickup

## Test plan

- [ ] Verify Mermaid diagrams render correctly on https://hypershift.pages.dev/how-to/agentic-sdlc/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ASDLC workflow documentation to include a new readiness validation step in the Scope Refinement phase to ensure comprehensive issue preparation.
  * Modified workflow diagrams and activity tables to reflect the readiness validation gate positioned between issue creation and agent-driven code generation within the Hands-off Delivery workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->