### PR TITLE
CNTRLPLANE-3352: Convert GHA callers to use reusable workflows @main

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -6,16 +6,8 @@ on:
       - main
       - release-4.22
 
-permissions:
-  contents: read
-
 jobs:
   codespell:
-    name: Codespell
-    runs-on: arc-runner-set
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - run: make verify-codespell
+    uses: openshift/hypershift/.github/workflows/codespell-reusable.yaml@main
+    permissions:
+      contents: read

--- a/.github/workflows/cpo-container-sync.yaml
+++ b/.github/workflows/cpo-container-sync.yaml
@@ -6,16 +6,8 @@ on:
       - main
       - release-4.22
 
-permissions:
-  contents: read
-
 jobs:
   cpo-container-sync:
-    name: CPO Container Sync
-    runs-on: arc-runner-set
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - run: make cpo-container-sync
+    uses: openshift/hypershift/.github/workflows/cpo-container-sync-reusable.yaml@main
+    permissions:
+      contents: read

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -8,7 +8,6 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/docs-build.yaml'
-      - '.github/workflows/docs-build-reusable.yaml'
 
 jobs:
   build:

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -8,31 +8,10 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/docs-build.yaml'
-
-permissions:
-  contents: read
+      - '.github/workflows/docs-build-reusable.yaml'
 
 jobs:
   build:
-    name: Build Docs
-    runs-on: arc-runner-set
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: '3.x'
-          pip-install: '-r docs/requirements.txt'
-        env:
-          PIP_CACHE_DIR: ${{ runner.temp }}/.pip-cache
-      - name: Build documentation
-        run: mkdocs build --strict
-        working-directory: docs
-      - name: Save PR metadata
-        run: echo "${{ github.event.pull_request.number }}" > docs/site/pr-number.txt
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: docs-site
-          path: docs/site
+    uses: openshift/hypershift/.github/workflows/docs-build-reusable.yaml@main
+    permissions:
+      contents: read

--- a/.github/workflows/envtest-kube-reusable.yaml
+++ b/.github/workflows/envtest-kube-reusable.yaml
@@ -24,18 +24,18 @@ jobs:
       - name: Check for relevant file changes
         id: check
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          CREATED: ${{ github.event.created }}
-          PR_DIFF_REF: origin/${{ github.base_ref }}...HEAD
-          PUSH_DIFF_REF: ${{ github.event.before }}..HEAD
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
         run: |
