### PR TITLE
CNTRLPLANE-3093,CNTRLPLANE-3096,CNTRLPLANE-3095,CNTRLPLANE-3098: lower Azure WI webhook test version gate to 4.20

### DIFF
--- a/test/e2e/util/azure.go
+++ b/test/e2e/util/azure.go
@@ -102,7 +102,7 @@ func ValidateAzureWorkloadIdentityWebhookMutation(t testing.TB, ctx context.Cont
 
 func EnsureAzureWorkloadIdentityWebhookMutation(t *testing.T, ctx context.Context, guestClient crclient.Client) {
 	t.Run("EnsureAzureWorkloadIdentityWebhookMutation", func(t *testing.T) {
-		AtLeast(t, Version422)
+		AtLeast(t, Version420)
 		ValidateAzureWorkloadIdentityWebhookMutation(t, ctx, guestClient)
 	})
 }

--- a/test/e2e/v2/tests/hosted_cluster_azure_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_azure_test.go
@@ -51,7 +51,7 @@ func AzurePublicClusterTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		It("should mutate pods with workload identity federated credentials", func() {
-			e2eutil.GinkgoAtLeast(e2eutil.Version422)
+			e2eutil.GinkgoAtLeast(e2eutil.Version420)
 			testCtx := getTestCtx()
 			hc := testCtx.GetHostedCluster()
 			e2eutil.WaitForGuestKubeConfig(GinkgoTB(), testCtx.Context, testCtx.MgmtClient, hc)


### PR DESCRIPTION
## What this PR does / why we need it:

Lowers the Azure workload identity webhook e2e test version gate from `Version422` to `Version420`. The feature was originally implemented for 4.22 (#7867) but was backported to 4.20 (#7998) and 4.21 (#7997). The e2e test should run on all versions where the feature is available.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-3093](https://redhat.atlassian.net/browse/CNTRLPLANE-3093), fixes [CNTRLPLANE-3096](https://redhat.atlassian.net/browse/CNTRLPLANE-3096)

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted version compatibility testing for Azure Workload Identity Webhook support to cover earlier versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->