### PR TITLE
NO-JIRA: ci(deps): bump GitHub Actions dependencies

### DIFF
--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Read PR number
         id: pr
         run: echo "number=$(cat site/pr-number.txt)" >> "$GITHUB_OUTPUT"
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
         env:

--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Deploy to Cloudflare Pages
         env:
           npm_config_cache: ${{ runner.temp }}/.npm
-        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## What this PR does / why we need it:

Bumps GitHub Actions dependencies in the docs-deploy workflow:
- `cloudflare/wrangler-action` from 3.14.1 to 3.15.0
- `actions/setup-node` from 6.3.0 to 6.4.0

Cherry-picked from #8268 and #8326 with gitlint fixes applied.

## Which issue(s) this PR fixes:
Fixes #8268, fixes #8326

## Special notes for your reviewer:

Minor version bumps for GitHub Actions used in the docs deployment workflow.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow tools to latest versions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->