### PR TITLE
[release-4.18] OCPBUGS-84180: fix(cno): use brackets only for IPv6 in server URL

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/clusternetworkoperator.go
@@ -52,7 +52,13 @@ const (
 set -xeuo pipefail
 
 kc=/configs/management
-kubectl --kubeconfig $kc config set clusters.default.server "https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}"
+# Use brackets only for IPv6 addresses (contain colons), not for IPv4 or hostnames
+# This is required for CVE-2025-47912 compliance: Go's net/url rejects IPv4 in brackets
+case "${KUBERNETES_SERVICE_HOST}" in
+  *:*) server="https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}" ;;
+  *)   server="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}" ;;
+esac
+kubectl --kubeconfig $kc config set clusters.default.server "$server"
 kubectl --kubeconfig $kc config set clusters.default.certificate-authority {{ .MgmtTokenDir }}/ca.crt
 kubectl --kubeconfig $kc config set users.admin.tokenFile {{ .MgmtTokenDir }}/token
 kubectl --kubeconfig $kc config set contexts.default.cluster default

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_No_private_apiserver_connectivity__proxy_apiserver_address_is_set.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_No_private_apiserver_connectivity__proxy_apiserver_address_is_set.yaml
@@ -218,7 +218,13 @@ spec:
           set -xeuo pipefail
 
           kc=/configs/management
-          kubectl --kubeconfig $kc config set clusters.default.server "https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}"
+          # Use brackets only for IPv6 addresses (contain colons), not for IPv4 or hostnames
+          # This is required for CVE-2025-47912 compliance: Go's net/url rejects IPv4 in brackets
+          case "${KUBERNETES_SERVICE_HOST}" in
+            *:*) server="https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}" ;;
+            *)   server="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}" ;;
+          esac
+          kubectl --kubeconfig $kc config set clusters.default.server "$server"
           kubectl --kubeconfig $kc config set clusters.default.certificate-authority /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
           kubectl --kubeconfig $kc config set users.admin.tokenFile /var/run/secrets/kubernetes.io/serviceaccount/token
           kubectl --kubeconfig $kc config set contexts.default.cluster default

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Preserve_existing_resources.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Preserve_existing_resources.yaml
@@ -221,7 +221,13 @@ spec:
           set -xeuo pipefail
 
           kc=/configs/management
-          kubectl --kubeconfig $kc config set clusters.default.server "https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}"
+          # Use brackets only for IPv6 addresses (contain colons), not for IPv4 or hostnames
+          # This is required for CVE-2025-47912 compliance: Go's net/url rejects IPv4 in brackets
+          case "${KUBERNETES_SERVICE_HOST}" in
+            *:*) server="https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}" ;;
+            *)   server="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}" ;;
+          esac
+          kubectl --kubeconfig $kc config set clusters.default.server "$server"
           kubectl --kubeconfig $kc config set clusters.default.certificate-authority /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
           kubectl --kubeconfig $kc config set users.admin.tokenFile /var/run/secrets/kubernetes.io/serviceaccount/token
           kubectl --kubeconfig $kc config set contexts.default.cluster default

--- a/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Private_apiserver_connectivity__proxy_apiserver_address_is_unset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/cno/testdata/zz_fixture_TestReconcileDeployment_Private_apiserver_connectivity__proxy_apiserver_address_is_unset.yaml
@@ -216,7 +216,13 @@ spec:
           set -xeuo pipefail
 
           kc=/configs/management
-          kubectl --kubeconfig $kc config set clusters.default.server "https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}"
+          # Use brackets only for IPv6 addresses (contain colons), not for IPv4 or hostnames
+          # This is required for CVE-2025-47912 compliance: Go's net/url rejects IPv4 in brackets
+          case "${KUBERNETES_SERVICE_HOST}" in
+            *:*) server="https://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}" ;;
+            *)   server="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}" ;;
+          esac
+          kubectl --kubeconfig $kc config set clusters.default.server "$server"
           kubectl --kubeconfig $kc config set clusters.default.certificate-authority /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
           kubectl --kubeconfig $kc config set users.admin.tokenFile /var/run/secrets/kubernetes.io/serviceaccount/token
           kubectl --kubeconfig $kc config set contexts.default.cluster default


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry-pick of #7461 to release-4.18. The rewrite-config init container was unconditionally wrapping KUBERNETES_SERVICE_HOST in brackets, creating URLs like `https://[172.29.0.1]:443`. Go 1.24.8+ (CVE-2025-47912) now rejects IPv4 addresses in brackets per RFC 3986.

Uses a case statement to detect IPv6 (contains colon) and only add brackets for those addresses.

**Which issue(s) this PR fixes**:
Fixes https://issues.redhat.com/browse/OCPBUGS-84143

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

/assign sdodson