### PR TITLE
NO-JIRA: fix(karpenter): resolve HCP karpenter finalizer when AutoNode is disabled

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/karpenter.go
+++ b/hypershift-operator/controllers/hostedcluster/karpenter.go
@@ -118,18 +118,16 @@ spec:
 }
 
 // resolveKarpenterFinalizer removes the karpenter finalizer from the HCP
-// when the karpenter-operator cannot do so itself because the guest KAS is down.
+// when the karpenter-operator cannot do so itself. This covers two scenarios:
 //
-// This breaks the deadlock where:
-//  1. The HostedCluster deletion waits for the HCP to be removed
-//  2. The HCP can't be removed because it has the karpenter finalizer
-//  3. The karpenter-operator can't remove the finalizer because the guest KAS is down
-//     and it depends on guest-side watches to function
+//  1. The guest KAS is down during HostedCluster deletion, so the karpenter-operator
+//     cannot reach its guest-side watches to process the finalizer.
+//  2. AutoNode was disabled before the HostedCluster was deleted, so the karpenter-operator
+//     deployment was removed and cannot process the finalizer at all.
+//
+// Without this fallback the HCP would be stuck in terminating with the karpenter finalizer
+// blocking deletion indefinitely.
 func (r *HostedClusterReconciler) resolveKarpenterFinalizer(ctx context.Context, hc *hyperv1.HostedCluster) error {
-	if !karpenterutil.IsKarpenterEnabled(hc.Spec.AutoNode) {
-		return nil
-	}
-
 	log := ctrl.LoggerFrom(ctx)
 	cpNamespace := manifests.HostedControlPlaneNamespace(hc.Namespace, hc.Name)
 
@@ -142,12 +140,19 @@ func (r *HostedClusterReconciler) resolveKarpenterFinalizer(ctx context.Context,
 		return nil
 	}
 
-	kasAvailable, err := isKASAvailable(ctx, hcp.Namespace, r.Client)
-	if err != nil {
-		return fmt.Errorf("failed to check KAS availability: %w", err)
-	}
-	if kasAvailable {
-		return nil
+	// When AutoNode is still enabled, defer to the karpenter-operator for graceful
+	// cleanup — only force-remove the finalizer once the guest KAS is down and the
+	// operator can no longer reach its watches.
+	// When AutoNode is disabled, the karpenter-operator deployment is already gone,
+	// so there is no controller to process the finalizer and we must remove it immediately.
+	if karpenterutil.IsKarpenterEnabled(hc.Spec.AutoNode) {
+		kasAvailable, err := isKASAvailable(ctx, hcp.Namespace, r.Client)
+		if err != nil {
+			return fmt.Errorf("failed to check KAS availability: %w", err)
+		}
+		if kasAvailable {
+			return nil
+		}
 	}
 
 	original := hcp.DeepCopy()

--- a/hypershift-operator/controllers/hostedcluster/karpenter_test.go
+++ b/hypershift-operator/controllers/hostedcluster/karpenter_test.go
@@ -47,21 +47,21 @@ func TestResolveKarpenterFinalizer(t *testing.T) {
 		expectError     bool
 	}{
 		{
-			name: "karpenter not enabled, no-op",
+			name: "When karpenter is not enabled and HCP has no finalizer it should no-op",
 			hc: &hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: hcName, Namespace: hcNamespace},
 				Spec:       hyperv1.HostedClusterSpec{},
 			},
 		},
 		{
-			name: "HCP not found, no-op",
+			name: "When HCP is not found it should no-op",
 			hc: &hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: hcName, Namespace: hcNamespace},
 				Spec:       hyperv1.HostedClusterSpec{AutoNode: autoNode},
 			},
 		},
 		{
-			name: "HCP exists without finalizer, no-op",
+			name: "When HCP exists without finalizer it should no-op",
 			hc: &hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: hcName, Namespace: hcNamespace},
 				Spec:       hyperv1.HostedClusterSpec{AutoNode: autoNode},
@@ -74,7 +74,7 @@ func TestResolveKarpenterFinalizer(t *testing.T) {
 			expectFinalizer: ptr.To(false),
 		},
 		{
-			name: "KAS available, finalizer retained",
+			name: "When karpenter is enabled and KAS is available it should retain the finalizer",
 			hc: &hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: hcName, Namespace: hcNamespace},
 				Spec:       hyperv1.HostedClusterSpec{AutoNode: autoNode},