-          if [ "$EVENT_NAME" = "workflow_dispatch" ] || [ "$CREATED" = "true" ]; then
+          set -euo pipefail
+          if [ -n "${PR_BASE_SHA:-}" ] && [ -n "${PR_HEAD_SHA:-}" ]; then
+            ref="${PR_BASE_SHA}...${PR_HEAD_SHA}"
+          elif [ -n "${PUSH_BEFORE_SHA:-}" ] && [ "$PUSH_BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
+            ref="${PUSH_BEFORE_SHA}..HEAD"
+          else
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
-          fi
-          ref="$PUSH_DIFF_REF"
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            ref="$PR_DIFF_REF"
           fi
           if git diff --name-only "$ref" | grep -qE '^(api/|test/envtest/|cmd/install/assets/crds/hypershift-operator/tests/|karpenter-operator/controllers/karpenter/assets/tests/|\.github/workflows/envtest-kube(-reusable)?\.yaml$)'; then
             echo "should_run=true"

--- a/.github/workflows/envtest-kube.yaml
+++ b/.github/workflows/envtest-kube.yaml
@@ -1,88 +1,14 @@
 name: Envtest Vanilla Kube API Validation
 
 on:
-  push:
-    branches:
-      - main
-      - release-4.22
   pull_request:
     branches:
       - main
       - release-4.22
   workflow_dispatch: {}
 
-permissions:
-  contents: read
-
 jobs:
-  changes:
-    name: Detect Changes
-    runs-on: arc-runner-set
-    outputs:
-      should_run: ${{ steps.check.outputs.should_run }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Check for relevant file changes
-        id: check
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          CREATED: ${{ github.event.created }}
-          PR_DIFF_REF: origin/${{ github.base_ref }}...HEAD
-          PUSH_DIFF_REF: ${{ github.event.before }}..HEAD
-        run: |
-          if [ "$EVENT_NAME" = "workflow_dispatch" ] || [ "$CREATED" = "true" ]; then
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          ref="$PUSH_DIFF_REF"
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            ref="$PR_DIFF_REF"
-          fi
-          if git diff --name-only "$ref" | grep -qE '^(api/|test/envtest/|cmd/install/assets/crds/hypershift-operator/tests/|karpenter-operator/controllers/karpenter/assets/tests/|\.github/workflows/envtest-kube\.yaml$)'; then
-            echo "should_run=true"
-          else
-            echo "should_run=false"
-          fi >> "$GITHUB_OUTPUT"
-
   envtest-kube:
-    name: Envtest Vanilla Kube ${{ matrix.version }}
-    needs: changes
-    if: needs.changes.outputs.should_run == 'true'
-    runs-on: arc-runner-set
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        version: ["1.31.0", "1.32.0", "1.33.0", "1.34.0", "1.35.0"]
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - run: make test-envtest-kube ENVTEST_KUBE_VERSIONS="${{ matrix.version }}"
-
-  conclusion:
-    name: Conclusion
-    needs:
-      - changes
-      - envtest-kube
-    if: always()
-    runs-on: arc-runner-set
-    steps:
-      - name: Aggregate results
-        run: |
-          changes_result="${{ needs.changes.result }}"
-          envtest_result="${{ needs.envtest-kube.result }}"
-          if [ "$changes_result" != "success" ]; then
-            echo "Change detection failed: $changes_result"
-            exit 1
-          fi
-          if [ "$envtest_result" = "success" ] || [ "$envtest_result" = "skipped" ]; then
-            echo "All envtest jobs passed or were skipped"
-            exit 0
-          else
-            echo "Envtest jobs failed: $envtest_result"
-            exit 1
-          fi
+    uses: openshift/hypershift/.github/workflows/envtest-kube-reusable.yaml@main
+    permissions:
+      contents: read

--- a/.github/workflows/envtest-ocp-reusable.yaml
+++ b/.github/workflows/envtest-ocp-reusable.yaml
@@ -24,18 +24,18 @@ jobs:
       - name: Check for relevant file changes
         id: check
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          CREATED: ${{ github.event.created }}
-          PR_DIFF_REF: origin/${{ github.base_ref }}...HEAD
-          PUSH_DIFF_REF: ${{ github.event.before }}..HEAD
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
         run: |
-          if [ "$EVENT_NAME" = "workflow_dispatch" ] || [ "$CREATED" = "true" ]; then
+          set -euo pipefail
+          if [ -n "${PR_BASE_SHA:-}" ] && [ -n "${PR_HEAD_SHA:-}" ]; then
+            ref="${PR_BASE_SHA}...${PR_HEAD_SHA}"
+          elif [ -n "${PUSH_BEFORE_SHA:-}" ] && [ "$PUSH_BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
+            ref="${PUSH_BEFORE_SHA}..HEAD"
+          else
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0
-          fi
-          ref="$PUSH_DIFF_REF"
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            ref="$PR_DIFF_REF"
           fi
           if git diff --name-only "$ref" | grep -qE '^(api/|test/envtest/|cmd/install/assets/crds/hypershift-operator/tests/|karpenter-operator/controllers/karpenter/assets/tests/|\.github/workflows/envtest-ocp(-reusable)?\.yaml$)'; then
             echo "should_run=true"

--- a/.github/workflows/envtest-ocp.yaml
+++ b/.github/workflows/envtest-ocp.yaml
@@ -1,89 +1,14 @@
 name: Envtest OCP API Validation
 
 on:
-  push:
-    branches:
-      - main
-      - release-4.22
   pull_request:
     branches:
       - main
       - release-4.22
   workflow_dispatch: {}
 
-permissions:
-  contents: read
-
 jobs:
-  changes:
-    name: Detect Changes
-    runs-on: arc-runner-set
-    outputs:
-      should_run: ${{ steps.check.outputs.should_run }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Check for relevant file changes
-        id: check
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          CREATED: ${{ github.event.created }}
-          PR_DIFF_REF: origin/${{ github.base_ref }}...HEAD
-          PUSH_DIFF_REF: ${{ github.event.before }}..HEAD
-        run: |
-          if [ "$EVENT_NAME" = "workflow_dispatch" ] || [ "$CREATED" = "true" ]; then
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          ref="$PUSH_DIFF_REF"
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            ref="$PR_DIFF_REF"
-          fi
-          if git diff --name-only "$ref" | grep -qE '^(api/|test/envtest/|cmd/install/assets/crds/hypershift-operator/tests/|karpenter-operator/controllers/karpenter/assets/tests/|\.github/workflows/envtest-ocp\.yaml$)'; then
-            echo "should_run=true"
-          else
-            echo "should_run=false"
-          fi >> "$GITHUB_OUTPUT"
-
   envtest-ocp:
-    name: Envtest OCP (K8s ${{ matrix.version }})
-    needs: changes
-    if: needs.changes.outputs.should_run == 'true'
-    runs-on: arc-runner-set
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        # OCP 4.17=1.30, 4.18=1.31, 4.19=1.32, 4.20=1.33, 4.21=1.34, 4.22=1.35
-        version: ["1.30.3", "1.31.2", "1.32.1", "1.33.2", "1.34.1", "1.35.1"]
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - run: make test-envtest-ocp ENVTEST_OCP_K8S_VERSIONS="${{ matrix.version }}"
-
-  conclusion:
-    name: Conclusion
-    needs:
-      - changes
-      - envtest-ocp
-    if: always()
-    runs-on: arc-runner-set
-    steps:
-      - name: Aggregate results
-        run: |
-          changes_result="${{ needs.changes.result }}"
-          envtest_result="${{ needs.envtest-ocp.result }}"
-          if [ "$changes_result" != "success" ]; then
-            echo "Change detection failed: $changes_result"
-            exit 1
-          fi
-          if [ "$envtest_result" = "success" ] || [ "$envtest_result" = "skipped" ]; then
-            echo "All envtest jobs passed or were skipped"
-            exit 0
-          else
-            echo "Envtest jobs failed: $envtest_result"
-            exit 1
-          fi
+    uses: openshift/hypershift/.github/workflows/envtest-ocp-reusable.yaml@main
+    permissions:
+      contents: read

--- a/.github/workflows/gitlint.yaml
+++ b/.github/workflows/gitlint.yaml
@@ -6,20 +6,8 @@ on:
       - main
       - release-4.22
 
-permissions:
-  contents: read
-
 jobs:
   gitlint:
-    name: Gitlint
-    runs-on: arc-runner-set
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - run: make run-gitlint
-        env:
-          PULL_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PULL_PULL_SHA: ${{ github.event.pull_request.head.sha }}
+    uses: openshift/hypershift/.github/workflows/gitlint-reusable.yaml@main
+    permissions:
+      contents: read

--- a/.github/workflows/lint-reusable.yaml
+++ b/.github/workflows/lint-reusable.yaml
@@ -16,7 +16,10 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - run: git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
+      - run: |
+          if [ -n "${{ github.base_ref }}" ]; then
+            git fetch origin "${{ github.base_ref }}:${{ github.base_ref }}"
+          fi
       - name: Use pre-built lint tools
         run: |
           if [ -d /opt/lint-tools ]; then

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,25 +6,8 @@ on:
       - main
       - release-4.22
 
-permissions:
-  contents: read
-
 jobs:
   lint:
-    name: Lint
-    runs-on: arc-runner-set
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-      - run: git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
-      - name: Use pre-built lint tools
-        run: |
-          if [ -d /opt/lint-tools ]; then
-            mkdir -p hack/tools/bin
-            cp /opt/lint-tools/golangci-lint hack/tools/bin/
-            cp /opt/lint-tools/kube-api-linter.so hack/tools/bin/
-            touch hack/tools/bin/golangci-lint hack/tools/bin/kube-api-linter.so
-          fi
-      - run: make lint
+    uses: openshift/hypershift/.github/workflows/lint-reusable.yaml@main
+    permissions:
+      contents: read

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,105 +1,15 @@
 name: Unit Tests
 
 on:
-  push:
-    branches:
-      - main
-      - release-4.22
   pull_request:
     branches:
       - main
       - release-4.22
   workflow_dispatch: {}
 
-permissions:
-  contents: read
-
 jobs:
-  changes:
-    name: Detect Changes
-    runs-on: arc-runner-set
-    timeout-minutes: 5
-    outputs:
-      run_tests: ${{ steps.changes.outputs.run_tests }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - uses: actions/setup-go@v5
-        env:
-          HOME: /tmp
-        with:
-          go-version-file: go.mod
-          cache: false
-      - name: Check for non-contrib changes
-        id: changes
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "run_tests=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
-          else
-            if [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
-              echo "run_tests=true" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            FILES=$(git diff --name-only ${{ github.event.before }}..${{ github.sha }})
-          fi
-          if echo "$FILES" | grep -qvE '^(contrib|\.github|docs)/'; then
-            echo "run_tests=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run_tests=false" >> "$GITHUB_OUTPUT"
-          fi
-
   test:
-    name: Unit Tests (${{ matrix.shard }})
-    needs: changes
-    if: needs.changes.outputs.run_tests == 'true'
-    runs-on: arc-runner-set
-    timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - shard: cpo-hostedcontrolplane
-            packages: ./control-plane-operator/controllers/hostedcontrolplane/...
-          - shard: cpo-other
-            packages: ./control-plane-operator/controllers/awsprivatelink/... ./control-plane-operator/controllers/azureprivatelinkservice/... ./control-plane-operator/controllers/gcpprivateserviceconnect/... ./control-plane-operator/controllers/healthcheck/... ./control-plane-operator/controllers/openshiftmanager/... ./control-plane-operator/endpoint-resolver/... ./control-plane-operator/hostedclusterconfigoperator/... ./control-plane-operator/metrics-proxy/...
-          - shard: hypershift-operator
-            packages: ./hypershift-operator/...
-          - shard: cmd-support
-            packages: ./cmd/... ./support/...
-          - shard: other
-            packages: ./karpenter-operator/... ./control-plane-pki-operator/... ./contrib/... ./ignition-server/... ./pkg/... ./dnsresolver/... ./product-cli/... ./client/... ./test/integration/... ./test/e2e/util/... ./test/util/... ./availability-prober/... ./konnectivity-socks5-proxy/... ./konnectivity-https-proxy/... ./kubernetes-default-proxy/... ./kubevirtexternalinfra/... ./etcd-defrag/... ./etcd-backup/... ./etcd-recovery/... ./etcd-upload/... ./kas-bootstrap/... ./sharedingress-config-generator/... ./sync-fg-configmap/... ./sync-global-pullsecret/... ./token-minter/...
-    env:
-      GOCACHE: /tmp/go-build-cache
-      GOMODCACHE: /tmp/go-mod-cache
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - uses: actions/setup-go@v5
-        env:
-          HOME: /tmp
-        with:
-          go-version-file: go.mod
-          cache: false
-      - name: Restore Go build cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: /tmp/go-build-cache
-          key: go-build-${{ matrix.shard }}-${{ hashFiles('go.mod') }}-${{ github.sha }}
-          restore-keys: go-build-${{ matrix.shard }}-${{ hashFiles('go.mod') }}-
-      - name: Run tests
-        run: make test-shard TEST_PACKAGES="${{ matrix.packages }}" COVER_PROFILE="cover-${{ matrix.shard }}.out"
-      - name: Upload to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        env:
-          HOME: /tmp
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          files: cover-${{ matrix.shard }}.out
-          flags: ${{ matrix.shard }}
+    uses: openshift/hypershift/.github/workflows/test-reusable.yaml@main
+    permissions:
+      contents: read
+    secrets: inherit

--- a/.github/workflows/verify-reusable.yaml
+++ b/.github/workflows/verify-reusable.yaml
@@ -16,6 +16,9 @@ jobs:
         with:
           persist-credentials: false
       - run: make generate update
+      - run: make staticcheck
+      - run: make fmt
+      - run: make vet
       - run: |
           git update-index --refresh
           git diff-index --cached --quiet --ignore-submodules HEAD --
@@ -27,6 +30,3 @@ jobs:
             echo "$STATUS"
             exit 1
           fi
-      - run: make staticcheck
-      - run: make fmt
-      - run: make vet

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -6,30 +6,8 @@ on:
       - main
       - release-4.22
 
-permissions:
-  contents: read
-
 jobs:
   verify:
-    name: Verify
-    runs-on: arc-runner-set
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - run: make generate update
-      - run: |
-          git update-index --refresh
-          git diff-index --cached --quiet --ignore-submodules HEAD --
-          git diff-files --quiet --ignore-submodules
-          git diff --exit-code HEAD --
-          STATUS=$(git status -s)
-          if [ -n "$STATUS" ]; then
-            echo "untracked files detected:"
-            echo "$STATUS"
-            exit 1
-          fi
-      - run: make staticcheck
-      - run: make fmt
-      - run: make vet
+    uses: openshift/hypershift/.github/workflows/verify-reusable.yaml@main
+    permissions:
+      contents: read

--- a/support/util/annotations_test.go
+++ b/support/util/annotations_test.go
@@ -13,6 +13,57 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+func TestHasAnnotationWithValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		key         string
+		value       string
+		want        bool
+	}{
+		{
+			name:        "When annotation exists with matching value it should return true",
+			annotations: map[string]string{"foo": "bar"},
+			key:         "foo",
+			value:       "bar",
+			want:        true,
+		},
+		{
+			name:        "When annotation exists with different value it should return false",
+			annotations: map[string]string{"foo": "baz"},
+			key:         "foo",
+			value:       "bar",
+			want:        false,
+		},
+		{
+			name:        "When annotation does not exist it should return false",
+			annotations: map[string]string{"other": "value"},
+			key:         "foo",
+			value:       "bar",
+			want:        false,
+		},
+		{
+			name:        "When annotations map is nil it should return false",
+			annotations: nil,
+			key:         "foo",
+			value:       "bar",
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			obj := &metav1.ObjectMeta{Annotations: tt.annotations}
+			if got := HasAnnotationWithValue(obj, tt.key, tt.value); got != tt.want {
+				t.Fatalf("HasAnnotationWithValue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestHostedClusterFromAnnotation(t *testing.T) {
 	t.Parallel()
 

--- a/test/envtest/generator.go
+++ b/test/envtest/generator.go
@@ -188,12 +188,12 @@ func GenerateTestSuite(suiteSpec SuiteSpec) {
 						},
 					})
 					return err
-				}, "30s", "1s").Should(Succeed(), "CRD should install successfully")
+				}, "120s", "1s").Should(Succeed(), "CRD should install successfully")
 				Expect(crds).To(HaveLen(1), "Only one CRD should have been installed")
 				crd = crds[0]
 
 				Expect(envtest.WaitForCRDs(cfg, crds, envtest.CRDInstallOptions{
-					MaxTime: 30 * time.Second,
+					MaxTime: 120 * time.Second,
 				})).To(Succeed())
 			})
 
@@ -212,7 +212,7 @@ func GenerateTestSuite(suiteSpec SuiteSpec) {
 				Eventually(func() bool {
 					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(crd), &apiextensionsv1.CustomResourceDefinition{})
 					return apierrors.IsNotFound(err)
-				}, "30s", "1s").Should(BeTrue(), fmt.Sprintf("CRD %s should be fully removed", crd.Name))
+				}, "120s", "1s").Should(BeTrue(), fmt.Sprintf("CRD %s should be fully removed", crd.Name))
 			})
 
 			generateOnCreateTable(suiteSpec.Tests.OnCreate)
