### PR TITLE
[release-4.20] OCPBUGS-77109: Add UserAgent telemetry to CPO Azure SDK clients

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -91,6 +91,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys"
 	"github.com/Azure/msi-dataplane/pkg/dataplane"
 
@@ -2829,8 +2830,22 @@ func (r *HostedControlPlaneReconciler) validateAzureKMSConfig(ctx context.Contex
 		return
 	}
 
+	keysCloudConfig, err := hyperazureutil.GetAzureCloudConfiguration(hcp.Spec.Platform.Azure.Cloud)
+	if err != nil {
+		conditions.SetFalseCondition(hcp, hyperv1.ValidAzureKMSConfig, hyperv1.InvalidAzureCredentialsReason,
+			fmt.Sprintf("failed to get Azure cloud configuration for keys client: %v", err))
+		return
+	}
+
 	vaultURL := fmt.Sprintf("https://%s.%s", azureKmsSpec.ActiveKey.KeyVaultName, azureKeyVaultDNSSuffix)
-	keysClient, err := azkeys.NewClient(vaultURL, cred, nil)
+	keysClient, err := azkeys.NewClient(vaultURL, cred, &azkeys.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud: keysCloudConfig,
+			Telemetry: policy.TelemetryOptions{
+				ApplicationID: hyperazureutil.CPOUserAgent,
+			},
+		},
+	})
 	if err != nil {
 		conditions.SetFalseCondition(hcp, hyperv1.ValidAzureKMSConfig, hyperv1.AzureErrorReason,
 			fmt.Sprintf("failed to create azure keys client: %v", err))
@@ -2910,10 +2925,10 @@ func (r *HostedControlPlaneReconciler) verifyResourceGroupLocationsMatch(ctx con
 		creds     azcore.TokenCredential
 		found, ok bool
 		err       error
+		key       = hcp.Namespace + cpoAzureCredentials
+		log       = ctrl.LoggerFrom(ctx)
+		cloudName = hcp.Spec.Platform.Azure.Cloud
 	)
-
-	key := hcp.Namespace + cpoAzureCredentials
-	log := ctrl.LoggerFrom(ctx)
 
 	// We need to only store the Azure credentials once and reuse them after that.
 	storedCreds, found := r.cpoAzureCredentialsLoaded.Load(key)
@@ -2935,17 +2950,17 @@ func (r *HostedControlPlaneReconciler) verifyResourceGroupLocationsMatch(ctx con
 	}
 
 	// Retrieve full vnet information from the VNET ID
-	vnet, err := hyperazureutil.GetVnetInfoFromVnetID(ctx, hcp.Spec.Platform.Azure.VnetID, hcp.Spec.Platform.Azure.SubscriptionID, creds)
+	vnet, err := hyperazureutil.GetVnetInfoFromVnetID(ctx, hcp.Spec.Platform.Azure.VnetID, hcp.Spec.Platform.Azure.SubscriptionID, creds, cloudName)
 	if err != nil {
 		return fmt.Errorf("failed to get vnet info to verify its location: %v", err)
 	}
 	// Retrieve full network security group information from the network security group ID
-	nsg, err := hyperazureutil.GetNetworkSecurityGroupInfo(ctx, hcp.Spec.Platform.Azure.SecurityGroupID, hcp.Spec.Platform.Azure.SubscriptionID, creds)
+	nsg, err := hyperazureutil.GetNetworkSecurityGroupInfo(ctx, hcp.Spec.Platform.Azure.SecurityGroupID, hcp.Spec.Platform.Azure.SubscriptionID, creds, cloudName)
 	if err != nil {
 		return fmt.Errorf("failed to get network security group info to verify its location: %v", err)
 	}
 	// Retrieve full resource group information from the resource group name
-	rg, err := hyperazureutil.GetResourceGroupInfo(ctx, hcp.Spec.Platform.Azure.ResourceGroupName, hcp.Spec.Platform.Azure.SubscriptionID, creds)
+	rg, err := hyperazureutil.GetResourceGroupInfo(ctx, hcp.Spec.Platform.Azure.ResourceGroupName, hcp.Spec.Platform.Azure.SubscriptionID, creds, cloudName)
 	if err != nil {
 		return fmt.Errorf("failed to get resource group info to verify its location: %v", err)
 	}

--- a/support/azureutil/azureutil.go
+++ b/support/azureutil/azureutil.go
@@ -12,12 +12,47 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v5"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 )
+
+// CPOUserAgent is the User-Agent identifier for the Control Plane Operator.
+// Azure SDK has a 24-character limit for ApplicationID, and spaces are replaced with "/".
+const CPOUserAgent = "hypershift-cpo"
+
+// GetAzureCloudConfiguration converts a cloud name string to the Azure SDK cloud.Configuration.
+// This function maps the cloud names used in the HyperShift API to the corresponding Azure SDK cloud configurations.
+// Valid cloud names are: AzurePublicCloud, AzureUSGovernmentCloud, AzureChinaCloud, and empty string (defaults to AzurePublicCloud).
+func GetAzureCloudConfiguration(cloudName string) (cloud.Configuration, error) {
+	switch cloudName {
+	case "AzurePublicCloud", "":
+		return cloud.AzurePublic, nil
+	case "AzureUSGovernmentCloud":
+		return cloud.AzureGovernment, nil
+	case "AzureChinaCloud":
+		return cloud.AzureChina, nil
+	default:
+		return cloud.Configuration{}, fmt.Errorf("unknown Azure cloud: %s", cloudName)
+	}
+}
+
+// NewARMClientOptions creates Azure ARM client options with proper cloud configuration
+// and telemetry settings for the Control Plane Operator.
+func NewARMClientOptions(cloudConfig cloud.Configuration) *arm.ClientOptions {
+	return &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud: cloudConfig,
+			Telemetry: policy.TelemetryOptions{
+				ApplicationID: CPOUserAgent,
+			},
+		},
+	}
+}
 
 // GetSubnetNameFromSubnetID extracts the subnet name from a subnet ID
 // Example subnet ID: /subscriptions/<subscriptionID>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/virtualNetworks/<vnetName>/subnets/<subnetName>
