### PR TITLE
CNTRLPLANE-3352: Add reusable GHA workflow definitions

### DIFF
--- a/.github/workflows/codespell-reusable.yaml
+++ b/.github/workflows/codespell-reusable.yaml
@@ -1,0 +1,18 @@
+name: Codespell (Reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Codespell
+    runs-on: arc-runner-set
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - run: make verify-codespell

--- a/.github/workflows/cpo-container-sync-reusable.yaml
+++ b/.github/workflows/cpo-container-sync-reusable.yaml
@@ -1,0 +1,18 @@
+name: CPO Container Sync (Reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  cpo-container-sync:
+    name: CPO Container Sync
+    runs-on: arc-runner-set
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - run: make cpo-container-sync

--- a/.github/workflows/docs-build-reusable.yaml
+++ b/.github/workflows/docs-build-reusable.yaml
@@ -1,0 +1,32 @@
+name: Docs Build (Reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build Docs
+    runs-on: arc-runner-set
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.x'
+          pip-install: '-r docs/requirements.txt'
+        env:
+          PIP_CACHE_DIR: ${{ runner.temp }}/.pip-cache
+      - name: Build documentation
+        run: mkdocs build --strict
+        working-directory: docs
+      - name: Save PR metadata
+        run: echo "${{ github.event.pull_request.number }}" > docs/site/pr-number.txt
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: docs-site
+          path: docs/site

--- a/.github/workflows/envtest-kube-reusable.yaml
+++ b/.github/workflows/envtest-kube-reusable.yaml
@@ -1,0 +1,84 @@
+name: Envtest Vanilla Kube API Validation (Reusable)
+
+on:
+  workflow_call:
+  push:
+    branches:
+      - main
+      - release-4.22
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: Detect Changes
+    runs-on: arc-runner-set
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Check for relevant file changes
+        id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CREATED: ${{ github.event.created }}
+          PR_DIFF_REF: origin/${{ github.base_ref }}...HEAD
+          PUSH_DIFF_REF: ${{ github.event.before }}..HEAD
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] || [ "$CREATED" = "true" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          ref="$PUSH_DIFF_REF"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            ref="$PR_DIFF_REF"
+          fi
+          if git diff --name-only "$ref" | grep -qE '^(api/|test/envtest/|cmd/install/assets/crds/hypershift-operator/tests/|karpenter-operator/controllers/karpenter/assets/tests/|\.github/workflows/envtest-kube(-reusable)?\.yaml$)'; then
+            echo "should_run=true"
+          else
+            echo "should_run=false"
+          fi >> "$GITHUB_OUTPUT"
+
+  envtest-kube:
+    name: Envtest Vanilla Kube ${{ matrix.version }}
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
+    runs-on: arc-runner-set
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1.31.0", "1.32.0", "1.33.0", "1.34.0", "1.35.0"]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - run: make test-envtest-kube ENVTEST_KUBE_VERSIONS="${{ matrix.version }}"
+
+  conclusion:
+    name: Conclusion
+    needs:
+      - changes
+      - envtest-kube
+    if: always()
+    runs-on: arc-runner-set
+    steps:
+      - name: Aggregate results
+        run: |
+          changes_result="${{ needs.changes.result }}"
+          envtest_result="${{ needs.envtest-kube.result }}"
+          if [ "$changes_result" != "success" ]; then
+            echo "Change detection failed: $changes_result"
+            exit 1
+          fi
+          if [ "$envtest_result" = "success" ] || [ "$envtest_result" = "skipped" ]; then
+            echo "All envtest jobs passed or were skipped"
+            exit 0
+          else
+            echo "Envtest jobs failed: $envtest_result"
+            exit 1
+          fi

--- a/.github/workflows/envtest-ocp-reusable.yaml
+++ b/.github/workflows/envtest-ocp-reusable.yaml
@@ -1,0 +1,85 @@
+name: Envtest OCP API Validation (Reusable)
+
+on:
+  workflow_call:
+  push:
+    branches:
+      - main
+      - release-4.22
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: Detect Changes
+    runs-on: arc-runner-set
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Check for relevant file changes
+        id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CREATED: ${{ github.event.created }}
+          PR_DIFF_REF: origin/${{ github.base_ref }}...HEAD
+          PUSH_DIFF_REF: ${{ github.event.before }}..HEAD
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] || [ "$CREATED" = "true" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          ref="$PUSH_DIFF_REF"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            ref="$PR_DIFF_REF"
+          fi
+          if git diff --name-only "$ref" | grep -qE '^(api/|test/envtest/|cmd/install/assets/crds/hypershift-operator/tests/|karpenter-operator/controllers/karpenter/assets/tests/|\.github/workflows/envtest-ocp(-reusable)?\.yaml$)'; then
+            echo "should_run=true"
+          else
+            echo "should_run=false"
+          fi >> "$GITHUB_OUTPUT"
+
+  envtest-ocp:
+    name: Envtest OCP (K8s ${{ matrix.version }})
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
+    runs-on: arc-runner-set
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        # OCP 4.17=1.30, 4.18=1.31, 4.19=1.32, 4.20=1.33, 4.21=1.34, 4.22=1.35
+        version: ["1.30.3", "1.31.2", "1.32.1", "1.33.2", "1.34.1", "1.35.1"]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - run: make test-envtest-ocp ENVTEST_OCP_K8S_VERSIONS="${{ matrix.version }}"
+
+  conclusion:
+    name: Conclusion
+    needs:
+      - changes
+      - envtest-ocp
+    if: always()
+    runs-on: arc-runner-set
+    steps:
+      - name: Aggregate results
+        run: |
+          changes_result="${{ needs.changes.result }}"
+          envtest_result="${{ needs.envtest-ocp.result }}"
+          if [ "$changes_result" != "success" ]; then
+            echo "Change detection failed: $changes_result"
+            exit 1
+          fi
+          if [ "$envtest_result" = "success" ] || [ "$envtest_result" = "skipped" ]; then
+            echo "All envtest jobs passed or were skipped"
+            exit 0
+          else
+            echo "Envtest jobs failed: $envtest_result"
+            exit 1
+          fi

--- a/.github/workflows/gitlint-reusable.yaml
+++ b/.github/workflows/gitlint-reusable.yaml
@@ -1,0 +1,22 @@
+name: Gitlint (Reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  gitlint:
+    name: Gitlint
+    runs-on: arc-runner-set
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - run: make run-gitlint
+        env:
+          PULL_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PULL_PULL_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/lint-reusable.yaml
+++ b/.github/workflows/lint-reusable.yaml
@@ -1,0 +1,28 @@
+name: Lint (Reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: arc-runner-set
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - run: git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
+      - name: Use pre-built lint tools
+        run: |
+          if [ -d /opt/lint-tools ]; then
+            mkdir -p hack/tools/bin
+            cp /opt/lint-tools/golangci-lint hack/tools/bin/
+            cp /opt/lint-tools/kube-api-linter.so hack/tools/bin/
+            touch hack/tools/bin/golangci-lint hack/tools/bin/kube-api-linter.so
+          fi
+      - run: make lint

--- a/.github/workflows/test-reusable.yaml
+++ b/.github/workflows/test-reusable.yaml
@@ -1,0 +1,104 @@
+name: Unit Tests (Reusable)
+
+on:
+  workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: false
+  push:
+    branches:
+      - main
+      - release-4.22
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: Detect Changes
+    runs-on: arc-runner-set
+    timeout-minutes: 5
+    outputs:
+      run_tests: ${{ steps.changes.outputs.run_tests }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        env:
+          HOME: /tmp
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Check for non-contrib changes
+        id: changes
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "run_tests=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          else
+            if [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
+              echo "run_tests=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            FILES=$(git diff --name-only ${{ github.event.before }}..${{ github.sha }})
+          fi
+          if echo "$FILES" | grep -qvE '^(contrib|\.github|docs)/'; then
+            echo "run_tests=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_tests=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  test:
+    name: Unit Tests (${{ matrix.shard }})
+    needs: changes
+    if: needs.changes.outputs.run_tests == 'true'
+    runs-on: arc-runner-set
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: cpo-hostedcontrolplane
+            packages: ./control-plane-operator/controllers/hostedcontrolplane/...
+          - shard: cpo-other
+            packages: ./control-plane-operator/controllers/awsprivatelink/... ./control-plane-operator/controllers/azureprivatelinkservice/... ./control-plane-operator/controllers/gcpprivateserviceconnect/... ./control-plane-operator/controllers/healthcheck/... ./control-plane-operator/controllers/openshiftmanager/... ./control-plane-operator/endpoint-resolver/... ./control-plane-operator/hostedclusterconfigoperator/... ./control-plane-operator/metrics-proxy/...
+          - shard: hypershift-operator
+            packages: ./hypershift-operator/...
+          - shard: cmd-support
+            packages: ./cmd/... ./support/...
+          - shard: other
+            packages: ./karpenter-operator/... ./control-plane-pki-operator/... ./contrib/... ./ignition-server/... ./pkg/... ./dnsresolver/... ./product-cli/... ./client/... ./test/integration/... ./test/e2e/util/... ./test/util/... ./availability-prober/... ./konnectivity-socks5-proxy/... ./konnectivity-https-proxy/... ./kubernetes-default-proxy/... ./kubevirtexternalinfra/... ./etcd-defrag/... ./etcd-backup/... ./etcd-recovery/... ./etcd-upload/... ./kas-bootstrap/... ./sharedingress-config-generator/... ./sync-fg-configmap/... ./sync-global-pullsecret/... ./token-minter/...
+    env:
+      GOCACHE: /tmp/go-build-cache
+      GOMODCACHE: /tmp/go-mod-cache
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        env:
+          HOME: /tmp
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Restore Go build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: /tmp/go-build-cache
+          key: go-build-${{ matrix.shard }}-${{ hashFiles('go.mod') }}-${{ github.sha }}
+          restore-keys: go-build-${{ matrix.shard }}-${{ hashFiles('go.mod') }}-
+      - name: Run tests
+        run: make test-shard TEST_PACKAGES="${{ matrix.packages }}" COVER_PROFILE="cover-${{ matrix.shard }}.out"
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        env:
+          HOME: /tmp
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: cover-${{ matrix.shard }}.out
+          flags: ${{ matrix.shard }}

--- a/.github/workflows/verify-reusable.yaml
+++ b/.github/workflows/verify-reusable.yaml
@@ -1,0 +1,32 @@
+name: Verify (Reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: arc-runner-set
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - run: make generate update
+      - run: |
+          git update-index --refresh
+          git diff-index --cached --quiet --ignore-submodules HEAD --
+          git diff-files --quiet --ignore-submodules
+          git diff --exit-code HEAD --
+          STATUS=$(git status -s)
+          if [ -n "$STATUS" ]; then
+            echo "untracked files detected:"
+            echo "$STATUS"
+            exit 1
+          fi
+      - run: make staticcheck
+      - run: make fmt
+      - run: make vet


### PR DESCRIPTION
## What this PR does / why we need it:

Adds 9 dormant reusable workflow files (`*-reusable.yaml`) that will be referenced by caller stubs in a follow-up PR. This is the first of two PRs implementing reusable workflows to eliminate the `verify-workflows` Prow job and forced rebases.

**Workflows added:**
- codespell-reusable.yaml
- cpo-container-sync-reusable.yaml
- docs-build-reusable.yaml
- envtest-kube-reusable.yaml
- envtest-ocp-reusable.yaml
- gitlint-reusable.yaml
- lint-reusable.yaml
- test-reusable.yaml
- verify-reusable.yaml

**Improvements over originals:**
- lint: adds `persist-credentials: false` (was missing in original)
- test: pins `actions/setup-go` to SHA `40f1582b2485089dde7abd97c1529aa768e1baff` (v5.6.0)
- envtest-kube/ocp: updates change detection grep to match both original and reusable filenames

These files are inert until callers reference them. The follow-up PR (#8387) converts all 9 callers to thin stubs that `uses: ...@main`.

**Why two PRs:** The `@main` ref in caller stubs requires the reusable files to exist on main first. Merging the reusable files first avoids this bootstrap problem.

**Future release branches (4.23+):** Will need push/PR trigger branch lists updated in both caller and reusable files.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-3352](https://redhat.atlassian.net/browse/CNTRLPLANE-3352)

## Special notes for your reviewer:

- These files are dormant — nothing calls them yet. They will only activate when the follow-up PR converts callers to use `@main` refs.
- The envtest and test reusable workflows have both `workflow_call` and `push` triggers so direct pushes to main/release branches still work after the caller conversion.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)