### PR TITLE
fix(e2e): set NodePoolReplicas=1 for KubeVirt TestNodePool

### DIFF
--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -219,11 +219,14 @@ func executeNodePoolTests(t *testing.T, nodePoolTestCasesPerHostedCluster []Host
 				clusterOpts.AWSPlatform.SharedRole = false
 			}
 
-			// On OpenStack, we need to create at least one replica of the default nodepool
-			// so we can create the Route53 record for the ingress router. If we don't do that,
-			// the HostedCluster conditions won't be met and the test will fail as some operators
-			// will be marked as degraded.
-			if globalOpts.Platform == hyperv1.OpenStackPlatform {
+			// On OpenStack and KubeVirt, we need to create at least one replica of the default nodepool.
+			// On OpenStack, this is needed to create the Route53 record for the ingress router.
+			// On KubeVirt, CNO requires worker nodes to probe the network MTU before it can
+			// deploy its operands (ovnkube-control-plane, network-node-identity, multus-admission-controller),
+			// without which controlPlaneVersion never reaches Completed.
+			// If we don't do that, the HostedCluster conditions won't be met and the test will
+			// fail as some operators will be marked as degraded.
+			if globalOpts.Platform == hyperv1.OpenStackPlatform || globalOpts.Platform == hyperv1.KubevirtPlatform {
 				clusterOpts.NodePoolReplicas = 1
 			}
 


### PR DESCRIPTION
## What this PR does / why we need it:

On KubeVirt, CNO requires worker nodes to probe the network MTU before deploying its operands (`ovnkube-control-plane`, `network-node-identity`, `multus-admission-controller`). When `TestNodePool` creates HostedClusters with `NodePoolReplicas=0` (to let individual sub-tests create their own NodePools), CNO never creates these deployments because it cannot complete the MTU probe without nodes.

This causes the CNO ControlPlaneComponent's `RolloutComplete` condition to stay `False` with `WaitingForOperands`, which blocks `controlPlaneVersion` from reaching `Completed`. All `TestNodePool` sub-tests then time out after 20 minutes during the `ValidateHostedCluster` phase.

This is the same class of issue that was fixed for OpenStack in PR #4868, where at least one default nodepool replica is needed for operators to function correctly. This PR applies the same workaround for KubeVirt.

## Which issue(s) this PR fixes:

Fixes KubeVirt `TestNodePool` e2e failures caused by `controlPlaneVersion` stuck at `Partial`.

## Special notes for your reviewer:

The failure was observed in https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/8365/pull-ci-openshift-hypershift-main-e2e-kubevirt-aws-ovn/2049482298985811968 where all 3 HostedClusters (HC0, HC1, HC2) timed out identically with:

```
controlPlaneVersion state is Partial, expected Completed
```

The CNO component dump confirmed the blocking condition:
```yaml
status:
  conditions:
  - message: |
      failed to get deployment ovnkube-control-plane: Deployment.apps "ovnkube-control-plane" not found
      failed to get deployment network-node-identity: Deployment.apps "network-node-identity" not found
      failed to get deployment multus-admission-controller: Deployment.apps "multus-admission-controller" not found
    reason: WaitingForOperands
    status: "False"
    type: RolloutComplete
```

On cloud platforms (AWS, Azure, GCP), CNO can deploy these operands without worker nodes because it gets network configuration from cloud metadata. On KubeVirt (and OpenStack), CNO relies on probing actual worker nodes for MTU discovery.

Note: A proper fix would make `checkOperandsRolloutStatus` in `cno/component.go` tolerate missing operand deployments when there are no worker nodes. This workaround unblocks KubeVirt CI in the meantime.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end tests to ensure the default NodePool has at least one replica on both OpenStack and KubeVirt, for consistent hosted-cluster conditions.
* **Documentation**
  * Clarified KubeVirt-specific note about worker MTU probing affecting operand rollout and why skipping the first hosted-cluster can lead to degraded operators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->