### PR TITLE
WIP: ARO-24037 feat(azure): enable ACR image pulls via Projected SA

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/rbac.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests/rbac.go
@@ -258,3 +258,19 @@ func CloudNetworkConfigControllerServiceAccountRoleBinding() *rbacv1.ClusterRole
 		},
 	}
 }
+
+func NodeCredentialProviderTokenAudienceClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "system:node:credential-provider-token-audience",
+		},
+	}
+}
+
+func NodeCredentialProviderTokenAudienceClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "system:node:credential-provider-token-audience",
+		},
+	}
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile.go
@@ -784,3 +784,39 @@ func ReconcileCloudNetworkConfigControllerServiceAccountClusterRoleBinding(r *rb
 	}
 	return nil
 }
+
+// ReconcileNodeCredentialProviderTokenAudienceClusterRole grants system:nodes
+// permission to request service account tokens for the credential provider
+// audience used by KEP-4412 projected service account tokens for image pulls.
+// Required by the ServiceAccountNodeAudienceRestriction feature gate (K8s 1.33+).
+func ReconcileNodeCredentialProviderTokenAudienceClusterRole(r *rbacv1.ClusterRole) error {
+	r.Rules = []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"serviceaccounts/token"},
+			Verbs:     []string{"create"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"api://AzureADTokenExchange"},
+			Verbs:     []string{"request-serviceaccounts-token-audience"},
+		},
+	}
+	return nil
+}
+
+func ReconcileNodeCredentialProviderTokenAudienceClusterRoleBinding(r *rbacv1.ClusterRoleBinding) error {
+	r.RoleRef = rbacv1.RoleRef{
+		APIGroup: rbacv1.SchemeGroupVersion.Group,
+		Kind:     "ClusterRole",
+		Name:     "system:node:credential-provider-token-audience",
+	}
+	r.Subjects = []rbacv1.Subject{
+		{
+			APIGroup: rbacv1.SchemeGroupVersion.Group,
+			Kind:     "Group",
+			Name:     "system:nodes",
+		},
+	}
+	return nil
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/rbac/reconcile_test.go
@@ -1,0 +1,59 @@
+package rbac
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func TestReconcileNodeCredentialProviderTokenAudienceClusterRole(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	t.Run("When reconciling it should set correct rules", func(t *testing.T) {
+		r := &rbacv1.ClusterRole{}
+		err := ReconcileNodeCredentialProviderTokenAudienceClusterRole(r)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(r.Rules).To(HaveLen(2))
+
+		g.Expect(r.Rules[0].APIGroups).To(Equal([]string{""}))
+		g.Expect(r.Rules[0].Resources).To(Equal([]string{"serviceaccounts/token"}))
+		g.Expect(r.Rules[0].Verbs).To(Equal([]string{"create"}))
+
+		g.Expect(r.Rules[1].APIGroups).To(Equal([]string{""}))
+		g.Expect(r.Rules[1].Resources).To(Equal([]string{"api://AzureADTokenExchange"}))
+		g.Expect(r.Rules[1].Verbs).To(Equal([]string{"request-serviceaccounts-token-audience"}))
+	})
+
+	t.Run("When reconciling it should not use a wildcard audience", func(t *testing.T) {
+		r := &rbacv1.ClusterRole{}
+		err := ReconcileNodeCredentialProviderTokenAudienceClusterRole(r)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		for _, rule := range r.Rules {
+			for _, resource := range rule.Resources {
+				g.Expect(resource).ToNot(Equal("*"), "audience resource must be scoped, not wildcard")
+			}
+		}
+	})
+}
+
+func TestReconcileNodeCredentialProviderTokenAudienceClusterRoleBinding(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	t.Run("When reconciling it should bind to system:nodes group", func(t *testing.T) {
+		r := &rbacv1.ClusterRoleBinding{}
+		err := ReconcileNodeCredentialProviderTokenAudienceClusterRoleBinding(r)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(r.RoleRef.Kind).To(Equal("ClusterRole"))
+		g.Expect(r.RoleRef.Name).To(Equal("system:node:credential-provider-token-audience"))
+		g.Expect(r.RoleRef.APIGroup).To(Equal("rbac.authorization.k8s.io"))
+
+		g.Expect(r.Subjects).To(HaveLen(1))
+		g.Expect(r.Subjects[0].Kind).To(Equal("Group"))
+		g.Expect(r.Subjects[0].Name).To(Equal("system:nodes"))
+	})
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1182,6 +1182,9 @@ func (r *reconciler) reconcileRBAC(ctx context.Context, hcp *hyperv1.HostedContr
 
 			manifestAndReconcile[*rbacv1.ClusterRole]{manifest: manifests.CloudNetworkConfigControllerServiceAccountRole, reconcile: rbac.ReconcileCloudNetworkConfigControllerServiceAccountClusterRole},
 			manifestAndReconcile[*rbacv1.ClusterRoleBinding]{manifest: manifests.CloudNetworkConfigControllerServiceAccountRoleBinding, reconcile: rbac.ReconcileCloudNetworkConfigControllerServiceAccountClusterRoleBinding},
+
+			manifestAndReconcile[*rbacv1.ClusterRole]{manifest: manifests.NodeCredentialProviderTokenAudienceClusterRole, reconcile: rbac.ReconcileNodeCredentialProviderTokenAudienceClusterRole},
+			manifestAndReconcile[*rbacv1.ClusterRoleBinding]{manifest: manifests.NodeCredentialProviderTokenAudienceClusterRoleBinding, reconcile: rbac.ReconcileNodeCredentialProviderTokenAudienceClusterRoleBinding},
 		)
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it:

Add RBAC to guest clusters allowing kubelets to request projected service account tokens
for the `api://AzureADTokenExchange` audience. This is one of the prerequisites for
KEP-4412 ACR image pulls via federated workload identity on ARO HCP.

When a pod's ServiceAccount is annotated with ACR credentials, the kubelet requests a
projected SA token from the API server. The token is exchanged with Azure AD via a
federated identity credential on a User-Assigned Managed Identity, which returns an
access token used to pull from private ACR — no pull secrets or node-level identity
attachment required.

The `ServiceAccountNodeAudienceRestriction` admission controller (enabled by default
in K8s 1.33+) requires RBAC authorization for the requested audience. Without this
ClusterRole, the token request is denied and the image pull fails. OCP 4.21 ships
K8s 1.34 where KEP-4412 is beta and the kubelet credential provider SA token support
is enabled by default.

Gated behind `azureutil.IsAroHCP()` — only applies to managed ARO HCP clusters.

References:
- [KEP-4412](https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/4412-projected-service-account-tokens-for-kubelet-image-credential-providers/README.md)
- [K8s v1.34 blog](https://kubernetes.io/blog/2025/09/03/kubernetes-v1-34-sa-tokens-image-pulls-beta/)
- [OCP enhancement #1987](https://github.com/openshift/enhancements/pull/1987)

## Which issue(s) this PR fixes:

Fixes [ARO-24037](https://redhat.atlassian.net/browse/ARO-24037)

## Special notes for your reviewer:

### Test Plan

- [ ] Validated end-to-end on OCP 4.21.9 (K8s 1.34.6) personal dev environment
- [ ] Pod pulled private ACR image in 3.3s via projected SA token with RBAC applied
- [ ] Verified without RBAC the same pod fails with `audience not authorized` error
- [ ] `make test` passes
- [ ] `make build` passes

Validated on personal dev environment: OCP 4.21.9 (K8s 1.34.6), ARO HCP.

#### Prerequisites

- Private ACR with a test image
- User-Assigned MI with AcrPull role on the ACR
- Federated identity credential on the MI trusting the HC's OIDC issuer
- `tokenAttributes` injected into worker nodes via MachineConfig (CS-side, not part of this PR)

#### Steps

1. Apply RBAC to guest cluster:
```bash
oc --kubeconfig /tmp/guest-kubeconfig apply -f - <<'EOF'
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: system:node:credential-provider-token-audience
rules:
- apiGroups: [""]
  resources: ["serviceaccounts/token"]
  verbs: ["create"]
- verbs: ["request-serviceaccounts-token-audience"]
  apiGroups: [""]
  resources: ["api://AzureADTokenExchange"]
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: system:node:credential-provider-token-audience
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: system:node:credential-provider-token-audience
subjects:
- apiGroup: rbac.authorization.k8s.io
  kind: Group
  name: system:nodes
EOF

2. Create annotated ServiceAccount:
oc --kubeconfig /tmp/guest-kubeconfig create namespace acr-sa-test
oc --kubeconfig /tmp/guest-kubeconfig apply -f - <<EOF
apiVersion: v1
kind: ServiceAccount
metadata:
  name: acr-pull-sa
  namespace: acr-sa-test
  annotations:
    kubernetes.azure.com/acr-client-id: "${MI_CLIENT_ID}"
    kubernetes.azure.com/acr-tenant-id: "${TENANT_ID}"
EOF

3. Deploy test pod pulling from private ACR:
oc --kubeconfig /tmp/guest-kubeconfig apply -f - <<EOF
apiVersion: v1
kind: Pod
metadata:
  name: acr-sa-test
  namespace: acr-sa-test
spec:
  serviceAccountName: acr-pull-sa
  containers:
  - name: test
    image: ${ACR_NAME}.azurecr.io/private-nginx:latest
  restartPolicy: Never
EOF

4. Verify pod pulls successfully:
oc --kubeconfig /tmp/guest-kubeconfig get pod acr-sa-test -n acr-sa-test
# NAME          READY   STATUS    RESTARTS   AGE
# acr-sa-test   1/1     Running   0          9s

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled service account token request capabilities for node credential providers, supporting Azure AD token exchange in hosted clusters.

* **Tests**
  * Added tests to validate credential provider token audience RBAC configuration and role binding assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->