### PR TITLE
CNTRLPLANE-3343: Extract support/k8sutil package from support/util

### DIFF
--- a/control-plane-operator/controllers/azureprivatelinkservice/observer.go
+++ b/control-plane-operator/controllers/azureprivatelinkservice/observer.go
@@ -30,8 +30,8 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/azureutil"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/upsert"
-	supportutil "github.com/openshift/hypershift/support/util"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -98,14 +98,14 @@ func (r *AzurePrivateLinkServiceObserver) Reconcile(ctx context.Context, req ctr
 	}
 
 	// Extract LoadBalancer IP and validate it's ready
-	loadBalancerIP, hasValidIP := supportutil.ExtractLoadBalancerIP(svc)
+	loadBalancerIP, hasValidIP := k8sutil.ExtractLoadBalancerIP(svc)
 	if !hasValidIP {
 		logger.Info("LoadBalancer IP not ready yet, will retry")
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
 	// Find HostedControlPlane from service OwnerReference
-	hcpName := supportutil.ExtractHostedControlPlaneOwnerName(svc.OwnerReferences)
+	hcpName := k8sutil.ExtractHostedControlPlaneOwnerName(svc.OwnerReferences)
 	if hcpName == "" {
 		return ctrl.Result{}, fmt.Errorf("service does not have HostedControlPlane owner reference")
 	}
@@ -157,8 +157,8 @@ func (r *AzurePrivateLinkServiceObserver) reconcileAzurePrivateLinkService(ctx c
 		if azurePLS.Annotations == nil {
 			azurePLS.Annotations = make(map[string]string)
 		}
-		if hcAnnotation, exists := hcp.Annotations[supportutil.HostedClusterAnnotation]; exists {
-			azurePLS.Annotations[supportutil.HostedClusterAnnotation] = hcAnnotation
+		if hcAnnotation, exists := hcp.Annotations[k8sutil.HostedClusterAnnotation]; exists {
+			azurePLS.Annotations[k8sutil.HostedClusterAnnotation] = hcAnnotation
 		}
 
 		// Set spec fields from HCP Azure platform configuration

--- a/control-plane-operator/controllers/azureprivatelinkservice/observer_test.go
+++ b/control-plane-operator/controllers/azureprivatelinkservice/observer_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
-	supportutil "github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -79,7 +79,7 @@ func TestReconcile(t *testing.T) {
 				Namespace: testNamespace,
 				UID:       testHCPUID,
 				Annotations: map[string]string{
-					supportutil.HostedClusterAnnotation: "clusters/test-cluster",
+					k8sutil.HostedClusterAnnotation: "clusters/test-cluster",
 				},
 			},
 			Spec: hyperv1.HostedControlPlaneSpec{
@@ -343,7 +343,7 @@ func TestReconcile(t *testing.T) {
 				g.Expect(azurePLS.OwnerReferences[0].Name).To(Equal(testHCPName))
 
 				// Verify HostedCluster annotation is copied
-				g.Expect(azurePLS.Annotations).To(HaveKeyWithValue(supportutil.HostedClusterAnnotation, "clusters/test-cluster"))
+				g.Expect(azurePLS.Annotations).To(HaveKeyWithValue(k8sutil.HostedClusterAnnotation, "clusters/test-cluster"))
 			} else {
 				// Verify no AzurePrivateLinkService was created
 				azurePLSList := &hyperv1.AzurePrivateLinkServiceList{}

--- a/control-plane-operator/controllers/gcpprivateserviceconnect/observer.go
+++ b/control-plane-operator/controllers/gcpprivateserviceconnect/observer.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/upsert"
-	supportutil "github.com/openshift/hypershift/support/util"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -83,14 +83,14 @@ func (r *GCPPrivateServiceObserver) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	// Extract LoadBalancer IP and validate it's ready
-	loadBalancerIP, hasValidIP := supportutil.ExtractLoadBalancerIP(svc)
+	loadBalancerIP, hasValidIP := k8sutil.ExtractLoadBalancerIP(svc)
 	if !hasValidIP {
 		r.log.Info("LoadBalancer IP not ready yet")
 		return ctrl.Result{}, nil
 	}
 
 	// Find HostedControlPlane from service OwnerReference
-	hcpName := supportutil.ExtractHostedControlPlaneOwnerName(svc.OwnerReferences)
+	hcpName := k8sutil.ExtractHostedControlPlaneOwnerName(svc.OwnerReferences)
 	if hcpName == "" {
 		return ctrl.Result{}, fmt.Errorf("service does not have HostedControlPlane owner reference")
 	}
@@ -140,8 +140,8 @@ func (r *GCPPrivateServiceObserver) reconcileGCPPrivateServiceConnect(ctx contex
 		if gcpPSC.Annotations == nil {
 			gcpPSC.Annotations = make(map[string]string)
 		}
-		if hcAnnotation, exists := hcp.Annotations[supportutil.HostedClusterAnnotation]; exists {
-			gcpPSC.Annotations[supportutil.HostedClusterAnnotation] = hcAnnotation
+		if hcAnnotation, exists := hcp.Annotations[k8sutil.HostedClusterAnnotation]; exists {
+			gcpPSC.Annotations[k8sutil.HostedClusterAnnotation] = hcAnnotation
 		}
 
 		// Set spec fields

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -79,6 +79,7 @@ import (
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/events"
 	"github.com/openshift/hypershift/support/globalconfig"
+	"github.com/openshift/hypershift/support/k8sutil"
 	karpenterutil "github.com/openshift/hypershift/support/karpenter"
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/netutil"
@@ -1135,7 +1136,7 @@ func (r *HostedControlPlaneReconciler) reconcileCPOV2(ctx context.Context, hcp *
 		roleBinding := ignitionmanifests.ProxyRoleBinding(hcp.Namespace)
 
 		for _, resource := range []client.Object{role, sa, roleBinding} {
-			if _, err := util.DeleteIfNeeded(ctx, r.Client, resource); err != nil {
+			if _, err := k8sutil.DeleteIfNeeded(ctx, r.Client, resource); err != nil {
 				r.Log.Error(err, "Failed to delete deprecated resource", "resource", client.ObjectKeyFromObject(resource).String())
 			}
 		}
@@ -1251,7 +1252,7 @@ func IsStorageAndCSIManaged(hostedControlPlane *hyperv1.HostedControlPlane) bool
 func (r *HostedControlPlaneReconciler) reconcileDefaultServiceAccount(ctx context.Context, hcp *hyperv1.HostedControlPlane, createOrUpdate upsert.CreateOrUpdateFN) error {
 	defaultSA := common.DefaultServiceAccount(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r.Client, defaultSA, func() error {
-		util.EnsurePullSecret(defaultSA, common.PullSecret(hcp.Namespace).Name)
+		k8sutil.EnsurePullSecret(defaultSA, common.PullSecret(hcp.Namespace).Name)
 		return nil
 	}); err != nil {
 		return err
@@ -1885,7 +1886,7 @@ func (r *HostedControlPlaneReconciler) reconcileUnmanagedEtcd(ctx context.Contex
 func (r *HostedControlPlaneReconciler) cleanupOldKonnectivityServerDeployment(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
 	serverDeployment := manifests.KonnectivityServerDeployment(hcp.Namespace)
 	// Remove the konnectivity-server deployment if it exists
-	if _, err := util.DeleteIfNeeded(ctx, r, serverDeployment); err != nil {
+	if _, err := k8sutil.DeleteIfNeeded(ctx, r, serverDeployment); err != nil {
 		return fmt.Errorf("failed to remove konnectivity-server deployment: %w", err)
 	}
 	return nil
@@ -1899,7 +1900,7 @@ func (r *HostedControlPlaneReconciler) cleanupOldPKIOperatorDeployment(ctx conte
 		},
 	}
 	// Remove the pki-operator deployment if it exists with outdated selector.
-	if _, err := util.DeleteIfNeededWithPredicate(ctx, r, deployment, func(d *appsv1.Deployment) bool {
+	if _, err := k8sutil.DeleteIfNeededWithPredicate(ctx, r, deployment, func(d *appsv1.Deployment) bool {
 		return d.Spec.Selector != nil && d.Spec.Selector.MatchLabels["name"] == "control-plane-pki-operator"
 	}); err != nil {
 		return fmt.Errorf("failed to remove pki-operator deployment: %w", err)
@@ -1963,18 +1964,18 @@ func (r *HostedControlPlaneReconciler) cleanupClusterNetworkOperatorResources(ct
 
 	// Clean up ovnkube-sbdb Route if exists
 	if hasRouteCap {
-		if _, err := util.DeleteIfNeeded(ctx, r.Client, manifests.OVNKubeSBDBRoute(hcp.Namespace)); err != nil {
+		if _, err := k8sutil.DeleteIfNeeded(ctx, r.Client, manifests.OVNKubeSBDBRoute(hcp.Namespace)); err != nil {
 			return fmt.Errorf("failed to clean up ovnkube-sbdb route: %w", err)
 		}
 	}
 
 	// Clean up ovnkube-master-external Service if exists
-	if _, err := util.DeleteIfNeeded(ctx, r.Client, manifests.MasterExternalService(hcp.Namespace)); err != nil {
+	if _, err := k8sutil.DeleteIfNeeded(ctx, r.Client, manifests.MasterExternalService(hcp.Namespace)); err != nil {
 		return fmt.Errorf("failed to clean up ovnkube-master-external service: %w", err)
 	}
 
 	// Clean up ovnkube-master-internal Service if exists
-	if _, err := util.DeleteIfNeeded(ctx, r.Client, manifests.MasterInternalService(hcp.Namespace)); err != nil {
+	if _, err := k8sutil.DeleteIfNeeded(ctx, r.Client, manifests.MasterInternalService(hcp.Namespace)); err != nil {
 		return fmt.Errorf("failed to clean up ovnkube-master-internal service: %w", err)
 	}
 
@@ -2086,7 +2087,7 @@ func (r *HostedControlPlaneReconciler) reconcileCoreIgnitionConfig(ctx context.C
 	// Ensure the imageDigestMirrorSet configmap has been removed if no longer needed
 	imageContentPolicyIgnitionConfig := manifests.ImageContentPolicyIgnitionConfig(hcp.GetNamespace())
 	if !p.HasImageMirrorPolicies {
-		_, err := util.DeleteIfNeeded(ctx, r.Client, imageContentPolicyIgnitionConfig)
+		_, err := k8sutil.DeleteIfNeeded(ctx, r.Client, imageContentPolicyIgnitionConfig)
 		if err != nil {
 			return fmt.Errorf("failed to delete image content source policy configuration configmap: %w", err)
 		}
@@ -2122,7 +2123,7 @@ func (r *HostedControlPlaneReconciler) cleanupOldRouterResources(ctx context.Con
 		manifests.RouterRoleBinding(hcp.Namespace),
 	}
 	for _, resource := range oldRouterResources {
-		if _, err := util.DeleteIfNeeded(ctx, r.Client, resource); err != nil {
+		if _, err := k8sutil.DeleteIfNeeded(ctx, r.Client, resource); err != nil {
 			return fmt.Errorf("failed to delete %T %s: %w", resource, resource.GetName(), err)
 		}
 	}
@@ -2227,7 +2228,7 @@ func removeServiceCASecret(ctx context.Context, c client.Client, secret *corev1.
 	} else {
 		_, ok := secret.Annotations["service.alpha.openshift.io/originating-service-name"]
 		if ok {
-			_, err := util.DeleteIfNeeded(ctx, c, secret)
+			_, err := k8sutil.DeleteIfNeeded(ctx, c, secret)
 			if err != nil {
 				return fmt.Errorf("failed to delete secret generated by service-ca: %w", err)
 			}
@@ -2235,7 +2236,7 @@ func removeServiceCASecret(ctx context.Context, c client.Client, secret *corev1.
 
 		_, ok = secret.Annotations["service.beta.openshift.io/originating-service-name"]
 		if ok {
-			_, err := util.DeleteIfNeeded(ctx, c, secret)
+			_, err := k8sutil.DeleteIfNeeded(ctx, c, secret)
 			if err != nil {
 				return fmt.Errorf("failed to delete secret generated by service-ca: %w", err)
 			}
@@ -2520,7 +2521,7 @@ func (r *HostedControlPlaneReconciler) reconcileDefaultSecurityGroup(ctx context
 
 		// Update the last-applied-security-group-tags annotation on the HCP with the tags applied to the SG.
 		// This is used to track changes to the tags and update them if necessary.
-		if err := util.UpdateObject(ctx, r.Client, hcp, func() error {
+		if err := k8sutil.UpdateObject(ctx, r.Client, hcp, func() error {
 			if err := updateLastAppliedSecurityGroupTagsAnnotation(hcp, desiredTags); err != nil {
 				return fmt.Errorf("failed to update last applied security group tags annotation")
 			}
@@ -2551,7 +2552,7 @@ func (r *HostedControlPlaneReconciler) reconcileDefaultSecurityGroup(ctx context
 	} else {
 		// Ensure the last-applied-security-group-tags annotation is set on the HCP on SG creation.
 		// This is used to track changes to the tags and update them if necessary.
-		if err := util.UpdateObject(ctx, r.Client, hcp, func() error {
+		if err := k8sutil.UpdateObject(ctx, r.Client, hcp, func() error {
 			if err := updateLastAppliedSecurityGroupTagsAnnotation(hcp, appliedTags); err != nil {
 				return fmt.Errorf("failed to update last applied security group tags annotation")
 			}
@@ -2847,7 +2848,8 @@ func (r *HostedControlPlaneReconciler) validateAWSKMSConfig(ctx context.Context,
 		return
 	}
 
-	token, err := util.CreateTokenForServiceAccount(ctx, manifests.KASContainerAWSKMSProviderServiceAccount(), guestClient)
+	sa := manifests.KASContainerAWSKMSProviderServiceAccount()
+	token, err := k8sutil.CreateTokenForServiceAccount(ctx, sa, k8sutil.ServiceAccountClient(guestClient, sa.Namespace))
 	if err != nil {
 		// service account might not be created in the guest cluster or KAS is not operational.
 		condition := metav1.Condition{

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -31,6 +31,7 @@ import (
 	fakecapabilities "github.com/openshift/hypershift/support/capabilities/fake"
 	"github.com/openshift/hypershift/support/certs"
 	controlplanecomponent "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/netutil"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	fakereleaseprovider "github.com/openshift/hypershift/support/releaseinfo/fake"
@@ -38,7 +39,6 @@ import (
 	"github.com/openshift/hypershift/support/testutil"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
 	"github.com/openshift/hypershift/support/upsert"
-	"github.com/openshift/hypershift/support/util"
 	"github.com/openshift/hypershift/support/util/fakeimagemetadataprovider"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -1284,7 +1284,7 @@ func TestControlPlaneComponents(t *testing.T) {
 					}
 				}
 
-				yaml, err := util.SerializeResource(obj, api.Scheme)
+				yaml, err := k8sutil.SerializeResource(obj, api.Scheme)
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/infra.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/infra.go
@@ -18,6 +18,7 @@ import (
 	hyperazureutil "github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/events"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/netutil"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
@@ -358,7 +359,7 @@ func (r *Reconciler) reconcileOAuthServerService(ctx context.Context, hcp *hyper
 	oauthExternalPrivateRoute := manifests.OauthServerExternalPrivateRoute(hcp.Namespace)
 	if netutil.IsPublicHCP(hcp) {
 		// Remove the external private route if it exists
-		_, err := util.DeleteIfNeeded(ctx, r.Client, oauthExternalPrivateRoute)
+		_, err := k8sutil.DeleteIfNeeded(ctx, r.Client, oauthExternalPrivateRoute)
 		if err != nil {
 			return fmt.Errorf("failed to delete OAuth external private route: %w", err)
 		}
@@ -375,7 +376,7 @@ func (r *Reconciler) reconcileOAuthServerService(ctx context.Context, hcp *hyper
 		}
 	} else {
 		// Remove the external public route if it exists
-		_, err := util.DeleteIfNeeded(ctx, r.Client, oauthExternalPublicRoute)
+		_, err := k8sutil.DeleteIfNeeded(ctx, r.Client, oauthExternalPublicRoute)
 		if err != nil {
 			return fmt.Errorf("failed to delete OAuth external public route: %w", err)
 		}
@@ -389,7 +390,7 @@ func (r *Reconciler) reconcileOAuthServerService(ctx context.Context, hcp *hyper
 			}
 		} else {
 			// Remove the external private route if it exists when hostname is not specified
-			_, err := util.DeleteIfNeeded(ctx, r.Client, oauthExternalPrivateRoute)
+			_, err := k8sutil.DeleteIfNeeded(ctx, r.Client, oauthExternalPrivateRoute)
 			if err != nil {
 				return fmt.Errorf("failed to delete OAuth external private route: %w", err)
 			}
@@ -444,10 +445,10 @@ func (r *Reconciler) reconcileHCPRouterServices(ctx context.Context, hcp *hyperv
 	pubSvc := manifests.RouterPublicService(hcp.Namespace)
 	privSvc := manifests.PrivateRouterService(hcp.Namespace)
 	if !routerutil.UseHCPRouter(hcp) {
-		if _, err := util.DeleteIfNeeded(ctx, r.Client, pubSvc); err != nil {
+		if _, err := k8sutil.DeleteIfNeeded(ctx, r.Client, pubSvc); err != nil {
 			return fmt.Errorf("failed to delete public router service: %w", err)
 		}
-		if _, err := util.DeleteIfNeeded(ctx, r.Client, privSvc); err != nil {
+		if _, err := k8sutil.DeleteIfNeeded(ctx, r.Client, privSvc); err != nil {
 			return fmt.Errorf("failed to delete private router service: %w", err)
 		}
 		return nil
@@ -456,7 +457,7 @@ func (r *Reconciler) reconcileHCPRouterServices(ctx context.Context, hcp *hyperv
 	// ARO HCP doesn't need LB services; Swift handles connectivity.
 	// Only reconcile a ClusterIP private router service.
 	if hyperazureutil.IsAroHCP() {
-		if _, err := util.DeleteIfNeeded(ctx, r.Client, pubSvc); err != nil {
+		if _, err := k8sutil.DeleteIfNeeded(ctx, r.Client, pubSvc); err != nil {
 			return fmt.Errorf("failed to delete public router service: %w", err)
 		}
 		if _, err := createOrUpdate(ctx, r.Client, privSvc, func() error {
@@ -475,7 +476,7 @@ func (r *Reconciler) reconcileHCPRouterServices(ctx context.Context, hcp *hyperv
 			return fmt.Errorf("failed to reconcile private router service: %w", err)
 		}
 	} else {
-		if _, err := util.DeleteIfNeeded(ctx, r.Client, privSvc); err != nil {
+		if _, err := k8sutil.DeleteIfNeeded(ctx, r.Client, privSvc); err != nil {
 			return fmt.Errorf("failed to delete private router service: %w", err)
 		}
 	}
@@ -489,7 +490,7 @@ func (r *Reconciler) reconcileHCPRouterServices(ctx context.Context, hcp *hyperv
 			return fmt.Errorf("failed to reconcile router service: %w", err)
 		}
 	} else {
-		if _, err := util.DeleteIfNeeded(ctx, r.Client, pubSvc); err != nil {
+		if _, err := k8sutil.DeleteIfNeeded(ctx, r.Client, pubSvc); err != nil {
 			return fmt.Errorf("failed to delete public router service: %w", err)
 		}
 	}
@@ -707,7 +708,7 @@ func (r *Reconciler) reconcileRouterServiceStatus(ctx context.Context, svc *core
 		err = fmt.Errorf("failed to get router service (%s): %w", svc.Name, err)
 		return
 	}
-	if message, err = util.CollectLBMessageIfNotProvisioned(svc, messageCollector); err != nil || message != "" {
+	if message, err = k8sutil.CollectLBMessageIfNotProvisioned(svc, messageCollector); err != nil || message != "" {
 		return
 	}
 	switch {

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -5,8 +5,8 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/azureutil"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/netutil"
-	"github.com/openshift/hypershift/support/util"
 
 	routev1 "github.com/openshift/api/route/v1"
 
@@ -33,7 +33,7 @@ func ReconcileRouterService(svc *corev1.Service, internal, crossZoneLoadBalancin
 		if crossZoneLoadBalancingEnabled {
 			svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"] = "true"
 		}
-		util.ApplyAWSLoadBalancerTargetNodesAnnotation(svc, hcp)
+		k8sutil.ApplyAWSLoadBalancerTargetNodesAnnotation(svc, hcp)
 	}
 
 	if hcp.Spec.Platform.Type == hyperv1.GCPPlatform {

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -10,8 +10,8 @@ import (
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/events"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/netutil"
-	"github.com/openshift/hypershift/support/util"
 
 	routev1 "github.com/openshift/api/route/v1"
 
@@ -31,7 +31,7 @@ func kasLabels() map[string]string {
 func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingStrategy, owner *metav1.OwnerReference, apiServerServicePort int, apiAllowedCIDRBlocks []string, hcp *hyperv1.HostedControlPlane) error {
 	isPublic := netutil.IsPublicHCP(hcp)
 	isPrivate := netutil.IsPrivateHCP(hcp)
-	util.EnsureOwnerRef(svc, owner)
+	k8sutil.EnsureOwnerRef(svc, owner)
 	if svc.Spec.Selector == nil {
 		svc.Spec.Selector = kasLabels()
 	}
@@ -104,7 +104,7 @@ func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingSt
 }
 
 func ReconcileServiceClusterIP(svc *corev1.Service, owner *metav1.OwnerReference) error {
-	util.EnsureOwnerRef(svc, owner)
+	k8sutil.EnsureOwnerRef(svc, owner)
 	if svc.Spec.Selector == nil {
 		svc.Spec.Selector = kasLabels()
 	}
@@ -138,7 +138,7 @@ func ReconcileServiceClusterIP(svc *corev1.Service, owner *metav1.OwnerReference
 func ReconcileServiceStatus(svc *corev1.Service, strategy *hyperv1.ServicePublishingStrategy, apiServerPort int, messageCollector events.MessageCollector) (host string, port int32, message string, err error) {
 	switch strategy.Type {
 	case hyperv1.LoadBalancer:
-		if message, err := util.CollectLBMessageIfNotProvisioned(svc, messageCollector); err != nil || message != "" {
+		if message, err := k8sutil.CollectLBMessageIfNotProvisioned(svc, messageCollector); err != nil || message != "" {
 			return host, port, message, err
 		}
 		port = int32(apiServerPort)
@@ -164,7 +164,7 @@ func ReconcileServiceStatus(svc *corev1.Service, strategy *hyperv1.ServicePublis
 		port = svc.Spec.Ports[0].NodePort
 		host = strategy.NodePort.Address
 	case hyperv1.Route:
-		if message, err := util.CollectLBMessageIfNotProvisioned(svc, messageCollector); err != nil || message != "" {
+		if message, err := k8sutil.CollectLBMessageIfNotProvisioned(svc, messageCollector); err != nil || message != "" {
 			return host, port, message, err
 		}
 		host = strategy.Route.Hostname
@@ -174,7 +174,7 @@ func ReconcileServiceStatus(svc *corev1.Service, strategy *hyperv1.ServicePublis
 }
 
 func ReconcilePrivateService(svc *corev1.Service, hcp *hyperv1.HostedControlPlane, owner *metav1.OwnerReference) error {
-	util.EnsureOwnerRef(svc, owner)
+	k8sutil.EnsureOwnerRef(svc, owner)
 	svc.Spec.Selector = kasLabels()
 
 	// Setting this to PreferDualStack will make the service to be created with IPv4 and IPv6 addresses if the management cluster is dual stack.
@@ -237,7 +237,7 @@ func reconcileExternalRoute(route *routev1.Route, owner *metav1.OwnerReference, 
 	if hostname == "" {
 		return fmt.Errorf("route hostname is required for service APIServer")
 	}
-	util.EnsureOwnerRef(route, owner)
+	k8sutil.EnsureOwnerRef(route, owner)
 	netutil.AddHCPRouteLabel(route)
 	route.Spec.Host = hostname
 	route.Spec.To = routev1.RouteTargetReference{
@@ -254,7 +254,7 @@ func reconcileExternalRoute(route *routev1.Route, owner *metav1.OwnerReference, 
 }
 
 func ReconcileInternalRoute(route *routev1.Route, owner *metav1.OwnerReference) error {
-	util.EnsureOwnerRef(route, owner)
+	k8sutil.EnsureOwnerRef(route, owner)
 	route.Spec.Host = fmt.Sprintf("api.%s.hypershift.local", owner.Name)
 	// Assumes owner is the HCP
 	return netutil.ReconcileInternalRoute(route, "", manifests.KubeAPIServerService("").Name)

--- a/control-plane-operator/controllers/hostedcontrolplane/mcs/reconcile.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/mcs/reconcile.go
@@ -3,7 +3,7 @@ package mcs
 import (
 	"github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/certs"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 
@@ -69,7 +69,7 @@ func ReconcileMachineConfigServerConfig(cm *corev1.ConfigMap, p *MCSParams) erro
 }
 
 func serialize(obj client.Object) (string, error) {
-	return util.SerializeResource(obj, api.Scheme)
+	return k8sutil.SerializeResource(obj, api.Scheme)
 }
 
 var (
@@ -81,7 +81,7 @@ func init() {
 }
 
 func serializeConfigPool(obj client.Object) (string, error) {
-	return util.SerializeResource(obj, machineConfigPoolScheme)
+	return k8sutil.SerializeResource(obj, machineConfigPoolScheme)
 }
 
 func masterConfigPool() *mcfgv1.MachineConfigPool {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/podspec"
-	"github.com/openshift/hypershift/support/util"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -34,7 +34,7 @@ func (capi *CAPIManagerOptions) adaptDeployment(cpContext component.WorkloadCont
 	if deployment.Annotations == nil {
 		deployment.Annotations = make(map[string]string)
 	}
-	deployment.Annotations[util.HostedClusterAnnotation] = cpContext.HCP.Annotations[util.HostedClusterAnnotation]
+	deployment.Annotations[k8sutil.HostedClusterAnnotation] = cpContext.HCP.Annotations[k8sutil.HostedClusterAnnotation]
 
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/deployment_test.go
@@ -8,9 +8,9 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/testutil"
-	"github.com/openshift/hypershift/support/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -58,11 +58,11 @@ func TestAdaptDeployment(t *testing.T) {
 			name:    "When HCP has hosted cluster annotation, it should set deployment annotation",
 			version: "4.19.0",
 			hcpAnnotations: map[string]string{
-				util.HostedClusterAnnotation: "test-namespace/test-cluster",
+				k8sutil.HostedClusterAnnotation: "test-namespace/test-cluster",
 			},
 			expectedArgs:     []string{"--feature-gates=MachineSetPreflightChecks=false"},
 			expectedImage:    "cluster-capi-controllers",
-			expectedAnnotKey: util.HostedClusterAnnotation,
+			expectedAnnotKey: k8sutil.HostedClusterAnnotation,
 		},
 	}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/secret.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/secret.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/openshift/hypershift/support/certs"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -16,7 +16,7 @@ func adaptWebhookTLSSecret(cpContext component.WorkloadContext, secret *corev1.S
 	if secret.Annotations == nil {
 		secret.Annotations = make(map[string]string)
 	}
-	secret.Annotations[util.HostedClusterAnnotation] = cpContext.HCP.Annotations[util.HostedClusterAnnotation]
+	secret.Annotations[k8sutil.HostedClusterAnnotation] = cpContext.HCP.Annotations[k8sutil.HostedClusterAnnotation]
 
 	existingPrivateKeyKey := secret.Data[corev1.TLSPrivateKeyKey]
 	existingTLSCertKey := secret.Data[corev1.TLSCertKey]

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/secret_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/capi_manager/secret_test.go
@@ -7,7 +7,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -94,24 +94,24 @@ func TestAdaptWebhookTLSSecret(t *testing.T) {
 			name:         "When HCP has hosted cluster annotation, it should set secret annotation",
 			existingData: map[string][]byte{},
 			hcpAnnotations: map[string]string{
-				util.HostedClusterAnnotation: "test-namespace/test-cluster",
+				k8sutil.HostedClusterAnnotation: "test-namespace/test-cluster",
 			},
 			validate: func(t *testing.T, g *WithT, secret *corev1.Secret, err error) {
 				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(secret.Annotations).To(HaveKey(util.HostedClusterAnnotation))
-				g.Expect(secret.Annotations[util.HostedClusterAnnotation]).To(Equal("test-namespace/test-cluster"))
+				g.Expect(secret.Annotations).To(HaveKey(k8sutil.HostedClusterAnnotation))
+				g.Expect(secret.Annotations[k8sutil.HostedClusterAnnotation]).To(Equal("test-namespace/test-cluster"))
 			},
 		},
 		{
 			name:         "When secret has no annotations field, it should create annotations map",
 			existingData: map[string][]byte{},
 			hcpAnnotations: map[string]string{
-				util.HostedClusterAnnotation: "test-namespace/test-cluster",
+				k8sutil.HostedClusterAnnotation: "test-namespace/test-cluster",
 			},
 			validate: func(t *testing.T, g *WithT, secret *corev1.Secret, err error) {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(secret.Annotations).ToNot(BeNil())
-				g.Expect(secret.Annotations[util.HostedClusterAnnotation]).To(Equal("test-namespace/test-cluster"))
+				g.Expect(secret.Annotations[k8sutil.HostedClusterAnnotation]).To(Equal("test-namespace/test-cluster"))
 			},
 		},
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/capi_provider/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/capi_provider/deployment.go
@@ -2,8 +2,8 @@ package capiprovider
 
 import (
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/proxy"
-	"github.com/openshift/hypershift/support/util"
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,7 +23,7 @@ func (capi *CAPIProviderOptions) adaptDeployment(cpContext component.WorkloadCon
 	if deployment.Annotations == nil {
 		deployment.Annotations = make(map[string]string)
 	}
-	deployment.Annotations[util.HostedClusterAnnotation] = cpContext.HCP.Annotations[util.HostedClusterAnnotation]
+	deployment.Annotations[k8sutil.HostedClusterAnnotation] = cpContext.HCP.Annotations[k8sutil.HostedClusterAnnotation]
 
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/capi_provider/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/capi_provider/deployment_test.go
@@ -8,7 +8,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -63,14 +63,14 @@ func TestAdaptDeployment(t *testing.T) {
 				},
 			},
 			hcpAnnotations: map[string]string{
-				util.HostedClusterAnnotation: "test-namespace/test-cluster",
+				k8sutil.HostedClusterAnnotation: "test-namespace/test-cluster",
 			},
 			expectedServiceAcct: "capi-provider",
 			expectedLabels: map[string]string{
 				"control-plane": "capi-provider-controller-manager",
 				"app":           "capi-provider-controller-manager",
 			},
-			expectedAnnotKey: util.HostedClusterAnnotation,
+			expectedAnnotKey: k8sutil.HostedClusterAnnotation,
 		},
 	}
 
@@ -191,7 +191,7 @@ func TestAdaptDeployment_WithNilAnnotations(t *testing.T) {
 			Name:      "test-hcp",
 			Namespace: "test-namespace",
 			Annotations: map[string]string{
-				util.HostedClusterAnnotation: "test-namespace/test-cluster",
+				k8sutil.HostedClusterAnnotation: "test-namespace/test-cluster",
 			},
 		},
 	}
@@ -229,5 +229,5 @@ func TestAdaptDeployment_WithNilAnnotations(t *testing.T) {
 
 	// Should create annotations map and set the annotation
 	g.Expect(deployment.Annotations).ToNot(BeNil())
-	g.Expect(deployment.Annotations[util.HostedClusterAnnotation]).To(Equal("test-namespace/test-cluster"))
+	g.Expect(deployment.Annotations[k8sutil.HostedClusterAnnotation]).To(Equal("test-namespace/test-cluster"))
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/capi_provider/role.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/capi_provider/role.go
@@ -2,7 +2,7 @@ package capiprovider
 
 import (
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 )
@@ -15,6 +15,6 @@ func (capi *CAPIProviderOptions) adaptRole(cpContext component.WorkloadContext, 
 	if role.Annotations == nil {
 		role.Annotations = make(map[string]string)
 	}
-	role.Annotations[util.HostedClusterAnnotation] = cpContext.HCP.Annotations[util.HostedClusterAnnotation]
+	role.Annotations[k8sutil.HostedClusterAnnotation] = cpContext.HCP.Annotations[k8sutil.HostedClusterAnnotation]
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/capi_provider/role_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/capi_provider/role_test.go
@@ -7,7 +7,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -93,10 +93,10 @@ func TestAdaptRole(t *testing.T) {
 				},
 			},
 			hcpAnnotations: map[string]string{
-				util.HostedClusterAnnotation: "test-namespace/test-cluster",
+				k8sutil.HostedClusterAnnotation: "test-namespace/test-cluster",
 			},
 			expectedTotalRules:   2,
-			expectedAnnotKey:     util.HostedClusterAnnotation,
+			expectedAnnotKey:     k8sutil.HostedClusterAnnotation,
 			expectedAnnotValue:   "test-namespace/test-cluster",
 			shouldAppendPlatform: true,
 		},
@@ -192,7 +192,7 @@ func TestAdaptRole_WithNilAnnotations(t *testing.T) {
 			Name:      "test-hcp",
 			Namespace: "test-namespace",
 			Annotations: map[string]string{
-				util.HostedClusterAnnotation: "test-namespace/test-cluster",
+				k8sutil.HostedClusterAnnotation: "test-namespace/test-cluster",
 			},
 		},
 	}
@@ -211,5 +211,5 @@ func TestAdaptRole_WithNilAnnotations(t *testing.T) {
 
 	// Should create annotations map and set the annotation
 	g.Expect(role.Annotations).ToNot(BeNil())
-	g.Expect(role.Annotations[util.HostedClusterAnnotation]).To(Equal("test-namespace/test-cluster"))
+	g.Expect(role.Annotations[k8sutil.HostedClusterAnnotation]).To(Equal("test-namespace/test-cluster"))
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/aws/config_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/aws/config_test.go
@@ -8,8 +8,8 @@ import (
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/testutil"
-	"github.com/openshift/hypershift/support/util"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,7 +36,7 @@ func TestConfig(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	yaml, err := util.SerializeResource(cm, api.Scheme)
+	yaml, err := k8sutil.SerializeResource(cm, api.Scheme)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/config_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/azure/config_test.go
@@ -8,8 +8,8 @@ import (
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/testutil"
-	"github.com/openshift/hypershift/support/util"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +35,7 @@ func TestConfig(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	yaml, err := util.SerializeResource(cm, api.Scheme)
+	yaml, err := k8sutil.SerializeResource(cm, api.Scheme)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/gcp/config_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/gcp/config_test.go
@@ -7,8 +7,8 @@ import (
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/testutil"
-	"github.com/openshift/hypershift/support/util"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,7 +31,7 @@ func TestConfig(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	yaml, err := util.SerializeResource(cm, api.Scheme)
+	yaml, err := k8sutil.SerializeResource(cm, api.Scheme)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/kubevirt/config_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/kubevirt/config_test.go
@@ -7,8 +7,8 @@ import (
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/testutil"
-	"github.com/openshift/hypershift/support/util"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,7 +42,7 @@ func TestConfig(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	yaml, err := util.SerializeResource(cm, api.Scheme)
+	yaml, err := k8sutil.SerializeResource(cm, api.Scheme)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/powervs/config_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cloud_controller_manager/powervs/config_test.go
@@ -10,8 +10,8 @@ import (
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/testutil"
-	"github.com/openshift/hypershift/support/util"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,7 +36,7 @@ func TestAdaptConfig(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	yaml, err := util.SerializeResource(cm, api.Scheme)
+	yaml, err := k8sutil.SerializeResource(cm, api.Scheme)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/clusterpolicy/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/clusterpolicy/config.go
@@ -7,7 +7,7 @@ import (
 	"github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	openshiftcpv1 "github.com/openshift/api/openshiftcontrolplane/v1"
 
@@ -24,7 +24,7 @@ func adaptConfigMap(cpContext component.WorkloadContext, cm *corev1.ConfigMap) e
 	}
 
 	cmConfig := &openshiftcpv1.OpenShiftControllerManagerConfig{}
-	if err := util.DeserializeResource(cm.Data[configKey], cmConfig, api.Scheme); err != nil {
+	if err := k8sutil.DeserializeResource(cm.Data[configKey], cmConfig, api.Scheme); err != nil {
 		return fmt.Errorf("unable to decode existing openshift cluster policy controller configuration: %w", err)
 	}
 
@@ -34,7 +34,7 @@ func adaptConfigMap(cpContext component.WorkloadContext, cm *corev1.ConfigMap) e
 	}
 
 	adaptConfig(cmConfig, cpContext.HCP.Spec.Configuration, featureGates)
-	configStr, err := util.SerializeResource(cmConfig, api.Scheme)
+	configStr, err := k8sutil.SerializeResource(cmConfig, api.Scheme)
 	if err != nil {
 		return fmt.Errorf("failed to serialize openshift cluster policy controller configuration: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/controlplaneoperator/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/controlplaneoperator/deployment.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/images"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/proxy"
@@ -186,7 +187,7 @@ func (cpo *ControlPlaneOperatorOptions) adaptDeployment(cpContext component.Work
 	if deployment.Annotations == nil {
 		deployment.Annotations = make(map[string]string)
 	}
-	deployment.Annotations[util.HostedClusterAnnotation] = hcp.Annotations[util.HostedClusterAnnotation]
+	deployment.Annotations[k8sutil.HostedClusterAnnotation] = hcp.Annotations[k8sutil.HostedClusterAnnotation]
 
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/controlplaneoperator/podmonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/controlplaneoperator/podmonitor.go
@@ -2,6 +2,7 @@ package controlplaneoperator
 
 import (
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/util"
 
@@ -18,7 +19,7 @@ func (cpo *ControlPlaneOperatorOptions) adaptPodMonitor(cpContext component.Work
 	if podMonitor.Annotations == nil {
 		podMonitor.Annotations = map[string]string{}
 	}
-	podMonitor.Annotations[util.HostedClusterAnnotation] = client.ObjectKeyFromObject(cpo.HostedCluster).String()
+	podMonitor.Annotations[k8sutil.HostedClusterAnnotation] = client.ObjectKeyFromObject(cpo.HostedCluster).String()
 
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/controlplaneoperator/role.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/controlplaneoperator/role.go
@@ -8,8 +8,8 @@ import (
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/rhobsmonitoring"
-	"github.com/openshift/hypershift/support/util"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 )
@@ -56,7 +56,7 @@ func adaptRole(cpContext component.WorkloadContext, role *rbacv1.Role) error {
 	if role.Annotations == nil {
 		role.Annotations = map[string]string{}
 	}
-	role.Annotations[util.HostedClusterAnnotation] = cpContext.HCP.Annotations[util.HostedClusterAnnotation]
+	role.Annotations[k8sutil.HostedClusterAnnotation] = cpContext.HCP.Annotations[k8sutil.HostedClusterAnnotation]
 
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kcm/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kcm/config.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/openshift/hypershift/support/api"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	kcpv1 "github.com/openshift/api/kubecontrolplane/v1"
 
@@ -21,7 +21,7 @@ const (
 func adaptConfig(cpContext component.WorkloadContext, cm *corev1.ConfigMap) error {
 	data := cm.Data[KubeControllerManagerConfigKey]
 	config := &kcpv1.KubeControllerManagerConfig{}
-	if err := util.DeserializeResource(data, config, api.Scheme); err != nil {
+	if err := k8sutil.DeserializeResource(data, config, api.Scheme); err != nil {
 		return fmt.Errorf("unable to decode existing KubeControllerManager configuration: %w", err)
 	}
 
@@ -33,7 +33,7 @@ func adaptConfig(cpContext component.WorkloadContext, cm *corev1.ConfigMap) erro
 		config.ServiceServingCert.CertFile = "/etc/kubernetes/certs/service-ca/service-ca.crt"
 	}
 
-	configStr, err := util.SerializeResource(config, api.Scheme)
+	configStr, err := k8sutil.SerializeResource(config, api.Scheme)
 	if err != nil {
 		return fmt.Errorf("failed to serialize KubeControllerManager configuration: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kcm/config_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kcm/config_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/api"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	kcpv1 "github.com/openshift/api/kubecontrolplane/v1"
 
@@ -53,7 +53,7 @@ func TestAdaptConfig(t *testing.T) {
 				g.Expect(cm.Data).To(HaveKey(KubeControllerManagerConfigKey))
 
 				config := &kcpv1.KubeControllerManagerConfig{}
-				decodeErr := util.DeserializeResource(cm.Data[KubeControllerManagerConfigKey], config, api.Scheme)
+				decodeErr := k8sutil.DeserializeResource(cm.Data[KubeControllerManagerConfigKey], config, api.Scheme)
 				g.Expect(decodeErr).ToNot(HaveOccurred())
 				g.Expect(config.ServiceServingCert.CertFile).To(Equal("/etc/kubernetes/certs/service-ca/service-ca.crt"))
 			},
@@ -68,7 +68,7 @@ func TestAdaptConfig(t *testing.T) {
 				g.Expect(cm.Data).To(HaveKey(KubeControllerManagerConfigKey))
 
 				config := &kcpv1.KubeControllerManagerConfig{}
-				decodeErr := util.DeserializeResource(cm.Data[KubeControllerManagerConfigKey], config, api.Scheme)
+				decodeErr := k8sutil.DeserializeResource(cm.Data[KubeControllerManagerConfigKey], config, api.Scheme)
 				g.Expect(decodeErr).ToNot(HaveOccurred())
 				g.Expect(config.ServiceServingCert.CertFile).To(BeEmpty())
 			},

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/config_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/config_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/testutil"
-	"github.com/openshift/hypershift/support/util"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -98,7 +98,7 @@ func TestGenerateConfig(t *testing.T) {
 			}
 			g.Expect(data.Profiles).To(HaveLen(len(tc.expectedProfiles)))
 
-			configMapYaml, err := util.SerializeResource(cm, api.Scheme)
+			configMapYaml, err := k8sutil.SerializeResource(cm, api.Scheme)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oapi/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oapi/config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/globalconfig"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	configv1 "github.com/openshift/api/config/v1"
 	openshiftcpv1 "github.com/openshift/api/openshiftcontrolplane/v1"
@@ -29,7 +29,7 @@ func adaptConfigMap(cpContext component.WorkloadContext, cm *corev1.ConfigMap) e
 	}
 
 	openshiftAPIServerConfig := &openshiftcpv1.OpenShiftAPIServerConfig{}
-	if err := util.DeserializeResource(cm.Data[openshiftAPIServerConfigKey], openshiftAPIServerConfig, api.Scheme); err != nil {
+	if err := k8sutil.DeserializeResource(cm.Data[openshiftAPIServerConfigKey], openshiftAPIServerConfig, api.Scheme); err != nil {
 		return fmt.Errorf("failed to decode existing openshift apiserver configuration: %w", err)
 	}
 
@@ -43,7 +43,7 @@ func adaptConfigMap(cpContext component.WorkloadContext, cm *corev1.ConfigMap) e
 		return err
 	}
 	adaptConfig(openshiftAPIServerConfig, cpContext.HCP, observedConfig.Project, featureGates)
-	serializedConfig, err := util.SerializeResource(openshiftAPIServerConfig, api.Scheme)
+	serializedConfig, err := k8sutil.SerializeResource(openshiftAPIServerConfig, api.Scheme)
 	if err != nil {
 		return fmt.Errorf("failed to serialize openshift apiserver configuration: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/globalconfig"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	osinv1 "github.com/openshift/api/osin/v1"
 
@@ -47,12 +47,12 @@ func adaptConfigMap(cpContext component.WorkloadContext, cm *corev1.ConfigMap) e
 	}
 
 	oauthConfig := &osinv1.OsinServerConfig{}
-	if err := util.DeserializeResource(cm.Data[oauthServerConfigKey], oauthConfig, api.Scheme); err != nil {
+	if err := k8sutil.DeserializeResource(cm.Data[oauthServerConfigKey], oauthConfig, api.Scheme); err != nil {
 		return fmt.Errorf("failed to decode existing oauth server configuration: %w", err)
 	}
 
 	adaptOAuthConfig(cpContext, oauthConfig)
-	serializedConfig, err := util.SerializeResource(oauthConfig, api.Scheme)
+	serializedConfig, err := k8sutil.SerializeResource(oauthConfig, api.Scheme)
 	if err != nil {
 		return fmt.Errorf("failed to serialize oauth server configuration: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ocm/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ocm/config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/globalconfig"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	buildv1 "github.com/openshift/api/build/v1"
 	configv1 "github.com/openshift/api/config/v1"
@@ -31,7 +31,7 @@ func adaptConfigMap(cpContext component.WorkloadContext, cm *corev1.ConfigMap) e
 	}
 
 	ocmConfig := &openshiftcpv1.OpenShiftControllerManagerConfig{}
-	err := util.DeserializeResource(cm.Data[configKey], ocmConfig, api.Scheme)
+	err := k8sutil.DeserializeResource(cm.Data[configKey], ocmConfig, api.Scheme)
 	if err != nil {
 		return fmt.Errorf("unable to decode existing openshift controller manager configuration: %w", err)
 	}
@@ -44,7 +44,7 @@ func adaptConfigMap(cpContext component.WorkloadContext, cm *corev1.ConfigMap) e
 	if err == nil && existingCM.Data != nil {
 		if existingConfigStr, exists := existingCM.Data[configKey]; exists && len(existingConfigStr) > 0 {
 			existingConfig := &openshiftcpv1.OpenShiftControllerManagerConfig{}
-			if err := util.DeserializeResource(existingConfigStr, existingConfig, api.Scheme); err == nil {
+			if err := k8sutil.DeserializeResource(existingConfigStr, existingConfig, api.Scheme); err == nil {
 				existingControllers = existingConfig.Controllers
 			}
 		}
@@ -60,7 +60,7 @@ func adaptConfigMap(cpContext component.WorkloadContext, cm *corev1.ConfigMap) e
 		return err
 	}
 	adaptConfig(ocmConfig, cpContext.HCP.Spec.Configuration, cpContext.ReleaseImageProvider, observedConfig.Build, cpContext.HCP.Spec.Capabilities, featureGates, existingControllers)
-	configStr, err := util.SerializeResource(ocmConfig, api.Scheme)
+	configStr, err := k8sutil.SerializeResource(ocmConfig, api.Scheme)
 	if err != nil {
 		return fmt.Errorf("failed to serialize openshift controller manager configuration: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/ocm/config_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/ocm/config_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	controlplanecomponent "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	"github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/testutil"
-	"github.com/openshift/hypershift/support/util"
 
 	v1 "github.com/openshift/api/config/v1"
 	openshiftcpv1 "github.com/openshift/api/openshiftcontrolplane/v1"
@@ -69,19 +69,19 @@ func TestReconcileOpenShiftControllerManagerConfig(t *testing.T) {
 			}
 
 			config := &openshiftcpv1.OpenShiftControllerManagerConfig{}
-			err = util.DeserializeResource(configMap.Data[configKey], config, api.Scheme)
+			err = k8sutil.DeserializeResource(configMap.Data[configKey], config, api.Scheme)
 			if err != nil {
 				t.Fatalf("unable to decode existing openshift controller manager configuration: %v", err)
 			}
 
 			adaptConfig(config, hcp.Spec.Configuration, imageProvider, buildConfig, hcp.Spec.Capabilities, []string{"foo=true", "bar=false"}, nil)
-			configStr, err := util.SerializeResource(config, api.Scheme)
+			configStr, err := k8sutil.SerializeResource(config, api.Scheme)
 			if err != nil {
 				t.Fatalf("failed to serialize openshift controller manager configuration: %v", err)
 			}
 			configMap.Data[configKey] = configStr
 
-			configMapYaml, err := util.SerializeResource(configMap, api.Scheme)
+			configMapYaml, err := k8sutil.SerializeResource(configMap, api.Scheme)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/config.go
@@ -7,7 +7,7 @@ import (
 	"github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	openshiftcpv1 "github.com/openshift/api/openshiftcontrolplane/v1"
 
@@ -24,12 +24,12 @@ func adaptConfigMap(cpContext component.WorkloadContext, cm *corev1.ConfigMap) e
 	}
 
 	config := &openshiftcpv1.OpenShiftControllerManagerConfig{}
-	if err := util.DeserializeResource(cm.Data[configKey], config, api.Scheme); err != nil {
+	if err := k8sutil.DeserializeResource(cm.Data[configKey], config, api.Scheme); err != nil {
 		return fmt.Errorf("unable to decode existing openshift route controller manager configuration: %w", err)
 	}
 
 	adaptConfig(config, cpContext.HCP.Spec.Configuration, cpContext.HCP.Spec.Capabilities)
-	configStr, err := util.SerializeResource(config, api.Scheme)
+	configStr, err := k8sutil.SerializeResource(config, api.Scheme)
 	if err != nil {
 		return fmt.Errorf("failed to serialize openshift route controller manager configuration: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/config_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/routecm/config_test.go
@@ -7,8 +7,8 @@ import (
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	"github.com/openshift/hypershift/support/api"
 	controlplanecomponent "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/testutil"
-	"github.com/openshift/hypershift/support/util"
 
 	v1 "github.com/openshift/api/config/v1"
 
@@ -48,7 +48,7 @@ func TestReconcileOpenShiftRouteControllerManagerConfig(t *testing.T) {
 	if err := adaptConfigMap(controlplanecomponent.WorkloadContext{HCP: hcp}, configMap); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	configMapYaml, err := util.SerializeResource(configMap, api.Scheme)
+	configMapYaml, err := k8sutil.SerializeResource(configMap, api.Scheme)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -50,6 +50,7 @@ import (
 	"github.com/openshift/hypershift/support/capabilities"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/globalconfig"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/netutil"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/upsert"
@@ -334,14 +335,14 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 
 			// Delete binding first to avoid dangling reference
 			binding := manifests.ValidatingAdmissionPolicyBinding(fmt.Sprintf("%s-binding", registryConfigManagementStateAdmissionPolicy.Name))
-			_, err := util.DeleteIfNeeded(ctx, r.client, binding)
+			_, err := k8sutil.DeleteIfNeeded(ctx, r.client, binding)
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to delete ValidatingAdmissionPolicyBinding %s: %v", binding.Name, err)
 			}
 
 			// Delete policy
 			vap := manifests.ValidatingAdmissionPolicy(registryConfigManagementStateAdmissionPolicy.Name)
-			if _, err := util.DeleteIfNeeded(ctx, r.client, vap); err != nil {
+			if _, err := k8sutil.DeleteIfNeeded(ctx, r.client, vap); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to delete ValidatingAdmissionPolicy %s: %v", vap.Name, err)
 			}
 		}
@@ -484,13 +485,13 @@ func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 					}
 					config := &openshiftcpv1.OpenShiftControllerManagerConfig{}
 					if configStr, exists := ocmConfigMap.Data[ocm.ConfigKey]; exists && len(configStr) > 0 {
-						err := util.DeserializeResource(configStr, config, api.Scheme)
+						err := k8sutil.DeserializeResource(configStr, config, api.Scheme)
 						if err != nil {
 							return fmt.Errorf("unable to decode existing openshift controller manager configuration: %w", err)
 						}
 					}
 					config.Controllers = []string{"*", fmt.Sprintf("-%s", openshiftcpv1.OpenShiftServiceAccountPullSecretsController)}
-					configStr, err := util.SerializeResource(config, api.Scheme)
+					configStr, err := k8sutil.SerializeResource(config, api.Scheme)
 					if err != nil {
 						return fmt.Errorf("failed to serialize openshift controller manager configuration: %w", err)
 					}
@@ -896,10 +897,10 @@ func (r *reconciler) reconcileMetricsForwarder(ctx context.Context, hcp *hyperv1
 	podMonitor := manifests.MetricsForwarderPodMonitor()
 
 	if _, disabled := hcp.Annotations[hyperv1.DisableMonitoringServices]; disabled {
-		return util.DeleteAllIfNeeded(ctx, r.client, deployment, cm, servingCA, podMonitor)
+		return k8sutil.DeleteAllIfNeeded(ctx, r.client, deployment, cm, servingCA, podMonitor)
 	}
 	if _, enabled := hcp.Annotations[hyperv1.EnableMetricsForwarding]; !enabled {
-		return util.DeleteAllIfNeeded(ctx, r.client, deployment, cm, servingCA, podMonitor)
+		return k8sutil.DeleteAllIfNeeded(ctx, r.client, deployment, cm, servingCA, podMonitor)
 	}
 
 	route := &routev1.Route{}
@@ -1442,7 +1443,7 @@ func (r *reconciler) reconcileAuthOIDC(ctx context.Context, hcp *hyperv1.HostedC
 						errs = append(errs, fmt.Errorf("failed to get OIDCClient secret %s: %w", oidcClient.ClientSecret.Name, err))
 						continue
 					}
-					if azureutil.IsAroHCP() && util.HasAnnotationWithValue(&src, hyperv1.HostedClusterSourcedAnnotation, "true") {
+					if azureutil.IsAroHCP() && k8sutil.HasAnnotationWithValue(&src, hyperv1.HostedClusterSourcedAnnotation, "true") {
 						// This is a day-2 secret. We shouldn't copy it, instead it'll be provided by the end-user on the hosted cluster.
 						continue
 					}
@@ -1496,7 +1497,7 @@ func (r *reconciler) reconcileKonnectivityAgent(ctx context.Context, hcp *hyperv
 	} else {
 		hostedKonnectivityCA := manifests.KonnectivityHostedCAConfigMap()
 		if _, err := r.CreateOrUpdate(ctx, r.client, hostedKonnectivityCA, func() error {
-			util.CopyConfigMap(hostedKonnectivityCA, controlPlaneKonnectivityCA)
+			k8sutil.CopyConfigMap(hostedKonnectivityCA, controlPlaneKonnectivityCA)
 			return nil
 		}); err != nil {
 			errs = append(errs, fmt.Errorf("failed to reconcile konnectivity CA config map: %w", err))
@@ -1996,7 +1997,7 @@ func (r *reconciler) reconcileUserCertCABundle(ctx context.Context, hcp *hyperv1
 		}
 	} else {
 		// If the HostedControlPlane has no additional trust bundle, delete the user-ca-bundle ConfigMap if it exists
-		if deleted, err := util.DeleteIfNeeded(ctx, r.client, userCAConfigMap); err != nil {
+		if deleted, err := k8sutil.DeleteIfNeeded(ctx, r.client, userCAConfigMap); err != nil {
 			return fmt.Errorf("failed to delete unused user-ca-bundle ConfigMap: %w", err)
 		} else if deleted {
 			log.Info("deleted unused user-ca-bundle ConfigMap", "name", userCAConfigMap.Name, "namespace", userCAConfigMap.Namespace)
@@ -2021,7 +2022,7 @@ func (r *reconciler) reconcileProxyCABundle(ctx context.Context, hcp *hyperv1.Ho
 			return fmt.Errorf("failed to reconcile the proxy CA bundle ConfigMap: %w", err)
 		}
 	} else {
-		if _, err := util.DeleteIfNeeded(ctx, r.client, proxyCADestination); err != nil {
+		if _, err := k8sutil.DeleteIfNeeded(ctx, r.client, proxyCADestination); err != nil {
 			return err
 		}
 	}
@@ -2309,7 +2310,7 @@ func (r *reconciler) reconcileOLM(ctx context.Context, hcp *hyperv1.HostedContro
 	for _, catalog := range catalogs {
 		cs := catalog.manifest()
 		if operatorHub.Spec.DisableAllDefaultSources {
-			if _, err := util.DeleteIfNeeded(ctx, r.client, cs); err != nil {
+			if _, err := k8sutil.DeleteIfNeeded(ctx, r.client, cs); err != nil {
 				if !apierrors.IsNotFound(err) {
 					errs = append(errs, fmt.Errorf("failed to delete catalogSource %s/%s: %w", cs.Namespace, cs.Name, err))
 				}
@@ -2945,7 +2946,7 @@ func (r *reconciler) reconcileKubeletConfig(ctx context.Context) error {
 			continue
 		}
 		log.Info("delete mirror config ConfigMap", "config", client.ObjectKeyFromObject(cm).String())
-		if _, err := util.DeleteIfNeeded(ctx, r.client, cm); err != nil {
+		if _, err := k8sutil.DeleteIfNeeded(ctx, r.client, cm); err != nil {
 			return fmt.Errorf("failed to delete ConfigMap %s: %w", client.ObjectKeyFromObject(cm).String(), err)
 		}
 	}
@@ -2966,7 +2967,7 @@ func (r *reconciler) deleteImmutableConfigMapIfNeeded(ctx context.Context, log l
 
 	if existingCM.Immutable != nil && *existingCM.Immutable {
 		log.Info("deleting immutable KubeletConfig ConfigMap to recreate as mutable", "configMap", client.ObjectKeyFromObject(existingCM).String())
-		if _, err := util.DeleteIfNeeded(ctx, r.client, existingCM); err != nil {
+		if _, err := k8sutil.DeleteIfNeeded(ctx, r.client, existingCM); err != nil {
 			return fmt.Errorf("failed to delete immutable ConfigMap %s: %w", client.ObjectKeyFromObject(existingCM).String(), err)
 		}
 	}
@@ -3415,7 +3416,7 @@ func (r *reconciler) reconcileImageContentPolicyType(ctx context.Context, hcp *h
 	icsp := globalconfig.ImageContentSourcePolicy()
 
 	// Delete any current ICSP
-	_, err := util.DeleteIfNeeded(ctx, r.client, icsp)
+	_, err := k8sutil.DeleteIfNeeded(ctx, r.client, icsp)
 	if err != nil {
 		return fmt.Errorf("failed to delete image content source policy configuration configmap: %w", err)
 	}

--- a/etcd-recovery/etcdrecovery.go
+++ b/etcd-recovery/etcdrecovery.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	hyperapi "github.com/openshift/hypershift/support/api"
-	hyperutil "github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -382,12 +382,12 @@ func recoverEtcd(ctx context.Context, opt options, status etcdStatus) error {
 		return err
 	}
 	log.Info("Deleting pvc", "pvc", crclient.ObjectKeyFromObject(pvc))
-	if _, err := hyperutil.DeleteIfNeeded(ctx, kclient, pvc); err != nil {
+	if _, err := k8sutil.DeleteIfNeeded(ctx, kclient, pvc); err != nil {
 		log.Error(err, "failed to delete pvc", "pvc", crclient.ObjectKeyFromObject(pvc))
 	}
 
 	log.Info("Deleting pod", "pod", crclient.ObjectKeyFromObject(pod))
-	if _, err := hyperutil.DeleteIfNeeded(ctx, kclient, pod); err != nil {
+	if _, err := k8sutil.DeleteIfNeeded(ctx, kclient, pod); err != nil {
 		log.Error(err, "failed to delete pod", "pod", crclient.ObjectKeyFromObject(pod))
 	}
 

--- a/hypershift-operator/controllers/etcdbackup/reconciler.go
+++ b/hypershift-operator/controllers/etcdbackup/reconciler.go
@@ -10,6 +10,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/featuregate"
 	supportconfig "github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	hyperutil "github.com/openshift/hypershift/support/util"
 
@@ -325,7 +326,7 @@ func (r *HCPEtcdBackupReconciler) updateHCPBackupCondition(ctx context.Context, 
 // (TTLSecondsAfterFinished) before the next reconcile extracts it.
 func (r *HCPEtcdBackupReconciler) updateHostedClusterBackupURL(ctx context.Context, hcp *hyperv1.HostedControlPlane, snapshotURL string) error {
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		hc, err := hyperutil.HostedClusterFromAnnotation(ctx, r.Client, hcp)
+		hc, err := k8sutil.HostedClusterFromAnnotation(ctx, r.Client, hcp)
 		if err != nil {
 			return err
 		}

--- a/hypershift-operator/controllers/etcdbackup/reconciler_test.go
+++ b/hypershift-operator/controllers/etcdbackup/reconciler_test.go
@@ -11,8 +11,8 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/featuregate"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/releaseinfo"
-	hyperutil "github.com/openshift/hypershift/support/util"
 
 	configv1 "github.com/openshift/api/config/v1"
 	imageapi "github.com/openshift/api/image/v1"
@@ -118,7 +118,7 @@ func newHostedControlPlane() *hyperv1.HostedControlPlane {
 			Name:      testHCPName,
 			Namespace: testHCPNamespace,
 			Annotations: map[string]string{
-				hyperutil.HostedClusterAnnotation: testHCNamespace + "/" + testHCName,
+				k8sutil.HostedClusterAnnotation: testHCNamespace + "/" + testHCName,
 			},
 		},
 		Spec: hyperv1.HostedControlPlaneSpec{

--- a/hypershift-operator/controllers/hostedcluster/createorupdate_annotation_enforcer.go
+++ b/hypershift-operator/controllers/hostedcluster/createorupdate_annotation_enforcer.go
@@ -3,8 +3,8 @@ package hostedcluster
 import (
 	"context"
 
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/upsert"
-	"github.com/openshift/hypershift/support/util"
 
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -28,7 +28,7 @@ func createOrUpdateWithAnnotationFactory(upstream upsert.CreateOrUpdateProvider)
 				if annotations == nil {
 					annotations = map[string]string{}
 				}
-				annotations[util.HostedClusterAnnotation] = req.String()
+				annotations[k8sutil.HostedClusterAnnotation] = req.String()
 				obj.SetAnnotations(annotations)
 				return nil
 			}

--- a/hypershift-operator/controllers/hostedcluster/createorupdate_annotation_enforcer_test.go
+++ b/hypershift-operator/controllers/hostedcluster/createorupdate_annotation_enforcer_test.go
@@ -3,8 +3,8 @@ package hostedcluster
 import (
 	"testing"
 
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/upsert"
-	hyperutil "github.com/openshift/hypershift/support/util"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,7 +51,7 @@ func TestCreateOrUpdateWithAnnotationFactory(t *testing.T) {
 					Name:      "foo",
 					Namespace: "bar",
 					Annotations: map[string]string{
-						hyperutil.HostedClusterAnnotation: annotationValue,
+						k8sutil.HostedClusterAnnotation: annotationValue,
 					},
 				},
 			},
@@ -85,8 +85,8 @@ func TestCreateOrUpdateWithAnnotationFactory(t *testing.T) {
 					Name:      "foo",
 					Namespace: "bar",
 					Annotations: map[string]string{
-						hyperutil.HostedClusterAnnotation: annotationValue,
-						"foo":                             "bar",
+						k8sutil.HostedClusterAnnotation: annotationValue,
+						"foo":                           "bar",
 					},
 				},
 			},

--- a/hypershift-operator/controllers/hostedcluster/etcd_recovery.go
+++ b/hypershift-operator/controllers/hostedcluster/etcd_recovery.go
@@ -11,8 +11,8 @@ import (
 	cpomanifests "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	etcdrecoverymanifests "github.com/openshift/hypershift/hypershift-operator/controllers/manifests/etcdrecovery"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/upsert"
-	hyperutil "github.com/openshift/hypershift/support/util"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -152,7 +152,7 @@ func (r *HostedClusterReconciler) reconcileETCDMemberRecovery(ctx context.Contex
 
 	recoverySA := etcdrecoverymanifests.EtcdRecoveryServiceAccount(hcpNS)
 	if _, err := createOrUpdate(ctx, r.Client, recoverySA, func() error {
-		hyperutil.EnsurePullSecret(recoverySA, common.PullSecret("").Name)
+		k8sutil.EnsurePullSecret(recoverySA, common.PullSecret("").Name)
 		return nil
 	}); err != nil {
 		return nil, fmt.Errorf("failed to reconcile etcd-recovery job service account: %w", err)
@@ -233,22 +233,22 @@ func (r *HostedClusterReconciler) cleanupEtcdRecoveryObjects(ctx context.Context
 	hcpNS := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
 
 	recoveryJob := etcdrecoverymanifests.EtcdRecoveryJob(hcpNS)
-	if _, err := hyperutil.DeleteIfNeededWithOptions(ctx, r.Client, recoveryJob, crclient.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
+	if _, err := k8sutil.DeleteIfNeededWithOptions(ctx, r.Client, recoveryJob, crclient.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
 		return fmt.Errorf("failed to cleanup etcd recovery job: %w", err)
 	}
 
 	recoverySA := etcdrecoverymanifests.EtcdRecoveryServiceAccount(hcpNS)
-	if _, err := hyperutil.DeleteIfNeeded(ctx, r.Client, recoverySA); err != nil {
+	if _, err := k8sutil.DeleteIfNeeded(ctx, r.Client, recoverySA); err != nil {
 		return fmt.Errorf("failed to cleanup etcd-recovery job service account: %w", err)
 	}
 
 	recoveryRoleBinding := etcdrecoverymanifests.EtcdRecoveryRoleBinding(hcpNS)
-	if _, err := hyperutil.DeleteIfNeeded(ctx, r.Client, recoveryRoleBinding); err != nil {
+	if _, err := k8sutil.DeleteIfNeeded(ctx, r.Client, recoveryRoleBinding); err != nil {
 		return fmt.Errorf("failed to cleanup etcd-recovery role binding: %w", err)
 	}
 
 	recoveryRole := etcdrecoverymanifests.EtcdRecoveryRole(hcpNS)
-	if _, err := hyperutil.DeleteIfNeeded(ctx, r.Client, recoveryRole); err != nil {
+	if _, err := k8sutil.DeleteIfNeeded(ctx, r.Client, recoveryRole); err != nil {
 		return fmt.Errorf("failed to cleanup etcd-recovery role: %w", err)
 	}
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -61,6 +61,7 @@ import (
 	controlplanecomponent "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/globalconfig"
 	"github.com/openshift/hypershift/support/infraid"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/netutil"
 	"github.com/openshift/hypershift/support/oidc"
@@ -266,21 +267,21 @@ func (r *HostedClusterReconciler) managedResources() []client.Object {
 
 	// Watch based on platforms installed
 	if platformsInstalled := os.Getenv("PLATFORMS_INSTALLED"); len(platformsInstalled) > 0 {
-		managedResources = append(managedResources, hyperutil.GetHostedClusterManagedResources(platformsInstalled)...)
+		managedResources = append(managedResources, k8sutil.GetHostedClusterManagedResources(platformsInstalled)...)
 	} else {
-		managedResources = append(managedResources, hyperutil.BaseResources...)
-		managedResources = append(managedResources, hyperutil.AWSResources...)
-		managedResources = append(managedResources, hyperutil.AzureResources...)
-		managedResources = append(managedResources, hyperutil.IBMCloudResources...)
-		managedResources = append(managedResources, hyperutil.KubevirtResources...)
-		managedResources = append(managedResources, hyperutil.AgentResources...)
-		managedResources = append(managedResources, hyperutil.OpenStackResources...)
+		managedResources = append(managedResources, k8sutil.BaseResources...)
+		managedResources = append(managedResources, k8sutil.AWSResources...)
+		managedResources = append(managedResources, k8sutil.AzureResources...)
+		managedResources = append(managedResources, k8sutil.IBMCloudResources...)
+		managedResources = append(managedResources, k8sutil.KubevirtResources...)
+		managedResources = append(managedResources, k8sutil.AgentResources...)
+		managedResources = append(managedResources, k8sutil.OpenStackResources...)
 	}
 
 	// Only watch managed Azure resources if the HO is explicitly configured to do so. Otherwise, the HO will fail to
 	// reconcile HostedClusters since some CRs are only installed in the managed Azure use case.
 	if azureutil.IsAroHCP() {
-		managedResources = append(managedResources, hyperutil.ManagedAzure...)
+		managedResources = append(managedResources, k8sutil.ManagedAzure...)
 	}
 
 	// Watch if etcd recovery is enabled
@@ -1918,7 +1919,7 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 						Name:      hcluster.Status.CustomKubeconfig.Name,
 					},
 				}
-				if _, err := hyperutil.DeleteIfNeeded(ctx, r.Client, customKubeconfig); err != nil {
+				if _, err := k8sutil.DeleteIfNeeded(ctx, r.Client, customKubeconfig); err != nil {
 					return ctrl.Result{}, fmt.Errorf("failed to delete custom external kubeconfig secret %q: %w", client.ObjectKeyFromObject(customKubeconfig), err)
 				}
 				hcluster.Status.CustomKubeconfig = nil
@@ -2314,7 +2315,7 @@ func reconcileHostedControlPlaneAnnotations(hcp *hyperv1.HostedControlPlane, hcl
 		hcp.Annotations = map[string]string{}
 	}
 
-	hcp.Annotations[hyperutil.HostedClusterAnnotation] = client.ObjectKeyFromObject(hcluster).String()
+	hcp.Annotations[k8sutil.HostedClusterAnnotation] = client.ObjectKeyFromObject(hcluster).String()
 
 	// These annotations are copied from the HostedCluster
 	mirroredAnnotations := []string{
@@ -2326,7 +2327,7 @@ func reconcileHostedControlPlaneAnnotations(hcp *hyperv1.HostedControlPlane, hcl
 		hyperv1.IBMCloudKMSProviderImage,
 		hyperv1.AWSKMSProviderImage,
 		hyperv1.PortierisImageAnnotation,
-		hyperutil.DebugDeploymentsAnnotation,
+		k8sutil.DebugDeploymentsAnnotation,
 		hyperv1.DisableProfilingAnnotation,
 		hyperv1.PrivateIngressControllerAnnotation,
 		hyperv1.IngressControllerLoadBalancerScope,
@@ -2613,7 +2614,7 @@ func (r *HostedClusterReconciler) reconcileCAPIProvider(cpContext controlplaneco
 	}
 	if err == nil {
 		if capiProviderDeployment.Spec.Template.ObjectMeta.Labels[hyperv1.ControlPlaneComponentLabel] != "capi-provider" {
-			_, err = hyperutil.DeleteIfNeeded(cpContext, cpContext.Client, capiProviderDeployment)
+			_, err = k8sutil.DeleteIfNeeded(cpContext, cpContext.Client, capiProviderDeployment)
 			// Always return an error so we can retry when the cache is updated
 			return fmt.Errorf("provider with outdated labels exists, delete result: %w", err)
 		}
@@ -2944,7 +2945,7 @@ func reconcileCAPICluster(cluster *capiv1.Cluster, hcluster *hyperv1.HostedClust
 	}
 
 	cluster.Annotations = map[string]string{
-		hyperutil.HostedClusterAnnotation: client.ObjectKeyFromObject(hcluster).String(),
+		k8sutil.HostedClusterAnnotation: client.ObjectKeyFromObject(hcluster).String(),
 	}
 	cluster.Spec = capiv1.ClusterSpec{
 		ControlPlaneEndpoint: capiv1.APIEndpoint{},
@@ -3324,10 +3325,10 @@ func deleteGCPPrivateServiceConnect(ctx context.Context, c client.Client, _ *hyp
 }
 
 func deleteControlPlaneOperatorRBAC(ctx context.Context, c client.Client, rbacNamespace string, controlPlaneNamespace string) error {
-	if _, err := hyperutil.DeleteIfNeeded(ctx, c, &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "control-plane-operator-" + controlPlaneNamespace, Namespace: rbacNamespace}}); err != nil {
+	if _, err := k8sutil.DeleteIfNeeded(ctx, c, &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "control-plane-operator-" + controlPlaneNamespace, Namespace: rbacNamespace}}); err != nil {
 		return err
 	}
-	if _, err := hyperutil.DeleteIfNeeded(ctx, c, &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "control-plane-operator-" + controlPlaneNamespace, Namespace: rbacNamespace}}); err != nil {
+	if _, err := k8sutil.DeleteIfNeeded(ctx, c, &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "control-plane-operator-" + controlPlaneNamespace, Namespace: rbacNamespace}}); err != nil {
 		return err
 	}
 	return nil
@@ -3375,7 +3376,7 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 		return false, err
 	}
 	if hc != nil && len(hc.Spec.InfraID) > 0 {
-		exists, err := hyperutil.DeleteIfNeeded(ctx, r.Client, &capiv1.Cluster{
+		exists, err := k8sutil.DeleteIfNeeded(ctx, r.Client, &capiv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      hc.Spec.InfraID,
 				Namespace: controlPlaneNamespace,
@@ -3459,7 +3460,7 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 		}
 	}
 
-	_, err = hyperutil.DeleteIfNeeded(ctx, r.Client, clusterapi.CAPIManagerClusterRoleBinding(controlPlaneNamespace))
+	_, err = k8sutil.DeleteIfNeeded(ctx, r.Client, clusterapi.CAPIManagerClusterRoleBinding(controlPlaneNamespace))
 	if err != nil {
 		return false, err
 	}
@@ -3468,7 +3469,7 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 	// We want to ensure the HCP resource is deleted before deleting the Namespace.
 	// Otherwise the CPO will be deleted leaving the HCP in a perpetual terminating state preventing further progress.
 	// NOTE: The advancing case is when Get() or Delete() returns an error that the HCP is not found
-	exists, err := hyperutil.DeleteIfNeeded(ctx, r.Client, controlplaneoperator.HostedControlPlane(controlPlaneNamespace, hc.Name))
+	exists, err := k8sutil.DeleteIfNeeded(ctx, r.Client, controlplaneoperator.HostedControlPlane(controlPlaneNamespace, hc.Name))
 	if err != nil {
 		return false, err
 	}
@@ -3489,7 +3490,7 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 
 	// Block until the namespace is deleted, so that if a hostedcluster is deleted and then re-created with the same name
 	// we don't error initially because we can not create new content in a namespace that is being deleted.
-	exists, err = hyperutil.DeleteIfNeeded(ctx, r.Client, &corev1.Namespace{
+	exists, err = k8sutil.DeleteIfNeeded(ctx, r.Client, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: controlPlaneNamespace},
 	})
 	if err != nil {
@@ -3511,7 +3512,7 @@ func enqueueHostedClustersFunc(metricsSet metrics.MetricsSet, operatorNamespace 
 			requests := []reconcile.Request{}
 			annotations := obj.GetAnnotations()
 			if annotations != nil {
-				hostedClusterName := obj.GetAnnotations()[hyperutil.HostedClusterAnnotation]
+				hostedClusterName := obj.GetAnnotations()[k8sutil.HostedClusterAnnotation]
 				if hostedClusterName != "" {
 					return []reconcile.Request{
 						{NamespacedName: hyperutil.ParseNamespacedName(hostedClusterName)},
@@ -3557,7 +3558,7 @@ func enqueueHostedClustersFunc(metricsSet metrics.MetricsSet, operatorNamespace 
 				return []reconcile.Request{}
 			}
 			if len(hcpList.Items) == 1 {
-				hcAnnotation := hcpList.Items[0].Annotations[hyperutil.HostedClusterAnnotation]
+				hcAnnotation := hcpList.Items[0].Annotations[k8sutil.HostedClusterAnnotation]
 				if hcAnnotation != "" {
 					return []reconcile.Request{{NamespacedName: hyperutil.ParseNamespacedName(hcAnnotation)}}
 				}
@@ -3589,7 +3590,7 @@ func enqueueHostedClustersFunc(metricsSet metrics.MetricsSet, operatorNamespace 
 							log.Error(err, "failed to get hcp")
 							return []reconcile.Request{}
 						}
-						if hcAnnotation := hcp.Annotations[hyperutil.HostedClusterAnnotation]; hcAnnotation != "" {
+						if hcAnnotation := hcp.Annotations[k8sutil.HostedClusterAnnotation]; hcAnnotation != "" {
 							return []reconcile.Request{{NamespacedName: hyperutil.ParseNamespacedName(hcAnnotation)}}
 						}
 						return []reconcile.Request{}
@@ -5105,7 +5106,7 @@ func ensureReferencedResourceAnnotation(ctx context.Context, client client.Clien
 }
 
 func ensureHostedResourcesAreEmpty(ctx context.Context, crclient client.Client, hcluster *hyperv1.HostedCluster, obj client.Object) error {
-	if !azureutil.IsAroHCP() || !hyperutil.HasAnnotationWithValue(obj, hyperv1.HostedClusterSourcedAnnotation, "true") {
+	if !azureutil.IsAroHCP() || !k8sutil.HasAnnotationWithValue(obj, hyperv1.HostedClusterSourcedAnnotation, "true") {
 		return nil
 	}
 	var cm corev1.Secret
@@ -5144,7 +5145,7 @@ func (r *HostedClusterReconciler) reconcileAdditionalTrustBundle(ctx context.Con
 	dest := controlplaneoperator.UserCABundle(controlPlaneNamespace)
 	if hcluster.Spec.AdditionalTrustBundle == nil {
 		// If the HostedCluster has no additional trust bundle, delete the destination ConfigMap if it exists
-		if _, err := hyperutil.DeleteIfNeeded(ctx, r.Client, dest); err != nil {
+		if _, err := k8sutil.DeleteIfNeeded(ctx, r.Client, dest); err != nil {
 			return fmt.Errorf("failed to delete unused additionalTrustBundle: %w", err)
 		}
 		return nil

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -35,6 +35,7 @@ import (
 	fakecapabilities "github.com/openshift/hypershift/support/capabilities/fake"
 	"github.com/openshift/hypershift/support/config"
 	controlplanecomponent "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
 	"github.com/openshift/hypershift/support/releaseinfo/testutils"
@@ -633,7 +634,7 @@ func TestReconcileHostedControlPlaneAnnotations(t *testing.T) {
 			},
 			expectedAnnotations: map[string]string{
 				hyperv1.SwiftPodNetworkInstanceAnnotation:          "swift-network-instance",
-				hyperutil.HostedClusterAnnotation:                  hcKey,
+				k8sutil.HostedClusterAnnotation:                    hcKey,
 				hyperv1.DisableClusterAutoscalerAnnotation:         "true",
 				hyperv1.DisableAWSNodeTerminationHandlerAnnotation: "true",
 			},
@@ -646,7 +647,7 @@ func TestReconcileHostedControlPlaneAnnotations(t *testing.T) {
 			expectedAnnotations: map[string]string{
 				hyperv1.RestartDateAnnotation:                      "01012024",
 				previouslySyncedRestartDateAnnotation:              "01012024",
-				hyperutil.HostedClusterAnnotation:                  hcKey,
+				k8sutil.HostedClusterAnnotation:                    hcKey,
 				hyperv1.DisableClusterAutoscalerAnnotation:         "true",
 				hyperv1.DisableAWSNodeTerminationHandlerAnnotation: "true",
 			},
@@ -663,7 +664,7 @@ func TestReconcileHostedControlPlaneAnnotations(t *testing.T) {
 			expectedAnnotations: map[string]string{
 				hyperv1.RestartDateAnnotation:                      "05012024",
 				previouslySyncedRestartDateAnnotation:              "05012024",
-				hyperutil.HostedClusterAnnotation:                  hcKey,
+				k8sutil.HostedClusterAnnotation:                    hcKey,
 				hyperv1.DisableClusterAutoscalerAnnotation:         "true",
 				hyperv1.DisableAWSNodeTerminationHandlerAnnotation: "true",
 			},
@@ -680,7 +681,7 @@ func TestReconcileHostedControlPlaneAnnotations(t *testing.T) {
 			expectedAnnotations: map[string]string{
 				hyperv1.RestartDateAnnotation:                      "some other value",
 				previouslySyncedRestartDateAnnotation:              "01012024",
-				hyperutil.HostedClusterAnnotation:                  hcKey,
+				k8sutil.HostedClusterAnnotation:                    hcKey,
 				hyperv1.DisableClusterAutoscalerAnnotation:         "true",
 				hyperv1.DisableAWSNodeTerminationHandlerAnnotation: "true",
 			},
@@ -697,7 +698,7 @@ func TestReconcileHostedControlPlaneAnnotations(t *testing.T) {
 			expectedAnnotations: map[string]string{
 				hyperv1.RestartDateAnnotation:                      "05012024",
 				previouslySyncedRestartDateAnnotation:              "05012024",
-				hyperutil.HostedClusterAnnotation:                  hcKey,
+				k8sutil.HostedClusterAnnotation:                    hcKey,
 				hyperv1.DisableClusterAutoscalerAnnotation:         "true",
 				hyperv1.DisableAWSNodeTerminationHandlerAnnotation: "true",
 			},
@@ -705,7 +706,7 @@ func TestReconcileHostedControlPlaneAnnotations(t *testing.T) {
 		{
 			name: "Initial reconcile",
 			hcAnnotations: map[string]string{
-				hyperutil.DebugDeploymentsAnnotation:                         "control-plane-operator",
+				k8sutil.DebugDeploymentsAnnotation:                           "control-plane-operator",
 				hyperv1.EtcdPriorityClass:                                    "high-priority",
 				hyperv1.RequestServingNodeAdditionalSelectorAnnotation:       "node-size=m5xl",
 				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test1": "test1",
@@ -714,13 +715,13 @@ func TestReconcileHostedControlPlaneAnnotations(t *testing.T) {
 				"foo":                                                        "bar", // should not be copied
 			},
 			expectedAnnotations: map[string]string{
-				hyperutil.DebugDeploymentsAnnotation:                         "control-plane-operator",
+				k8sutil.DebugDeploymentsAnnotation:                           "control-plane-operator",
 				hyperv1.EtcdPriorityClass:                                    "high-priority",
 				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test1": "test1",
 				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test2": "test2",
 				hyperv1.KubeAPIServerGoAwayChance:                            "0.001",
 				hyperv1.RequestServingNodeAdditionalSelectorAnnotation:       "node-size=m5xl",
-				hyperutil.HostedClusterAnnotation:                            hcKey,
+				k8sutil.HostedClusterAnnotation:                              hcKey,
 				hyperv1.DisableClusterAutoscalerAnnotation:                   "true",
 				hyperv1.DisableAWSNodeTerminationHandlerAnnotation:           "true",
 			},
@@ -728,7 +729,7 @@ func TestReconcileHostedControlPlaneAnnotations(t *testing.T) {
 		{
 			name: "Initial reconcile - autoscaling needed",
 			hcAnnotations: map[string]string{
-				hyperutil.DebugDeploymentsAnnotation:                         "control-plane-operator",
+				k8sutil.DebugDeploymentsAnnotation:                           "control-plane-operator",
 				hyperv1.EtcdPriorityClass:                                    "high-priority",
 				hyperv1.RequestServingNodeAdditionalSelectorAnnotation:       "node-size=m5xl",
 				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test1": "test1",
@@ -736,12 +737,12 @@ func TestReconcileHostedControlPlaneAnnotations(t *testing.T) {
 				"foo": "bar",
 			},
 			expectedAnnotations: map[string]string{
-				hyperutil.DebugDeploymentsAnnotation:                         "control-plane-operator",
+				k8sutil.DebugDeploymentsAnnotation:                           "control-plane-operator",
 				hyperv1.EtcdPriorityClass:                                    "high-priority",
 				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test1": "test1",
 				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test2": "test2",
 				hyperv1.RequestServingNodeAdditionalSelectorAnnotation:       "node-size=m5xl",
-				hyperutil.HostedClusterAnnotation:                            hcKey,
+				k8sutil.HostedClusterAnnotation:                              hcKey,
 				hyperv1.DisableAWSNodeTerminationHandlerAnnotation:           "true",
 			},
 			isAutoscalingNeeded: true,
@@ -749,14 +750,14 @@ func TestReconcileHostedControlPlaneAnnotations(t *testing.T) {
 		{
 			name: "Existing disable autoscaling annotation, autoscaling no longer needed",
 			hcAnnotations: map[string]string{
-				hyperutil.DebugDeploymentsAnnotation: "control-plane-operator",
+				k8sutil.DebugDeploymentsAnnotation: "control-plane-operator",
 			},
 			hcpAnnotations: map[string]string{
 				hyperv1.DisableClusterAutoscalerAnnotation: "true",
 			},
 			expectedAnnotations: map[string]string{
-				hyperutil.DebugDeploymentsAnnotation:               "control-plane-operator",
-				hyperutil.HostedClusterAnnotation:                  hcKey,
+				k8sutil.DebugDeploymentsAnnotation:                 "control-plane-operator",
+				k8sutil.HostedClusterAnnotation:                    hcKey,
 				hyperv1.DisableAWSNodeTerminationHandlerAnnotation: "true",
 			},
 			isAutoscalingNeeded: true,
@@ -773,7 +774,7 @@ func TestReconcileHostedControlPlaneAnnotations(t *testing.T) {
 				"foo": "bar",
 			},
 			hcpAnnotations: map[string]string{
-				hyperutil.DebugDeploymentsAnnotation:                           "control-plane-operator",
+				k8sutil.DebugDeploymentsAnnotation:                             "control-plane-operator",
 				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test1":   "test1",
 				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test3":   "test3",
 				hyperv1.ResourceRequestOverrideAnnotationPrefix + "-override4": "override4",
@@ -787,7 +788,7 @@ func TestReconcileHostedControlPlaneAnnotations(t *testing.T) {
 				hyperv1.IdentityProviderOverridesAnnotationPrefix + "-test2":   "test2",
 				hyperv1.ResourceRequestOverrideAnnotationPrefix + "-override1": "override1",
 				hyperv1.ResourceRequestOverrideAnnotationPrefix + "-override2": "override2",
-				hyperutil.HostedClusterAnnotation:                              hcKey,
+				k8sutil.HostedClusterAnnotation:                                hcKey,
 				hyperv1.DisableClusterAutoscalerAnnotation:                     "true",
 				hyperv1.DisableAWSNodeTerminationHandlerAnnotation:             "true",
 				"unrelated": "test",
@@ -800,7 +801,7 @@ func TestReconcileHostedControlPlaneAnnotations(t *testing.T) {
 			},
 			hcpAnnotations: map[string]string{},
 			expectedAnnotations: map[string]string{
-				hyperutil.HostedClusterAnnotation:                  hcKey,
+				k8sutil.HostedClusterAnnotation:                    hcKey,
 				hyperv1.AWSKarpenterDefaultInstanceProfile:         "test-instance-profile",
 				hyperv1.DisableClusterAutoscalerAnnotation:         "true",
 				hyperv1.DisableAWSNodeTerminationHandlerAnnotation: "true",
@@ -812,7 +813,7 @@ func TestReconcileHostedControlPlaneAnnotations(t *testing.T) {
 			hcAnnotations:                     map[string]string{},
 			hcpAnnotations:                    map[string]string{},
 			expectedAnnotations: map[string]string{
-				hyperutil.HostedClusterAnnotation:          hcKey,
+				k8sutil.HostedClusterAnnotation:            hcKey,
 				hyperv1.DisableClusterAutoscalerAnnotation: "true",
 			},
 		},
@@ -822,7 +823,7 @@ func TestReconcileHostedControlPlaneAnnotations(t *testing.T) {
 			hcAnnotations:                     map[string]string{},
 			hcpAnnotations:                    map[string]string{},
 			expectedAnnotations: map[string]string{
-				hyperutil.HostedClusterAnnotation:                  hcKey,
+				k8sutil.HostedClusterAnnotation:                    hcKey,
 				hyperv1.DisableClusterAutoscalerAnnotation:         "true",
 				hyperv1.DisableAWSNodeTerminationHandlerAnnotation: "true",
 			},
@@ -835,7 +836,7 @@ func TestReconcileHostedControlPlaneAnnotations(t *testing.T) {
 				hyperv1.DisableAWSNodeTerminationHandlerAnnotation: "true",
 			},
 			expectedAnnotations: map[string]string{
-				hyperutil.HostedClusterAnnotation:          hcKey,
+				k8sutil.HostedClusterAnnotation:            hcKey,
 				hyperv1.DisableClusterAutoscalerAnnotation: "true",
 			},
 		},
@@ -1152,7 +1153,7 @@ func TestReconcileCAPICluster(t *testing.T) {
 			expectedCAPICluster: &v1beta1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						hyperutil.HostedClusterAnnotation: "master/cluster1",
+						k8sutil.HostedClusterAnnotation: "master/cluster1",
 					},
 					Namespace: "master-cluster1",
 					Name:      "cluster1",
@@ -1210,7 +1211,7 @@ func TestReconcileCAPICluster(t *testing.T) {
 			expectedCAPICluster: &v1beta1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						hyperutil.HostedClusterAnnotation: "master/cluster1",
+						k8sutil.HostedClusterAnnotation: "master/cluster1",
 					},
 					Namespace: "master-cluster1",
 					Name:      "cluster1",
@@ -4746,7 +4747,7 @@ func TestReconcileComponents(t *testing.T) {
 			t.Fatalf("failed to get deployment: %v", err)
 		}
 
-		yaml, err := hyperutil.SerializeResource(deployment, api.Scheme)
+		yaml, err := k8sutil.SerializeResource(deployment, api.Scheme)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -4768,7 +4769,7 @@ func TestReconcileComponents(t *testing.T) {
 			controlPaneComponent.Status.Conditions[i].LastTransitionTime = metav1.Time{}
 		}
 
-		yaml, err = hyperutil.SerializeResource(controlPaneComponent, api.Scheme)
+		yaml, err = k8sutil.SerializeResource(controlPaneComponent, api.Scheme)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go
@@ -8,8 +8,8 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
 	"github.com/openshift/hypershift/support/images"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/upsert"
-	hyperutil "github.com/openshift/hypershift/support/util"
 
 	agentv1 "github.com/openshift/cluster-api-provider-agent/api/v1beta1"
 
@@ -207,7 +207,7 @@ func reconcileAgentCluster(agentCluster *agentv1.AgentCluster, ignEndpoint, cont
 func (Agent) DeleteCredentials(ctx context.Context, c client.Client,
 	hc *hyperv1.HostedCluster,
 	controlPlaneNamespace string) error {
-	if _, err := hyperutil.DeleteIfNeeded(ctx, c, &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace), Namespace: hc.Spec.Platform.Agent.AgentNamespace}}); err != nil {
+	if _, err := k8sutil.DeleteIfNeeded(ctx, c, &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%s", CredentialsRBACPrefix, controlPlaneNamespace), Namespace: hc.Spec.Platform.Agent.AgentNamespace}}); err != nil {
 		return fmt.Errorf("failed to clean up CAPI provider rolebinding: %w", err)
 	}
 	return nil

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/gcp/gcp.go
@@ -24,8 +24,8 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/gcputil"
 	"github.com/openshift/hypershift/support/images"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/upsert"
-	supportutil "github.com/openshift/hypershift/support/util"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -156,9 +156,9 @@ func (p GCP) reconcileGCPCluster(gcpCluster *capigcp.GCPCluster, hcluster *hyper
 	if gcpCluster.Spec.AdditionalLabels == nil {
 		gcpCluster.Spec.AdditionalLabels = make(map[string]string)
 	}
-	gcpCluster.Spec.AdditionalLabels[supportutil.GCPLabelCluster] = hcluster.Name
+	gcpCluster.Spec.AdditionalLabels[k8sutil.GCPLabelCluster] = hcluster.Name
 	if hcluster.Spec.InfraID != "" {
-		gcpCluster.Spec.AdditionalLabels[supportutil.GCPLabelInfraID] = hcluster.Spec.InfraID
+		gcpCluster.Spec.AdditionalLabels[k8sutil.GCPLabelInfraID] = hcluster.Spec.InfraID
 	}
 
 	// Set control plane endpoint (following AWS pattern)

--- a/hypershift-operator/controllers/hostedcluster/karpenter.go
+++ b/hypershift-operator/controllers/hostedcluster/karpenter.go
@@ -23,9 +23,9 @@ import (
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/controlplaneoperator"
 	controlplanecomponent "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/k8sutil"
 	karpenterutil "github.com/openshift/hypershift/support/karpenter"
 	"github.com/openshift/hypershift/support/upsert"
-	hyperutil "github.com/openshift/hypershift/support/util"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -92,7 +92,7 @@ spec:
 			}
 		}
 		// Also delete the taint ConfigMap — it is only valid while Karpenter is enabled.
-		if _, err := hyperutil.DeleteIfNeeded(cpContext, r.Client, &corev1.ConfigMap{
+		if _, err := k8sutil.DeleteIfNeeded(cpContext, r.Client, &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      karpenterutil.KarpenterTaintConfigMapName,
 				Namespace: cpContext.HCP.Namespace,

--- a/hypershift-operator/controllers/hostedcluster/network_policies.go
+++ b/hypershift-operator/controllers/hostedcluster/network_policies.go
@@ -15,10 +15,10 @@ import (
 	"github.com/openshift/hypershift/support/awsutil"
 	"github.com/openshift/hypershift/support/capabilities"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/netutil"
 	"github.com/openshift/hypershift/support/rhobsmonitoring"
 	"github.com/openshift/hypershift/support/upsert"
-	hyperutil "github.com/openshift/hypershift/support/util"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -55,7 +55,7 @@ func (r *HostedClusterReconciler) reconcileNetworkPolicies(ctx context.Context, 
 			return fmt.Errorf("failed to reconcile ingress network policy: %w", err)
 		}
 	} else {
-		if _, err := hyperutil.DeleteIfNeeded(ctx, r.Client, policy); err != nil {
+		if _, err := k8sutil.DeleteIfNeeded(ctx, r.Client, policy); err != nil {
 			return fmt.Errorf("failed to delete ingress network policy: %w", err)
 		}
 	}

--- a/hypershift-operator/controllers/manifests/controlplanepkioperator/reconcile_test.go
+++ b/hypershift-operator/controllers/manifests/controlplanepkioperator/reconcile_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/openshift/hypershift/control-plane-pki-operator/certificates"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/controlplanepkioperator"
 	"github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/testutil"
-	"github.com/openshift/hypershift/support/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -23,7 +23,7 @@ func TestReconcileCSRApproverClusterRole(t *testing.T) {
 	if err := controlplanepkioperator.ReconcileCSRApproverClusterRole(clusterRole, hostedCluster, certificates.CustomerBreakGlassSigner, certificates.SREBreakGlassSigner); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	clusterRoleYaml, err := util.SerializeResource(clusterRole, api.Scheme)
+	clusterRoleYaml, err := k8sutil.SerializeResource(clusterRole, api.Scheme)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -39,7 +39,7 @@ func TestReconcileCSRSignerClusterRole(t *testing.T) {
 	if err := controlplanepkioperator.ReconcileCSRSignerClusterRole(clusterRole, hostedCluster, certificates.CustomerBreakGlassSigner, certificates.SREBreakGlassSigner); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	clusterRoleYaml, err := util.SerializeResource(clusterRole, api.Scheme)
+	clusterRoleYaml, err := k8sutil.SerializeResource(clusterRole, api.Scheme)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -57,7 +57,7 @@ func TestReconcileCSRApproverClusterRoleBinding(t *testing.T) {
 	if err := controlplanepkioperator.ReconcileClusterRoleBinding(clusterRoleBinding, clusterRole, serviceAccount); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	clusterRoleBindingYaml, err := util.SerializeResource(clusterRoleBinding, api.Scheme)
+	clusterRoleBindingYaml, err := k8sutil.SerializeResource(clusterRoleBinding, api.Scheme)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestReconcileCSRSignerClusterRoleBinding(t *testing.T) {
 	if err := controlplanepkioperator.ReconcileClusterRoleBinding(clusterRoleBinding, clusterRole, serviceAccount); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	clusterRoleBindingYaml, err := util.SerializeResource(clusterRoleBinding, api.Scheme)
+	clusterRoleBindingYaml, err := k8sutil.SerializeResource(clusterRoleBinding, api.Scheme)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/hypershift-operator/controllers/nodepool/gcp.go
+++ b/hypershift-operator/controllers/nodepool/gcp.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/releaseinfo"
-	supportutil "github.com/openshift/hypershift/support/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -60,7 +60,7 @@ func (c *CAPI) gcpMachineTemplate(_ context.Context, templateNameGenerator func(
 			Labels: map[string]string{
 				capiv1.ClusterNameLabel:                 c.capiClusterName,
 				hyperv1.NodePoolLabel:                   c.nodePool.Name,
-				supportutil.HostedClusterAnnotation:     hc.Name,
+				k8sutil.HostedClusterAnnotation:         hc.Name,
 				capiv1.TemplateClonedFromNameAnnotation: templateName,
 			},
 		},
@@ -282,9 +282,9 @@ func configureGCPLabels(hcGCPPlatform *hyperv1.GCPPlatformSpec, gcpPlatform *hyp
 	}
 
 	// Add HyperShift-specific labels for resource identification
-	labels[supportutil.GCPLabelCluster] = clusterName
+	labels[k8sutil.GCPLabelCluster] = clusterName
 	if infraID != "" {
-		labels[supportutil.GCPLabelInfraID] = infraID
+		labels[k8sutil.GCPLabelInfraID] = infraID
 	}
 
 	return labels

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift/hypershift/support/awsapi"
 	"github.com/openshift/hypershift/support/capabilities"
 	"github.com/openshift/hypershift/support/images"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/supportedversion"
 	"github.com/openshift/hypershift/support/upsert"
@@ -169,7 +170,7 @@ func (r *NodePoolReconciler) managedResources() []client.Object {
 
 	if platformsInstalled := os.Getenv("PLATFORMS_INSTALLED"); len(platformsInstalled) > 0 {
 		// Watch based on platforms installed
-		managedResources = append(managedResources, supportutil.GetNodePoolManagedResources(platformsInstalled)...)
+		managedResources = append(managedResources, k8sutil.GetNodePoolManagedResources(platformsInstalled)...)
 	} else {
 		// Watch all CAPI platform related resources
 		managedResources = append(managedResources, capiRelatedNodePoolManagedResourcesToWatch...)
@@ -907,7 +908,7 @@ func (r *NodePoolReconciler) getNodePoolNamespacedName(nodePoolName string, cont
 	}); err != nil || len(hcpList.Items) < 1 {
 		return types.NamespacedName{Name: nodePoolName}, err
 	}
-	hostedCluster, ok := hcpList.Items[0].Annotations[supportutil.HostedClusterAnnotation]
+	hostedCluster, ok := hcpList.Items[0].Annotations[k8sutil.HostedClusterAnnotation]
 	if !ok {
 		return types.NamespacedName{Name: nodePoolName}, fmt.Errorf("failed to get Hosted Cluster name for HostedControlPlane %s", hcpList.Items[0].Name)
 	}
@@ -1188,7 +1189,7 @@ func deleteConfigByLabel(ctx context.Context, c client.Client, lbl map[string]st
 	}
 	for i := range cmList.Items {
 		cm := &cmList.Items[i]
-		if _, err := supportutil.DeleteIfNeeded(ctx, c, cm); err != nil {
+		if _, err := k8sutil.DeleteIfNeeded(ctx, c, cm); err != nil {
 			return err
 		}
 	}

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -15,11 +15,11 @@ import (
 	ignserver "github.com/openshift/hypershift/ignition-server/controllers"
 	kvinfra "github.com/openshift/hypershift/kubevirtexternalinfra"
 	"github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	fakereleaseprovider "github.com/openshift/hypershift/support/releaseinfo/fake"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
 	"github.com/openshift/hypershift/support/upsert"
-	"github.com/openshift/hypershift/support/util"
 	fakeimagemetadataprovider "github.com/openshift/hypershift/support/util/fakeimagemetadataprovider"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -350,7 +350,7 @@ func TestGetNodePoolNamespacedName(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: testControlPlaneNamespace,
 					Annotations: map[string]string{
-						util.HostedClusterAnnotation: types.NamespacedName{Name: "hosted-cluster-1", Namespace: testNodePoolNamespace}.String(),
+						k8sutil.HostedClusterAnnotation: types.NamespacedName{Name: "hosted-cluster-1", Namespace: testNodePoolNamespace}.String(),
 					},
 				},
 			},

--- a/hypershift-operator/controllers/nodepool/nto.go
+++ b/hypershift-operator/controllers/nodepool/nto.go
@@ -13,8 +13,8 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/backwardcompat"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/netutil"
-	supportutil "github.com/openshift/hypershift/support/util"
 
 	configv1 "github.com/openshift/api/config/v1"
 	configv1alpha1 "github.com/openshift/api/config/v1alpha1"
@@ -85,7 +85,7 @@ func (r *NodePoolReconciler) reconcileMirroredConfigs(ctx context.Context, logr 
 		if !toDelete.Has(existingConfig.Name) {
 			continue
 		}
-		_, err := supportutil.DeleteIfNeeded(ctx, r.Client, existingConfig)
+		_, err := k8sutil.DeleteIfNeeded(ctx, r.Client, existingConfig)
 		if err != nil {
 			return fmt.Errorf("failed to delete ConfigMap %s: %w", client.ObjectKeyFromObject(existingConfig).String(), err)
 		}
@@ -518,7 +518,7 @@ func (r *NodePoolReconciler) ntoReconcile(ctx context.Context, nodePool *hyperv1
 
 	tunedConfigMap := TunedConfigMap(controlPlaneNamespace, nodePool.Name)
 	if tunedConfig == "" {
-		if _, err := supportutil.DeleteIfNeeded(ctx, r.Client, tunedConfigMap); err != nil {
+		if _, err := k8sutil.DeleteIfNeeded(ctx, r.Client, tunedConfigMap); err != nil {
 			return fmt.Errorf("failed to delete tunedConfig ConfigMap: %w", err)
 		}
 	} else {
@@ -557,7 +557,7 @@ func (r *NodePoolReconciler) ntoReconcile(ctx context.Context, nodePool *hyperv1
 		for i := range existingPerformanceProfileConfigMapList.Items {
 			ppConfigMap := &existingPerformanceProfileConfigMapList.Items[i]
 			if ppConfigMap.Name != performanceProfileConfigMap.Name {
-				if _, err := supportutil.DeleteIfNeeded(ctx, r.Client, ppConfigMap); err != nil {
+				if _, err := k8sutil.DeleteIfNeeded(ctx, r.Client, ppConfigMap); err != nil {
 					return fmt.Errorf("failed to delete performanceProfile ConfigMap: %w", err)
 				}
 			}

--- a/hypershift-operator/controllers/nodepool/token.go
+++ b/hypershift-operator/controllers/nodepool/token.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests/ignitionserver"
 	"github.com/openshift/hypershift/support/backwardcompat"
 	"github.com/openshift/hypershift/support/globalconfig"
+	"github.com/openshift/hypershift/support/k8sutil"
 	karpenterutil "github.com/openshift/hypershift/support/karpenter"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/upsert"
@@ -305,7 +306,7 @@ func (t *Token) reconcileTokenSecret(tokenSecret *corev1.Secret) error {
 	if karpenterutil.IsKarpenterEnabled(t.hostedCluster.Spec.AutoNode) {
 		npLabels := t.nodePool.GetLabels()
 		if npLabels != nil && npLabels[karpenterutil.ManagedByKarpenterLabel] == "true" {
-			tokenSecret.Annotations[supportutil.HostedClusterAnnotation] = client.ObjectKeyFromObject(t.ConfigGenerator.hostedCluster).String()
+			tokenSecret.Annotations[k8sutil.HostedClusterAnnotation] = client.ObjectKeyFromObject(t.ConfigGenerator.hostedCluster).String()
 			if tokenSecret.Labels == nil {
 				tokenSecret.Labels = make(map[string]string)
 			}

--- a/hypershift-operator/controllers/platform/aws/controller.go
+++ b/hypershift-operator/controllers/platform/aws/controller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/hypershift/support/awsapi"
 	"github.com/openshift/hypershift/support/capabilities"
 	"github.com/openshift/hypershift/support/globalconfig"
+	"github.com/openshift/hypershift/support/k8sutil"
 	karpenterutil "github.com/openshift/hypershift/support/karpenter"
 	"github.com/openshift/hypershift/support/upsert"
 	supportutil "github.com/openshift/hypershift/support/util"
@@ -382,7 +383,7 @@ func reconcileAWSEndpointService(ctx context.Context, c client.Client, awsEndpoi
 	if awsEndpointService.Annotations == nil {
 		awsEndpointService.Annotations = make(map[string]string)
 	}
-	awsEndpointService.Annotations[supportutil.HostedClusterAnnotation] = fmt.Sprintf("%s/%s", hc.Namespace, hc.Name)
+	awsEndpointService.Annotations[k8sutil.HostedClusterAnnotation] = fmt.Sprintf("%s/%s", hc.Namespace, hc.Name)
 	return reconcileAWSEndpointServiceSubnetIDs(ctx, c, awsEndpointService, hc)
 }
 
@@ -840,7 +841,7 @@ func (r *AWSEndpointServiceReconciler) hostedControlPlane(ctx context.Context, h
 }
 
 func hostedClusterNamespaceAndName(hcp *hyperv1.HostedControlPlane) (string, string) {
-	hcNamespaceName, exists := hcp.Annotations[supportutil.HostedClusterAnnotation]
+	hcNamespaceName, exists := hcp.Annotations[k8sutil.HostedClusterAnnotation]
 	if !exists {
 		return "", ""
 	}

--- a/hypershift-operator/controllers/platform/azure/controller.go
+++ b/hypershift-operator/controllers/platform/azure/controller.go
@@ -35,6 +35,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/azureutil"
+	"github.com/openshift/hypershift/support/k8sutil"
 	supportutil "github.com/openshift/hypershift/support/util"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -185,7 +186,7 @@ func (r *AzurePrivateLinkServiceController) Reconcile(ctx context.Context, req c
 	}
 
 	// 4. Find the hosted cluster using annotation (set by CPO-side observer)
-	hc, err := supportutil.HostedClusterFromAnnotation(ctx, r.Client, azPLS)
+	hc, err := k8sutil.HostedClusterFromAnnotation(ctx, r.Client, azPLS)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get hosted cluster: %w", err)
 	}

--- a/hypershift-operator/controllers/platform/azure/controller_test.go
+++ b/hypershift-operator/controllers/platform/azure/controller_test.go
@@ -14,7 +14,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	hyperapi "github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/azureutil"
-	supportutil "github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -160,7 +160,7 @@ func TestReconcile_WhenHostedClusterIsPaused_ItShouldRequeueAfterPauseExpiry(t *
 			Namespace:  "test-ns",
 			Finalizers: []string{azurePLSFinalizer},
 			Annotations: map[string]string{
-				supportutil.HostedClusterAnnotation: "test-ns/test-cluster",
+				k8sutil.HostedClusterAnnotation: "test-ns/test-cluster",
 			},
 		},
 		Spec: hyperv1.AzurePrivateLinkServiceSpec{
@@ -219,7 +219,7 @@ func TestReconcile_WhenLoadBalancerIPIsSet_ItShouldCreateAPLS(t *testing.T) {
 			Namespace:  "test-ns",
 			Finalizers: []string{azurePLSFinalizer},
 			Annotations: map[string]string{
-				supportutil.HostedClusterAnnotation: "test-ns/test-cluster",
+				k8sutil.HostedClusterAnnotation: "test-ns/test-cluster",
 			},
 		},
 		Spec: hyperv1.AzurePrivateLinkServiceSpec{
@@ -315,7 +315,7 @@ func TestReconcile_WhenPLSAlreadyExists_ItShouldUpdateStatus(t *testing.T) {
 			Namespace:  "test-ns",
 			Finalizers: []string{azurePLSFinalizer},
 			Annotations: map[string]string{
-				supportutil.HostedClusterAnnotation: "test-ns/test-cluster",
+				k8sutil.HostedClusterAnnotation: "test-ns/test-cluster",
 			},
 		},
 		Spec: hyperv1.AzurePrivateLinkServiceSpec{
@@ -592,7 +592,7 @@ func TestReconcile_WhenLoadBalancerIPNotSet_ItShouldRequeue(t *testing.T) {
 			Namespace:  "test-ns",
 			Finalizers: []string{azurePLSFinalizer},
 			Annotations: map[string]string{
-				supportutil.HostedClusterAnnotation: "test-ns/test-cluster",
+				k8sutil.HostedClusterAnnotation: "test-ns/test-cluster",
 			},
 		},
 		Spec: hyperv1.AzurePrivateLinkServiceSpec{
@@ -911,7 +911,7 @@ func TestReconcile_WhenAdditionalAllowedSubscriptionsChange_ItShouldUpdatePLS(t 
 			Namespace:  "test-ns",
 			Finalizers: []string{azurePLSFinalizer},
 			Annotations: map[string]string{
-				supportutil.HostedClusterAnnotation: "test-ns/test-cluster",
+				k8sutil.HostedClusterAnnotation: "test-ns/test-cluster",
 			},
 		},
 		Spec: hyperv1.AzurePrivateLinkServiceSpec{
@@ -1031,7 +1031,7 @@ func TestReconcile_WhenAdditionalAllowedSubscriptionsMatch_ItShouldNotUpdatePLS(
 			Namespace:  "test-ns",
 			Finalizers: []string{azurePLSFinalizer},
 			Annotations: map[string]string{
-				supportutil.HostedClusterAnnotation: "test-ns/test-cluster",
+				k8sutil.HostedClusterAnnotation: "test-ns/test-cluster",
 			},
 		},
 		Spec: hyperv1.AzurePrivateLinkServiceSpec{

--- a/hypershift-operator/controllers/platform/gcp/privateserviceconnect_controller.go
+++ b/hypershift-operator/controllers/platform/gcp/privateserviceconnect_controller.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/upsert"
-	supportutil "github.com/openshift/hypershift/support/util"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -127,7 +127,7 @@ func (r *GCPPrivateServiceConnectReconciler) Reconcile(ctx context.Context, req 
 	}
 
 	// 4. Find the hosted cluster using annotation (set by customer-side controller)
-	hc, err := supportutil.HostedClusterFromAnnotation(ctx, r.Client, gcpPSC)
+	hc, err := k8sutil.HostedClusterFromAnnotation(ctx, r.Client, gcpPSC)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get hosted cluster: %w", err)
 	}

--- a/hypershift-operator/controllers/platform/gcp/privateserviceconnect_controller_test.go
+++ b/hypershift-operator/controllers/platform/gcp/privateserviceconnect_controller_test.go
@@ -9,8 +9,8 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	hyperapi "github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/upsert"
-	supportutil "github.com/openshift/hypershift/support/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -164,7 +164,7 @@ func TestReconcile_PausedUntil(t *testing.T) {
 			Name:      "test-cluster",
 			Namespace: "test-namespace",
 			Annotations: map[string]string{
-				supportutil.HostedClusterAnnotation: "test-namespace/test-cluster",
+				k8sutil.HostedClusterAnnotation: "test-namespace/test-cluster",
 			},
 		},
 		Spec: hyperv1.HostedControlPlaneSpec{
@@ -178,7 +178,7 @@ func TestReconcile_PausedUntil(t *testing.T) {
 			Namespace:  "test-namespace",
 			Finalizers: []string{"hypershift.openshift.io/gcp-private-service-connect"}, // Add finalizer so it gets past initial checks
 			Annotations: map[string]string{
-				supportutil.HostedClusterAnnotation: "test-namespace/test-cluster",
+				k8sutil.HostedClusterAnnotation: "test-namespace/test-cluster",
 			},
 		},
 		Spec: hyperv1.GCPPrivateServiceConnectSpec{

--- a/hypershift-operator/controllers/resourcebasedcpautoscaler/controller.go
+++ b/hypershift-operator/controllers/resourcebasedcpautoscaler/controller.go
@@ -8,7 +8,7 @@ import (
 	schedulingv1alpha1 "github.com/openshift/hypershift/api/scheduling/v1alpha1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/manifests"
 	controlplaneautoscalermanifests "github.com/openshift/hypershift/hypershift-operator/controllers/manifests/controlplaneautoscaler"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 
@@ -129,7 +129,7 @@ func (r *ControlPlaneAutoscalerController) Reconcile(ctx context.Context, reques
 	vpa := controlplaneautoscalermanifests.KubeAPIServerVerticalPodAutoscaler(cpNamespace)
 
 	if hc.Annotations[hyperv1.ResourceBasedControlPlaneAutoscalingAnnotation] != "true" || hc.Annotations[hyperv1.TopologyAnnotation] != hyperv1.DedicatedRequestServingComponentsTopology {
-		_, err := util.DeleteIfNeeded(ctx, r, vpa)
+		_, err := k8sutil.DeleteIfNeeded(ctx, r, vpa)
 		return ctrl.Result{}, err
 	}
 

--- a/hypershift-operator/controllers/scheduler/aws/autoscaler.go
+++ b/hypershift-operator/controllers/scheduler/aws/autoscaler.go
@@ -12,7 +12,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	schedulingv1alpha1 "github.com/openshift/hypershift/api/scheduling/v1alpha1"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 
@@ -239,7 +239,7 @@ func hostedClusterMachineSetsToScaleDown(ctx context.Context, hostedCluster *hyp
 	var result []machinev1beta1.MachineSet
 	log := ctrl.LoggerFrom(ctx)
 
-	additionalNodeSelector := util.ParseNodeSelector(hostedCluster.Annotations[hyperv1.RequestServingNodeAdditionalSelectorAnnotation])
+	additionalNodeSelector := k8sutil.ParseNodeSelector(hostedCluster.Annotations[hyperv1.RequestServingNodeAdditionalSelectorAnnotation])
 	var sizeLabelSelector map[string]string
 	if sizeLabel := hostedCluster.Labels[hyperv1.HostedClusterSizeLabel]; sizeLabel != "" {
 		sizeLabelSelector = map[string]string{hyperv1.NodeSizeLabel: sizeLabel}

--- a/hypershift-operator/controllers/scheduler/aws/dedicated_request_serving_nodes.go
+++ b/hypershift-operator/controllers/scheduler/aws/dedicated_request_serving_nodes.go
@@ -10,6 +10,7 @@ import (
 	schedulingv1alpha1 "github.com/openshift/hypershift/api/scheduling/v1alpha1"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/hostedcluster"
 	schedulerutil "github.com/openshift/hypershift/hypershift-operator/controllers/scheduler/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
@@ -764,7 +765,7 @@ func (r *DedicatedServingComponentSchedulerAndSizer) ensureHostedClusterLabelAnd
 
 func (r *DedicatedServingComponentSchedulerAndSizer) deletePlaceholderDeployment(ctx context.Context, hc *hyperv1.HostedCluster) error {
 	deployment := placeholderDeployment(hc)
-	_, err := util.DeleteIfNeeded(ctx, r, deployment)
+	_, err := k8sutil.DeleteIfNeeded(ctx, r, deployment)
 	return err
 }
 

--- a/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
+++ b/hypershift-operator/controllers/sharedingress/sharedingress_controller.go
@@ -13,9 +13,9 @@ import (
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/capabilities"
 	supportconfig "github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/netutil"
 	"github.com/openshift/hypershift/support/upsert"
-	"github.com/openshift/hypershift/support/util"
 
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -275,7 +275,7 @@ func (r *SharedIngressReconciler) reconcileDefaultServiceAccount(ctx context.Con
 	defaultSA := common.DefaultServiceAccount(RouterNamespace)
 	if _, err := r.createOrUpdate(ctx, r.Client, defaultSA, func() error {
 		if pullSecretPresent {
-			util.EnsurePullSecret(defaultSA, PullSecret().Name)
+			k8sutil.EnsurePullSecret(defaultSA, PullSecret().Name)
 		}
 		return nil
 	}); err != nil {
@@ -288,7 +288,7 @@ func (r *SharedIngressReconciler) reconcileConfigGeneratorControllerRBAC(ctx con
 	sa := RouterServiceAccount()
 	if _, err := r.createOrUpdate(ctx, r.Client, sa, func() error {
 		if pullSecretPresent {
-			util.EnsurePullSecret(sa, PullSecret().Name)
+			k8sutil.EnsurePullSecret(sa, PullSecret().Name)
 		}
 		return nil
 	}); err != nil {

--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/certs"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
 	"github.com/openshift/hypershift/support/util"
@@ -483,7 +484,7 @@ func (p *LocalIgnitionProvider) GetPayload(ctx context.Context, releaseImage, cu
 			corev1.DockerConfigJsonKey: pullSecret,
 		}
 		pullSecretObject.Type = corev1.SecretTypeDockerConfigJson
-		serializedPullSecret, err := util.SerializeResource(pullSecretObject, api.Scheme)
+		serializedPullSecret, err := k8sutil.SerializeResource(pullSecretObject, api.Scheme)
 		if err != nil {
 			return fmt.Errorf("failed to serialize pull-secret.yaml: %w", err)
 		}

--- a/karpenter-operator/controllers/karpenterignition/karpenterignition_controller_test.go
+++ b/karpenter-operator/controllers/karpenterignition/karpenterignition_controller_test.go
@@ -13,11 +13,11 @@ import (
 	hyperkarpenterv1 "github.com/openshift/hypershift/api/karpenter/v1"
 	"github.com/openshift/hypershift/api/util/ipnet"
 	"github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/k8sutil"
 	karpenterutil "github.com/openshift/hypershift/support/karpenter"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/releaseinfo/testutils"
 	"github.com/openshift/hypershift/support/thirdparty/library-go/pkg/image/dockerv1client"
-	supportutil "github.com/openshift/hypershift/support/util"
 	fakeimagemetadataprovider "github.com/openshift/hypershift/support/util/fakeimagemetadataprovider"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -248,7 +248,7 @@ kind: Config`),
 		if strings.HasPrefix(secret.Name, tokenPrefix) {
 			initialTokenSecretName = secret.Name
 			g.Expect(secret.Data).To(HaveKey("token"))
-			g.Expect(secret.Annotations).To(HaveKey(supportutil.HostedClusterAnnotation), "token secret should have HostedClusterAnnotation")
+			g.Expect(secret.Annotations).To(HaveKey(k8sutil.HostedClusterAnnotation), "token secret should have HostedClusterAnnotation")
 			g.Expect(secret.Labels).To(HaveKeyWithValue(karpenterutil.ManagedByKarpenterLabel, "true"), "token secret should have ManagedByKarpenterLabel")
 		}
 		if strings.HasPrefix(secret.Name, userDataPrefix) {

--- a/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller.go
+++ b/karpenter-operator/controllers/nodeclass/ec2_nodeclass_controller.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/hypershift/karpenter-operator/controllers/karpenter/assets"
 	supportassets "github.com/openshift/hypershift/support/assets"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/k8sutil"
 	karpenterutil "github.com/openshift/hypershift/support/karpenter"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
@@ -152,7 +153,7 @@ func (r *EC2NodeClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	if !openshiftEC2NodeClass.DeletionTimestamp.IsZero() {
-		exists, err := util.DeleteIfNeeded(ctx, r.guestClient, ec2NodeClass)
+		exists, err := k8sutil.DeleteIfNeeded(ctx, r.guestClient, ec2NodeClass)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -485,7 +486,7 @@ func (r *EC2NodeClassReconciler) reconcileKarpenterSubnetsConfigMap(ctx context.
 	// delete the ConfigMap (no NodeClasses exist, or none have subnets in status yet).
 	// The ConfigMap is also cleaned up automatically via owner reference when HCP is deleted.
 	if subnetIDSet.Len() == 0 {
-		if _, err := util.DeleteIfNeeded(ctx, r.managementClient, configMap); err != nil {
+		if _, err := k8sutil.DeleteIfNeeded(ctx, r.managementClient, configMap); err != nil {
 			return fmt.Errorf("failed to delete karpenter subnets configmap: %w", err)
 		}
 		log.Info("Deleted karpenter subnets configmap (no OpenshiftEC2NodeClass resources with resolved subnets)")

--- a/support/config/featuregates.go
+++ b/support/config/featuregates.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/openshift/hypershift/support/api"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -35,7 +35,7 @@ func ParseFeatureGates(cm *corev1.ConfigMap) (*configv1.FeatureGate, error) {
 	if len(manifest) == 0 {
 		return nil, fmt.Errorf("empty featuregate manifest")
 	}
-	if err := util.DeserializeResource(manifest, fg, api.Scheme); err != nil {
+	if err := k8sutil.DeserializeResource(manifest, fg, api.Scheme); err != nil {
 		return nil, fmt.Errorf("failed to deserialize feature gate resource: %w", err)
 	}
 	return fg, nil

--- a/support/config/ownerref.go
+++ b/support/config/ownerref.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"github.com/openshift/hypershift/support/api"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -15,7 +15,7 @@ type OwnerRef struct {
 }
 
 func (c OwnerRef) ApplyTo(obj client.Object) {
-	util.EnsureOwnerRef(obj, c.Reference)
+	k8sutil.EnsureOwnerRef(obj, c.Reference)
 }
 
 func OwnerRefFrom(obj client.Object) OwnerRef {

--- a/support/controlplane-component/common.go
+++ b/support/controlplane-component/common.go
@@ -2,7 +2,7 @@ package controlplanecomponent
 
 import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -38,7 +38,7 @@ func SetHostedClusterAnnotation() option {
 			if annotations == nil {
 				annotations = map[string]string{}
 			}
-			annotations[util.HostedClusterAnnotation] = cpContext.HCP.Annotations[util.HostedClusterAnnotation]
+			annotations[k8sutil.HostedClusterAnnotation] = cpContext.HCP.Annotations[k8sutil.HostedClusterAnnotation]
 			resource.SetAnnotations(annotations)
 			return nil
 		}

--- a/support/controlplane-component/controlplane-component.go
+++ b/support/controlplane-component/controlplane-component.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/infra"
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/metrics"
 	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/upsert"
@@ -205,7 +206,7 @@ func (c *controlPlaneWorkload[T]) delete(cpContext ControlPlaneContext) error {
 	workloadObj.SetName(c.Name())
 	workloadObj.SetNamespace(cpContext.HCP.Namespace)
 
-	_, err := util.DeleteIfNeeded(cpContext, cpContext.Client, workloadObj)
+	_, err := k8sutil.DeleteIfNeeded(cpContext, cpContext.Client, workloadObj)
 	if err != nil {
 		return err
 	}
@@ -228,7 +229,7 @@ func (c *controlPlaneWorkload[T]) delete(cpContext ControlPlaneContext) error {
 			}
 		}
 
-		_, err = util.DeleteIfNeeded(cpContext, cpContext.Client, obj)
+		_, err = k8sutil.DeleteIfNeeded(cpContext, cpContext.Client, obj)
 		return err
 	}); err != nil {
 		return err
@@ -240,7 +241,7 @@ func (c *controlPlaneWorkload[T]) delete(cpContext ControlPlaneContext) error {
 			Namespace: cpContext.HCP.Namespace,
 		},
 	}
-	_, err = util.DeleteIfNeeded(cpContext, cpContext.Client, component)
+	_, err = k8sutil.DeleteIfNeeded(cpContext, cpContext.Client, component)
 	return err
 }
 
@@ -267,7 +268,7 @@ func (c *controlPlaneWorkload[T]) update(cpContext ControlPlaneContext) error {
 				}
 			}
 		case *corev1.ServiceAccount:
-			util.EnsurePullSecret(typedObj, common.PullSecret("").Name)
+			k8sutil.EnsurePullSecret(typedObj, common.PullSecret("").Name)
 		}
 
 		adapter, exist := c.manifestsAdapters[manifestName]

--- a/support/controlplane-component/defaults.go
+++ b/support/controlplane-component/defaults.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	karpenterassets "github.com/openshift/hypershift/karpenter-operator/controllers/karpenter/assets"
 	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/podspec"
 	"github.com/openshift/hypershift/support/util"
 
@@ -306,7 +307,7 @@ func (c *controlPlaneWorkload[T]) setControlPlaneIsolation(podTemplate *corev1.P
 
 		var additionalRequestServingNodeSelector map[string]string
 		if hcp.Annotations[hyperv1.RequestServingNodeAdditionalSelectorAnnotation] != "" {
-			additionalRequestServingNodeSelector = util.ParseNodeSelector(hcp.Annotations[hyperv1.RequestServingNodeAdditionalSelectorAnnotation])
+			additionalRequestServingNodeSelector = k8sutil.ParseNodeSelector(hcp.Annotations[hyperv1.RequestServingNodeAdditionalSelectorAnnotation])
 		}
 		for key, value := range additionalRequestServingNodeSelector {
 			nodeSelectorRequirements = append(nodeSelectorRequirements, corev1.NodeSelectorRequirement{
@@ -668,7 +669,7 @@ func DefaultReplicas(hcp *hyperv1.HostedControlPlane, options ComponentOptions, 
 // debugDeploymentsAnnotation value, indicating the Component should be considered to
 // be in development mode.
 func debugComponentsSet(hcp *hyperv1.HostedControlPlane) sets.Set[string] {
-	val, exists := hcp.Annotations[util.DebugDeploymentsAnnotation]
+	val, exists := hcp.Annotations[k8sutil.DebugDeploymentsAnnotation]
 	if !exists {
 		return nil
 	}

--- a/support/controlplane-component/generic-adapter.go
+++ b/support/controlplane-component/generic-adapter.go
@@ -2,7 +2,7 @@ package controlplanecomponent
 
 import (
 	"github.com/openshift/hypershift/support/config"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -67,7 +67,7 @@ func (ga *genericAdapter) reconcile(cpContext ControlPlaneContext, obj client.Ob
 			ownerRefHCP := config.OwnerRefFrom(cpContext.HCP)
 			if capiutil.HasOwnerRef(objOwnerRefs, *ownerRefHCP.Reference) {
 				// delete the object only if it has HCP ownerRef
-				_, err := util.DeleteIfNeeded(cpContext, cpContext.Client, obj)
+				_, err := k8sutil.DeleteIfNeeded(cpContext, cpContext.Client, obj)
 				return err
 			}
 			return nil

--- a/support/controlplane-component/job.go
+++ b/support/controlplane-component/job.go
@@ -2,7 +2,7 @@ package controlplanecomponent
 
 import (
 	assets "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/assets"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -58,12 +58,12 @@ func (c *jobProvider) IsReady(job *batchv1.Job) (status metav1.ConditionStatus, 
 // It checks if the job is complete or failed and returns the corresponding status.
 // If the job is neither complete nor failed, it returns unknown status.
 func JobCompletionStatus(job *batchv1.Job) (status metav1.ConditionStatus, reason string, message string) {
-	complete := util.FindJobCondition(job, batchv1.JobComplete)
+	complete := k8sutil.FindJobCondition(job, batchv1.JobComplete)
 	if complete != nil && complete.Status == corev1.ConditionTrue {
 		return metav1.ConditionTrue, "JobComplete", "Job completed successfully"
 	}
 
-	failed := util.FindJobCondition(job, batchv1.JobFailed)
+	failed := k8sutil.FindJobCondition(job, batchv1.JobFailed)
 	if failed != nil && failed.Status == corev1.ConditionTrue {
 		// If the job failed, we return false and the reason and message from the condition to provide more context.
 		// we set default values for the reason and message if not set to avoid errors as reason and message are required fields

--- a/support/globalconfig/observed.go
+++ b/support/globalconfig/observed.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/openshift/hypershift/support/api"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -28,7 +28,7 @@ type ObservedConfig struct {
 }
 
 func ReconcileObservedConfig(cm *corev1.ConfigMap, config runtime.Object) error {
-	serializedConfig, err := util.SerializeResource(config, api.Scheme)
+	serializedConfig, err := k8sutil.SerializeResource(config, api.Scheme)
 	if err != nil {
 		return fmt.Errorf("cannot serialize config: %w", err)
 	}
@@ -41,7 +41,7 @@ func deserializeObservedConfig(cm *corev1.ConfigMap, config runtime.Object) erro
 	if !exists {
 		return fmt.Errorf("observed config key not found in configmap")
 	}
-	return util.DeserializeResource(serializedConfig, config, api.Scheme)
+	return k8sutil.DeserializeResource(serializedConfig, config, api.Scheme)
 }
 
 // ReadObservedConfig reads global configuration resources from configmaps that

--- a/support/k8sutil/annotations.go
+++ b/support/k8sutil/annotations.go
@@ -1,4 +1,4 @@
-package util
+package k8sutil
 
 import (
 	"context"

--- a/support/k8sutil/annotations_test.go
+++ b/support/k8sutil/annotations_test.go
@@ -1,8 +1,9 @@
-package util
+package k8sutil
 
 import (
-	"context"
 	"testing"
+
+	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 
@@ -56,10 +57,9 @@ func TestHasAnnotationWithValue(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			g := NewWithT(t)
 			obj := &metav1.ObjectMeta{Annotations: tt.annotations}
-			if got := HasAnnotationWithValue(obj, tt.key, tt.value); got != tt.want {
-				t.Fatalf("HasAnnotationWithValue() = %v, want %v", got, tt.want)
-			}
+			g.Expect(HasAnnotationWithValue(obj, tt.key, tt.value)).To(Equal(tt.want))
 		})
 	}
 }
@@ -156,7 +156,7 @@ func TestHostedClusterFromAnnotation(t *testing.T) {
 			errSubstr: "invalid",
 		},
 		{
-			name: "When HostedCluster does not exist it should return a not found error",
+			name: "When annotation is valid but HostedCluster does not exist it should return an error",
 			obj: &hyperv1.AzurePrivateLinkService{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-pls",
@@ -184,25 +184,12 @@ func TestHostedClusterFromAnnotation(t *testing.T) {
 			wantHCNS: "clusters",
 			wantHCN:  "my-cluster",
 		},
-		{
-			name: "When annotation has extra slashes it should handle SplitN correctly",
-			obj: &hyperv1.AzurePrivateLinkService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pls",
-					Namespace: "ns",
-					Annotations: map[string]string{
-						HostedClusterAnnotation: "clusters/name/extra",
-					},
-				},
-			},
-			wantErr:   true,
-			errSubstr: "failed to get hosted cluster",
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			g := NewWithT(t)
 
 			builder := fake.NewClientBuilder().WithScheme(scheme)
 			for _, obj := range tt.existing {
@@ -210,35 +197,17 @@ func TestHostedClusterFromAnnotation(t *testing.T) {
 			}
 			fakeClient := builder.Build()
 
-			hc, err := HostedClusterFromAnnotation(context.Background(), fakeClient, tt.obj)
+			hc, err := HostedClusterFromAnnotation(t.Context(), fakeClient, tt.obj)
 			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("expected error containing %q, got nil", tt.errSubstr)
-				}
-				if tt.errSubstr != "" && !contains(err.Error(), tt.errSubstr) {
-					t.Fatalf("expected error containing %q, got %q", tt.errSubstr, err.Error())
+				g.Expect(err).To(HaveOccurred())
+				if tt.errSubstr != "" {
+					g.Expect(err).To(MatchError(ContainSubstring(tt.errSubstr)))
 				}
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if hc.Namespace != tt.wantHCNS || hc.Name != tt.wantHCN {
-				t.Fatalf("expected HC %s/%s, got %s/%s", tt.wantHCNS, tt.wantHCN, hc.Namespace, hc.Name)
-			}
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(hc.Namespace).To(Equal(tt.wantHCNS))
+			g.Expect(hc.Name).To(Equal(tt.wantHCN))
 		})
 	}
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && searchSubstring(s, substr)
-}
-
-func searchSubstring(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/support/k8sutil/constants.go
+++ b/support/k8sutil/constants.go
@@ -1,0 +1,20 @@
+package k8sutil
+
+const (
+	// DebugDeploymentsAnnotation contains a comma separated list of deployment names which should always be scaled to 0
+	// for development.
+	DebugDeploymentsAnnotation = "hypershift.openshift.io/debug-deployments"
+	// EnableHostedClustersAnnotationScopingEnv is the env var that enables annotation-based scoping for hosted clusters.
+	EnableHostedClustersAnnotationScopingEnv = "ENABLE_HOSTEDCLUSTERS_ANNOTATION_SCOPING"
+	// HostedClustersScopeAnnotationEnv is the env var that specifies the scope annotation value to match.
+	HostedClustersScopeAnnotationEnv = "HOSTEDCLUSTERS_SCOPE_ANNOTATION"
+	// HostedClustersScopeAnnotation is the annotation key used to scope hosted clusters to specific operators.
+	HostedClustersScopeAnnotation = "hypershift.openshift.io/scope"
+	// HostedClusterAnnotation is the annotation key that links a resource to its owning HostedCluster (namespace/name).
+	HostedClusterAnnotation = "hypershift.openshift.io/cluster"
+
+	// GCPLabelCluster is the GCP resource label key used to identify the HostedCluster name.
+	GCPLabelCluster = "hypershift-openshift-io-cluster"
+	// GCPLabelInfraID is the GCP resource label key used to identify the infrastructure ID.
+	GCPLabelInfraID = "hypershift-openshift-io-infra-id"
+)

--- a/support/k8sutil/job.go
+++ b/support/k8sutil/job.go
@@ -1,4 +1,4 @@
-package util
+package k8sutil
 
 import (
 	batchv1 "k8s.io/api/batch/v1"

--- a/support/k8sutil/job_test.go
+++ b/support/k8sutil/job_test.go
@@ -1,0 +1,48 @@
+package k8sutil
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFindJobCondition(t *testing.T) {
+	t.Run("When condition exists it should return a pointer to it", func(t *testing.T) {
+		g := NewWithT(t)
+		job := &batchv1.Job{
+			Status: batchv1.JobStatus{
+				Conditions: []batchv1.JobCondition{
+					{Type: batchv1.JobComplete, Status: "True", Reason: "done"},
+				},
+			},
+		}
+		cond := FindJobCondition(job, batchv1.JobComplete)
+		g.Expect(cond).ToNot(BeNil())
+		g.Expect(cond.Reason).To(Equal("done"))
+	})
+
+	t.Run("When condition does not exist it should return nil", func(t *testing.T) {
+		g := NewWithT(t)
+		job := &batchv1.Job{
+			Status: batchv1.JobStatus{
+				Conditions: []batchv1.JobCondition{
+					{Type: batchv1.JobComplete, Status: "True"},
+				},
+			},
+		}
+		cond := FindJobCondition(job, batchv1.JobFailed)
+		g.Expect(cond).To(BeNil())
+	})
+
+	t.Run("When job has no conditions it should return nil", func(t *testing.T) {
+		g := NewWithT(t)
+		job := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		}
+		cond := FindJobCondition(job, batchv1.JobComplete)
+		g.Expect(cond).To(BeNil())
+	})
+}

--- a/support/k8sutil/object.go
+++ b/support/k8sutil/object.go
@@ -1,0 +1,134 @@
+package k8sutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/util/retry"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CopyConfigMap copies the .Data field of configMap source into configmap cm.
+func CopyConfigMap(cm, source *corev1.ConfigMap) {
+	cm.Data = map[string]string{}
+	for k, v := range source.Data {
+		cm.Data[k] = v
+	}
+}
+
+func UpdateObject[T client.Object](ctx context.Context, c client.Client, obj T, mutate func() error) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+			return err
+		}
+
+		original := obj.DeepCopyObject().(T)
+		if err := mutate(); err != nil {
+			return err
+		}
+
+		return c.Patch(ctx, obj, client.MergeFrom(original))
+	})
+}
+
+func DeleteIfNeededWithOptions(ctx context.Context, c client.Client, o client.Object, opts ...client.DeleteOption) (exists bool, err error) {
+	if err := c.Get(ctx, client.ObjectKeyFromObject(o), o); err != nil {
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("error getting %T: %w", o, err)
+	}
+	if o.GetDeletionTimestamp() != nil {
+		return true, nil
+	}
+	if err := c.Delete(ctx, o, opts...); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("error deleting %T: %w", o, err)
+	}
+
+	return true, nil
+}
+
+func DeleteIfNeededWithPredicate[T client.Object](ctx context.Context, c client.Client, o T, predicate func(T) bool) (exists bool, err error) {
+	if err := c.Get(ctx, client.ObjectKeyFromObject(o), o); err != nil {
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("error getting %T: %w", o, err)
+	}
+	if o.GetDeletionTimestamp() != nil {
+		return true, nil
+	}
+	if !predicate(o) {
+		return true, nil
+	}
+	if err := c.Delete(ctx, o); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("error deleting %T: %w", o, err)
+	}
+
+	return true, nil
+}
+
+func DeleteAllIfNeeded(ctx context.Context, c client.Client, o ...client.Object) error {
+	errs := []error{}
+	for _, obj := range o {
+		_, err := DeleteIfNeededWithOptions(ctx, c, obj)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+func DeleteIfNeeded(ctx context.Context, c client.Client, o client.Object) (exists bool, err error) {
+	return DeleteIfNeededWithOptions(ctx, c, o)
+}
+
+// ParseNodeSelector parses a comma separated string of key=value pairs into a map.
+func ParseNodeSelector(str string) map[string]string {
+	if len(str) == 0 {
+		return nil
+	}
+	parts := strings.Split(str, ",")
+	result := make(map[string]string)
+	for _, part := range parts {
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		if len(kv[0]) == 0 || len(kv[1]) == 0 {
+			continue
+		}
+		result[kv[0]] = kv[1]
+	}
+	return result
+}
+
+func ApplyAWSLoadBalancerTargetNodesAnnotation(svc *corev1.Service, hcp *hyperv1.HostedControlPlane) {
+	if hcp.Spec.Platform.Type != hyperv1.AWSPlatform {
+		return
+	}
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+	selectors, ok := hcp.Annotations[hyperv1.AWSLoadBalancerTargetNodesAnnotation]
+	if ok {
+		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-target-node-labels"] = selectors
+	}
+}

--- a/support/k8sutil/object_test.go
+++ b/support/k8sutil/object_test.go
@@ -1,0 +1,519 @@
+package k8sutil
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestCopyConfigMap(t *testing.T) {
+	t.Run("When source has data it should deep copy all entries", func(t *testing.T) {
+		g := NewWithT(t)
+		source := &corev1.ConfigMap{
+			Data: map[string]string{"key1": "val1", "key2": "val2"},
+		}
+		dest := &corev1.ConfigMap{}
+
+		CopyConfigMap(dest, source)
+
+		g.Expect(dest.Data).To(Equal(map[string]string{"key1": "val1", "key2": "val2"}))
+		source.Data["key1"] = "mutated"
+		g.Expect(dest.Data["key1"]).To(Equal("val1"))
+	})
+
+	t.Run("When source has empty data it should set empty map", func(t *testing.T) {
+		g := NewWithT(t)
+		source := &corev1.ConfigMap{Data: map[string]string{}}
+		dest := &corev1.ConfigMap{}
+
+		CopyConfigMap(dest, source)
+
+		g.Expect(dest.Data).To(BeEmpty())
+	})
+
+	t.Run("When source has nil data it should set empty map", func(t *testing.T) {
+		g := NewWithT(t)
+		source := &corev1.ConfigMap{}
+		dest := &corev1.ConfigMap{}
+
+		CopyConfigMap(dest, source)
+
+		g.Expect(dest.Data).To(BeEmpty())
+	})
+}
+
+func TestDeleteIfNeededWithOptions(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	t.Run("When object exists it should delete and return exists=true", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+
+		exists, err := DeleteIfNeededWithOptions(t.Context(), c, cm)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(exists).To(BeTrue())
+
+		err = c.Get(t.Context(), crclient.ObjectKeyFromObject(cm), &corev1.ConfigMap{})
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	})
+
+	t.Run("When object does not exist it should return exists=false without error", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "missing", Namespace: "default"}}
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		exists, err := DeleteIfNeededWithOptions(t.Context(), c, cm)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(exists).To(BeFalse())
+	})
+
+	t.Run("When object has a deletion timestamp it should return exists=true without deleting again", func(t *testing.T) {
+		g := NewWithT(t)
+		now := metav1.Now()
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Name: "deleting", Namespace: "default",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"test-finalizer"},
+		}}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+
+		exists, err := DeleteIfNeededWithOptions(t.Context(), c, cm)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(exists).To(BeTrue())
+	})
+
+	t.Run("When Get returns a non-NotFound error it should propagate the error", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}}
+		c := fake.NewClientBuilder().WithScheme(scheme).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(ctx context.Context, client crclient.WithWatch, key crclient.ObjectKey, obj crclient.Object, opts ...crclient.GetOption) error {
+					return fmt.Errorf("connection refused")
+				},
+			}).Build()
+
+		exists, err := DeleteIfNeededWithOptions(t.Context(), c, cm)
+		g.Expect(err).To(MatchError(ContainSubstring("connection refused")))
+		g.Expect(exists).To(BeFalse())
+	})
+
+	t.Run("When Delete returns NotFound due to race it should return exists=false", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(ctx context.Context, client crclient.WithWatch, obj crclient.Object, opts ...crclient.DeleteOption) error {
+					return apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "test")
+				},
+			}).Build()
+
+		exists, err := DeleteIfNeededWithOptions(t.Context(), c, cm)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(exists).To(BeFalse())
+	})
+
+	t.Run("When Delete returns a non-NotFound error it should propagate the error", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(ctx context.Context, client crclient.WithWatch, obj crclient.Object, opts ...crclient.DeleteOption) error {
+					return fmt.Errorf("forbidden")
+				},
+			}).Build()
+
+		exists, err := DeleteIfNeededWithOptions(t.Context(), c, cm)
+		g.Expect(err).To(MatchError(ContainSubstring("forbidden")))
+		g.Expect(exists).To(BeFalse())
+	})
+}
+
+func TestDeleteIfNeeded(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	t.Run("When object exists it should delete it", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+
+		exists, err := DeleteIfNeeded(t.Context(), c, cm)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(exists).To(BeTrue())
+	})
+
+	t.Run("When object does not exist it should return false", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "missing", Namespace: "default"}}
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		exists, err := DeleteIfNeeded(t.Context(), c, cm)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(exists).To(BeFalse())
+	})
+}
+
+func TestDeleteIfNeededWithPredicate(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	t.Run("When predicate returns true it should delete", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+
+		exists, err := DeleteIfNeededWithPredicate(t.Context(), c, cm, func(*corev1.ConfigMap) bool { return true })
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(exists).To(BeTrue())
+
+		err = c.Get(t.Context(), crclient.ObjectKeyFromObject(cm), &corev1.ConfigMap{})
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	})
+
+	t.Run("When predicate returns false it should not delete", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+
+		exists, err := DeleteIfNeededWithPredicate(t.Context(), c, cm, func(*corev1.ConfigMap) bool { return false })
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(exists).To(BeTrue())
+
+		err = c.Get(t.Context(), crclient.ObjectKeyFromObject(cm), &corev1.ConfigMap{})
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("When object does not exist it should return false", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "missing", Namespace: "default"}}
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		exists, err := DeleteIfNeededWithPredicate(t.Context(), c, cm, func(*corev1.ConfigMap) bool { return true })
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(exists).To(BeFalse())
+	})
+
+	t.Run("When object has a deletion timestamp it should return exists=true without deleting", func(t *testing.T) {
+		g := NewWithT(t)
+		now := metav1.Now()
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Name: "deleting", Namespace: "default",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"test-finalizer"},
+		}}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+
+		exists, err := DeleteIfNeededWithPredicate(t.Context(), c, cm, func(*corev1.ConfigMap) bool { return true })
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(exists).To(BeTrue())
+	})
+
+	t.Run("When Get returns a non-NotFound error it should propagate the error", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}}
+		c := fake.NewClientBuilder().WithScheme(scheme).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(ctx context.Context, client crclient.WithWatch, key crclient.ObjectKey, obj crclient.Object, opts ...crclient.GetOption) error {
+					return fmt.Errorf("connection refused")
+				},
+			}).Build()
+
+		exists, err := DeleteIfNeededWithPredicate(t.Context(), c, cm, func(*corev1.ConfigMap) bool { return true })
+		g.Expect(err).To(MatchError(ContainSubstring("connection refused")))
+		g.Expect(exists).To(BeFalse())
+	})
+
+	t.Run("When Delete returns NotFound due to race it should return exists=false", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(ctx context.Context, client crclient.WithWatch, obj crclient.Object, opts ...crclient.DeleteOption) error {
+					return apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "test")
+				},
+			}).Build()
+
+		exists, err := DeleteIfNeededWithPredicate(t.Context(), c, cm, func(*corev1.ConfigMap) bool { return true })
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(exists).To(BeFalse())
+	})
+
+	t.Run("When Delete returns a non-NotFound error it should propagate the error", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(ctx context.Context, client crclient.WithWatch, obj crclient.Object, opts ...crclient.DeleteOption) error {
+					return fmt.Errorf("forbidden")
+				},
+			}).Build()
+
+		exists, err := DeleteIfNeededWithPredicate(t.Context(), c, cm, func(*corev1.ConfigMap) bool { return true })
+		g.Expect(err).To(MatchError(ContainSubstring("forbidden")))
+		g.Expect(exists).To(BeFalse())
+	})
+}
+
+func TestDeleteAllIfNeeded(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	t.Run("When all objects exist it should delete them without error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		cm1 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm-1", Namespace: "default"}}
+		cm2 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm-2", Namespace: "default"}}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm1, cm2).Build()
+
+		err := DeleteAllIfNeeded(t.Context(), c, cm1, cm2)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		err = c.Get(t.Context(), crclient.ObjectKeyFromObject(cm1), &corev1.ConfigMap{})
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "cm1 should be deleted")
+		err = c.Get(t.Context(), crclient.ObjectKeyFromObject(cm2), &corev1.ConfigMap{})
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "cm2 should be deleted")
+	})
+
+	t.Run("When no objects are provided it should return nil", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		err := DeleteAllIfNeeded(t.Context(), c)
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("When an object does not exist it should not return an error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "nonexistent", Namespace: "default"}}
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		err := DeleteAllIfNeeded(t.Context(), c, cm)
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("When Get fails for multiple objects it should aggregate errors", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		cm1 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm-1", Namespace: "default"}}
+		cm2 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm-2", Namespace: "default"}}
+		c := fake.NewClientBuilder().WithScheme(scheme).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(ctx context.Context, client crclient.WithWatch, key crclient.ObjectKey, obj crclient.Object, opts ...crclient.GetOption) error {
+					return fmt.Errorf("api unavailable")
+				},
+			}).Build()
+
+		err := DeleteAllIfNeeded(t.Context(), c, cm1, cm2)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("api unavailable"))
+	})
+}
+
+func TestUpdateObject(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	t.Run("When mutation succeeds it should patch the object", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Data:       map[string]string{"key": "old"},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+
+		err := UpdateObject(t.Context(), c, cm, func() error {
+			cm.Data["key"] = "new"
+			return nil
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		updated := &corev1.ConfigMap{}
+		err = c.Get(t.Context(), crclient.ObjectKeyFromObject(cm), updated)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(updated.Data["key"]).To(Equal("new"))
+	})
+
+	t.Run("When mutate returns an error it should propagate the error", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Data:       map[string]string{"key": "old"},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+
+		err := UpdateObject(t.Context(), c, cm, func() error {
+			return fmt.Errorf("mutation failed")
+		})
+		g.Expect(err).To(MatchError(ContainSubstring("mutation failed")))
+
+		unchanged := &corev1.ConfigMap{}
+		err = c.Get(t.Context(), crclient.ObjectKeyFromObject(cm), unchanged)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(unchanged.Data["key"]).To(Equal("old"))
+	})
+
+	t.Run("When object does not exist it should return a not-found error", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "missing", Namespace: "default"},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		err := UpdateObject(t.Context(), c, cm, func() error {
+			return nil
+		})
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	})
+
+	t.Run("When patch returns a conflict it should retry and succeed", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Data:       map[string]string{"key": "old"},
+		}
+
+		var patchCalls atomic.Int32
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Patch: func(ctx context.Context, client crclient.WithWatch, obj crclient.Object, patch crclient.Patch, opts ...crclient.PatchOption) error {
+					if patchCalls.Add(1) == 1 {
+						return apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, "test", fmt.Errorf("conflict"))
+					}
+					return client.Patch(ctx, obj, patch, opts...)
+				},
+			}).Build()
+
+		err := UpdateObject(t.Context(), c, cm, func() error {
+			cm.Data["key"] = "new"
+			return nil
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(patchCalls.Load()).To(BeNumerically(">=", int32(2)))
+
+		updated := &corev1.ConfigMap{}
+		err = c.Get(t.Context(), crclient.ObjectKeyFromObject(cm), updated)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(updated.Data["key"]).To(Equal("new"))
+	})
+}
+
+func TestParseNodeSelector(t *testing.T) {
+	tests := []struct {
+		name string
+		str  string
+		want map[string]string
+	}{
+		{
+			name: "When input has multiple key=value pairs it should return all entries",
+			str:  "key1=value1,key2=value2,key3=value3",
+			want: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			},
+		},
+		{
+			name: "When entries have empty values it should skip them",
+			str:  "key1=,key2=value2,key3=",
+			want: map[string]string{
+				"key2": "value2",
+			},
+		},
+		{
+			name: "When entries have empty keys it should skip them",
+			str:  "=value1,key2=value2,=value3",
+			want: map[string]string{
+				"key2": "value2",
+			},
+		},
+		{
+			name: "When input is empty it should return nil",
+			str:  "",
+			want: nil,
+		},
+		{
+			name: "When entries lack an = separator it should skip them",
+			str:  "key1=value1,key2,key3=value3",
+			want: map[string]string{
+				"key1": "value1",
+				"key3": "value3",
+			},
+		},
+		{
+			name: "When values contain = characters it should preserve them",
+			str:  "key1=value1=one,key2,key3=value3=three",
+			want: map[string]string{
+				"key1": "value1=one",
+				"key3": "value3=three",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := ParseNodeSelector(tt.str)
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestApplyAWSLoadBalancerTargetNodesAnnotation(t *testing.T) {
+	t.Run("When platform is AWS and annotation is present it should set service annotation", func(t *testing.T) {
+		g := NewWithT(t)
+		svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+		hcp := &hyperv1.HostedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					hyperv1.AWSLoadBalancerTargetNodesAnnotation: "node.kubernetes.io/role=worker",
+				},
+			},
+			Spec: hyperv1.HostedControlPlaneSpec{
+				Platform: hyperv1.PlatformSpec{Type: hyperv1.AWSPlatform},
+			},
+		}
+
+		ApplyAWSLoadBalancerTargetNodesAnnotation(svc, hcp)
+		g.Expect(svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-target-node-labels"]).To(Equal("node.kubernetes.io/role=worker"))
+	})
+
+	t.Run("When platform is not AWS it should not modify annotations", func(t *testing.T) {
+		g := NewWithT(t)
+		svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+		hcp := &hyperv1.HostedControlPlane{
+			Spec: hyperv1.HostedControlPlaneSpec{
+				Platform: hyperv1.PlatformSpec{Type: hyperv1.AzurePlatform},
+			},
+		}
+
+		ApplyAWSLoadBalancerTargetNodesAnnotation(svc, hcp)
+		g.Expect(svc.Annotations).To(BeNil())
+	})
+
+	t.Run("When platform is AWS but annotation is absent it should not set service annotation", func(t *testing.T) {
+		g := NewWithT(t)
+		svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+		hcp := &hyperv1.HostedControlPlane{
+			Spec: hyperv1.HostedControlPlaneSpec{
+				Platform: hyperv1.PlatformSpec{Type: hyperv1.AWSPlatform},
+			},
+		}
+
+		ApplyAWSLoadBalancerTargetNodesAnnotation(svc, hcp)
+		g.Expect(svc.Annotations).ToNot(HaveKey("service.beta.kubernetes.io/aws-load-balancer-target-node-labels"))
+	})
+}

--- a/support/k8sutil/ownerref.go
+++ b/support/k8sutil/ownerref.go
@@ -1,4 +1,4 @@
-package util
+package k8sutil
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/support/k8sutil/ownerref_test.go
+++ b/support/k8sutil/ownerref_test.go
@@ -1,0 +1,78 @@
+package k8sutil
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestEnsureOwnerRef(t *testing.T) {
+	t.Run("When no owner refs exist it should add the new one", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+		ref := &metav1.OwnerReference{
+			APIVersion: "v1",
+			Kind:       "Namespace",
+			Name:       "default",
+			UID:        types.UID("abc"),
+		}
+
+		EnsureOwnerRef(cm, ref)
+		g.Expect(cm.GetOwnerReferences()).To(HaveLen(1))
+		g.Expect(cm.GetOwnerReferences()[0].Name).To(Equal("default"))
+	})
+
+	t.Run("When matching owner ref exists it should update it", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				OwnerReferences: []metav1.OwnerReference{
+					{APIVersion: "v1", Kind: "Namespace", Name: "default", UID: types.UID("abc")},
+				},
+			},
+		}
+		ref := &metav1.OwnerReference{
+			APIVersion: "v1",
+			Kind:       "Namespace",
+			Name:       "default",
+			UID:        types.UID("abc"),
+			Controller: boolPtr(true),
+		}
+
+		EnsureOwnerRef(cm, ref)
+		g.Expect(cm.GetOwnerReferences()).To(HaveLen(1))
+		g.Expect(*cm.GetOwnerReferences()[0].Controller).To(BeTrue())
+	})
+
+	t.Run("When ownerRef is nil it should be a no-op", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+
+		EnsureOwnerRef(cm, nil)
+		g.Expect(cm.GetOwnerReferences()).To(BeEmpty())
+	})
+
+	t.Run("When owner ref is idempotent it should not duplicate", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+		ref := &metav1.OwnerReference{
+			APIVersion: "v1",
+			Kind:       "Namespace",
+			Name:       "default",
+			UID:        types.UID("abc"),
+		}
+
+		EnsureOwnerRef(cm, ref)
+		EnsureOwnerRef(cm, ref)
+		g.Expect(cm.GetOwnerReferences()).To(HaveLen(1))
+	})
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/support/k8sutil/resources.go
+++ b/support/k8sutil/resources.go
@@ -1,4 +1,4 @@
-package util
+package k8sutil
 
 import (
 	"strings"
@@ -118,7 +118,7 @@ func GetNodePoolManagedResources(platformsInstalled string) []client.Object {
 
 	platformsInstalledList := strings.Split(platformsInstalled, ",")
 	for _, platform := range platformsInstalledList {
-		platform = strings.ToLower(strings.TrimSpace(platform))
+		platform = strings.TrimSpace(platform)
 		switch {
 		case strings.EqualFold(platform, string(hyperv1.AWSPlatform)):
 			managedResources = append(managedResources, AWSNodePoolResources...)

--- a/support/k8sutil/resources_test.go
+++ b/support/k8sutil/resources_test.go
@@ -1,90 +1,86 @@
-package util
+package k8sutil
 
 import (
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestGetHostedClusterManagedResources(t *testing.T) {
-	testCases := []struct {
+	tests := []struct {
 		name               string
 		platformsInstalled string
 		expectedObjectsSet sets.Set[client.Object]
 	}{
 		{
-			name:               "when no platforms are installed, expect no resources",
+			name:               "When no platforms are installed it should return no resources",
 			platformsInstalled: "",
 			expectedObjectsSet: sets.Set[client.Object]{},
 		},
 		{
-			name:               "when only the None platform is installed, expect no resources",
+			name:               "When only the None platform is installed it should return no resources",
 			platformsInstalled: "None",
 			expectedObjectsSet: sets.Set[client.Object]{},
 		},
 		{
-			name:               "when only the AWS platform is installed, expect only AWS resources",
+			name:               "When only the AWS platform is installed it should return only AWS resources",
 			platformsInstalled: "AWS",
 			expectedObjectsSet: sets.New[client.Object](append(BaseResources, AWSResources...)...),
 		},
 		{
-			name:               "when the Azure and AWS platforms are installed, expect only Azure and AWS resources",
-			platformsInstalled: "azure,AWS", // testing case insensitivity here
+			name:               "When the Azure and AWS platforms are installed it should return both resource sets",
+			platformsInstalled: "azure,AWS",
 			expectedObjectsSet: sets.New[client.Object](
 				append(append(BaseResources, AWSResources...), AzureResources...)...,
 			),
 		},
 	}
 
-	for _, tc := range testCases {
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			g := NewWithT(t)
 			actualObjects := GetHostedClusterManagedResources(tc.platformsInstalled)
 			actualObjectSet := sets.New[client.Object](actualObjects...)
-
-			if diff := cmp.Diff(actualObjectSet, tc.expectedObjectsSet); diff != "" {
-				t.Errorf("the set of managed resources did not match expected set of managed resources: %s", diff)
-			}
+			g.Expect(actualObjectSet).To(Equal(tc.expectedObjectsSet))
 		})
 	}
 }
 
 func TestGetNodePoolManagedResources(t *testing.T) {
-	testCases := []struct {
+	tests := []struct {
 		name               string
 		platformsInstalled string
 		expectedObjectsSet sets.Set[client.Object]
 	}{
 		{
-			name:               "when no platforms are installed, expect no resources",
+			name:               "When no platforms are installed it should return no resources",
 			platformsInstalled: "",
 			expectedObjectsSet: sets.Set[client.Object]{},
 		},
 		{
-			name:               "when only the AWS platform is installed, expect only AWS NodePool resources",
+			name:               "When only the AWS platform is installed it should return only AWS NodePool resources",
 			platformsInstalled: "AWS",
 			expectedObjectsSet: sets.New[client.Object](AWSNodePoolResources...),
 		},
 		{
-			name:               "when the Azure platform is installed, expect only Azure NodePool resources",
-			platformsInstalled: "azure", // testing case insensitivity here
+			name:               "When the Azure platform is installed it should return only Azure NodePool resources",
+			platformsInstalled: "azure",
 			expectedObjectsSet: sets.New[client.Object](AzureNodePoolResources...),
 		},
 	}
 
-	for _, tc := range testCases {
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			g := NewWithT(t)
 			actualObjects := GetNodePoolManagedResources(tc.platformsInstalled)
 			actualObjectSet := sets.New[client.Object](actualObjects...)
-
-			if diff := cmp.Diff(actualObjectSet, tc.expectedObjectsSet); diff != "" {
-				t.Errorf("the set of managed resources did not match expected set of managed resources: %s", diff)
-			}
+			g.Expect(actualObjectSet).To(Equal(tc.expectedObjectsSet))
 		})
 	}
 }

--- a/support/k8sutil/serializer.go
+++ b/support/k8sutil/serializer.go
@@ -1,4 +1,4 @@
-package util
+package k8sutil
 
 import (
 	"bytes"
@@ -15,7 +15,10 @@ func DeserializeResource(data string, resource runtime.Object, objectTyper runti
 		return fmt.Errorf("cannot determine GVK of resource of type %T: %w", resource, err)
 	}
 	_, _, err = hyperapi.YamlSerializer.Decode([]byte(data), &gvks[0], resource)
-	return err
+	if err != nil {
+		return fmt.Errorf("failed to decode resource: %w", err)
+	}
+	return nil
 }
 
 func SerializeResource(resource runtime.Object, objectTyper runtime.ObjectTyper) (string, error) {
@@ -26,7 +29,7 @@ func SerializeResource(resource runtime.Object, objectTyper runtime.ObjectTyper)
 	}
 	resource.GetObjectKind().SetGroupVersionKind(gvks[0])
 	if err = hyperapi.YamlSerializer.Encode(resource, out); err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to encode resource: %w", err)
 	}
 	return out.String(), nil
 }

--- a/support/k8sutil/serializer_test.go
+++ b/support/k8sutil/serializer_test.go
@@ -1,0 +1,72 @@
+package k8sutil
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperapi "github.com/openshift/hypershift/support/api"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestSerializeDeserializeRoundTrip(t *testing.T) {
+	t.Run("When serializing and deserializing a ConfigMap it should round-trip", func(t *testing.T) {
+		g := NewWithT(t)
+		original := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Data:       map[string]string{"key": "value"},
+		}
+
+		data, err := SerializeResource(original, hyperapi.Scheme)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(data).ToNot(BeEmpty())
+
+		restored := &corev1.ConfigMap{}
+		err = DeserializeResource(data, restored, hyperapi.Scheme)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(restored.Name).To(Equal("test"))
+		g.Expect(restored.Data["key"]).To(Equal("value"))
+	})
+}
+
+func TestSerializeResource(t *testing.T) {
+	t.Run("When resource is valid it should produce YAML output", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		}
+
+		data, err := SerializeResource(cm, hyperapi.Scheme)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(data).To(ContainSubstring("kind: ConfigMap"))
+		g.Expect(data).To(ContainSubstring("name: test"))
+	})
+
+	t.Run("When resource type is unregistered it should return a GVK error", func(t *testing.T) {
+		g := NewWithT(t)
+		emptyScheme := runtime.NewScheme()
+		cm := &corev1.ConfigMap{}
+		_, err := SerializeResource(cm, emptyScheme)
+		g.Expect(err).To(MatchError(ContainSubstring("cannot determine GVK")))
+	})
+}
+
+func TestDeserializeResource(t *testing.T) {
+	t.Run("When YAML is invalid it should return an error", func(t *testing.T) {
+		g := NewWithT(t)
+		cm := &corev1.ConfigMap{}
+		err := DeserializeResource("not valid yaml: {{{", cm, hyperapi.Scheme)
+		g.Expect(err).To(HaveOccurred())
+	})
+
+	t.Run("When resource type is unregistered it should return a GVK error", func(t *testing.T) {
+		g := NewWithT(t)
+		emptyScheme := runtime.NewScheme()
+		cm := &corev1.ConfigMap{}
+		err := DeserializeResource("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: test", cm, emptyScheme)
+		g.Expect(err).To(MatchError(ContainSubstring("cannot determine GVK")))
+	})
+}

--- a/support/k8sutil/service.go
+++ b/support/k8sutil/service.go
@@ -1,4 +1,4 @@
-package util
+package k8sutil
 
 import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"

--- a/support/k8sutil/service_test.go
+++ b/support/k8sutil/service_test.go
@@ -1,7 +1,9 @@
-package util
+package k8sutil
 
 import (
 	"testing"
+
+	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 
@@ -18,6 +20,12 @@ func TestExtractLoadBalancerIP(t *testing.T) {
 		wantIP string
 		wantOK bool
 	}{
+		{
+			name:   "When service is nil it should return empty and false",
+			svc:    nil,
+			wantIP: "",
+			wantOK: false,
+		},
 		{
 			name: "When service has a valid ingress IP it should return the IP and true",
 			svc: &corev1.Service{
@@ -79,9 +87,10 @@ func TestExtractLoadBalancerIP(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got, ok := ExtractLoadBalancerIP(tt.svc); got != tt.wantIP || ok != tt.wantOK {
-				t.Errorf("ExtractLoadBalancerIP() = (%q, %v), want (%q, %v)", got, ok, tt.wantIP, tt.wantOK)
-			}
+			g := NewWithT(t)
+			gotIP, gotOK := ExtractLoadBalancerIP(tt.svc)
+			g.Expect(gotIP).To(Equal(tt.wantIP))
+			g.Expect(gotOK).To(Equal(tt.wantOK))
 		})
 	}
 }
@@ -163,9 +172,8 @@ func TestExtractHostedControlPlaneOwnerName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := ExtractHostedControlPlaneOwnerName(tt.ownerRefs); got != tt.want {
-				t.Errorf("ExtractHostedControlPlaneOwnerName() = %q, want %q", got, tt.want)
-			}
+			g := NewWithT(t)
+			g.Expect(ExtractHostedControlPlaneOwnerName(tt.ownerRefs)).To(Equal(tt.want))
 		})
 	}
 }

--- a/support/k8sutil/services.go
+++ b/support/k8sutil/services.go
@@ -1,4 +1,4 @@
-package util
+package k8sutil
 
 import (
 	"fmt"

--- a/support/k8sutil/services_test.go
+++ b/support/k8sutil/services_test.go
@@ -1,0 +1,74 @@
+package k8sutil
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type fakeMessageCollector struct {
+	messages []string
+	err      error
+}
+
+func (f *fakeMessageCollector) ErrorMessages(_ client.Object) ([]string, error) {
+	return f.messages, f.err
+}
+
+func TestCollectLBMessageIfNotProvisioned(t *testing.T) {
+	t.Run("When load balancer is provisioned it should return empty string", func(t *testing.T) {
+		g := NewWithT(t)
+		svc := &corev1.Service{
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.1"}},
+				},
+			},
+		}
+
+		msg, err := CollectLBMessageIfNotProvisioned(svc, &fakeMessageCollector{})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(msg).To(BeEmpty())
+	})
+
+	t.Run("When load balancer is not provisioned and no events it should return default message", func(t *testing.T) {
+		g := NewWithT(t)
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-svc"},
+		}
+
+		msg, err := CollectLBMessageIfNotProvisioned(svc, &fakeMessageCollector{})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(msg).To(ContainSubstring("my-svc load balancer is not provisioned"))
+	})
+
+	t.Run("When load balancer is not provisioned and events exist it should include event messages", func(t *testing.T) {
+		g := NewWithT(t)
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-svc"},
+		}
+		collector := &fakeMessageCollector{messages: []string{"quota exceeded"}}
+
+		msg, err := CollectLBMessageIfNotProvisioned(svc, collector)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(msg).To(ContainSubstring("quota exceeded"))
+	})
+
+	t.Run("When message collector returns an error it should return the error with a default message", func(t *testing.T) {
+		g := NewWithT(t)
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-svc"},
+		}
+		collector := &fakeMessageCollector{err: fmt.Errorf("event list failed")}
+
+		msg, err := CollectLBMessageIfNotProvisioned(svc, collector)
+		g.Expect(err).To(MatchError(ContainSubstring("event list failed")))
+		g.Expect(msg).To(ContainSubstring("my-svc load balancer is not provisioned"))
+	})
+}

--- a/support/k8sutil/svcaccounts.go
+++ b/support/k8sutil/svcaccounts.go
@@ -1,4 +1,4 @@
-package util
+package k8sutil
 
 import (
 	"context"
@@ -9,7 +9,13 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
+
+type ServiceAccountTokenCreator interface {
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.ServiceAccount, error)
+	CreateToken(ctx context.Context, name string, tokenRequest *authenticationv1.TokenRequest, opts metav1.CreateOptions) (*authenticationv1.TokenRequest, error)
+}
 
 func EnsurePullSecret(serviceAccount *corev1.ServiceAccount, secretName string) {
 	for _, secretRef := range serviceAccount.ImagePullSecrets {
@@ -23,8 +29,15 @@ func EnsurePullSecret(serviceAccount *corev1.ServiceAccount, secretName string) 
 	})
 }
 
-func CreateTokenForServiceAccount(ctx context.Context, serviceAccount *corev1.ServiceAccount, client *kubernetes.Clientset) (string, error) {
-	serviceAccount, err := client.CoreV1().ServiceAccounts(serviceAccount.Namespace).Get(ctx, serviceAccount.Name, metav1.GetOptions{})
+func ServiceAccountClient(client kubernetes.Interface, namespace string) corev1client.ServiceAccountInterface {
+	return client.CoreV1().ServiceAccounts(namespace)
+}
+
+func CreateTokenForServiceAccount(ctx context.Context, serviceAccount *corev1.ServiceAccount, saClient ServiceAccountTokenCreator) (string, error) {
+	if serviceAccount == nil {
+		return "", fmt.Errorf("serviceaccount is nil")
+	}
+	serviceAccount, err := saClient.Get(ctx, serviceAccount.Name, metav1.GetOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return "", fmt.Errorf("failed to get serviceaccount: %w", err)
@@ -38,8 +51,7 @@ func CreateTokenForServiceAccount(ctx context.Context, serviceAccount *corev1.Se
 		},
 	}
 
-	// Create the service account token
-	token, err := client.CoreV1().ServiceAccounts(serviceAccount.Namespace).CreateToken(ctx, serviceAccount.Name, treq, metav1.CreateOptions{})
+	token, err := saClient.CreateToken(ctx, serviceAccount.Name, treq, metav1.CreateOptions{})
 	if err != nil {
 		return "", fmt.Errorf("failed to create token: %w", err)
 	}

--- a/support/k8sutil/svcaccounts_test.go
+++ b/support/k8sutil/svcaccounts_test.go
@@ -1,0 +1,126 @@
+package k8sutil
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestEnsurePullSecret(t *testing.T) {
+	t.Run("When secret is not present it should add it", func(t *testing.T) {
+		g := NewWithT(t)
+		sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+
+		EnsurePullSecret(sa, "my-secret")
+		g.Expect(sa.ImagePullSecrets).To(HaveLen(1))
+		g.Expect(sa.ImagePullSecrets[0].Name).To(Equal("my-secret"))
+	})
+
+	t.Run("When secret is already present it should not duplicate", func(t *testing.T) {
+		g := NewWithT(t)
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			ImagePullSecrets: []corev1.LocalObjectReference{
+				{Name: "my-secret"},
+			},
+		}
+
+		EnsurePullSecret(sa, "my-secret")
+		g.Expect(sa.ImagePullSecrets).To(HaveLen(1))
+	})
+
+	t.Run("When adding a different secret it should append", func(t *testing.T) {
+		g := NewWithT(t)
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			ImagePullSecrets: []corev1.LocalObjectReference{
+				{Name: "existing-secret"},
+			},
+		}
+
+		EnsurePullSecret(sa, "new-secret")
+		g.Expect(sa.ImagePullSecrets).To(HaveLen(2))
+	})
+}
+
+type mockSAClient struct {
+	sa       *corev1.ServiceAccount
+	getErr   error
+	token    *authenticationv1.TokenRequest
+	tokenErr error
+}
+
+func (m *mockSAClient) Get(_ context.Context, _ string, _ metav1.GetOptions) (*corev1.ServiceAccount, error) {
+	return m.sa, m.getErr
+}
+
+func (m *mockSAClient) CreateToken(_ context.Context, _ string, _ *authenticationv1.TokenRequest, _ metav1.CreateOptions) (*authenticationv1.TokenRequest, error) {
+	return m.token, m.tokenErr
+}
+
+func TestCreateTokenForServiceAccount(t *testing.T) {
+	t.Run("When service account is nil it should return an error", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := CreateTokenForServiceAccount(t.Context(), nil, &mockSAClient{})
+		g.Expect(err).To(MatchError(ContainSubstring("serviceaccount is nil")))
+	})
+
+	t.Run("When service account exists and token creation succeeds it should return the token", func(t *testing.T) {
+		g := NewWithT(t)
+		sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "test-sa", Namespace: "default"}}
+		client := &mockSAClient{
+			sa: sa,
+			token: &authenticationv1.TokenRequest{
+				Status: authenticationv1.TokenRequestStatus{Token: "my-token-value"},
+			},
+		}
+
+		token, err := CreateTokenForServiceAccount(t.Context(), sa, client)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(token).To(Equal("my-token-value"))
+	})
+
+	t.Run("When service account is not found it should return a not-found error", func(t *testing.T) {
+		g := NewWithT(t)
+		sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "missing-sa", Namespace: "default"}}
+		client := &mockSAClient{
+			getErr: apierrors.NewNotFound(schema.GroupResource{Resource: "serviceaccounts"}, "missing-sa"),
+		}
+
+		_, err := CreateTokenForServiceAccount(t.Context(), sa, client)
+		g.Expect(err).To(MatchError(ContainSubstring("serviceaccount not found")))
+	})
+
+	t.Run("When Get returns a non-NotFound error it should propagate the error", func(t *testing.T) {
+		g := NewWithT(t)
+		sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "test-sa", Namespace: "default"}}
+		client := &mockSAClient{
+			getErr: fmt.Errorf("connection refused"),
+		}
+
+		_, err := CreateTokenForServiceAccount(t.Context(), sa, client)
+		g.Expect(err).To(MatchError(ContainSubstring("failed to get serviceaccount")))
+		g.Expect(err).To(MatchError(ContainSubstring("connection refused")))
+	})
+
+	t.Run("When token creation fails it should return a token error", func(t *testing.T) {
+		g := NewWithT(t)
+		sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "test-sa", Namespace: "default"}}
+		client := &mockSAClient{
+			sa:       sa,
+			tokenErr: fmt.Errorf("token request denied"),
+		}
+
+		_, err := CreateTokenForServiceAccount(t.Context(), sa, client)
+		g.Expect(err).To(MatchError(ContainSubstring("failed to create token")))
+		g.Expect(err).To(MatchError(ContainSubstring("token request denied")))
+	})
+}

--- a/support/upsert/apply.go
+++ b/support/upsert/apply.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"maps"
 
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/netutil"
-	"github.com/openshift/hypershift/support/util"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -81,14 +81,14 @@ func (p *applyProvider) ApplyManifest(ctx context.Context, c crclient.Client, ob
 		switch typedObj := obj.(type) {
 		case *batchv1.Job:
 			existingTyped := existing.(*batchv1.Job)
-			failed := util.FindJobCondition(existingTyped, batchv1.JobFailed)
+			failed := k8sutil.FindJobCondition(existingTyped, batchv1.JobFailed)
 			if failed == nil || failed.Status == corev1.ConditionFalse {
 				if equality.Semantic.DeepDerivative(typedObj.Spec, existingTyped.Spec) {
 					return controllerutil.OperationResultNone, nil
 				}
 			}
 			// Delete the job if it has failed or it needs to be updated
-			_, err := util.DeleteIfNeededWithOptions(ctx, c, obj, crclient.PropagationPolicy(metav1.DeletePropagationForeground))
+			_, err := k8sutil.DeleteIfNeededWithOptions(ctx, c, obj, crclient.PropagationPolicy(metav1.DeletePropagationForeground))
 			return controllerutil.OperationResultNone, err
 		}
 	}

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -7,7 +7,6 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"hash/fnv"
 	"io"
@@ -20,36 +19,19 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	cmdutil "github.com/openshift/hypershift/cmd/util"
 	controlplaneoperatoroverrides "github.com/openshift/hypershift/hypershift-operator/controlplaneoperator-overrides"
+	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	kubeclient "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/util/retry"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/blang/semver"
 	ignitionapi "github.com/coreos/ignition/v2/config/v3_2/types"
-)
-
-const (
-	// DebugDeploymentsAnnotation contains a comma separated list of deployment names which should always be scaled to 0
-	// for development.
-	DebugDeploymentsAnnotation               = "hypershift.openshift.io/debug-deployments"
-	EnableHostedClustersAnnotationScopingEnv = "ENABLE_HOSTEDCLUSTERS_ANNOTATION_SCOPING"
-	HostedClustersScopeAnnotationEnv         = "HOSTEDCLUSTERS_SCOPE_ANNOTATION"
-	HostedClustersScopeAnnotation            = "hypershift.openshift.io/scope"
-	HostedClusterAnnotation                  = "hypershift.openshift.io/cluster"
-
-	// GCPLabelCluster is the GCP resource label key used to identify the HostedCluster name.
-	GCPLabelCluster = "hypershift-openshift-io-cluster"
-	// GCPLabelInfraID is the GCP resource label key used to identify the infrastructure ID.
-	GCPLabelInfraID = "hypershift-openshift-io-infra-id"
 )
 
 type JSONMapper func(jsonData []byte) []byte
@@ -74,90 +56,6 @@ func ParseNamespacedName(name string) types.NamespacedName {
 		return types.NamespacedName{Namespace: parts[0], Name: parts[1]}
 	}
 	return types.NamespacedName{Name: parts[0]}
-}
-
-// CopyConfigMap copies the .Data field of configMap `source` into configmap `cm`
-func CopyConfigMap(cm, source *corev1.ConfigMap) {
-	cm.Data = map[string]string{}
-	for k, v := range source.Data {
-		cm.Data[k] = v
-	}
-}
-
-func UpdateObject[T client.Object](ctx context.Context, c client.Client, obj T, mutate func() error) error {
-	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
-			return err
-		}
-
-		original := obj.DeepCopyObject().(T)
-		if err := mutate(); err != nil {
-			return err
-		}
-
-		return c.Patch(ctx, obj, client.MergeFrom(original))
-	})
-}
-
-func DeleteIfNeededWithOptions(ctx context.Context, c client.Client, o client.Object, opts ...client.DeleteOption) (exists bool, err error) {
-	if err := c.Get(ctx, client.ObjectKeyFromObject(o), o); err != nil {
-		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
-			return false, nil
-		}
-		return false, fmt.Errorf("error getting %T: %w", o, err)
-	}
-	if o.GetDeletionTimestamp() != nil {
-		return true, nil
-	}
-	if err := c.Delete(ctx, o, opts...); err != nil {
-		if apierrors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, fmt.Errorf("error deleting %T: %w", o, err)
-	}
-
-	return true, nil
-}
-
-func DeleteIfNeededWithPredicate[T client.Object](ctx context.Context, c client.Client, o T, predicate func(T) bool) (exists bool, err error) {
-	if err := c.Get(ctx, client.ObjectKeyFromObject(o), o); err != nil {
-		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
-			return false, nil
-		}
-		return false, fmt.Errorf("error getting %T: %w", o, err)
-	}
-	if o.GetDeletionTimestamp() != nil {
-		return true, nil
-	}
-	if !predicate(o) {
-		return true, nil
-	}
-	if err := c.Delete(ctx, o); err != nil {
-		if apierrors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, fmt.Errorf("error deleting %T: %w", o, err)
-	}
-
-	return true, nil
-}
-
-func DeleteAllIfNeeded(ctx context.Context, c client.Client, o ...client.Object) error {
-	errs := []error{}
-	for _, obj := range o {
-		_, err := DeleteIfNeededWithOptions(ctx, c, obj)
-		if err != nil {
-			errs = append(errs, err)
-		}
-	}
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-	return nil
-}
-
-func DeleteIfNeeded(ctx context.Context, c client.Client, o client.Object) (exists bool, err error) {
-	return DeleteIfNeededWithOptions(ctx, c, o)
 }
 
 func HCControlPlaneReleaseImage(hcluster *hyperv1.HostedCluster) string {
@@ -394,39 +292,6 @@ func ConvertImageRegistryOverrideStringToMap(envVar string) map[string][]string 
 	return imageRegistryOverrides
 }
 
-// ParseNodeSelector parses a comma separated string of key=value pairs into a map
-func ParseNodeSelector(str string) map[string]string {
-	if len(str) == 0 {
-		return nil
-	}
-	parts := strings.Split(str, ",")
-	result := make(map[string]string)
-	for _, part := range parts {
-		kv := strings.SplitN(part, "=", 2)
-		if len(kv) != 2 {
-			continue
-		}
-		if len(kv[0]) == 0 || len(kv[1]) == 0 {
-			continue
-		}
-		result[kv[0]] = kv[1]
-	}
-	return result
-}
-
-func ApplyAWSLoadBalancerTargetNodesAnnotation(svc *corev1.Service, hcp *hyperv1.HostedControlPlane) {
-	if hcp.Spec.Platform.Type != hyperv1.AWSPlatform {
-		return
-	}
-	if svc.Annotations == nil {
-		svc.Annotations = make(map[string]string)
-	}
-	selectors, ok := hcp.Annotations[hyperv1.AWSLoadBalancerTargetNodesAnnotation]
-	if ok {
-		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-target-node-labels"] = selectors
-	}
-}
-
 func GetKubeClientSet() (kubeclient.Interface, error) {
 	cfg, err := cmdutil.GetConfig()
 	if err != nil {
@@ -508,8 +373,8 @@ func getImageArchitecture(ctx context.Context, image string, pullSecretBytes []b
 // default behavior is to accept all events for hostedclusters that do not have the annotation.
 // The ENABLE_HOSTEDCLUSTERS_ANNOTATION_SCOPING env var must also be set to "true" to enable the scoping feature.
 func PredicatesForHostedClusterAnnotationScoping(r client.Reader) predicate.Predicate {
-	hcAnnotationScopingEnabledEnvVal := os.Getenv(EnableHostedClustersAnnotationScopingEnv)
-	hcScopeAnnotationEnvVal := os.Getenv(HostedClustersScopeAnnotationEnv)
+	hcAnnotationScopingEnabledEnvVal := os.Getenv(k8sutil.EnableHostedClustersAnnotationScopingEnv)
+	hcScopeAnnotationEnvVal := os.Getenv(k8sutil.HostedClustersScopeAnnotationEnv)
 	filter := func(obj client.Object) bool {
 		if hcAnnotationScopingEnabledEnvVal != "true" {
 			return true // process event; the scoping feature has not been enabled via the ENABLE_HOSTEDCLUSTERS_ANNOTATION_SCOPING env var
@@ -535,14 +400,14 @@ func getHostedClusterScopeAnnotation(obj client.Object, r client.Reader) string 
 	switch obj := obj.(type) {
 	case *hyperv1.HostedCluster:
 		if obj.GetAnnotations() != nil {
-			return obj.GetAnnotations()[HostedClustersScopeAnnotation]
+			return obj.GetAnnotations()[k8sutil.HostedClustersScopeAnnotation]
 		}
 	case *hyperv1.NodePool:
 		hostedClusterName = fmt.Sprintf("%s/%s", obj.Namespace, obj.Spec.ClusterName)
 	default:
 		if obj.GetAnnotations() != nil {
 			nodePoolName = obj.GetAnnotations()["hypershift.openshift.io/nodePool"]
-			hostedClusterName = obj.GetAnnotations()[HostedClusterAnnotation]
+			hostedClusterName = obj.GetAnnotations()[k8sutil.HostedClusterAnnotation]
 		}
 		if nodePoolName != "" {
 			namespacedName := ParseNamespacedName(nodePoolName)
@@ -564,7 +429,7 @@ func getHostedClusterScopeAnnotation(obj client.Object, r client.Reader) string 
 		return ""
 	}
 	if hcluster.GetAnnotations() != nil {
-		return hcluster.GetAnnotations()[HostedClustersScopeAnnotation]
+		return hcluster.GetAnnotations()[k8sutil.HostedClustersScopeAnnotation]
 	}
 	return ""
 }

--- a/support/util/util_test.go
+++ b/support/util/util_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/openshift/hypershift/support/api"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	apiversion "k8s.io/apimachinery/pkg/version"
@@ -262,66 +261,6 @@ func testDecompressFuncErr(t *testing.T, payload []byte) {
 	g.Expect(out).ToNot(BeNil(), "should return an initialized bytes.Buffer")
 	g.Expect(out.Bytes()).To(BeNil(), "should be a nil byte slice")
 	g.Expect(out.String()).To(BeEmpty(), "should be an empty string")
-}
-
-func TestParseNodeSelector(t *testing.T) {
-	tests := []struct {
-		name string
-		str  string
-		want map[string]string
-	}{
-		{
-			name: "Given a valid node selector string, it should return a map of key value pairs",
-			str:  "key1=value1,key2=value2,key3=value3",
-			want: map[string]string{
-				"key1": "value1",
-				"key2": "value2",
-				"key3": "value3",
-			},
-		},
-		{
-			name: "Given a valid node selector string with empty values, it should return a map of key value pairs",
-			str:  "key1=,key2=value2,key3=",
-			want: map[string]string{
-				"key2": "value2",
-			},
-		},
-		{
-			name: "Given a valid node selector string with empty keys, it should return a map of key value pairs",
-			str:  "=value1,key2=value2,=value3",
-			want: map[string]string{
-				"key2": "value2",
-			},
-		},
-		{
-			name: "Given a valid node selector string with empty string, it should return an empty map",
-			str:  "",
-			want: nil,
-		},
-		{
-			name: "Given a valid node selector string with invalid key value pairs, it should return a map of key value pairs",
-			str:  "key1=value1,key2,key3=value3",
-			want: map[string]string{
-				"key1": "value1",
-				"key3": "value3",
-			},
-		},
-		{
-			name: "Given a valid node selector string with values that include =, it should return a map of key value pairs",
-			str:  "key1=value1=one,key2,key3=value3=three",
-			want: map[string]string{
-				"key1": "value1=one",
-				"key3": "value3=three",
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := NewWithT(t)
-			got := ParseNodeSelector(tt.str)
-			g.Expect(got).To(Equal(tt.want))
-		})
-	}
 }
 
 func TestSanitizeIgnitionPayload(t *testing.T) {
@@ -852,41 +791,4 @@ func TestCountAvailableNodes(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestDeleteAllIfNeeded(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-
-	t.Run("When all objects exist it should delete them without error", func(t *testing.T) {
-		g := NewGomegaWithT(t)
-		cm1 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm-1", Namespace: "default"}}
-		cm2 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm-2", Namespace: "default"}}
-		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm1, cm2).Build()
-
-		err := DeleteAllIfNeeded(context.Background(), c, cm1, cm2)
-		g.Expect(err).ToNot(HaveOccurred())
-
-		err = c.Get(context.Background(), crclient.ObjectKeyFromObject(cm1), &corev1.ConfigMap{})
-		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "cm1 should be deleted")
-		err = c.Get(context.Background(), crclient.ObjectKeyFromObject(cm2), &corev1.ConfigMap{})
-		g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "cm2 should be deleted")
-	})
-
-	t.Run("When no objects are provided it should return nil", func(t *testing.T) {
-		g := NewGomegaWithT(t)
-		c := fake.NewClientBuilder().WithScheme(scheme).Build()
-
-		err := DeleteAllIfNeeded(context.Background(), c)
-		g.Expect(err).ToNot(HaveOccurred())
-	})
-
-	t.Run("When an object does not exist it should not return an error", func(t *testing.T) {
-		g := NewGomegaWithT(t)
-		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "nonexistent", Namespace: "default"}}
-		c := fake.NewClientBuilder().WithScheme(scheme).Build()
-
-		err := DeleteAllIfNeeded(context.Background(), c, cm)
-		g.Expect(err).ToNot(HaveOccurred())
-	})
 }

--- a/test/e2e/util/cilium.go
+++ b/test/e2e/util/cilium.go
@@ -13,7 +13,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/assets"
 	"github.com/openshift/hypershift/support/azureutil"
-	hyperutil "github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	configv1 "github.com/openshift/api/config/v1"
 	securityv1 "github.com/openshift/api/security/v1"
@@ -530,7 +530,7 @@ func CleanupCiliumConnectivityTestResources(ctx context.Context, t *testing.T, g
 			Name: "cilium-test",
 		},
 	}
-	if _, err := hyperutil.DeleteIfNeeded(ctx, guestClient, scc); err != nil {
+	if _, err := k8sutil.DeleteIfNeeded(ctx, guestClient, scc); err != nil {
 		t.Logf("Warning: failed to delete SCC: %v", err)
 	}
 
@@ -540,7 +540,7 @@ func CleanupCiliumConnectivityTestResources(ctx context.Context, t *testing.T, g
 			Name: ciliumTestNamespace,
 		},
 	}
-	if _, err := hyperutil.DeleteIfNeeded(ctx, guestClient, ns); err != nil {
+	if _, err := k8sutil.DeleteIfNeeded(ctx, guestClient, ns); err != nil {
 		t.Logf("Warning: failed to delete namespace: %v", err)
 	}
 

--- a/test/e2e/util/reqserving/setup.go
+++ b/test/e2e/util/reqserving/setup.go
@@ -17,7 +17,7 @@ import (
 	scheduleraws "github.com/openshift/hypershift/hypershift-operator/controllers/scheduler/aws"
 	schedulerutil "github.com/openshift/hypershift/hypershift-operator/controllers/scheduler/util"
 	"github.com/openshift/hypershift/support/api"
-	"github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -171,7 +171,7 @@ func ConfigureClusterAutoscaler(ctx context.Context, client crclient.Client, dry
 		if err := client.Get(ctx, crclient.ObjectKeyFromObject(autoscaler), autoscaler); err != nil {
 			return fmt.Errorf("failed to get cluster autoscaler resource: %w", err)
 		}
-		yaml, err := util.SerializeResource(autoscaler, api.Scheme)
+		yaml, err := k8sutil.SerializeResource(autoscaler, api.Scheme)
 		if err != nil {
 			return fmt.Errorf("failed to serialize cluster autoscaler resource: %w", err)
 		}
@@ -216,7 +216,7 @@ func ConfigureMachineHealthCheck(ctx context.Context, client crclient.Client, dr
 		if err := client.Get(ctx, crclient.ObjectKeyFromObject(mhc), mhc); err != nil {
 			return fmt.Errorf("failed to get machine health check resource: %w", err)
 		}
-		yaml, err := util.SerializeResource(mhc, api.Scheme)
+		yaml, err := k8sutil.SerializeResource(mhc, api.Scheme)
 		if err != nil {
 			return fmt.Errorf("failed to serialize machine health check resource: %w", err)
 		}
@@ -434,9 +434,9 @@ func ConfigureControlPlaneMachineSets(ctx context.Context, client crclient.Clien
 			if err := updateClient.List(ctx, machineSetList, crclient.InNamespace("openshift-machine-api")); err != nil {
 				return fmt.Errorf("failed to list machinesets: %w", err)
 			}
-			yaml, err := util.SerializeResource(machineSetList, api.Scheme)
+			yaml, err := k8sutil.SerializeResource(machineSetList, api.Scheme)
 			if err != nil {
-				return fmt.Errorf("failed to serialize cluster sizing configuration resource: %w", err)
+				return fmt.Errorf("failed to serialize machine set list: %w", err)
 			}
 			if err := os.WriteFile(outputFile, []byte(yaml), 0644); err != nil {
 				return fmt.Errorf("failed to write machine sets to file: %w", err)
@@ -448,7 +448,7 @@ func ConfigureControlPlaneMachineSets(ctx context.Context, client crclient.Clien
 			if err := updateClient.List(ctx, machineAutoscalerList, crclient.InNamespace("openshift-machine-api")); err != nil {
 				return fmt.Errorf("failed to list machine autoscalers: %w", err)
 			}
-			yaml, err := util.SerializeResource(machineAutoscalerList, api.Scheme)
+			yaml, err := k8sutil.SerializeResource(machineAutoscalerList, api.Scheme)
 			if err != nil {
 				return fmt.Errorf("failed to serialize machine autoscalers: %w", err)
 			}
@@ -507,7 +507,7 @@ func ConfigureClusterSizingConfiguration(ctx context.Context, dryRunOpts *DryRun
 		if err := updateClient.Get(ctx, crclient.ObjectKeyFromObject(csc), csc); err != nil {
 			return fmt.Errorf("failed to get cluster sizing configuration: %w", err)
 		}
-		yaml, err := util.SerializeResource(csc, api.Scheme)
+		yaml, err := k8sutil.SerializeResource(csc, api.Scheme)
 		if err != nil {
 			return fmt.Errorf("failed to serialize cluster sizing configuration resource: %w", err)
 		}

--- a/test/e2e/util/requestserving.go
+++ b/test/e2e/util/requestserving.go
@@ -11,7 +11,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	awsscheduler "github.com/openshift/hypershift/hypershift-operator/controllers/scheduler/aws"
 	hyperapi "github.com/openshift/hypershift/support/api"
-	supportutil "github.com/openshift/hypershift/support/util"
+	"github.com/openshift/hypershift/support/k8sutil"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -130,7 +130,7 @@ func TearDownNodePools(ctx context.Context, t *testing.T, kubeconfigPath string,
 	var errs []error
 	for _, np := range nodePools {
 		t.Logf("Tearing down custom nodepool %s/%s", np.Namespace, np.Name)
-		_, err := supportutil.DeleteIfNeeded(ctx, mgmtParentClient, np)
+		_, err := k8sutil.DeleteIfNeeded(ctx, mgmtParentClient, np)
 		if err != nil {
 			errs = append(errs, err)
 		}


### PR DESCRIPTION
## What this PR does / why we need it:

Extracts generic Kubernetes resource helpers from the monolithic `support/util/` package (600+ importers) into a focused `support/k8sutil/` package for better discoverability and reduced blast radius. Follows the same extraction pattern as #8360 (netutil extraction from [CNTRLPLANE-3342](https://redhat.atlassian.net/browse/CNTRLPLANE-3342)).

**Moved files:** `annotations.go`, `constants.go`, `job.go`, `object.go`, `ownerref.go`, `resources.go`, `serializer.go`, `service.go`, `services.go`, `svcaccounts.go`

**Moved functions from util.go:** `UpdateObject`, `DeleteIfNeeded`, `DeleteIfNeededWithOptions`, `DeleteIfNeededWithPredicate`, `DeleteAllIfNeeded`, `CopyConfigMap`, `ParseNodeSelector`, `ApplyAWSLoadBalancerTargetNodesAnnotation`

**Constants moved to constants.go:** `HostedClusterAnnotation`, `HostedClustersScopeAnnotation`, `DebugDeploymentsAnnotation`, `GCPLabelCluster`, `GCPLabelInfraID`, and env var constants

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/CNTRLPLANE-3343

## Special notes for your reviewer:

- Clean break from `support/util` — no forwarding functions
- 47 new unit tests with gomega assertions and Gherkin-style naming
- New package is automatically covered by GHA unit test sharding (`cmd-support` shard uses `./support/...`)
- `util.PredicatesForHostedClusterAnnotationScoping` now imports `HostedClusterAnnotation` from k8sutil (util → k8sutil dependency is fine since k8sutil does NOT import from util)

## Claude Code skills used:

This PR was developed end-to-end using the following Claude Code skills:

- **`behavior-driven-testing`** — Guided all 47 unit tests: Gherkin-style naming ("When X, it should Y"), table-driven tests, gomega assertions, and behavior-focused coverage
- **`superpowers:test-driven-development`** — Enforced RED-GREEN-REFACTOR cycle: tests written first, verified failing, then code moved to make them pass
- **`git-commit-format`** — Conventional commit format with required footers (Signed-off-by, Commit-Message-Assisted-by)
- **`restructure-hypershift-commits`** — Organized commits by component boundary (HO → CPO → E2E)
- **`code-review:pre-commit-review`** — Pre-commit quality review with Go language profile and HyperShift project profile
- **`superpowers:verification-before-completion`** — Enforced `make verify`, `make test`, `make lint`, `go build ./...` verification before claiming completion
- **`superpowers:requesting-code-review`** — Dispatched code-reviewer subagent for independent review after each major phase

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal Kubernetes helpers and annotation keys into a unified utilities package and updated usage across controllers and support code.
  * No changes to user-visible behavior, public APIs, or reconciliation outcomes.

* **Tests**
  * Updated and added unit tests to validate the utilities consolidation and preserve existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->