@@ -244,7 +244,7 @@ func GenerateCRDInstallTest(featureSet string) {
 				CRDs: crdsToInstall,
 			})
 			return err
-		}, "60s", "1s").Should(Succeed(), "all CRDs should install without error")
+		}, "120s", "1s").Should(Succeed(), "all CRDs should install without error")
 		Expect(crds).To(HaveLen(len(allCRDs)), "all CRDs should have been installed")
 		Expect(envtest.WaitForCRDs(cfg, crds, envtest.CRDInstallOptions{})).To(Succeed())
 
@@ -259,7 +259,7 @@ func GenerateCRDInstallTest(featureSet string) {
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, key, &apiextensionsv1.CustomResourceDefinition{})
 				return apierrors.IsNotFound(err)
-			}, "30s", "1s").Should(BeTrue(), fmt.Sprintf("CRD %s should be fully removed", crd.Name))
+			}, "120s", "1s").Should(BeTrue(), fmt.Sprintf("CRD %s should be fully removed", crd.Name))
 		}
 	})
 }


### PR DESCRIPTION
## What this PR does / why we need it:

Converts all 9 GHA workflow callers to thin stubs that reference reusable workflow definitions via `@main`. This is the second of two PRs — it depends on #8386 which has already been merged.

After this PR merges, every PR-triggered GHA run automatically uses the latest workflow definition from main, eliminating the need for:
- The `verify-workflows` Prow job in openshift/release
- Forced rebases when workflow files change on main

