### PR TITLE
NO-JIRA: fix(e2e): prevent agent unbinding and node reboots during backup/restore

### DIFF
--- a/test/e2e/v2/backuprestore/cleanup.go
+++ b/test/e2e/v2/backuprestore/cleanup.go
@@ -20,7 +20,26 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	agentMachineGVK = schema.GroupVersionKind{
+		Group:   "capi-provider.agent-install.openshift.io",
+		Version: "v1beta1",
+		Kind:    "AgentMachine",
+	}
+	agentClusterGVK = schema.GroupVersionKind{
+		Group:   "capi-provider.agent-install.openshift.io",
+		Version: "v1beta1",
+		Kind:    "AgentCluster",
+	}
+	clusterDeploymentGVK = schema.GroupVersionKind{
+		Group:   "hive.openshift.io",
+		Version: "v1",
+		Kind:    "ClusterDeployment",
+	}
 )
 
 const (
@@ -372,21 +391,11 @@ func PauseAgentCAPIResources(testCtx *internal.TestContext, logger logr.Logger) 
 	ns := testCtx.ControlPlaneNamespace
 	logger.Info("Pausing Agent CAPI resources", "namespace", ns)
 
-	agentMachineGVK := schema.GroupVersionKind{
-		Group:   "capi-provider.agent-install.openshift.io",
-		Version: "v1beta1",
-		Kind:    "AgentMachine",
-	}
-	if err := setAnnotationOnResources(testCtx, ns, agentMachineGVK, "cluster.x-k8s.io/paused", "true", logger); err != nil {
+	patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{%q:%q}}}`, capiv1.PausedAnnotation, "true"))
+	if err := patchResourcesByGVK(testCtx, ns, agentMachineGVK, patch, logger); err != nil {
 		return fmt.Errorf("failed to pause AgentMachine resources: %w", err)
 	}
-
-	agentClusterGVK := schema.GroupVersionKind{
-		Group:   "capi-provider.agent-install.openshift.io",
-		Version: "v1beta1",
-		Kind:    "AgentCluster",
-	}
-	if err := setAnnotationOnResources(testCtx, ns, agentClusterGVK, "cluster.x-k8s.io/paused", "true", logger); err != nil {
+	if err := patchResourcesByGVK(testCtx, ns, agentClusterGVK, patch, logger); err != nil {
 		return fmt.Errorf("failed to pause AgentCluster resources: %w", err)
 	}
 
@@ -399,21 +408,11 @@ func UnpauseAgentCAPIResources(testCtx *internal.TestContext, logger logr.Logger
 	ns := testCtx.ControlPlaneNamespace
 	logger.Info("Unpausing Agent CAPI resources", "namespace", ns)
 
-	agentMachineGVK := schema.GroupVersionKind{
-		Group:   "capi-provider.agent-install.openshift.io",
-		Version: "v1beta1",
-		Kind:    "AgentMachine",
-	}
-	if err := removeAnnotationFromResources(testCtx, ns, agentMachineGVK, "cluster.x-k8s.io/paused", logger); err != nil {
+	patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{%q:null}}}`, capiv1.PausedAnnotation))
+	if err := patchResourcesByGVK(testCtx, ns, agentMachineGVK, patch, logger); err != nil {
 		return fmt.Errorf("failed to unpause AgentMachine resources: %w", err)
 	}
