### PR TITLE
CNTRLPLANE-2539: Move generation of the CAPI Provider Role

### DIFF
--- a/cmd/cluster/agent/create.go
+++ b/cmd/cluster/agent/create.go
@@ -8,7 +8,6 @@ import (
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	"github.com/openshift/hypershift/support/globalconfig"
 
-	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -107,25 +106,7 @@ func (o *CreateOptions) GenerateNodePools(defaultNodePool core.DefaultNodePoolCo
 }
 
 func (o *CreateOptions) GenerateResources() ([]crclient.Object, error) {
-	return []crclient.Object{
-		&rbacv1.Role{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Role",
-				APIVersion: rbacv1.SchemeGroupVersion.String(),
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: o.AgentNamespace,
-				Name:      "capi-provider-role",
-			},
-			Rules: []rbacv1.PolicyRule{
-				{
-					APIGroups: []string{"agent-install.openshift.io"},
-					Resources: []string{"agents"},
-					Verbs:     []string{"*"},
-				},
-			},
-		},
-	}, nil
+	return nil, nil
 }
 
 var _ core.Platform = (*CreateOptions)(nil)

--- a/cmd/cluster/agent/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
+++ b/cmd/cluster/agent/testdata/zz_fixture_TestCreateCluster_minimal_flags_necessary_to_render.yaml
@@ -15,18 +15,6 @@ metadata:
   name: example-pull-secret
   namespace: clusters
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: capi-provider-role
-rules:
-- apiGroups:
-  - agent-install.openshift.io
-  resources:
-  - agents
-  verbs:
-  - '*'
----
 apiVersion: v1
 data:
   key: 7o9RQL/BlcNrBWfNBVrJg55oKrDDaDu2kfoULl9MNIE=

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2895,10 +2895,8 @@ func (r *HostedClusterReconciler) reconcileCAPIProvider(cpContext controlplaneco
 		},
 	}
 	err = cpContext.Client.Get(cpContext, client.ObjectKeyFromObject(capiProviderDeployment), capiProviderDeployment)
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to fetch capi provider deployment: %w", err)
-		}
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to fetch capi provider deployment: %w", err)
 	}
 	if err == nil {
 		if capiProviderDeployment.Spec.Template.ObjectMeta.Labels[hyperv1.ControlPlaneComponentLabel] != "capi-provider" {

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/clusterapi"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/k8sutil"
@@ -29,6 +30,10 @@ const (
 	// TODO Pin to specific release
 	imageCAPAgent         = "quay.io/edge-infrastructure/cluster-api-provider-agent:latest"
 	CredentialsRBACPrefix = "cluster-api-agent"
+	CAPIProviderRoleName  = "capi-provider-role"
+	// capiProviderAgentRBACLabel marks Role/RoleBinding reconciled for the agent CAPI provider.
+	capiProviderAgentRBACLabelKey   = "hypershift.openshift.io/capi-provider-agent-rbac"
+	capiProviderAgentRBACLabelValue = "true"
 )
 
 type Agent struct{}
@@ -132,10 +137,53 @@ func (p Agent) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hy
 	return deploymentSpec, nil
 }
 
-// TODO add a new method to Platform interface?
 func (p Agent) ReconcileCredentials(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
 	hcluster *hyperv1.HostedCluster,
 	controlPlaneNamespace string) error {
+	return ReconcileCAPIProviderRole(ctx, c, createOrUpdate, hcluster, controlPlaneNamespace)
+}
+
+// setHypershiftMetadata ensures the object has HyperShift label and annotation set.
+func setHypershiftMetadata(obj client.Object, hcluster *hyperv1.HostedCluster) {
+	if obj.GetLabels() == nil {
+		obj.SetLabels(map[string]string{})
+	}
+	obj.GetLabels()[capiProviderAgentRBACLabelKey] = capiProviderAgentRBACLabelValue
+	if obj.GetAnnotations() == nil {
+		obj.SetAnnotations(map[string]string{})
+	}
+	obj.GetAnnotations()[k8sutil.HostedClusterAnnotation] = client.ObjectKeyFromObject(hcluster).String()
+}
+
+// ReconcileCAPIProviderRole creates the RBAC Role and RoleBinding in the agent
+// namespace so the CAPI provider can manage Agent resources. Each HostedCluster
+// creates its own Role (named per control plane namespace) to enable proper
+// lifecycle management and watch-based reconciliation.
+func ReconcileCAPIProviderRole(ctx context.Context, c client.Client, createOrUpdate upsert.CreateOrUpdateFN,
+	hcluster *hyperv1.HostedCluster,
+	controlPlaneNamespace string) error {
+
+	roleName := fmt.Sprintf("%s-%s", CAPIProviderRoleName, controlPlaneNamespace)
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: hcluster.Spec.Platform.Agent.AgentNamespace,
+			Name:      roleName,
+		},
+	}
+	_, err := createOrUpdate(ctx, c, role, func() error {
+		setHypershiftMetadata(role, hcluster)
+		role.Rules = []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"agent-install.openshift.io"},
+				Resources: []string{"agents"},
+				Verbs:     []string{"get", "list", "watch", "update", "patch"},
+			},
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to reconcile Agent Role: %w", err)
+	}
 
 	roleBinding := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -143,18 +191,19 @@ func (p Agent) ReconcileCredentials(ctx context.Context, c client.Client, create
 			Name:      fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace),
 		},
 	}
