### PR TITLE
OCPBUGS-38898: fix kubeadmin password hash reconciliation to compare password against stored hash

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kubeadminpassword/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kubeadminpassword/reconcile.go
@@ -9,13 +9,15 @@ import (
 )
 
 func ReconcileKubeadminPasswordHashSecret(secret *corev1.Secret, passwordSecret *corev1.Secret) error {
+	password := passwordSecret.Data["password"]
 	if secret.Data != nil {
 		hash, hasHash := secret.Data["kubeadmin"]
 		if hasHash && len(hash) > 0 {
-			return nil
+			if bcrypt.CompareHashAndPassword(hash, password) == nil {
+				return nil
+			}
 		}
 	}
-	password := passwordSecret.Data["password"]
 	passwordHash, err := bcrypt.GenerateFromPassword(password, bcrypt.DefaultCost)
 	if err != nil {
 		return fmt.Errorf("failed to generate password hash: %w", err)

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kubeadminpassword/reconcile_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kubeadminpassword/reconcile_test.go
@@ -1,0 +1,77 @@
+package kubeadminpassword
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+func TestReconcileKubeadminPasswordHashSecret(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		existingHash  []byte
+		password      []byte
+		expectNewHash bool
+	}{
+		"When no existing hash it should generate a new hash": {
+			password:      []byte("adminpass"),
+			expectNewHash: true,
+		},
+		"When existing hash does not match the password it should regenerate the hash": {
+			existingHash:  []byte("stale-non-matching-hash"),
+			password:      []byte("adminpass"),
+			expectNewHash: true,
+		},
+		"When existing hash is a valid bcrypt hash of a different password it should regenerate the hash": {
+			existingHash: func() []byte {
+				h, _ := bcrypt.GenerateFromPassword([]byte("old-password"), bcrypt.MinCost)
+				return h
+			}(),
+			password:      []byte("adminpass"),
+			expectNewHash: true,
+		},
+		"When hash already matches password it should not regenerate": {
+			existingHash: func() []byte {
+				h, _ := bcrypt.GenerateFromPassword([]byte("adminpass"), bcrypt.MinCost)
+				return h
+			}(),
+			password:      []byte("adminpass"),
+			expectNewHash: false,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kubeadmin-password-hash",
+					Namespace: "kube-system",
+				},
+			}
+			if test.existingHash != nil {
+				secret.Data = map[string][]byte{"kubeadmin": test.existingHash}
+			}
+			passwordSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kubeadmin-password",
+					Namespace: "master-cluster1",
+				},
+				Data: map[string][]byte{"password": test.password},
+			}
+
+			err := ReconcileKubeadminPasswordHashSecret(secret, passwordSecret)
+			g.Expect(err).To(BeNil())
+			g.Expect(secret.Data["kubeadmin"]).ToNot(BeEmpty())
+			g.Expect(bcrypt.CompareHashAndPassword(secret.Data["kubeadmin"], test.password)).To(BeNil())
+
+			if !test.expectNewHash {
+				g.Expect(secret.Data["kubeadmin"]).To(Equal(test.existingHash))
+			}
+		})
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap/zaptest"
+	"golang.org/x/crypto/bcrypt"
 )
 
 type testClient struct {
@@ -69,11 +70,16 @@ var initialObjects = []client.Object{
 	globalconfig.ProjectConfig(),
 	globalconfig.BuildConfig(),
 	globalconfig.ProxyConfig(),
-	// Not running bcrypt hashing for the kubeadmin secret massively speeds up the tests, 4s vs 0.1s (and for -race its ~10x that)
+	// Use a valid bcrypt hash of "test" (matching fakeKubeadminPasswordSecret) so the
+	// CompareHashAndPassword check passes and avoids re-hashing on every reconcile.
+	// MinCost keeps the tests fast (~0.1s vs ~4s with DefaultCost, ~10x worse with -race).
 	&corev1.Secret{
 		ObjectMeta: manifests.KubeadminPasswordHashSecret().ObjectMeta,
 		Data: map[string][]byte{
-			"kubeadmin": []byte("something"),
+			"kubeadmin": func() []byte {
+				h, _ := bcrypt.GenerateFromPassword([]byte("test"), bcrypt.MinCost)
+				return h
+			}(),
 		},
 	},
 	manifests.NodeTuningClusterOperator(),
@@ -483,7 +489,9 @@ func TestReconcileKubeadminPasswordHashSecret(t *testing.T) {
 	tests := map[string]struct {
 		inputHCP                                 *hyperv1.HostedControlPlane
 		inputObjects                             []client.Object
+		existingHashSecret                       *corev1.Secret
 		expectKubeadminPasswordHashSecretToExist bool
+		expectHashPreserved                      bool
 	}{
 		"when kubeadminPasswordSecret exists the hash secret is created": {
 			inputHCP: &hyperv1.HostedControlPlane{
@@ -505,6 +513,62 @@ func TestReconcileKubeadminPasswordHashSecret(t *testing.T) {
 			},
 			expectKubeadminPasswordHashSecretToExist: true,
 		},
+		"When existing hash does not match the password it should regenerate the hash": {
+			inputHCP: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testHCPName,
+					Namespace: testNamespace,
+				},
+			},
+			inputObjects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: manifests.KubeadminPasswordSecret(testNamespace).ObjectMeta,
+					Data: map[string][]byte{
+						"password": []byte(`adminpass`),
+					},
+				},
+				&appsv1.Deployment{
+					ObjectMeta: manifests.OAuthDeployment(testNamespace).ObjectMeta,
+				},
+			},
+			existingHashSecret: &corev1.Secret{
+				ObjectMeta: manifests.KubeadminPasswordHashSecret().ObjectMeta,
+				Data: map[string][]byte{
+					"kubeadmin": []byte("stale-non-matching-hash"),
+				},
+			},
+			expectKubeadminPasswordHashSecretToExist: true,
+		},
+		"When hash already matches password it should not regenerate": {
+			inputHCP: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testHCPName,
+					Namespace: testNamespace,
+				},
+			},
+			inputObjects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: manifests.KubeadminPasswordSecret(testNamespace).ObjectMeta,
+					Data: map[string][]byte{
+						"password": []byte(`adminpass`),
+					},
+				},
+				&appsv1.Deployment{
+					ObjectMeta: manifests.OAuthDeployment(testNamespace).ObjectMeta,
+				},
+			},
+			existingHashSecret: &corev1.Secret{
+				ObjectMeta: manifests.KubeadminPasswordHashSecret().ObjectMeta,
+				Data: map[string][]byte{
+					"kubeadmin": func() []byte {
+						h, _ := bcrypt.GenerateFromPassword([]byte("adminpass"), bcrypt.MinCost)
+						return h
+					}(),
+				},
+			},
+			expectKubeadminPasswordHashSecretToExist: true,
+			expectHashPreserved:                      true,
+		},
 		"when kubeadminPasswordSecret doesn't exist the hash secret is not created": {
 			inputHCP: &hyperv1.HostedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
@@ -523,8 +587,12 @@ func TestReconcileKubeadminPasswordHashSecret(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
+			guestClientBuilder := fake.NewClientBuilder().WithScheme(api.Scheme)
+			if test.existingHashSecret != nil {
+				guestClientBuilder = guestClientBuilder.WithObjects(test.existingHashSecret)
+			}
 			r := &reconciler{
-				client:                 fake.NewClientBuilder().WithScheme(api.Scheme).Build(),
+				client:                 guestClientBuilder.Build(),
 				CreateOrUpdateProvider: &simpleCreateOrUpdater{},
 				cpClient:               fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(append(test.inputObjects, test.inputHCP)...).Build(),
 				hcpName:                testHCPName,
@@ -536,7 +604,17 @@ func TestReconcileKubeadminPasswordHashSecret(t *testing.T) {
 				actualKubeAdminSecret := manifests.KubeadminPasswordHashSecret()
 				err := r.client.Get(t.Context(), client.ObjectKeyFromObject(actualKubeAdminSecret), actualKubeAdminSecret)
 				g.Expect(err).To(BeNil())
-				g.Expect(len(actualKubeAdminSecret.Data["kubeadmin"]) > 0).To(BeTrue())
+				g.Expect(actualKubeAdminSecret.Data["kubeadmin"]).ToNot(BeEmpty())
+				if test.expectHashPreserved {
+					g.Expect(actualKubeAdminSecret.Data["kubeadmin"]).To(Equal(test.existingHashSecret.Data["kubeadmin"]))
+				}
+				passwordSecret := manifests.KubeadminPasswordSecret(testNamespace)
+				err = r.cpClient.Get(t.Context(), client.ObjectKeyFromObject(passwordSecret), passwordSecret)
+				g.Expect(err).To(BeNil())
+				g.Expect(bcrypt.CompareHashAndPassword(
+					actualKubeAdminSecret.Data["kubeadmin"],
+					passwordSecret.Data["password"],
+				)).To(BeNil())
 			} else {
 				actualKubeAdminSecret := manifests.KubeadminPasswordHashSecret()
 				err := r.client.Get(t.Context(), client.ObjectKeyFromObject(actualKubeAdminSecret), actualKubeAdminSecret)


### PR DESCRIPTION
## What this PR does / why we need it:

Previously, `ReconcileKubeadminPasswordHashSecret` would skip hash generation
whenever a non-empty `kubeadmin` hash already existed in the secret, without
verifying that the hash actually corresponded to the current password. This
meant that if the password secret was updated, the stale bcrypt hash would
persist and the new password would never take effect.

A concrete example is etcd restoration: after restoring an HCP cluster, a new
kubeadmin password is generated, but the restored secret still contains the old
bcrypt hash. Since the old hash is non-empty, the reconciler would short-circuit
and never regenerate, leaving the hash permanently out of sync with the new
password.

This PR fixes the reconciliation logic to use `bcrypt.CompareHashAndPassword`
to verify the existing hash matches the current password before short-circuiting.
If the comparison fails (password changed), a new hash is generated and stored.

## Which issue(s) this PR fixes:

Fixes OCPBUGS-38898

## Special notes for your reviewer:

- The `password` variable read is moved before the early-return check so it is
  available for the `bcrypt.CompareHashAndPassword` call.
- No new dependencies are introduced; `bcrypt` was already imported.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin password handling now verifies stored password hashes and only treats them as current when they match the provided plaintext; stale or invalid hashes are regenerated and updated to maintain reliable access.

* **Tests**
  * Expanded unit tests for admin password reconciliation to cover matching, stale, and empty-hash scenarios and to validate that reconciled hashes authenticate correctly against the source plaintext.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->