### PR TITLE
OCPBUGS-84572: fix(cpo): generate EBS CSI driver operator serving cert in CPO

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1744,6 +1744,19 @@ func (r *HostedControlPlaneReconciler) reconcilePKI(ctx context.Context, hcp *hy
 			return fmt.Errorf("failed to reconcile %s secret: %w", awsPodIdentityWebhookServingCert.Name, err)
 		}
 
+		// AWS EBS CSI driver operator serving cert
+		awsEBSCsiDriverOperatorServingCert := manifests.AWSEBSCsiDriverOperatorServingCert(hcp.Namespace)
+		awsEBSCsiDriverOperatorService := manifests.AWSEBSCsiDriverOperatorMetricsService(hcp.Namespace)
+		err = removeServiceCAAnnotationAndSecret(ctx, r.Client, awsEBSCsiDriverOperatorService, awsEBSCsiDriverOperatorServingCert)
+		if err != nil {
+			r.Log.Error(err, "failed to remove service ca annotation and secret")
+		}
+		if _, err = createOrUpdate(ctx, r, awsEBSCsiDriverOperatorServingCert, func() error {
+			return pki.ReconcileAWSEBSCsiDriverOperatorMetricsServingCertSecret(awsEBSCsiDriverOperatorServingCert, rootCASecret, p.OwnerRef)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile aws ebs csi driver operator serving cert: %w", err)
+		}
+
 		awsEBSCsiDriverControllerMetricsService := manifests.AWSEBSCsiDriverControllerMetricsService(hcp.Namespace)
 		if err = r.Get(ctx, client.ObjectKeyFromObject(awsEBSCsiDriverControllerMetricsService), awsEBSCsiDriverControllerMetricsService); err != nil {
 			if !apierrors.IsNotFound(err) {

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/aws_ebs_csi_driver_operator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/aws_ebs_csi_driver_operator.go
@@ -1,0 +1,18 @@
+package manifests
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func AWSEBSCsiDriverOperatorMetricsService(namespace string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws-ebs-csi-driver-operator-metrics",
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "None",
+		},
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -380,6 +380,10 @@ func AzureFileCsiDriverControllerMetricsServingCert(ns string) *corev1.Secret {
 	return secretFor(ns, "azure-file-csi-driver-controller-metrics-serving-cert")
 }
 
+func AWSEBSCsiDriverOperatorServingCert(ns string) *corev1.Secret {
+	return secretFor(ns, "aws-ebs-csi-driver-operator-serving-cert")
+}
+
 func AWSEBSCsiDriverControllerMetricsServingCert(ns string) *corev1.Secret {
 	return secretFor(ns, "aws-ebs-csi-driver-controller-metrics-serving-cert")
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/aws_ebs_csi_driver_operator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/aws_ebs_csi_driver_operator.go
@@ -1,0 +1,19 @@
+package pki
+
+import (
+	"fmt"
+
+	"github.com/openshift/hypershift/support/config"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func ReconcileAWSEBSCsiDriverOperatorMetricsServingCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+	dnsNames := []string{
+		fmt.Sprintf("aws-ebs-csi-driver-operator-metrics.%s.svc", secret.Namespace),
+		fmt.Sprintf("aws-ebs-csi-driver-operator-metrics.%s.svc.cluster.local", secret.Namespace),
+		"aws-ebs-csi-driver-operator-metrics",
+		"localhost",
+	}
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "aws-ebs-csi-driver-operator-metrics", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/aws_ebs_csi_driver_operator_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/aws_ebs_csi_driver_operator_test.go
@@ -1,0 +1,87 @@
+package pki
+
+import (
+	"testing"
+
+	"github.com/openshift/hypershift/support/certs"
+	"github.com/openshift/hypershift/support/config"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+)
+
+func TestReconcileAWSEBSCsiDriverOperatorMetricsServingCertSecret(t *testing.T) {
+	namespace := "test-namespace"
+
+	ownerRef := config.OwnerRef{
+		Reference: &metav1.OwnerReference{
+			APIVersion: "v1",
+			Kind:       "HostedControlPlane",
+			Name:       "test-hcp",
+			UID:        types.UID("test-uid"),
+			Controller: ptr.To(true),
+		},
+	}
+
+	ca := &corev1.Secret{}
+	ca.Name = "test-ca"
+	ca.Namespace = namespace
+	err := reconcileSelfSignedCA(ca, ownerRef, "test-org", "test-ca")
+	if err != nil {
+		t.Fatalf("failed to create CA: %v", err)
+	}
+
+	secret := &corev1.Secret{}
+	secret.Name = "aws-ebs-csi-driver-operator-serving-cert"
+	secret.Namespace = namespace
+
+	err = ReconcileAWSEBSCsiDriverOperatorMetricsServingCertSecret(secret, ca, ownerRef)
+	if err != nil {
+		t.Fatalf("failed to reconcile cert: %v", err)
+	}
+
+	if secret.Data == nil {
+		t.Fatal("secret data is nil")
+	}
+
+	if _, ok := secret.Data[corev1.TLSCertKey]; !ok {
+		t.Fatal("secret missing tls.crt")
+	}
+
+	if _, ok := secret.Data[corev1.TLSPrivateKeyKey]; !ok {
+		t.Fatal("secret missing tls.key")
+	}
+
+	cert, err := certs.PemToCertificate(secret.Data[corev1.TLSCertKey])
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+
+	expectedDNSNames := map[string]bool{
+		"aws-ebs-csi-driver-operator-metrics." + namespace + ".svc":               true,
+		"aws-ebs-csi-driver-operator-metrics." + namespace + ".svc.cluster.local": true,
+		"aws-ebs-csi-driver-operator-metrics":                                     true,
+		"localhost":                                                               true,
+	}
+
+	if len(cert.DNSNames) != len(expectedDNSNames) {
+		t.Errorf("expected %d DNS names, got %d", len(expectedDNSNames), len(cert.DNSNames))
+	}
+
+	for _, name := range cert.DNSNames {
+		if !expectedDNSNames[name] {
+			t.Errorf("unexpected DNS name: %s", name)
+		}
+	}
+
+	expectedCN := "aws-ebs-csi-driver-operator-metrics"
+	if cert.Subject.CommonName != expectedCN {
+		t.Errorf("expected CN %s, got %s", expectedCN, cert.Subject.CommonName)
+	}
+
+	if len(cert.Subject.Organization) == 0 || cert.Subject.Organization[0] != "openshift" {
+		t.Errorf("expected Organization [openshift], got %v", cert.Subject.Organization)
+	}
+}


### PR DESCRIPTION
## Summary

- Generate the `aws-ebs-csi-driver-operator-serving-cert` TLS secret in the CPO instead of relying on the service-ca operator
- Removes the service-ca annotation from the existing `aws-ebs-csi-driver-operator-metrics` service to prevent ownership conflicts with the service-ca operator on OpenShift management clusters
- Follows the same pattern used for Azure Disk/File CSI driver operator certs and the existing AWS EBS controller metrics cert ([acebcc919](https://github.com/openshift/hypershift/commit/acebcc919))

## Problem

The `aws-ebs-csi-driver-operator` deployment mounts a TLS serving cert from secret `aws-ebs-csi-driver-operator-serving-cert`. On OpenShift, the [service-ca operator](https://github.com/openshift/service-ca-operator) generates this cert automatically for services annotated with `service.beta.kubernetes.io/serving-cert-secret-name`. On non-OpenShift management clusters (e.g. EKS), the service-ca operator does not exist, so the secret is never created and the operator pod fails to start with `FailedMount`.

Without the EBS CSI driver operator, no CSI driver pods are deployed on the data plane, blocking PersistentVolume support on the guest cluster.

The CPO already handles the analogous case for the EBS CSI driver **controller** metrics cert (commit [acebcc919](https://github.com/openshift/hypershift/commit/acebcc919)), but the **operator** serving cert was not covered.

## Context

This is part of a broader effort to remove the CPO's dependency on the service-ca operator for TLS cert generation in hosted control plane namespaces. See [OCPBUGS-34662](https://redhat.atlassian.net/browse/OCPBUGS-34662) / [#7538](https://github.com/openshift/hypershift/pull/7538) for the full scope.

Bug: [OCPBUGS-84572](https://redhat.atlassian.net/browse/OCPBUGS-84572)

## Test plan

- [x] Unit test for cert generation (`TestReconcileAWSEBSCsiDriverOperatorMetricsServingCertSecret`)
- [x] Verify `aws-ebs-csi-driver-operator` pod starts successfully on a non-OpenShift management cluster
- [x] Verify PersistentVolumeClaim binding works on the guest cluster
- [ ] E2E: `ci/prow/e2e-aws` (validates no reconciliation fight with service-ca on OpenShift management clusters)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provisioning of an AWS EBS CSI driver operator metrics TLS certificate signed by the control-plane CA.
  * Added a headless metrics Service for the AWS EBS CSI driver operator.
  * Any existing service-ca–managed serving-cert annotation/secret for the operator metrics Service is cleared before provisioning; cleanup errors are logged, while certificate provisioning errors surface as reconciliation failures.

* **Tests**
  * Unit tests added to verify the TLS secret contains key/cert and expected X.509 SANs and subject fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->