### PR TITLE
Add Azure self-managed v2 e2e test specs

### DIFF
--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -126,7 +126,7 @@ func TestCreateCluster(t *testing.T) {
 
 		if globalOpts.Platform == hyperv1.AzurePlatform || globalOpts.Platform == hyperv1.AWSPlatform {
 			// ensure Ingress Operator configuration is properly applied
-			e2eutil.EnsureIngressOperatorConfiguration(t, ctx, mgtClient, guestClient, hostedCluster)
+			e2eutil.EnsureIngressOperatorConfiguration(t, ctx, guestClient, hostedCluster)
 		}
 	}).WithAssetReader(content.ReadFile).
 		Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, "create-cluster", globalOpts.ServiceAccountSigningKey)

--- a/test/e2e/util/azure.go
+++ b/test/e2e/util/azure.go
@@ -17,86 +17,93 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func EnsureAzureWorkloadIdentityWebhookMutation(t *testing.T, ctx context.Context, guestClient crclient.Client) {
-	t.Run("EnsureAzureWorkloadIdentityWebhookMutation", func(t *testing.T) {
-		AtLeast(t, Version422)
-		g := NewWithT(t)
+func ValidateAzureWorkloadIdentityWebhookMutation(t testing.TB, ctx context.Context, guestClient crclient.Client) {
+	g := NewWithT(t)
 
-		nsName := fmt.Sprintf("azure-wi-e2e-%d", time.Now().UnixNano())
-		testNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
-		g.Expect(guestClient.Create(ctx, testNamespace)).To(Succeed(), "failed to create test namespace")
+	nsName := fmt.Sprintf("azure-wi-e2e-%d", time.Now().UnixNano())
+	testNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
+	g.Expect(guestClient.Create(ctx, testNamespace)).To(Succeed(), "failed to create test namespace")
+	defer func() {
+		_ = guestClient.Delete(context.Background(), testNamespace)
+	}()
 
-		serviceAccount := &corev1.ServiceAccount{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "azure-wi-test-sa",
-				Namespace: nsName,
-				Annotations: map[string]string{
-					"azure.workload.identity/client-id": "00000000-0000-0000-0000-000000000000",
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "azure-wi-test-sa",
+			Namespace: nsName,
+			Annotations: map[string]string{
+				"azure.workload.identity/client-id": "00000000-0000-0000-0000-000000000000",
+			},
+		},
+	}
+	g.Expect(guestClient.Create(ctx, serviceAccount)).To(Succeed(), "failed to create test service account")
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "azure-wi-webhook-test-pod",
+			Namespace: nsName,
+			Labels: map[string]string{
+				"azure.workload.identity/use": "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: serviceAccount.Name,
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: ptr.To(true),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
 				},
 			},
-		}
-		g.Expect(guestClient.Create(ctx, serviceAccount)).To(Succeed(), "failed to create test service account")
-
-		pod := &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "azure-wi-webhook-test-pod",
-				Namespace: nsName,
-				Labels: map[string]string{
-					"azure.workload.identity/use": "true",
-				},
-			},
-			Spec: corev1.PodSpec{
-				ServiceAccountName: serviceAccount.Name,
-				SecurityContext: &corev1.PodSecurityContext{
-					RunAsNonRoot: ptr.To(true),
-					SeccompProfile: &corev1.SeccompProfile{
-						Type: corev1.SeccompProfileTypeRuntimeDefault,
-					},
-				},
-				Containers: []corev1.Container{
-					{
-						Name:    "app",
-						Image:   "registry.k8s.io/pause:3.10",
-						Command: []string{"/pause"},
-						SecurityContext: &corev1.SecurityContext{
-							AllowPrivilegeEscalation: ptr.To(false),
-							Capabilities: &corev1.Capabilities{
-								Drop: []corev1.Capability{"ALL"},
-							},
+			Containers: []corev1.Container{
+				{
+					Name:    "app",
+					Image:   "registry.k8s.io/pause:3.10",
+					Command: []string{"/pause"},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: ptr.To(false),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"ALL"},
 						},
 					},
 				},
-				RestartPolicy: corev1.RestartPolicyNever,
 			},
-		}
-		g.Expect(guestClient.Create(ctx, pod)).To(Succeed(), "failed to create pod for webhook mutation test")
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+	g.Expect(guestClient.Create(ctx, pod)).To(Succeed(), "failed to create pod for webhook mutation test")
 
-		EventuallyObject(
-			t,
-			ctx,
-			"Azure workload identity webhook to mutate test pod",
-			func(ctx context.Context) (*corev1.Pod, error) {
-				mutatedPod := &corev1.Pod{}
-				err := guestClient.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, mutatedPod)
-				return mutatedPod, err
+	EventuallyObject(
+		t,
+		ctx,
+		"Azure workload identity webhook to mutate test pod",
+		func(ctx context.Context) (*corev1.Pod, error) {
+			mutatedPod := &corev1.Pod{}
+			err := guestClient.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, mutatedPod)
+			return mutatedPod, err
+		},
+		[]Predicate[*corev1.Pod]{
+			func(mutatedPod *corev1.Pod) (bool, string, error) {
+				if hasProjectedTokenVolume(mutatedPod.Spec.Volumes) {
+					return true, "", nil
+				}
+				return false, "expected projected service account token volume to be injected", nil
 			},
-			[]Predicate[*corev1.Pod]{
-				func(mutatedPod *corev1.Pod) (bool, string, error) {
-					if hasProjectedTokenVolume(mutatedPod.Spec.Volumes) {
-						return true, "", nil
-					}
-					return false, "expected projected service account token volume to be injected", nil
-				},
-				func(mutatedPod *corev1.Pod) (bool, string, error) {
-					if hasAzureFederatedTokenEnv(mutatedPod.Spec.Containers) {
-						return true, "", nil
-					}
-					return false, "expected AZURE_FEDERATED_TOKEN_FILE env var in pod containers", nil
-				},
+			func(mutatedPod *corev1.Pod) (bool, string, error) {
+				if hasAzureFederatedTokenEnv(mutatedPod.Spec.Containers) {
+					return true, "", nil
+				}
+				return false, "expected AZURE_FEDERATED_TOKEN_FILE env var in pod containers", nil
 			},
-			WithTimeout(3*time.Minute),
-			WithInterval(5*time.Second),
-		)
+		},
+		WithTimeout(3*time.Minute),
+		WithInterval(5*time.Second),
+	)
+}
+
+func EnsureAzureWorkloadIdentityWebhookMutation(t *testing.T, ctx context.Context, guestClient crclient.Client) {
+	t.Run("EnsureAzureWorkloadIdentityWebhookMutation", func(t *testing.T) {
+		AtLeast(t, Version422)
+		ValidateAzureWorkloadIdentityWebhookMutation(t, ctx, guestClient)
 	})
 }
 