-
-	agentClusterGVK := schema.GroupVersionKind{
-		Group:   "capi-provider.agent-install.openshift.io",
-		Version: "v1beta1",
-		Kind:    "AgentCluster",
-	}
-	if err := removeAnnotationFromResources(testCtx, ns, agentClusterGVK, "cluster.x-k8s.io/paused", logger); err != nil {
+	if err := patchResourcesByGVK(testCtx, ns, agentClusterGVK, patch, logger); err != nil {
 		return fmt.Errorf("failed to unpause AgentCluster resources: %w", err)
 	}
 
@@ -450,45 +449,21 @@ func annotateAgentsSkipSpokeCleanup(testCtx *internal.TestContext, agentNamespac
 		Version: "v1beta1",
 		Kind:    "Agent",
 	}
-	return setAnnotationOnResources(testCtx, agentNamespace, agentGVK,
-		"agent.agent-install.openshift.io/skip-spoke-cleanup", "true", logger)
+	patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{%q:%q}}}`,
+		"agent.agent-install.openshift.io/skip-spoke-cleanup", "true"))
+	return patchResourcesByGVK(testCtx, agentNamespace, agentGVK, patch, logger)
 }
 
 // setClusterDeploymentPreserveOnDelete sets spec.preserveOnDelete=true on all ClusterDeployment
 // CRs in the given namespace. This prevents agents from being unbound when the ClusterDeployment
 // is deleted, avoiding Ironic-triggered node reboots.
 func setClusterDeploymentPreserveOnDelete(testCtx *internal.TestContext, namespace string, logger logr.Logger) error {
-	cdGVK := schema.GroupVersionKind{
-		Group:   "hive.openshift.io",
-		Version: "v1",
-		Kind:    "ClusterDeployment",
-	}
-
-	list := &unstructured.UnstructuredList{}
-	list.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   cdGVK.Group,
-		Version: cdGVK.Version,
-		Kind:    cdGVK.Kind + "List",
-	})
-
-	if err := testCtx.MgmtClient.List(testCtx.Context, list, crclient.InNamespace(namespace)); err != nil {
-		return fmt.Errorf("failed to list ClusterDeployments in namespace %s: %w", namespace, err)
-	}
-
-	patch := []byte(`{"spec":{"preserveOnDelete":true}}`)
-	for i := range list.Items {
-		obj := &list.Items[i]
-		logger.Info("Setting preserveOnDelete on ClusterDeployment", "name", obj.GetName(), "namespace", obj.GetNamespace())
-		if err := testCtx.MgmtClient.Patch(testCtx.Context, obj, crclient.RawPatch(types.MergePatchType, patch)); err != nil {
-			return fmt.Errorf("failed to patch ClusterDeployment %s: %w", obj.GetName(), err)
-		}
-	}
-
-	return nil
+	return patchResourcesByGVK(testCtx, namespace, clusterDeploymentGVK,
+		[]byte(`{"spec":{"preserveOnDelete":true}}`), logger)
 }
 
-// setAnnotationOnResources adds an annotation to all resources of the given GVK in the namespace.
-func setAnnotationOnResources(testCtx *internal.TestContext, namespace string, gvk schema.GroupVersionKind, annotation, value string, logger logr.Logger) error {
+// patchResourcesByGVK applies a merge patch to all resources of the given GVK in the namespace.
+func patchResourcesByGVK(testCtx *internal.TestContext, namespace string, gvk schema.GroupVersionKind, patch []byte, logger logr.Logger) error {
 	list := &unstructured.UnstructuredList{}
 	list.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   gvk.Group,
@@ -500,35 +475,9 @@ func setAnnotationOnResources(testCtx *internal.TestContext, namespace string, g
 		return fmt.Errorf("failed to list %s in namespace %s: %w", gvk.Kind, namespace, err)
 	}
 
-	patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{%q:%q}}}`, annotation, value))
 	for i := range list.Items {
 		obj := &list.Items[i]
-		logger.Info("Setting annotation on resource", "kind", gvk.Kind, "name", obj.GetName(), "annotation", annotation)
-		if err := testCtx.MgmtClient.Patch(testCtx.Context, obj, crclient.RawPatch(types.MergePatchType, patch)); err != nil {
-			return fmt.Errorf("failed to patch %s %s: %w", gvk.Kind, obj.GetName(), err)
-		}
-	}
-
-	return nil
-}
-
-// removeAnnotationFromResources removes an annotation from all resources of the given GVK in the namespace.
-func removeAnnotationFromResources(testCtx *internal.TestContext, namespace string, gvk schema.GroupVersionKind, annotation string, logger logr.Logger) error {
-	list := &unstructured.UnstructuredList{}
-	list.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   gvk.Group,
-		Version: gvk.Version,
-		Kind:    gvk.Kind + "List",
-	})
-
-	if err := testCtx.MgmtClient.List(testCtx.Context, list, crclient.InNamespace(namespace)); err != nil {
-		return fmt.Errorf("failed to list %s in namespace %s: %w", gvk.Kind, namespace, err)
-	}
-
-	patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{%q:null}}}`, annotation))
-	for i := range list.Items {
-		obj := &list.Items[i]
-		logger.Info("Removing annotation from resource", "kind", gvk.Kind, "name", obj.GetName(), "annotation", annotation)
+		logger.Info("Patching resource", "kind", gvk.Kind, "name", obj.GetName(), "namespace", obj.GetNamespace())
 		if err := testCtx.MgmtClient.Patch(testCtx.Context, obj, crclient.RawPatch(types.MergePatchType, patch)); err != nil {
 			return fmt.Errorf("failed to patch %s %s: %w", gvk.Kind, obj.GetName(), err)
 		}

--- a/test/e2e/v2/backuprestore/cleanup.go
+++ b/test/e2e/v2/backuprestore/cleanup.go
@@ -42,6 +42,14 @@ const (
 // 6. Wait for control plane namespace to be fully deleted
 // 7. Wait for hosted cluster namespace to be fully deleted
 func BreakHostedClusterPreservingMachines(testCtx *internal.TestContext, logger logr.Logger) error {
+	// Agent platform: prepare resources to prevent agent unbinding and node reboots
+	if testCtx.GetHostedCluster().Spec.Platform.Type == hyperv1.AgentPlatform {
+		logger.Info("Preparing Agent platform resources before break")
+		if err := prepareAgentPlatformForBreak(testCtx, logger); err != nil {
+			return fmt.Errorf("failed to prepare Agent platform for break: %w", err)
+		}
+	}
+
 	// Step 1: Force delete HCP namespace (without waiting for completion)
 	// This removes the CAPI controller early, leaving machine resources orphaned
 	if err := deleteControlPlaneNamespace(testCtx, 0); err != nil {
@@ -355,6 +363,178 @@ func deleteNamespace(testCtx *internal.TestContext, namespace string, gracePerio
 		}
 		return false, nil
 	})
+}
+
+// PauseAgentCAPIResources pauses AgentMachine and AgentCluster CRs by adding the
+// cluster.x-k8s.io/paused annotation. This prevents the CAPI provider from reconciling
+// these resources during backup operations.
+func PauseAgentCAPIResources(testCtx *internal.TestContext, logger logr.Logger) error {
+	ns := testCtx.ControlPlaneNamespace
+	logger.Info("Pausing Agent CAPI resources", "namespace", ns)
+
+	agentMachineGVK := schema.GroupVersionKind{
+		Group:   "capi-provider.agent-install.openshift.io",
+		Version: "v1beta1",
+		Kind:    "AgentMachine",
+	}
+	if err := setAnnotationOnResources(testCtx, ns, agentMachineGVK, "cluster.x-k8s.io/paused", "true", logger); err != nil {
+		return fmt.Errorf("failed to pause AgentMachine resources: %w", err)
+	}
+
+	agentClusterGVK := schema.GroupVersionKind{
+		Group:   "capi-provider.agent-install.openshift.io",
+		Version: "v1beta1",
+		Kind:    "AgentCluster",
+	}
+	if err := setAnnotationOnResources(testCtx, ns, agentClusterGVK, "cluster.x-k8s.io/paused", "true", logger); err != nil {
+		return fmt.Errorf("failed to pause AgentCluster resources: %w", err)
+	}
+
+	return nil
+}
+
+// UnpauseAgentCAPIResources removes the cluster.x-k8s.io/paused annotation from
+// AgentMachine and AgentCluster CRs, allowing the CAPI provider to resume reconciliation.
+func UnpauseAgentCAPIResources(testCtx *internal.TestContext, logger logr.Logger) error {
+	ns := testCtx.ControlPlaneNamespace
+	logger.Info("Unpausing Agent CAPI resources", "namespace", ns)
+
+	agentMachineGVK := schema.GroupVersionKind{
+		Group:   "capi-provider.agent-install.openshift.io",
+		Version: "v1beta1",
+		Kind:    "AgentMachine",
+	}
+	if err := removeAnnotationFromResources(testCtx, ns, agentMachineGVK, "cluster.x-k8s.io/paused", logger); err != nil {
+		return fmt.Errorf("failed to unpause AgentMachine resources: %w", err)
+	}
+
+	agentClusterGVK := schema.GroupVersionKind{
+		Group:   "capi-provider.agent-install.openshift.io",
+		Version: "v1beta1",
+		Kind:    "AgentCluster",
+	}
+	if err := removeAnnotationFromResources(testCtx, ns, agentClusterGVK, "cluster.x-k8s.io/paused", logger); err != nil {
+		return fmt.Errorf("failed to unpause AgentCluster resources: %w", err)
+	}
+
+	return nil
+}
+
+// prepareAgentPlatformForBreak prepares Agent platform resources before breaking the cluster.
+// It annotates Agent CRs with skip-spoke-cleanup and sets preserveOnDelete on ClusterDeployment
+// to prevent agents from being unbound and hosts from being rebooted by Ironic.
+func prepareAgentPlatformForBreak(testCtx *internal.TestContext, logger logr.Logger) error {
+	hc := testCtx.GetHostedCluster()
+	if hc.Spec.Platform.Agent == nil || hc.Spec.Platform.Agent.AgentNamespace == "" {
+		return fmt.Errorf("agent namespace not set on HostedCluster")
+	}
+
+	agentNamespace := hc.Spec.Platform.Agent.AgentNamespace
+	if err := annotateAgentsSkipSpokeCleanup(testCtx, agentNamespace, logger); err != nil {
+		return fmt.Errorf("failed to annotate agents with skip-spoke-cleanup: %w", err)
+	}
+
+	if err := setClusterDeploymentPreserveOnDelete(testCtx, testCtx.ControlPlaneNamespace, logger); err != nil {
+		return fmt.Errorf("failed to set preserveOnDelete on ClusterDeployment: %w", err)
+	}
+
+	return nil
+}
+
+// annotateAgentsSkipSpokeCleanup adds the agent.agent-install.openshift.io/skip-spoke-cleanup
+// annotation to all Agent CRs in the given namespace. This prevents agents (hosts) from being
+// removed from the hosted cluster as nodes during deletion.
+func annotateAgentsSkipSpokeCleanup(testCtx *internal.TestContext, agentNamespace string, logger logr.Logger) error {
+	agentGVK := schema.GroupVersionKind{
+		Group:   "agent-install.openshift.io",
+		Version: "v1beta1",
+		Kind:    "Agent",
+	}
+	return setAnnotationOnResources(testCtx, agentNamespace, agentGVK,
+		"agent.agent-install.openshift.io/skip-spoke-cleanup", "true", logger)
+}
+
+// setClusterDeploymentPreserveOnDelete sets spec.preserveOnDelete=true on all ClusterDeployment
+// CRs in the given namespace. This prevents agents from being unbound when the ClusterDeployment
+// is deleted, avoiding Ironic-triggered node reboots.
+func setClusterDeploymentPreserveOnDelete(testCtx *internal.TestContext, namespace string, logger logr.Logger) error {
+	cdGVK := schema.GroupVersionKind{
+		Group:   "hive.openshift.io",
+		Version: "v1",
+		Kind:    "ClusterDeployment",
+	}
+
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   cdGVK.Group,
+		Version: cdGVK.Version,
+		Kind:    cdGVK.Kind + "List",
+	})
+
+	if err := testCtx.MgmtClient.List(testCtx.Context, list, crclient.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("failed to list ClusterDeployments in namespace %s: %w", namespace, err)
+	}
+
+	patch := []byte(`{"spec":{"preserveOnDelete":true}}`)
+	for i := range list.Items {
+		obj := &list.Items[i]
+		logger.Info("Setting preserveOnDelete on ClusterDeployment", "name", obj.GetName(), "namespace", obj.GetNamespace())
+		if err := testCtx.MgmtClient.Patch(testCtx.Context, obj, crclient.RawPatch(types.MergePatchType, patch)); err != nil {
+			return fmt.Errorf("failed to patch ClusterDeployment %s: %w", obj.GetName(), err)
+		}
+	}
+
+	return nil
+}
+
+// setAnnotationOnResources adds an annotation to all resources of the given GVK in the namespace.
+func setAnnotationOnResources(testCtx *internal.TestContext, namespace string, gvk schema.GroupVersionKind, annotation, value string, logger logr.Logger) error {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   gvk.Group,
+		Version: gvk.Version,
+		Kind:    gvk.Kind + "List",
+	})
+
+	if err := testCtx.MgmtClient.List(testCtx.Context, list, crclient.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("failed to list %s in namespace %s: %w", gvk.Kind, namespace, err)
+	}
+
+	patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{%q:%q}}}`, annotation, value))
+	for i := range list.Items {
+		obj := &list.Items[i]
+		logger.Info("Setting annotation on resource", "kind", gvk.Kind, "name", obj.GetName(), "annotation", annotation)
+		if err := testCtx.MgmtClient.Patch(testCtx.Context, obj, crclient.RawPatch(types.MergePatchType, patch)); err != nil {
+			return fmt.Errorf("failed to patch %s %s: %w", gvk.Kind, obj.GetName(), err)
+		}
+	}
+
+	return nil
+}
+
+// removeAnnotationFromResources removes an annotation from all resources of the given GVK in the namespace.
+func removeAnnotationFromResources(testCtx *internal.TestContext, namespace string, gvk schema.GroupVersionKind, annotation string, logger logr.Logger) error {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   gvk.Group,
+		Version: gvk.Version,
+		Kind:    gvk.Kind + "List",
+	})
+
+	if err := testCtx.MgmtClient.List(testCtx.Context, list, crclient.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("failed to list %s in namespace %s: %w", gvk.Kind, namespace, err)
+	}
+
+	patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{%q:null}}}`, annotation))
+	for i := range list.Items {
+		obj := &list.Items[i]
+		logger.Info("Removing annotation from resource", "kind", gvk.Kind, "name", obj.GetName(), "annotation", annotation)
+		if err := testCtx.MgmtClient.Patch(testCtx.Context, obj, crclient.RawPatch(types.MergePatchType, patch)); err != nil {
+			return fmt.Errorf("failed to patch %s %s: %w", gvk.Kind, obj.GetName(), err)
+		}
+	}
+
+	return nil
 }
 
 // deleteControlPlaneNamespace deletes the HCP namespace.

--- a/test/e2e/v2/tests/backup_restore_test.go
+++ b/test/e2e/v2/tests/backup_restore_test.go
@@ -174,6 +174,17 @@ var _ = Describe("BackupRestore", Label("backup-restore"), Ordered, Serial, func
 
 	Context(ContextBackup, func() {
 		It("should create backup and schedule successfully", func() {
+			if testCtx.GetHostedCluster().Spec.Platform.Type == hyperv1.AgentPlatform {
+				By("Pausing AgentMachine and AgentCluster CRs")
+				err := backuprestore.PauseAgentCAPIResources(testCtx, GinkgoLogr.WithName("backup-restore"))
+				Expect(err).NotTo(HaveOccurred())
+				DeferCleanup(func() {
+					if err := backuprestore.UnpauseAgentCAPIResources(testCtx, GinkgoLogr.WithName("backup-restore")); err != nil {
+						GinkgoWriter.Printf("Failed to unpause Agent CAPI resources during cleanup: %v\n", err)
+					}
+				})
+			}
+
 			// Create schedule first to test parallel execution of backup and schedule and
 			// to speed up the test execution.
 			By("Creating schedule")
@@ -219,6 +230,7 @@ var _ = Describe("BackupRestore", Label("backup-restore"), Ordered, Serial, func
 			By("Waiting for schedule to have one backup completed")
 			err = backuprestore.WaitForScheduleCompletion(testCtx, scheduleName)
 			Expect(err).NotTo(HaveOccurred())
+
 		})
 	})
 
@@ -340,6 +352,12 @@ func executeRestore(testCtx *internal.TestContext, restoreOpts *backuprestore.OA
 	By("Waiting for restore to complete")
 	err = backuprestore.WaitForRestoreCompletion(testCtx, restoreOpts.Name)
 	Expect(err).NotTo(HaveOccurred())
+
+	if testCtx.GetHostedCluster().Spec.Platform.Type == hyperv1.AgentPlatform {
+		By("Unpausing AgentMachine and AgentCluster CRs again as the Restore brings back paused resources")
+		err = backuprestore.UnpauseAgentCAPIResources(testCtx, GinkgoLogr.WithName("backup-restore"))
+		Expect(err).NotTo(HaveOccurred())
+	}
 
 	if postRestoreHook != nil {
 		By("Running platform-specific post-restore operations")

--- a/test/e2e/v2/tests/backup_restore_test.go
+++ b/test/e2e/v2/tests/backup_restore_test.go
@@ -84,7 +84,10 @@ var backupRestorePlatforms = map[hyperv1.PlatformType]backupRestorePlatformConfi
 	},
 	hyperv1.AgentPlatform: {
 		excludeWorkloads: []string{"router", "karpenter", "karpenter-operator", "cloud-network-config-controller"},
-		postRestoreHook:  nil,
+		postRestoreHook: func(testCtx *internal.TestContext) error {
+			// Restore brings back paused CAPI resources; unpause them so reconciliation resumes.
+			return backuprestore.UnpauseAgentCAPIResources(testCtx, GinkgoLogr.WithName("backup-restore"))
+		},
 	},
 	hyperv1.KubevirtPlatform: {
 		excludeWorkloads: []string{"router", "karpenter", "karpenter-operator", "cloud-network-config-controller"},
@@ -352,12 +355,6 @@ func executeRestore(testCtx *internal.TestContext, restoreOpts *backuprestore.OA
 	By("Waiting for restore to complete")
 	err = backuprestore.WaitForRestoreCompletion(testCtx, restoreOpts.Name)
 	Expect(err).NotTo(HaveOccurred())
-
-	if testCtx.GetHostedCluster().Spec.Platform.Type == hyperv1.AgentPlatform {
-		By("Unpausing AgentMachine and AgentCluster CRs again as the Restore brings back paused resources")
-		err = backuprestore.UnpauseAgentCAPIResources(testCtx, GinkgoLogr.WithName("backup-restore"))
-		Expect(err).NotTo(HaveOccurred())
-	}
 
 	if postRestoreHook != nil {
 		By("Running platform-specific post-restore operations")


### PR DESCRIPTION
## What this PR does / why we need it:

Add Agent platform-specific safeguards to the backup/restore e2e test to prevent catastrophic node reboots caused by agent unbinding during the break phase.

Before breaking the hosted cluster:
- Annotate Agent CRs with skip-spoke-cleanup to prevent host removal
- Set preserveOnDelete on ClusterDeployment to prevent agent unbinding

During backup/schedule creation:
- Pause AgentMachine and AgentCluster CRs to prevent CAPI provider interference while Velero captures the cluster state

All mutations use unstructured objects with merge patches since Agent and ClusterDeployment types are not vendored in this repository.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Required for https://github.com/openshift/release/pull/76214 to pass tests for backup/restore on Agent platform.
Pre-tested in https://github.com/openshift/release/pull/77576
Related slack discussion: https://redhat-external.slack.com/archives/C01C8502FMM/p1775670567221459?thread_ts=1775549367.838709&cid=C01C8502FMM

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup/restore reliability for Agent-platform clusters by adding preparation and preservation steps for control-plane resources and ensuring pause/unpause of cluster resources to prevent unintended deletions or state drift.

* **Tests**
  * Added Agent-platform end-to-end test coverage for backup and restore flows that verify pause/unpause and preservation behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->