### PR TITLE
OCPBUGS-84551: fix(ingress): set FIPS_ENABLED env var on ingress operator

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ingressoperator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ingressoperator/deployment.go
@@ -22,6 +22,12 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 			Name: "CANARY_IMAGE", Value: cpContext.UserReleaseImageProvider.GetImage("cluster-ingress-operator"),
 		})
 
+		if cpContext.HCP.Spec.FIPS {
+			podspec.UpsertEnvVar(c, corev1.EnvVar{
+				Name: "FIPS_ENABLED", Value: "true",
+			})
+		}
+
 		// For managed Azure deployments, we pass an environment variable, MANAGED_AZURE_HCP_CREDENTIALS_FILE_PATH, so
 		// we authenticate with Azure API through UserAssignedCredential authentication. We also mount the
 		// SecretProviderClass for the Secrets Store CSI driver to use; it will grab the JSON object stored in the

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ingressoperator/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ingressoperator/deployment_test.go
@@ -1,0 +1,79 @@
+package ingressoperator
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/podspec"
+	"github.com/openshift/hypershift/support/testutil"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAdaptDeployment(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		fips     bool
+		validate func(*WithT, *corev1.Container)
+	}{
+		{
+			name: "When FIPS is enabled, it should set FIPS_ENABLED env var to true",
+			fips: true,
+			validate: func(g *WithT, container *corev1.Container) {
+				g.Expect(container.Env).To(ContainElement(corev1.EnvVar{
+					Name:  "FIPS_ENABLED",
+					Value: "true",
+				}))
+			},
+		},
+		{
+			name: "When FIPS is not enabled, it should not set FIPS_ENABLED env var",
+			fips: false,
+			validate: func(g *WithT, container *corev1.Container) {
+				for _, env := range container.Env {
+					g.Expect(env.Name).ToNot(Equal("FIPS_ENABLED"))
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: "test-namespace",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					FIPS: tc.fips,
+				},
+			}
+
+			cpContext := component.WorkloadContext{
+				HCP:                      hcp,
+				UserReleaseImageProvider: testutil.FakeImageProvider(),
+			}
+
+			deployment, err := assets.LoadDeploymentManifest(ComponentName)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			err = adaptDeployment(cpContext, deployment)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			container := podspec.FindContainer(ComponentName, deployment.Spec.Template.Spec.Containers)
+			g.Expect(container).ToNot(BeNil(), "ingress-operator container should exist")
+
+			tc.validate(g, container)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- The ingress operator determines FIPS mode by reading `/proc/sys/crypto/fips_enabled` on the node where it runs. In hosted clusters, the ingress operator runs on the management cluster, which may have a different FIPS state than the hosted cluster. This causes the operator to deploy routers with incorrect cipher configuration when the FIPS states differ.
- Set `FIPS_ENABLED=true` on the ingress operator container when the hosted cluster has FIPS enabled, so the operator uses the correct cipher suite regardless of the management cluster's FIPS state.

## Test plan

- [ ] Verify unit tests pass: `go test ./control-plane-operator/controllers/hostedcontrolplane/v2/ingressoperator/ -v`
- [ ] Create a FIPS-enabled hosted cluster and verify the ingress operator deployment has `FIPS_ENABLED=true` set
- [ ] Create a non-FIPS hosted cluster and verify the ingress operator deployment does not have `FIPS_ENABLED` set
- [ ] Verify the ingress operator deploys routers with correct FIPS cipher configuration on a FIPS-enabled hosted cluster running on a non-FIPS management cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ingress operator now enables FIPS mode when FIPS is turned on in the hosted control plane configuration (exposes FIPS_ENABLED to the operator).

* **Tests**
  * Added unit tests validating that the ingress operator receives the FIPS_ENABLED setting when FIPS is true and does not when false.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->