@@ -86,7 +86,7 @@ func TestResolveKarpenterFinalizer(t *testing.T) {
 			expectFinalizer: ptr.To(true),
 		},
 		{
-			name: "KAS deployment missing, finalizer removed",
+			name: "When karpenter is enabled and KAS deployment is missing it should remove the finalizer",
 			hc: &hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: hcName, Namespace: hcNamespace},
 				Spec:       hyperv1.HostedClusterSpec{AutoNode: autoNode},
@@ -97,7 +97,7 @@ func TestResolveKarpenterFinalizer(t *testing.T) {
 			expectFinalizer: ptr.To(false),
 		},
 		{
-			name: "KAS exists but not available, finalizer removed",
+			name: "When karpenter is enabled and KAS exists but is not available it should remove the finalizer",
 			hc: &hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: hcName, Namespace: hcNamespace},
 				Spec:       hyperv1.HostedClusterSpec{AutoNode: autoNode},
@@ -109,7 +109,7 @@ func TestResolveKarpenterFinalizer(t *testing.T) {
 			expectFinalizer: ptr.To(false),
 		},
 		{
-			name: "KAS exists but no Available condition, finalizer removed",
+			name: "When karpenter is enabled and KAS exists but has no Available condition it should remove the finalizer",
 			hc: &hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: hcName, Namespace: hcNamespace},
 				Spec:       hyperv1.HostedClusterSpec{AutoNode: autoNode},
@@ -122,6 +122,29 @@ func TestResolveKarpenterFinalizer(t *testing.T) {
 						Namespace: cpNamespace,
 					},
 				},
+			},
+			expectFinalizer: ptr.To(false),
+		},
+		{
+			name: "When karpenter is disabled and HCP has a stale finalizer it should remove the finalizer immediately",
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: hcName, Namespace: hcNamespace},
+				Spec:       hyperv1.HostedClusterSpec{},
+			},
+			objects: []crclient.Object{
+				hcpWithFinalizer(hcName, cpNamespace),
+			},
+			expectFinalizer: ptr.To(false),
+		},
+		{
+			name: "When karpenter is disabled and KAS is still available it should remove the finalizer immediately",
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: hcName, Namespace: hcNamespace},
+				Spec:       hyperv1.HostedClusterSpec{},
+			},
+			objects: []crclient.Object{
+				hcpWithFinalizer(hcName, cpNamespace),
+				kasDeployment(cpNamespace, true),
 			},
 			expectFinalizer: ptr.To(false),
 		},


### PR DESCRIPTION
## Summary

When AutoNode is disabled before HostedCluster deletion, the karpenter-operator deployment is removed and cannot process the HCP karpenter finalizer. The `resolveKarpenterFinalizer` fallback previously early-returned when `IsKarpenterEnabled` was false, leaving the HCP stuck in terminating indefinitely.

### Root cause

The `resolveKarpenterFinalizer` function had a guard:
```go
if !karpenterutil.IsKarpenterEnabled(hc.Spec.AutoNode) {
    return nil
}
```
This skipped the fallback entirely when AutoNode was disabled, even though the HCP still had the finalizer from when Karpenter was previously enabled.

### Fix

Remove the early-return guard and instead use `IsKarpenterEnabled` to decide the cleanup strategy:
- **AutoNode enabled**: defer to the karpenter-operator for graceful cleanup — only force-remove the finalizer once the guest KAS is down
- **AutoNode disabled**: remove the finalizer immediately since no controller exists to handle it

### Test plan

- [x] Existing `TestResolveKarpenterFinalizer` cases pass (renamed to Gherkin)
- [x] New test: "When karpenter is disabled and HCP has a stale finalizer it should remove the finalizer immediately"
- [x] New test: "When karpenter is disabled and KAS is still available it should remove the finalizer immediately"

/cc @maxcao13 @jkyros

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where disabling node auto-scaling could cause HostedCluster deletion to hang indefinitely. The system now properly removes cleanup markers when auto-scaling is disabled, and only defers removal when enabled and the cluster is accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->