### PR TITLE
NO-JIRA: docs: clarify that control plane downgrades are not supported

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,11 @@ See [docs/content/reference/goals-and-design-invariants.md](docs/content/referen
 
 See [docs/content/reference/versioning-support.md](docs/content/reference/versioning-support.md) for release cycle, version skew policies, and support matrices for the HyperShift Operator, CPO, and other components.
 
+### Upgrades lifecycle
+
+See [docs/content/how-to/upgrades.md](docs/content/how-to/upgrades.md) for Control Plane and Data Plane upgrades
+
+
 ## Dependencies and Modules
 
 This is a Go 1.25+ project using:

--- a/docs/content/how-to/upgrades.md
+++ b/docs/content/how-to/upgrades.md
@@ -7,6 +7,8 @@ Control Plane upgrades are driven by the HostedCluster, while Node upgrades are 
 
 For a cluster to keep fully operational during an upgrade process, Control Plane and Nodes upgrades need to be orchestrated while satisfying [Kubernetes version skew policy](https://kubernetes.io/releases/version-skew-policy/) at any time. The supported OCP versions are dictated by the running HyperShift Operator [see here](../reference/versioning-support.md) for more details on versioning.
 
+Control Plane downgrades (moving `.spec.release` to an earlier version) are not supported. Once a HostedCluster has been upgraded, the change cannot be reversed.
+
 ## HostedCluster
 `.spec.release` dictates the version of the Control Plane.
 

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -24430,6 +24430,8 @@ Control Plane upgrades are driven by the HostedCluster, while Node upgrades are 
 
 For a cluster to keep fully operational during an upgrade process, Control Plane and Nodes upgrades need to be orchestrated while satisfying Kubernetes version skew policy at any time. The supported OCP versions are dictated by the running HyperShift Operator see here for more details on versioning.
 
+Control Plane downgrades (moving `.spec.release` to an earlier version) are not supported. Once a HostedCluster has been upgraded, the change cannot be reversed.
+
 ## HostedCluster
 `.spec.release` dictates the version of the Control Plane.
 


### PR DESCRIPTION
## Summary
- Adds an admonition to the upgrades guide making explicit that control plane downgrades (moving `.spec.release` to an earlier version) are not supported
- Reinforces the fail-forward upgrade policy

## Test plan
- [ ] Verify docs render correctly with `mkdocs serve`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Control Plane downgrades are unsupported once a HostedCluster has been upgraded to a newer release; the change is irreversible.
  * Added an "Upgrades lifecycle" section linking to the upgrades how-to for guidance on Control Plane and Data Plane upgrade behavior and considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->