### PR TITLE
CNTRLPLANE-3351: e2e: add opt-in CPU resource request overrides for control plane components

### DIFF
--- a/test/e2e/util/options.go
+++ b/test/e2e/util/options.go
@@ -226,12 +226,9 @@ func (o *Options) DefaultClusterOptions(t *testing.T) PlatformAgnosticOptions {
 			ClusterCIDR:                      []string{"10.132.0.0/14"},
 			BeforeApply:                      o.BeforeApply,
 			Log:                              NewLogr(t),
-			Annotations: []string{
-				fmt.Sprintf("%s=true", hyperv1.CleanupCloudResourcesAnnotation),
-				fmt.Sprintf("%s=true", hyperv1.SkipReleaseImageValidation),
-			},
-			EtcdStorageClass:           o.ConfigurableClusterOptions.EtcdStorageClass,
-			DisableClusterCapabilities: o.ConfigurableClusterOptions.DisableClusterCapabilities,
+			Annotations:                      e2eDefaultAnnotations(),
+			EtcdStorageClass:                 o.ConfigurableClusterOptions.EtcdStorageClass,
+			DisableClusterCapabilities:       o.ConfigurableClusterOptions.DisableClusterCapabilities,
 		},
 		NonePlatform:        o.DefaultNoneOptions(),
 		AWSPlatform:         o.DefaultAWSOptions(),
@@ -602,4 +599,27 @@ func (s *stringMapVar) Set(value string) error {
 
 func shouldTestCPOOverride() bool {
 	return os.Getenv("TEST_CPO_OVERRIDE") == "1"
+}
+
+func e2eDefaultAnnotations() []string {
+	annotations := []string{
+		fmt.Sprintf("%s=true", hyperv1.CleanupCloudResourcesAnnotation),
+		fmt.Sprintf("%s=true", hyperv1.SkipReleaseImageValidation),
+	}
+	if os.Getenv("E2E_RESOURCE_REQUEST_OVERRIDES") == "1" {
+		annotations = append(annotations,
+			fmt.Sprintf("%s/ignition-server.ignition-server=cpu=200m", hyperv1.ResourceRequestOverrideAnnotationPrefix),
+			fmt.Sprintf("%s/control-plane-operator.control-plane-operator=cpu=500m", hyperv1.ResourceRequestOverrideAnnotationPrefix),
+			fmt.Sprintf("%s/packageserver.packageserver=cpu=50m", hyperv1.ResourceRequestOverrideAnnotationPrefix),
+			fmt.Sprintf("%s/certified-operators-catalog.registry=cpu=30m", hyperv1.ResourceRequestOverrideAnnotationPrefix),
+			fmt.Sprintf("%s/community-operators-catalog.registry=cpu=30m", hyperv1.ResourceRequestOverrideAnnotationPrefix),
+			fmt.Sprintf("%s/redhat-marketplace-catalog.registry=cpu=30m", hyperv1.ResourceRequestOverrideAnnotationPrefix),
+			fmt.Sprintf("%s/redhat-operators-catalog.registry=cpu=30m", hyperv1.ResourceRequestOverrideAnnotationPrefix),
+			fmt.Sprintf("%s/hosted-cluster-config-operator.hosted-cluster-config-operator=cpu=100m", hyperv1.ResourceRequestOverrideAnnotationPrefix),
+			fmt.Sprintf("%s/control-plane-pki-operator.control-plane-pki-operator=cpu=30m", hyperv1.ResourceRequestOverrideAnnotationPrefix),
+			fmt.Sprintf("%s/kube-apiserver.kube-apiserver=cpu=500m", hyperv1.ResourceRequestOverrideAnnotationPrefix),
+			fmt.Sprintf("%s/cluster-version-operator.cluster-version-operator=cpu=75m", hyperv1.ResourceRequestOverrideAnnotationPrefix),
+		)
+	}
+	return annotations
 }


### PR DESCRIPTION
## What this PR does / why we need it:

Cherry-picks the resource request override annotations from #8350 (by @csrwng) but makes them **opt-in** via `E2E_RESOURCE_REQUEST_OVERRIDES=1` env var.

Control plane pod CPU requests are far below actual usage (e.g. ignition-server requests 10m but peaks at 960m). The scheduler sees ~3,015m per cluster and packs too many clusters onto a few nodes. Actual peak is ~8,000m per cluster, causing CPU starvation that delays CRD establishment and triggers test timeouts.

When enabled, overrides CPU requests for control plane pods to better reflect actual consumption (~4700m per cluster vs. ~3015m default), preventing scheduler over-packing. The env var lets us enable it selectively for affected jobs (e.g. Azure e2e) first, without inadvertently breaking other jobs that are running fine.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-3351](https://redhat.atlassian.net/browse/CNTRLPLANE-3351)

## Special notes for your reviewer:

- Follows the same env var pattern as `TEST_CPO_OVERRIDE`
- CPU values are from @csrwng's analysis in #8350, based on observed averages from Azure e2e runs
- To enable for a Prow job, set `E2E_RESOURCE_REQUEST_OVERRIDES=1` in the job env

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Centralized default test annotations and made them environment-driven.
  * Default cleanup and validation annotations are preserved.
  * New opt-in behavior: setting an environment switch adds CPU resource-override annotations for control-plane and operator components during e2e runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->