--- a/test/e2e/util/eventually.go
+++ b/test/e2e/util/eventually.go
@@ -82,7 +82,7 @@ func WithFilteredConditionDump(matchers ...Condition) EventuallyOption {
 }
 
 // EventuallyObject polls until the predicate is fulfilled on the object.
-func EventuallyObject[T client.Object](t *testing.T, ctx context.Context, objective string, getter func(context.Context) (T, error), predicates []Predicate[T], options ...EventuallyOption) {
+func EventuallyObject[T client.Object](t testing.TB, ctx context.Context, objective string, getter func(context.Context) (T, error), predicates []Predicate[T], options ...EventuallyOption) {
 	t.Helper()
 	opts := defaultOptions()
 	for _, option := range options {
@@ -209,7 +209,7 @@ func summarizePredicteResults(results []predicateResult) bool {
 	return done
 }
 
-func printStatus[T client.Object](t *testing.T, lastTimestamp time.Time, object T, done bool, reasons []string) {
+func printStatus[T client.Object](t testing.TB, lastTimestamp time.Time, object T, done bool, reasons []string) {
 	if len(reasons) == 0 {
 		return
 	}
@@ -236,7 +236,7 @@ type predicateResult struct {
 }
 
 // EventuallyObjects polls until the predicate is fulfilled on each of a set of objects.
-func EventuallyObjects[T client.Object](t *testing.T, ctx context.Context, objective string, getter func(context.Context) ([]T, error), groupPredicates []Predicate[[]T], predicates []Predicate[T], options ...EventuallyOption) {
+func EventuallyObjects[T client.Object](t testing.TB, ctx context.Context, objective string, getter func(context.Context) ([]T, error), groupPredicates []Predicate[[]T], predicates []Predicate[T], options ...EventuallyOption) {
 	t.Helper()
 	opts := defaultOptions()
 	for _, option := range options {
@@ -376,7 +376,7 @@ type predicateReasons struct {
 	reasons []string
 }
 
-func printCollectionStatus[T client.Object](t *testing.T, lastTimestamp time.Time, done bool, reasons map[types.NamespacedName]predicateReasons) {
+func printCollectionStatus[T client.Object](t testing.TB, lastTimestamp time.Time, done bool, reasons map[types.NamespacedName]predicateReasons) {
 	prefix := ""
 	if !done {
 		prefix = "in"

--- a/test/e2e/util/oauth.go
+++ b/test/e2e/util/oauth.go
@@ -93,7 +93,7 @@ func EnsureOAuthWithIdentityProvider(t *testing.T, ctx context.Context, client c
 	})
 }
 
-func guestRestConfig(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) (*restclient.Config, error) {
+func guestRestConfig(t testing.TB, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) (*restclient.Config, error) {
 	guestKubeConfigSecretData := WaitForGuestKubeConfig(t, ctx, client, hostedCluster)
 	guestConfig, err := clientcmd.RESTConfigFromKubeConfig(guestKubeConfigSecretData)
 	if err != nil {
@@ -111,7 +111,7 @@ func WaitForOAuthToken(t *testing.T, ctx context.Context, oauthRoute *routev1.Ro
 
 // WaitForOAuthTokenByHost performs the OAuth token request flow against the given host.
 // This supports both Route-based and LoadBalancer-based OAuth endpoints.
-func WaitForOAuthTokenByHost(t *testing.T, ctx context.Context, oauthHost string, restConfig *restclient.Config, username, password string) string {
+func WaitForOAuthTokenByHost(t testing.TB, ctx context.Context, oauthHost string, restConfig *restclient.Config, username, password string) string {
 	g := NewWithT(t)
 
 	oauthClient := configmanifests.OAuthServerChallengingClient().Name
@@ -125,7 +125,10 @@ func WaitForOAuthTokenByHost(t *testing.T, ctx context.Context, oauthHost string
 	transport, err := restclient.TransportFor(restclient.AnonymousClientConfig(restConfig))
 	g.Expect(err).ToNot(HaveOccurred(), "error getting transport")
 
-	httpClient := &http.Client{Transport: transport}
+	httpClient := &http.Client{
+		Transport: transport,
+		Timeout:   15 * time.Second,
+	}
 	httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		// don't resolve redirects and return the response instead
 		return http.ErrUseLastResponse
@@ -133,7 +136,8 @@ func WaitForOAuthTokenByHost(t *testing.T, ctx context.Context, oauthHost string
 
 	var access_token string
 	err = wait.PollUntilContextTimeout(ctx, time.Second, time.Minute*2, true, func(ctx context.Context) (done bool, err error) {
-		resp, err := httpClient.Do(request)
+		req := request.Clone(ctx)
+		resp, err := httpClient.Do(req)
 		if err != nil {
 			t.Logf("Waiting for OAuth token request to succeed")
 			return false, nil
@@ -240,7 +244,7 @@ func extractAccessToken(resp *http.Response) (string, error) {
 
 const OAuthServerConfigKey = "config.yaml"
 
-func WaitForOauthConfig(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+func WaitForOauthConfig(t testing.TB, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	g := NewWithT(t)
 
 	hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
@@ -306,7 +310,7 @@ func validateClusterPreIDP(t *testing.T, ctx context.Context, client crclient.Cl
 // external endpoint allocated and for the /healthz endpoint to return HTTP 200.
 // It returns the OAuth hostname from the HostedCluster's service publishing strategy,
 // which matches the TLS certificate SANs, rather than the raw LoadBalancer IP.
-func WaitForOAuthLoadBalancerReady(t *testing.T, ctx context.Context, client crclient.Client, restConfig *restclient.Config, hostedCluster *hyperv1.HostedCluster) string {
+func WaitForOAuthLoadBalancerReady(t testing.TB, ctx context.Context, client crclient.Client, restConfig *restclient.Config, hostedCluster *hyperv1.HostedCluster) string {
 	g := NewWithT(t)
 
 	// Get the OAuth hostname from the HostedCluster's service publishing strategy.
@@ -374,83 +378,87 @@ func WaitForOAuthLoadBalancerReady(t *testing.T, ctx context.Context, client crc
 	return oauthHost
 }
 
+func ValidateOAuthWithIdentityProviderViaLoadBalancer(t testing.TB, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+	g := NewWithT(t)
+
+	guestConfig, err := guestRestConfig(t, ctx, client, hostedCluster)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Wait for OAuth LoadBalancer to be ready
+	oauthHost := WaitForOAuthLoadBalancerReady(t, ctx, client, guestConfig, hostedCluster)
+
+	// Validate kubeadmin login through the LoadBalancer (works without IDPs)
+	hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
+	kubeadminPasswordSecret := configmanifests.KubeadminPasswordSecret(hcpNamespace)
+	err = client.Get(ctx, crclient.ObjectKeyFromObject(kubeadminPasswordSecret), kubeadminPasswordSecret)
+	g.Expect(err).ToNot(HaveOccurred())
+	password := string(kubeadminPasswordSecret.Data["password"])
+	accessToken := WaitForOAuthTokenByHost(t, ctx, oauthHost, guestConfig, "kubeadmin", password)
+
+	user, err := GetUserForToken(guestConfig, accessToken)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(user.Name).To(Equal("kube:admin"))
+
+	// Set up htpasswd identity provider
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "htpasswd",
+			Namespace: hostedCluster.Namespace,
+		},
+		Data: map[string][]byte{
+			"htpasswd": []byte("testuser:$2y$05$0Fk2s.0FbLy0FZ82JAqajOV/kbT/wqKX5/QFKgps6J69J2jY6r5ZG"),
+		},
+	}
+	err = client.Create(ctx, &secret)
+	g.Expect(err).ToNot(HaveOccurred(), "failed to create htpasswd secret")
+
+	err = UpdateObject(t, ctx, client, hostedCluster, func(obj *hyperv1.HostedCluster) {
+		if obj.Spec.Configuration == nil {
+			obj.Spec.Configuration = &hyperv1.ClusterConfiguration{}
+		}
+		obj.Spec.Configuration.OAuth = &v1.OAuthSpec{
+			IdentityProviders: []v1.IdentityProvider{
+				{
+					Name:          "my_htpasswd_provider",
+					MappingMethod: v1.MappingMethodClaim,
+					IdentityProviderConfig: v1.IdentityProviderConfig{
+						Type: v1.IdentityProviderTypeHTPasswd,
+						HTPasswd: &v1.HTPasswdIdentityProvider{
+							FileData: v1.SecretNameReference{
+								Name: secret.Name,
+							},
+						},
+					},
+				},
+			},
+		}
+	})
+	g.Expect(err).ToNot(HaveOccurred(), "failed to update hostedcluster identity providers")
+
+	// Wait for OAuth config to pick up the new identity provider
+	WaitForOauthConfig(t, ctx, client, hostedCluster)
+
+	// Validate testuser login through the LoadBalancer
+	accessToken = WaitForOAuthTokenByHost(t, ctx, oauthHost, guestConfig, "testuser", "password")
+
+	user, err = GetUserForToken(guestConfig, accessToken)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(user.Name).To(Equal("testuser"))
+
+	// Validate kubeadmin secret was removed after IDP was added
+	validateClusterPostIDP(t, ctx, client, hostedCluster)
+}
+
 // EnsureOAuthWithIdentityProviderViaLoadBalancer is the LoadBalancer equivalent of
 // EnsureOAuthWithIdentityProvider. It validates the OAuth flow when the OAuthServer
 // is published via a LoadBalancer Service instead of a Route.
 func EnsureOAuthWithIdentityProviderViaLoadBalancer(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("EnsureOAuthWithIdentityProviderViaLoadBalancer", func(t *testing.T) {
-		g := NewWithT(t)
-
-		guestConfig, err := guestRestConfig(t, ctx, client, hostedCluster)
-		g.Expect(err).ToNot(HaveOccurred())
-
-		// Wait for OAuth LoadBalancer to be ready
-		oauthHost := WaitForOAuthLoadBalancerReady(t, ctx, client, guestConfig, hostedCluster)
-
-		// Validate kubeadmin login through the LoadBalancer (works without IDPs)
-		hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
-		kubeadminPasswordSecret := configmanifests.KubeadminPasswordSecret(hcpNamespace)
-		err = client.Get(ctx, crclient.ObjectKeyFromObject(kubeadminPasswordSecret), kubeadminPasswordSecret)
-		g.Expect(err).ToNot(HaveOccurred())
-		password := string(kubeadminPasswordSecret.Data["password"])
-		accessToken := WaitForOAuthTokenByHost(t, ctx, oauthHost, guestConfig, "kubeadmin", password)
-
-		user, err := GetUserForToken(guestConfig, accessToken)
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(user.Name).To(Equal("kube:admin"))
-
-		// Set up htpasswd identity provider
-		secret := corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "htpasswd",
-				Namespace: hostedCluster.Namespace,
-			},
-			Data: map[string][]byte{
-				"htpasswd": []byte("testuser:$2y$05$0Fk2s.0FbLy0FZ82JAqajOV/kbT/wqKX5/QFKgps6J69J2jY6r5ZG"),
-			},
-		}
-		err = client.Create(ctx, &secret)
-		g.Expect(err).ToNot(HaveOccurred(), "failed to create htpasswd secret")
-
-		err = UpdateObject(t, ctx, client, hostedCluster, func(obj *hyperv1.HostedCluster) {
-			if obj.Spec.Configuration == nil {
-				obj.Spec.Configuration = &hyperv1.ClusterConfiguration{}
-			}
-			obj.Spec.Configuration.OAuth = &v1.OAuthSpec{
-				IdentityProviders: []v1.IdentityProvider{
-					{
-						Name:          "my_htpasswd_provider",
-						MappingMethod: v1.MappingMethodClaim,
-						IdentityProviderConfig: v1.IdentityProviderConfig{
-							Type: v1.IdentityProviderTypeHTPasswd,
-							HTPasswd: &v1.HTPasswdIdentityProvider{
-								FileData: v1.SecretNameReference{
-									Name: secret.Name,
-								},
-							},
-						},
-					},
-				},
-			}
-		})
-		g.Expect(err).ToNot(HaveOccurred(), "failed to update hostedcluster identity providers")
-
-		// Wait for OAuth config to pick up the new identity provider
-		WaitForOauthConfig(t, ctx, client, hostedCluster)
-
-		// Validate testuser login through the LoadBalancer
-		accessToken = WaitForOAuthTokenByHost(t, ctx, oauthHost, guestConfig, "testuser", "password")
-
-		user, err = GetUserForToken(guestConfig, accessToken)
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(user.Name).To(Equal("testuser"))
-
-		// Validate kubeadmin secret was removed after IDP was added
-		validateClusterPostIDP(t, ctx, client, hostedCluster)
+		ValidateOAuthWithIdentityProviderViaLoadBalancer(t, ctx, client, hostedCluster)
 	})
 }
 
-func validateClusterPostIDP(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+func validateClusterPostIDP(t testing.TB, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	g := NewWithT(t)
 
 	// update HC status

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -168,7 +168,7 @@ func InitGuestClients(ctx context.Context, t *testing.T, g Gomega, mgtClient crc
 	}
 }
 
-func UpdateObject[T crclient.Object](t *testing.T, ctx context.Context, client crclient.Client, original T, mutate func(obj T)) error {
+func UpdateObject[T crclient.Object](t testing.TB, ctx context.Context, client crclient.Client, original T, mutate func(obj T)) error {
 	return wait.PollUntilContextTimeout(ctx, time.Second, time.Minute*1, true, func(ctx context.Context) (done bool, err error) {
 		if err := client.Get(ctx, crclient.ObjectKeyFromObject(original), original); err != nil {
 			t.Logf("failed to retrieve object %s, will retry: %v", original.GetName(), err)
@@ -292,7 +292,7 @@ func WaitForCustomKubeconfig(t *testing.T, ctx context.Context, client crclient.
 	return data
 }
 
-func WaitForGuestKubeConfig(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) []byte {
+func WaitForGuestKubeConfig(t testing.TB, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) []byte {
 	var guestKubeConfigSecretRef crclient.ObjectKey
 	EventuallyObject(t, ctx, fmt.Sprintf("kubeconfig to be published for HostedCluster %s/%s", hostedCluster.Namespace, hostedCluster.Name),
 		func(ctx context.Context) (*hyperv1.HostedCluster, error) {
@@ -3475,23 +3475,43 @@ func EnsureDefaultSecurityGroupTags(t *testing.T, ctx context.Context, client cr
 	})
 }
 
+func ValidateKubeAPIServerAllowedCIDRs(t testing.TB, ctx context.Context, mgmtClient crclient.Client, guestConfig *rest.Config, hc *hyperv1.HostedCluster) {
+	g := NewWithT(t)
+
+	// Save original APIServer networking to restore after test
+	var originalAPIServer *hyperv1.APIServerNetworking
+	if hc.Spec.Networking.APIServer != nil {
+		originalAPIServer = hc.Spec.Networking.APIServer.DeepCopy()
+	}
+	defer func() {
+		err := UpdateObject(t, ctx, mgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+			if originalAPIServer != nil {
+				obj.Spec.Networking.APIServer = originalAPIServer.DeepCopy()
+			} else {
+				obj.Spec.Networking.APIServer = nil
+			}
+		})
+		g.Expect(err).NotTo(HaveOccurred(), "failed to restore HostedCluster API server CIDRs")
+	}()
+
+	kubeClient, err := kubeclient.NewForConfig(guestConfig)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// ensure that kube-apiserver is not reachable from anywhere
+	ensureAPIServerAllowedCIDRs(ctx, t, g, mgmtClient, kubeClient, hc, []string{"0.0.0.0/32"}, false)
+	// ensure kube-apiserver is reachable when allowed CIDRs allow access from everywhere
+	// This is useful for testing purposes, as it allows us to access the kube-apiserver from any IP
+	// In a production environment, this should be restricted to specific CIDRs
+	ensureAPIServerAllowedCIDRs(ctx, t, g, mgmtClient, kubeClient, hc, append([]string{"0.0.0.0/0"}, generateTestCIDRs250()...), true)
+}
+
 func EnsureKubeAPIServerAllowedCIDRs(t *testing.T, ctx context.Context, mgmtClient crclient.Client, guestConfig *rest.Config, hc *hyperv1.HostedCluster) {
 	t.Run("EnsureKubeAPIServerAllowedCIDRs", func(t *testing.T) {
-		g := NewWithT(t)
-
-		kubeClient, err := kubeclient.NewForConfig(guestConfig)
-		g.Expect(err).NotTo(HaveOccurred())
-
-		// ensure that kube-apiserver is not reachable from anywhere
-		ensureAPIServerAllowedCIDRs(ctx, t, g, mgmtClient, kubeClient, hc, []string{"0.0.0.0/32"}, false)
-		// ensure kube-apiserver is reachable when allowed CIDRs allow access from everywhere
-		// This is useful for testing purposes, as it allows us to access the kube-apiserver from any IP
-		// In a production environment, this should be restricted to specific CIDRs
-		ensureAPIServerAllowedCIDRs(ctx, t, g, mgmtClient, kubeClient, hc, append([]string{"0.0.0.0/0"}, generateTestCIDRs250()...), true)
+		ValidateKubeAPIServerAllowedCIDRs(t, ctx, mgmtClient, guestConfig, hc)
 	})
 }
 
-func ensureAPIServerAllowedCIDRs(ctx context.Context, t *testing.T, g Gomega, mgmtClient crclient.Client, guestClient *kubeclient.Clientset, hc *hyperv1.HostedCluster, allowedCIDRs []string, shouldBeReachable bool) {
+func ensureAPIServerAllowedCIDRs(ctx context.Context, t testing.TB, g Gomega, mgmtClient crclient.Client, guestClient *kubeclient.Clientset, hc *hyperv1.HostedCluster, allowedCIDRs []string, shouldBeReachable bool) {
 	err := UpdateObject(t, ctx, mgmtClient, hc, func(obj *hyperv1.HostedCluster) {
 		if obj.Spec.Networking.APIServer == nil {
 			obj.Spec.Networking.APIServer = &hyperv1.APIServerNetworking{}

--- a/test/e2e/util/util_ingress_operator_configuration.go
+++ b/test/e2e/util/util_ingress_operator_configuration.go
@@ -17,51 +17,55 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+func ValidateIngressOperatorConfiguration(t testing.TB, ctx context.Context, guestClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+	g := NewWithT(t)
+
+	// Verify the HostedCluster has the expected Ingress Operator configuration
+	t.Logf("Verifying HostedCluster %s/%s has custom Ingress Operator endpointPublishingStrategy", hostedCluster.Namespace, hostedCluster.Name)
+	g.Expect(hostedCluster.Spec.OperatorConfiguration).NotTo(BeNil(), "OperatorConfiguration should be set")
+	g.Expect(hostedCluster.Spec.OperatorConfiguration.IngressOperator).NotTo(BeNil(), "IngressOperator configuration should be set")
+	g.Expect(hostedCluster.Spec.OperatorConfiguration.IngressOperator.EndpointPublishingStrategy).NotTo(BeNil(), "EndpointPublishingStrategy should be set")
+	g.Expect(hostedCluster.Spec.OperatorConfiguration.IngressOperator.EndpointPublishingStrategy.Type).To(Equal(operatorv1.LoadBalancerServiceStrategyType), "EndpointPublishingStrategy should be LoadBalancerService")
+	g.Expect(hostedCluster.Spec.OperatorConfiguration.IngressOperator.EndpointPublishingStrategy.LoadBalancer).NotTo(BeNil(), "LoadBalancer configuration should be set")
+	g.Expect(hostedCluster.Spec.OperatorConfiguration.IngressOperator.EndpointPublishingStrategy.LoadBalancer.Scope).To(Equal(operatorv1.InternalLoadBalancer), "LoadBalancer scope should be Internal")
+
+	// Wait for the IngressController in the guest cluster to reflect the custom strategy
+	t.Logf("Validating IngressController in guest cluster reflects the custom endpointPublishingStrategy")
+	EventuallyObject(t, ctx, "IngressController default in guest cluster to reflect the custom endpointPublishingStrategy",
+		func(ctx context.Context) (*operatorv1.IngressController, error) {
+			ingressController := &operatorv1.IngressController{}
+			err := guestClient.Get(ctx, types.NamespacedName{
+				Namespace: "openshift-ingress-operator",
+				Name:      "default",
+			}, ingressController)
+			return ingressController, err
+		},
+		[]Predicate[*operatorv1.IngressController]{
+			func(ic *operatorv1.IngressController) (done bool, reasons string, err error) {
+				if ic.Spec.EndpointPublishingStrategy == nil {
+					return false, "EndpointPublishingStrategy is nil in IngressController", nil
+				}
+				if ic.Spec.EndpointPublishingStrategy.Type != operatorv1.LoadBalancerServiceStrategyType {
+					return false, fmt.Sprintf("expected EndpointPublishingStrategy type LoadBalancerService, got %s", ic.Spec.EndpointPublishingStrategy.Type), nil
+				}
+				if ic.Spec.EndpointPublishingStrategy.LoadBalancer == nil {
+					return false, "LoadBalancer configuration is nil in IngressController", nil
+				}
+				if ic.Spec.EndpointPublishingStrategy.LoadBalancer.Scope != operatorv1.InternalLoadBalancer {
+					return false, fmt.Sprintf("expected LoadBalancer scope Internal, got %s", ic.Spec.EndpointPublishingStrategy.LoadBalancer.Scope), nil
+				}
+				return true, "Successfully validated custom endpointPublishingStrategy", nil
+			},
+		},
+		WithTimeout(5*time.Minute),
+	)
+}
+
 // EnsureIngressOperatorConfiguration tests that the Ingress Operator configuration on the HostedCluster
 // is properly reflected in the hosted cluster's IngressController and that the Ingress Operator doesn't report any errors via HCP conditions.
-func EnsureIngressOperatorConfiguration(t *testing.T, ctx context.Context, mgmtClient crclient.Client, guestClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+func EnsureIngressOperatorConfiguration(t *testing.T, ctx context.Context, guestClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("EnsureIngressOperatorConfiguration", func(t *testing.T) {
 		AtLeast(t, Version421)
-		g := NewWithT(t)
-
-		// Verify the HostedCluster has the expected Ingress Operator configuration
-		t.Logf("Verifying HostedCluster %s/%s has custom Ingress Operator endpointPublishingStrategy", hostedCluster.Namespace, hostedCluster.Name)
-		g.Expect(hostedCluster.Spec.OperatorConfiguration).NotTo(BeNil(), "OperatorConfiguration should be set")
-		g.Expect(hostedCluster.Spec.OperatorConfiguration.IngressOperator).NotTo(BeNil(), "IngressOperator configuration should be set")
-		g.Expect(hostedCluster.Spec.OperatorConfiguration.IngressOperator.EndpointPublishingStrategy).NotTo(BeNil(), "EndpointPublishingStrategy should be set")
-		g.Expect(hostedCluster.Spec.OperatorConfiguration.IngressOperator.EndpointPublishingStrategy.Type).To(Equal(operatorv1.LoadBalancerServiceStrategyType), "EndpointPublishingStrategy should be LoadBalancerService")
-		g.Expect(hostedCluster.Spec.OperatorConfiguration.IngressOperator.EndpointPublishingStrategy.LoadBalancer).NotTo(BeNil(), "LoadBalancer configuration should be set")
-		g.Expect(hostedCluster.Spec.OperatorConfiguration.IngressOperator.EndpointPublishingStrategy.LoadBalancer.Scope).To(Equal(operatorv1.InternalLoadBalancer), "LoadBalancer scope should be Internal")
-
-		// Wait for the IngressController in the guest cluster to reflect the custom strategy
-		t.Logf("Validating IngressController in guest cluster reflects the custom endpointPublishingStrategy")
-		EventuallyObject(t, ctx, "IngressController default in guest cluster to reflect the custom endpointPublishingStrategy",
-			func(ctx context.Context) (*operatorv1.IngressController, error) {
-				ingressController := &operatorv1.IngressController{}
-				err := guestClient.Get(ctx, types.NamespacedName{
-					Namespace: "openshift-ingress-operator",
-					Name:      "default",
-				}, ingressController)
-				return ingressController, err
-			},
-			[]Predicate[*operatorv1.IngressController]{
-				func(ic *operatorv1.IngressController) (done bool, reasons string, err error) {
-					if ic.Spec.EndpointPublishingStrategy == nil {
-						return false, "EndpointPublishingStrategy is nil in IngressController", nil
-					}
-					if ic.Spec.EndpointPublishingStrategy.Type != operatorv1.LoadBalancerServiceStrategyType {
-						return false, fmt.Sprintf("expected EndpointPublishingStrategy type LoadBalancerService, got %s", ic.Spec.EndpointPublishingStrategy.Type), nil
-					}
-					if ic.Spec.EndpointPublishingStrategy.LoadBalancer == nil {
-						return false, "LoadBalancer configuration is nil in IngressController", nil
-					}
-					if ic.Spec.EndpointPublishingStrategy.LoadBalancer.Scope != operatorv1.InternalLoadBalancer {
-						return false, fmt.Sprintf("expected LoadBalancer scope Internal, got %s", ic.Spec.EndpointPublishingStrategy.LoadBalancer.Scope), nil
-					}
-					return true, "Successfully validated custom endpointPublishingStrategy", nil
-				},
-			},
-			WithTimeout(5*time.Minute),
-		)
+		ValidateIngressOperatorConfiguration(t, ctx, guestClient, hostedCluster)
 	})
 }

--- a/test/e2e/v2/internal/env_vars.go
+++ b/test/e2e/v2/internal/env_vars.go
@@ -159,4 +159,15 @@ func init() {
 		false,
 		filepath.Join(os.Getenv("HOME"), ".aws", "credentials"),
 	)
+	// Azure self-managed test environment variables
+	RegisterEnvVar(
+		"AZURE_PRIVATE_NAT_SUBNET_ID",
+		"Azure resource ID of the NAT subnet for Private Link Service. Auto-created by PLS controller if not set.",
+		false,
+	)
+	RegisterEnvVar(
+		"AZURE_PRIVATE_ADDITIONAL_ALLOWED_SUBSCRIPTIONS",
+		"Comma-separated list of Azure subscription IDs permitted to create Private Endpoints.",
+		false,
+	)
 }

--- a/test/e2e/v2/internal/test_context.go
+++ b/test/e2e/v2/internal/test_context.go
@@ -100,8 +100,8 @@ func (tc *TestContext) GetHostedClusterClient() crclient.Client {
 		}
 
 		kubeconfigData, ok := kubeconfigSecret.Data["kubeconfig"]
-		if !ok {
-			panic(fmt.Sprintf("kubeconfig secret %s/%s does not contain 'kubeconfig' key", hc.Namespace, hc.Status.KubeConfig.Name))
+		if !ok || len(kubeconfigData) == 0 {
+			panic(fmt.Sprintf("kubeconfig key not found or empty in secret %s/%s", hc.Namespace, hc.Status.KubeConfig.Name))
 		}
 
 		restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigData)

--- a/test/e2e/v2/tests/hosted_cluster_azure_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_azure_test.go
@@ -1,0 +1,328 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hcpmanifests "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/azureutil"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	"github.com/openshift/hypershift/test/e2e/v2/internal"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// AzurePublicClusterTest registers tests for Azure public cluster validation.
+// These tests verify workload identity, KAS allowed CIDRs, and ingress operator configuration
+// on Azure platform clusters.
+func AzurePublicClusterTest(getTestCtx internal.TestContextGetter) {
+	Context("Azure Public Cluster", Label("Azure", "self-managed-azure-public"), func() {
+		BeforeEach(func() {
+			testCtx := getTestCtx()
+			hc := testCtx.GetHostedCluster()
+			if hc == nil || hc.Spec.Platform.Type != hyperv1.AzurePlatform {
+				Skip("Azure public cluster tests are only for Azure platform")
+			}
+		})
+
+		It("should mutate pods with workload identity federated credentials", func() {
+			e2eutil.GinkgoAtLeast(e2eutil.Version422)
+			testCtx := getTestCtx()
+			hostedClusterClient := testCtx.GetHostedClusterClient()
+			Expect(hostedClusterClient).NotTo(BeNil(), "hosted cluster client is nil; HostedCluster may not have KubeConfig status set")
+
+			e2eutil.ValidateAzureWorkloadIdentityWebhookMutation(GinkgoTB(), testCtx.Context, hostedClusterClient)
+		})
+
+		It("should have expected KAS allowed CIDRs", func() {
+			testCtx := getTestCtx()
+			hc := testCtx.GetHostedCluster()
+			hostedClusterClient := testCtx.GetHostedClusterClient()
+			Expect(hostedClusterClient).NotTo(BeNil(), "hosted cluster client is nil; HostedCluster may not have KubeConfig status set")
+
+			kubeconfigData := e2eutil.WaitForGuestKubeConfig(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, hc)
+			restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigData)
+			Expect(err).NotTo(HaveOccurred(), "failed to create hosted cluster REST config")
+
+			e2eutil.ValidateKubeAPIServerAllowedCIDRs(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, restConfig, hc)
+		})
+
+		It("should have Ingress Operator configuration applied", func() {
+			e2eutil.GinkgoAtLeast(e2eutil.Version421)
+			testCtx := getTestCtx()
+			hc := testCtx.GetHostedCluster()
+			hostedClusterClient := testCtx.GetHostedClusterClient()
+			Expect(hostedClusterClient).NotTo(BeNil(), "hosted cluster client is nil; HostedCluster may not have KubeConfig status set")
+
+			e2eutil.ValidateIngressOperatorConfiguration(GinkgoTB(), testCtx.Context, hostedClusterClient, hc)
+		})
+	})
+}
+
+// AzurePrivateTopologyTest registers tests for Azure private cluster topology validation.
+// These tests verify private-router Service annotation, PrivateLinkService CRs, and DNS zone configuration
+// on Azure clusters with Private topology.
+func AzurePrivateTopologyTest(getTestCtx internal.TestContextGetter) {
+	Context("Azure Private Topology", Label("Azure", "self-managed-azure-private"), Ordered, func() {
+		var testCtx *internal.TestContext
+		var controlPlaneNamespace string
+
+		BeforeAll(func() {
+			testCtx = getTestCtx()
+			hc := testCtx.GetHostedCluster()
+			if hc == nil || hc.Spec.Platform.Type != hyperv1.AzurePlatform {
+				Skip("Azure private topology tests are only for Azure platform")
+			}
+			if hc.Spec.Platform.Azure == nil || hc.Spec.Platform.Azure.Topology != hyperv1.AzureTopologyPrivate {
+				Skip("Azure private topology tests require Private topology")
+			}
+
+			controlPlaneNamespace = testCtx.ControlPlaneNamespace
+			Expect(controlPlaneNamespace).NotTo(BeEmpty(), "control plane namespace must be set")
+		})
+
+		It("should have Azure internal LB annotation on private-router Service", func() {
+			ctx := testCtx.Context
+			e2eutil.EventuallyObject(GinkgoTB(), ctx, "private-router Service has Azure internal LB annotation",
+				func(ctx context.Context) (*corev1.Service, error) {
+					svc := &corev1.Service{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: controlPlaneNamespace,
+							Name:      "private-router",
+						},
+					}
+					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(svc), svc)
+					return svc, err
+				},
+				[]e2eutil.Predicate[*corev1.Service]{
+					func(svc *corev1.Service) (done bool, reasons string, err error) {
+						val, ok := svc.Annotations[azureutil.InternalLoadBalancerAnnotation]
+						if !ok || val != azureutil.InternalLoadBalancerValue {
+							return false, fmt.Sprintf("expected annotation %q to be %q, got %q (present: %v)",
+								azureutil.InternalLoadBalancerAnnotation, azureutil.InternalLoadBalancerValue, val, ok), nil
+						}
+						return true, "private-router Service has internal LB annotation", nil
+					},
+				},
+				e2eutil.WithTimeout(10*time.Minute),
+			)
+		})
+
+		It("should create AzurePrivateLinkService CR with PLS alias", func() {
+			ctx := testCtx.Context
+			e2eutil.EventuallyObjects(GinkgoTB(), ctx, "AzurePrivateLinkService CR is created with PLS alias",
+				func(ctx context.Context) ([]*hyperv1.AzurePrivateLinkService, error) {
+					plsList := &hyperv1.AzurePrivateLinkServiceList{}
+					err := testCtx.MgmtClient.List(ctx, plsList, crclient.InNamespace(controlPlaneNamespace))
+					if err != nil {
+						return nil, err
+					}
+					items := make([]*hyperv1.AzurePrivateLinkService, len(plsList.Items))
+					for i := range plsList.Items {
+						items[i] = &plsList.Items[i]
+					}
+					return items, nil
+				},
+				[]e2eutil.Predicate[[]*hyperv1.AzurePrivateLinkService]{
+					func(items []*hyperv1.AzurePrivateLinkService) (done bool, reasons string, err error) {
+						if len(items) == 0 {
+							return false, "no AzurePrivateLinkService CRs found in HCP namespace", nil
+						}
+						for _, pls := range items {
+							if pls.Status.PrivateLinkServiceAlias != "" {
+								return true, fmt.Sprintf("PLS alias is %q", pls.Status.PrivateLinkServiceAlias), nil
+							}
+						}
+						return false, "no AzurePrivateLinkService has a PLS alias yet", nil
+					},
+				},
+				nil,
+				e2eutil.WithTimeout(15*time.Minute),
+				e2eutil.WithInterval(15*time.Second),
+			)
+		})
+
+		It("should populate Private Endpoint IP in PLS status", func() {
+			ctx := testCtx.Context
+			e2eutil.EventuallyObjects(GinkgoTB(), ctx, "AzurePrivateLinkService has Private Endpoint IP",
+				func(ctx context.Context) ([]*hyperv1.AzurePrivateLinkService, error) {
+					plsList := &hyperv1.AzurePrivateLinkServiceList{}
+					err := testCtx.MgmtClient.List(ctx, plsList, crclient.InNamespace(controlPlaneNamespace))
+					if err != nil {
+						return nil, err
+					}
+					items := make([]*hyperv1.AzurePrivateLinkService, len(plsList.Items))
+					for i := range plsList.Items {
+						items[i] = &plsList.Items[i]
+					}
+					return items, nil
+				},
+				[]e2eutil.Predicate[[]*hyperv1.AzurePrivateLinkService]{
+					func(items []*hyperv1.AzurePrivateLinkService) (done bool, reasons string, err error) {
+						if len(items) == 0 {
+							return false, "no AzurePrivateLinkService CRs found", nil
+						}
+						for _, pls := range items {
+							if pls.Status.PrivateEndpointIP != "" {
+								return true, fmt.Sprintf("Private Endpoint IP is %q", pls.Status.PrivateEndpointIP), nil
+							}
+						}
+						return false, "no AzurePrivateLinkService has a Private Endpoint IP yet", nil
+					},
+				},
+				nil,
+				e2eutil.WithTimeout(15*time.Minute),
+				e2eutil.WithInterval(15*time.Second),
+			)
+		})
+
+		It("should populate Private DNS Zone ID in PLS status", func() {
+			ctx := testCtx.Context
+			e2eutil.EventuallyObjects(GinkgoTB(), ctx, "AzurePrivateLinkService has Private DNS Zone ID",
+				func(ctx context.Context) ([]*hyperv1.AzurePrivateLinkService, error) {
+					plsList := &hyperv1.AzurePrivateLinkServiceList{}
+					err := testCtx.MgmtClient.List(ctx, plsList, crclient.InNamespace(controlPlaneNamespace))
+					if err != nil {
+						return nil, err
+					}
+					items := make([]*hyperv1.AzurePrivateLinkService, len(plsList.Items))
+					for i := range plsList.Items {
+						items[i] = &plsList.Items[i]
+					}
+					return items, nil
+				},
+				[]e2eutil.Predicate[[]*hyperv1.AzurePrivateLinkService]{
+					func(items []*hyperv1.AzurePrivateLinkService) (done bool, reasons string, err error) {
+						if len(items) == 0 {
+							return false, "no AzurePrivateLinkService CRs found", nil
+						}
+						for _, pls := range items {
+							if pls.Status.PrivateDNSZoneID != "" {
+								return true, fmt.Sprintf("Private DNS Zone ID is %q", pls.Status.PrivateDNSZoneID), nil
+							}
+						}
+						return false, "no AzurePrivateLinkService has a Private DNS Zone ID yet", nil
+					},
+				},
+				nil,
+				e2eutil.WithTimeout(15*time.Minute),
+				e2eutil.WithInterval(15*time.Second),
+			)
+		})
+	})
+}
+
+// hasOAuthLoadBalancerStrategy returns true if the HostedCluster has OAuthServer
+// configured with LoadBalancer publishing strategy.
+func hasOAuthLoadBalancerStrategy(hc *hyperv1.HostedCluster) bool {
+	for _, svc := range hc.Spec.Services {
+		if svc.Service == hyperv1.OAuthServer {
+			return svc.ServicePublishingStrategy.Type == hyperv1.LoadBalancer
+		}
+	}
+	return false
+}
+
+// AzureOAuthLoadBalancerTest registers tests for Azure OAuth LoadBalancer publishing validation.
+// These tests verify that OAuth is properly exposed via a LoadBalancer Service and that the
+// OAuth token flow works through that endpoint.
+func AzureOAuthLoadBalancerTest(getTestCtx internal.TestContextGetter) {
+	Context("Azure OAuth LoadBalancer", Label("Azure", "self-managed-azure-oauth-lb"), func() {
+		BeforeEach(func() {
+			testCtx := getTestCtx()
+			hc := testCtx.GetHostedCluster()
+			if hc == nil || hc.Spec.Platform.Type != hyperv1.AzurePlatform {
+				Skip("Azure OAuth LB tests are only for Azure platform")
+			}
+			if !hasOAuthLoadBalancerStrategy(hc) {
+				Skip("Azure OAuth LB tests require OAuthServer with LoadBalancer publishing strategy")
+			}
+		})
+
+		It("should create oauth-openshift Service as LoadBalancer with external IP", func() {
+			testCtx := getTestCtx()
+			ctx := testCtx.Context
+			controlPlaneNamespace := testCtx.ControlPlaneNamespace
+
+			e2eutil.EventuallyObject(GinkgoTB(), ctx, "oauth-openshift Service is LoadBalancer with external IP",
+				func(ctx context.Context) (*corev1.Service, error) {
+					svc := hcpmanifests.OauthServerService(controlPlaneNamespace)
+					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(svc), svc)
+					return svc, err
+				},
+				[]e2eutil.Predicate[*corev1.Service]{
+					func(svc *corev1.Service) (done bool, reasons string, err error) {
+						if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+							return false, fmt.Sprintf("expected Service type LoadBalancer, got %s", svc.Spec.Type), nil
+						}
+						return true, "oauth-openshift Service is type LoadBalancer", nil
+					},
+					func(svc *corev1.Service) (done bool, reasons string, err error) {
+						if len(svc.Status.LoadBalancer.Ingress) == 0 {
+							return false, "LoadBalancer has no ingress entries yet", nil
+						}
+						ingress := svc.Status.LoadBalancer.Ingress[0]
+						if ingress.IP == "" && ingress.Hostname == "" {
+							return false, "LoadBalancer ingress has no IP or hostname", nil
+						}
+						host := ingress.IP
+						if host == "" {
+							host = ingress.Hostname
+						}
+						return true, fmt.Sprintf("oauth-openshift LoadBalancer has external endpoint: %s", host), nil
+					},
+				},
+				e2eutil.WithTimeout(10*time.Minute),
+			)
+		})
+
+		It("should complete OAuth token flow through LoadBalancer endpoint", func() {
+			testCtx := getTestCtx()
+			hc := testCtx.GetHostedCluster()
+
+			e2eutil.ValidateOAuthWithIdentityProviderViaLoadBalancer(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, hc)
+		})
+	})
+}
+
+// RegisterHostedClusterAzureTests registers all Azure-specific hosted cluster tests.
+func RegisterHostedClusterAzureTests(getTestCtx internal.TestContextGetter) {
+	AzurePublicClusterTest(getTestCtx)
+	AzurePrivateTopologyTest(getTestCtx)
+	AzureOAuthLoadBalancerTest(getTestCtx)
+}
+
+var _ = Describe("Hosted Cluster Azure", Label("hosted-cluster-azure"), func() {
+	var testCtx *internal.TestContext
+
+	BeforeEach(func() {
+		testCtx = internal.GetTestContext()
+		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
+	})
+
+	RegisterHostedClusterAzureTests(func() *internal.TestContext { return testCtx })
+})


### PR DESCRIPTION
## Summary
- Adds v2 Ginkgo test specs for Azure self-managed e2e tests
- Three test groups: `self-managed-azure-public`, `self-managed-azure-private`, `self-managed-azure-oauth-lb`
- Target branch for CI rehearsal of release repo PR openshift/release#77674

This PR is against the `azure-self-managed-e2e` branch (not main) so we can rehearse the full v2 workflow with actual test specs before merging to main.

Related PRs:
- openshift/release#77674 — CI workflow for e2e-azure-v2-self-managed
- openshift/hypershift#8204 — Same code, targeted at main