### PR TITLE
WIP: ARO-24037 feat(azure): enable ACR image pulls via managed identity on worker nodes

### DIFF
--- a/api/hypershift/v1beta1/azure.go
+++ b/api/hypershift/v1beta1/azure.go
@@ -469,6 +469,21 @@ type AzurePlatformSpec struct {
 	// +kubebuilder:validation:MaxLength=255
 	TenantID string `json:"tenantID"`
 
+	// acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+	// that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+	// When set, the identity is attached to worker VM scale sets and configured in the worker
+	// cloud provider config so kubelet's credential provider can authenticate to ACR without
+	// image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+	//
+	// The expected format is:
+	//   /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+	//
+	// +kubebuilder:validation:XValidation:rule="self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')",message="acrImagePullManagedIdentityID must be an ARM resource ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}"
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=512
+	// +optional
+	AcrImagePullManagedIdentityID string `json:"acrImagePullManagedIdentityID,omitempty"`
+
 	// topology specifies the network topology of the API server endpoint for the hosted cluster.
 	// - Public: The API server is accessible only via a public endpoint.
 	// - PublicAndPrivate: The API server is accessible via both public and private endpoints.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -4254,6 +4254,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -4381,6 +4381,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -4245,6 +4245,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -4265,6 +4265,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -4578,6 +4578,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -4718,6 +4718,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -4699,6 +4699,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
@@ -4245,6 +4245,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -4310,6 +4310,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -4267,6 +4267,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -4263,6 +4263,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -4321,6 +4321,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -4245,6 +4245,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -4132,6 +4132,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AutoNodeKarpenter.yaml
@@ -4261,6 +4261,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -4123,6 +4123,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -4143,6 +4143,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -4456,6 +4456,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -4596,6 +4596,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -4577,6 +4577,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
@@ -4123,6 +4123,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -4188,6 +4188,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -4145,6 +4145,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -4141,6 +4141,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -4199,6 +4199,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -4123,6 +4123,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/client/applyconfiguration/hypershift/v1beta1/azureplatformspec.go
+++ b/client/applyconfiguration/hypershift/v1beta1/azureplatformspec.go
@@ -24,17 +24,18 @@ import (
 // AzurePlatformSpecApplyConfiguration represents a declarative configuration of the AzurePlatformSpec type for use
 // with apply.
 type AzurePlatformSpecApplyConfiguration struct {
-	Cloud                     *string                                             `json:"cloud,omitempty"`
-	Location                  *string                                             `json:"location,omitempty"`
-	ResourceGroupName         *string                                             `json:"resourceGroup,omitempty"`
-	VnetID                    *string                                             `json:"vnetID,omitempty"`
-	SubnetID                  *string                                             `json:"subnetID,omitempty"`
-	SubscriptionID            *string                                             `json:"subscriptionID,omitempty"`
-	SecurityGroupID           *string                                             `json:"securityGroupID,omitempty"`
-	AzureAuthenticationConfig *AzureAuthenticationConfigurationApplyConfiguration `json:"azureAuthenticationConfig,omitempty"`
-	TenantID                  *string                                             `json:"tenantID,omitempty"`
-	Topology                  *hypershiftv1beta1.AzureTopologyType                `json:"topology,omitempty"`
-	Private                   *AzurePrivateSpecApplyConfiguration                 `json:"private,omitempty"`
+	Cloud                         *string                                             `json:"cloud,omitempty"`
+	Location                      *string                                             `json:"location,omitempty"`
+	ResourceGroupName             *string                                             `json:"resourceGroup,omitempty"`
+	VnetID                        *string                                             `json:"vnetID,omitempty"`
+	SubnetID                      *string                                             `json:"subnetID,omitempty"`
+	SubscriptionID                *string                                             `json:"subscriptionID,omitempty"`
+	SecurityGroupID               *string                                             `json:"securityGroupID,omitempty"`
+	AzureAuthenticationConfig     *AzureAuthenticationConfigurationApplyConfiguration `json:"azureAuthenticationConfig,omitempty"`
+	TenantID                      *string                                             `json:"tenantID,omitempty"`
+	AcrImagePullManagedIdentityID *string                                             `json:"acrImagePullManagedIdentityID,omitempty"`
+	Topology                      *hypershiftv1beta1.AzureTopologyType                `json:"topology,omitempty"`
+	Private                       *AzurePrivateSpecApplyConfiguration                 `json:"private,omitempty"`
 }
 
 // AzurePlatformSpecApplyConfiguration constructs a declarative configuration of the AzurePlatformSpec type for use with
@@ -112,6 +113,14 @@ func (b *AzurePlatformSpecApplyConfiguration) WithAzureAuthenticationConfig(valu
 // If called multiple times, the TenantID field is set to the value of the last call.
 func (b *AzurePlatformSpecApplyConfiguration) WithTenantID(value string) *AzurePlatformSpecApplyConfiguration {
 	b.TenantID = &value
+	return b
+}
+
+// WithAcrImagePullManagedIdentityID sets the AcrImagePullManagedIdentityID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the AcrImagePullManagedIdentityID field is set to the value of the last call.
+func (b *AzurePlatformSpecApplyConfiguration) WithAcrImagePullManagedIdentityID(value string) *AzurePlatformSpecApplyConfiguration {
+	b.AcrImagePullManagedIdentityID = &value
 	return b
 }
 

--- a/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.azure.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.azure.testsuite.yaml
@@ -813,3 +813,358 @@ tests:
             type: Route
             route: {}
     expectedError: "workloadIdentities.controlPlaneOperator is required when Private Link is configured with WorkloadIdentities authentication"
+
+  # --- ACR image pull managed identity validation ---
+  - name: When acrImagePullManagedIdentityID has valid ARM format it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: Azure
+          azure:
+            location: eastus
+            resourceGroupName: test-rg
+            vnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet"
+            subnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet"
+            subscriptionID: "12345678-1234-5678-9012-123456789012"
+            securityGroupID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/test-nsg"
+            tenantID: "87654321-4321-8765-2109-876543210987"
+            acrImagePullManagedIdentityID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity"
+            azureAuthenticationConfig:
+              azureAuthenticationConfigType: ManagedIdentities
+              managedIdentities:
+                controlPlane:
+                  managedIdentitiesKeyVault:
+                    name: test-kv
+                    tenantID: "87654321-4321-8765-2109-876543210987"
+                  cloudProvider:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: cloud-provider-secret
+                    objectEncoding: utf-8
+                  nodePoolManagement:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: node-pool-secret
+                    objectEncoding: utf-8
+                  controlPlaneOperator:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: cpo-secret
+                    objectEncoding: utf-8
+                  imageRegistry:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: image-registry-secret
+                    objectEncoding: utf-8
+                  ingress:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: ingress-secret
+                    objectEncoding: utf-8
+                  network:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: network-secret
+                    objectEncoding: utf-8
+                  disk:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: disk-secret
+                    objectEncoding: utf-8
+                  file:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: file-secret
+                    objectEncoding: utf-8
+                dataPlane:
+                  imageRegistryMSIClientID: "12345678-1234-5678-9012-123456789012"
+                  diskMSIClientID: "12345678-1234-5678-9012-123456789012"
+                  fileMSIClientID: "12345678-1234-5678-9012-123456789012"
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+
+  - name: When acrImagePullManagedIdentityID has lowercase resourcegroups it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: Azure
+          azure:
+            location: eastus
+            resourceGroupName: test-rg
+            vnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet"
+            subnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet"
+            subscriptionID: "12345678-1234-5678-9012-123456789012"
+            securityGroupID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/test-nsg"
+            tenantID: "87654321-4321-8765-2109-876543210987"
+            acrImagePullManagedIdentityID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourcegroups/test-rg/providers/microsoft.managedidentity/userassignedidentities/test-identity"
+            azureAuthenticationConfig:
+              azureAuthenticationConfigType: ManagedIdentities
+              managedIdentities:
+                controlPlane:
+                  managedIdentitiesKeyVault:
+                    name: test-kv
+                    tenantID: "87654321-4321-8765-2109-876543210987"
+                  cloudProvider:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: cloud-provider-secret
+                    objectEncoding: utf-8
+                  nodePoolManagement:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: node-pool-secret
+                    objectEncoding: utf-8
+                  controlPlaneOperator:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: cpo-secret
+                    objectEncoding: utf-8
+                  imageRegistry:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: image-registry-secret
+                    objectEncoding: utf-8
+                  ingress:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: ingress-secret
+                    objectEncoding: utf-8
+                  network:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: network-secret
+                    objectEncoding: utf-8
+                  disk:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: disk-secret
+                    objectEncoding: utf-8
+                  file:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: file-secret
+                    objectEncoding: utf-8
+                dataPlane:
+                  imageRegistryMSIClientID: "12345678-1234-5678-9012-123456789012"
+                  diskMSIClientID: "12345678-1234-5678-9012-123456789012"
+                  fileMSIClientID: "12345678-1234-5678-9012-123456789012"
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+
+  - name: When acrImagePullManagedIdentityID has invalid format it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: Azure
+          azure:
+            location: eastus
+            resourceGroupName: test-rg
+            vnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet"
+            subnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet"
+            subscriptionID: "12345678-1234-5678-9012-123456789012"
+            securityGroupID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/test-nsg"
+            tenantID: "87654321-4321-8765-2109-876543210987"
+            acrImagePullManagedIdentityID: "not-a-valid-resource-id"
+            azureAuthenticationConfig:
+              azureAuthenticationConfigType: ManagedIdentities
+              managedIdentities:
+                controlPlane:
+                  managedIdentitiesKeyVault:
+                    name: test-kv
+                    tenantID: "87654321-4321-8765-2109-876543210987"
+                  cloudProvider:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: cloud-provider-secret
+                    objectEncoding: utf-8
+                  nodePoolManagement:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: node-pool-secret
+                    objectEncoding: utf-8
+                  controlPlaneOperator:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: cpo-secret
+                    objectEncoding: utf-8
+                  imageRegistry:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: image-registry-secret
+                    objectEncoding: utf-8
+                  ingress:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: ingress-secret
+                    objectEncoding: utf-8
+                  network:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: network-secret
+                    objectEncoding: utf-8
+                  disk:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: disk-secret
+                    objectEncoding: utf-8
+                  file:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: file-secret
+                    objectEncoding: utf-8
+                dataPlane:
+                  imageRegistryMSIClientID: "12345678-1234-5678-9012-123456789012"
+                  diskMSIClientID: "12345678-1234-5678-9012-123456789012"
+                  fileMSIClientID: "12345678-1234-5678-9012-123456789012"
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    expectedError: "acrImagePullManagedIdentityID must be an ARM resource ID in the format"
+
+  - name: When acrImagePullManagedIdentityID has wrong provider namespace it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: Azure
+          azure:
+            location: eastus
+            resourceGroupName: test-rg
+            vnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet"
+            subnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet"
+            subscriptionID: "12345678-1234-5678-9012-123456789012"
+            securityGroupID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/test-nsg"
+            tenantID: "87654321-4321-8765-2109-876543210987"
+            acrImagePullManagedIdentityID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/test-vm"
+            azureAuthenticationConfig:
+              azureAuthenticationConfigType: ManagedIdentities
+              managedIdentities:
+                controlPlane:
+                  managedIdentitiesKeyVault:
+                    name: test-kv
+                    tenantID: "87654321-4321-8765-2109-876543210987"
+                  cloudProvider:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: cloud-provider-secret
+                    objectEncoding: utf-8
+                  nodePoolManagement:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: node-pool-secret
+                    objectEncoding: utf-8
+                  controlPlaneOperator:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: cpo-secret
+                    objectEncoding: utf-8
+                  imageRegistry:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: image-registry-secret
+                    objectEncoding: utf-8
+                  ingress:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: ingress-secret
+                    objectEncoding: utf-8
+                  network:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: network-secret
+                    objectEncoding: utf-8
+                  disk:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: disk-secret
+                    objectEncoding: utf-8
+                  file:
+                    clientID: "12345678-1234-5678-9012-123456789012"
+                    credentialsSecretName: file-secret
+                    objectEncoding: utf-8
+                dataPlane:
+                  imageRegistryMSIClientID: "12345678-1234-5678-9012-123456789012"
+                  diskMSIClientID: "12345678-1234-5678-9012-123456789012"
+                  fileMSIClientID: "12345678-1234-5678-9012-123456789012"
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    expectedError: "acrImagePullManagedIdentityID must be an ARM resource ID in the format"

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
@@ -5183,6 +5183,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
@@ -4747,6 +4747,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -5094,6 +5094,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
@@ -5063,6 +5063,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
@@ -4625,6 +4625,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -4974,6 +4974,23 @@ spec:
                   azure:
                     description: azure defines azure specific settings
                     properties:
+                      acrImagePullManagedIdentityID:
+                        description: |-
+                          acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+                          that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+                          When set, the identity is attached to worker VM scale sets and configured in the worker
+                          cloud provider config so kubelet's credential provider can authenticate to ACR without
+                          image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+
+                          The expected format is:
+                            /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: acrImagePullManagedIdentityID must be an ARM resource
+                            ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+                          rule: self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')
                       azureAuthenticationConfig:
                         description: |-
                           azureAuthenticationConfig is the type of Azure authentication configuration to use to authenticate with Azure's

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/config.go
@@ -28,6 +28,10 @@ func adaptConfig(cpContext component.WorkloadContext, cm *corev1.ConfigMap) erro
 		return err
 	}
 
+	if cpContext.HCP.Spec.Platform.Azure.AcrImagePullManagedIdentityID != "" {
+		cfg.UserAssignedIdentityID = cpContext.HCP.Spec.Platform.Azure.AcrImagePullManagedIdentityID
+	}
+
 	serializedConfig, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to serialize cloudconfig: %w", err)
@@ -199,4 +203,5 @@ type AzureConfig struct {
 	ClusterServiceLoadBalancerHealthProbeMode       string `json:"clusterServiceLoadBalancerHealthProbeMode"`
 	ClusterServiceSharedLoadBalancerHealthProbePath string `json:"clusterServiceSharedLoadBalancerHealthProbePath,omitempty"`
 	ClusterServiceSharedLoadBalancerHealthProbePort int32  `json:"clusterServiceSharedLoadBalancerHealthProbePort,omitempty"`
+	UserAssignedIdentityID                          string `json:"userAssignedIdentityID,omitempty"`
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/config_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/config_test.go
@@ -77,6 +77,53 @@ func newTestHCP(annotations map[string]string) *hyperv1.HostedControlPlane {
 	}
 }
 
+func TestConfigWithAcrMI(t *testing.T) {
+	hcp := newTestHCP(nil)
+	hcp.Namespace = "HCP_NAMESPACE"
+	hcp.Spec.Platform.Azure.AcrImagePullManagedIdentityID = "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-mi"
+
+	cm := &corev1.ConfigMap{}
+	_, _, err := assets.LoadManifestInto(ComponentName, "config.yaml", cm)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cpContext := component.WorkloadContext{
+		HCP: hcp,
+	}
+	err = adaptConfig(cpContext, cm)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	yaml, err := util.SerializeResource(cm, api.Scheme)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	testutil.CompareWithFixture(t, yaml)
+}
+
+func TestConfigSecretDoesNotContainAcrMI(t *testing.T) {
+	hcp := newTestHCP(nil)
+	hcp.Namespace = "HCP_NAMESPACE"
+	hcp.Spec.Platform.Azure.AcrImagePullManagedIdentityID = "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-mi"
+
+	secret := &corev1.Secret{
+		Data: map[string][]byte{},
+	}
+	cpContext := component.WorkloadContext{
+		HCP: hcp,
+	}
+	err := adaptConfigSecret(cpContext, secret)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cloudConf := string(secret.Data[ConfigKey])
+	if strings.Contains(cloudConf, "userAssignedIdentityID") {
+		t.Fatalf("CP secret should NOT contain userAssignedIdentityID, got: %s", cloudConf)
+	}
+}
+
 func TestConfigErrorStates(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/testdata/zz_fixture_TestConfigWithAcrMI.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/testdata/zz_fixture_TestConfigWithAcrMI.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+data:
+  cloud.conf: |-
+    {
+      "cloud": "AzurePublicCloud",
+      "tenantId": "my-tenant-id",
+      "useManagedIdentityExtension": false,
+      "useFederatedWorkloadIdentityExtension": true,
+      "subscriptionId": "my-subscription-id",
+      "aadClientId": "my-client-id",
+      "aadClientSecret": "",
+      "aadClientCertPath": "",
+      "aadFederatedTokenFile": "/var/run/secrets/openshift/serviceaccount/token",
+      "aadMSIDataPlaneIdentityPath": "",
+      "resourceGroup": "my-resource-group",
+      "location": "eastus",
+      "vnetName": "my-vnet",
+      "vnetResourceGroup": "my-vnet-rg",
+      "subnetName": "my-subnet",
+      "securityGroupName": "my-security-group",
+      "securityGroupResourceGroup": "my-sg-rg",
+      "routeTableName": "",
+      "cloudProviderBackoff": true,
+      "cloudProviderBackoffDuration": 6,
+      "useInstanceMetadata": true,
+      "loadBalancerSku": "standard",
+      "disableOutboundSNAT": true,
+      "loadBalancerName": "my-infra-ID",
+      "clusterServiceLoadBalancerHealthProbeMode": "shared",
+      "userAssignedIdentityID": "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-mi"
+    }
+kind: ConfigMap
+metadata:
+  name: azure-cloud-config

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -34358,6 +34358,24 @@ string
 </tr>
 <tr>
 <td>
+<code>acrImagePullManagedIdentityID</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+When set, the identity is attached to worker VM scale sets and configured in the worker
+cloud provider config so kubelet&rsquo;s credential provider can authenticate to ACR without
+image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).</p>
+<p>The expected format is:
+/subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>topology</code></br>
 <em>
 <a href="#hypershift.openshift.io/v1beta1.AzureTopologyType">

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -3924,6 +3924,24 @@ string
 </tr>
 <tr>
 <td>
+<code>acrImagePullManagedIdentityID</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+When set, the identity is attached to worker VM scale sets and configured in the worker
+cloud provider config so kubelet&rsquo;s credential provider can authenticate to ACR without
+image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).</p>
+<p>The expected format is:
+/subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>topology</code></br>
 <em>
 <a href="#hypershift.openshift.io/v1beta1.AzureTopologyType">

--- a/hypershift-operator/controllers/nodepool/azure.go
+++ b/hypershift-operator/controllers/nodepool/azure.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	capiazure "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	capzutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 
 	"github.com/blang/semver"
 )
