### PR TITLE
NO-JIRA: Extend timeout for CRD removal during integration tests

### DIFF
--- a/test/envtest/generator.go
+++ b/test/envtest/generator.go
@@ -251,15 +251,28 @@ func GenerateCRDInstallTest(featureSet string) {
 		// Uninstall after validation and wait for full removal so that
 		// subsequent per-suite tests do not hit a stale CRD that is still
 		// being deleted by the API server.
-		Expect(envtest.UninstallCRDs(cfg, envtest.CRDInstallOptions{
-			CRDs: crds,
-		})).ToNot(HaveOccurred())
+		for _, crd := range crds {
+			Expect(k8sClient.Delete(ctx, crd)).To(SatisfyAny(Succeed(), WithTransform(apierrors.IsNotFound, BeTrue())))
+		}
+
 		for _, crd := range crds {
 			key := client.ObjectKeyFromObject(crd)
 			Eventually(func() bool {
+				// Check if the CRD exists
 				err := k8sClient.Get(ctx, key, &apiextensionsv1.CustomResourceDefinition{})
-				return apierrors.IsNotFound(err)
-			}, "120s", "1s").Should(BeTrue(), fmt.Sprintf("CRD %s should be fully removed", crd.Name))
+				if apierrors.IsNotFound(err) {
+					return true
+				}
+
+				// Attempt to delete it if it still exists
+
+				if err := k8sClient.Delete(ctx, crd); apierrors.IsNotFound(err) {
+					return true
+				}
+
+				// Return false, the next iteration will see the CRD gone.
+				return false
+			}, "30s", "200ms").Should(BeTrue(), fmt.Sprintf("CRD %s should be fully removed", crd.Name))
 		}
 	})
 }


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

After adjusting the output and running this in CI, I could see that the failures were because the deletiontimestamp wasn't set. I've updated the logic to make this more robust - if it sees that the CRD isn't gone, it will attempt to delete it again.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved CRD uninstallation verification: missing resources are treated as successful removal, polling now retries deletions until resources are confirmed removed, polling is more responsive (shorter interval), and failure messages are clearer and more descriptive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->