### PR TITLE
OCPBUGS-84508: Fix NLB name parsing for EKS Auto Mode hostnames

### DIFF
--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
@@ -170,7 +170,7 @@ func (r *PrivateServiceObserver) Reconcile(ctx context.Context, req ctrl.Request
 			Namespace: r.HCPNamespace,
 		},
 	}
-	lbName := strings.Split(strings.Split(svc.Status.LoadBalancer.Ingress[0].Hostname, ".")[0], "-")[0]
+	lbName := extractNLBName(svc.Status.LoadBalancer.Ingress[0].Hostname)
 	if _, err := r.CreateOrUpdate(ctx, r, awsEndpointService, func() error {
 		awsEndpointService.Spec.NetworkLoadBalancerName = lbName
 		if hcp.Spec.Platform.AWS != nil {
@@ -182,6 +182,31 @@ func (r *PrivateServiceObserver) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	r.log.Info("reconcile complete", "request", req)
 	return ctrl.Result{}, nil
+}
+
+// extractNLBName extracts the NLB name from its DNS hostname.
+//
+// AWS NLB DNS format is "{name}-{id}.elb.{region}.amazonaws.com"
+// where {name} is the value passed to CreateLoadBalancer and {id} is an
+// AWS-assigned hex suffix.
+// Ref: https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#dns-name
+//
+// The in-tree cloud provider generates hyphen-free names ("a" + UID),
+// but the AWS LB Controller (EKS Auto Mode) uses "k8s-{ns}-{svc}-{hash}".
+// We strip only the last dash-delimited segment (the AWS-assigned ID)
+// because {id} is always hex (no hyphens), as shown in every AWS API
+// example and required structurally — since {name} may contain hyphens,
+// a hyphenated {id} would make the format ambiguous.
+//
+// In-tree name generation: https://github.com/kubernetes/cloud-provider/blob/v0.32.3/cloud.go#L89-L98
+// AWS LB Controller name generation: https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/v2.12.0/pkg/service/model_build_load_balancer.go#L591-L608
+func extractNLBName(hostname string) string {
+	firstLabel := strings.Split(hostname, ".")[0]
+	lastDash := strings.LastIndex(firstLabel, "-")
+	if lastDash == -1 {
+		return firstLabel
+	}
+	return firstLabel[:lastDash]
 }
 
 // errDependencyViolation is returned when AWS reports a DependencyViolation,

--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller_test.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller_test.go
@@ -910,3 +910,33 @@ func TestReconcileDeletionSharedVPC(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractNLBName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		hostname string
+		expected string
+	}{
+		{
+			name:     "When standard NLB hostname it should extract name without hyphens",
+			hostname: "a1b2c3d4e5f6g7-1234567890abcdef.elb.us-east-1.amazonaws.com",
+			expected: "a1b2c3d4e5f6g7",
+		},
+		{
+			name:     "When EKS Auto Mode NLB hostname it should extract full name with hyphens",
+			hostname: "k8s-clusters-kubeapis-db6fee3a62-8008741421d14306.elb.us-east-1.amazonaws.com",
+			expected: "k8s-clusters-kubeapis-db6fee3a62",
+		},
+		{
+			name:     "When hostname has no hyphens it should return the first label as-is",
+			hostname: "somename.elb.us-east-1.amazonaws.com",
+			expected: "somename",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(extractNLBName(tc.hostname)).To(Equal(tc.expected))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- The `PrivateServiceObserver` extracts the NLB name from the Kubernetes Service's load balancer hostname to populate `AWSEndpointService.Spec.NetworkLoadBalancerName`. The current parsing splits on the first `-`, which fails for NLBs provisioned by the AWS Load Balancer Controller (EKS Auto Mode), where names contain hyphens (e.g. `k8s-clusters-kubeapis-db6fee3a62`).
- Extracts the NLB name by stripping only the last dash-delimited segment (the AWS-assigned ID suffix), which works for both standard and EKS Auto Mode NLB hostnames.

## Background

AWS NLB DNS hostnames follow the format `{name}-{id}.elb.{region}.amazonaws.com`, where `{name}` is the exact value passed to `CreateLoadBalancer` and `{id}` is an AWS-assigned hex suffix ([AWS docs](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#dns-name)).

**Backwards compatibility:** The `{id}` suffix is always hex (no hyphens), as shown in every AWS API example. This is also structurally required — since `{name}` [may contain hyphens](https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateLoadBalancer.html), a hyphenated `{id}` would make the hostname format ambiguous. `LastIndex("-")` therefore always lands on the boundary between `{name}` and `{id}`, producing the same result as `Split("-")[0]` when the name has no hyphens.

The two NLB name generation paths:
- **In-tree cloud provider** (OpenShift): generates `"a" + serviceUID` with [all hyphens stripped](https://github.com/kubernetes/cloud-provider/blob/v0.32.3/cloud.go#L89-L98) — purely alphanumeric, so both old and new parsing are identical.
- **AWS LB Controller** (EKS Auto Mode): generates [`k8s-{ns}-{svc}-{hash}`](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/v2.12.0/pkg/service/model_build_load_balancer.go#L591-L608) — always contains hyphens, where the old `Split("-")[0]` extracted only `k8s`.

## Jira
https://issues.redhat.com/browse/OCPBUGS-84508

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected extraction of network load balancer names from AWS hostnames so names with multiple hyphens are preserved and resolved correctly, preventing misidentification of services.

* **Tests**
  * Added unit tests validating name-extraction behavior across several hostname formats to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->