### PR TITLE
OSDOCS-19432: docs: add cluster capabilities how-to and contributor guide

### DIFF
--- a/api/AGENTS.md
+++ b/api/AGENTS.md
@@ -105,7 +105,7 @@ See `api/hypershift/v1beta1/nodepool_types_test.go` for an example of this patte
 
 All API CEL validations must be covered with envtests, see test/envtest/README.md for details
 
-#### Key make targets for API work:
+#### Key make targets for API work
 
 ```bash
 make api               # Regenerate all CRDs, deepcopy, clients
@@ -118,3 +118,7 @@ make test-envtest-ocp  # Run envtest for CEL validations
 ```
 
 All these must pass for any change before creating a PR
+
+## Cluster Capabilities
+
+The `OptionalCapability` type and `Capabilities` struct in `api/hypershift/v1beta1/hostedcluster_types.go` control which OpenShift operators are deployed in the hosted control plane. When adding a new capability constant or modifying CEL validation rules on the `Capabilities` struct, see [Adding a New Cluster Capability](../docs/content/contribute/add-a-capability.md) for the full implementation checklist and reference PRs.

--- a/docs/content/contribute/add-a-capability.md
+++ b/docs/content/contribute/add-a-capability.md
@@ -1,0 +1,136 @@
+# Adding a New Cluster Capability
+
+This guide describes how to add support for a new optional capability to the HostedCluster API, following the pattern established by the existing capabilities (ImageRegistry, Console, NodeTuning, etc.).
+
+For user-facing documentation on how capabilities work, see [Cluster Capabilities](../how-to/cluster-capabilities.md).
+
+## Background: OpenShift Capabilities
+
+HyperShift's capability system builds on top of OpenShift's `ClusterVersionCapability` type defined in the [openshift/api](https://github.com/openshift/api) module. The full set of known capabilities is defined in [`config/v1/types_cluster_version.go`](https://github.com/openshift/api/blob/master/config/v1/types_cluster_version.go) as the `KnownClusterVersionCapabilities` list and includes:
+
+| OpenShift Capability | Supported in HyperShift |
+|---|---|
+| `openshift-samples` | Yes |
+| `baremetal` | Yes |
+| `marketplace` | No |
+| `Console` | Yes |
+| `Insights` | Yes |
+| `Storage` | No |
+| `CSISnapshot` | No |
+| `NodeTuning` | Yes |
+| `MachineAPI` | No |
+| `Build` | No |
+| `DeploymentConfig` | No |
+| `ImageRegistry` | Yes |
+| `OperatorLifecycleManager` | No |
+| `OperatorLifecycleManagerV1` | No |
+| `CloudCredential` | No |
+| `Ingress` | Yes |
+| `CloudControllerManager` | No |
+
+When adding a new capability to HyperShift, the value **must** correspond to an existing `ClusterVersionCapability` constant from that upstream list. HyperShift's `CalculateEnabledCapabilities` function uses the upstream `ClusterVersionCapabilitySetCurrent` as the default set and then applies the explicitly enabled/disabled overrides. See `support/capabilities/hosted_control_plane_capabilities.go:68-90`.
+
+## Implementation Checklist
+
+### 1. Define the Capability Constant
+
+Add a new `OptionalCapability` constant in [`api/hypershift/v1beta1/hostedcluster_types.go`](https://github.com/openshift/hypershift/blob/main/api/hypershift/v1beta1/hostedcluster_types.go) alongside the existing ones (lines 477-483). The value must reference the corresponding `configv1.ClusterVersionCapability`:
+
+```go
+const MyCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityMyCapability)
+```
+
+Update the `// +kubebuilder:validation:Enum=...` tag on the `OptionalCapability` type (line 474) to include the new value.
+
+### 2. Add a Capability Helper Function
+
+Add an `Is<Name>CapabilityEnabled` function in [`support/capabilities/hosted_control_plane_capabilities.go`](https://github.com/openshift/hypershift/blob/main/support/capabilities/hosted_control_plane_capabilities.go). Follow the existing pattern:
+
+```go
+func IsMyCapabilityEnabled(capabilities *hyperv1.Capabilities) bool {
+    if capabilities == nil {
+        return true
+    }
+    for _, disabledCap := range capabilities.Disabled {
+        if disabledCap == hyperv1.MyCapability {
+            return false
+        }
+    }
+    return true
+}
+```
+
+### 3. Wire It Into the Controllers
+
+Depending on where the component's resources are reconciled, add checks to skip reconciliation when the capability is disabled. Common integration points:
+
+- **Control Plane Operator (CPO)** controllers under `control-plane-operator/controllers/hostedcontrolplane/` for control-plane-side operator deployments.
+- **Hosted Cluster Config Operator (HCCO)** controllers under `control-plane-operator/hostedclusterconfigoperator/controllers/resources/` for guest-cluster-side resources.
+- **CPOv2 components** under `control-plane-operator/controllers/hostedcontrolplane/v2/` for components using the new control plane component framework. Use the `IsDisabled()` method on the component to gate reconciliation based on capability state.
+
+Look at how existing capabilities gate their resources. For example:
+
+- `IsImageRegistryCapabilityEnabled` is checked in the registry operator component, nodepool controller, and KAS params.
+- `IsNodeTuningCapabilityEnabled` is checked in the NTO component and config operator.
+- `IsIngressCapabilityEnabled` is checked in the ingress operator component and config operator.
+
+### 4. Update the CLI Help Text
+
+Update the `--disable-cluster-capabilities` flag description in [`cmd/cluster/core/create.go`](https://github.com/openshift/hypershift/blob/main/cmd/cluster/core/create.go) (line 111) to include the new value in the supported values list.
+
+### 5. Regenerate CRDs and Vendored API
+
+Since `api/` is a separate Go module, you must run:
+
+```shell
+make update
+```
+
+This regenerates CRDs, revendors the API module, and updates generated clients.
+
+### 6. Add Tests
+
+Add test cases for the new helper function in [`support/capabilities/hosted_control_plane_capabilities_test.go`](https://github.com/openshift/hypershift/blob/main/support/capabilities/hosted_control_plane_capabilities_test.go). Cover:
+
+- Capability enabled by default (nil `Capabilities`).
+- Capability explicitly disabled.
+- Capability not in the disabled list (still enabled).
+
+### 7. Add CEL Validation (If Needed)
+
+If the new capability has cross-capability dependencies (like Ingress requiring Console to also be disabled), add a CEL validation rule on the `Disabled` field in the `Capabilities` struct (line 514 area). See the existing Ingress/Console constraint as an example:
+
+```go
+// +kubebuilder:validation:XValidation:rule="!self.exists(cap, cap == 'Ingress') || self.exists(cap, cap == 'Console')",message="Ingress capability can only be disabled if Console capability is also disabled"
+```
+
+## Reference PRs
+
+These PRs show the full implementation pattern for each capability that has been added:
+
+| Capability | PR | Description |
+|---|---|---|
+| ImageRegistry | [#5456](https://github.com/openshift/hypershift/pull/5456), [#5964](https://github.com/openshift/hypershift/pull/5964) | Initial implementation behind feature gate, then GA and backport to main |
+| openshift-samples | [#6197](https://github.com/openshift/hypershift/pull/6197) | Disabling the Samples operator |
+| Insights | [#6246](https://github.com/openshift/hypershift/pull/6246) | Disabling the Insights operator |
+| Console | [#6183](https://github.com/openshift/hypershift/pull/6183) | Disabling the Console operator (generic disable framework) |
+| NodeTuning | [#6356](https://github.com/openshift/hypershift/pull/6356) | Disabling the Node Tuning Operator |
+| Ingress | [#6319](https://github.com/openshift/hypershift/pull/6319) | Disabling the Ingress operator (with Console dependency constraint) |
+| baremetal | [#6158](https://github.com/openshift/hypershift/pull/6158) | Enable field support and baremetal default exclusion |
+
+The best PRs to use as a template are the simpler single-capability additions like [#6197](https://github.com/openshift/hypershift/pull/6197) (openshift-samples) or [#6246](https://github.com/openshift/hypershift/pull/6246) (Insights).
+
+## Key Code Locations
+
+| What | Path |
+|---|---|
+| `OptionalCapability` type and constants | `api/hypershift/v1beta1/hostedcluster_types.go:474-483` |
+| `Capabilities` struct and CEL rules | `api/hypershift/v1beta1/hostedcluster_types.go:485-516` |
+| `HostedClusterSpec.Capabilities` field | `api/hypershift/v1beta1/hostedcluster_types.go:829-835` |
+| `HostedControlPlaneSpec.Capabilities` field | `api/hypershift/v1beta1/hosted_controlplane.go:265-266` |
+| Capability helper functions | `support/capabilities/hosted_control_plane_capabilities.go` |
+| Capability helper tests | `support/capabilities/hosted_control_plane_capabilities_test.go` |
+| `CalculateEnabledCapabilities` (net capability set) | `support/capabilities/hosted_control_plane_capabilities.go:68-90` |
+| CLI flag definition | `cmd/cluster/core/create.go:111` |
+| CLI capability wiring | `cmd/cluster/core/create.go:361-368, 767-779` |
+| OpenShift `ClusterVersionCapability` definitions | [`openshift/api` `config/v1/types_cluster_version.go`](https://github.com/openshift/api/blob/master/config/v1/types_cluster_version.go) |

--- a/docs/content/how-to/cluster-capabilities.md
+++ b/docs/content/how-to/cluster-capabilities.md
@@ -1,0 +1,85 @@
+# Cluster Capabilities
+
+HyperShift allows administrators to enable or disable optional OpenShift components at cluster creation time through the **capabilities** API. This reduces resource consumption and attack surface by preventing unnecessary operators and operands from being deployed.
+
+## Default Behavior
+
+When `spec.capabilities` is not set on a HostedCluster, the cluster uses the OpenShift version's `DefaultCapabilitySet` with the `baremetal` capability excluded. This means most optional components are enabled by default.
+
+!!! important
+    Capabilities are **immutable** after cluster creation. They cannot be changed once the HostedCluster is created.
+
+## Supported Capabilities
+
+| Capability | Description |
+|---|---|
+| `ImageRegistry` | OpenShift Image Registry operator and its operands, including cloud storage infrastructure (S3 buckets, IAM users, etc.) |
+| `openshift-samples` | OpenShift Samples operator, which manages example ImageStreams and Templates |
+| `Insights` | Insights operator, which collects and uploads cluster telemetry data |
+| `baremetal` | Bare metal infrastructure operator. Excluded from the default set; must be explicitly enabled if needed |
+| `Console` | OpenShift web console operator and its operands |
+| `NodeTuning` | Node Tuning Operator (NTO), which manages node-level performance tuning via TuneD and PerformanceProfiles |
+| `Ingress` | OpenShift Ingress operator, which manages the cluster's default router |
+
+## Constraints
+
+The following rules apply when combining capability settings:
+
+- **No overlap**: A capability cannot appear in both `enabled` and `disabled` lists simultaneously.
+- **Console requires Ingress**: The `Ingress` capability can only be disabled if `Console` is also disabled, because the console depends on Ingress ([OCPBUGS-58422](https://issues.redhat.com/browse/OCPBUGS-58422)).
+- **Version requirement**: Disabling `openshift-samples`, `Insights`, `Console`, `NodeTuning`, or `Ingress` requires OpenShift 4.20 or later. `ImageRegistry` and `baremetal` can be disabled on earlier versions.
+- **Baremetal default exclusion**: The `baremetal` capability is already excluded from the default set. Explicitly disabling it is a no-op; explicitly enabling it will add it to the cluster.
+
+## Usage
+
+### CLI
+
+Use the `--disable-cluster-capabilities` flag when creating a cluster:
+
+```shell
+hypershift create cluster aws \
+  --name my-cluster \
+  --disable-cluster-capabilities=ImageRegistry,Console,Ingress
+```
+
+Multiple capabilities can be specified as a comma-separated list. The supported values are: `ImageRegistry`, `openshift-samples`, `Insights`, `baremetal`, `Console`, `NodeTuning`, `Ingress`.
+
+### HostedCluster Manifest
+
+To disable capabilities via the HostedCluster resource directly, set `spec.capabilities.disabled`:
+
+```yaml
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  name: my-cluster
+  namespace: clusters
+spec:
+  capabilities:
+    disabled:
+      - ImageRegistry
+      - Console
+      - Ingress
+  # ... rest of spec
+```
+
+To explicitly enable a capability that is not in the default set (e.g., `baremetal`):
+
+```yaml
+spec:
+  capabilities:
+    enabled:
+      - baremetal
+```
+
+Both `enabled` and `disabled` can be used together, as long as no capability appears in both lists:
+
+```yaml
+spec:
+  capabilities:
+    enabled:
+      - baremetal
+    disabled:
+      - ImageRegistry
+      - openshift-samples
+```

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -5,6 +5,148 @@ for use with AI tools like NotebookLM.
 
 ---
 
+## Source: docs/content/contribute/add-a-capability.md
+
+# Adding a New Cluster Capability
+
+This guide describes how to add support for a new optional capability to the HostedCluster API, following the pattern established by the existing capabilities (ImageRegistry, Console, NodeTuning, etc.).
+
+For user-facing documentation on how capabilities work, see Cluster Capabilities.
+
+## Background: OpenShift Capabilities
+
+HyperShift's capability system builds on top of OpenShift's `ClusterVersionCapability` type defined in the openshift/api module. The full set of known capabilities is defined in `config/v1/types_cluster_version.go` as the `KnownClusterVersionCapabilities` list and includes:
+
+| OpenShift Capability | Supported in HyperShift |
+|---|---|
+| `openshift-samples` | Yes |
+| `baremetal` | Yes |
+| `marketplace` | No |
+| `Console` | Yes |
+| `Insights` | Yes |
+| `Storage` | No |
+| `CSISnapshot` | No |
+| `NodeTuning` | Yes |
+| `MachineAPI` | No |
+| `Build` | No |
+| `DeploymentConfig` | No |
+| `ImageRegistry` | Yes |
+| `OperatorLifecycleManager` | No |
+| `OperatorLifecycleManagerV1` | No |
+| `CloudCredential` | No |
+| `Ingress` | Yes |
+| `CloudControllerManager` | No |
+
+When adding a new capability to HyperShift, the value **must** correspond to an existing `ClusterVersionCapability` constant from that upstream list. HyperShift's `CalculateEnabledCapabilities` function uses the upstream `ClusterVersionCapabilitySetCurrent` as the default set and then applies the explicitly enabled/disabled overrides. See `support/capabilities/hosted_control_plane_capabilities.go:68-90`.
+
+## Implementation Checklist
+
+### 1. Define the Capability Constant
+
+Add a new `OptionalCapability` constant in `api/hypershift/v1beta1/hostedcluster_types.go` alongside the existing ones (lines 477-483). The value must reference the corresponding `configv1.ClusterVersionCapability`:
+
+```go
+const MyCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityMyCapability)
+```
+
+Update the `// +kubebuilder:validation:Enum=...` tag on the `OptionalCapability` type (line 474) to include the new value.
+
+### 2. Add a Capability Helper Function
+
+Add an `Is<Name>CapabilityEnabled` function in `support/capabilities/hosted_control_plane_capabilities.go`. Follow the existing pattern:
+
+```go
+func IsMyCapabilityEnabled(capabilities *hyperv1.Capabilities) bool {
+    if capabilities == nil {
+        return true
+    }
+    for _, disabledCap := range capabilities.Disabled {
+        if disabledCap == hyperv1.MyCapability {
+            return false
+        }
+    }
+    return true
+}
+```
+
+### 3. Wire It Into the Controllers
+
+Depending on where the component's resources are reconciled, add checks to skip reconciliation when the capability is disabled. Common integration points:
+
+- **Control Plane Operator (CPO)** controllers under `control-plane-operator/controllers/hostedcontrolplane/` for control-plane-side operator deployments.
+- **Hosted Cluster Config Operator (HCCO)** controllers under `control-plane-operator/hostedclusterconfigoperator/controllers/resources/` for guest-cluster-side resources.
+- **CPOv2 components** under `control-plane-operator/controllers/hostedcontrolplane/v2/` for components using the new control plane component framework. Use the `IsDisabled()` method on the component to gate reconciliation based on capability state.
+
+Look at how existing capabilities gate their resources. For example:
+
+- `IsImageRegistryCapabilityEnabled` is checked in the registry operator component, nodepool controller, and KAS params.
+- `IsNodeTuningCapabilityEnabled` is checked in the NTO component and config operator.
+- `IsIngressCapabilityEnabled` is checked in the ingress operator component and config operator.
+
+### 4. Update the CLI Help Text
+
+Update the `--disable-cluster-capabilities` flag description in `cmd/cluster/core/create.go` (line 111) to include the new value in the supported values list.
+
+### 5. Regenerate CRDs and Vendored API
+
+Since `api/` is a separate Go module, you must run:
+
+```shell
+make update
+```
+
+This regenerates CRDs, revendors the API module, and updates generated clients.
+
+### 6. Add Tests
+
+Add test cases for the new helper function in `support/capabilities/hosted_control_plane_capabilities_test.go`. Cover:
+
+- Capability enabled by default (nil `Capabilities`).
+- Capability explicitly disabled.
+- Capability not in the disabled list (still enabled).
+
+### 7. Add CEL Validation (If Needed)
+
+If the new capability has cross-capability dependencies (like Ingress requiring Console to also be disabled), add a CEL validation rule on the `Disabled` field in the `Capabilities` struct (line 514 area). See the existing Ingress/Console constraint as an example:
+
+```go
+// +kubebuilder:validation:XValidation:rule="!self.exists(cap, cap == 'Ingress') || self.exists(cap, cap == 'Console')",message="Ingress capability can only be disabled if Console capability is also disabled"
+```
+
+## Reference PRs
+
+These PRs show the full implementation pattern for each capability that has been added:
+
+| Capability | PR | Description |
+|---|---|---|
+| ImageRegistry | #5456, #5964 | Initial implementation behind feature gate, then GA and backport to main |
+| openshift-samples | #6197 | Disabling the Samples operator |
+| Insights | #6246 | Disabling the Insights operator |
+| Console | #6183 | Disabling the Console operator (generic disable framework) |
+| NodeTuning | #6356 | Disabling the Node Tuning Operator |
+| Ingress | #6319 | Disabling the Ingress operator (with Console dependency constraint) |
+| baremetal | #6158 | Enable field support and baremetal default exclusion |
+
+The best PRs to use as a template are the simpler single-capability additions like #6197 (openshift-samples) or #6246 (Insights).
+
+## Key Code Locations
+
+| What | Path |
+|---|---|
+| `OptionalCapability` type and constants | `api/hypershift/v1beta1/hostedcluster_types.go:474-483` |
+| `Capabilities` struct and CEL rules | `api/hypershift/v1beta1/hostedcluster_types.go:485-516` |
+| `HostedClusterSpec.Capabilities` field | `api/hypershift/v1beta1/hostedcluster_types.go:829-835` |
+| `HostedControlPlaneSpec.Capabilities` field | `api/hypershift/v1beta1/hosted_controlplane.go:265-266` |
+| Capability helper functions | `support/capabilities/hosted_control_plane_capabilities.go` |
+| Capability helper tests | `support/capabilities/hosted_control_plane_capabilities_test.go` |
+| `CalculateEnabledCapabilities` (net capability set) | `support/capabilities/hosted_control_plane_capabilities.go:68-90` |
+| CLI flag definition | `cmd/cluster/core/create.go:111` |
+| CLI capability wiring | `cmd/cluster/core/create.go:361-368, 767-779` |
+| OpenShift `ClusterVersionCapability` definitions | `openshift/api` `config/v1/types_cluster_version.go` |
+
+
+---
+
 ## Source: docs/content/contribute/branch-process.md
 
 ## OCP Branching Tasks for the HyperShift Team
@@ -15337,6 +15479,97 @@ Use `--ginkgo.label-filter` to run specific test categories. Use `--ginkgo.v` fo
 ```bash
 # Run a single test by name (regex match against the full description path)
 bin/test-e2e-v2 --ginkgo.focus="should not indicate rapid rollouts" --ginkgo.v
+```
+
+
+---
+
+## Source: docs/content/how-to/cluster-capabilities.md
+
+# Cluster Capabilities
+
+HyperShift allows administrators to enable or disable optional OpenShift components at cluster creation time through the **capabilities** API. This reduces resource consumption and attack surface by preventing unnecessary operators and operands from being deployed.
+
+## Default Behavior
+
+When `spec.capabilities` is not set on a HostedCluster, the cluster uses the OpenShift version's `DefaultCapabilitySet` with the `baremetal` capability excluded. This means most optional components are enabled by default.
+
+!!! important
+    Capabilities are **immutable** after cluster creation. They cannot be changed once the HostedCluster is created.
+
+## Supported Capabilities
+
+| Capability | Description |
+|---|---|
+| `ImageRegistry` | OpenShift Image Registry operator and its operands, including cloud storage infrastructure (S3 buckets, IAM users, etc.) |
+| `openshift-samples` | OpenShift Samples operator, which manages example ImageStreams and Templates |
+| `Insights` | Insights operator, which collects and uploads cluster telemetry data |
+| `baremetal` | Bare metal infrastructure operator. Excluded from the default set; must be explicitly enabled if needed |
+| `Console` | OpenShift web console operator and its operands |
+| `NodeTuning` | Node Tuning Operator (NTO), which manages node-level performance tuning via TuneD and PerformanceProfiles |
+| `Ingress` | OpenShift Ingress operator, which manages the cluster's default router |
+
+## Constraints
+
+The following rules apply when combining capability settings:
+
+- **No overlap**: A capability cannot appear in both `enabled` and `disabled` lists simultaneously.
+- **Console requires Ingress**: The `Ingress` capability can only be disabled if `Console` is also disabled, because the console depends on Ingress (OCPBUGS-58422).
+- **Version requirement**: Disabling `openshift-samples`, `Insights`, `Console`, `NodeTuning`, or `Ingress` requires OpenShift 4.20 or later. `ImageRegistry` and `baremetal` can be disabled on earlier versions.
+- **Baremetal default exclusion**: The `baremetal` capability is already excluded from the default set. Explicitly disabling it is a no-op; explicitly enabling it will add it to the cluster.
+
+## Usage
+
+### CLI
+
+Use the `--disable-cluster-capabilities` flag when creating a cluster:
+
+```shell
+hypershift create cluster aws \
+  --name my-cluster \
+  --disable-cluster-capabilities=ImageRegistry,Console,Ingress
+```
+
+Multiple capabilities can be specified as a comma-separated list. The supported values are: `ImageRegistry`, `openshift-samples`, `Insights`, `baremetal`, `Console`, `NodeTuning`, `Ingress`.
+
+### HostedCluster Manifest
+
+To disable capabilities via the HostedCluster resource directly, set `spec.capabilities.disabled`:
+
+```yaml
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  name: my-cluster
+  namespace: clusters
+spec:
+  capabilities:
+    disabled:
+      - ImageRegistry
+      - Console
+      - Ingress
+  # ... rest of spec
+```
+
+To explicitly enable a capability that is not in the default set (e.g., `baremetal`):
+
+```yaml
+spec:
+  capabilities:
+    enabled:
+      - baremetal
+```
+
+Both `enabled` and `disabled` can be used together, as long as no capability appears in both lists:
+
+```yaml
+spec:
+  capabilities:
+    enabled:
+      - baremetal
+    disabled:
+      - ImageRegistry
+      - openshift-samples
 ```
 
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
     - 'Global Pull Secret': how-to/common/global-pull-secret.md
     - 'HCP Networking Requirements': how-to/common/hcp-networking-requirements.md
     - how-to/common/multi-arch-on-hcp.md
+  - 'Cluster Capabilities': how-to/cluster-capabilities.md
   - how-to/metrics-sets.md
   - 'Configure OCP components':
     - how-to/configure-ocp-components/index.md
@@ -401,6 +402,7 @@ nav:
   - 'HO/CPO Release Process': contribute/release-process.md
   - 'OCP Branching Tasks': contribute/branch-process.md
   - 'Custom Images': contribute/custom-images.md
+  - 'Add a Capability': contribute/add-a-capability.md
   - 'Onboard a Platform': contribute/onboard-a-platform.md
   - 'Run Tests': contribute/run-tests.md
   - 'Develop in Cluster': contribute/develop_in_cluster.md


### PR DESCRIPTION
## What this PR does / why we need it:

Adds two new documentation pages for the cluster capabilities feature:

- **User-facing how-to** (`docs/content/how-to/cluster-capabilities.md`): Explains how to disable/enable optional capabilities (`ImageRegistry`, `openshift-samples`, `Insights`, `baremetal`, `Console`, `NodeTuning`, `Ingress`) at cluster creation time. Covers constraints (Ingress/Console dependency, OCP 4.20+ requirement, immutability), CLI usage, and HostedCluster manifest examples.
- **Contributor guide** (`docs/content/contribute/add-a-capability.md`): Step-by-step implementation checklist for adding a new capability, including a reference table of all upstream OpenShift `ClusterVersionCapability` values and which ones HyperShift already supports. Links to the PRs that introduced each existing capability.

Today the only documentation is the auto-generated API reference and a single CLI flag mention in the Azure how-to. This PR fills that gap.

## Which issue(s) this PR fixes:

Fixes [OSDOCS-19432](https://redhat.atlassian.net/browse/OSDOCS-19432)

## Special notes for your reviewer:

The upstream OpenShift capabilities are defined in [`openshift/api` `config/v1/types_cluster_version.go`](https://github.com/openshift/api/blob/master/config/v1/types_cluster_version.go). HyperShift currently supports 7 of the 16 known capabilities. The contributor guide includes a table mapping all of them so developers can see what's available to add next.

Key constraint documented: Ingress can only be disabled if Console is also disabled (OCPBUGS-58422).

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a how-to guide for Cluster Capabilities, covering supported capability names, default behavior, immutability after creation, enable/disable constraints, and CLI/manifest examples.
  * Added a contributor guide for introducing new optional HostedCluster capabilities, including an implementation/testing checklist and guidance for CEL `XValidation` dependency rules.
  * Updated site navigation to include the new “Cluster Capabilities” and “Add a Capability” pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->