-	_, err := createOrUpdate(ctx, c, roleBinding, func() error {
+	_, err = createOrUpdate(ctx, c, roleBinding, func() error {
+		setHypershiftMetadata(roleBinding, hcluster)
 		roleBinding.Subjects = []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
-				Name:      "capi-provider",
+				Name:      clusterapi.CAPIProviderServiceAccount(controlPlaneNamespace).Name,
 				Namespace: controlPlaneNamespace,
 			},
 		}
 		roleBinding.RoleRef = rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
+			APIGroup: rbacv1.GroupName,
 			Kind:     "Role",
-			Name:     "capi-provider-role",
+			Name:     roleName,
 		}
 		return nil
 	})
@@ -204,11 +253,35 @@ func reconcileAgentCluster(agentCluster *agentv1.AgentCluster, ignEndpoint, cont
 	return nil
 }
 
+// DeleteCredentials removes this HostedCluster's CAPI provider Role and RoleBinding.
+// Each cluster has its own Role, so both can be safely deleted without affecting other clusters.
+// Also cleans up legacy shared Role (without -<cpNamespace> suffix) if it exists.
 func (Agent) DeleteCredentials(ctx context.Context, c client.Client,
 	hc *hyperv1.HostedCluster,
 	controlPlaneNamespace string) error {
-	if _, err := k8sutil.DeleteIfNeeded(ctx, c, &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace), Namespace: hc.Spec.Platform.Agent.AgentNamespace}}); err != nil {
-		return fmt.Errorf("failed to clean up CAPI provider rolebinding: %w", err)
+	agentNS := hc.Spec.Platform.Agent.AgentNamespace
+	roleName := fmt.Sprintf("%s-%s", CAPIProviderRoleName, controlPlaneNamespace)
+	bindingName := fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace)
+
+	if _, err := k8sutil.DeleteIfNeeded(ctx, c, &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: bindingName, Namespace: agentNS},
+	}); err != nil {
+		return fmt.Errorf("failed to clean up CAPI provider RoleBinding: %w", err)
 	}
+
+	if _, err := k8sutil.DeleteIfNeeded(ctx, c, &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: roleName, Namespace: agentNS},
+	}); err != nil {
+		return fmt.Errorf("failed to clean up CAPI provider Role: %w", err)
+	}
+
+	// Clean up legacy shared Role (created before per-cluster Roles were introduced)
+	legacyRoleName := CAPIProviderRoleName
+	if _, err := k8sutil.DeleteIfNeeded(ctx, c, &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: legacyRoleName, Namespace: agentNS},
+	}); err != nil {
+		return fmt.Errorf("failed to clean up legacy CAPI provider Role: %w", err)
+	}
+
 	return nil
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
 	hyperapi "github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/upsert"
 
 	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1beta1"
@@ -27,85 +28,220 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestReconcileCredentials(t *testing.T) {
-	g := NewGomegaWithT(t)
-	platform := &Agent{}
-	hostedCluster := &hyperv1.HostedCluster{
+func newTestHostedCluster(name, agentNamespace string) *hyperv1.HostedCluster {
+	return &hyperv1.HostedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "clusters",
+			Name:      name,
+		},
 		Spec: hyperv1.HostedClusterSpec{
 			Platform: hyperv1.PlatformSpec{
 				Type: hyperv1.AgentPlatform,
 				Agent: &hyperv1.AgentPlatformSpec{
-					AgentNamespace: "test",
+					AgentNamespace: agentNamespace,
 				},
 			},
 		},
 	}
-	controlPlaneNamespace := "test"
-	client := fake.NewClientBuilder().Build()
+}
 
