### PR TITLE
OCPBUGS-84555: fix(cpo): include serving cert CAs in bootstrap and external admin kubeconfigs

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kubeconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kubeconfig.go
@@ -112,6 +112,20 @@ func adaptKASBootstrapContainerKubeconfigSecret(cpContext component.WorkloadCont
 	return nil
 }
 
+// generateKubeConfigWithServingCerts builds a kubeconfig that trusts both the root CA and any
+// additional serving certificate CAs from namedCertificates. It fetches the combined CA bundle
+// and the specified client certificate secret, then generates the kubeconfig bytes.
+func generateKubeConfigWithServingCerts(cpContext component.WorkloadContext, certSecret *corev1.Secret, url string) ([]byte, error) {
+	totalRootCA, err := combineRootCAWithServingCerts(cpContext)
+	if err != nil {
+		return nil, fmt.Errorf("failed to include serving certificates: %w", err)
+	}
+	if err := cpContext.Client.Get(cpContext, client.ObjectKeyFromObject(certSecret), certSecret); err != nil {
+		return nil, fmt.Errorf("failed to get client cert secret %s: %w", certSecret.Name, err)
+	}
+	return generateKubeConfig(totalRootCA, certSecret, url)
+}
+
 func adapExternalAdminKubeconfigSecret(cpContext component.WorkloadContext, secret *corev1.Secret) error {
 	if cpContext.HCP.Spec.KubeConfig != nil {
 		secret.Name = cpContext.HCP.Spec.KubeConfig.Name
@@ -122,7 +136,8 @@ func adapExternalAdminKubeconfigSecret(cpContext component.WorkloadContext, secr
 	if !util.IsPublicHCP(cpContext.HCP) && !util.IsRouteKAS(cpContext.HCP) {
 		url = internalURL(cpContext.InfraStatus, cpContext.HCP.Name)
 	}
-	kubeconfig, err := GenerateKubeConfig(cpContext, manifests.SystemAdminClientCertSecret(cpContext.HCP.Namespace), url)
+
+	kubeconfig, err := generateKubeConfigWithServingCerts(cpContext, manifests.SystemAdminClientCertSecret(cpContext.HCP.Namespace), url)
 	if err != nil {
 		return fmt.Errorf("failed to generate kubeconfig: %w", err)
 	}
@@ -138,17 +153,7 @@ func adaptCustomAdminKubeconfigSecret(cpContext component.WorkloadContext, secre
 	hcp := cpContext.HCP
 	url := customExternalURL(hcp.Spec.KubeAPIServerDNSName, cpContext.InfraStatus.APIPort)
 
-	totalRootCA, err := combineRootCAWithServingCerts(cpContext)
-	if err != nil {
-		return fmt.Errorf("failed to include serving certificates: %w", err)
-	}
-
-	certSecret := manifests.SystemAdminClientCertSecret(hcp.Namespace)
-	if err := cpContext.Client.Get(cpContext, client.ObjectKeyFromObject(certSecret), certSecret); err != nil {
-		return fmt.Errorf("failed to get system admin client cert secret: %w", err)
-	}
-
-	kubeconfig, err := generateKubeConfig(totalRootCA, certSecret, url)
+	kubeconfig, err := generateKubeConfigWithServingCerts(cpContext, manifests.SystemAdminClientCertSecret(hcp.Namespace), url)
 	if err != nil {
 		return fmt.Errorf("failed to generate kubeconfig: %w", err)
 	}
@@ -166,7 +171,8 @@ func adaptBootstrapKubeconfigSecret(cpContext component.WorkloadContext, secret 
 	if util.IsPrivateHCP(cpContext.HCP) {
 		url = internalURL(cpContext.InfraStatus, cpContext.HCP.Name)
 	}
-	kubeconfig, err := GenerateKubeConfig(cpContext, manifests.KASMachineBootstrapClientCertSecret(cpContext.HCP.Namespace), url)
+
+	kubeconfig, err := generateKubeConfigWithServingCerts(cpContext, manifests.KASMachineBootstrapClientCertSecret(cpContext.HCP.Namespace), url)
 	if err != nil {
 		return fmt.Errorf("failed to generate kubeconfig: %w", err)
 	}
@@ -314,7 +320,10 @@ func combineRootCAWithServingCerts(cpContext component.WorkloadContext) (*corev1
 	// Write the root CA cert first
 	buffer.Write(rootCA.Data[certs.CASignerCertMapKey])
 
-	// Collect and write all additional certificates
+	// Append the tls.crt from each named certificate secret. In practice tls.crt contains the
+	// full PEM chain (leaf + intermediates + signing CA), so appending it to the trust bundle
+	// gives clients the CA needed to verify the serving certificate. Self-signed certs (as used
+	// in e2e tests) also work because the leaf itself is the trust anchor.
 	for _, servingCert := range hcp.Spec.Configuration.APIServer.ServingCerts.NamedCertificates {
 		certSecret := &corev1.Secret{}
 		if err := cpContext.Client.Get(cpContext, client.ObjectKey{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kubeconfig_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kubeconfig_test.go
@@ -1,0 +1,197 @@
+package kas
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/certs"
+	controlplanecomponent "github.com/openshift/hypershift/support/controlplane-component"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientcmd "k8s.io/client-go/tools/clientcmd"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGenerateKubeConfigWithServingCerts(t *testing.T) {
+	t.Parallel()
+
+	const (
+		namespace = "test-namespace"
+		serverURL = "https://api.example.com:6443"
+	)
+
+	rootCAPEM := []byte("-----BEGIN CERTIFICATE-----\nROOTCA\n-----END CERTIFICATE-----\n")
+	servingCertPEM := []byte("-----BEGIN CERTIFICATE-----\nSERVINGCERT\n-----END CERTIFICATE-----\n")
+	clientCertPEM := []byte("-----BEGIN CERTIFICATE-----\nCLIENTCERT\n-----END CERTIFICATE-----\n")
+	clientKeyPEM := []byte("-----BEGIN RSA PRIVATE KEY-----\nCLIENTKEY\n-----END RSA PRIVATE KEY-----\n")
+
+	testCases := []struct {
+		name             string
+		namedCerts       []configv1.APIServerNamedServingCert
+		servingSecrets   []*corev1.Secret
+		expectCACombined bool
+	}{
+		{
+			name:             "When no named certificates are configured, it should return a kubeconfig with only the root CA",
+			namedCerts:       nil,
+			expectCACombined: false,
+		},
+		{
+			name: "When named certificates are configured, it should append the serving cert to the CA bundle",
+			namedCerts: []configv1.APIServerNamedServingCert{
+				{
+					Names:              []string{"api.custom.example.com"},
+					ServingCertificate: configv1.SecretNameReference{Name: "custom-serving-cert"},
+				},
+			},
+			servingSecrets: []*corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "custom-serving-cert", Namespace: namespace},
+					Data:       map[string][]byte{"tls.crt": servingCertPEM, "tls.key": []byte("key")},
+				},
+			},
+			expectCACombined: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			rootCASecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "root-ca", Namespace: namespace},
+				Data: map[string][]byte{
+					certs.CASignerCertMapKey: rootCAPEM,
+				},
+			}
+
+			clientCertSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "admin-client-cert", Namespace: namespace},
+				Data: map[string][]byte{
+					corev1.TLSCertKey:       clientCertPEM,
+					corev1.TLSPrivateKeyKey: clientKeyPEM,
+				},
+			}
+
+			objects := []corev1.Secret{*rootCASecret, *clientCertSecret}
+			for _, s := range tc.servingSecrets {
+				objects = append(objects, *s)
+			}
+
+			clientBuilder := fake.NewClientBuilder().WithScheme(api.Scheme)
+			for i := range objects {
+				clientBuilder.WithObjects(&objects[i])
+			}
+
+			var apiServerConfig *configv1.APIServerSpec
+			if len(tc.namedCerts) > 0 {
+				apiServerConfig = &configv1.APIServerSpec{
+					ServingCerts: configv1.APIServerServingCerts{
+						NamedCertificates: tc.namedCerts,
+					},
+				}
+			}
+
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: namespace,
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: apiServerConfig,
+					},
+				},
+			}
+
+			cpContext := controlplanecomponent.WorkloadContext{
+				Context: t.Context(),
+				HCP:     hcp,
+				Client:  clientBuilder.Build(),
+			}
+
+			certSecretRef := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "admin-client-cert", Namespace: namespace},
+			}
+
+			kubeconfigBytes, err := generateKubeConfigWithServingCerts(cpContext, certSecretRef, serverURL)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(kubeconfigBytes).ToNot(BeEmpty())
+
+			kubeconfig, err := clientcmd.Load(kubeconfigBytes)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(kubeconfig.Clusters).To(HaveKey("cluster"))
+
+			caData := kubeconfig.Clusters["cluster"].CertificateAuthorityData
+			g.Expect(caData).To(ContainSubstring("ROOTCA"))
+
+			if tc.expectCACombined {
+				g.Expect(caData).To(ContainSubstring("SERVINGCERT"))
+			} else {
+				g.Expect(caData).ToNot(ContainSubstring("SERVINGCERT"))
+			}
+
+			g.Expect(kubeconfig.Clusters["cluster"].Server).To(Equal(serverURL))
+			g.Expect(kubeconfig.AuthInfos).To(HaveKey("admin"))
+			g.Expect(kubeconfig.AuthInfos["admin"].ClientCertificateData).To(Equal(clientCertPEM))
+			g.Expect(kubeconfig.AuthInfos["admin"].ClientKeyData).To(Equal(clientKeyPEM))
+		})
+	}
+}
+
+func TestGenerateKubeConfigWithServingCerts_WhenRootCAIsMissing(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	cpContext := controlplanecomponent.WorkloadContext{
+		Context: t.Context(),
+		HCP: &hyperv1.HostedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-hcp", Namespace: "test-ns"},
+		},
+		Client: fake.NewClientBuilder().WithScheme(api.Scheme).Build(),
+	}
+
+	certSecretRef := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "some-cert", Namespace: "test-ns"},
+	}
+
+	_, err := generateKubeConfigWithServingCerts(cpContext, certSecretRef, "https://api:6443")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("failed to include serving certificates"))
+}
+
+func TestGenerateKubeConfigWithServingCerts_WhenClientCertIsMissing(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	rootCASecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "root-ca", Namespace: "test-ns"},
+		Data: map[string][]byte{
+			certs.CASignerCertMapKey: []byte("-----BEGIN CERTIFICATE-----\nCA\n-----END CERTIFICATE-----\n"),
+		},
+	}
+
+	cpContext := controlplanecomponent.WorkloadContext{
+		Context: t.Context(),
+		HCP: &hyperv1.HostedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-hcp", Namespace: "test-ns"},
+		},
+		Client: fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(rootCASecret).Build(),
+	}
+
+	certSecretRef := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "missing-cert", Namespace: "test-ns"},
+	}
+
+	_, err := generateKubeConfigWithServingCerts(cpContext, certSecretRef, "https://api:6443")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("failed to get client cert secret"))
+}


