### PR TITLE
OCPBUGS-84509: Add AWS LB Controller cross-zone load balancing annotation

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/infra/infra_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/infra_test.go
@@ -1212,6 +1212,7 @@ func TestReconcileAPIServerService(t *testing.T) {
 	}
 	withCrossZoneAnnotation := func(svc *corev1.Service) {
 		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"] = "true"
+		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-attributes"] = "load_balancing.cross_zone.enabled=true"
 	}
 	withLoadBalancerSourceRanges := func(svc *corev1.Service) {
 		svc.Spec.LoadBalancerSourceRanges = allowCIDRString
@@ -1491,6 +1492,7 @@ func TestReconcileHCPRouterServices(t *testing.T) {
 	}
 	withCrossZoneAnnotation := func(svc *corev1.Service) {
 		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"] = "true"
+		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-attributes"] = "load_balancing.cross_zone.enabled=true"
 	}
 	tests := []struct {
 		name                         string

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_AWS_Private_KAS_LoadBalancer.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_AWS_Private_KAS_LoadBalancer.yaml
@@ -125,6 +125,7 @@ services:
       loadBalancer: {}
   - metadata:
       annotations:
+        service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
         service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
         service.beta.kubernetes.io/aws-load-balancer-internal: "true"
         service.beta.kubernetes.io/aws-load-balancer-type: nlb
@@ -248,6 +249,7 @@ services:
       loadBalancer: {}
   - metadata:
       annotations:
+        service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
         service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
         service.beta.kubernetes.io/aws-load-balancer-internal: "true"
         service.beta.kubernetes.io/aws-load-balancer-type: nlb

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_AWS_Private_Route.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_AWS_Private_Route.yaml
@@ -269,6 +269,7 @@ services:
       loadBalancer: {}
   - metadata:
       annotations:
+        service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
         service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
         service.beta.kubernetes.io/aws-load-balancer-internal: "true"
         service.beta.kubernetes.io/aws-load-balancer-type: nlb

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_AWS_PublicAndPrivate_KAS_LoadBalancer.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_AWS_PublicAndPrivate_KAS_LoadBalancer.yaml
@@ -94,6 +94,7 @@ services:
       loadBalancer: {}
   - metadata:
       annotations:
+        service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
         service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
         service.beta.kubernetes.io/aws-load-balancer-type: nlb
       labels:
@@ -122,6 +123,7 @@ services:
       loadBalancer: {}
   - metadata:
       annotations:
+        service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
         service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
         service.beta.kubernetes.io/aws-load-balancer-internal: "true"
         service.beta.kubernetes.io/aws-load-balancer-type: nlb
@@ -245,6 +247,7 @@ services:
       loadBalancer: {}
   - metadata:
       annotations:
+        service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
         service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
         service.beta.kubernetes.io/aws-load-balancer-internal: "true"
         service.beta.kubernetes.io/aws-load-balancer-type: nlb

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_AWS_PublicAndPrivate_Route.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_AWS_PublicAndPrivate_Route.yaml
@@ -265,6 +265,7 @@ services:
       loadBalancer: {}
   - metadata:
       annotations:
+        service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
         service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
         service.beta.kubernetes.io/aws-load-balancer-internal: "true"
         service.beta.kubernetes.io/aws-load-balancer-type: nlb
@@ -285,6 +286,7 @@ services:
       loadBalancer: {}
   - metadata:
       annotations:
+        service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
         service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
         service.beta.kubernetes.io/aws-load-balancer-type: nlb
       labels:

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -30,7 +30,10 @@ func ReconcileRouterService(svc *corev1.Service, internal, crossZoneLoadBalancin
 			svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-internal"] = "true"
 		}
 		if crossZoneLoadBalancingEnabled {
+			// In-tree AWS cloud provider annotation for cross-zone load balancing (OpenShift management clusters).
 			svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"] = "true"
+			// AWS Load Balancer Controller annotation for cross-zone load balancing (EKS Auto Mode).
+			svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-attributes"] = "load_balancing.cross_zone.enabled=true"
 		}
 		util.ApplyAWSLoadBalancerTargetNodesAnnotation(svc, hcp)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router_test.go
@@ -48,6 +48,9 @@ func TestReconcileRouterServiceAnnotations(t *testing.T) {
 	if got := svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"]; got != "true" {
 		t.Fatalf("expected cross-zone load balancing annotation to be 'true', got %q", got)
 	}
+	if got := svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-attributes"]; got != "load_balancing.cross_zone.enabled=true" {
+		t.Fatalf("expected load balancer attributes annotation, got %q", got)
+	}
 	if got := svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-target-node-labels"]; got != targetNodesLabel {
 		t.Fatalf("expected target node labels annotation to be '%s', got %q", targetNodesLabel, got)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -80,7 +80,10 @@ func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingSt
 				// To ensure that requirement is satisfied in Regions with more than 3 zones, managed services create subnets in all of them.
 				// That and having this enabled in the load balancers would make the private link communication to always succeed.
 				// Without this the connection might go to a subnet without Node and so it would be rejected.
+				// In-tree AWS cloud provider annotation for cross-zone load balancing (OpenShift management clusters).
 				svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"] = "true"
+				// AWS Load Balancer Controller annotation for cross-zone load balancing (EKS Auto Mode).
+				svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-attributes"] = "load_balancing.cross_zone.enabled=true"
 			}
 		} else {
 			svc.Spec.Type = corev1.ServiceTypeClusterIP
@@ -208,7 +211,10 @@ func ReconcilePrivateService(svc *corev1.Service, hcp *hyperv1.HostedControlPlan
 	case hyperv1.AzurePlatform:
 		svc.Annotations[azureutil.InternalLoadBalancerAnnotation] = azureutil.InternalLoadBalancerValue
 	default:
+		// In-tree AWS cloud provider annotation for cross-zone load balancing (OpenShift management clusters).
 		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"] = "true"
+		// AWS Load Balancer Controller annotation for cross-zone load balancing (EKS Auto Mode).
+		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-attributes"] = "load_balancing.cross_zone.enabled=true"
 		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-internal"] = "true"
 		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service_test.go
@@ -180,6 +180,7 @@ func TestReconcileServiceAzureInternalLB(t *testing.T) {
 func TestReconcilePrivateService(t *testing.T) {
 	azureILBAnnotation := azureutil.InternalLoadBalancerAnnotation
 	awsCrossZoneAnnotation := "service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"
+	awsLBAttributesAnnotation := "service.beta.kubernetes.io/aws-load-balancer-attributes"
 	awsInternalAnnotation := "service.beta.kubernetes.io/aws-load-balancer-internal"
 	awsNLBAnnotation := "service.beta.kubernetes.io/aws-load-balancer-type"
 
@@ -318,6 +319,7 @@ func TestReconcilePrivateService(t *testing.T) {
 				g.Expect(svc.Annotations).To(HaveKeyWithValue(azureILBAnnotation, "true"))
 				// Azure should NOT have AWS annotations
 				g.Expect(svc.Annotations).ToNot(HaveKey(awsCrossZoneAnnotation))
+				g.Expect(svc.Annotations).ToNot(HaveKey(awsLBAttributesAnnotation))
 				g.Expect(svc.Annotations).ToNot(HaveKey(awsInternalAnnotation))
 				g.Expect(svc.Annotations).ToNot(HaveKey(awsNLBAnnotation))
 			}
@@ -325,6 +327,7 @@ func TestReconcilePrivateService(t *testing.T) {
 			// Verify AWS annotations
 			if tc.expectAWSAnnotations {
 				g.Expect(svc.Annotations).To(HaveKeyWithValue(awsCrossZoneAnnotation, "true"))
+				g.Expect(svc.Annotations).To(HaveKeyWithValue(awsLBAttributesAnnotation, "load_balancing.cross_zone.enabled=true"))
 				g.Expect(svc.Annotations).To(HaveKeyWithValue(awsInternalAnnotation, "true"))
 				g.Expect(svc.Annotations).To(HaveKeyWithValue(awsNLBAnnotation, "nlb"))
 				// Non-Azure should NOT have Azure ILB annotation


### PR DESCRIPTION
## Summary

- HyperShift sets cross-zone load balancing on private NLBs using the in-tree AWS cloud provider annotation (`aws-load-balancer-cross-zone-load-balancing-enabled`). The AWS Load Balancer Controller (used by EKS Auto Mode) does not recognize this annotation, resulting in NLBs created without cross-zone load balancing.
- Adds the AWS Load Balancer Controller annotation (`aws-load-balancer-attributes: "load_balancing.cross_zone.enabled=true"`) alongside the existing one in all three locations: `ReconcileRouterService`, `ReconcileService`, and `ReconcilePrivateService`.

## Background

The in-tree AWS cloud provider and the AWS Load Balancer Controller use different Service annotations to configure the same NLB behavior. The in-tree provider uses `service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled` ([k8s docs](https://kubernetes.io/docs/concepts/services-networking/service/#aws-nlb-support)), while the AWS LB Controller uses `service.beta.kubernetes.io/aws-load-balancer-attributes` with the `load_balancing.cross_zone.enabled` attribute ([AWS LB Controller docs](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/service/annotations/#additive-annotations)). Both annotations can safely coexist — each controller ignores the other's annotations.

Cross-zone load balancing is required for PrivateLink connectivity. Without it, connections from a VPC Endpoint that land on an availability zone with no management cluster node are silently dropped ([AWS cross-zone docs](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#cross-zone-load-balancing)).

## Jira
https://issues.redhat.com/browse/OCPBUGS-84509

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled AWS cross-zone load balancing for control plane API server, router, and private services to improve traffic distribution across availability zones.

* **Tests**
  * Updated test validations to verify the AWS load balancer attribute configuration for cross-zone behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->