### PR TITLE
SPLAT-2741: Add SetSecurityGroups perms for AWS CCM for BYO SG on AWS NLB

### DIFF
--- a/cmd/infra/aws/delegating_client.go
+++ b/cmd/infra/aws/delegating_client.go
@@ -547,6 +547,9 @@ func (c *elasticloadbalancingv2Client) ModifyTargetGroupAttributes(ctx context.C
 func (c *elasticloadbalancingv2Client) RegisterTargets(ctx context.Context, input *elasticloadbalancingv2.RegisterTargetsInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.RegisterTargetsOutput, error) {
 	return c.cloudController.elasticloadbalancingv2Client.RegisterTargets(ctx, input, optFns...)
 }
+func (c *elasticloadbalancingv2Client) SetSecurityGroups(ctx context.Context, input *elasticloadbalancingv2.SetSecurityGroupsInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.SetSecurityGroupsOutput, error) {
+	return c.cloudController.elasticloadbalancingv2Client.SetSecurityGroups(ctx, input, optFns...)
+}
 
 // route53Client delegates to individual component clients for API calls we know those components will have privileges to make.
 type route53Client struct {

--- a/cmd/infra/aws/delegatingclientgenerator/main.go
+++ b/cmd/infra/aws/delegatingclientgenerator/main.go
@@ -308,6 +308,7 @@ func adjustAPIs(delegates aws.ServicesByDelegate) aws.ServicesByDelegate {
 			"ModifyListener",
 			"ModifyTargetGroup",
 			"ModifyTargetGroupAttributes",
+			"SetSecurityGroups",
 		),
 		"elasticloadbalancingv2": sets.New(
 			"ApplySecurityGroupsToLoadBalancer",

--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -214,6 +214,7 @@ var (
         "elasticloadbalancing:ModifyTargetGroup",
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:SetLoadBalancerPoliciesOfListener",
+        "elasticloadbalancing:SetSecurityGroups",
         "iam:CreateServiceLinkedRole",
         "kms:DescribeKey"
       ],
@@ -939,6 +940,7 @@ func (o *CreateIAMOptions) CreateOIDCResources(ctx context.Context, iamClient aw
 		// The permissions are:
 		// - elasticloadbalancing:DescribeTargetGroupAttributes
 		// - elasticloadbalancing:ModifyTargetGroupAttributes
+		// - elasticloadbalancing:SetSecurityGroups
 		//
 		// https://issues.redhat.com/browse/OCPBUGS-65885
 		//
@@ -949,7 +951,8 @@ func (o *CreateIAMOptions) CreateOIDCResources(ctx context.Context, iamClient aw
 				"Effect": "Allow",
 				"Action": [
 					"elasticloadbalancing:DescribeTargetGroupAttributes",
-					"elasticloadbalancing:ModifyTargetGroupAttributes"
+					"elasticloadbalancing:ModifyTargetGroupAttributes",
+					"elasticloadbalancing:SetSecurityGroups"
 				],
 				"Resource": "*"
 			}`

--- a/cmd/infra/aws/iam_test.go
+++ b/cmd/infra/aws/iam_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -575,6 +576,110 @@ func TestCreateWorkerInstanceProfile(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCreateOIDCResources(t *testing.T) {
+	const (
+		providerName = "s3.example.com/" + testInfraID
+		providerARN  = "arn:aws:iam::123456789012:oidc-provider/" + providerName
+		baseDomain   = "example.com"
+	)
+
+	mockOIDCRoleCreation := func(m *awsapi.MockIAMAPI, roleCount int) {
+		m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, input *iam.GetRoleInput, _ ...func(*iam.Options)) (*iam.GetRoleOutput, error) {
+				return nil, noSuchEntity()
+			}).Times(roleCount)
+		m.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, input *iam.CreateRoleInput, _ ...func(*iam.Options)) (*iam.CreateRoleOutput, error) {
+				return &iam.CreateRoleOutput{Role: testRole(*input.RoleName)}, nil
+			}).Times(roleCount)
+		m.EXPECT().AttachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&iam.AttachRolePolicyOutput{}, nil).Times(7)
+	}
+
+	mockOIDCProviderLookup := func(m *awsapi.MockIAMAPI) {
+		m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&iam.ListOpenIDConnectProvidersOutput{
+				OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{
+					{Arn: aws.String(providerARN)},
+				},
+			}, nil)
+	}
+
+	t.Run("When using ROSA managed policies with separate roles it should create inline policies with SetSecurityGroups", func(t *testing.T) {
+		g := NewWithT(t)
+		ctrl := gomock.NewController(t)
+		mockIAM := awsapi.NewMockIAMAPI(ctrl)
+
+		mockOIDCProviderLookup(mockIAM)
+		mockOIDCRoleCreation(mockIAM, 7)
+
+		var policyDocuments []string
+		mockIAM.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, input *iam.PutRolePolicyInput, _ ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error) {
+				policyDocuments = append(policyDocuments, *input.PolicyDocument)
+				return &iam.PutRolePolicyOutput{}, nil
+			}).Times(2)
+
+		opts := &CreateIAMOptions{
+			InfraID:                testInfraID,
+			IssuerURL:              testIssuerURL,
+			BaseDomain:             baseDomain,
+			UseROSAManagedPolicies: true,
+		}
+		output, err := opts.CreateOIDCResources(context.Background(), mockIAM, logr.Discard(), false)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(output).NotTo(BeNil())
+		g.Expect(output.Roles.IngressARN).NotTo(Equal(output.Roles.KubeCloudControllerARN))
+
+		hasSetSecurityGroups := false
+		for _, doc := range policyDocuments {
+			if strings.Contains(doc, "elasticloadbalancing:SetSecurityGroups") {
+				hasSetSecurityGroups = true
+			}
+		}
+		g.Expect(hasSetSecurityGroups).To(BeTrue())
+	})
+
+	t.Run("When using ROSA managed policies with shared role it should create merged inline policy with SetSecurityGroups", func(t *testing.T) {
+		g := NewWithT(t)
+		ctrl := gomock.NewController(t)
+		mockIAM := awsapi.NewMockIAMAPI(ctrl)
+
+		mockOIDCProviderLookup(mockIAM)
+
+		sharedRoleName := testInfraID + "-shared-role"
+		mockIAM.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, noSuchEntity())
+		mockIAM.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&iam.CreateRoleOutput{Role: testRole(sharedRoleName)}, nil)
+		mockIAM.EXPECT().AttachRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&iam.AttachRolePolicyOutput{}, nil).Times(7)
+
+		var policyDocument string
+		mockIAM.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, input *iam.PutRolePolicyInput, _ ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error) {
+				policyDocument = *input.PolicyDocument
+				return &iam.PutRolePolicyOutput{}, nil
+			})
+
+		opts := &CreateIAMOptions{
+			InfraID:                testInfraID,
+			IssuerURL:              testIssuerURL,
+			BaseDomain:             baseDomain,
+			UseROSAManagedPolicies: true,
+			SharedRole:             true,
+		}
+		output, err := opts.CreateOIDCResources(context.Background(), mockIAM, logr.Discard(), false)
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(output).NotTo(BeNil())
+		g.Expect(output.Roles.IngressARN).To(Equal(output.Roles.KubeCloudControllerARN))
+		g.Expect(policyDocument).To(ContainSubstring("elasticloadbalancing:SetSecurityGroups"))
+		g.Expect(policyDocument).To(ContainSubstring("route53:ChangeResourceRecordSets"))
+	})
 }
 
 func TestEnsureHostedZonePrefix(t *testing.T) {

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -56498,6 +56498,7 @@ And these are samples for each one of the roles Hypershift uses:
                     "elasticloadbalancing:ModifyTargetGroupAttributes",
                     "elasticloadbalancing:RegisterTargets",
                     "elasticloadbalancing:SetLoadBalancerPoliciesOfListener",
+                    "elasticloadbalancing:SetSecurityGroups",
                     "iam:CreateServiceLinkedRole",
                     "kms:DescribeKey"
                 ],

--- a/docs/content/reference/infrastructure/aws.md
+++ b/docs/content/reference/infrastructure/aws.md
@@ -508,6 +508,7 @@ And these are samples for each one of the roles Hypershift uses:
                     "elasticloadbalancing:ModifyTargetGroupAttributes",
                     "elasticloadbalancing:RegisterTargets",
                     "elasticloadbalancing:SetLoadBalancerPoliciesOfListener",
+                    "elasticloadbalancing:SetSecurityGroups",
                     "iam:CreateServiceLinkedRole",
                     "kms:DescribeKey"
                 ],

--- a/support/awsapi/elasticloadbalancingv2.go
+++ b/support/awsapi/elasticloadbalancingv2.go
@@ -36,6 +36,7 @@ type ELBV2API interface {
 	ModifyTargetGroup(ctx context.Context, input *elasticloadbalancingv2.ModifyTargetGroupInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.ModifyTargetGroupOutput, error)
 	ModifyTargetGroupAttributes(ctx context.Context, input *elasticloadbalancingv2.ModifyTargetGroupAttributesInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.ModifyTargetGroupAttributesOutput, error)
 	RegisterTargets(ctx context.Context, input *elasticloadbalancingv2.RegisterTargetsInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.RegisterTargetsOutput, error)
+	SetSecurityGroups(ctx context.Context, input *elasticloadbalancingv2.SetSecurityGroupsInput, optFns ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.SetSecurityGroupsOutput, error)
 }
 
 // Ensure *elasticloadbalancingv2.Client implements ELBV2API


### PR DESCRIPTION
## What this PR does / why we need it:
This PR adds the `elasticloadbalancing:SetSecurityGroups` IAM permission which is required to support the upcoming AWS CCM feature that adds support for BYO Security Groups (SG) on AWS Network Load Balancers (See https://github.com/kubernetes/cloud-provider-aws/pull/1379).

The permission is required by AWS CCM to be able to swap byo security groups and move from managed to BYO SGs and from BYO to managed without deleting and recreating the load balancer. This permission is the Network Load Balancer equivalent of the already present `ApplySecurityGroupsToLoadBalancer` which however only applies to Classic Load Balancers.

References / related work:
- PR to add support for BYO SG on NLBs to AWS CCM: https://github.com/kubernetes/cloud-provider-aws/pull/1379
- PR to add `SetSecurityGroups` IAM permission on Openshift Installer: https://github.com/openshift/installer/pull/10512
- PR to add `SetSecurityGroups` IAM permission to ROSA policy: https://github.com/openshift/managed-cluster-config/pull/2727

This work is part of OCPSTRAT-1553.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes #[SPLAT-2741](https://redhat.atlassian.net/browse/SPLAT-2741) 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for managing load balancer security groups through the cloud controller.
  * Expanded supported AWS permissions so the platform can use the new load balancer security group action when needed.

* **Documentation**
  * Updated AWS IAM policy examples to include the new load balancer security group permission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->