@@ -85,8 +120,8 @@ func GetVnetNameAndResourceGroupFromVnetID(vnetID string) (string, string, error
 }
 
 // GetVnetInfoFromVnetID extracts the full information on a VNET from a VNET ID by first getting the VNET name and
-// its resource group's name and then using those parameters to query the full information on the VNET using Azure's SDK
-func GetVnetInfoFromVnetID(ctx context.Context, vnetID string, subscriptionID string, azureCreds azcore.TokenCredential) (armnetwork.VirtualNetworksClientGetResponse, error) {
+// its resource group's name and then using those parameters to query the full information on the VNET using Azure's SDK.
+func GetVnetInfoFromVnetID(ctx context.Context, vnetID string, subscriptionID string, azureCreds azcore.TokenCredential, cloudName string) (armnetwork.VirtualNetworksClientGetResponse, error) {
 	partialVnetInfo, err := arm.ParseResourceID(vnetID)
 	if err != nil {
 		return armnetwork.VirtualNetworksClientGetResponse{}, fmt.Errorf("failed to parse vnet information from vnet ID %q: %v", vnetID, err)
@@ -104,7 +139,7 @@ func GetVnetInfoFromVnetID(ctx context.Context, vnetID string, subscriptionID st
 		return armnetwork.VirtualNetworksClientGetResponse{}, fmt.Errorf("failed to parse vnet resource group name from %q", vnetID)
 	}
 
-	vnet, err := getFullVnetInfo(ctx, subscriptionID, partialVnetInfo.ResourceGroupName, partialVnetInfo.Name, azureCreds)
+	vnet, err := getFullVnetInfo(ctx, subscriptionID, partialVnetInfo.ResourceGroupName, partialVnetInfo.Name, azureCreds, cloudName)
 	if err != nil {
 		return armnetwork.VirtualNetworksClientGetResponse{}, err
 	}
@@ -112,9 +147,14 @@ func GetVnetInfoFromVnetID(ctx context.Context, vnetID string, subscriptionID st
 	return vnet, nil
 }
 
-// getFullVnetInfo gets the full information on a VNET
-func getFullVnetInfo(ctx context.Context, subscriptionID string, vnetResourceGroupName string, clientVnetName string, azureCreds azcore.TokenCredential) (armnetwork.VirtualNetworksClientGetResponse, error) {
-	networksClient, err := armnetwork.NewVirtualNetworksClient(subscriptionID, azureCreds, nil)
+// getFullVnetInfo gets the full information on a VNET.
+func getFullVnetInfo(ctx context.Context, subscriptionID string, vnetResourceGroupName string, clientVnetName string, azureCreds azcore.TokenCredential, cloudName string) (armnetwork.VirtualNetworksClientGetResponse, error) {
+	cloudConfig, err := GetAzureCloudConfiguration(cloudName)
+	if err != nil {
+		return armnetwork.VirtualNetworksClientGetResponse{}, fmt.Errorf("failed to get Azure cloud configuration: %w", err)
+	}
+
+	networksClient, err := armnetwork.NewVirtualNetworksClient(subscriptionID, azureCreds, NewARMClientOptions(cloudConfig))
 	if err != nil {
 		return armnetwork.VirtualNetworksClientGetResponse{}, fmt.Errorf("failed to create new virtual networks client: %w", err)
 	}
@@ -147,14 +187,19 @@ func getFullVnetInfo(ctx context.Context, subscriptionID string, vnetResourceGro
 	return vnet, nil
 }
 
-// GetNetworkSecurityGroupInfo gets the full information on a network security group based on its ID
-func GetNetworkSecurityGroupInfo(ctx context.Context, nsgID string, subscriptionID string, azureCreds azcore.TokenCredential) (armnetwork.SecurityGroupsClientGetResponse, error) {
+// GetNetworkSecurityGroupInfo gets the full information on a network security group based on its ID.
+func GetNetworkSecurityGroupInfo(ctx context.Context, nsgID string, subscriptionID string, azureCreds azcore.TokenCredential, cloudName string) (armnetwork.SecurityGroupsClientGetResponse, error) {
 	partialNSGInfo, err := arm.ParseResourceID(nsgID)
 	if err != nil {
 		return armnetwork.SecurityGroupsClientGetResponse{}, fmt.Errorf("failed to parse network security group id %q: %v", nsgID, err)
 	}
 
-	securityGroupClient, err := armnetwork.NewSecurityGroupsClient(subscriptionID, azureCreds, nil)
+	cloudConfig, err := GetAzureCloudConfiguration(cloudName)
+	if err != nil {
+		return armnetwork.SecurityGroupsClientGetResponse{}, fmt.Errorf("failed to get Azure cloud configuration: %w", err)
+	}
+
+	securityGroupClient, err := armnetwork.NewSecurityGroupsClient(subscriptionID, azureCreds, NewARMClientOptions(cloudConfig))
 	if err != nil {
 		return armnetwork.SecurityGroupsClientGetResponse{}, fmt.Errorf("failed to create security group client: %w", err)
 	}
@@ -167,9 +212,14 @@ func GetNetworkSecurityGroupInfo(ctx context.Context, nsgID string, subscription
 	return nsg, nil
 }
 
-// GetResourceGroupInfo gets the full information on a resource group based on its name
-func GetResourceGroupInfo(ctx context.Context, rgName string, subscriptionID string, azureCreds azcore.TokenCredential) (armresources.ResourceGroupsClientGetResponse, error) {
-	resourceGroupClient, err := armresources.NewResourceGroupsClient(subscriptionID, azureCreds, nil)
+// GetResourceGroupInfo gets the full information on a resource group based on its name.
+func GetResourceGroupInfo(ctx context.Context, rgName string, subscriptionID string, azureCreds azcore.TokenCredential, cloudName string) (armresources.ResourceGroupsClientGetResponse, error) {
+	cloudConfig, err := GetAzureCloudConfiguration(cloudName)
+	if err != nil {
+		return armresources.ResourceGroupsClientGetResponse{}, fmt.Errorf("failed to get Azure cloud configuration: %w", err)
+	}
+
+	resourceGroupClient, err := armresources.NewResourceGroupsClient(subscriptionID, azureCreds, NewARMClientOptions(cloudConfig))
 	if err != nil {
 		return armresources.ResourceGroupsClientGetResponse{}, fmt.Errorf("failed to create new resource groups client: %w", err)
 	}

--- a/support/azureutil/azureutil_test.go
+++ b/support/azureutil/azureutil_test.go
@@ -6,6 +6,8 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/config"
 
@@ -349,6 +351,45 @@ func TestCreateVolumeForAzureSecretStoreProviderClass(t *testing.T) {
 			if got := CreateVolumeForAzureSecretStoreProviderClass(tt.secretStoreVolumeName, tt.secretProviderClassName); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("CreateVolumeForAzureSecretStoreProviderClass() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestNewARMClientOptions(t *testing.T) {
+	tests := []struct {
+		name               string
+		cloudConfig        cloud.Configuration
+		wantApplicationID  string
+		wantCloudActiveDir string
+	}{
+		{
+			name:               "When public cloud is provided it should return options with correct cloud and telemetry",
+			cloudConfig:        cloud.AzurePublic,
+			wantApplicationID:  CPOUserAgent,
+			wantCloudActiveDir: cloud.AzurePublic.ActiveDirectoryAuthorityHost,
+		},
+		{
+			name:               "When government cloud is provided it should return options with correct cloud and telemetry",
+			cloudConfig:        cloud.AzureGovernment,
+			wantApplicationID:  CPOUserAgent,
+			wantCloudActiveDir: cloud.AzureGovernment.ActiveDirectoryAuthorityHost,
+		},
+		{
+			name:               "When China cloud is provided it should return options with correct cloud and telemetry",
+			cloudConfig:        cloud.AzureChina,
+			wantApplicationID:  CPOUserAgent,
+			wantCloudActiveDir: cloud.AzureChina.ActiveDirectoryAuthorityHost,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			got := NewARMClientOptions(tt.cloudConfig)
+
+			g.Expect(got).NotTo(BeNil())
+			g.Expect(got.Cloud.ActiveDirectoryAuthorityHost).To(Equal(tt.wantCloudActiveDir))
+			g.Expect(got.Telemetry.ApplicationID).To(Equal(tt.wantApplicationID))
 		})
 	}
 }

--- a/support/azureutil/azureutil_test.go
+++ b/support/azureutil/azureutil_test.go
@@ -6,10 +6,10 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
-
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/config"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"


### PR DESCRIPTION
## Summary
Manual cherry-pick of #7620 to `release-4.20` with conflict resolution.

The cherrypick-robot [failed](https://github.com/openshift/hypershift/pull/7620#issuecomment-3931182081) due to merge conflicts in `support/azureutil/azureutil.go` and `support/azureutil/azureutil_test.go`. The conflicts arose because the original commits depended on `GetAzureCloudConfiguration` (from commit 40e255a634, "make Azure SDK clients cloud-agnostic") which was not present on `release-4.20`.

## Commits cherry-picked
- fd6dcef075b6: feat(support/azureutil): Add UserAgent telemetry for Azure ARM clients
- c279efc41bd0: feat(cpo): Add UserAgent telemetry to Azure Key Vault client

## Fixes applied
- Included `GetAzureCloudConfiguration` helper function (from 40e255a634) as a prerequisite dependency
- Resolved merge conflicts in `support/azureutil/azureutil.go` and `support/azureutil/azureutil_test.go`

## References
- Original PR: #7620
- JIRA: OCPBUGS-77109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>