### PR TITLE
OCPBUGS-84307: Clarify --base-domain flag default behavior

### DIFF
--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -67,7 +67,7 @@ func BindOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
 func bindCoreOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
 	flags.StringVar(&opts.Namespace, "namespace", opts.Namespace, "A namespace to contain the generated resources")
 	flags.StringVar(&opts.Name, "name", opts.Name, "A name for the cluster")
-	flags.StringVar(&opts.BaseDomain, "base-domain", opts.BaseDomain, "The ingress base domain for the cluster")
+	flags.StringVar(&opts.BaseDomain, "base-domain", opts.BaseDomain, "The ingress base domain for the cluster. When omitted for HCP kubevirt cluster, it defaults to management cluster's apps domain.")
 	flags.StringVar(&opts.BaseDomainPrefix, "base-domain-prefix", opts.BaseDomainPrefix, "The ingress base domain prefix for the cluster, defaults to cluster name. Use 'none' for an empty prefix")
 	flags.StringVar(&opts.ExternalDNSDomain, "external-dns-domain", opts.ExternalDNSDomain, "Sets hostname to opinionated values in the specified domain for services with publishing type LoadBalancer or Route.")
 	flags.StringVar(&opts.NetworkType, "network-type", opts.NetworkType, "Enum specifying the cluster SDN provider. Supports either Calico, OVNKubernetes, OpenShiftSDN or Other.")

--- a/cmd/cluster/core/create.go
+++ b/cmd/cluster/core/create.go
@@ -67,7 +67,7 @@ func BindOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
 func bindCoreOptions(opts *RawCreateOptions, flags *pflag.FlagSet) {
 	flags.StringVar(&opts.Namespace, "namespace", opts.Namespace, "A namespace to contain the generated resources")
 	flags.StringVar(&opts.Name, "name", opts.Name, "A name for the cluster")
-	flags.StringVar(&opts.BaseDomain, "base-domain", opts.BaseDomain, "The ingress base domain for the cluster. When omitted for HCP kubevirt cluster, it defaults to management cluster's apps domain.")
+	flags.StringVar(&opts.BaseDomain, "base-domain", opts.BaseDomain, "The ingress base domain for the cluster. If omitted for an HCP KubeVirt cluster, this defaults to the management cluster's apps domain.")
 	flags.StringVar(&opts.BaseDomainPrefix, "base-domain-prefix", opts.BaseDomainPrefix, "The ingress base domain prefix for the cluster, defaults to cluster name. Use 'none' for an empty prefix")
 	flags.StringVar(&opts.ExternalDNSDomain, "external-dns-domain", opts.ExternalDNSDomain, "Sets hostname to opinionated values in the specified domain for services with publishing type LoadBalancer or Route.")
 	flags.StringVar(&opts.NetworkType, "network-type", opts.NetworkType, "Enum specifying the cluster SDN provider. Supports either Calico, OVNKubernetes, OpenShiftSDN or Other.")

--- a/cmd/cluster/core/create_test.go
+++ b/cmd/cluster/core/create_test.go
@@ -23,7 +23,41 @@ import (
 
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/spf13/pflag"
 )
+
+func TestBindOptions(t *testing.T) {
+	t.Run("When flags are parsed it should populate the options struct", func(t *testing.T) {
+		g := NewWithT(t)
+		opts := DefaultOptions()
+		flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		BindOptions(opts, flags)
+
+		err := flags.Parse([]string{
+			"--base-domain=example.com",
+			"--name=my-cluster",
+			"--namespace=my-ns",
+		})
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(opts.BaseDomain).To(Equal("example.com"))
+		g.Expect(opts.Name).To(Equal("my-cluster"))
+		g.Expect(opts.Namespace).To(Equal("my-ns"))
+	})
+
+	t.Run("When base-domain flag is omitted the pflag default should be empty", func(t *testing.T) {
+		g := NewWithT(t)
+		opts := DefaultOptions()
+		flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		BindOptions(opts, flags)
+
+		err := flags.Parse([]string{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(opts.BaseDomain).To(BeEmpty())
+	})
+}
 
 func TestValidateMgmtClusterAndNodePoolCPUArchitectures(t *testing.T) {
 	ctx := t.Context()


### PR DESCRIPTION
## What this PR does / why we need it:

Updates the help text for the `--base-domain` flag in the `hypershift create cluster` command
to clarify that when omitted, it defaults to the management cluster's apps domain. This
improves discoverability so users know the flag is optional and understand the fallback behavior.

## Which issue(s) this PR fixes:

Fixes OCPBUGS-84307

## Special notes for your reviewer:

Single-line help text change, no functional impact.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified CLI help for the --base-domain flag: when omitted for HCP kubevirt clusters it defaults to the management cluster’s apps domain.

* **Tests**
  * Added unit tests for CLI flag binding/parsing to confirm base domain, cluster name, and namespace behavior when provided or omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->