**Callers converted:**
- codespell.yaml
- cpo-container-sync.yaml
- docs-build.yaml
- envtest-kube.yaml
- envtest-ocp.yaml
- gitlint.yaml
- lint.yaml
- test.yaml
- verify.yaml

**Key details:**
- `docs-build.yaml` preserves `name: Docs Build` so `docs-deploy.yaml`'s `workflow_run` trigger continues working
- `test.yaml` uses `secrets: inherit` to pass `CODECOV_TOKEN`
- Push triggers for main/release branches remain on the reusable workflows (not the callers)
- Check names will change from `JobName` to `caller-job / JobName` — cosmetic only, nothing gates on these

**Next step after merge:** Remove `verify-workflows` Prow job from openshift/release after a few days of bake time.

**Future release branches (4.23+):** Will need push/PR trigger branch lists updated in both caller and reusable files.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-3352](https://redhat.atlassian.net/browse/CNTRLPLANE-3352)

## Special notes for your reviewer:

- #8386 (dormant reusable workflow files) has already been merged, so GHA CI should pass on this PR.
- Forks: `@main` ref to upstream is intentional — fork PRs always get the latest upstream workflow.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * CI/CD workflows refactored to invoke reusable workflow components for consistency; job-level permissions tightened and several workflow triggers/flows simplified.

* **Tests**
  * Added unit tests verifying annotation lookup returns true only when a key’s value exactly matches, and false for absent keys, differing values, or nil annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->