-	err := platform.ReconcileCredentials(t.Context(),
-		client, upsert.New(false).CreateOrUpdate,
-		hostedCluster, controlPlaneNamespace)
-	g.Expect(err).ToNot(HaveOccurred())
+func TestReconcileCAPIProviderRole(t *testing.T) {
+	t.Parallel()
 
-	roleBinding := &rbacv1.RoleBinding{}
-	err = client.Get(t.Context(), types.NamespacedName{
-		Namespace: hostedCluster.Spec.Platform.Agent.AgentNamespace,
-		Name:      fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace),
-	}, roleBinding)
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(roleBinding.Subjects[0].Namespace).To(BeIdenticalTo(controlPlaneNamespace))
-	g.Expect(roleBinding.Subjects[0].Kind).To(BeIdenticalTo("ServiceAccount"))
-	g.Expect(roleBinding.Subjects[0].Name).To(BeIdenticalTo("capi-provider"))
+	t.Run("When reconciling RBAC it should create Role and RoleBinding", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		hostedCluster := newTestHostedCluster("test-cluster", "test")
+		controlPlaneNamespace := "test-cp"
+		client := fake.NewClientBuilder().Build()
+
+		err := ReconcileCAPIProviderRole(t.Context(),
+			client, upsert.New(false).CreateOrUpdate,
+			hostedCluster, controlPlaneNamespace)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		roleBinding := &rbacv1.RoleBinding{}
+		err = client.Get(t.Context(), types.NamespacedName{
+			Namespace: hostedCluster.Spec.Platform.Agent.AgentNamespace,
+			Name:      fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace),
+		}, roleBinding)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(roleBinding.Subjects[0].Namespace).To(BeIdenticalTo(controlPlaneNamespace))
+		g.Expect(roleBinding.Subjects[0].Kind).To(BeIdenticalTo("ServiceAccount"))
+		g.Expect(roleBinding.Subjects[0].Name).To(BeIdenticalTo("capi-provider"))
+		g.Expect(roleBinding.Labels[capiProviderAgentRBACLabelKey]).To(Equal(capiProviderAgentRBACLabelValue))
+		g.Expect(roleBinding.Annotations[k8sutil.HostedClusterAnnotation]).To(Equal("clusters/test-cluster"))
+		g.Expect(roleBinding.RoleRef.APIGroup).To(Equal(rbacv1.GroupName))
+
+		roleName := fmt.Sprintf("%s-%s", CAPIProviderRoleName, controlPlaneNamespace)
+		g.Expect(roleBinding.RoleRef.Name).To(Equal(roleName))
+
+		role := &rbacv1.Role{}
+		err = client.Get(t.Context(), types.NamespacedName{
+			Namespace: hostedCluster.Spec.Platform.Agent.AgentNamespace,
+			Name:      roleName,
+		}, role)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(role.Labels[capiProviderAgentRBACLabelKey]).To(Equal(capiProviderAgentRBACLabelValue))
+		g.Expect(role.Annotations[k8sutil.HostedClusterAnnotation]).To(Equal("clusters/test-cluster"))
+		g.Expect(role.Rules).To(HaveLen(1))
+		g.Expect(role.Rules[0].APIGroups).To(Equal([]string{"agent-install.openshift.io"}))
+		g.Expect(role.Rules[0].Resources).To(Equal([]string{"agents"}))
+		g.Expect(role.Rules[0].Verbs).To(Equal([]string{"get", "list", "watch", "update", "patch"}))
+	})
+
+	t.Run("When called multiple times it should be idempotent", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		hostedCluster := newTestHostedCluster("test-cluster", "test")
+		controlPlaneNamespace := "test-cp"
+		client := fake.NewClientBuilder().Build()
+
+		err := ReconcileCAPIProviderRole(t.Context(),
+			client, upsert.New(false).CreateOrUpdate,
+			hostedCluster, controlPlaneNamespace)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = ReconcileCAPIProviderRole(t.Context(),
+			client, upsert.New(false).CreateOrUpdate,
+			hostedCluster, controlPlaneNamespace)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		roleName := fmt.Sprintf("%s-%s", CAPIProviderRoleName, controlPlaneNamespace)
+		role := &rbacv1.Role{}
+		err = client.Get(t.Context(), types.NamespacedName{
+			Namespace: hostedCluster.Spec.Platform.Agent.AgentNamespace,
+			Name:      roleName,
+		}, role)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(role.Rules).To(HaveLen(1))
+		g.Expect(role.Rules[0].APIGroups).To(Equal([]string{"agent-install.openshift.io"}))
+		g.Expect(role.Rules[0].Resources).To(Equal([]string{"agents"}))
+		g.Expect(role.Rules[0].Verbs).To(Equal([]string{"get", "list", "watch", "update", "patch"}))
+		g.Expect(role.Labels[capiProviderAgentRBACLabelKey]).To(Equal(capiProviderAgentRBACLabelValue))
+		g.Expect(role.Annotations[k8sutil.HostedClusterAnnotation]).To(Equal("clusters/test-cluster"))
+	})
 }
 
 func TestDeleteCredentials(t *testing.T) {
-	g := NewGomegaWithT(t)
-	platform := &Agent{}
-	hostedCluster := &hyperv1.HostedCluster{
-		Spec: hyperv1.HostedClusterSpec{
-			Platform: hyperv1.PlatformSpec{
-				Type: hyperv1.AgentPlatform,
-				Agent: &hyperv1.AgentPlatformSpec{
-					AgentNamespace: "test",
-				},
-			},
-		},
-	}
-	controlPlaneNamespace := "test"
-	client := fake.NewClientBuilder().Build()
+	t.Parallel()
 
-	// test noop
-	err := platform.DeleteCredentials(t.Context(),
-		client,
-		hostedCluster, controlPlaneNamespace)
-	g.Expect(err).ToNot(HaveOccurred())
+	t.Run("When deleting non-existent resources it should not error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		platform := &Agent{}
+		hostedCluster := newTestHostedCluster("test-cluster", "test")
+		controlPlaneNamespace := "test-cp"
+		client := fake.NewClientBuilder().Build()
 
-	// Create the creds
-	err = platform.ReconcileCredentials(t.Context(),
-		client, upsert.New(false).CreateOrUpdate,
-		hostedCluster, controlPlaneNamespace)
-	g.Expect(err).ToNot(HaveOccurred())
+		err := platform.DeleteCredentials(t.Context(),
+			client,
+			hostedCluster, controlPlaneNamespace)
+		g.Expect(err).ToNot(HaveOccurred())
+	})
 