### PR DESCRIPTION
## Summary

When using Route-based API server publishing with `namedCertificates` (i.e. the KAS serving certificate is signed by an external/corporate CA), two kubeconfigs were generated with only the HyperShift internal `root-ca` in their `certificate-authority-data`:

1. **Bootstrap kubeconfig** (`adaptBootstrapKubeconfigSecret`): used by worker kubelets to bootstrap into the cluster. This caused `x509: certificate signed by unknown authority` failures during node join.
2. **External admin kubeconfig** (`adapExternalAdminKubeconfigSecret`): the default admin kubeconfig generated for clusters that do not set `kubeAPIServerDNSName`. Clients (oc/kubectl) using this kubeconfig would also fail TLS verification.

The custom admin kubeconfig (`adaptCustomAdminKubeconfigSecret`, enabled only when `kubeAPIServerDNSName` is set) already used `combineRootCAWithServingCerts` and worked correctly.

## Fix

Apply the same `combineRootCAWithServingCerts` call to both affected functions, aligning trust across all generated kubeconfigs. When no `namedCertificates` are configured, behaviour is unchanged (only `root-ca` is included).

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./control-plane-operator/controllers/hostedcontrolplane/v2/kas/...` passes
- [x] `go test ./control-plane-operator/controllers/hostedcontrolplane/v2/kas/...` passes
- Manually verified on a lab HostedCluster with Route-based publishing and corporate CA: worker node joins successfully after bootstrap kubeconfig includes the serving cert CA chain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin and bootstrap kubeconfigs now include serving certificates in the combined root CA bundle, improving trust coverage.
  * More specific error messages when merging root CAs or retrieving certificate secrets for clearer diagnostics.
  * Kubeconfig creation now consistently ensures client certificate secrets are retrieved before generating and storing the kubeconfig.

* **Refactor**
  * Centralized kubeconfig generation to remove duplicated logic and streamline secret handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->