### PR TITLE
OCPBUGS-84236: Guard Infrastructure CR lookup in AWSEndpointServiceReconciler

### DIFF
--- a/hypershift-operator/controllers/platform/aws/controller.go
+++ b/hypershift-operator/controllers/platform/aws/controller.go
@@ -12,11 +12,11 @@ import (
 	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/awsapi"
+	"github.com/openshift/hypershift/support/capabilities"
+	"github.com/openshift/hypershift/support/globalconfig"
 	karpenterutil "github.com/openshift/hypershift/support/karpenter"
 	"github.com/openshift/hypershift/support/upsert"
 	supportutil "github.com/openshift/hypershift/support/util"
-
-	configv1 "github.com/openshift/api/config/v1"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -60,8 +60,9 @@ const (
 type AWSEndpointServiceReconciler struct {
 	client.Client
 	upsert.CreateOrUpdateProvider
-	ec2Client   awsapi.EC2API
-	elbv2Client awsapi.ELBV2API
+	ManagementClusterCapabilities capabilities.CapabiltyChecker
+	ec2Client                     awsapi.EC2API
+	elbv2Client                   awsapi.ELBV2API
 }
 
 func awsEndpointServicesByName(ns string) []reconcile.Request {
@@ -548,22 +549,25 @@ func (r *AWSEndpointServiceReconciler) reconcileAWSEndpointServiceStatus(ctx con
 			return fmt.Errorf("load balancer %s is not yet active", *lbARN)
 		}
 
-		managementClusterInfrastructure := &configv1.Infrastructure{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}
-		if err := r.Get(ctx, client.ObjectKeyFromObject(managementClusterInfrastructure), managementClusterInfrastructure); err != nil {
-			return fmt.Errorf("failed to get management cluster infrastructure: %w", err)
-		}
-
 		// create the Endpoint Service
+		tags := apiTagToEC2Tag(awsEndpointService.Spec.ResourceTags)
+		if r.ManagementClusterCapabilities.Has(capabilities.CapabilityInfrastructure) {
+			managementClusterInfrastructure := globalconfig.InfrastructureConfig()
+			if err := r.Get(ctx, client.ObjectKeyFromObject(managementClusterInfrastructure), managementClusterInfrastructure); err != nil {
+				return fmt.Errorf("failed to get management cluster infrastructure: %w", err)
+			}
+			tags = append(tags, ec2types.Tag{
+				Key:   aws.String("kubernetes.io/cluster/" + managementClusterInfrastructure.Status.InfrastructureName),
+				Value: aws.String("owned"),
+			})
+		}
 		createEndpointServiceOutput, err := ec2Client.CreateVpcEndpointServiceConfiguration(ctx, &ec2.CreateVpcEndpointServiceConfigurationInput{
 			// TODO: we should probably do some sort of automated acceptance check against the VPC ID in the HostedCluster
 			AcceptanceRequired:      aws.Bool(false),
 			NetworkLoadBalancerArns: []string{aws.ToString(lbARN)},
 			TagSpecifications: []ec2types.TagSpecification{{
 				ResourceType: ec2types.ResourceTypeVpcEndpointService,
-				Tags: append(apiTagToEC2Tag(awsEndpointService.Spec.ResourceTags), ec2types.Tag{
-					Key:   aws.String("kubernetes.io/cluster/" + managementClusterInfrastructure.Status.InfrastructureName),
-					Value: aws.String("owned"),
-				}),
+				Tags:         tags,
 			}},
 		})
 		if err != nil {

--- a/hypershift-operator/controllers/platform/aws/controller_test.go
+++ b/hypershift-operator/controllers/platform/aws/controller_test.go
@@ -10,6 +10,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	hyperapi "github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/awsapi"
+	"github.com/openshift/hypershift/support/capabilities"
 	karpenterutil "github.com/openshift/hypershift/support/karpenter"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -41,6 +42,7 @@ func TestReconcileAWSEndpointServiceStatus(t *testing.T) {
 
 	tests := []struct {
 		name                        string
+		hasInfraCapability          bool
 		additionalAllowedPrincipals []string
 		existingAllowedPrincipals   []string
 		expectedPrincipalsToAdd     []string
@@ -48,18 +50,26 @@ func TestReconcileAWSEndpointServiceStatus(t *testing.T) {
 	}{
 		{
 			name:                    "no additional principals",
+			hasInfraCapability:      true,
 			expectedPrincipalsToAdd: []string{mockControlPlaneOperatorRoleArn},
 		},
 		{
 			name:                        "additional principals",
+			hasInfraCapability:          true,
 			additionalAllowedPrincipals: []string{"additional1", "additional2"},
 			expectedPrincipalsToAdd:     []string{mockControlPlaneOperatorRoleArn, "additional1", "additional2"},
 		},
 		{
 			name:                       "removing extra principals",
+			hasInfraCapability:         true,
 			existingAllowedPrincipals:  []string{"existing1", "existing2"},
 			expectedPrincipalsToAdd:    []string{mockControlPlaneOperatorRoleArn},
 			expectedPrincipalsToRemove: []string{"existing1", "existing2"},
+		},
+		{
+			name:                    "no infrastructure capability omits owned tag",
+			hasInfraCapability:      false,
+			expectedPrincipalsToAdd: []string{mockControlPlaneOperatorRoleArn},
 		},
 	}
 
@@ -73,11 +83,14 @@ func TestReconcileAWSEndpointServiceStatus(t *testing.T) {
 				State:           &elbv2types.LoadBalancerState{Code: elbv2types.LoadBalancerStateEnumActive},
 			}}}, nil)
 
-			infra := &configv1.Infrastructure{
-				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-				Status:     configv1.InfrastructureStatus{InfrastructureName: "management-cluster-infra-id"},
+			clientBuilder := fake.NewClientBuilder().WithScheme(hyperapi.Scheme)
+			if test.hasInfraCapability {
+				clientBuilder = clientBuilder.WithObjects(&configv1.Infrastructure{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status:     configv1.InfrastructureStatus{InfrastructureName: "management-cluster-infra-id"},
+				})
 			}
-			client := fake.NewClientBuilder().WithScheme(hyperapi.Scheme).WithObjects(infra).Build()
+			client := clientBuilder.Build()
 
 			existingAllowedPrincipals := make([]ec2types.AllowedPrincipal, len(test.existingAllowedPrincipals))
 			for i, p := range test.existingAllowedPrincipals {
@@ -103,7 +116,19 @@ func TestReconcileAWSEndpointServiceStatus(t *testing.T) {
 				}).
 				Return(&ec2.ModifyVpcEndpointServicePermissionsOutput{}, nil)
 
-			r := AWSEndpointServiceReconciler{Client: client}
+			r := AWSEndpointServiceReconciler{
+				Client: client,
+				ManagementClusterCapabilities: &capabilities.MockCapabilityChecker{
+					MockHas: func(caps ...capabilities.CapabilityType) bool {
+						for _, c := range caps {
+							if c == capabilities.CapabilityInfrastructure {
+								return test.hasInfraCapability
+							}
+						}
+						return false
+					},
+				},
+			}
 
 			if err := r.reconcileAWSEndpointServiceStatus(t.Context(), &hyperv1.AWSEndpointService{}, &hyperv1.HostedCluster{
 				Spec: hyperv1.HostedClusterSpec{
@@ -120,12 +145,19 @@ func TestReconcileAWSEndpointServiceStatus(t *testing.T) {
 				t.Fatalf("reconcileAWSEndpointServiceStatus failed: %v", err)
 			}
 
-			if actual, expected := aws.ToString(created.TagSpecifications[0].Tags[0].Key), "kubernetes.io/cluster/management-cluster-infra-id"; actual != expected {
-				t.Errorf("expected first tag key to be %s, was %s", expected, actual)
-			}
-
-			if actual, expected := aws.ToString(created.TagSpecifications[0].Tags[0].Value), "owned"; actual != expected {
-				t.Errorf("expected first tags value to be %s, was %s", expected, actual)
+			if test.hasInfraCapability {
+				if actual, expected := aws.ToString(created.TagSpecifications[0].Tags[0].Key), "kubernetes.io/cluster/management-cluster-infra-id"; actual != expected {
+					t.Errorf("expected first tag key to be %s, was %s", expected, actual)
+				}
+				if actual, expected := aws.ToString(created.TagSpecifications[0].Tags[0].Value), "owned"; actual != expected {
+					t.Errorf("expected first tags value to be %s, was %s", expected, actual)
+				}
+			} else {
+				for _, tag := range created.TagSpecifications[0].Tags {
+					if aws.ToString(tag.Value) == "owned" {
+						t.Errorf("expected no owned tag when infrastructure capability is absent, but found tag: %s", aws.ToString(tag.Key))
+					}
+				}
 			}
 
 			actualToAdd := map[string]struct{}{mockControlPlaneOperatorRoleArn: {}}

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -512,8 +512,9 @@ func run(ctx context.Context, opts *StartOptions, log logr.Logger) error {
 	switch hyperv1.PlatformType(opts.PrivatePlatform) {
 	case hyperv1.AWSPlatform:
 		if err := (&aws.AWSEndpointServiceReconciler{
-			Client:                 mgr.GetClient(),
-			CreateOrUpdateProvider: createOrUpdate,
+			Client:                        mgr.GetClient(),
+			CreateOrUpdateProvider:        createOrUpdate,
+			ManagementClusterCapabilities: mgmtClusterCaps,
 		}).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create controller: %w", err)
 		}


### PR DESCRIPTION
## Summary
- The `AWSEndpointServiceReconciler` unconditionally fetched the `config.openshift.io/v1 Infrastructure` CR to tag VPC Endpoint Services with the management cluster's `InfrastructureName`. This fails on non-OpenShift management clusters (e.g. EKS) that lack this API, blocking private HCP reconciliation entirely.
- Guards the lookup behind `ManagementClusterCapabilities.Has(CapabilityInfrastructure)`, matching the existing pattern used by `hostedcluster_controller` and `sharedingress_controller`. When the capability is absent, the owned tag is simply omitted.
- Adds a test case for the no-capability path.

## Jira
https://issues.redhat.com/browse/OCPBUGS-84236

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * EC2 tags are now built from resource specs and the management-cluster infrastructure tag is added only when the management cluster reports the infrastructure capability.

* **Tests**
  * Tests updated to validate tagging behavior both with and without the management-cluster infrastructure capability.

* **Chores**
  * Controller wiring updated to supply management-cluster capability checks to the reconciler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->