-	// Verify the roleBinding exists
-	roleBinding := &rbacv1.RoleBinding{}
-	err = client.Get(t.Context(), types.NamespacedName{
-		Namespace: hostedCluster.Spec.Platform.Agent.AgentNamespace,
-		Name:      fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace),
-	}, roleBinding)
-	g.Expect(err).ToNot(HaveOccurred())
+	t.Run("When deleting credentials it should remove Role and RoleBinding", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		platform := &Agent{}
+		hostedCluster := newTestHostedCluster("test-cluster", "test")
+		controlPlaneNamespace := "test-cp"
+		client := fake.NewClientBuilder().Build()
 
-	err = platform.DeleteCredentials(t.Context(),
-		client,
-		hostedCluster, controlPlaneNamespace)
-	g.Expect(err).ToNot(HaveOccurred())
+		// Create the RBAC resources
+		err := ReconcileCAPIProviderRole(t.Context(),
+			client, upsert.New(false).CreateOrUpdate,
+			hostedCluster, controlPlaneNamespace)
+		g.Expect(err).ToNot(HaveOccurred())
 
-	roleBinding = &rbacv1.RoleBinding{}
-	err = client.Get(t.Context(), types.NamespacedName{
-		Namespace: hostedCluster.Spec.Platform.Agent.AgentNamespace,
-		Name:      fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace),
-	}, roleBinding)
-	g.Expect(apierrors.IsNotFound(err)).To(Equal(true))
+		roleName := fmt.Sprintf("%s-%s", CAPIProviderRoleName, controlPlaneNamespace)
+		bindingName := fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace)
+
+		// Verify the RoleBinding exists
+		roleBinding := &rbacv1.RoleBinding{}
+		err = client.Get(t.Context(), types.NamespacedName{
+			Namespace: hostedCluster.Spec.Platform.Agent.AgentNamespace,
+			Name:      bindingName,
+		}, roleBinding)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Verify the Role exists
+		role := &rbacv1.Role{}
+		err = client.Get(t.Context(), types.NamespacedName{
+			Namespace: hostedCluster.Spec.Platform.Agent.AgentNamespace,
+			Name:      roleName,
+		}, role)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Delete credentials
+		err = platform.DeleteCredentials(t.Context(),
+			client,
+			hostedCluster, controlPlaneNamespace)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Verify RoleBinding is deleted
+		roleBinding = &rbacv1.RoleBinding{}
+		err = client.Get(t.Context(), types.NamespacedName{
+			Namespace: hostedCluster.Spec.Platform.Agent.AgentNamespace,
+			Name:      bindingName,
+		}, roleBinding)
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "RoleBinding should be deleted")
+
+		// Verify Role is deleted
+		role = &rbacv1.Role{}
+		err = client.Get(t.Context(), types.NamespacedName{
+			Namespace: hostedCluster.Spec.Platform.Agent.AgentNamespace,
+			Name:      roleName,
+		}, role)
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "Role should be deleted")
+	})
+
+	t.Run("When multiple clusters share the same agent namespace it should delete independently", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		platform := &Agent{}
+		agentNamespace := "shared-agent-ns"
+		hostedCluster1 := newTestHostedCluster("cluster1", agentNamespace)
+		hostedCluster2 := newTestHostedCluster("cluster2", agentNamespace)
+		cpNamespace1 := "cp-one"
+		cpNamespace2 := "cp-two"
+		c := fake.NewClientBuilder().Build()
+
+		err := ReconcileCAPIProviderRole(t.Context(), c, upsert.New(false).CreateOrUpdate, hostedCluster1, cpNamespace1)
+		g.Expect(err).ToNot(HaveOccurred())
+		err = ReconcileCAPIProviderRole(t.Context(), c, upsert.New(false).CreateOrUpdate, hostedCluster2, cpNamespace2)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Delete cluster1's credentials
+		err = platform.DeleteCredentials(t.Context(), c, hostedCluster1, cpNamespace1)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Cluster1's Role and RoleBinding should be deleted
+		role1Name := fmt.Sprintf("%s-%s", CAPIProviderRoleName, cpNamespace1)
+		role := &rbacv1.Role{}
+		err = c.Get(t.Context(), types.NamespacedName{Namespace: agentNamespace, Name: role1Name}, role)
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "cluster1's Role should be deleted")
+
+		rb1Name := fmt.Sprintf("%s-%s", CredentialsRBACPrefix, cpNamespace1)
+		rb := &rbacv1.RoleBinding{}
+		err = c.Get(t.Context(), types.NamespacedName{Namespace: agentNamespace, Name: rb1Name}, rb)
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "cluster1's RoleBinding should be deleted")
+
+		// Cluster2's Role and RoleBinding should still exist
+		role2Name := fmt.Sprintf("%s-%s", CAPIProviderRoleName, cpNamespace2)
+		err = c.Get(t.Context(), types.NamespacedName{Namespace: agentNamespace, Name: role2Name}, role)
+		g.Expect(err).ToNot(HaveOccurred(), "cluster2's Role should remain untouched")
+
+		rb2Name := fmt.Sprintf("%s-%s", CredentialsRBACPrefix, cpNamespace2)
+		err = c.Get(t.Context(), types.NamespacedName{Namespace: agentNamespace, Name: rb2Name}, rb)
+		g.Expect(err).ToNot(HaveOccurred(), "cluster2's RoleBinding should remain untouched")
+
+		// Delete cluster2's credentials
+		err = platform.DeleteCredentials(t.Context(), c, hostedCluster2, cpNamespace2)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Now cluster2's resources should be deleted too
+		err = c.Get(t.Context(), types.NamespacedName{Namespace: agentNamespace, Name: role2Name}, role)
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "cluster2's Role should be deleted")
+
+		err = c.Get(t.Context(), types.NamespacedName{Namespace: agentNamespace, Name: rb2Name}, rb)
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "cluster2's RoleBinding should be deleted")
+	})
 }
 
 func TestReconcileCAPIInfraCR(t *testing.T) {


### PR DESCRIPTION
[CNTRLPLANE-2539](https://redhat.atlassian.net/browse/CNTRLPLANE-2539): Move generation of CAPI Provider Role from cli to operator

## What this PR does / why we need it:

Supports work in ZTP deployment of HCP clusters by taking Role generation (which is a security risk in gitops workflows) out of the CLI or manual steps and into the operator. Now the operator will handle the role creation, and gitops based deployments do not require relaxing security restrictions to create Roles.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-2539](https://redhat.atlassian.net/browse/CNTRLPLANE-2539)

## Special notes for your reviewer:

## Checklist:
- [ + ] Subject and description added to both, commit and PR.
- [ + ] Relevant issues have been referenced.
- [ ? ] This change includes docs. 
- [ + ] This change includes unit tests.

## AI Assistance

- Model Used: Claude with claude-sonnet-4@20250514 in CLI and in VS Code IDE integration
- Scope: Planning, Test writing, and Code
- Level: Code generation and Code assistance
- Human Review: Quick code review by @cwilkers, manual testing of multiple use cases on local cluster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * RBAC role emission removed from the legacy creation path; agent credential lifecycle now centralizes role management and only deletes a shared role when no remaining bindings reference it.

* **Tests**
  * Added and extended tests to verify shared role creation, idempotent reconciliation, preservation across multiple hosted clusters, and deletion once unreferenced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->