### PR TITLE
CNTRLPLANE-3340: Extract support/podspec package from support/util

### DIFF
--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -18,10 +18,10 @@ import (
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/metrics"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/rhobsmonitoring"
 	"github.com/openshift/hypershift/support/supportedversion"
-	"github.com/openshift/hypershift/support/util"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -1023,7 +1023,7 @@ func (o HyperShiftOperatorDeployment) Build() *appsv1.Deployment {
 
 	if o.AdditionalTrustBundle != nil {
 		// Add trusted-ca mount with optional configmap
-		util.DeploymentAddTrustBundleVolume(&corev1.LocalObjectReference{Name: o.AdditionalTrustBundle.Name}, deployment)
+		podspec.DeploymentAddTrustBundleVolume(&corev1.LocalObjectReference{Name: o.AdditionalTrustBundle.Name}, deployment)
 	}
 
 	if o.OpenShiftTrustBundle != nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/providerconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/cloud/aws/providerconfig.go
@@ -1,14 +1,14 @@
 package aws
 
 import (
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
-	Provider          = util.AWSCloudProviderName
+	Provider          = podspec.AWSCloudProviderName
 	ProviderConfigKey = "aws.conf"
 )
 

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/kubeconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/kubeconfig.go
@@ -6,11 +6,11 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 )
 
 const (
-	KubeconfigKey = util.KubeconfigKey
+	KubeconfigKey = podspec.KubeconfigKey
 )
 
 func InClusterKASURL(platformType hyperv1.PlatformType) string {

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/idp_convert.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/idp_convert.go
@@ -17,8 +17,8 @@ import (
 	kas "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	manifests "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/konnectivityproxy"
+	"github.com/openshift/hypershift/support/podspec"
 	supportproxy "github.com/openshift/hypershift/support/proxy"
-	"github.com/openshift/hypershift/support/util"
 
 	configv1 "github.com/openshift/api/config/v1"
 	osinv1 "github.com/openshift/api/osin/v1"
@@ -60,7 +60,7 @@ type idpData struct {
 
 type IDPVolumeMountInfo struct {
 	Container    string
-	VolumeMounts util.PodVolumeMounts
+	VolumeMounts podspec.VolumeMounts
 	Volumes      []corev1.Volume
 }
 
@@ -92,8 +92,8 @@ func ConvertIdentityProviders(ctx context.Context, identityProviders []configv1.
 	errs := []error{}
 	volumeMountInfo := &IDPVolumeMountInfo{
 		Container: oauthContainerMain().Name,
-		VolumeMounts: util.PodVolumeMounts{
-			oauthContainerMain().Name: util.ContainerVolumeMounts{},
+		VolumeMounts: podspec.VolumeMounts{
+			oauthContainerMain().Name: podspec.ContainerMounts{},
 		},
 	}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/idp_convert_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/idp_convert_test.go
@@ -12,7 +12,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	configv1 "github.com/openshift/api/config/v1"
 	osinv1 "github.com/openshift/api/osin/v1"
@@ -29,8 +29,8 @@ func TestOpenIDProviderConversion(t *testing.T) {
 	groupsInput := []configv1.OpenIDClaim{"groups"}
 	volumeMountInfo := &IDPVolumeMountInfo{
 		Container: oauthContainerMain().Name,
-		VolumeMounts: util.PodVolumeMounts{
-			oauthContainerMain().Name: util.ContainerVolumeMounts{},
+		VolumeMounts: podspec.VolumeMounts{
+			oauthContainerMain().Name: podspec.ContainerMounts{},
 		},
 	}
 	const namespace = "test"

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/params.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	configv1 "github.com/openshift/api/config/v1"
 	osinv1 "github.com/openshift/api/osin/v1"
@@ -62,7 +62,7 @@ func NewOAuthServerParams(hcp *hyperv1.HostedControlPlane, releaseImageProvider 
 		ExternalHost:            host,
 		ExternalPort:            port,
 		OAuthServerImage:        releaseImageProvider.GetImage("oauth-server"),
-		AvailabilityProberImage: releaseImageProvider.GetImage(util.AvailabilityProberImageName),
+		AvailabilityProberImage: releaseImageProvider.GetImage(podspec.AvailabilityProberImageName),
 		Availability:            hcp.Spec.ControllerAvailabilityPolicy,
 		ProxyImage:              releaseImageProvider.GetImage("socks5-proxy"),
 		OAuthNoProxy:            []string{manifests.KubeAPIServerService("").Name, config.AuditWebhookService},

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/kas.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
 	supportpki "github.com/openshift/hypershift/support/pki"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiserver/pkg/authentication/serviceaccount"
@@ -98,7 +98,7 @@ func ReconcileKubeConfig(secret, cert *corev1.Secret, ca *corev1.ConfigMap, url 
 		secret.Data = map[string][]byte{}
 	}
 	if key == "" {
-		key = util.KubeconfigKey
+		key = podspec.KubeconfigKey
 	}
 	if secret.Labels == nil {
 		secret.Labels = map[string]string{}

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/kas_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/kas_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/openshift/hypershift/support/certs"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
@@ -103,9 +103,9 @@ func TestReconcileServiceAccountKubeconfigWithURL(t *testing.T) {
 				t.Fatalf("failed to reconcile kubeconfig: %v", err)
 			}
 
-			kubeconfigData, hasKubeconfig := secret.Data[util.KubeconfigKey]
+			kubeconfigData, hasKubeconfig := secret.Data[podspec.KubeconfigKey]
 			if !hasKubeconfig {
-				t.Fatalf("expected %q key to be present in secret data", util.KubeconfigKey)
+				t.Fatalf("expected %q key to be present in secret data", podspec.KubeconfigKey)
 			}
 
 			kubeconfig, err := clientcmd.Load(kubeconfigData)

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/autoscaler/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/autoscaler/component.go
@@ -6,7 +6,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -44,7 +44,7 @@ func NewComponent() component.ControlPlaneComponent {
 			component.WithAdaptFunction(adaptPodMonitor),
 		).
 		WithPredicate(predicate).
-		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{}).
+		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{}).
 		Build()
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/autoscaler/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/autoscaler/deployment.go
@@ -8,7 +8,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -207,7 +207,7 @@ func appendBasicIgnoreLabels(args []string, platformType hyperv1.PlatformType) [
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
 	hcp := cpContext.HCP
 
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		if image, ok := cpContext.HCP.Annotations[hyperv1.ClusterAutoscalerImage]; ok {
 			c.Image = image
 		}
@@ -217,7 +217,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		c.Args = append(c.Args, autoscalerArgs(&hcp.Spec.Autoscaling, hcp.Spec.Platform.Type, ctrl.LoggerFrom(cpContext))...)
 	})
 
-	util.UpdateVolume(kubeconfigVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
+	podspec.UpdateVolume(kubeconfigVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
 		v.Secret.SecretName = manifests.KASServiceCAPIKubeconfigSecret(hcp.Namespace, hcp.Spec.InfraID).Name
 	})
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/awsnodeterminationhandler/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/awsnodeterminationhandler/deployment.go
@@ -8,7 +8,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -36,7 +36,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 	}
 
 	// Update the aws-node-termination-handler container environment variables and image
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		for i := range c.Env {
 			switch c.Env[i].Name {
 			case "AWS_REGION":
@@ -53,7 +53,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 
 	// Update the token-minter-kube container with the proper audience
 	// The token-minter command is embedded in a shell script, so we need to do string replacement
-	util.UpdateContainer(tokenMinterKubeContainerName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(tokenMinterKubeContainerName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		for i := range c.Args {
 			if strings.Contains(c.Args[i], "--token-audience=") {
 				c.Args[i] = strings.Replace(c.Args[i], "--token-audience=", fmt.Sprintf("--token-audience=%s", issuerURL), 1)

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/util"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -20,7 +21,7 @@ func (capi *CAPIManagerOptions) adaptDeployment(cpContext component.WorkloadCont
 		return fmt.Errorf("failed to parse version (%s): %w", versionStr, err)
 	}
 
-	util.UpdateContainer("manager", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer("manager", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		if version.GE(config.Version419) {
 			c.Args = append(c.Args, "--feature-gates=MachineSetPreflightChecks=false")
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment_test.go
@@ -8,6 +8,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/testutil"
 	"github.com/openshift/hypershift/support/util"
 
@@ -98,7 +99,7 @@ func TestAdaptDeployment(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// Find the manager container
-			managerContainer := util.FindContainer("manager", deployment.Spec.Template.Spec.Containers)
+			managerContainer := podspec.FindContainer("manager", deployment.Spec.Template.Spec.Containers)
 			g.Expect(managerContainer).ToNot(BeNil())
 
 			// Check expected args

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/capi_provider/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/capi_provider/component.go
@@ -3,7 +3,7 @@ package capiprovider
 import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -44,7 +44,7 @@ func NewComponent(deploymentSpec *appsv1.DeploymentSpec, platformPolicyRules []r
 	builder := component.NewDeploymentComponent(ComponentName, capi).
 		WithAdaptFunction(capi.adaptDeployment).
 		WithPredicate(predicate).
-		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{}).
+		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{}).
 		WithManifestAdapter(
 			"role.yaml",
 			component.WithAdaptFunction(capi.adaptRole),

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/deployment.go
@@ -6,7 +6,7 @@ import (
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -17,7 +17,7 @@ const (
 )
 
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
-	util.UpdateContainer(containerName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(containerName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Args = append(c.Args,
 			fmt.Sprintf("--cluster-name=%s", cpContext.HCP.Spec.InfraID),
 		)

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/kubevirt/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/kubevirt/deployment.go
@@ -5,7 +5,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -33,7 +33,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, buildInfraKubeconfigVolume())
 	}
 
-	util.UpdateContainer(containerName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(containerName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Args = append(c.Args,
 			fmt.Sprintf("--cluster-name=%s", clusterName),
 		)

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/openstack/deployment.go
@@ -3,7 +3,7 @@ package openstack
 import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -30,7 +30,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, buildTrustedCAVolume())
 	}
 
-	util.UpdateContainer(containerName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(containerName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Env = append(c.Env, corev1.EnvVar{
 			Name:  "OCP_INFRASTRUCTURE_NAME",
 			Value: cpContext.HCP.Spec.InfraID,
@@ -45,7 +45,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		}
 	})
 
-	util.UpdateVolume(secretOCCMVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
+	podspec.UpdateVolume(secretOCCMVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
 		v.Secret.SecretName = credentialsSecret.Name
 	})
 	return nil

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/powervs/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/powervs/deployment.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -20,7 +20,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		return fmt.Errorf(".spec.platform.powervs is not defined")
 	}
 
-	util.UpdateVolume(cloudCredsVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
+	podspec.UpdateVolume(cloudCredsVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
 		v.Secret.SecretName = hcp.Spec.Platform.PowerVS.KubeCloudControllerCreds.Name
 	})
 	return nil

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/powervs/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/powervs/deployment_test.go
@@ -8,7 +8,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -64,7 +64,7 @@ func TestAdaptDeployment(t *testing.T) {
 		err := adaptDeployment(cpContext, deployment)
 		g.Expect(err).ToNot(HaveOccurred())
 
-		cloudCredsVol := util.FindVolume(cloudCredsVolumeName, deployment.Spec.Template.Spec.Volumes)
+		cloudCredsVol := podspec.FindVolume(cloudCredsVolumeName, deployment.Spec.Template.Spec.Volumes)
 		g.Expect(cloudCredsVol).ToNot(BeNil(), "cloud-creds volume should exist")
 		g.Expect(cloudCredsVol.Secret.SecretName).To(Equal("my-cloud-creds-secret"))
 	})
@@ -135,15 +135,15 @@ func TestAdaptDeployment(t *testing.T) {
 
 		g.Expect(deployment.Spec.Template.Spec.Volumes).To(HaveLen(3))
 
-		otherVol := util.FindVolume("other-volume", deployment.Spec.Template.Spec.Volumes)
+		otherVol := podspec.FindVolume("other-volume", deployment.Spec.Template.Spec.Volumes)
 		g.Expect(otherVol).ToNot(BeNil(), "other-volume should exist")
 		g.Expect(otherVol.Secret.SecretName).To(Equal("other-secret"))
 
-		cloudCredsVol := util.FindVolume(cloudCredsVolumeName, deployment.Spec.Template.Spec.Volumes)
+		cloudCredsVol := podspec.FindVolume(cloudCredsVolumeName, deployment.Spec.Template.Spec.Volumes)
 		g.Expect(cloudCredsVol).ToNot(BeNil(), "cloud-creds volume should exist")
 		g.Expect(cloudCredsVol.Secret.SecretName).To(Equal("updated-creds"))
 
-		anotherVol := util.FindVolume("yet-another-volume", deployment.Spec.Template.Spec.Volumes)
+		anotherVol := podspec.FindVolume("yet-another-volume", deployment.Spec.Template.Spec.Volumes)
 		g.Expect(anotherVol).ToNot(BeNil(), "yet-another-volume should exist")
 		g.Expect(anotherVol.ConfigMap.Name).To(Equal("some-configmap"))
 	})
@@ -232,7 +232,7 @@ func TestAdaptDeploymentWithAssets(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 
 		// Find the cloud-creds volume and verify it was updated
-		cloudCredsVol := util.FindVolume(cloudCredsVolumeName, deployment.Spec.Template.Spec.Volumes)
+		cloudCredsVol := podspec.FindVolume(cloudCredsVolumeName, deployment.Spec.Template.Spec.Volumes)
 		g.Expect(cloudCredsVol).ToNot(BeNil(), "cloud-creds volume should exist in deployment")
 		g.Expect(cloudCredsVol.Secret.SecretName).To(Equal("asset-test-creds"))
 	})

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_credential_operator/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_credential_operator/component.go
@@ -4,7 +4,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	oapiv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/oapi"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -43,7 +43,7 @@ func NewComponent() component.ControlPlaneComponent {
 			Namespace: "openshift-cloud-credential-operator",
 			MountPath: "/etc/kubernetes",
 		}).
-		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{
+		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{
 			KubeconfigVolumeName:          component.ServiceAccountKubeconfigVolumeName,
 			WaitForInfrastructureResource: true,
 			RequiredAPIs: []schema.GroupVersionKind{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_credential_operator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_credential_operator/deployment.go
@@ -2,16 +2,16 @@ package cco
 
 import (
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
-	"github.com/openshift/hypershift/support/util"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
-		util.UpsertEnvVar(c, corev1.EnvVar{
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+		podspec.UpsertEnvVar(c, corev1.EnvVar{
 			Name:  "RELEASE_VERSION",
 			Value: cpContext.ReleaseImageProvider.Version(),
 		})

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_credential_operator/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_credential_operator/deployment_test.go
@@ -8,8 +8,8 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/testutil"
-	"github.com/openshift/hypershift/support/util"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -118,7 +118,7 @@ func TestAdaptDeployment(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// Find the cloud-credential-operator container
-			ccoContainer := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+			ccoContainer := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 			g.Expect(ccoContainer).ToNot(BeNil(), "cloud-credential-operator container should exist")
 
 			tc.validate(g, ccoContainer)

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/clusterpolicy/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/clusterpolicy/component.go
@@ -3,7 +3,7 @@ package clusterpolicy
 import (
 	oapiv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/oapi"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 )
 
 const (
@@ -37,6 +37,6 @@ func NewComponent() component.ControlPlaneComponent {
 			component.WithAdaptFunction(adaptConfigMap),
 		).
 		WithDependencies(oapiv2.ComponentName).
-		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{}).
+		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{}).
 		Build()
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cno/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cno/component.go
@@ -9,6 +9,7 @@ import (
 	oapiv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/oapi"
 	"github.com/openshift/hypershift/support/azureutil"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/util"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -63,7 +64,7 @@ func NewComponent() component.ControlPlaneComponent {
 			},
 			KubeconfingVolumeName: "hosted-etc-kube",
 		}).
-		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{
+		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{
 			KubeconfigVolumeName: "hosted-etc-kube",
 			RequiredAPIs: []schema.GroupVersionKind{
 				{Group: "operator.openshift.io", Version: "v1", Kind: "Network"},
@@ -180,7 +181,7 @@ func checkOperandsRolloutStatus(cpContext component.WorkloadContext) (bool, erro
 			}
 		}
 
-		if !util.IsDeploymentReady(cpContext, deployment) {
+		if !podspec.IsDeploymentReady(cpContext, deployment) {
 			errs = append(errs, fmt.Errorf("deployment %s is not ready", operand.DeploymentName))
 		}
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cno/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cno/deployment.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/rhobsmonitoring"
 	"github.com/openshift/hypershift/support/util"
@@ -22,15 +23,15 @@ import (
 
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
 	cnoEnvVars := buildCNOEnvVars(cpContext)
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Env = append(c.Env, cnoEnvVars...)
 	})
 
-	util.UpdateContainer("client-token-minter", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer("client-token-minter", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Args = append(c.Args, "--token-audience", cpContext.HCP.Spec.IssuerURL)
 	})
 
-	util.UpdateContainer("init-client-token-minter", deployment.Spec.Template.Spec.InitContainers, func(c *corev1.Container) {
+	podspec.UpdateContainer("init-client-token-minter", deployment.Spec.Template.Spec.InitContainers, func(c *corev1.Container) {
 		c.Args = append(c.Args, "--token-audience", cpContext.HCP.Spec.IssuerURL)
 	})
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/configoperator/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/configoperator/component.go
@@ -4,7 +4,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/capabilities"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -57,8 +57,8 @@ func NewComponent(registryOverrides map[string]string, openShiftImageRegistryOve
 		Build()
 }
 
-func hccpAvailabilityProberOpts(caps *hyperv1.Capabilities) util.AvailabilityProberOpts {
-	availabilityProberOpts := util.AvailabilityProberOpts{
+func hccpAvailabilityProberOpts(caps *hyperv1.Capabilities) podspec.AvailabilityProberOpts {
+	availabilityProberOpts := podspec.AvailabilityProberOpts{
 		KubeconfigVolumeName: "kubeconfig",
 		RequiredAPIs: []schema.GroupVersionKind{
 			{Group: "imageregistry.operator.openshift.io", Version: "v1", Kind: "Config"},

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/configoperator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/configoperator/deployment.go
@@ -7,6 +7,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/util"
 
@@ -34,7 +35,7 @@ func (h *hcco) adaptDeployment(cpContext component.WorkloadContext, deployment *
 	hcp := cpContext.HCP
 	openShiftVersion := cpContext.ReleaseImageProvider.Version()
 
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Command = append(c.Command,
 			"--platform-type", string(hcp.Spec.Platform.Type),
 			fmt.Sprintf("--enable-ci-debug-output=%t", cpContext.EnableCIDebugOutput),
@@ -91,19 +92,19 @@ func (h *hcco) adaptDeployment(cpContext component.WorkloadContext, deployment *
 		}
 	})
 
-	util.UpdateVolume(kubeconfigVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
+	podspec.UpdateVolume(kubeconfigVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
 		v.VolumeSource.Secret.SecretName = manifests.HCCOKubeconfigSecret("").Name
 	})
-	util.UpdateVolume(rootCAVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
+	podspec.UpdateVolume(rootCAVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
 		v.VolumeSource.ConfigMap.Name = manifests.RootCAConfigMap("").Name
 	})
-	util.UpdateVolume(clusterSignerCAVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
+	podspec.UpdateVolume(clusterSignerCAVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
 		v.VolumeSource.ConfigMap.Name = manifests.KubeletClientCABundle("").Name
 	})
 
 	if isExternalInfraKubevirt(hcp) {
 		// injects the kubevirt credentials secret volume, volume mount path, and appends cli arg.
-		util.DeploymentAddKubevirtInfraCredentials(deployment)
+		podspec.DeploymentAddKubevirtInfraCredentials(deployment)
 	}
 
 	return nil

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/controlplaneoperator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/controlplaneoperator/deployment.go
@@ -12,6 +12,7 @@ import (
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/images"
 	"github.com/openshift/hypershift/support/metrics"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/rhobsmonitoring"
 	"github.com/openshift/hypershift/support/util"
@@ -28,7 +29,7 @@ const (
 func (cpo *ControlPlaneOperatorOptions) adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
 	hcp := cpContext.HCP
 
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Image = cpo.Image
 
 		imageOverrides := cpo.HostedCluster.Annotations[hyperv1.ImageOverridesAnnotation]
@@ -168,7 +169,7 @@ func (cpo *ControlPlaneOperatorOptions) adaptDeployment(cpContext component.Work
 
 	if hcp.Spec.AdditionalTrustBundle != nil {
 		// Add trusted-ca mount with optional configmap
-		util.DeploymentAddTrustBundleVolume(hcp.Spec.AdditionalTrustBundle, deployment)
+		podspec.DeploymentAddTrustBundleVolume(hcp.Spec.AdditionalTrustBundle, deployment)
 	}
 
 	cpo.applyPlatformSpecificConfig(hcp, deployment)

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/csi/kubevirt/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/csi/kubevirt/deployment.go
@@ -5,7 +5,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -22,7 +22,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 
 	const infraClusterKubeconfigMount = "/var/run/secrets/infracluster"
 
-	util.UpdateContainer(containerName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(containerName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Args = append(c.Args, fmt.Sprintf("--infra-cluster-kubeconfig=%s/kubeconfig", infraClusterKubeconfigMount))
 
 		externalKubeconfigVolumeMount := corev1.VolumeMount{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/component.go
@@ -7,8 +7,8 @@ import (
 	oapiv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/oapi"
 	"github.com/openshift/hypershift/support/awsutil"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/rhobsmonitoring"
-	"github.com/openshift/hypershift/support/util"
 )
 
 const (
@@ -65,7 +65,7 @@ func NewComponent(enableCVOManagementClusterMetricsAccess bool) component.Contro
 			component.WithPredicate(cvo.isManagementClusterMetricsAccessEnabled),
 		).
 		WithDependencies(oapiv2.ComponentName).
-		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{
+		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{
 			KubeconfigVolumeName: "kubeconfig",
 		}).
 		Build()

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/hypershift/support/capabilities"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/rhobsmonitoring"
 	"github.com/openshift/hypershift/support/util"
 
@@ -63,7 +64,7 @@ func (cvo *clusterVersionOperator) adaptDeployment(cpContext component.WorkloadC
 		return fmt.Errorf("failed to discover CVO release images: %w", err)
 	}
 
-	util.UpdateContainer("prepare-payload", deployment.Spec.Template.Spec.InitContainers, func(c *corev1.Container) {
+	podspec.UpdateContainer("prepare-payload", deployment.Spec.Template.Spec.InitContainers, func(c *corev1.Container) {
 		c.Args = []string{
 			"-c",
 			preparePayloadScript(cpContext.HCP.Spec.Platform.Type, util.HCPOAuthEnabled(cpContext.HCP), featureSet),
@@ -94,15 +95,15 @@ func (cvo *clusterVersionOperator) adaptDeployment(cpContext component.WorkloadC
 	if err != nil {
 		return err
 	}
-	util.UpdateContainer("bootstrap", deployment.Spec.Template.Spec.InitContainers, func(c *corev1.Container) {
+	podspec.UpdateContainer("bootstrap", deployment.Spec.Template.Spec.InitContainers, func(c *corev1.Container) {
 		c.Env = append(c.Env, corev1.EnvVar{
 			Name:  "CLUSTER_VERSION_JSON",
 			Value: string(clusterVersionJSON),
 		})
 	})
 
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
-		util.UpsertEnvVar(c, corev1.EnvVar{
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+		podspec.UpsertEnvVar(c, corev1.EnvVar{
 			Name:  "RELEASE_IMAGE",
 			Value: dataPlaneReleaseImage,
 		})

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/dnsoperator/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/dnsoperator/component.go
@@ -3,7 +3,7 @@ package dnsoperator
 import (
 	oapiv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/oapi"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -41,7 +41,7 @@ func NewComponent() component.ControlPlaneComponent {
 			MountPath: "/etc/kubernetes",
 		}).
 		WithDependencies(oapiv2.ComponentName).
-		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{
+		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{
 			KubeconfigVolumeName: component.ServiceAccountKubeconfigVolumeName,
 			RequiredAPIs: []schema.GroupVersionKind{
 				{Group: "operator.openshift.io", Version: "v1", Kind: "DNS"},

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/dnsoperator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/dnsoperator/deployment.go
@@ -2,7 +2,7 @@ package dnsoperator
 
 import (
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -11,7 +11,7 @@ import (
 )
 
 func adaptDeployment(cpContext component.WorkloadContext, obj *appsv1.Deployment) error {
-	util.UpdateContainer("dns-operator", obj.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer("dns-operator", obj.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		// TODO (alberto): enforce ImagePullPolicy in component defaults.
 		c.ImagePullPolicy = corev1.PullIfNotPresent
 		c.Command = []string{"dns-operator"}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/dnsoperator/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/dnsoperator/deployment_test.go
@@ -8,8 +8,8 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/testutil"
-	"github.com/openshift/hypershift/support/util"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -34,7 +34,7 @@ func TestAdaptDeployment(t *testing.T) {
 				err = adaptDeployment(cpContext, deployment)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				dnsContainer := util.FindContainer("dns-operator", deployment.Spec.Template.Spec.Containers)
+				dnsContainer := podspec.FindContainer("dns-operator", deployment.Spec.Template.Spec.Containers)
 
 				g.Expect(dnsContainer).ToNot(BeNil())
 				g.Expect(dnsContainer.Command).To(Equal([]string{"dns-operator"}))
@@ -50,7 +50,7 @@ func TestAdaptDeployment(t *testing.T) {
 				err = adaptDeployment(cpContext, deployment)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				dnsContainer := util.FindContainer("dns-operator", deployment.Spec.Template.Spec.Containers)
+				dnsContainer := podspec.FindContainer("dns-operator", deployment.Spec.Template.Spec.Containers)
 
 				g.Expect(dnsContainer).ToNot(BeNil())
 				g.Expect(dnsContainer.ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
@@ -66,7 +66,7 @@ func TestAdaptDeployment(t *testing.T) {
 				err = adaptDeployment(cpContext, deployment)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				dnsContainer := util.FindContainer("dns-operator", deployment.Spec.Template.Spec.Containers)
+				dnsContainer := podspec.FindContainer("dns-operator", deployment.Spec.Template.Spec.Containers)
 
 				g.Expect(dnsContainer).ToNot(BeNil())
 				g.Expect(dnsContainer.Env).To(HaveLen(5))
@@ -93,7 +93,7 @@ func TestAdaptDeployment(t *testing.T) {
 				err = adaptDeployment(cpContext, deployment)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				dnsContainer := util.FindContainer("dns-operator", deployment.Spec.Template.Spec.Containers)
+				dnsContainer := podspec.FindContainer("dns-operator", deployment.Spec.Template.Spec.Containers)
 
 				g.Expect(dnsContainer).ToNot(BeNil())
 				g.Expect(dnsContainer.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceCPU, resource.MustParse("10m")))
@@ -110,7 +110,7 @@ func TestAdaptDeployment(t *testing.T) {
 				err = adaptDeployment(cpContext, deployment)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				dnsContainer := util.FindContainer("dns-operator", deployment.Spec.Template.Spec.Containers)
+				dnsContainer := podspec.FindContainer("dns-operator", deployment.Spec.Template.Spec.Containers)
 
 				g.Expect(dnsContainer).ToNot(BeNil())
 				g.Expect(dnsContainer.TerminationMessagePolicy).To(Equal(corev1.TerminationMessageFallbackToLogsOnError))

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/statefulset.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/statefulset.go
@@ -8,6 +8,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/util"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -25,7 +26,7 @@ func adaptStatefulSet(cpContext component.WorkloadContext, sts *appsv1.StatefulS
 		return fmt.Errorf("error checking the ClusterNetworkCIDR: %v", err)
 	}
 
-	util.UpdateContainer(ComponentName, sts.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, sts.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		replicas := component.DefaultReplicas(hcp, &etcd{}, ComponentName)
 		var members []string
 		for i := range replicas {
@@ -40,22 +41,22 @@ func adaptStatefulSet(cpContext component.WorkloadContext, sts *appsv1.StatefulS
 		)
 
 		if !ipv4 {
-			util.UpsertEnvVar(c, corev1.EnvVar{
+			podspec.UpsertEnvVar(c, corev1.EnvVar{
 				Name:  "ETCD_LISTEN_PEER_URLS",
 				Value: "https://[$(POD_IP)]:2380",
 			})
-			util.UpsertEnvVar(c, corev1.EnvVar{
+			podspec.UpsertEnvVar(c, corev1.EnvVar{
 				Name:  "ETCD_LISTEN_CLIENT_URLS",
 				Value: "https://[$(POD_IP)]:2379,https://localhost:2379",
 			})
-			util.UpsertEnvVar(c, corev1.EnvVar{
+			podspec.UpsertEnvVar(c, corev1.EnvVar{
 				Name:  "ETCD_LISTEN_METRICS_URLS",
 				Value: "https://[::]:2382",
 			})
 		}
 	})
 
-	util.UpdateContainer("etcd-metrics", sts.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer("etcd-metrics", sts.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		var loInterface, allInterfaces string
 		if ipv4 {
 			loInterface = "127.0.0.1"

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/fg/job.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/fg/job.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/openshift/hypershift/support/api"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -36,7 +36,7 @@ func adaptJob(cpContext component.WorkloadContext, job *batchv1.Job) error {
 	}
 	featureGateYaml := featureGateBuffer.String()
 
-	util.UpdateContainer("render-feature-gates", job.Spec.Template.Spec.InitContainers, func(c *corev1.Container) {
+	podspec.UpdateContainer("render-feature-gates", job.Spec.Template.Spec.InitContainers, func(c *corev1.Container) {
 		c.Env = append(c.Env,
 			corev1.EnvVar{
 				Name:  "PAYLOAD_VERSION",
@@ -48,7 +48,7 @@ func adaptJob(cpContext component.WorkloadContext, job *batchv1.Job) error {
 			},
 		)
 	})
-	util.UpdateContainer("apply", job.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer("apply", job.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Env = append(c.Env,
 			corev1.EnvVar{
 				Name:  "PAYLOAD_VERSION",

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/fg/job_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/fg/job_test.go
@@ -8,8 +8,8 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/testutil"
-	"github.com/openshift/hypershift/support/util"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -41,23 +41,23 @@ func TestAdaptJob(t *testing.T) {
 				g.Expect(err).ToNot(HaveOccurred())
 
 				// Check render-feature-gates init container
-				renderContainer := util.FindContainer("render-feature-gates", job.Spec.Template.Spec.InitContainers)
+				renderContainer := podspec.FindContainer("render-feature-gates", job.Spec.Template.Spec.InitContainers)
 				g.Expect(renderContainer).ToNot(BeNil())
 
-				payloadVersionEnv := util.FindEnvVar("PAYLOAD_VERSION", renderContainer.Env)
+				payloadVersionEnv := podspec.FindEnvVar("PAYLOAD_VERSION", renderContainer.Env)
 				g.Expect(payloadVersionEnv).ToNot(BeNil())
 				g.Expect(payloadVersionEnv.Value).To(Equal(testutil.FakeImageProvider().Version()))
 
-				featureGateEnv := util.FindEnvVar("FEATURE_GATE_YAML", renderContainer.Env)
+				featureGateEnv := podspec.FindEnvVar("FEATURE_GATE_YAML", renderContainer.Env)
 				g.Expect(featureGateEnv).ToNot(BeNil())
 				g.Expect(featureGateEnv.Value).To(ContainSubstring("kind: FeatureGate"))
 				g.Expect(featureGateEnv.Value).To(ContainSubstring("name: cluster"))
 
 				// Check apply container
-				applyContainer := util.FindContainer("apply", job.Spec.Template.Spec.Containers)
+				applyContainer := podspec.FindContainer("apply", job.Spec.Template.Spec.Containers)
 				g.Expect(applyContainer).ToNot(BeNil())
 
-				applyPayloadVersionEnv := util.FindEnvVar("PAYLOAD_VERSION", applyContainer.Env)
+				applyPayloadVersionEnv := podspec.FindEnvVar("PAYLOAD_VERSION", applyContainer.Env)
 				g.Expect(applyPayloadVersionEnv).ToNot(BeNil())
 				g.Expect(applyPayloadVersionEnv.Value).To(Equal(testutil.FakeImageProvider().Version()))
 			},
@@ -82,10 +82,10 @@ func TestAdaptJob(t *testing.T) {
 			validate: func(g Gomega, job *batchv1.Job, err error) {
 				g.Expect(err).ToNot(HaveOccurred())
 
-				renderContainer := util.FindContainer("render-feature-gates", job.Spec.Template.Spec.InitContainers)
+				renderContainer := podspec.FindContainer("render-feature-gates", job.Spec.Template.Spec.InitContainers)
 				g.Expect(renderContainer).ToNot(BeNil())
 
-				featureGateEnv := util.FindEnvVar("FEATURE_GATE_YAML", renderContainer.Env)
+				featureGateEnv := podspec.FindEnvVar("FEATURE_GATE_YAML", renderContainer.Env)
 				g.Expect(featureGateEnv).ToNot(BeNil())
 				g.Expect(featureGateEnv.Value).To(ContainSubstring("featureSet: TechPreviewNoUpgrade"))
 			},
@@ -119,10 +119,10 @@ func TestAdaptJob(t *testing.T) {
 			validate: func(g Gomega, job *batchv1.Job, err error) {
 				g.Expect(err).ToNot(HaveOccurred())
 
-				renderContainer := util.FindContainer("render-feature-gates", job.Spec.Template.Spec.InitContainers)
+				renderContainer := podspec.FindContainer("render-feature-gates", job.Spec.Template.Spec.InitContainers)
 				g.Expect(renderContainer).ToNot(BeNil())
 
-				featureGateEnv := util.FindEnvVar("FEATURE_GATE_YAML", renderContainer.Env)
+				featureGateEnv := podspec.FindEnvVar("FEATURE_GATE_YAML", renderContainer.Env)
 				g.Expect(featureGateEnv).ToNot(BeNil())
 				g.Expect(featureGateEnv.Value).To(ContainSubstring("featureSet: CustomNoUpgrade"))
 				g.Expect(featureGateEnv.Value).To(ContainSubstring("CustomFeature1"))
@@ -168,14 +168,14 @@ func TestAdaptJobPreservesExistingEnvVars(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// Add existing env vars to containers
-	renderContainer := util.FindContainer("render-feature-gates", job.Spec.Template.Spec.InitContainers)
+	renderContainer := podspec.FindContainer("render-feature-gates", job.Spec.Template.Spec.InitContainers)
 	g.Expect(renderContainer).ToNot(BeNil())
 	renderContainer.Env = append(renderContainer.Env, corev1.EnvVar{
 		Name:  "EXISTING_VAR",
 		Value: "existing-value",
 	})
 
-	applyContainer := util.FindContainer("apply", job.Spec.Template.Spec.Containers)
+	applyContainer := podspec.FindContainer("apply", job.Spec.Template.Spec.Containers)
 	g.Expect(applyContainer).ToNot(BeNil())
 	applyContainer.Env = append(applyContainer.Env, corev1.EnvVar{
 		Name:  "ANOTHER_EXISTING_VAR",
@@ -192,13 +192,13 @@ func TestAdaptJobPreservesExistingEnvVars(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// Check that existing env vars are preserved
-	renderContainer = util.FindContainer("render-feature-gates", job.Spec.Template.Spec.InitContainers)
-	existingVar := util.FindEnvVar("EXISTING_VAR", renderContainer.Env)
+	renderContainer = podspec.FindContainer("render-feature-gates", job.Spec.Template.Spec.InitContainers)
+	existingVar := podspec.FindEnvVar("EXISTING_VAR", renderContainer.Env)
 	g.Expect(existingVar).ToNot(BeNil())
 	g.Expect(existingVar.Value).To(Equal("existing-value"))
 
-	applyContainer = util.FindContainer("apply", job.Spec.Template.Spec.Containers)
-	anotherExistingVar := util.FindEnvVar("ANOTHER_EXISTING_VAR", applyContainer.Env)
+	applyContainer = podspec.FindContainer("apply", job.Spec.Template.Spec.Containers)
+	anotherExistingVar := podspec.FindEnvVar("ANOTHER_EXISTING_VAR", applyContainer.Env)
 	g.Expect(anotherExistingVar).ToNot(BeNil())
 	g.Expect(anotherExistingVar.Value).To(Equal("another-existing-value"))
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver/deployment.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
 	"github.com/openshift/hypershift/support/api"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/util"
 
@@ -39,21 +40,21 @@ func (ign *ignitionServer) adaptDeployment(cpContext component.WorkloadContext, 
 		}
 		featureGateYAML := featureGateBuffer.String()
 
-		util.UpdateContainer("fetch-feature-gate", deployment.Spec.Template.Spec.InitContainers, func(c *corev1.Container) {
-			util.UpsertEnvVar(c, corev1.EnvVar{
+		podspec.UpdateContainer("fetch-feature-gate", deployment.Spec.Template.Spec.InitContainers, func(c *corev1.Container) {
+			podspec.UpsertEnvVar(c, corev1.EnvVar{
 				Name:  "FEATURE_GATE_YAML",
 				Value: featureGateYAML,
 			})
 		})
 	}
 
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Args = append(c.Args,
 			"--registry-overrides", util.ConvertRegistryOverridesToCommandLineFlag(ign.releaseProvider.GetRegistryOverrides()),
 			"--platform", string(hcp.Spec.Platform.Type),
 		)
 
-		util.UpsertEnvVar(c, corev1.EnvVar{
+		podspec.UpsertEnvVar(c, corev1.EnvVar{
 			Name:  "OPENSHIFT_IMG_OVERRIDES",
 			Value: util.ConvertOpenShiftImageRegistryOverridesToCommandLineFlag(ign.releaseProvider.GetOpenShiftImageRegistryOverrides()),
 		})
@@ -63,11 +64,11 @@ func (ign *ignitionServer) adaptDeployment(cpContext component.WorkloadContext, 
 
 	if hcp.Spec.AdditionalTrustBundle != nil {
 		// Add trusted-ca mount with optional configmap
-		util.DeploymentAddTrustBundleVolume(hcp.Spec.AdditionalTrustBundle, deployment)
+		podspec.DeploymentAddTrustBundleVolume(hcp.Spec.AdditionalTrustBundle, deployment)
 	}
 
 	if hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform {
-		util.UpdateVolume("serving-cert", deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
+		podspec.UpdateVolume("serving-cert", deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
 			v.Secret.SecretName = ignitionserver.IgnitionServingCertSecret("").Name
 		})
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy/deployment.go
@@ -2,22 +2,22 @@ package ignitionserverproxy
 
 import (
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
-	"github.com/openshift/hypershift/support/util"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
-	util.UpdateContainer("haproxy", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer("haproxy", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		proxy.SetEnvVars(&c.Env)
 	})
 
 	hcp := cpContext.HCP
 	if hcp.Spec.AdditionalTrustBundle != nil {
 		// Add trusted-ca mount with optional configmap
-		util.DeploymentAddTrustBundleVolume(hcp.Spec.AdditionalTrustBundle, deployment)
+		podspec.DeploymentAddTrustBundleVolume(hcp.Spec.AdditionalTrustBundle, deployment)
 	}
 
 	return nil

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ignitionserver_proxy/deployment_test.go
@@ -8,7 +8,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -67,7 +67,7 @@ func TestAdaptDeployment(t *testing.T) {
 
 			// Verify trust bundle volume configuration
 			if tc.expectTrustBundleVolume {
-				volume := util.FindVolume(tc.expectedVolumeName, deployment.Spec.Template.Spec.Volumes)
+				volume := podspec.FindVolume(tc.expectedVolumeName, deployment.Spec.Template.Spec.Volumes)
 				g.Expect(volume).ToNot(BeNil(), "trust bundle volume should exist")
 				g.Expect(volume.ConfigMap).ToNot(BeNil(), "volume should use ConfigMap source")
 				g.Expect(volume.ConfigMap.Name).To(Equal(tc.expectedConfigMapName))
@@ -76,7 +76,7 @@ func TestAdaptDeployment(t *testing.T) {
 				g.Expect(volume.ConfigMap.Items[0].Path).To(Equal("user-ca-bundle.pem"))
 			} else {
 				// Verify trust bundle volume is NOT present when not configured
-				g.Expect(util.FindVolume("trusted-ca", deployment.Spec.Template.Spec.Volumes)).To(BeNil(), "trust bundle volume should not exist")
+				g.Expect(podspec.FindVolume("trusted-ca", deployment.Spec.Template.Spec.Volumes)).To(BeNil(), "trust bundle volume should not exist")
 			}
 
 			// Verify trust bundle mount on first container (DeploymentAddTrustBundleVolume adds to first container)
@@ -84,7 +84,7 @@ func TestAdaptDeployment(t *testing.T) {
 				g.Expect(deployment.Spec.Template.Spec.Containers).ToNot(BeEmpty(), "deployment should have containers")
 
 				firstContainer := &deployment.Spec.Template.Spec.Containers[0]
-				mount := util.FindVolumeMount(tc.expectedVolumeName, firstContainer.VolumeMounts)
+				mount := podspec.FindVolumeMount(tc.expectedVolumeName, firstContainer.VolumeMounts)
 				g.Expect(mount).ToNot(BeNil(), "trust bundle volume mount should exist on first container")
 				g.Expect(mount.MountPath).To(Equal("/etc/pki/tls/certs"))
 				g.Expect(mount.ReadOnly).To(BeTrue())
@@ -92,7 +92,7 @@ func TestAdaptDeployment(t *testing.T) {
 				// Verify trust bundle mount is NOT present
 				if len(deployment.Spec.Template.Spec.Containers) > 0 {
 					firstContainer := &deployment.Spec.Template.Spec.Containers[0]
-					g.Expect(util.FindVolumeMount("trusted-ca", firstContainer.VolumeMounts)).To(BeNil(), "trust bundle volume mount should not exist")
+					g.Expect(podspec.FindVolumeMount("trusted-ca", firstContainer.VolumeMounts)).To(BeNil(), "trust bundle volume mount should not exist")
 				}
 			}
 		})
@@ -126,19 +126,19 @@ func TestAdaptDeploymentWithProxyEnvVars(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// Find haproxy container
-	haproxyContainer := util.FindContainer("haproxy", deployment.Spec.Template.Spec.Containers)
+	haproxyContainer := podspec.FindContainer("haproxy", deployment.Spec.Template.Spec.Containers)
 	g.Expect(haproxyContainer).ToNot(BeNil(), "haproxy container should exist")
 
 	// Verify proxy env vars are set
-	httpProxy := util.FindEnvVar("HTTP_PROXY", haproxyContainer.Env)
+	httpProxy := podspec.FindEnvVar("HTTP_PROXY", haproxyContainer.Env)
 	g.Expect(httpProxy).ToNot(BeNil())
 	g.Expect(httpProxy.Value).To(Equal("http://proxy.example.com:8080"))
 
-	httpsProxy := util.FindEnvVar("HTTPS_PROXY", haproxyContainer.Env)
+	httpsProxy := podspec.FindEnvVar("HTTPS_PROXY", haproxyContainer.Env)
 	g.Expect(httpsProxy).ToNot(BeNil())
 	g.Expect(httpsProxy.Value).To(Equal("https://proxy.example.com:8443"))
 
-	noProxy := util.FindEnvVar("NO_PROXY", haproxyContainer.Env)
+	noProxy := podspec.FindEnvVar("NO_PROXY", haproxyContainer.Env)
 	g.Expect(noProxy).ToNot(BeNil())
 	g.Expect(noProxy.Value).To(ContainSubstring("localhost"))
 	g.Expect(noProxy.Value).To(ContainSubstring("kube-apiserver"))

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ingressoperator/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ingressoperator/component.go
@@ -5,7 +5,7 @@ import (
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/capabilities"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
@@ -59,7 +59,7 @@ func NewComponent() component.ControlPlaneComponent {
 			},
 			KubeconfingVolumeName: "admin-kubeconfig",
 		}).
-		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{
+		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{
 			KubeconfigVolumeName: component.ServiceAccountKubeconfigVolumeName,
 			RequiredAPIs: []schema.GroupVersionKind{
 				{Group: "route.openshift.io", Version: "v1", Kind: "Route"},

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ingressoperator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ingressoperator/deployment.go
@@ -4,21 +4,21 @@ import (
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
-		util.UpsertEnvVar(c, corev1.EnvVar{
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+		podspec.UpsertEnvVar(c, corev1.EnvVar{
 			Name: "RELEASE_VERSION", Value: cpContext.UserReleaseImageProvider.Version(),
 		})
-		util.UpsertEnvVar(c, corev1.EnvVar{
+		podspec.UpsertEnvVar(c, corev1.EnvVar{
 			Name: "IMAGE", Value: cpContext.UserReleaseImageProvider.GetImage("haproxy-router"),
 		})
-		util.UpsertEnvVar(c, corev1.EnvVar{
+		podspec.UpsertEnvVar(c, corev1.EnvVar{
 			Name: "CANARY_IMAGE", Value: cpContext.UserReleaseImageProvider.GetImage("cluster-ingress-operator"),
 		})
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/karpenter/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/karpenter/component.go
@@ -7,7 +7,7 @@ import (
 	karpenteroperatorv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	karpenterutil "github.com/openshift/hypershift/support/karpenter"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -45,7 +45,7 @@ func NewComponent() component.ControlPlaneComponent {
 		).
 		WithPredicate(predicate).
 		WithDependencies(karpenteroperatorv2.ComponentName).
-		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{}).
+		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{}).
 		Build()
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/karpenter/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/karpenter/deployment.go
@@ -4,8 +4,8 @@ import (
 	hyperkarpenterv1 "github.com/openshift/hypershift/api/karpenter/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
-	"github.com/openshift/hypershift/support/util"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -20,11 +20,11 @@ const (
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
 	hcp := cpContext.HCP
 
-	util.UpdateVolume(kubeconfigVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
+	podspec.UpdateVolume(kubeconfigVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
 		v.Secret.SecretName = manifests.KASServiceCAPIKubeconfigSecret(hcp.Namespace, hcp.Spec.InfraID).Name
 	})
 
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Env = append(c.Env,
 			corev1.EnvVar{
 				Name:  "AWS_REGION",

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/component.go
@@ -6,7 +6,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	karpenterutil "github.com/openshift/hypershift/support/karpenter"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -54,7 +54,7 @@ func NewComponent(options *KarpenterOperatorOptions) component.ControlPlaneCompo
 			ServiceAccountNameSpace: "kube-system",
 			KubeconfigSecretName:    "service-network-admin-kubeconfig",
 		}).
-		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{}).
+		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{}).
 		Build()
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment.go
@@ -5,9 +5,9 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/rhobsmonitoring"
-	"github.com/openshift/hypershift/support/util"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -16,7 +16,7 @@ import (
 func (karp *KarpenterOperatorOptions) adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
 	hcp := cpContext.HCP
 
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Image = karp.HyperShiftOperatorImage
 		c.Args = append(c.Args,
 			"--hypershift-operator-image="+karp.HyperShiftOperatorImage,
@@ -37,7 +37,7 @@ func (karp *KarpenterOperatorOptions) adaptDeployment(cpContext component.Worklo
 				},
 			},
 		)
-		util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+		podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 			c.Env = append(c.Env,
 				corev1.EnvVar{
 					Name:  "AWS_SHARED_CREDENTIALS_FILE",

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/karpenteroperator/deployment_test.go
@@ -8,8 +8,8 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	controlplanecomponent "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/rhobsmonitoring"
-	"github.com/openshift/hypershift/support/util"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,13 +48,13 @@ func TestAdaptDeployment(t *testing.T) {
 				))
 
 				// Verify the secret name for provider-creds
-				providerCredsVolume := util.FindVolume("provider-creds", deploymentObj.Spec.Template.Spec.Volumes)
+				providerCredsVolume := podspec.FindVolume("provider-creds", deploymentObj.Spec.Template.Spec.Volumes)
 				g.Expect(providerCredsVolume).ToNot(BeNil())
 				g.Expect(providerCredsVolume.VolumeSource.Secret).ToNot(BeNil())
 				g.Expect(providerCredsVolume.VolumeSource.Secret.SecretName).To(Equal("karpenter-credentials"))
 
 				// Verify container configuration
-				container := util.FindContainer(ComponentName, deploymentObj.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deploymentObj.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil(), "container %s should exist", ComponentName)
 				g.Expect(container.Image).To(Equal("quay.io/hypershift/operator:latest"))
 
@@ -104,7 +104,7 @@ func TestAdaptDeployment(t *testing.T) {
 				err = opts.adaptDeployment(cpContext, deploymentObj)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				container := util.FindContainer(ComponentName, deploymentObj.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deploymentObj.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil(), "container %s should exist", ComponentName)
 				g.Expect(container.Args).To(ContainElement("--control-plane-operator-image=quay.io/hypershift/cpo:v1.0"))
 			},
@@ -124,7 +124,7 @@ func TestAdaptDeployment(t *testing.T) {
 				err = opts.adaptDeployment(cpContext, deploymentObj)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				container := util.FindContainer(ComponentName, deploymentObj.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deploymentObj.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil(), "container %s should exist", ComponentName)
 				g.Expect(container.Env).To(ContainElement(
 					corev1.EnvVar{
@@ -149,9 +149,9 @@ func TestAdaptDeployment(t *testing.T) {
 				err = opts.adaptDeployment(cpContext, deploymentObj)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				container := util.FindContainer(ComponentName, deploymentObj.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deploymentObj.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil(), "container %s should exist", ComponentName)
-				g.Expect(util.FindEnvVar(rhobsmonitoring.EnvironmentVariable, container.Env)).To(BeNil())
+				g.Expect(podspec.FindEnvVar(rhobsmonitoring.EnvironmentVariable, container.Env)).To(BeNil())
 			},
 		},
 		{
@@ -168,16 +168,16 @@ func TestAdaptDeployment(t *testing.T) {
 				g.Expect(err).ToNot(HaveOccurred())
 
 				// Verify NO provider-creds volume is added for non-AWS
-				g.Expect(util.FindVolume("provider-creds", deploymentObj.Spec.Template.Spec.Volumes)).To(BeNil())
+				g.Expect(podspec.FindVolume("provider-creds", deploymentObj.Spec.Template.Spec.Volumes)).To(BeNil())
 
-				container := util.FindContainer(ComponentName, deploymentObj.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deploymentObj.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil(), "container %s should exist", ComponentName)
 				g.Expect(container.Image).To(Equal("quay.io/hypershift/operator:latest"))
 
 				// Verify AWS-specific env vars are NOT present
-				g.Expect(util.FindEnvVar("AWS_SHARED_CREDENTIALS_FILE", container.Env)).To(BeNil())
-				g.Expect(util.FindEnvVar("AWS_REGION", container.Env)).To(BeNil())
-				g.Expect(util.FindEnvVar("AWS_SDK_LOAD_CONFIG", container.Env)).To(BeNil())
+				g.Expect(podspec.FindEnvVar("AWS_SHARED_CREDENTIALS_FILE", container.Env)).To(BeNil())
+				g.Expect(podspec.FindEnvVar("AWS_REGION", container.Env)).To(BeNil())
+				g.Expect(podspec.FindEnvVar("AWS_SDK_LOAD_CONFIG", container.Env)).To(BeNil())
 
 				// Verify basic args are set
 				g.Expect(container.Args).To(ContainElements(

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/deployment.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/util"
 
@@ -58,7 +59,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 	hcp := cpContext.HCP
 	updateMainContainer(&deployment.Spec.Template.Spec, hcp)
 
-	util.UpdateContainer("konnectivity-server", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer("konnectivity-server", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		serverCount := component.DefaultReplicas(hcp, &KubeAPIServer{}, ComponentName)
 		c.Args = append(c.Args,
 			"--server-count",
@@ -87,20 +88,20 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 	}
 
 	if hcp.Spec.Configuration.GetAuditPolicyConfig().Profile == configv1.NoneAuditProfileType {
-		util.RemoveContainer("audit-logs", &deployment.Spec.Template.Spec)
+		podspec.RemoveContainer("audit-logs", &deployment.Spec.Template.Spec)
 	}
 
 	// With managed etcd, we should wait for the known etcd client service name to
 	// at least resolve before starting up to avoid futile connection attempts and
 	// pod crashing. For unmanaged, make no assumptions.
 	if hcp.Spec.Etcd.ManagementType == hyperv1.Unmanaged {
-		util.RemoveInitContainer("wait-for-etcd", &deployment.Spec.Template.Spec)
+		podspec.RemoveInitContainer("wait-for-etcd", &deployment.Spec.Template.Spec)
 	}
 
 	// If the built-in OAuth stack is not enabled, there is no need to do the auth-related
 	// bootstrapping step.
 	if hcp.Spec.Configuration != nil && !util.ConfigOAuthEnabled(hcp.Spec.Configuration.Authentication) {
-		util.RemoveInitContainer("init-auth-bootstrap-render", &deployment.Spec.Template.Spec)
+		podspec.RemoveInitContainer("init-auth-bootstrap-render", &deployment.Spec.Template.Spec)
 	}
 
 	if portieris, ok := hcp.Annotations[hyperv1.PortierisImageAnnotation]; ok {
@@ -163,7 +164,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 }
 
 func updateMainContainer(podSpec *corev1.PodSpec, hcp *hyperv1.HostedControlPlane) {
-	util.UpdateContainer(ComponentName, podSpec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, podSpec.Containers, func(c *corev1.Container) {
 		c.Ports[0].ContainerPort = util.KASPodPort(hcp)
 
 		kasVerbosityLevel := 2
@@ -246,7 +247,7 @@ func updateMainContainer(podSpec *corev1.PodSpec, hcp *hyperv1.HostedControlPlan
 func applyKASAuditWebhookConfigFileVolume(podSpec *corev1.PodSpec, auditWebhookRef *corev1.LocalObjectReference) {
 	podSpec.Volumes = append(podSpec.Volumes, buildKASAuditWebhookConfigFileVolume(auditWebhookRef))
 
-	util.UpdateContainer(ComponentName, podSpec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, podSpec.Containers, func(c *corev1.Container) {
 		c.VolumeMounts = append(c.VolumeMounts, kasAuditWebhookConfigFileVolumeMount.ContainerMounts(ComponentName)...)
 	})
 }
@@ -254,7 +255,7 @@ func applyKASAuditWebhookConfigFileVolume(podSpec *corev1.PodSpec, auditWebhookR
 func applyGenericSecretEncryptionConfig(podSpec *corev1.PodSpec) {
 	podSpec.Volumes = append(podSpec.Volumes, buildVolumeSecretEncryptionConfigFile())
 
-	util.UpdateContainer(ComponentName, podSpec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, podSpec.Containers, func(c *corev1.Container) {
 		c.Args = append(c.Args, fmt.Sprintf("--encryption-provider-config=%s/%s", genericSecretEncryptionConfigFileVolumeMount.Path(ComponentName, secretEncryptionConfigFileVolumeName), secretEncryptionConfigurationKey))
 
 		c.VolumeMounts = append(c.VolumeMounts, genericSecretEncryptionConfigFileVolumeMount.ContainerMounts(ComponentName)...)
@@ -280,7 +281,7 @@ func updateBootstrapInitContainer(deployment *appsv1.Deployment, hcp *hyperv1.Ho
 	}
 	featureGateYaml := featureGateBuffer.String()
 
-	util.UpdateContainer(name, deployment.Spec.Template.Spec.InitContainers, func(c *corev1.Container) {
+	podspec.UpdateContainer(name, deployment.Spec.Template.Spec.InitContainers, func(c *corev1.Container) {
 		c.Env = append(c.Env,
 			corev1.EnvVar{
 				Name:  "PAYLOAD_VERSION",
@@ -471,7 +472,7 @@ const (
 )
 
 var (
-	volumeMounts = util.PodVolumeMounts{
+	volumeMounts = podspec.VolumeMounts{
 		ComponentName: {
 			workLogsVolumeName:                "/var/log/kube-apiserver",
 			authConfigVolumeName:              "/etc/kubernetes/auth",
@@ -492,19 +493,19 @@ var (
 		},
 	}
 
-	cloudProviderConfigVolumeMount = util.PodVolumeMounts{
+	cloudProviderConfigVolumeMount = podspec.VolumeMounts{
 		ComponentName: {
 			cloudConfigVolumeName: "/etc/kubernetes/cloud",
 		},
 	}
 
-	kasAuditWebhookConfigFileVolumeMount = util.PodVolumeMounts{
+	kasAuditWebhookConfigFileVolumeMount = podspec.VolumeMounts{
 		ComponentName: {
 			auditWebhookConfigFileVolumeName: "/etc/kubernetes/auditwebhook",
 		},
 	}
 
-	genericSecretEncryptionConfigFileVolumeMount = util.PodVolumeMounts{
+	genericSecretEncryptionConfigFileVolumeMount = podspec.VolumeMounts{
 		ComponentName: {
 			secretEncryptionConfigFileVolumeName: "/etc/kubernetes/secret-encryption",
 		},

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms.go
@@ -7,7 +7,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms"
 	"github.com/openshift/hypershift/support/api"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -28,7 +28,7 @@ func applyKMSConfig(podSpec *corev1.PodSpec, secretEncryptionData *hyperv1.Secre
 
 	podSpec.Containers = append(podSpec.Containers, kmsPodConfig.Containers...)
 	podSpec.Volumes = append(podSpec.Volumes, kmsPodConfig.Volumes...)
-	util.UpdateContainer(ComponentName, podSpec.Containers, kmsPodConfig.KASContainerMutate)
+	podspec.UpdateContainer(ComponentName, podSpec.Containers, kmsPodConfig.KASContainerMutate)
 
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms/aws.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms/aws.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/aws"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -30,7 +30,7 @@ const (
 )
 
 var (
-	awsKMSVolumeMounts = util.PodVolumeMounts{
+	awsKMSVolumeMounts = podspec.VolumeMounts{
 		KasMainContainerName: {
 			kasVolumeKMSSocket().Name: "/var/run",
 		},
@@ -141,16 +141,16 @@ func (p *awsKMSProvider) GenerateKMSPodConfig() (*KMSPodConfig, error) {
 	}
 
 	podConfig := &KMSPodConfig{}
-	podConfig.Containers = append(podConfig.Containers, util.BuildContainer(kasContainerAWSKMSTokenMinter(), buildKASContainerAWSKMSTokenMinter(p.tokenMinterImage)))
-	podConfig.Containers = append(podConfig.Containers, util.BuildContainer(kasContainerAWSKMSActive(), buildKASContainerAWSKMS(p.kmsImage, p.activeKey.ARN, p.awsRegion, fmt.Sprintf("%s/%s", awsKMSVolumeMounts.Path(KasMainContainerName, kasVolumeKMSSocket().Name), activeAWSKMSUnixSocketFileName), activeAWSKMSHealthPort)))
+	podConfig.Containers = append(podConfig.Containers, podspec.BuildContainer(kasContainerAWSKMSTokenMinter(), buildKASContainerAWSKMSTokenMinter(p.tokenMinterImage)))
+	podConfig.Containers = append(podConfig.Containers, podspec.BuildContainer(kasContainerAWSKMSActive(), buildKASContainerAWSKMS(p.kmsImage, p.activeKey.ARN, p.awsRegion, fmt.Sprintf("%s/%s", awsKMSVolumeMounts.Path(KasMainContainerName, kasVolumeKMSSocket().Name), activeAWSKMSUnixSocketFileName), activeAWSKMSHealthPort)))
 	if p.backupKey != nil && len(p.backupKey.ARN) > 0 {
-		podConfig.Containers = append(podConfig.Containers, util.BuildContainer(kasContainerAWSKMSBackup(), buildKASContainerAWSKMS(p.kmsImage, p.backupKey.ARN, p.awsRegion, fmt.Sprintf("%s/%s", awsKMSVolumeMounts.Path(KasMainContainerName, kasVolumeKMSSocket().Name), backupAWSKMSUnixSocketFileName), backupAWSKMSHealthPort)))
+		podConfig.Containers = append(podConfig.Containers, podspec.BuildContainer(kasContainerAWSKMSBackup(), buildKASContainerAWSKMS(p.kmsImage, p.backupKey.ARN, p.awsRegion, fmt.Sprintf("%s/%s", awsKMSVolumeMounts.Path(KasMainContainerName, kasVolumeKMSSocket().Name), backupAWSKMSUnixSocketFileName), backupAWSKMSHealthPort)))
 	}
 
 	podConfig.Volumes = append(podConfig.Volumes,
-		util.BuildVolume(kasVolumeAWSKMSCredentials(), buildVolumeAWSKMSCredentials(aws.AWSKMSCredsSecret("").Name)),
-		util.BuildVolume(kasVolumeKMSSocket(), buildVolumeKMSSocket),
-		util.BuildVolume(kasVolumeAWSKMSCloudProviderToken(), buildKASVolumeAWSKMSCloudProviderToken),
+		podspec.BuildVolume(kasVolumeAWSKMSCredentials(), buildVolumeAWSKMSCredentials(aws.AWSKMSCredsSecret("").Name)),
+		podspec.BuildVolume(kasVolumeKMSSocket(), buildVolumeKMSSocket),
+		podspec.BuildVolume(kasVolumeAWSKMSCloudProviderToken(), buildKASVolumeAWSKMSCloudProviderToken),
 	)
 
 	podConfig.KASContainerMutate = func(c *corev1.Container) {
@@ -256,7 +256,7 @@ func buildKASContainerAWSKMSTokenMinter(image string) func(*corev1.Container) {
 			fmt.Sprintf("--service-account-namespace=%s", manifests.KASContainerAWSKMSProviderServiceAccount().Namespace),
 			fmt.Sprintf("--service-account-name=%s", manifests.KASContainerAWSKMSProviderServiceAccount().Name),
 			fmt.Sprintf("--token-file=%s", path.Join(awsKMSVolumeMounts.Path(c.Name, kasVolumeAWSKMSCloudProviderToken().Name), "token")),
-			fmt.Sprintf("--kubeconfig=%s", path.Join(awsKMSVolumeMounts.Path(c.Name, kasVolumeLocalhostKubeconfig), util.KubeconfigKey)),
+			fmt.Sprintf("--kubeconfig=%s", path.Join(awsKMSVolumeMounts.Path(c.Name, kasVolumeLocalhostKubeconfig), podspec.KubeconfigKey)),
 		}
 		c.Resources.Requests = corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("10m"),

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms/azure.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms/azure.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/secretproviderclass"
 	"github.com/openshift/hypershift/support/util"
 
@@ -36,7 +37,7 @@ const (
 )
 
 var (
-	azureKMSVolumeMounts = util.PodVolumeMounts{
+	azureKMSVolumeMounts = podspec.VolumeMounts{
 		KasMainContainerName: {
 			kasVolumeKMSSocket().Name: "/opt",
 		},
@@ -123,19 +124,19 @@ func (p *azureKMSProvider) GenerateKMSPodConfig() (*KMSPodConfig, error) {
 	podConfig := &KMSPodConfig{}
 
 	podConfig.Volumes = append(podConfig.Volumes,
-		util.BuildVolume(kasVolumeAzureKMSCredentials(), buildVolumeAzureKMSCredentials),
-		util.BuildVolume(kasVolumeKMSSocket(), buildVolumeKMSSocket),
-		util.BuildVolume(kasVolumeKMSSecretStore(), buildVolumeKMSSecretStore),
+		podspec.BuildVolume(kasVolumeAzureKMSCredentials(), buildVolumeAzureKMSCredentials),
+		podspec.BuildVolume(kasVolumeKMSSocket(), buildVolumeKMSSocket),
+		podspec.BuildVolume(kasVolumeKMSSecretStore(), buildVolumeKMSSecretStore),
 	)
 
 	podConfig.Containers = append(podConfig.Containers,
-		util.BuildContainer(
+		podspec.BuildContainer(
 			kasContainerAzureKMSActive(),
 			p.buildKASContainerAzureKMS(p.kmsSpec.ActiveKey, azureActiveKMSUnixSocket, azureActiveKMSHealthPort, azureActiveKMSMetricsAddr)),
 	)
 	if p.kmsSpec.BackupKey != nil {
 		podConfig.Containers = append(podConfig.Containers,
-			util.BuildContainer(
+			podspec.BuildContainer(
 				kasContainerAzureKMSBackup(),
 				p.buildKASContainerAzureKMS(*p.kmsSpec.BackupKey, azureBackupKMSUnixSocket, azureBackupKMSHealthPort, azureBackupKMSMetricsAddr)),
 		)

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms/ibmcloud.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kms/ibmcloud.go
@@ -9,7 +9,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	ibmCloudKMSVolumeMounts = util.PodVolumeMounts{
+	ibmCloudKMSVolumeMounts = podspec.VolumeMounts{
 		KasMainContainerName: {
 			kasVolumeKMSSocket().Name: "/tmp",
 		},
@@ -275,7 +275,7 @@ func (p *ibmCloudKMSProvider) GenerateKMSPodConfig() (*KMSPodConfig, error) {
 
 	podConfig := &KMSPodConfig{}
 
-	podConfig.Volumes = append(podConfig.Volumes, util.BuildVolume(kasVolumeKMSSocket(), buildVolumeKMSSocket), util.BuildVolume(kasVolumeIBMCloudKMSKP(), buildVolumeIBMCloudKMSKP), util.BuildVolume(kasVolumeIBMCloudKMSProjectedToken(), buildVolumeIBMCloudKMSProjectedToken))
+	podConfig.Volumes = append(podConfig.Volumes, podspec.BuildVolume(kasVolumeKMSSocket(), buildVolumeKMSSocket), podspec.BuildVolume(kasVolumeIBMCloudKMSKP(), buildVolumeIBMCloudKMSKP), podspec.BuildVolume(kasVolumeIBMCloudKMSProjectedToken(), buildVolumeIBMCloudKMSProjectedToken))
 	var customerAPIKeyReference *corev1.EnvVarSource
 	switch p.ibmCloud.Auth.Type {
 	case hyperv1.IBMCloudKMSUnmanagedAuth:
@@ -290,12 +290,12 @@ func (p *ibmCloudKMSProvider) GenerateKMSPodConfig() (*KMSPodConfig, error) {
 				Key: hyperv1.IBMCloudIAMAPIKeySecretKey,
 			},
 		}
-		podConfig.Volumes = append(podConfig.Volumes, util.BuildVolume(kasVolumeIBMCloudKMSCustomerCredentials(), buildVolumeIBMCloudKMSCustomerCredentials(p.ibmCloud.Auth.Unmanaged.Credentials.Name)))
+		podConfig.Volumes = append(podConfig.Volumes, podspec.BuildVolume(kasVolumeIBMCloudKMSCustomerCredentials(), buildVolumeIBMCloudKMSCustomerCredentials(p.ibmCloud.Auth.Unmanaged.Credentials.Name)))
 	case hyperv1.IBMCloudKMSManagedAuth:
 	default:
 		return nil, fmt.Errorf("unrecognized ibmcloud kms auth type %s", p.ibmCloud.Auth.Type)
 	}
-	podConfig.Containers = append(podConfig.Containers, util.BuildContainer(kasContainerIBMCloudKMS(), buildKASContainerIBMCloudKMS(p.kmsImage, p.ibmCloud.Region, kmsKPInfo, customerAPIKeyReference)))
+	podConfig.Containers = append(podConfig.Containers, podspec.BuildContainer(kasContainerIBMCloudKMS(), buildKASContainerIBMCloudKMS(p.kmsImage, p.ibmCloud.Region, kmsKPInfo, customerAPIKeyReference)))
 
 	podConfig.KASContainerMutate = func(c *corev1.Container) {
 		c.VolumeMounts = append(c.VolumeMounts, ibmCloudKMSVolumeMounts.ContainerMounts(KasMainContainerName)...)

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kubeconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/kubeconfig.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/util"
 
 	corev1 "k8s.io/api/core/v1"
@@ -22,7 +23,7 @@ import (
 )
 
 const (
-	KubeconfigKey = util.KubeconfigKey
+	KubeconfigKey = podspec.KubeconfigKey
 )
 
 func adaptServiceKubeconfigSecret(cpContext component.WorkloadContext, secret *corev1.Secret) error {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/portieries.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/portieries.go
@@ -1,7 +1,7 @@
 package kas
 
 import (
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -19,7 +19,7 @@ const (
 )
 
 var (
-	portieriesVolumeMounts = util.PodVolumeMounts{
+	portieriesVolumeMounts = podspec.VolumeMounts{
 		portierisContainerName: {
 			localhostKubeconfigVolumeName: "/etc/openshift/kubeconfig",
 			portierisCertsVolumeName:      "/etc/certs",

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kcm/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kcm/component.go
@@ -2,7 +2,7 @@ package kcm
 
 import (
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 )
 
 const (
@@ -33,7 +33,7 @@ func NewComponent() component.ControlPlaneComponent {
 			"servicemonitor.yaml",
 			component.WithAdaptFunction(adaptServiceMonitor),
 		).
-		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{}).
+		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{}).
 		Build()
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kcm/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kcm/deployment.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
 	"github.com/openshift/hypershift/support/util"
 
@@ -30,7 +31,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		return err
 	}
 
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Args = append(c.Args,
 			fmt.Sprintf("--cluster-cidr=%s", util.FirstClusterCIDR(hcp.Spec.Networking.ClusterNetwork)),
 			fmt.Sprintf("--service-cluster-ip-range=%s", util.FirstServiceCIDR(hcp.Spec.Networking.ServiceNetwork)),

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kcm/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kcm/deployment_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openshift/hypershift/api/util/ipnet"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -56,7 +56,7 @@ func TestAdaptDeployment(t *testing.T) {
 				g := NewWithT(t)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				container := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil())
 				g.Expect(container.Args).To(ContainElement("--cluster-cidr=10.132.0.0/14"))
 				g.Expect(container.Args).To(ContainElement("--service-cluster-ip-range=172.31.0.0/16"))
@@ -87,7 +87,7 @@ func TestAdaptDeployment(t *testing.T) {
 				g := NewWithT(t)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				container := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil())
 				g.Expect(container.Args).To(ContainElement("--cloud-provider=external"))
 			},
@@ -115,7 +115,7 @@ func TestAdaptDeployment(t *testing.T) {
 				g := NewWithT(t)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				container := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil())
 				g.Expect(container.Args).To(ContainElement("--allocate-node-cidrs=true"))
 			},
@@ -143,7 +143,7 @@ func TestAdaptDeployment(t *testing.T) {
 				g := NewWithT(t)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				container := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil())
 				g.Expect(container.Args).To(ContainElement("--allocate-node-cidrs=false"))
 			},
@@ -170,7 +170,7 @@ func TestAdaptDeployment(t *testing.T) {
 				g := NewWithT(t)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				container := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil())
 				g.Expect(container.Args).To(ContainElement("--allocate-node-cidrs=false"))
 			},
@@ -200,7 +200,7 @@ func TestAdaptDeployment(t *testing.T) {
 				g := NewWithT(t)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				container := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil())
 				g.Expect(container.Args).To(ContainElement("--node-monitor-grace-period=55s"))
 			},
@@ -230,7 +230,7 @@ func TestAdaptDeployment(t *testing.T) {
 				g := NewWithT(t)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				container := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil())
 				g.Expect(container.Args).To(ContainElement("--node-monitor-grace-period=50s"))
 			},
@@ -264,7 +264,7 @@ func TestAdaptDeployment(t *testing.T) {
 				g := NewWithT(t)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				container := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil())
 
 				tlsProfile := &configv1.TLSSecurityProfile{
@@ -304,7 +304,7 @@ func TestAdaptDeployment(t *testing.T) {
 				g := NewWithT(t)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				container := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil())
 				g.Expect(container.Args).To(ContainElement("--profiling=false"))
 			},
@@ -355,7 +355,7 @@ func TestAdaptDeployment(t *testing.T) {
 				g := NewWithT(t)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				container := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil())
 				g.Expect(container.Args).To(ContainElement("--feature-gates=FeatureGate1=true"))
 				g.Expect(container.Args).To(ContainElement("--feature-gates=FeatureGate2=false"))
@@ -395,15 +395,15 @@ func TestAdaptDeployment(t *testing.T) {
 				g.Expect(err).ToNot(HaveOccurred())
 
 				// Check volume is added
-				vol := util.FindVolume("service-serving-ca", deployment.Spec.Template.Spec.Volumes)
+				vol := podspec.FindVolume("service-serving-ca", deployment.Spec.Template.Spec.Volumes)
 				g.Expect(vol).ToNot(BeNil(), "service-serving-ca volume should be added")
 				g.Expect(vol.VolumeSource.ConfigMap).ToNot(BeNil())
 				g.Expect(vol.VolumeSource.ConfigMap.Name).To(Equal("service-serving-ca"))
 
 				// Check volume mount is added
-				container := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil())
-				mount := util.FindVolumeMount("service-serving-ca", container.VolumeMounts)
+				mount := podspec.FindVolumeMount("service-serving-ca", container.VolumeMounts)
 				g.Expect(mount).ToNot(BeNil(), "service-serving-ca volume mount should be added")
 				g.Expect(mount.MountPath).To(Equal("/etc/kubernetes/certs/service-ca"))
 			},
@@ -432,12 +432,12 @@ func TestAdaptDeployment(t *testing.T) {
 				g.Expect(err).ToNot(HaveOccurred())
 
 				// Check volume is not added
-				g.Expect(util.FindVolume("service-serving-ca", deployment.Spec.Template.Spec.Volumes)).To(BeNil())
+				g.Expect(podspec.FindVolume("service-serving-ca", deployment.Spec.Template.Spec.Volumes)).To(BeNil())
 
 				// Check volume mount is not added
-				container := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil())
-				g.Expect(util.FindVolumeMount("service-serving-ca", container.VolumeMounts)).To(BeNil())
+				g.Expect(podspec.FindVolumeMount("service-serving-ca", container.VolumeMounts)).To(BeNil())
 			},
 		},
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kcm/kubeconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kcm/kubeconfig.go
@@ -6,7 +6,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	kasv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/kas"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -20,6 +20,6 @@ func adaptKubeconfig(cpContext component.WorkloadContext, secret *corev1.Secret)
 	if secret.Data == nil {
 		secret.Data = map[string][]byte{}
 	}
-	secret.Data[util.KubeconfigKey] = kubeconfig
+	secret.Data[podspec.KubeconfigKey] = kubeconfig
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kcm/kubeconfig_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kcm/kubeconfig_test.go
@@ -8,7 +8,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,8 +54,8 @@ func TestAdaptKubeconfig(t *testing.T) {
 			validate: func(t *testing.T, secret *corev1.Secret, err error) {
 				g := NewWithT(t)
 				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(secret.Data).To(HaveKey(util.KubeconfigKey))
-				g.Expect(secret.Data[util.KubeconfigKey]).ToNot(BeEmpty())
+				g.Expect(secret.Data).To(HaveKey(podspec.KubeconfigKey))
+				g.Expect(secret.Data[podspec.KubeconfigKey]).ToNot(BeEmpty())
 			},
 		},
 		{
@@ -86,7 +86,7 @@ func TestAdaptKubeconfig(t *testing.T) {
 				g := NewWithT(t)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(secret.Data).ToNot(BeNil())
-				g.Expect(secret.Data).To(HaveKey(util.KubeconfigKey))
+				g.Expect(secret.Data).To(HaveKey(podspec.KubeconfigKey))
 			},
 		},
 		{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/konnectivity_agent/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/konnectivity_agent/deployment.go
@@ -6,6 +6,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/util"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -21,7 +22,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		ips = append(ips, fmt.Sprintf("ipv4=%s", cpContext.InfraStatus.OauthAPIServerHost))
 	}
 
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		if image, ok := cpContext.HCP.Annotations[hyperv1.KonnectivityAgentImageAnnotation]; ok {
 			c.Image = image
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/konnectivity_agent/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/konnectivity_agent/deployment_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	"github.com/openshift/hypershift/support/api"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -142,7 +142,7 @@ func TestAdaptDeployment(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// Verify container exists
-			konnectivityContainer := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+			konnectivityContainer := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 			g.Expect(konnectivityContainer).ToNot(BeNil(), "konnectivity-agent container should exist")
 
 			// Verify image

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/component.go
@@ -2,7 +2,7 @@ package scheduler
 
 import (
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 )
 
 const (
@@ -40,6 +40,6 @@ func NewComponent() component.ControlPlaneComponent {
 			"kubeconfig.yaml",
 			component.WithAdaptFunction(adaptKubeconfig),
 		).
-		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{}).
+		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{}).
 		Build()
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/deployment.go
@@ -7,6 +7,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/util"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -19,7 +20,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		return err
 	}
 	configuration := cpContext.HCP.Spec.Configuration
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		if tlsMinVersion := config.MinTLSVersion(configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {
 			c.Args = append(c.Args, fmt.Sprintf("--tls-min-version=%s", tlsMinVersion))
 		}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/kubeconfig.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/kubeconfig.go
@@ -6,7 +6,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	kasv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/kas"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -18,6 +18,6 @@ func adaptKubeconfig(cpContext component.WorkloadContext, secret *corev1.Secret)
 		return fmt.Errorf("failed to generate kubeconfig: %w", err)
 	}
 
-	secret.Data[util.KubeconfigKey] = kubeconfig
+	secret.Data[podspec.KubeconfigKey] = kubeconfig
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/machine_approver/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/machine_approver/component.go
@@ -6,7 +6,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -41,7 +41,7 @@ func NewComponent() component.ControlPlaneComponent {
 	return component.NewDeploymentComponent(ComponentName, &machineApprover{}).
 		WithAdaptFunction(adaptDeployment).
 		WithPredicate(predicate).
-		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{}).
+		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{}).
 		Build()
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/machine_approver/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/machine_approver/deployment.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -15,7 +15,7 @@ import (
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
 	hcp := cpContext.HCP
 	configuration := hcp.Spec.Configuration
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Args = append(c.Args, fmt.Sprintf("--machine-namespace=%s", hcp.Namespace))
 
 		if tlsMinVersion := config.MinTLSVersion(configuration.GetTLSSecurityProfile()); tlsMinVersion != "" {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/metrics_proxy/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/metrics_proxy/deployment.go
@@ -6,7 +6,7 @@ import (
 
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/metrics"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -31,7 +31,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		return fmt.Errorf("failed to build cert volumes: %w", err)
 	}
 
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		c.Args = append(c.Args,
 			"--metrics-set", string(metricsSet),
 		)

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/nto/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/nto/deployment.go
@@ -2,20 +2,20 @@ package nto
 
 import (
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
-		util.UpsertEnvVar(c, corev1.EnvVar{
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+		podspec.UpsertEnvVar(c, corev1.EnvVar{
 			Name:  "RELEASE_VERSION",
 			Value: cpContext.UserReleaseImageProvider.Version(),
 		})
 
-		util.UpsertEnvVar(c, corev1.EnvVar{
+		podspec.UpsertEnvVar(c, corev1.EnvVar{
 			Name:  "CLUSTER_NODE_TUNED_IMAGE",
 			Value: cpContext.UserReleaseImageProvider.GetImage(ComponentName),
 		})

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/nto/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/nto/deployment_test.go
@@ -8,8 +8,8 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/testutil"
-	"github.com/openshift/hypershift/support/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -73,11 +73,11 @@ func TestAdaptDeployment(t *testing.T) {
 			g.Expect(deployment.Spec.Template.Spec.Containers).ToNot(BeEmpty())
 			container := deployment.Spec.Template.Spec.Containers[0]
 
-			releaseVersionEnv := util.FindEnvVar("RELEASE_VERSION", container.Env)
+			releaseVersionEnv := podspec.FindEnvVar("RELEASE_VERSION", container.Env)
 			g.Expect(releaseVersionEnv).ToNot(BeNil())
 			g.Expect(releaseVersionEnv.Value).To(Equal(tc.expectedReleaseVersionEnv))
 
-			clusterNodeTunedImageEnv := util.FindEnvVar("CLUSTER_NODE_TUNED_IMAGE", container.Env)
+			clusterNodeTunedImageEnv := podspec.FindEnvVar("CLUSTER_NODE_TUNED_IMAGE", container.Env)
 			g.Expect(clusterNodeTunedImageEnv).ToNot(BeNil())
 			g.Expect(clusterNodeTunedImageEnv.Value).To(Equal(tc.expectedClusterNodeTunedEnv))
 		})

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oapi/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oapi/component.go
@@ -3,7 +3,7 @@ package oapi
 import (
 	kasv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/kas"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 )
 
 const (
@@ -52,6 +52,6 @@ func NewComponent() component.ControlPlaneComponent {
 		InjectKonnectivityContainer(component.KonnectivityContainerOptions{
 			Mode: component.HTTPS,
 		}).
-		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{}).
+		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{}).
 		Build()
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oapi/deployment.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/util"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -55,12 +56,12 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		config.AuditWebhookService,
 	}
 
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		if !util.HCPOAuthEnabled(cpContext.HCP) {
 			c.Args = append(c.Args, "--internal-oauth-disabled=true")
 		}
 
-		util.UpsertEnvVar(c, corev1.EnvVar{
+		podspec.UpsertEnvVar(c, corev1.EnvVar{
 			Name:  "NO_PROXY",
 			Value: strings.Join(noProxy, ","),
 		})
@@ -77,7 +78,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 	})
 
 	if cpContext.HCP.Spec.Configuration.GetAuditPolicyConfig().Profile == configv1.NoneAuditProfileType {
-		util.RemoveContainer("audit-logs", &deployment.Spec.Template.Spec)
+		podspec.RemoveContainer("audit-logs", &deployment.Spec.Template.Spec)
 	}
 
 	serviceServingCA, err := getServiceServingCA(cpContext)
@@ -96,7 +97,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 			},
 		})
 
-		util.UpdateContainer("oas-trust-anchor-generator", deployment.Spec.Template.Spec.InitContainers, func(c *corev1.Container) {
+		podspec.UpdateContainer("oas-trust-anchor-generator", deployment.Spec.Template.Spec.InitContainers, func(c *corev1.Container) {
 			c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{
 				Name:      "kube-controller-manager",
 				MountPath: "/run/service-ca-signer",
@@ -111,7 +112,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 	kasLivezURL := kas.InClusterKASURL(cpContext.HCP.Spec.Platform.Type) + "/livez"
 	deployment.Spec.Template.Spec.Containers = append(
 		deployment.Spec.Template.Spec.Containers,
-		util.KASReadinessCheckContainer(kasLivezURL),
+		podspec.KASReadinessCheckContainer(kasLivezURL),
 	)
 
 	return nil
@@ -125,7 +126,7 @@ func applyAuditWebhookConfigFileVolume(podSpec *corev1.PodSpec, auditWebhookRef 
 		},
 	})
 
-	util.UpdateContainer(ComponentName, podSpec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, podSpec.Containers, func(c *corev1.Container) {
 		c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{
 			Name:      auditWebhookConfigFileVolumeName,
 			MountPath: "/etc/kubernetes/auditwebhook",

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/component.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	oapiv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/oapi"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/util"
 
 	"k8s.io/utils/ptr"
@@ -78,7 +79,7 @@ func NewComponent() component.ControlPlaneComponent {
 				ConnectDirectlyToCloudAPIs: ptr.To(true),
 			},
 		}).
-		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{}).
+		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{}).
 		Build()
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/deployment.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -34,7 +34,7 @@ const (
 )
 
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		if cpContext.HCP.Spec.AuditWebhook != nil && len(cpContext.HCP.Spec.AuditWebhook.Name) > 0 {
 			c.Args = append(c.Args, fmt.Sprintf("--audit-webhook-config-file=%s", path.Join("/etc/kubernetes/auditwebhook", hyperv1.AuditWebhookKubeconfigKey)))
 			c.Args = append(c.Args, "--audit-webhook-mode=batch")
@@ -58,7 +58,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 				manifests.KubeAPIServerService("").Name, config.AuditWebhookService,
 				"iam.cloud.ibm.com", "iam.test.cloud.ibm.com",
 			}
-			util.UpsertEnvVar(c, corev1.EnvVar{
+			podspec.UpsertEnvVar(c, corev1.EnvVar{
 				Name:  "NO_PROXY",
 				Value: strings.Join(noProxy, ","),
 			})
@@ -67,7 +67,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 
 	configuration := cpContext.HCP.Spec.Configuration
 	if configuration.GetAuditPolicyConfig().Profile == configv1.NoneAuditProfileType {
-		util.RemoveContainer("audit-logs", &deployment.Spec.Template.Spec)
+		podspec.RemoveContainer("audit-logs", &deployment.Spec.Template.Spec)
 	}
 
 	if namedCertificates := configuration.GetNamedCertificates(); len(namedCertificates) > 0 {
@@ -77,17 +77,17 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 	if configuration != nil && configuration.OAuth != nil {
 		oauthTemplates := configuration.OAuth.Templates
 		if oauthTemplates.Error.Name != "" {
-			util.UpdateVolume(oauthErrorTemplateVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
+			podspec.UpdateVolume(oauthErrorTemplateVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
 				v.Secret.SecretName = oauthTemplates.Error.Name
 			})
 		}
 		if oauthTemplates.Login.Name != "" {
-			util.UpdateVolume(oauthLoginTemplateVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
+			podspec.UpdateVolume(oauthLoginTemplateVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
 				v.Secret.SecretName = oauthTemplates.Login.Name
 			})
 		}
 		if oauthTemplates.ProviderSelection.Name != "" {
-			util.UpdateVolume(oauthProvidersTemplateVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
+			podspec.UpdateVolume(oauthProvidersTemplateVolumeName, deployment.Spec.Template.Spec.Volumes, func(v *corev1.Volume) {
 				v.Secret.SecretName = oauthTemplates.ProviderSelection.Name
 			})
 		}
@@ -99,7 +99,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 			// A condition will be set on the HC to indicate the error
 			if len(volumeMountInfo.Volumes) > 0 {
 				deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, volumeMountInfo.Volumes...)
-				util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+				podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 					c.VolumeMounts = append(c.VolumeMounts, volumeMountInfo.VolumeMounts.ContainerMounts(ComponentName)...)
 				})
 			}
@@ -123,7 +123,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 }
 
 func applyNamedCertificateMounts(certs []configv1.APIServerNamedServingCert, spec *corev1.PodSpec) {
-	util.UpdateContainer(ComponentName, spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, spec.Containers, func(c *corev1.Container) {
 		for i, namedCert := range certs {
 			volumeName := fmt.Sprintf("named-cert-%d", i+1)
 			spec.Volumes = append(spec.Volumes, corev1.Volume{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/idp_convert.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/idp_convert.go
@@ -17,8 +17,8 @@ import (
 	manifests "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	kasv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/kas"
 	"github.com/openshift/hypershift/support/konnectivityproxy"
+	"github.com/openshift/hypershift/support/podspec"
 	supportproxy "github.com/openshift/hypershift/support/proxy"
-	"github.com/openshift/hypershift/support/util"
 
 	configv1 "github.com/openshift/api/config/v1"
 	osinv1 "github.com/openshift/api/osin/v1"
@@ -60,7 +60,7 @@ type idpData struct {
 
 type IDPVolumeMountInfo struct {
 	Container    string
-	VolumeMounts util.PodVolumeMounts
+	VolumeMounts podspec.VolumeMounts
 	Volumes      []corev1.Volume
 }
 
@@ -92,8 +92,8 @@ func ConvertIdentityProviders(ctx context.Context, identityProviders []configv1.
 	errs := []error{}
 	volumeMountInfo := &IDPVolumeMountInfo{
 		Container: ComponentName,
-		VolumeMounts: util.PodVolumeMounts{
-			ComponentName: util.ContainerVolumeMounts{},
+		VolumeMounts: podspec.VolumeMounts{
+			ComponentName: podspec.ContainerMounts{},
 		},
 	}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/idp_convert_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/idp_convert_test.go
@@ -12,7 +12,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	configv1 "github.com/openshift/api/config/v1"
 	osinv1 "github.com/openshift/api/osin/v1"
@@ -29,8 +29,8 @@ func TestOpenIDProviderConversion(t *testing.T) {
 	groupsInput := []configv1.OpenIDClaim{"groups"}
 	volumeMountInfo := &IDPVolumeMountInfo{
 		Container: ComponentName,
-		VolumeMounts: util.PodVolumeMounts{
-			ComponentName: util.ContainerVolumeMounts{},
+		VolumeMounts: podspec.VolumeMounts{
+			ComponentName: podspec.ContainerMounts{},
 		},
 	}
 	const namespace = "test"

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/component.go
@@ -4,6 +4,7 @@ import (
 	kasv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/kas"
 	oapiv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/oapi"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/util"
 
 	"k8s.io/utils/ptr"
@@ -46,7 +47,7 @@ func NewComponent() component.ControlPlaneComponent {
 			component.AdaptPodDisruptionBudget(),
 		).
 		WithDependencies(oapiv2.ComponentName).
-		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{}).
+		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{}).
 		InjectKonnectivityContainer(component.KonnectivityContainerOptions{
 			Mode: component.Socks5,
 			Socks5Options: component.Socks5Options{

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/deployment.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/util"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -38,7 +39,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		config.AuditWebhookService,
 	}
 
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		etcdURL := config.DefaultEtcdURL
 		if cpContext.HCP.Spec.Etcd.ManagementType == hyperv1.Unmanaged {
 			etcdURL = cpContext.HCP.Spec.Etcd.Unmanaged.Endpoint
@@ -62,14 +63,14 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 			c.Args = append(c.Args, fmt.Sprintf("--accesstoken-inactivity-timeout=%s", tokenInactivityTimeout))
 		}
 
-		util.UpsertEnvVar(c, corev1.EnvVar{
+		podspec.UpsertEnvVar(c, corev1.EnvVar{
 			Name:  "NO_PROXY",
 			Value: strings.Join(noProxy, ","),
 		})
 	})
 
 	if cpContext.HCP.Spec.Configuration.GetAuditPolicyConfig().Profile == configv1.NoneAuditProfileType {
-		util.RemoveContainer("audit-logs", &deployment.Spec.Template.Spec)
+		podspec.RemoveContainer("audit-logs", &deployment.Spec.Template.Spec)
 	}
 
 	if cpContext.HCP.Spec.AuditWebhook != nil && len(cpContext.HCP.Spec.AuditWebhook.Name) > 0 {
@@ -79,7 +80,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 	kasLivezURL := kas.InClusterKASURL(cpContext.HCP.Spec.Platform.Type) + "/livez"
 	deployment.Spec.Template.Spec.Containers = append(
 		deployment.Spec.Template.Spec.Containers,
-		util.KASReadinessCheckContainer(kasLivezURL),
+		podspec.KASReadinessCheckContainer(kasLivezURL),
 	)
 
 	return nil
@@ -93,7 +94,7 @@ func applyAuditWebhookConfigFileVolume(podSpec *corev1.PodSpec, auditWebhookRef 
 		},
 	})
 
-	util.UpdateContainer(ComponentName, podSpec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, podSpec.Containers, func(c *corev1.Container) {
 		c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{
 			Name:      auditWebhookConfigFileVolumeName,
 			MountPath: "/etc/kubernetes/auditwebhook",

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/deployment_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	"github.com/openshift/hypershift/support/api"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -58,7 +58,7 @@ func TestAdaptDeployment(t *testing.T) {
 				err := adaptDeployment(cpContext, deployment)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				container := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil())
 				g.Expect(container.Args).To(ContainElement("--etcd-servers=https://etcd-client:2379"))
 				g.Expect(container.Args).To(ContainElement("--api-audiences=https://test-issuer.example.com"))
@@ -97,12 +97,12 @@ func TestAdaptDeployment(t *testing.T) {
 				err := adaptDeployment(cpContext, deployment)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				container := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil())
 				g.Expect(container.Args).To(ContainElement("--etcd-servers=https://custom-etcd.example.com:2379"))
 
 				// Check NO_PROXY includes the custom etcd hostname
-				noProxyEnv := util.FindEnvVar("NO_PROXY", container.Env)
+				noProxyEnv := podspec.FindEnvVar("NO_PROXY", container.Env)
 				g.Expect(noProxyEnv).ToNot(BeNil())
 				g.Expect(noProxyEnv.Value).To(ContainSubstring("custom-etcd.example.com"))
 			},
@@ -145,7 +145,7 @@ func TestAdaptDeployment(t *testing.T) {
 				err := adaptDeployment(cpContext, deployment)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				container := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil())
 				g.Expect(container.Args).To(ContainElement("--tls-min-version=VersionTLS13"))
 			},
@@ -183,19 +183,19 @@ func TestAdaptDeployment(t *testing.T) {
 				err := adaptDeployment(cpContext, deployment)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				container := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil())
 				g.Expect(container.Args).To(ContainElement("--audit-webhook-config-file=/etc/kubernetes/auditwebhook/webhook-kubeconfig"))
 				g.Expect(container.Args).To(ContainElement("--audit-webhook-mode=batch"))
 				g.Expect(container.Args).To(ContainElement("--audit-webhook-initial-backoff=5s"))
 
 				// Check volume mount
-				volumeMount := util.FindVolumeMount(auditWebhookConfigFileVolumeName, container.VolumeMounts)
+				volumeMount := podspec.FindVolumeMount(auditWebhookConfigFileVolumeName, container.VolumeMounts)
 				g.Expect(volumeMount).ToNot(BeNil())
 				g.Expect(volumeMount.MountPath).To(Equal("/etc/kubernetes/auditwebhook"))
 
 				// Check volume
-				volume := util.FindVolume(auditWebhookConfigFileVolumeName, deployment.Spec.Template.Spec.Volumes)
+				volume := podspec.FindVolume(auditWebhookConfigFileVolumeName, deployment.Spec.Template.Spec.Volumes)
 				g.Expect(volume).ToNot(BeNil())
 				g.Expect(volume.VolumeSource.Secret).ToNot(BeNil())
 				g.Expect(volume.VolumeSource.Secret.SecretName).To(Equal("audit-webhook-secret"))
@@ -231,17 +231,17 @@ func TestAdaptDeployment(t *testing.T) {
 				err := adaptDeployment(cpContext, deployment)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				container := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil())
 				g.Expect(container.Args).ToNot(ContainElement(ContainSubstring("--audit-webhook-config-file")))
 				g.Expect(container.Args).ToNot(ContainElement("--audit-webhook-mode=batch"))
 
 				// Check volume mount doesn't exist
-				volumeMount := util.FindVolumeMount(auditWebhookConfigFileVolumeName, container.VolumeMounts)
+				volumeMount := podspec.FindVolumeMount(auditWebhookConfigFileVolumeName, container.VolumeMounts)
 				g.Expect(volumeMount).To(BeNil())
 
 				// Check volume doesn't exist
-				volume := util.FindVolume(auditWebhookConfigFileVolumeName, deployment.Spec.Template.Spec.Volumes)
+				volume := podspec.FindVolume(auditWebhookConfigFileVolumeName, deployment.Spec.Template.Spec.Volumes)
 				g.Expect(volume).To(BeNil())
 			},
 		},
@@ -284,7 +284,7 @@ func TestAdaptDeployment(t *testing.T) {
 				err := adaptDeployment(cpContext, deployment)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				container := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil())
 				g.Expect(container.Args).To(ContainElement("--accesstoken-inactivity-timeout=10m0s"))
 			},
@@ -324,7 +324,7 @@ func TestAdaptDeployment(t *testing.T) {
 				err := adaptDeployment(cpContext, deployment)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				container := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil())
 				g.Expect(container.Args).ToNot(ContainElement(ContainSubstring("--accesstoken-inactivity-timeout")))
 			},
@@ -359,7 +359,7 @@ func TestAdaptDeployment(t *testing.T) {
 				g.Expect(loadErr).ToNot(HaveOccurred())
 
 				// Verify audit-logs container exists in base manifest before adaptation
-				preContainer := util.FindContainer("audit-logs", deployment.Spec.Template.Spec.Containers)
+				preContainer := podspec.FindContainer("audit-logs", deployment.Spec.Template.Spec.Containers)
 				g.Expect(preContainer).ToNot(BeNil(), "audit-logs container should exist in base manifest")
 
 				cpContext := component.WorkloadContext{
@@ -370,7 +370,7 @@ func TestAdaptDeployment(t *testing.T) {
 				err := adaptDeployment(cpContext, deployment)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				container := util.FindContainer("audit-logs", deployment.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer("audit-logs", deployment.Spec.Template.Spec.Containers)
 				g.Expect(container).To(BeNil(), "audit-logs container should be removed after adaptation")
 			},
 		},
@@ -404,10 +404,10 @@ func TestAdaptDeployment(t *testing.T) {
 				err := adaptDeployment(cpContext, deployment)
 				g.Expect(err).ToNot(HaveOccurred())
 
-				container := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+				container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 				g.Expect(container).ToNot(BeNil())
 
-				noProxyEnv := util.FindEnvVar("NO_PROXY", container.Env)
+				noProxyEnv := podspec.FindEnvVar("NO_PROXY", container.Env)
 				g.Expect(noProxyEnv).ToNot(BeNil())
 				g.Expect(noProxyEnv.Value).To(ContainSubstring("kube-apiserver"))
 				g.Expect(noProxyEnv.Value).To(ContainSubstring("etcd-client"))
@@ -447,7 +447,7 @@ func TestAdaptDeployment(t *testing.T) {
 
 				// KAS readiness check container should be added
 				g.Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(originalContainerCount + 1))
-				kasReadinessContainer := util.FindContainer("kas-readiness-check", deployment.Spec.Template.Spec.Containers)
+				kasReadinessContainer := podspec.FindContainer("kas-readiness-check", deployment.Spec.Template.Spec.Containers)
 				g.Expect(kasReadinessContainer).ToNot(BeNil(), "kas-readiness-check container should be present")
 			},
 		},
@@ -482,7 +482,7 @@ func TestAdaptDeployment(t *testing.T) {
 				g.Expect(err).ToNot(HaveOccurred())
 
 				// Verify KAS readiness check container was added with /livez URL
-				kasReadinessContainer := util.FindContainer("kas-readiness-check", deployment.Spec.Template.Spec.Containers)
+				kasReadinessContainer := podspec.FindContainer("kas-readiness-check", deployment.Spec.Template.Spec.Containers)
 				g.Expect(kasReadinessContainer).ToNot(BeNil(), "KAS readiness check container should be present")
 				g.Expect(kasReadinessContainer.ReadinessProbe).ToNot(BeNil(), "KAS readiness check container should have a readiness probe")
 				g.Expect(kasReadinessContainer.ReadinessProbe.Exec).ToNot(BeNil(), "readiness probe should use exec")
@@ -538,17 +538,17 @@ func TestApplyAuditWebhookConfigFileVolume(t *testing.T) {
 			applyAuditWebhookConfigFileVolume(&deployment.Spec.Template.Spec, tc.auditWebhookRef)
 
 			// Check volume was added
-			volume := util.FindVolume(auditWebhookConfigFileVolumeName, deployment.Spec.Template.Spec.Volumes)
+			volume := podspec.FindVolume(auditWebhookConfigFileVolumeName, deployment.Spec.Template.Spec.Volumes)
 			g.Expect(volume).ToNot(BeNil())
 			g.Expect(volume.Name).To(Equal(tc.expectedVolume.Name))
 			g.Expect(volume.VolumeSource.Secret).ToNot(BeNil())
 			g.Expect(volume.VolumeSource.Secret.SecretName).To(Equal(tc.expectedVolume.VolumeSource.Secret.SecretName))
 
 			// Check volume mount was added to the component container
-			container := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+			container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 			g.Expect(container).ToNot(BeNil())
 
-			volumeMount := util.FindVolumeMount(auditWebhookConfigFileVolumeName, container.VolumeMounts)
+			volumeMount := podspec.FindVolumeMount(auditWebhookConfigFileVolumeName, container.VolumeMounts)
 			g.Expect(volumeMount).ToNot(BeNil())
 			g.Expect(volumeMount.MountPath).To(Equal(tc.expectedMountPath))
 		})
@@ -649,7 +649,7 @@ func TestAdaptDeploymentMultipleConfigurations(t *testing.T) {
 		err = adaptDeployment(cpContext, deployment)
 		g.Expect(err).ToNot(HaveOccurred())
 
-		container := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+		container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 		g.Expect(container).ToNot(BeNil())
 
 		// Check all configurations are applied
@@ -659,14 +659,14 @@ func TestAdaptDeploymentMultipleConfigurations(t *testing.T) {
 		g.Expect(container.Args).To(ContainElement("--tls-min-version=VersionTLS13"))
 
 		// Check volume and mount
-		volume := util.FindVolume(auditWebhookConfigFileVolumeName, deployment.Spec.Template.Spec.Volumes)
+		volume := podspec.FindVolume(auditWebhookConfigFileVolumeName, deployment.Spec.Template.Spec.Volumes)
 		g.Expect(volume).ToNot(BeNil())
 
-		volumeMount := util.FindVolumeMount(auditWebhookConfigFileVolumeName, container.VolumeMounts)
+		volumeMount := podspec.FindVolumeMount(auditWebhookConfigFileVolumeName, container.VolumeMounts)
 		g.Expect(volumeMount).ToNot(BeNil())
 
 		// Check NO_PROXY
-		noProxyEnv := util.FindEnvVar("NO_PROXY", container.Env)
+		noProxyEnv := podspec.FindEnvVar("NO_PROXY", container.Env)
 		g.Expect(noProxyEnv).ToNot(BeNil())
 		g.Expect(noProxyEnv.Value).To(ContainSubstring("custom-etcd.example.com"))
 	})

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/olm/catalog_operator/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/olm/catalog_operator/component.go
@@ -3,7 +3,7 @@ package catalogoperator
 import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -46,7 +46,7 @@ func NewComponent() component.ControlPlaneComponent {
 		InjectKonnectivityContainer(component.KonnectivityContainerOptions{
 			Mode: component.Socks5,
 		}).
-		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{
+		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{
 			KubeconfigVolumeName: "kubeconfig",
 			RequiredAPIs: []schema.GroupVersionKind{
 				{Group: "operators.coreos.com", Version: "v1alpha1", Kind: "CatalogSource"},

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/olm/catalog_operator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/olm/catalog_operator/deployment.go
@@ -5,7 +5,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -17,8 +17,8 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		noProxy = append(noProxy, "certified-operators", "community-operators", "redhat-operators", "redhat-marketplace")
 	}
 
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
-		util.UpsertEnvVars(c, []corev1.EnvVar{
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+		podspec.UpsertEnvVars(c, []corev1.EnvVar{
 			{Name: "RELEASE_VERSION", Value: cpContext.UserReleaseImageProvider.Version()},
 			{Name: "OLM_OPERATOR_IMAGE", Value: cpContext.ReleaseImageProvider.GetImage("operator-lifecycle-manager")},
 			{Name: "OPERATOR_REGISTRY_IMAGE", Value: cpContext.ReleaseImageProvider.GetImage("operator-registry")},

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/olm/catalog_operator/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/olm/catalog_operator/deployment_test.go
@@ -9,8 +9,8 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/testutil"
-	"github.com/openshift/hypershift/support/util"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,7 +81,7 @@ func TestAdaptDeployment(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// Verify environment variables
-			catalogOperatorContainer := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+			catalogOperatorContainer := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 			g.Expect(catalogOperatorContainer).ToNot(BeNil())
 
 			// Check RELEASE_VERSION

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/olm/catalogs/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/olm/catalogs/deployment.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
 	"github.com/openshift/hypershift/support/catalogs"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
 	"github.com/openshift/hypershift/support/util"
 
@@ -43,10 +44,10 @@ func (c *catalogOptions) adaptCatalogDeployment(cpContext component.WorkloadCont
 	}
 
 	if image != "" {
-		util.UpdateContainer("registry", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+		podspec.UpdateContainer("registry", deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 			c.Image = image
 		})
-		util.UpdateContainer("extract-content", deployment.Spec.Template.Spec.InitContainers, func(c *corev1.Container) {
+		podspec.UpdateContainer("extract-content", deployment.Spec.Template.Spec.InitContainers, func(c *corev1.Container) {
 			c.Image = image
 		})
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/olm/olm_operator/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/olm/olm_operator/component.go
@@ -3,7 +3,7 @@ package olmoperator
 import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -46,7 +46,7 @@ func NewComponent() component.ControlPlaneComponent {
 		InjectKonnectivityContainer(component.KonnectivityContainerOptions{
 			Mode: component.Socks5,
 		}).
-		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{
+		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{
 			KubeconfigVolumeName: "kubeconfig",
 			RequiredAPIs: []schema.GroupVersionKind{
 				{Group: "operators.coreos.com", Version: "v1alpha1", Kind: "CatalogSource"},

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/olm/olm_operator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/olm/olm_operator/deployment.go
@@ -5,7 +5,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -17,8 +17,8 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		noProxy = append(noProxy, "certified-operators", "community-operators", "redhat-operators", "redhat-marketplace")
 	}
 
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
-		util.UpsertEnvVars(c, []corev1.EnvVar{
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+		podspec.UpsertEnvVars(c, []corev1.EnvVar{
 			{Name: "RELEASE_VERSION", Value: cpContext.UserReleaseImageProvider.Version()},
 			{Name: "NO_PROXY", Value: strings.Join(noProxy, ",")},
 		})

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/olm/olm_operator/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/olm/olm_operator/deployment_test.go
@@ -9,8 +9,8 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/testutil"
-	"github.com/openshift/hypershift/support/util"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,7 +68,7 @@ func TestAdaptDeployment(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// Verify environment variables
-			olmOperatorContainer := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+			olmOperatorContainer := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 			g.Expect(olmOperatorContainer).ToNot(BeNil())
 
 			// Check RELEASE_VERSION

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/olm/packageserver/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/olm/packageserver/component.go
@@ -2,7 +2,7 @@ package packageserver
 
 import (
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -36,7 +36,7 @@ func NewComponent() component.ControlPlaneComponent {
 		InjectKonnectivityContainer(component.KonnectivityContainerOptions{
 			Mode: component.Socks5,
 		}).
-		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{
+		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{
 			KubeconfigVolumeName: "kubeconfig",
 			RequiredAPIs: []schema.GroupVersionKind{
 				{Group: "operators.coreos.com", Version: "v1alpha1", Kind: "CatalogSource"},

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/olm/packageserver/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/olm/packageserver/deployment.go
@@ -6,7 +6,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -21,8 +21,8 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 		noProxy = append(noProxy, "certified-operators", "community-operators", "redhat-operators", "redhat-marketplace")
 	}
 
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
-		util.UpsertEnvVars(c, []corev1.EnvVar{
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+		podspec.UpsertEnvVars(c, []corev1.EnvVar{
 			{Name: "RELEASE_VERSION", Value: cpContext.UserReleaseImageProvider.Version()},
 			{Name: "NO_PROXY", Value: strings.Join(noProxy, ",")},
 		})
@@ -35,7 +35,7 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 	kasLivezURL := kas.InClusterKASURL(hcp.Spec.Platform.Type) + "/livez"
 	deployment.Spec.Template.Spec.Containers = append(
 		deployment.Spec.Template.Spec.Containers,
-		util.KASReadinessCheckContainer(kasLivezURL),
+		podspec.KASReadinessCheckContainer(kasLivezURL),
 	)
 
 	return nil

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/olm/packageserver/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/olm/packageserver/deployment_test.go
@@ -9,8 +9,8 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/testutil"
-	"github.com/openshift/hypershift/support/util"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -104,7 +104,7 @@ func TestAdaptDeployment(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// Verify environment variables
-			packageServerContainer := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+			packageServerContainer := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 			g.Expect(packageServerContainer).ToNot(BeNil())
 
 			// Check RELEASE_VERSION
@@ -142,7 +142,7 @@ func TestAdaptDeployment(t *testing.T) {
 
 			// Verify KAS readiness check container is added
 			if tc.expectedKASReadinessCheck {
-				kasReadinessContainer := util.FindContainer("kas-readiness-check", deployment.Spec.Template.Spec.Containers)
+				kasReadinessContainer := podspec.FindContainer("kas-readiness-check", deployment.Spec.Template.Spec.Containers)
 				g.Expect(kasReadinessContainer).ToNot(BeNil(), "KAS readiness check container should be present")
 			}
 		})

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/pkioperator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/pkioperator/deployment.go
@@ -2,22 +2,22 @@ package pkioperator
 
 import (
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
-	"github.com/openshift/hypershift/support/util"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
 func (p *pkiOperator) adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		proxy.SetEnvVars(&c.Env)
 
-		util.UpsertEnvVar(c, corev1.EnvVar{
+		podspec.UpsertEnvVar(c, corev1.EnvVar{
 			Name:  "HOSTED_CONTROL_PLANE_NAME",
 			Value: cpContext.HCP.Name,
 		})
-		util.UpsertEnvVar(c, corev1.EnvVar{
+		podspec.UpsertEnvVar(c, corev1.EnvVar{
 			Name:  "CERT_ROTATION_SCALE",
 			Value: p.certRotationScale.String(),
 		})

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/pkioperator/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/pkioperator/deployment_test.go
@@ -9,7 +9,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -157,7 +157,7 @@ func TestAdaptDeployment(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// Find the control-plane-pki-operator container
-			pkiContainer := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+			pkiContainer := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 			g.Expect(pkiContainer).ToNot(BeNil(), "control-plane-pki-operator container should exist")
 
 			tc.validate(g, pkiContainer)
@@ -195,7 +195,7 @@ func TestAdaptDeploymentCombinedEnvVars(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// Find the control-plane-pki-operator container
-	pkiContainer := util.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+	pkiContainer := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
 	g.Expect(pkiContainer).ToNot(BeNil())
 
 	t.Run("When all configuration is set, it should include all environment variables", func(t *testing.T) {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/registryoperator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/registryoperator/deployment.go
@@ -4,19 +4,19 @@ import (
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
-	"github.com/openshift/hypershift/support/util"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		proxy.SetEnvVars(&c.Env)
 
 		version := cpContext.UserReleaseImageProvider.Version()
-		util.UpsertEnvVars(c, []corev1.EnvVar{
+		podspec.UpsertEnvVars(c, []corev1.EnvVar{
 			{Name: "RELEASE_VERSION", Value: version},
 			{Name: "OPERATOR_IMAGE_VERSION", Value: version},
 			{Name: "OPERATOR_IMAGE", Value: cpContext.ReleaseImageProvider.GetImage("cluster-image-registry-operator")},

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/snapshotcontroller/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/snapshotcontroller/component.go
@@ -6,7 +6,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	oapiv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/oapi"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -43,7 +43,7 @@ func NewComponent() component.ControlPlaneComponent {
 		WithAdaptFunction(adaptDeployment).
 		WithPredicate(isStorageAndCSIManaged).
 		WithDependencies(oapiv2.ComponentName).
-		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{
+		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{
 			KubeconfigVolumeName: "guest-kubeconfig",
 			RequiredAPIs: []schema.GroupVersionKind{
 				{Group: "operator.openshift.io", Version: "v1", Kind: "CSISnapshotController"},
@@ -76,7 +76,7 @@ func checkOperandsRolloutStatus(cpContext component.WorkloadContext) (bool, erro
 		}
 	}
 
-	if !util.IsDeploymentReady(cpContext, deployment) {
+	if !podspec.IsDeploymentReady(cpContext, deployment) {
 		return false, fmt.Errorf("deployment csi-snapshot-controller is not ready")
 	}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/snapshotcontroller/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/snapshotcontroller/deployment.go
@@ -4,14 +4,14 @@ import (
 	"strconv"
 
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		for i, env := range c.Env {
 			switch env.Name {
 			case "OPERATOR_IMAGE_VERSION":

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/storage/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/storage/component.go
@@ -8,7 +8,7 @@ import (
 	oapiv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/oapi"
 	"github.com/openshift/hypershift/support/azureutil"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -65,7 +65,7 @@ func NewComponent() component.ControlPlaneComponent {
 			component.WithPredicate(isAroHCP),
 		).
 		WithDependencies(oapiv2.ComponentName).
-		InjectAvailabilityProberContainer(util.AvailabilityProberOpts{
+		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{
 			KubeconfigVolumeName: "guest-kubeconfig",
 			RequiredAPIs: []schema.GroupVersionKind{
 				{Group: "operator.openshift.io", Version: "v1", Kind: "Storage"},
@@ -153,7 +153,7 @@ func checkOperandsRolloutStatus(cpContext component.WorkloadContext) (bool, erro
 			}
 		}
 
-		if !util.IsDeploymentReady(cpContext, deployment) {
+		if !podspec.IsDeploymentReady(cpContext, deployment) {
 			errs = append(errs, fmt.Errorf("deployment %s is not ready", operand.DeploymentName))
 		}
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/storage/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/storage/deployment.go
@@ -6,14 +6,14 @@ import (
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
 func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Deployment) error {
-	util.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
+	podspec.UpdateContainer(ComponentName, deployment.Spec.Template.Spec.Containers, func(c *corev1.Container) {
 		envReplacer := newEnvironmentReplacer(cpContext.ReleaseImageProvider, cpContext.UserReleaseImageProvider)
 		envReplacer.replaceEnvVars(c.Env)
 

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/thirdparty/kubernetes/pkg/credentialprovider"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
@@ -351,16 +352,16 @@ func buildGlobalPSVolumeMounts(globalPullSecretName string) []corev1.VolumeMount
 	return volumeMounts
 }
 
-// buildGlobalPSVolumes creates volumes for the GlobalPullSecret DaemonSet using util.BuildVolume pattern
+// buildGlobalPSVolumes creates volumes for the GlobalPullSecret DaemonSet using podspec.BuildVolume pattern
 func buildGlobalPSVolumes(globalPullSecretName string, originalPullSecretName string) []corev1.Volume {
 	var volumes []corev1.Volume
 
-	volumes = append(volumes, util.BuildVolume(globalPSVolumeKubeletConfig(), buildGlobalPSVolumeKubeletConfig))
-	volumes = append(volumes, util.BuildVolume(globalPSVolumeDbus(), buildGlobalPSVolumeDbus))
-	volumes = append(volumes, util.BuildVolume(globalPSVolumeOriginalPullSecret(), buildGlobalPSVolumeOriginalPullSecret(originalPullSecretName)))
+	volumes = append(volumes, podspec.BuildVolume(globalPSVolumeKubeletConfig(), buildGlobalPSVolumeKubeletConfig))
+	volumes = append(volumes, podspec.BuildVolume(globalPSVolumeDbus(), buildGlobalPSVolumeDbus))
+	volumes = append(volumes, podspec.BuildVolume(globalPSVolumeOriginalPullSecret(), buildGlobalPSVolumeOriginalPullSecret(originalPullSecretName)))
 
 	if globalPullSecretName != "" {
-		volumes = append(volumes, util.BuildVolume(globalPSVolumeGlobalPullSecret(), buildGlobalPSVolumeGlobalPullSecret(globalPullSecretName)))
+		volumes = append(volumes, podspec.BuildVolume(globalPSVolumeGlobalPullSecret(), buildGlobalPSVolumeGlobalPullSecret(globalPullSecretName)))
 	}
 
 	return volumes

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/konnectivity/reconcile.go
@@ -6,7 +6,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -23,8 +23,8 @@ const (
 )
 
 var (
-	volumeMounts = util.PodVolumeMounts{
-		konnectivityAgentContainer().Name: util.ContainerVolumeMounts{
+	volumeMounts = podspec.VolumeMounts{
+		konnectivityAgentContainer().Name: podspec.ContainerMounts{
 			konnectivityVolumeAgentCerts().Name: "/etc/konnectivity/agent",
 			konnectivityVolumeCACert().Name:     "/etc/konnectivity/ca",
 		},
@@ -69,11 +69,11 @@ func ReconcileAgentDaemonSet(daemonset *appsv1.DaemonSet, params *KonnectivityPa
 					RunAsUser: ptr.To[int64](1000),
 				},
 				Containers: []corev1.Container{
-					util.BuildContainer(konnectivityAgentContainer(), buildKonnectivityWorkerAgentContainer(params.Image, params.ExternalAddress, params.ExternalPort, proxy, useHostNetwork)),
+					podspec.BuildContainer(konnectivityAgentContainer(), buildKonnectivityWorkerAgentContainer(params.Image, params.ExternalAddress, params.ExternalPort, proxy, useHostNetwork)),
 				},
 				Volumes: []corev1.Volume{
-					util.BuildVolume(konnectivityVolumeAgentCerts(), buildKonnectivityVolumeWorkerAgentCerts),
-					util.BuildVolume(konnectivityVolumeCACert(), buildKonnectivityVolumeCACert),
+					podspec.BuildVolume(konnectivityVolumeAgentCerts(), buildKonnectivityVolumeWorkerAgentCerts),
+					podspec.BuildVolume(konnectivityVolumeCACert(), buildKonnectivityVolumeCACert),
 				},
 				PriorityClassName: systemNodeCriticalPriorityClass,
 				// Always run, even if nodes are not ready e.G. because there are networking issues as this helps a lot in debugging

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -38,6 +38,7 @@ import (
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/events"
 	"github.com/openshift/hypershift/support/metrics"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/supportedversion"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/reference"
@@ -412,12 +413,12 @@ func NewStartCommand() *cobra.Command {
 		}
 
 		componentImages := map[string]string{
-			util.AvailabilityProberImageName: availabilityProberImage,
-			"hosted-cluster-config-operator": hostedClusterConfigOperatorImage,
-			"socks5-proxy":                   socks5ProxyImage,
-			"token-minter":                   tokenMinterImage,
-			util.CPOImageName:                cpoImage,
-			util.CPPKIOImageName:             cpoImage,
+			podspec.AvailabilityProberImageName: availabilityProberImage,
+			"hosted-cluster-config-operator":    hostedClusterConfigOperatorImage,
+			"socks5-proxy":                      socks5ProxyImage,
+			"token-minter":                      tokenMinterImage,
+			podspec.CPOImageName:                cpoImage,
+			podspec.CPPKIOImageName:             cpoImage,
 		}
 		for _, pair := range strings.Split(imageOverridesStr, ",") {
 			if pair == "" {

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -63,6 +63,7 @@ import (
 	"github.com/openshift/hypershift/support/infraid"
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/oidc"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/secretproviderclass"
 	"github.com/openshift/hypershift/support/supportedversion"
@@ -1984,7 +1985,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 
 	imageProvider := imageprovider.New(releaseImage)
 	imageProvider.ComponentImages()["token-minter"] = utilitiesImage
-	imageProvider.ComponentImages()[hyperutil.AvailabilityProberImageName] = utilitiesImage
+	imageProvider.ComponentImages()[podspec.AvailabilityProberImageName] = utilitiesImage
 
 	securityContextUID := controlplanecomponent.DefaultSecurityContextUID
 	if r.SetDefaultSecurityContext {

--- a/hypershift-operator/controllers/scheduler/aws/dedicated_request_serving_nodes.go
+++ b/hypershift-operator/controllers/scheduler/aws/dedicated_request_serving_nodes.go
@@ -10,6 +10,7 @@ import (
 	schedulingv1alpha1 "github.com/openshift/hypershift/api/scheduling/v1alpha1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster"
 	schedulerutil "github.com/openshift/hypershift/hypershift-operator/controllers/scheduler/util"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
 
@@ -616,7 +617,7 @@ func (r *DedicatedServingComponentSchedulerAndSizer) Reconcile(ctx context.Conte
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	if deployment != nil && util.IsDeploymentReady(ctx, deployment) {
+	if deployment != nil && podspec.IsDeploymentReady(ctx, deployment) {
 		log.Info("placeholder ready, adding node labels")
 		nodes, err := r.deploymentNodes(ctx, deployment)
 		if err != nil {
@@ -702,7 +703,7 @@ func (r *DedicatedServingComponentSchedulerAndSizer) nodesFromPlaceholders(ctx c
 		if d.Labels[hyperv1.HostedClusterSizeLabel] != size {
 			continue
 		}
-		if util.IsDeploymentReady(ctx, d) {
+		if podspec.IsDeploymentReady(ctx, d) {
 			deployment = d
 			break
 		}

--- a/hypershift-operator/controllers/sharedingress/router.go
+++ b/hypershift-operator/controllers/sharedingress/router.go
@@ -6,7 +6,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/images"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -51,8 +51,8 @@ func ReconcileRouterDeployment(deployment *appsv1.Deployment, hypershiftOperator
 			},
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
-					util.BuildContainer(ConfigGeneratorContainer(), buildConfigGeneratorContainer(hypershiftOperatorImage)),
-					util.BuildContainer(hcpRouterContainerMain(), buildHCPRouterContainerMain()),
+					podspec.BuildContainer(ConfigGeneratorContainer(), buildConfigGeneratorContainer(hypershiftOperatorImage)),
+					podspec.BuildContainer(hcpRouterContainerMain(), buildHCPRouterContainerMain()),
 				},
 				Volumes: []corev1.Volume{
 					{

--- a/karpenter-operator/controllers/karpenter/karpenter_controller.go
+++ b/karpenter-operator/controllers/karpenter/karpenter_controller.go
@@ -18,6 +18,7 @@ import (
 	supportassets "github.com/openshift/hypershift/support/assets"
 	controlplanecomponent "github.com/openshift/hypershift/support/controlplane-component"
 	karpenterutil "github.com/openshift/hypershift/support/karpenter"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
@@ -288,7 +289,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 	imageProvider := imageprovider.New(releaseImage)
 	imageProvider.ComponentImages()["token-minter"] = r.ControlPlaneOperatorImage
-	imageProvider.ComponentImages()[util.AvailabilityProberImageName] = r.ControlPlaneOperatorImage
+	imageProvider.ComponentImages()[podspec.AvailabilityProberImageName] = r.ControlPlaneOperatorImage
 
 	cpContext := controlplanecomponent.ControlPlaneContext{
 		Context:              ctx,

--- a/support/controlplane-component/builder.go
+++ b/support/controlplane-component/builder.go
@@ -1,7 +1,7 @@
 package controlplanecomponent
 
 import (
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -86,7 +86,7 @@ func (b *controlPlaneWorkloadBuilder[T]) InjectKonnectivityContainer(opts Konnec
 	return b
 }
 
-func (b *controlPlaneWorkloadBuilder[T]) InjectAvailabilityProberContainer(opts util.AvailabilityProberOpts) *controlPlaneWorkloadBuilder[T] {
+func (b *controlPlaneWorkloadBuilder[T]) InjectAvailabilityProberContainer(opts podspec.AvailabilityProberOpts) *controlPlaneWorkloadBuilder[T] {
 	b.workload.availabilityProberOpts = &opts
 	return b
 }

--- a/support/controlplane-component/controlplane-component.go
+++ b/support/controlplane-component/controlplane-component.go
@@ -11,6 +11,7 @@ import (
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/metrics"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
 
@@ -143,7 +144,7 @@ type controlPlaneWorkload[T client.Object] struct {
 	// if provided, konnectivity proxy container and required volumes will be injected into the deployment/statefulset.
 	konnectivityContainerOpts *KonnectivityContainerOptions
 	// if provided, availabilityProber container and required volumes will be injected into the deployment/statefulset.
-	availabilityProberOpts *util.AvailabilityProberOpts
+	availabilityProberOpts *podspec.AvailabilityProberOpts
 	// if provided, token-minter container and required volumes will be injected into the deployment/statefulset.
 	tokenMinterContainerOpts *TokenMinterContainerOptions
 	// serviceAccountKubeConfigOpts will cause the generation of a secret with a kubeconfig using certificates for the given named service account

--- a/support/controlplane-component/defaults.go
+++ b/support/controlplane-component/defaults.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	karpenterassets "github.com/openshift/hypershift/karpenter-operator/controllers/karpenter/assets"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/util"
 
 	corev1 "k8s.io/api/core/v1"
@@ -112,11 +113,11 @@ func (c *controlPlaneWorkload[T]) setDefaultOptions(cpContext ControlPlaneContex
 	}
 
 	if c.availabilityProberOpts != nil {
-		availabilityProberImage := cpContext.ReleaseImageProvider.GetImage(util.AvailabilityProberImageName)
-		util.AvailabilityProber(
+		availabilityProberImage := cpContext.ReleaseImageProvider.GetImage(podspec.AvailabilityProberImageName)
+		podspec.AvailabilityProber(
 			kas.InClusterKASReadyURL(hcp.Spec.Platform.Type), availabilityProberImage,
 			&podTemplateSpec.Spec,
-			util.WithOptions(c.availabilityProberOpts))
+			podspec.WithOptions(c.availabilityProberOpts))
 	}
 
 	enforceTerminationMessagePolicy(podTemplateSpec.Spec.InitContainers)
@@ -149,7 +150,7 @@ func (c *controlPlaneWorkload[T]) setDefaultOptions(cpContext ControlPlaneContex
 	// Containers that need specific capabilities (e.g., NET_BIND_SERVICE for haproxy)
 	// should declare them in their deployment templates, and they will be preserved.
 	if hcp.Spec.Platform.Type == hyperv1.GCPPlatform {
-		if err := util.EnforceRestrictedSecurityContextToContainers(&podTemplateSpec.Spec); err != nil {
+		if err := podspec.EnforceRestrictedSecurityContextToContainers(&podTemplateSpec.Spec); err != nil {
 			return fmt.Errorf("failed to enforce restricted security context: %w", err)
 		}
 	}
@@ -577,7 +578,7 @@ func enforceImagePullPolicy(containers []corev1.Container) error {
 
 func enforceReadOnlyRootFilesystem(podSpec *corev1.PodSpec) {
 	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
-		Name: util.PodTmpDirMountName,
+		Name: podspec.PodTmpDirMountName,
 		VolumeSource: corev1.VolumeSource{
 			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
@@ -591,11 +592,11 @@ func enforceReadOnlyRootFilesystemContainers(containers []corev1.Container) {
 			containers[i].SecurityContext = &corev1.SecurityContext{}
 		}
 		if !slices.ContainsFunc(containers[i].VolumeMounts, func(vm corev1.VolumeMount) bool {
-			return vm.MountPath == util.PodTmpDirMountPath
+			return vm.MountPath == podspec.PodTmpDirMountPath
 		}) {
 			containers[i].VolumeMounts = append(containers[i].VolumeMounts, corev1.VolumeMount{
-				Name:      util.PodTmpDirMountName,
-				MountPath: util.PodTmpDirMountPath,
+				Name:      podspec.PodTmpDirMountName,
+				MountPath: podspec.PodTmpDirMountPath,
 			})
 		}
 		containers[i].SecurityContext.ReadOnlyRootFilesystem = ptr.To(true)

--- a/support/controlplane-component/deployment.go
+++ b/support/controlplane-component/deployment.go
@@ -6,7 +6,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -111,7 +111,7 @@ func (d *deploymentProvider) IsAvailable(object *appsv1.Deployment) (status meta
 
 // IsReady implements WorkloadProvider.
 func (d *deploymentProvider) IsReady(object *appsv1.Deployment) (status metav1.ConditionStatus, reason string, message string) {
-	if util.IsDeploymentReady(context.TODO(), object) {
+	if podspec.IsDeploymentReady(context.TODO(), object) {
 		status = metav1.ConditionTrue
 		reason = hyperv1.AsExpectedReason
 		message = fmt.Sprintf("Deployment %s successfully rolled out", object.Name)

--- a/support/controlplane-component/konnectivity-container.go
+++ b/support/controlplane-component/konnectivity-container.go
@@ -6,8 +6,8 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
-	"github.com/openshift/hypershift/support/util"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -104,7 +104,7 @@ func (opts KonnectivityContainerOptions) injectKonnectivityContainer(cpContext C
 		})
 	}
 
-	image := cpContext.ReleaseImageProvider.GetImage(util.CPOImageName)
+	image := cpContext.ReleaseImageProvider.GetImage(podspec.CPOImageName)
 
 	if opts.Mode == Dual {
 		opts.Mode = HTTPS

--- a/support/controlplane-component/statefulset.go
+++ b/support/controlplane-component/statefulset.go
@@ -6,7 +6,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -60,7 +60,7 @@ func (s *statefulSetProvider) IsAvailable(object *appsv1.StatefulSet) (status me
 
 // IsReady implements WorkloadProvider.
 func (s *statefulSetProvider) IsReady(sts *appsv1.StatefulSet) (status metav1.ConditionStatus, reason string, message string) {
-	if util.IsStatefulSetReady(context.TODO(), sts) {
+	if podspec.IsStatefulSetReady(context.TODO(), sts) {
 		status = metav1.ConditionTrue
 		reason = hyperv1.AsExpectedReason
 		message = fmt.Sprintf("Statefulset %s successfully rolled out", sts.Name)

--- a/support/controlplane-component/status.go
+++ b/support/controlplane-component/status.go
@@ -7,7 +7,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -237,7 +237,7 @@ func (c *controlPlaneWorkload[T]) checkOperandsRolloutStatus(cpContext WorkloadC
 			errs = append(errs, fmt.Errorf("deployment %s/%s has version %s, expected %s", deployment.Namespace, deployment.Name, releaseVersion, expectedVersion))
 			continue
 		}
-		if !util.IsDeploymentReady(cpContext, &deployment) {
+		if !podspec.IsDeploymentReady(cpContext, &deployment) {
 			errs = append(errs, fmt.Errorf("deployment %s/%s is not ready", deployment.Namespace, deployment.Name))
 		}
 	}

--- a/support/controlplane-component/token-minter-container.go
+++ b/support/controlplane-component/token-minter-container.go
@@ -6,7 +6,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/azureutil"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -161,7 +161,7 @@ func (opts TokenMinterContainerOptions) buildContainer(hcp *hyperv1.HostedContro
 			kubeconfingVolumeName = "kubeconfig"
 		}
 
-		container.Args = append(container.Args, fmt.Sprintf("--kubeconfig=%s", path.Join(kubeconfigMountPath, util.KubeconfigKey)))
+		container.Args = append(container.Args, fmt.Sprintf("--kubeconfig=%s", path.Join(kubeconfigMountPath, podspec.KubeconfigKey)))
 		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 			Name:      kubeconfingVolumeName,
 			MountPath: kubeconfigMountPath,

--- a/support/podspec/cloudprovidercreds.go
+++ b/support/podspec/cloudprovidercreds.go
@@ -1,4 +1,4 @@
-package util
+package podspec
 
 import (
 	"fmt"
@@ -14,15 +14,15 @@ const (
 	AWSCloudProviderName     = "aws"
 )
 
-func cloudProviderCredsVolumeMount(containerName string) PodVolumeMounts {
-	return PodVolumeMounts{
+func cloudProviderCredsVolumeMount(containerName string) VolumeMounts {
+	return VolumeMounts{
 		containerName: {
 			cloudProviderCredsVolume().Name: "/etc/kubernetes/secrets/cloud-provider",
 		},
 	}
 }
-func cloudProviderTokenVolumeMount(containerName string) PodVolumeMounts {
-	return PodVolumeMounts{
+func cloudProviderTokenVolumeMount(containerName string) VolumeMounts {
+	return VolumeMounts{
 		containerName: {
 			cloudProviderTokenVolume().Name: "/var/run/secrets/openshift/serviceaccount",
 		},

--- a/support/podspec/containers.go
+++ b/support/podspec/containers.go
@@ -1,4 +1,4 @@
-package util
+package podspec
 
 import (
 	"fmt"

--- a/support/podspec/containers_test.go
+++ b/support/podspec/containers_test.go
@@ -1,4 +1,4 @@
-package util
+package podspec
 
 import (
 	"testing"

--- a/support/podspec/deployment.go
+++ b/support/podspec/deployment.go
@@ -1,4 +1,4 @@
-package util
+package podspec
 
 import (
 	"context"

--- a/support/podspec/deployment_test.go
+++ b/support/podspec/deployment_test.go
@@ -1,4 +1,4 @@
-package util
+package podspec
 
 import (
 	"testing"

--- a/support/podspec/manifests.go
+++ b/support/podspec/manifests.go
@@ -1,4 +1,4 @@
-package util
+package podspec
 
 import (
 	corev1 "k8s.io/api/core/v1"

--- a/support/podspec/volumemounts.go
+++ b/support/podspec/volumemounts.go
@@ -1,4 +1,4 @@
-package util
+package podspec
 
 import (
 	"fmt"
@@ -7,10 +7,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-type ContainerVolumeMounts map[string]string
-type PodVolumeMounts map[string]ContainerVolumeMounts
+type ContainerMounts map[string]string
+type VolumeMounts map[string]ContainerMounts
 
-func (m PodVolumeMounts) Path(container, volume string) string {
+func (m VolumeMounts) Path(container, volume string) string {
 	containerMounts, ok := m[container]
 	if !ok {
 		panic(fmt.Sprintf("invalid pod container %s used when looking for mount", container))
@@ -22,7 +22,7 @@ func (m PodVolumeMounts) Path(container, volume string) string {
 	return mountPath
 }
 
-func (m PodVolumeMounts) ContainerMounts(container string) []corev1.VolumeMount {
+func (m VolumeMounts) ContainerMounts(container string) []corev1.VolumeMount {
 	result := []corev1.VolumeMount{}
 	containerMounts, ok := m[container]
 	if !ok {

--- a/support/podspec/volumes.go
+++ b/support/podspec/volumes.go
@@ -1,4 +1,4 @@
-package util
+package podspec
 
 import (
 	appsv1 "k8s.io/api/apps/v1"

--- a/support/releaseinfo/fake/fake.go
+++ b/support/releaseinfo/fake/fake.go
@@ -6,8 +6,8 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	haproxy "github.com/openshift/hypershift/hypershift-operator/controllers/nodepool/apiserver-haproxy"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/releaseinfo"
-	"github.com/openshift/hypershift/support/util"
 
 	imagev1 "github.com/openshift/api/image/v1"
 
@@ -59,7 +59,7 @@ func (f *FakeReleaseProvider) Lookup(_ context.Context, image string, _ []byte) 
 						From: &corev1.ObjectReference{Name: ""},
 					},
 					{
-						Name: util.AvailabilityProberImageName,
+						Name: podspec.AvailabilityProberImageName,
 						From: &corev1.ObjectReference{Name: ""},
 					},
 					{

--- a/support/releaseinfo/testutils/testutils.go
+++ b/support/releaseinfo/testutils/testutils.go
@@ -2,8 +2,8 @@ package testutils
 
 import (
 	haproxy "github.com/openshift/hypershift/hypershift-operator/controllers/nodepool/apiserver-haproxy"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/releaseinfo"
-	"github.com/openshift/hypershift/support/util"
 
 	imagev1 "github.com/openshift/api/image/v1"
 
@@ -48,7 +48,7 @@ func InitReleaseImageOrDie(version string) *releaseinfo.ReleaseImage {
 						From: &corev1.ObjectReference{Name: "capi-openstack"},
 					},
 					{
-						Name: util.AvailabilityProberImageName,
+						Name: podspec.AvailabilityProberImageName,
 						From: &corev1.ObjectReference{Name: ""},
 					},
 					{

--- a/test/e2e/autoscaling_test.go
+++ b/test/e2e/autoscaling_test.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -271,7 +271,7 @@ func testAutoscalingBalancing(ctx context.Context, mgtClient crclient.Client, ho
 			if !hasBalancingIgnoreLabel {
 				return false, "autoscaler deployment does not have balancing ignore label", nil
 			}
-			return util.IsDeploymentReady(ctx, autoscalerDeployment), "autoscaler deployment not ready", nil
+			return podspec.IsDeploymentReady(ctx, autoscalerDeployment), "autoscaler deployment not ready", nil
 		}}, e2eutil.WithInterval(10*time.Second), e2eutil.WithTimeout(5*time.Minute))
 
 		// Generate workload.

--- a/test/e2e/nodepool_additionalTrustBundlePropagation_test.go
+++ b/test/e2e/nodepool_additionalTrustBundlePropagation_test.go
@@ -10,7 +10,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -158,7 +158,7 @@ func (k *AdditionalTrustBundlePropagationTest) Run(t *testing.T, nodePool hyperv
 							return false, "Additional trust bundle configmap is still included in CPO", nil
 						}
 					}
-					if ready := util.IsDeploymentReady(k.ctx, obj); !ready {
+					if ready := podspec.IsDeploymentReady(k.ctx, obj); !ready {
 						return false, "Deployment is not ready", nil
 					}
 					return true, "Additional trust bundle configmap is not included in CPO", nil

--- a/test/e2e/nodepool_spot_termination_handler_test.go
+++ b/test/e2e/nodepool_spot_termination_handler_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/uuid"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -192,7 +192,7 @@ func (s *SpotTerminationHandlerTest) Run(t *testing.T, nodePool hyperv1.NodePool
 					if obj.Spec.Replicas == nil || *obj.Spec.Replicas == 0 {
 						return false, "Deployment has 0 replicas", nil
 					}
-					if ready := util.IsDeploymentReady(s.ctx, obj); !ready {
+					if ready := podspec.IsDeploymentReady(s.ctx, obj); !ready {
 						return false, "Deployment is not ready", nil
 					}
 					return true, "Deployment is ready", nil

--- a/test/e2e/util/reqserving/verifypods.go
+++ b/test/e2e/util/reqserving/verifypods.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
-	supportutil "github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -109,7 +109,7 @@ func VerifyRequestServingPodDistribution(ctx context.Context, hc *hyperv1.Hosted
 			if dep.Spec.Replicas == nil || *dep.Spec.Replicas != int32(expectedReplicas) {
 				errs = append(errs, fmt.Errorf("deployment %s has replicas %v, expected %d", depName, valueOrZero(dep.Spec.Replicas), expectedReplicas))
 			}
-			if !supportutil.IsDeploymentReady(pctx, dep) {
+			if !podspec.IsDeploymentReady(pctx, dep) {
 				errs = append(errs, fmt.Errorf("deployment %s not yet ready", depName))
 			}
 		}

--- a/test/e2e/util/reqserving/waitfor.go
+++ b/test/e2e/util/reqserving/waitfor.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
-	supportutil "github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -60,7 +60,7 @@ func WaitForControlPlaneWorkloadsReady(ctx context.Context, hc *hyperv1.HostedCl
 			return false, nil
 		}
 		for _, deployment := range deployments.Items {
-			if supportutil.IsDeploymentReady(ctx, &deployment) {
+			if podspec.IsDeploymentReady(ctx, &deployment) {
 				continue
 			}
 			return false, nil
@@ -82,7 +82,7 @@ func WaitForControlPlaneWorkloadsReady(ctx context.Context, hc *hyperv1.HostedCl
 			return false, nil
 		}
 		for _, statefulSet := range statefulSets.Items {
-			if supportutil.IsStatefulSetReady(ctx, &statefulSet) {
+			if podspec.IsStatefulSetReady(ctx, &statefulSet) {
 				continue
 			}
 			return false, nil

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -34,6 +34,7 @@ import (
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/conditions"
 	suppconfig "github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	hyperutil "github.com/openshift/hypershift/support/util"
 
@@ -1689,7 +1690,7 @@ func EnsurePodsWithEmptyDirPVsHaveSafeToEvictAnnotations(t *testing.T, ctx conte
 				hasTmpDirAnnotation := false
 				safe2EvictVolumes := strings.Split(pod.Annotations[suppconfig.PodSafeToEvictLocalVolumesKey], ",")
 				safe2EvictVolumes = slices.DeleteFunc(safe2EvictVolumes, func(s string) bool {
-					hasTmpDir := s == hyperutil.PodTmpDirMountName
+					hasTmpDir := s == podspec.PodTmpDirMountName
 					hasTmpDirAnnotation = hasTmpDirAnnotation || hasTmpDir
 					return s == "" || hasTmpDir
 				})
@@ -1851,7 +1852,7 @@ func EnsureReadOnlyRootFilesystem(t *testing.T, ctx context.Context, hostClient 
 					}
 				}
 				containerHasTmpDir := slices.ContainsFunc(c.VolumeMounts, func(v corev1.VolumeMount) bool {
-					return v.MountPath == hyperutil.PodTmpDirMountPath
+					return v.MountPath == podspec.PodTmpDirMountPath
 				})
 				g.Expect(containerHasTmpDir).To(BeTrue(), "container %s in pod %s does not have /tmp mounted, and it is expected to mount it", c.Name, pod.Name)
 			}
@@ -2389,7 +2390,7 @@ func EnsureKubeAPIDNSNameCustomCert(t *testing.T, ctx context.Context, mgmtClien
 			if err != nil {
 				return false
 			}
-			return hyperutil.IsDeploymentReady(ctx, kubeAPIServerDeployment)
+			return podspec.IsDeploymentReady(ctx, kubeAPIServerDeployment)
 		}, kasDeploymentTimeout, 10*time.Second).Should(BeTrue(), "failed to ensure KAS Deployment is ready")
 
 		// KAS deployment readiness should ensure certificate configuration is loaded

--- a/test/e2e/v2/internal/workload_registry.go
+++ b/test/e2e/v2/internal/workload_registry.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
-	supportutil "github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -533,7 +533,7 @@ func validateControlPlaneWorkloadsByType(testCtx *TestContext, workloadTypes []s
 			if err != nil {
 				return fmt.Errorf("failed to get deployment %s: %w", workload.Name, err)
 			}
-			if !supportutil.IsDeploymentReady(testCtx, deployment) {
+			if !podspec.IsDeploymentReady(testCtx, deployment) {
 				desired := int32(0)
 				if deployment.Spec.Replicas != nil {
 					desired = *deployment.Spec.Replicas
@@ -551,7 +551,7 @@ func validateControlPlaneWorkloadsByType(testCtx *TestContext, workloadTypes []s
 			if err != nil {
 				return fmt.Errorf("failed to get statefulset %s: %w", workload.Name, err)
 			}
-			if !supportutil.IsStatefulSetReady(testCtx, statefulSet) {
+			if !podspec.IsStatefulSetReady(testCtx, statefulSet) {
 				desired := int32(0)
 				if statefulSet.Spec.Replicas != nil {
 					desired = *statefulSet.Spec.Replicas

--- a/test/e2e/v2/tests/control_plane_workloads_test.go
+++ b/test/e2e/v2/tests/control_plane_workloads_test.go
@@ -28,7 +28,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
-	hyperutil "github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/podspec"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
 
@@ -306,7 +306,7 @@ func ReadOnlyRootFilesystemTmpDirMountTest(getTestCtx internal.TestContextGetter
 					for _, container := range pod.Spec.Containers {
 						hasTmpMount := false
 						for _, mount := range container.VolumeMounts {
-							if mount.MountPath == hyperutil.PodTmpDirMountPath {
+							if mount.MountPath == podspec.PodTmpDirMountPath {
 								hasTmpMount = true
 								break
 							}


### PR DESCRIPTION
## What this PR does / why we need it:

Extracts container, volume, deployment, and cloud provider credential helpers from the monolithic `support/util/` package into a new `support/podspec/` package. This is the first of 5 PRs to decompose the ~9,500 LOC kitchen-sink `support/util/` package into cohesive, compiler-enforced modules.

**Files moved:** `containers.go`, `volumes.go`, `volumemounts.go`, `cloudprovidercreds.go`, `deployment.go`, `manifests.go` (plus test files)

**Renames to avoid stuttering:**
- `PodVolumeMounts` → `VolumeMounts`
- `ContainerVolumeMounts` → `ContainerMounts`

All ~120 callers (primarily CPO v2 components) are updated to import from `support/podspec`.

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/CNTRLPLANE-3340

## Special notes for your reviewer:

This is a pure refactor — no behavioral changes. The diff is large because of the number of callers, but each file change is a mechanical import path update.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal podspec and helper utilities reorganized and renamed; callers updated. No user-visible behavior changes.
* **Tests**
  * Test suite updated to match the internal reorganization; validations and expected outcomes unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->