@@ -167,7 +168,7 @@ func getAzureMarketplaceMetadata(releaseImage *releaseinfo.ReleaseImage, arch st
 	return result, nil
 }
 
-func azureMachineTemplateSpec(nodePool *hyperv1.NodePool) (*capiazure.AzureMachineTemplateSpec, error) {
+func azureMachineTemplateSpec(nodePool *hyperv1.NodePool, hostedCluster *hyperv1.HostedCluster) (*capiazure.AzureMachineTemplateSpec, error) {
 	subnetName, err := azureutil.GetSubnetNameFromSubnetID(nodePool.Spec.Platform.Azure.SubnetID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine subnet name for Azure machine: %w", err)
@@ -244,6 +245,16 @@ func azureMachineTemplateSpec(nodePool *hyperv1.NodePool) (*capiazure.AzureMachi
 		}
 	}
 
+	if hostedCluster != nil && hostedCluster.Spec.Platform.Azure != nil && hostedCluster.Spec.Platform.Azure.AcrImagePullManagedIdentityID != "" {
+		azureMachineTemplate.Template.Spec.Identity = capiazure.VMIdentityUserAssigned
+		azureMachineTemplate.Template.Spec.UserAssignedIdentities = append(
+			azureMachineTemplate.Template.Spec.UserAssignedIdentities,
+			capiazure.UserAssignedIdentity{
+				ProviderID: capzutil.ProviderIDPrefix + hostedCluster.Spec.Platform.Azure.AcrImagePullManagedIdentityID,
+			},
+		)
+	}
+
 	azureMachineTemplate.Template.Spec.SSHPublicKey = dummySSHKey
 
 	return azureMachineTemplate, nil
@@ -255,7 +266,7 @@ func (c *CAPI) azureMachineTemplate(ctx context.Context, templateNameGenerator f
 		return nil, fmt.Errorf("failed to apply Azure image defaults: %w", err)
 	}
 
-	spec, err := azureMachineTemplateSpec(c.nodePool)
+	spec, err := azureMachineTemplateSpec(c.nodePool, c.hostedCluster)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate AzureMachineTemplateSpec: %w", err)
 	}

--- a/hypershift-operator/controllers/nodepool/azure_test.go
+++ b/hypershift-operator/controllers/nodepool/azure_test.go
@@ -22,6 +22,7 @@ func TestAzureMachineTemplateSpec(t *testing.T) {
 	testCases := []struct {
 		name                             string
 		nodePool                         *hyperv1.NodePool
+		hostedCluster                    *hyperv1.HostedCluster
 		expectedAzureMachineTemplateSpec *capiazure.AzureMachineTemplateSpec
 		expectedErr                      bool
 		expectedErrMsg                   string
@@ -507,12 +508,185 @@ func TestAzureMachineTemplateSpec(t *testing.T) {
 			expectedErr:    true,
 			expectedErrMsg: "failed to determine subnet name for Azure machine: failed to parse subnet name from \"/subscriptions/testSubscriptionID/resourceGroups/testResourceGroupName/providers/Microsoft.Network/virtualNetworks/testVnetName/subnets/\"",
 		},
+		{
+			name: "When HostedCluster has AcrImagePullManagedIdentityID set it should set UserAssigned identity",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.AzurePlatform,
+						Azure: &hyperv1.AzureNodePoolPlatform{
+							Image: hyperv1.AzureVMImage{
+								Type:    hyperv1.ImageID,
+								ImageID: ptr.To("testImageID"),
+							},
+							SubnetID: "/subscriptions/testSubscriptionID/resourceGroups/testResourceGroupName/providers/Microsoft.Network/virtualNetworks/testVnetName/subnets/testSubnetName",
+							VMSize:   "Standard_D2_v2",
+							OSDisk: hyperv1.AzureNodePoolOSDisk{
+								SizeGiB:                30,
+								DiskStorageAccountType: "Standard_LRS",
+							},
+						},
+					},
+				},
+			},
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+						Azure: &hyperv1.AzurePlatformSpec{
+							AcrImagePullManagedIdentityID: "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-mi",
+						},
+					},
+				},
+			},
+			expectedAzureMachineTemplateSpec: &capiazure.AzureMachineTemplateSpec{
+				Template: capiazure.AzureMachineTemplateResource{
+					ObjectMeta: clusterv1.ObjectMeta{Labels: nil, Annotations: nil},
+					Spec: capiazure.AzureMachineSpec{
+						ProviderID:    nil,
+						VMSize:        "Standard_D2_v2",
+						FailureDomain: nil,
+						Image: &capiazure.Image{
+							ID:             ptr.To("testImageID"),
+							SharedGallery:  nil,
+							Marketplace:    nil,
+							ComputeGallery: nil,
+						},
+						Identity: capiazure.VMIdentityUserAssigned,
+						UserAssignedIdentities: []capiazure.UserAssignedIdentity{
+							{ProviderID: "azure:///subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-mi"},
+						},
+						SystemAssignedIdentityRole: nil,
+						RoleAssignmentName:         "",
+						OSDisk: capiazure.OSDisk{
+							OSType:     "",
+							DiskSizeGB: ptr.To[int32](30),
+							ManagedDisk: &capiazure.ManagedDiskParameters{
+								StorageAccountType: "Standard_LRS",
+								DiskEncryptionSet:  nil,
+								SecurityProfile:    nil,
+							},
+							DiffDiskSettings: nil,
+							CachingType:      "",
+						},
+						DataDisks:              nil,
+						SSHPublicKey:           dummySSHKey,
+						AdditionalTags:         nil,
+						AdditionalCapabilities: nil,
+						AllocatePublicIP:       false,
+						EnableIPForwarding:     false,
+						AcceleratedNetworking:  nil,
+						Diagnostics:            nil,
+						SpotVMOptions:          nil,
+						SecurityProfile:        nil,
+						SubnetName:             "",
+						DNSServers:             nil,
+						VMExtensions:           nil,
+						NetworkInterfaces: []capiazure.NetworkInterface{
+							{
+								SubnetName:            "testSubnetName",
+								PrivateIPConfigs:      0,
+								AcceleratedNetworking: nil,
+							},
+						},
+						CapacityReservationGroupID: nil,
+					},
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "When HostedCluster has empty AcrImagePullManagedIdentityID it should not set UserAssigned identity",
+			nodePool: &hyperv1.NodePool{
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.AzurePlatform,
+						Azure: &hyperv1.AzureNodePoolPlatform{
+							Image: hyperv1.AzureVMImage{
+								Type:    hyperv1.ImageID,
+								ImageID: ptr.To("testImageID"),
+							},
+							SubnetID: "/subscriptions/testSubscriptionID/resourceGroups/testResourceGroupName/providers/Microsoft.Network/virtualNetworks/testVnetName/subnets/testSubnetName",
+							VMSize:   "Standard_D2_v2",
+							OSDisk: hyperv1.AzureNodePoolOSDisk{
+								SizeGiB:                30,
+								DiskStorageAccountType: "Standard_LRS",
+							},
+						},
+					},
+				},
+			},
+			hostedCluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type:  hyperv1.AzurePlatform,
+						Azure: &hyperv1.AzurePlatformSpec{},
+					},
+				},
+			},
+			expectedAzureMachineTemplateSpec: &capiazure.AzureMachineTemplateSpec{
+				Template: capiazure.AzureMachineTemplateResource{
+					ObjectMeta: clusterv1.ObjectMeta{Labels: nil, Annotations: nil},
+					Spec: capiazure.AzureMachineSpec{
+						ProviderID:    nil,
+						VMSize:        "Standard_D2_v2",
+						FailureDomain: nil,
+						Image: &capiazure.Image{
+							ID:             ptr.To("testImageID"),
+							SharedGallery:  nil,
+							Marketplace:    nil,
+							ComputeGallery: nil,
+						},
+						UserAssignedIdentities:     nil,
+						SystemAssignedIdentityRole: nil,
+						RoleAssignmentName:         "",
+						OSDisk: capiazure.OSDisk{
+							OSType:     "",
+							DiskSizeGB: ptr.To[int32](30),
+							ManagedDisk: &capiazure.ManagedDiskParameters{
+								StorageAccountType: "Standard_LRS",
+								DiskEncryptionSet:  nil,
+								SecurityProfile:    nil,
+							},
+							DiffDiskSettings: nil,
+							CachingType:      "",
+						},
+						DataDisks:              nil,
+						SSHPublicKey:           dummySSHKey,
+						AdditionalTags:         nil,
+						AdditionalCapabilities: nil,
+						AllocatePublicIP:       false,
+						EnableIPForwarding:     false,
+						AcceleratedNetworking:  nil,
+						Diagnostics:            nil,
+						SpotVMOptions:          nil,
+						SecurityProfile:        nil,
+						SubnetName:             "",
+						DNSServers:             nil,
+						VMExtensions:           nil,
+						NetworkInterfaces: []capiazure.NetworkInterface{
+							{
+								SubnetName:            "testSubnetName",
+								PrivateIPConfigs:      0,
+								AcceleratedNetworking: nil,
+							},
+						},
+						CapacityReservationGroupID: nil,
+					},
+				},
+			},
+			expectedErr: false,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 
-			azureSpec, err := azureMachineTemplateSpec(tc.nodePool)
+			hc := tc.hostedCluster
+			if hc == nil {
+				hc = &hyperv1.HostedCluster{}
+			}
+			azureSpec, err := azureMachineTemplateSpec(tc.nodePool, hc)
 			if tc.expectedErr {
 				g.Expect(err.Error()).To(ContainSubstring(tc.expectedErrMsg))
 			} else {

--- a/test/e2e/util/util_metrics_proxy.go
+++ b/test/e2e/util/util_metrics_proxy.go
@@ -185,7 +185,7 @@ func execInGuestPod(ctx context.Context, guestConfig *rest.Config, namespace, po
 // targetsAPIResponse wraps the Prometheus /api/v1/targets JSON envelope
 // around the upstream TargetsResult type.
 type targetsAPIResponse struct {
-	Status string                    `json:"status"`
+	Status string                     `json:"status"`
 	Data   prometheusv1.TargetsResult `json:"data"`
 }
 
@@ -198,4 +198,3 @@ type queryAPIResponse struct {
 		Result     model.Vector `json:"result"`
 	} `json:"data"`
 }
-

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/azure.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/azure.go
@@ -469,6 +469,21 @@ type AzurePlatformSpec struct {
 	// +kubebuilder:validation:MaxLength=255
 	TenantID string `json:"tenantID"`
 
+	// acrImagePullManagedIdentityID is the resource ID of a user-assigned managed identity
+	// that will be used by worker nodes to pull images from Azure Container Registry (ACR).
+	// When set, the identity is attached to worker VM scale sets and configured in the worker
+	// cloud provider config so kubelet's credential provider can authenticate to ACR without
+	// image pull secrets. The identity must have the AcrPull role assigned on the target ACR(s).
+	//
+	// The expected format is:
+	//   /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}
+	//
+	// +kubebuilder:validation:XValidation:rule="self.lowerAscii().matches('^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft.managedidentity/userassignedidentities/[^/]+$')",message="acrImagePullManagedIdentityID must be an ARM resource ID in the format /subscriptions/{subscriptionID}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}"
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=512
+	// +optional
+	AcrImagePullManagedIdentityID string `json:"acrImagePullManagedIdentityID,omitempty"`
+
 	// topology specifies the network topology of the API server endpoint for the hosted cluster.
 	// - Public: The API server is accessible only via a public endpoint.
 	// - PublicAndPrivate: The API server is accessible via both public and private endpoints.


### PR DESCRIPTION
Add support for configuring kubelet's image credential provider to
authenticate to Azure Container Registry (ACR) using a user-assigned
managed identity. This eliminates the need for static pull secrets
by leveraging IMDS-based token acquisition on worker nodes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional managed identity support for Azure Container Registry image pulling on worker nodes, providing an alternative authentication method for container image retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->