### PR TITLE
DO-NOT-MERGE: add interactive network topology diagrams

### DIFF
--- a/docs/content/contribute/add-a-capability.md
+++ b/docs/content/contribute/add-a-capability.md
@@ -1,0 +1,136 @@
+# Adding a New Cluster Capability
+
+This guide describes how to add support for a new optional capability to the HostedCluster API, following the pattern established by the existing capabilities (ImageRegistry, Console, NodeTuning, etc.).
+
+For user-facing documentation on how capabilities work, see [Cluster Capabilities](../how-to/cluster-capabilities.md).
+
+## Background: OpenShift Capabilities
+
+HyperShift's capability system builds on top of OpenShift's `ClusterVersionCapability` type defined in the [openshift/api](https://github.com/openshift/api) module. The full set of known capabilities is defined in [`config/v1/types_cluster_version.go`](https://github.com/openshift/api/blob/master/config/v1/types_cluster_version.go) as the `KnownClusterVersionCapabilities` list and includes:
+
+| OpenShift Capability | Supported in HyperShift |
+|---|---|
+| `openshift-samples` | Yes |
+| `baremetal` | Yes |
+| `marketplace` | No |
+| `Console` | Yes |
+| `Insights` | Yes |
+| `Storage` | No |
+| `CSISnapshot` | No |
+| `NodeTuning` | Yes |
+| `MachineAPI` | No |
+| `Build` | No |
+| `DeploymentConfig` | No |
+| `ImageRegistry` | Yes |
+| `OperatorLifecycleManager` | No |
+| `OperatorLifecycleManagerV1` | No |
+| `CloudCredential` | No |
+| `Ingress` | Yes |
+| `CloudControllerManager` | No |
+
+When adding a new capability to HyperShift, the value **must** correspond to an existing `ClusterVersionCapability` constant from that upstream list. HyperShift's `CalculateEnabledCapabilities` function uses the upstream `ClusterVersionCapabilitySetCurrent` as the default set and then applies the explicitly enabled/disabled overrides. See `support/capabilities/hosted_control_plane_capabilities.go:68-90`.
+
+## Implementation Checklist
+
+### 1. Define the Capability Constant
+
+Add a new `OptionalCapability` constant in [`api/hypershift/v1beta1/hostedcluster_types.go`](https://github.com/openshift/hypershift/blob/main/api/hypershift/v1beta1/hostedcluster_types.go) alongside the existing ones (lines 477-483). The value must reference the corresponding `configv1.ClusterVersionCapability`:
+
+```go
+const MyCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityMyCapability)
+```
+
+Update the `// +kubebuilder:validation:Enum=...` tag on the `OptionalCapability` type (line 474) to include the new value.
+
+### 2. Add a Capability Helper Function
+
+Add an `Is<Name>CapabilityEnabled` function in [`support/capabilities/hosted_control_plane_capabilities.go`](https://github.com/openshift/hypershift/blob/main/support/capabilities/hosted_control_plane_capabilities.go). Follow the existing pattern:
+
+```go
+func IsMyCapabilityEnabled(capabilities *hyperv1.Capabilities) bool {
+    if capabilities == nil {
+        return true
+    }
+    for _, disabledCap := range capabilities.Disabled {
+        if disabledCap == hyperv1.MyCapability {
+            return false
+        }
+    }
+    return true
+}
+```
+
+### 3. Wire It Into the Controllers
+
+Depending on where the component's resources are reconciled, add checks to skip reconciliation when the capability is disabled. Common integration points:
+
+- **Control Plane Operator (CPO)** controllers under `control-plane-operator/controllers/hostedcontrolplane/` for control-plane-side operator deployments.
+- **Hosted Cluster Config Operator (HCCO)** controllers under `control-plane-operator/hostedclusterconfigoperator/controllers/resources/` for guest-cluster-side resources.
+- **CPOv2 components** under `control-plane-operator/controllers/hostedcontrolplane/v2/` for components using the new control plane component framework. Use the `IsDisabled()` method on the component to gate reconciliation based on capability state.
+
+Look at how existing capabilities gate their resources. For example:
+
+- `IsImageRegistryCapabilityEnabled` is checked in the registry operator component, nodepool controller, and KAS params.
+- `IsNodeTuningCapabilityEnabled` is checked in the NTO component and config operator.
+- `IsIngressCapabilityEnabled` is checked in the ingress operator component and config operator.
+
+### 4. Update the CLI Help Text
+
+Update the `--disable-cluster-capabilities` flag description in [`cmd/cluster/core/create.go`](https://github.com/openshift/hypershift/blob/main/cmd/cluster/core/create.go) (line 111) to include the new value in the supported values list.
+
+### 5. Regenerate CRDs and Vendored API
+
+Since `api/` is a separate Go module, you must run:
+
+```shell
+make update
+```
+
+This regenerates CRDs, revendors the API module, and updates generated clients.
+
+### 6. Add Tests
+
+Add test cases for the new helper function in [`support/capabilities/hosted_control_plane_capabilities_test.go`](https://github.com/openshift/hypershift/blob/main/support/capabilities/hosted_control_plane_capabilities_test.go). Cover:
+
+- Capability enabled by default (nil `Capabilities`).
+- Capability explicitly disabled.
+- Capability not in the disabled list (still enabled).
+
+### 7. Add CEL Validation (If Needed)
+
+If the new capability has cross-capability dependencies (like Ingress requiring Console to also be disabled), add a CEL validation rule on the `Disabled` field in the `Capabilities` struct (line 514 area). See the existing Ingress/Console constraint as an example:
+
+```go
+// +kubebuilder:validation:XValidation:rule="!self.exists(cap, cap == 'Ingress') || self.exists(cap, cap == 'Console')",message="Ingress capability can only be disabled if Console capability is also disabled"
+```
+
+## Reference PRs
+
+These PRs show the full implementation pattern for each capability that has been added:
+
+| Capability | PR | Description |
+|---|---|---|
+| ImageRegistry | [#5456](https://github.com/openshift/hypershift/pull/5456), [#5964](https://github.com/openshift/hypershift/pull/5964) | Initial implementation behind feature gate, then GA and backport to main |
+| openshift-samples | [#6197](https://github.com/openshift/hypershift/pull/6197) | Disabling the Samples operator |
+| Insights | [#6246](https://github.com/openshift/hypershift/pull/6246) | Disabling the Insights operator |
+| Console | [#6183](https://github.com/openshift/hypershift/pull/6183) | Disabling the Console operator (generic disable framework) |
+| NodeTuning | [#6356](https://github.com/openshift/hypershift/pull/6356) | Disabling the Node Tuning Operator |
+| Ingress | [#6319](https://github.com/openshift/hypershift/pull/6319) | Disabling the Ingress operator (with Console dependency constraint) |
+| baremetal | [#6158](https://github.com/openshift/hypershift/pull/6158) | Enable field support and baremetal default exclusion |
+
+The best PRs to use as a template are the simpler single-capability additions like [#6197](https://github.com/openshift/hypershift/pull/6197) (openshift-samples) or [#6246](https://github.com/openshift/hypershift/pull/6246) (Insights).
+
+## Key Code Locations
+
+| What | Path |
+|---|---|
+| `OptionalCapability` type and constants | `api/hypershift/v1beta1/hostedcluster_types.go:474-483` |
+| `Capabilities` struct and CEL rules | `api/hypershift/v1beta1/hostedcluster_types.go:485-516` |
+| `HostedClusterSpec.Capabilities` field | `api/hypershift/v1beta1/hostedcluster_types.go:829-835` |
+| `HostedControlPlaneSpec.Capabilities` field | `api/hypershift/v1beta1/hosted_controlplane.go:265-266` |
+| Capability helper functions | `support/capabilities/hosted_control_plane_capabilities.go` |
+| Capability helper tests | `support/capabilities/hosted_control_plane_capabilities_test.go` |
+| `CalculateEnabledCapabilities` (net capability set) | `support/capabilities/hosted_control_plane_capabilities.go:68-90` |
+| CLI flag definition | `cmd/cluster/core/create.go:111` |
+| CLI capability wiring | `cmd/cluster/core/create.go:361-368, 767-779` |
+| OpenShift `ClusterVersionCapability` definitions | [`openshift/api` `config/v1/types_cluster_version.go`](https://github.com/openshift/api/blob/master/config/v1/types_cluster_version.go) |

--- a/docs/content/how-to/cluster-capabilities.md
+++ b/docs/content/how-to/cluster-capabilities.md
@@ -1,0 +1,85 @@
+# Cluster Capabilities
+
+HyperShift allows administrators to enable or disable optional OpenShift components at cluster creation time through the **capabilities** API. This reduces resource consumption and attack surface by preventing unnecessary operators and operands from being deployed.
+
+## Default Behavior
+
+When `spec.capabilities` is not set on a HostedCluster, the cluster uses the OpenShift version's `DefaultCapabilitySet` with the `baremetal` capability excluded. This means most optional components are enabled by default.
+
+!!! important
+    Capabilities are **immutable** after cluster creation. They cannot be changed once the HostedCluster is created.
+
+## Supported Capabilities
+
+| Capability | Description |
+|---|---|
+| `ImageRegistry` | OpenShift Image Registry operator and its operands, including cloud storage infrastructure (S3 buckets, IAM users, etc.) |
+| `openshift-samples` | OpenShift Samples operator, which manages example ImageStreams and Templates |
+| `Insights` | Insights operator, which collects and uploads cluster telemetry data |
+| `baremetal` | Bare metal infrastructure operator. Excluded from the default set; must be explicitly enabled if needed |
+| `Console` | OpenShift web console operator and its operands |
+| `NodeTuning` | Node Tuning Operator (NTO), which manages node-level performance tuning via TuneD and PerformanceProfiles |
+| `Ingress` | OpenShift Ingress operator, which manages the cluster's default router |
+
+## Constraints
+
+The following rules apply when combining capability settings:
+
+- **No overlap**: A capability cannot appear in both `enabled` and `disabled` lists simultaneously.
+- **Ingress requires Console**: The `Ingress` capability can only be disabled if `Console` is also disabled. This is due to a console dependency ([OCPBUGS-58422](https://issues.redhat.com/browse/OCPBUGS-58422)).
+- **Version requirement**: Disabling `openshift-samples`, `Insights`, `Console`, `NodeTuning`, or `Ingress` requires OpenShift 4.20 or later. `ImageRegistry` and `baremetal` can be disabled on earlier versions.
+- **Baremetal default exclusion**: The `baremetal` capability is already excluded from the default set. Explicitly disabling it is a no-op; explicitly enabling it will add it to the cluster.
+
+## Usage
+
+### CLI
+
+Use the `--disable-cluster-capabilities` flag when creating a cluster:
+
+```shell
+hypershift create cluster aws \
+  --name my-cluster \
+  --disable-cluster-capabilities=ImageRegistry,Console,Ingress
+```
+
+Multiple capabilities can be specified as a comma-separated list. The supported values are: `ImageRegistry`, `openshift-samples`, `Insights`, `baremetal`, `Console`, `NodeTuning`, `Ingress`.
+
+### HostedCluster Manifest
+
+To disable capabilities via the HostedCluster resource directly, set `spec.capabilities.disabled`:
+
+```yaml
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  name: my-cluster
+  namespace: clusters
+spec:
+  capabilities:
+    disabled:
+      - ImageRegistry
+      - Console
+      - Ingress
+  # ... rest of spec
+```
+
+To explicitly enable a capability that is not in the default set (e.g., `baremetal`):
+
+```yaml
+spec:
+  capabilities:
+    enabled:
+      - baremetal
+```
+
+Both `enabled` and `disabled` can be used together, as long as no capability appears in both lists:
+
+```yaml
+spec:
+  capabilities:
+    enabled:
+      - baremetal
+    disabled:
+      - ImageRegistry
+      - openshift-samples
+```

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -5,6 +5,148 @@ for use with AI tools like NotebookLM.
 
 ---
 
+## Source: docs/content/contribute/add-a-capability.md
+
+# Adding a New Cluster Capability
+
+This guide describes how to add support for a new optional capability to the HostedCluster API, following the pattern established by the existing capabilities (ImageRegistry, Console, NodeTuning, etc.).
+
+For user-facing documentation on how capabilities work, see Cluster Capabilities.
+
+## Background: OpenShift Capabilities
+
+HyperShift's capability system builds on top of OpenShift's `ClusterVersionCapability` type defined in the openshift/api module. The full set of known capabilities is defined in `config/v1/types_cluster_version.go` as the `KnownClusterVersionCapabilities` list and includes:
+
+| OpenShift Capability | Supported in HyperShift |
+|---|---|
+| `openshift-samples` | Yes |
+| `baremetal` | Yes |
+| `marketplace` | No |
+| `Console` | Yes |
+| `Insights` | Yes |
+| `Storage` | No |
+| `CSISnapshot` | No |
+| `NodeTuning` | Yes |
+| `MachineAPI` | No |
+| `Build` | No |
+| `DeploymentConfig` | No |
+| `ImageRegistry` | Yes |
+| `OperatorLifecycleManager` | No |
+| `OperatorLifecycleManagerV1` | No |
+| `CloudCredential` | No |
+| `Ingress` | Yes |
+| `CloudControllerManager` | No |
+
+When adding a new capability to HyperShift, the value **must** correspond to an existing `ClusterVersionCapability` constant from that upstream list. HyperShift's `CalculateEnabledCapabilities` function uses the upstream `ClusterVersionCapabilitySetCurrent` as the default set and then applies the explicitly enabled/disabled overrides. See `support/capabilities/hosted_control_plane_capabilities.go:68-90`.
+
+## Implementation Checklist
+
+### 1. Define the Capability Constant
+
+Add a new `OptionalCapability` constant in `api/hypershift/v1beta1/hostedcluster_types.go` alongside the existing ones (lines 477-483). The value must reference the corresponding `configv1.ClusterVersionCapability`:
+
+```go
+const MyCapability OptionalCapability = OptionalCapability(configv1.ClusterVersionCapabilityMyCapability)
+```
+
+Update the `// +kubebuilder:validation:Enum=...` tag on the `OptionalCapability` type (line 474) to include the new value.
+
+### 2. Add a Capability Helper Function
+
+Add an `Is<Name>CapabilityEnabled` function in `support/capabilities/hosted_control_plane_capabilities.go`. Follow the existing pattern:
+
+```go
+func IsMyCapabilityEnabled(capabilities *hyperv1.Capabilities) bool {
+    if capabilities == nil {
+        return true
+    }
+    for _, disabledCap := range capabilities.Disabled {
+        if disabledCap == hyperv1.MyCapability {
+            return false
+        }
+    }
+    return true
+}
+```
+
+### 3. Wire It Into the Controllers
+
+Depending on where the component's resources are reconciled, add checks to skip reconciliation when the capability is disabled. Common integration points:
+
+- **Control Plane Operator (CPO)** controllers under `control-plane-operator/controllers/hostedcontrolplane/` for control-plane-side operator deployments.
+- **Hosted Cluster Config Operator (HCCO)** controllers under `control-plane-operator/hostedclusterconfigoperator/controllers/resources/` for guest-cluster-side resources.
+- **CPOv2 components** under `control-plane-operator/controllers/hostedcontrolplane/v2/` for components using the new control plane component framework. Use the `IsDisabled()` method on the component to gate reconciliation based on capability state.
+
+Look at how existing capabilities gate their resources. For example:
+
+- `IsImageRegistryCapabilityEnabled` is checked in the registry operator component, nodepool controller, and KAS params.
+- `IsNodeTuningCapabilityEnabled` is checked in the NTO component and config operator.
+- `IsIngressCapabilityEnabled` is checked in the ingress operator component and config operator.
+
+### 4. Update the CLI Help Text
+
+Update the `--disable-cluster-capabilities` flag description in `cmd/cluster/core/create.go` (line 111) to include the new value in the supported values list.
+
+### 5. Regenerate CRDs and Vendored API
+
+Since `api/` is a separate Go module, you must run:
+
+```shell
+make update
+```
+
+This regenerates CRDs, revendors the API module, and updates generated clients.
+
+### 6. Add Tests
+
+Add test cases for the new helper function in `support/capabilities/hosted_control_plane_capabilities_test.go`. Cover:
+
+- Capability enabled by default (nil `Capabilities`).
+- Capability explicitly disabled.
+- Capability not in the disabled list (still enabled).
+
+### 7. Add CEL Validation (If Needed)
+
+If the new capability has cross-capability dependencies (like Ingress requiring Console to also be disabled), add a CEL validation rule on the `Disabled` field in the `Capabilities` struct (line 514 area). See the existing Ingress/Console constraint as an example:
+
+```go
+// +kubebuilder:validation:XValidation:rule="!self.exists(cap, cap == 'Ingress') || self.exists(cap, cap == 'Console')",message="Ingress capability can only be disabled if Console capability is also disabled"
+```
+
+## Reference PRs
+
+These PRs show the full implementation pattern for each capability that has been added:
+
+| Capability | PR | Description |
+|---|---|---|
+| ImageRegistry | #5456, #5964 | Initial implementation behind feature gate, then GA and backport to main |
+| openshift-samples | #6197 | Disabling the Samples operator |
+| Insights | #6246 | Disabling the Insights operator |
+| Console | #6183 | Disabling the Console operator (generic disable framework) |
+| NodeTuning | #6356 | Disabling the Node Tuning Operator |
+| Ingress | #6319 | Disabling the Ingress operator (with Console dependency constraint) |
+| baremetal | #6158 | Enable field support and baremetal default exclusion |
+
+The best PRs to use as a template are the simpler single-capability additions like #6197 (openshift-samples) or #6246 (Insights).
+
+## Key Code Locations
+
+| What | Path |
+|---|---|
+| `OptionalCapability` type and constants | `api/hypershift/v1beta1/hostedcluster_types.go:474-483` |
+| `Capabilities` struct and CEL rules | `api/hypershift/v1beta1/hostedcluster_types.go:485-516` |
+| `HostedClusterSpec.Capabilities` field | `api/hypershift/v1beta1/hostedcluster_types.go:829-835` |
+| `HostedControlPlaneSpec.Capabilities` field | `api/hypershift/v1beta1/hosted_controlplane.go:265-266` |
+| Capability helper functions | `support/capabilities/hosted_control_plane_capabilities.go` |
+| Capability helper tests | `support/capabilities/hosted_control_plane_capabilities_test.go` |
+| `CalculateEnabledCapabilities` (net capability set) | `support/capabilities/hosted_control_plane_capabilities.go:68-90` |
+| CLI flag definition | `cmd/cluster/core/create.go:111` |
+| CLI capability wiring | `cmd/cluster/core/create.go:361-368, 767-779` |
+| OpenShift `ClusterVersionCapability` definitions | `openshift/api` `config/v1/types_cluster_version.go` |
+
+
+---
+
 ## Source: docs/content/contribute/branch-process.md
 
 ## OCP Branching Tasks for the HyperShift Team
@@ -11946,6 +12088,97 @@ The workflow requires one secret configured at the repository level:
 
 3. Verify the workflow runs successfully on the next push to `main`.
 4. Delete the old token from your GitHub account.
+
+
+---
+
+## Source: docs/content/how-to/cluster-capabilities.md
+
+# Cluster Capabilities
+
+HyperShift allows administrators to enable or disable optional OpenShift components at cluster creation time through the **capabilities** API. This reduces resource consumption and attack surface by preventing unnecessary operators and operands from being deployed.
+
+## Default Behavior
+
+When `spec.capabilities` is not set on a HostedCluster, the cluster uses the OpenShift version's `DefaultCapabilitySet` with the `baremetal` capability excluded. This means most optional components are enabled by default.
+
+!!! important
+    Capabilities are **immutable** after cluster creation. They cannot be changed once the HostedCluster is created.
+
+## Supported Capabilities
+
+| Capability | Description |
+|---|---|
+| `ImageRegistry` | OpenShift Image Registry operator and its operands, including cloud storage infrastructure (S3 buckets, IAM users, etc.) |
+| `openshift-samples` | OpenShift Samples operator, which manages example ImageStreams and Templates |
+| `Insights` | Insights operator, which collects and uploads cluster telemetry data |
+| `baremetal` | Bare metal infrastructure operator. Excluded from the default set; must be explicitly enabled if needed |
+| `Console` | OpenShift web console operator and its operands |
+| `NodeTuning` | Node Tuning Operator (NTO), which manages node-level performance tuning via TuneD and PerformanceProfiles |
+| `Ingress` | OpenShift Ingress operator, which manages the cluster's default router |
+
+## Constraints
+
+The following rules apply when combining capability settings:
+
+- **No overlap**: A capability cannot appear in both `enabled` and `disabled` lists simultaneously.
+- **Ingress requires Console**: The `Ingress` capability can only be disabled if `Console` is also disabled. This is due to a console dependency (OCPBUGS-58422).
+- **Version requirement**: Disabling `openshift-samples`, `Insights`, `Console`, `NodeTuning`, or `Ingress` requires OpenShift 4.20 or later. `ImageRegistry` and `baremetal` can be disabled on earlier versions.
+- **Baremetal default exclusion**: The `baremetal` capability is already excluded from the default set. Explicitly disabling it is a no-op; explicitly enabling it will add it to the cluster.
+
+## Usage
+
+### CLI
+
+Use the `--disable-cluster-capabilities` flag when creating a cluster:
+
+```shell
+hypershift create cluster aws \
+  --name my-cluster \
+  --disable-cluster-capabilities=ImageRegistry,Console,Ingress
+```
+
+Multiple capabilities can be specified as a comma-separated list. The supported values are: `ImageRegistry`, `openshift-samples`, `Insights`, `baremetal`, `Console`, `NodeTuning`, `Ingress`.
+
+### HostedCluster Manifest
+
+To disable capabilities via the HostedCluster resource directly, set `spec.capabilities.disabled`:
+
+```yaml
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  name: my-cluster
+  namespace: clusters
+spec:
+  capabilities:
+    disabled:
+      - ImageRegistry
+      - Console
+      - Ingress
+  # ... rest of spec
+```
+
+To explicitly enable a capability that is not in the default set (e.g., `baremetal`):
+
+```yaml
+spec:
+  capabilities:
+    enabled:
+      - baremetal
+```
+
+Both `enabled` and `disabled` can be used together, as long as no capability appears in both lists:
+
+```yaml
+spec:
+  capabilities:
+    enabled:
+      - baremetal
+    disabled:
+      - ImageRegistry
+      - openshift-samples
+```
 
 
 ---

--- a/docs/content/reference/network-topology-viewer.html
+++ b/docs/content/reference/network-topology-viewer.html
@@ -1,0 +1,932 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>HyperShift Network Topology</title>
+<script src="https://unpkg.com/cytoscape@3.30.4/dist/cytoscape.min.js"></script>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+    background: #0f1117;
+    color: #e0e0e0;
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+  }
+  .toolbar {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 12px 20px;
+    background: #1a1d27;
+    border-bottom: 1px solid #2a2d3a;
+    flex-wrap: wrap;
+  }
+  .toolbar h1 {
+    font-size: 18px;
+    font-weight: 600;
+    color: #fff;
+    margin-right: 12px;
+  }
+  .toolbar select, .toolbar button {
+    padding: 6px 14px;
+    border-radius: 6px;
+    font-size: 13px;
+    cursor: pointer;
+  }
+  .toolbar select {
+    background: #2a2d3a;
+    color: #e0e0e0;
+    border: 1px solid #3a3d4a;
+  }
+  .toolbar button {
+    background: #3b82f6;
+    color: #fff;
+    border: none;
+    font-weight: 500;
+  }
+  .toolbar button:hover { background: #2563eb; }
+  .toolbar button.secondary {
+    background: #374151;
+  }
+  .toolbar button.secondary:hover { background: #4b5563; }
+  #cy {
+    flex: 1;
+    background: #0f1117;
+  }
+  .legend {
+    display: flex;
+    gap: 20px;
+    padding: 10px 20px;
+    background: #1a1d27;
+    border-top: 1px solid #2a2d3a;
+    flex-wrap: wrap;
+    font-size: 12px;
+  }
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .legend-swatch {
+    width: 30px;
+    height: 4px;
+    border-radius: 2px;
+  }
+  .legend-swatch.dashed {
+    background: repeating-linear-gradient(90deg,
+      var(--color) 0, var(--color) 6px,
+      transparent 6px, transparent 10px);
+  }
+  .legend-swatch.thick {
+    height: 8px;
+    border-radius: 4px;
+    opacity: 0.4;
+  }
+  .legend-node {
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+    border: 2px solid;
+  }
+  .tooltip {
+    position: absolute;
+    background: #1e2130;
+    border: 1px solid #3a3d4a;
+    border-radius: 8px;
+    padding: 10px 14px;
+    font-size: 12px;
+    max-width: 320px;
+    pointer-events: none;
+    z-index: 100;
+    display: none;
+    line-height: 1.5;
+  }
+  .tooltip .tt-title {
+    font-weight: 600;
+    color: #fff;
+    margin-bottom: 4px;
+  }
+  .tooltip .tt-desc {
+    color: #9ca3af;
+  }
+</style>
+</head>
+<body>
+
+<div class="toolbar">
+  <h1>HyperShift Network Topology</h1>
+  <select id="topology-select">
+    <optgroup label="AWS">
+      <option value="aws-public" selected>AWS Public (no ext DNS)</option>
+      <option value="aws-public-extdns">AWS Public (ext DNS)</option>
+      <option value="aws-private">AWS Private</option>
+    </optgroup>
+    <optgroup label="Azure">
+      <option value="azure-aro-hcp">Azure ARO HCP (Managed)</option>
+      <option value="azure-self-managed">Azure Self-Managed</option>
+    </optgroup>
+    <optgroup label="Other">
+      <option value="agent-nodeport">Agent / Bare Metal (NodePort)</option>
+    </optgroup>
+  </select>
+  <button class="secondary" id="btn-fit">Fit View</button>
+  <button id="btn-export">Export PNG</button>
+</div>
+
+<div id="cy"></div>
+<div id="tooltip" class="tooltip">
+  <div class="tt-title"></div>
+  <div class="tt-desc"></div>
+</div>
+
+<div class="legend">
+  <div class="legend-item">
+    <div class="legend-swatch" style="background: #3b82f6;"></div>
+    <span>Direct flow (data plane &rarr; control plane)</span>
+  </div>
+  <div class="legend-item">
+    <div class="legend-swatch" style="background: #f59e0b;"></div>
+    <span>Tunneled flow (via Konnectivity)</span>
+  </div>
+  <div class="legend-item">
+    <div class="legend-swatch thick" style="background: #f59e0b;"></div>
+    <span>Konnectivity tunnel</span>
+  </div>
+  <div class="legend-item">
+    <div class="legend-swatch dashed" style="--color: #10b981;"></div>
+    <span>Tunnel establishment</span>
+  </div>
+  <div class="legend-item">
+    <div class="legend-swatch" style="background: #8b5cf6;"></div>
+    <span>Private link / PSC / Swift</span>
+  </div>
+  <div class="legend-item">
+    <div class="legend-swatch thick" style="background: #e879a0;"></div>
+    <span>Network boundary</span>
+  </div>
+</div>
+
+<script>
+// ── Grid helper ──
+const COL_W = 180;
+const ROW_H = 60;
+function pos(col, row) {
+  return { x: col * COL_W, y: row * ROW_H };
+}
+
+// Network line: a very wide thin node representing a network boundary
+function netLine(id, label, row, color) {
+  return {
+    data: {
+      id,
+      label,
+      type: 'network-line',
+      netColor: color,
+    },
+    position: pos(2.5, row),
+  };
+}
+
+const STYLES = [
+  // ── Network boundary lines ──
+  {
+    selector: 'node[type="network-line"]',
+    style: {
+      'shape': 'rectangle',
+      'width': 2400,
+      'height': 4,
+      'background-color': 'data(netColor)',
+      'background-opacity': 0.5,
+      'border-width': 0,
+      'label': 'data(label)',
+      'text-valign': 'top',
+      'text-halign': 'left',
+      'font-size': '11px',
+      'font-weight': '700',
+      'color': 'data(netColor)',
+      'text-margin-y': -6,
+      'text-margin-x': 0,
+      'z-index': 0,
+      'events': 'no',
+    }
+  },
+  // ── Compound nodes (zones) ──
+  {
+    selector: 'node[type="zone"]',
+    style: {
+      'shape': 'round-rectangle',
+      'background-color': '#141720',
+      'border-color': '#2a2d3a',
+      'border-width': 1,
+      'border-opacity': 0.5,
+      'label': 'data(label)',
+      'text-valign': 'top',
+      'text-halign': 'center',
+      'font-size': '12px',
+      'color': '#4b5563',
+      'font-weight': '600',
+      'padding': '22px',
+      'text-margin-y': '-5px',
+      'background-opacity': 0.6,
+    }
+  },
+  {
+    selector: 'node[type="zone"][zone="mgmt"]',
+    style: {
+      'border-color': '#374151',
+      'background-color': '#111318',
+      'background-opacity': 0.4,
+    }
+  },
+  {
+    selector: 'node[type="zone"][zone="hcp"]',
+    style: {
+      'border-color': '#1e3a5f',
+      'background-color': '#0d1525',
+      'background-opacity': 0.5,
+    }
+  },
+  {
+    selector: 'node[type="zone"][zone="tunnel-consumers"]',
+    style: {
+      'border-color': '#92400e',
+      'background-color': 'rgba(245, 158, 11, 0.04)',
+      'border-width': 1,
+      'border-style': 'dashed',
+      'font-size': '10px',
+      'color': '#78350f',
+      'padding': '18px',
+    }
+  },
+  {
+    selector: 'node[type="zone"][zone="dataplane"]',
+    style: {
+      'border-color': '#1a4731',
+      'background-color': '#0d1a14',
+      'background-opacity': 0.5,
+    }
+  },
+  {
+    selector: 'node[type="zone"][zone="shared-ingress"]',
+    style: {
+      'border-color': '#374151',
+      'background-color': 'rgba(16, 185, 129, 0.04)',
+      'border-width': 1,
+      'border-style': 'dashed',
+      'font-size': '10px',
+      'color': '#4b5563',
+      'padding': '18px',
+    }
+  },
+  // ── Component nodes ──
+  {
+    selector: 'node[type="component"]',
+    style: {
+      'shape': 'round-rectangle',
+      'background-color': '#1e3a5f',
+      'border-color': '#3b82f6',
+      'border-width': 2,
+      'label': 'data(label)',
+      'text-valign': 'center',
+      'text-halign': 'center',
+      'font-size': '11px',
+      'color': '#e0e0e0',
+      'width': 'label',
+      'height': '30px',
+      'padding': '12px',
+      'font-weight': '500',
+      'z-index': 10,
+    }
+  },
+  {
+    selector: 'node[type="component"][role="konnectivity"]',
+    style: {
+      'background-color': '#3a2a1a',
+      'border-color': '#f59e0b',
+    }
+  },
+  {
+    selector: 'node[type="component"][role="infra"]',
+    style: {
+      'background-color': '#1a2a1a',
+      'border-color': '#10b981',
+    }
+  },
+  {
+    selector: 'node[type="component"][role="external"]',
+    style: {
+      'background-color': '#2a1a3a',
+      'border-color': '#8b5cf6',
+    }
+  },
+  {
+    selector: 'node[type="component"][role="user"]',
+    style: {
+      'background-color': '#1a1a2a',
+      'border-color': '#6366f1',
+      'shape': 'ellipse',
+      'width': 'label',
+      'height': '30px',
+      'padding': '14px',
+    }
+  },
+  {
+    selector: 'node[type="component"][role="sidecar-label"]',
+    style: {
+      'background-color': 'rgba(245, 158, 11, 0.15)',
+      'border-color': '#92400e',
+      'border-width': 1,
+      'border-style': 'dashed',
+      'font-size': '9px',
+      'color': '#d97706',
+      'height': '22px',
+      'padding': '8px',
+      'z-index': 10,
+    }
+  },
+  // ── Edges ──
+  {
+    selector: 'edge',
+    style: {
+      'width': 1.5,
+      'line-color': '#3b82f6',
+      'target-arrow-color': '#3b82f6',
+      'target-arrow-shape': 'triangle',
+      'curve-style': 'bezier',
+      'arrow-scale': 0.7,
+      'label': 'data(label)',
+      'font-size': '9px',
+      'color': '#6b7280',
+      'text-rotation': 'autorotate',
+      'text-margin-y': -8,
+      'text-background-color': '#0f1117',
+      'text-background-opacity': 0.85,
+      'text-background-padding': '2px',
+    }
+  },
+  {
+    selector: 'edge[flow="tunneled"]',
+    style: {
+      'line-color': '#f59e0b',
+      'target-arrow-color': '#f59e0b',
+    }
+  },
+  {
+    selector: 'edge[flow="tunnel-pipe"]',
+    style: {
+      'line-color': '#f59e0b',
+      'target-arrow-color': '#f59e0b',
+      'width': 10,
+      'opacity': 0.25,
+      'target-arrow-shape': 'none',
+      'source-arrow-shape': 'none',
+      'label': 'KONNECTIVITY TUNNEL',
+      'font-size': '9px',
+      'font-weight': '700',
+      'color': '#d97706',
+      'text-opacity': 1,
+      'text-background-opacity': 0,
+      'text-margin-y': 0,
+    }
+  },
+  {
+    selector: 'edge[flow="tunnel-establish"]',
+    style: {
+      'line-color': '#10b981',
+      'target-arrow-color': '#10b981',
+      'line-style': 'dashed',
+      'line-dash-pattern': [6, 4],
+    }
+  },
+  {
+    selector: 'edge[flow="private"]',
+    style: {
+      'line-color': '#8b5cf6',
+      'target-arrow-color': '#8b5cf6',
+    }
+  },
+  {
+    selector: 'edge[flow="internal"]',
+    style: {
+      'line-color': '#4b5563',
+      'target-arrow-color': '#4b5563',
+      'width': 1,
+    }
+  },
+  // ── Hover effects ──
+  {
+    selector: 'node:active, node:selected',
+    style: { 'overlay-opacity': 0 }
+  },
+  {
+    selector: '.highlighted',
+    style: { 'opacity': 1 }
+  },
+  {
+    selector: '.dimmed',
+    style: { 'opacity': 0.12 }
+  },
+  {
+    selector: 'node[type="network-line"].dimmed',
+    style: { 'opacity': 0.06 }
+  },
+];
+
+// ── Topology definitions ──
+
+function awsPublicTopology() {
+  return {
+    nodes: [
+      // Network boundary lines
+      netLine('net-external', 'External / Internet', -0.5, '#e879a0'),
+      netLine('net-mgmt', 'Management Cluster Network', 1.2, '#60a5fa'),
+      netLine('net-hcp', 'HCP Pod Network (konnectivity-server-local :8090)', 4, '#f59e0b'),
+      netLine('net-customer', 'Customer VPC Network', 9.8, '#34d399'),
+
+      // Zones
+      { data: { id: 'mgmt', label: 'Management Cluster (Provider VPC)', type: 'zone', zone: 'mgmt' } },
+      { data: { id: 'hcp', label: 'Hosted Control Plane Namespace', type: 'zone', zone: 'hcp', parent: 'mgmt' } },
+      { data: { id: 'tc', label: 'Tunnel consumers (via konnectivity proxy sidecars)', type: 'zone', zone: 'tunnel-consumers', parent: 'hcp' } },
+      { data: { id: 'dp', label: 'Data Plane (Customer VPC)', type: 'zone', zone: 'dataplane' } },
+
+      // External
+      { data: { id: 'users', label: 'External Users', type: 'component', role: 'user',
+          desc: 'End users / administrators accessing the hosted cluster API' },
+        position: pos(2.5, -1.5) },
+
+      // On management cluster network
+      { data: { id: 'kas-lb', label: 'KAS LoadBalancer', type: 'component', role: 'infra', parent: 'mgmt',
+          desc: 'AWS NLB/ELB exposing the Kubernetes API Server externally on :6443' },
+        position: pos(0.5, 2.5) },
+      { data: { id: 'mc-ingress', label: 'MC Ingress (Router)', type: 'component', role: 'infra', parent: 'mgmt',
+          desc: 'Management cluster OpenShift ingress controller (shared router). Exposes OAuth, Konnectivity, Ignition via Routes.' },
+        position: pos(3, 2.5) },
+
+      // HCP components (on HCP pod network)
+      { data: { id: 'kas', label: 'kube-apiserver', type: 'component', parent: 'hcp',
+          desc: 'Kubernetes API Server. Uses egress-selector config to route cluster traffic through Konnectivity.' },
+        position: pos(0, 5.5) },
+      { data: { id: 'etcd', label: 'etcd', type: 'component', parent: 'hcp',
+          desc: 'Cluster state store, accessed only by KAS' },
+        position: pos(-1, 5.5) },
+      { data: { id: 'konn-server', label: 'konnectivity-server', type: 'component', role: 'konnectivity', parent: 'hcp',
+          desc: 'Sidecar in KAS pod. Server endpoint :8090 (local, via konnectivity-server-local svc). Cluster endpoint :8091 (external, via Route/LB).' },
+        position: pos(1.2, 7) },
+      { data: { id: 'sidecar-label', label: '(sidecar in KAS pod)', type: 'component', role: 'sidecar-label', parent: 'hcp' },
+        position: pos(1.2, 8) },
+      { data: { id: 'konn-agent-cp', label: 'konnectivity-agent (CP)', type: 'component', role: 'konnectivity', parent: 'hcp',
+          desc: 'CP-side agent routing APIService traffic for aggregated APIs (openshift-apiserver, oauth, package-server) back to CP.' },
+        position: pos(3.5, 5.5) },
+
+      // Tunnel consumers
+      { data: { id: 'oapi', label: 'openshift-apiserver', type: 'component', parent: 'tc',
+          desc: 'Serves OpenShift resources (ImageStreams, etc). Uses konnectivity-https-proxy sidecar.' },
+        position: pos(3.5, 7) },
+      { data: { id: 'oauth', label: 'oauth-apiserver', type: 'component', parent: 'tc',
+          desc: 'Handles authentication. Uses both socks5 and https konnectivity proxies.' },
+        position: pos(3.5, 8) },
+      { data: { id: 'cno', label: 'cluster-network-operator', type: 'component', parent: 'tc',
+          desc: 'Manages cluster networking. Uses konnectivity-socks5-proxy for DP readiness checks.' },
+        position: pos(5, 7) },
+      { data: { id: 'ovn', label: 'ovnkube-control-plane', type: 'component', parent: 'tc',
+          desc: 'OVN control plane. Uses konnectivity-socks5-proxy for OVN interconnect.' },
+        position: pos(5, 8) },
+      { data: { id: 'ingress-op', label: 'ingress-operator', type: 'component', parent: 'tc',
+          desc: 'Manages ingress. Uses konnectivity-https-proxy for route health checks in DP.' },
+        position: pos(6.5, 7) },
+      { data: { id: 'olm', label: 'OLM (operator-lifecycle)', type: 'component', parent: 'tc',
+          desc: 'OLM operator + catalog operator + package-server. Uses konnectivity-socks5-proxy for GRPC to in-cluster catalogs.' },
+        position: pos(6.5, 8) },
+
+      // Data Plane (on customer VPC network)
+      { data: { id: 'konn-agent', label: 'konnectivity-agent', type: 'component', role: 'konnectivity', parent: 'dp',
+          desc: 'DaemonSet on every worker node. Establishes outbound tunnel to konnectivity-server on port 8091.' },
+        position: pos(1.2, 11) },
+      { data: { id: 'kubelet', label: 'kubelet', type: 'component', parent: 'dp',
+          desc: 'Node agent - serves logs, exec, port-forward requests via Konnectivity tunnel.' },
+        position: pos(3.5, 11) },
+      { data: { id: 'services', label: 'workload services', type: 'component', parent: 'dp',
+          desc: 'User workloads, webhooks, aggregated API endpoints in the data plane.' },
+        position: pos(5, 11) },
+      { data: { id: 'ovn-agent', label: 'OVN agents', type: 'component', parent: 'dp',
+          desc: 'ovnkube-node DaemonSet - network plugin agents on worker nodes.' },
+        position: pos(6.5, 11) },
+    ],
+    edges: [
+      { data: { source: 'users', target: 'kas-lb', label: 'kubectl / oc', flow: 'direct' } },
+      { data: { source: 'users', target: 'mc-ingress', label: 'OAuth login', flow: 'direct' } },
+      { data: { source: 'kas-lb', target: 'kas', label: ':6443', flow: 'direct' } },
+      { data: { source: 'mc-ingress', target: 'oauth', label: 'Route', flow: 'direct' } },
+      { data: { source: 'mc-ingress', target: 'konn-server', label: 'Route :8091', flow: 'direct' } },
+      { data: { source: 'kas', target: 'etcd', label: ':2379', flow: 'internal' } },
+      { data: { source: 'kas', target: 'konn-server', label: 'egress-selector', flow: 'tunneled' } },
+      { data: { source: 'kubelet', target: 'kas-lb', label: 'API registration', flow: 'direct' } },
+      { data: { source: 'konn-agent', target: 'mc-ingress', label: 'tunnel init :8091', flow: 'tunnel-establish' } },
+      { data: { source: 'konn-server', target: 'konn-agent', flow: 'tunnel-pipe' } },
+      { data: { source: 'konn-agent', target: 'kubelet', label: 'logs / exec / port-fwd', flow: 'tunneled' } },
+      { data: { source: 'konn-agent', target: 'services', label: 'webhooks', flow: 'tunneled' } },
+      { data: { source: 'konn-agent', target: 'ovn-agent', label: 'OVN interconnect', flow: 'tunneled' } },
+      { data: { source: 'oapi', target: 'konn-server', label: 'https-proxy', flow: 'tunneled' } },
+      { data: { source: 'oauth', target: 'konn-server', label: 'socks5 / https', flow: 'tunneled' } },
+      { data: { source: 'cno', target: 'konn-server', label: 'socks5', flow: 'tunneled' } },
+      { data: { source: 'ovn', target: 'konn-server', label: 'socks5', flow: 'tunneled' } },
+      { data: { source: 'ingress-op', target: 'konn-server', label: 'https-proxy', flow: 'tunneled' } },
+      { data: { source: 'olm', target: 'konn-server', label: 'socks5 (GRPC)', flow: 'tunneled' } },
+      { data: { source: 'konn-server', target: 'konn-agent-cp', label: 'APIService traffic', flow: 'tunneled' } },
+      { data: { source: 'konn-agent-cp', target: 'oapi', flow: 'tunneled' } },
+      { data: { source: 'konn-agent-cp', target: 'oauth', flow: 'tunneled' } },
+    ],
+  };
+}
+
+function awsPublicExtDnsTopology() {
+  return {
+    nodes: [
+      netLine('net-external', 'External / Internet', -0.5, '#e879a0'),
+      netLine('net-mgmt', 'Management Cluster Network', 1.2, '#60a5fa'),
+      netLine('net-hcp', 'HCP Pod Network', 4, '#f59e0b'),
+      netLine('net-customer', 'Customer VPC Network', 9.8, '#34d399'),
+
+      { data: { id: 'mgmt', label: 'Management Cluster (Provider VPC)', type: 'zone', zone: 'mgmt' } },
+      { data: { id: 'hcp', label: 'Hosted Control Plane Namespace', type: 'zone', zone: 'hcp', parent: 'mgmt' } },
+      { data: { id: 'tc', label: 'Tunnel consumers (via proxy sidecars)', type: 'zone', zone: 'tunnel-consumers', parent: 'hcp' } },
+      { data: { id: 'dp', label: 'Data Plane (Customer VPC)', type: 'zone', zone: 'dataplane' } },
+
+      { data: { id: 'users', label: 'External Users', type: 'component', role: 'user' }, position: pos(2, -1.5) },
+      { data: { id: 'hcp-router', label: 'HCP Router (ext LB)', type: 'component', role: 'infra', parent: 'hcp',
+          desc: 'Dedicated router with external LB, routes all services via external DNS hostnames' }, position: pos(1.5, 2.5) },
+
+      { data: { id: 'kas', label: 'kube-apiserver', type: 'component', parent: 'hcp' }, position: pos(0, 5.5) },
+      { data: { id: 'etcd', label: 'etcd', type: 'component', parent: 'hcp' }, position: pos(-1, 5.5) },
+      { data: { id: 'konn-server', label: 'konnectivity-server', type: 'component', role: 'konnectivity', parent: 'hcp' }, position: pos(1.2, 7) },
+      { data: { id: 'sidecar-label', label: '(sidecar in KAS pod)', type: 'component', role: 'sidecar-label', parent: 'hcp' }, position: pos(1.2, 8) },
+      { data: { id: 'konn-agent-cp', label: 'konnectivity-agent (CP)', type: 'component', role: 'konnectivity', parent: 'hcp' }, position: pos(3.5, 5.5) },
+
+      { data: { id: 'oapi', label: 'openshift-apiserver', type: 'component', parent: 'tc' }, position: pos(3.5, 7) },
+      { data: { id: 'oauth', label: 'oauth-apiserver', type: 'component', parent: 'tc' }, position: pos(3.5, 8) },
+      { data: { id: 'cno', label: 'cluster-network-operator', type: 'component', parent: 'tc' }, position: pos(5, 7) },
+      { data: { id: 'ovn', label: 'ovnkube-control-plane', type: 'component', parent: 'tc' }, position: pos(5, 8) },
+      { data: { id: 'ingress-op', label: 'ingress-operator', type: 'component', parent: 'tc' }, position: pos(6.5, 7) },
+      { data: { id: 'olm', label: 'OLM (operator-lifecycle)', type: 'component', parent: 'tc' }, position: pos(6.5, 8) },
+
+      { data: { id: 'konn-agent', label: 'konnectivity-agent', type: 'component', role: 'konnectivity', parent: 'dp' }, position: pos(1.2, 11) },
+      { data: { id: 'kubelet', label: 'kubelet', type: 'component', parent: 'dp' }, position: pos(3.5, 11) },
+      { data: { id: 'services', label: 'workload services', type: 'component', parent: 'dp' }, position: pos(5, 11) },
+      { data: { id: 'ovn-agent', label: 'OVN agents', type: 'component', parent: 'dp' }, position: pos(6.5, 11) },
+    ],
+    edges: [
+      { data: { source: 'users', target: 'hcp-router', label: 'api.cluster.example.com', flow: 'direct' } },
+      { data: { source: 'hcp-router', target: 'kas', label: 'Route', flow: 'direct' } },
+      { data: { source: 'hcp-router', target: 'oauth', label: 'Route', flow: 'direct' } },
+      { data: { source: 'hcp-router', target: 'konn-server', label: 'Route :8091', flow: 'direct' } },
+      { data: { source: 'kas', target: 'etcd', label: ':2379', flow: 'internal' } },
+      { data: { source: 'kas', target: 'konn-server', label: 'egress-selector', flow: 'tunneled' } },
+      { data: { source: 'kubelet', target: 'hcp-router', label: 'API registration', flow: 'direct' } },
+      { data: { source: 'konn-agent', target: 'hcp-router', label: 'tunnel init :8091', flow: 'tunnel-establish' } },
+      { data: { source: 'konn-server', target: 'konn-agent', flow: 'tunnel-pipe' } },
+      { data: { source: 'konn-agent', target: 'kubelet', label: 'logs / exec', flow: 'tunneled' } },
+      { data: { source: 'konn-agent', target: 'services', label: 'webhooks', flow: 'tunneled' } },
+      { data: { source: 'konn-agent', target: 'ovn-agent', label: 'OVN interconnect', flow: 'tunneled' } },
+      { data: { source: 'oapi', target: 'konn-server', label: 'https-proxy', flow: 'tunneled' } },
+      { data: { source: 'oauth', target: 'konn-server', label: 'socks5 / https', flow: 'tunneled' } },
+      { data: { source: 'cno', target: 'konn-server', label: 'socks5', flow: 'tunneled' } },
+      { data: { source: 'ovn', target: 'konn-server', label: 'socks5', flow: 'tunneled' } },
+      { data: { source: 'ingress-op', target: 'konn-server', label: 'https-proxy', flow: 'tunneled' } },
+      { data: { source: 'olm', target: 'konn-server', label: 'socks5 (GRPC)', flow: 'tunneled' } },
+      { data: { source: 'konn-server', target: 'konn-agent-cp', label: 'APIService traffic', flow: 'tunneled' } },
+      { data: { source: 'konn-agent-cp', target: 'oapi', flow: 'tunneled' } },
+      { data: { source: 'konn-agent-cp', target: 'oauth', flow: 'tunneled' } },
+    ],
+  };
+}
+
+function awsPrivateTopology() {
+  return {
+    nodes: [
+      netLine('net-mgmt', 'Management Cluster Network (Provider VPC)', 1.2, '#60a5fa'),
+      netLine('net-hcp', 'HCP Pod Network', 4, '#f59e0b'),
+      netLine('net-privatelink', 'AWS PrivateLink Boundary', 9.5, '#a78bfa'),
+      netLine('net-customer', 'Customer VPC Network', 10.5, '#34d399'),
+
+      { data: { id: 'mgmt', label: 'Management Cluster (Provider VPC)', type: 'zone', zone: 'mgmt' } },
+      { data: { id: 'hcp', label: 'Hosted Control Plane Namespace', type: 'zone', zone: 'hcp', parent: 'mgmt' } },
+      { data: { id: 'tc', label: 'Tunnel consumers (via proxy sidecars)', type: 'zone', zone: 'tunnel-consumers', parent: 'hcp' } },
+      { data: { id: 'dp', label: 'Data Plane (Customer VPC)', type: 'zone', zone: 'dataplane' } },
+
+      { data: { id: 'users', label: 'External Users (VPN)', type: 'component', role: 'user' }, position: pos(-0.5, -1.5) },
+      { data: { id: 'privatelink', label: 'AWS PrivateLink Endpoint', type: 'component', role: 'external',
+          desc: 'VPC endpoint service connecting customer VPC to provider VPC privately' }, position: pos(1.5, 10) },
+      { data: { id: 'hcp-router', label: 'HCP Router (internal LB)', type: 'component', role: 'infra', parent: 'hcp',
+          desc: 'Dedicated router with internal LB only, all traffic via PrivateLink' }, position: pos(1.5, 2.5) },
+
+      { data: { id: 'kas', label: 'kube-apiserver', type: 'component', parent: 'hcp' }, position: pos(0, 5.5) },
+      { data: { id: 'etcd', label: 'etcd', type: 'component', parent: 'hcp' }, position: pos(-1, 5.5) },
+      { data: { id: 'konn-server', label: 'konnectivity-server', type: 'component', role: 'konnectivity', parent: 'hcp' }, position: pos(1.2, 7) },
+      { data: { id: 'sidecar-label', label: '(sidecar in KAS pod)', type: 'component', role: 'sidecar-label', parent: 'hcp' }, position: pos(1.2, 8) },
+      { data: { id: 'konn-agent-cp', label: 'konnectivity-agent (CP)', type: 'component', role: 'konnectivity', parent: 'hcp' }, position: pos(3.5, 5.5) },
+
+      { data: { id: 'oapi', label: 'openshift-apiserver', type: 'component', parent: 'tc' }, position: pos(3.5, 7) },
+      { data: { id: 'oauth', label: 'oauth-apiserver', type: 'component', parent: 'tc' }, position: pos(3.5, 8) },
+      { data: { id: 'cno', label: 'cluster-network-operator', type: 'component', parent: 'tc' }, position: pos(5, 7) },
+      { data: { id: 'ovn', label: 'ovnkube-control-plane', type: 'component', parent: 'tc' }, position: pos(5, 8) },
+      { data: { id: 'ingress-op', label: 'ingress-operator', type: 'component', parent: 'tc' }, position: pos(6.5, 7) },
+      { data: { id: 'olm', label: 'OLM (operator-lifecycle)', type: 'component', parent: 'tc' }, position: pos(6.5, 8) },
+
+      { data: { id: 'konn-agent', label: 'konnectivity-agent', type: 'component', role: 'konnectivity', parent: 'dp' }, position: pos(1.2, 12) },
+      { data: { id: 'kubelet', label: 'kubelet', type: 'component', parent: 'dp' }, position: pos(3.5, 12) },
+      { data: { id: 'services', label: 'workload services', type: 'component', parent: 'dp' }, position: pos(5, 12) },
+      { data: { id: 'ovn-agent', label: 'OVN agents', type: 'component', parent: 'dp' }, position: pos(6.5, 12) },
+    ],
+    edges: [
+      { data: { source: 'users', target: 'privatelink', label: 'VPN / Direct Connect', flow: 'private' } },
+      { data: { source: 'privatelink', target: 'hcp-router', label: 'PrivateLink', flow: 'private' } },
+      { data: { source: 'kubelet', target: 'privatelink', label: 'API access', flow: 'private' } },
+      { data: { source: 'konn-agent', target: 'privatelink', label: 'tunnel init', flow: 'tunnel-establish' } },
+      { data: { source: 'hcp-router', target: 'kas', label: 'Route', flow: 'direct' } },
+      { data: { source: 'hcp-router', target: 'oauth', label: 'Route', flow: 'direct' } },
+      { data: { source: 'hcp-router', target: 'konn-server', label: 'Route :8091', flow: 'direct' } },
+      { data: { source: 'kas', target: 'etcd', label: ':2379', flow: 'internal' } },
+      { data: { source: 'kas', target: 'konn-server', label: 'egress-selector', flow: 'tunneled' } },
+      { data: { source: 'konn-server', target: 'konn-agent', flow: 'tunnel-pipe' } },
+      { data: { source: 'konn-agent', target: 'kubelet', label: 'logs / exec', flow: 'tunneled' } },
+      { data: { source: 'konn-agent', target: 'services', label: 'webhooks', flow: 'tunneled' } },
+      { data: { source: 'konn-agent', target: 'ovn-agent', label: 'OVN interconnect', flow: 'tunneled' } },
+      { data: { source: 'oapi', target: 'konn-server', label: 'https-proxy', flow: 'tunneled' } },
+      { data: { source: 'oauth', target: 'konn-server', label: 'socks5 / https', flow: 'tunneled' } },
+      { data: { source: 'cno', target: 'konn-server', label: 'socks5', flow: 'tunneled' } },
+      { data: { source: 'ovn', target: 'konn-server', label: 'socks5', flow: 'tunneled' } },
+      { data: { source: 'ingress-op', target: 'konn-server', label: 'https-proxy', flow: 'tunneled' } },
+      { data: { source: 'olm', target: 'konn-server', label: 'socks5 (GRPC)', flow: 'tunneled' } },
+      { data: { source: 'konn-server', target: 'konn-agent-cp', label: 'APIService traffic', flow: 'tunneled' } },
+      { data: { source: 'konn-agent-cp', target: 'oapi', flow: 'tunneled' } },
+      { data: { source: 'konn-agent-cp', target: 'oauth', flow: 'tunneled' } },
+    ],
+  };
+}
+
+function azureAroHcpTopology() {
+  return {
+    nodes: [
+      netLine('net-external', 'External / Internet', -0.5, '#e879a0'),
+      netLine('net-aks', 'AKS Management Cluster Network', 1.2, '#60a5fa'),
+      netLine('net-hcp', 'HCP Pod Network', 4, '#f59e0b'),
+      netLine('net-swift', 'Azure Swift (Service Networking)', 9.5, '#a78bfa'),
+      netLine('net-customer', 'Customer VNet', 10.5, '#34d399'),
+
+      { data: { id: 'mgmt', label: 'AKS Management Cluster', type: 'zone', zone: 'mgmt' } },
+      { data: { id: 'hcp', label: 'Hosted Control Plane Namespace', type: 'zone', zone: 'hcp', parent: 'mgmt' } },
+      { data: { id: 'tc', label: 'Tunnel consumers (via proxy sidecars)', type: 'zone', zone: 'tunnel-consumers', parent: 'hcp' } },
+      { data: { id: 'shared-ingress', label: 'Shared Ingress (hypershift-sharedingress ns)', type: 'zone', zone: 'shared-ingress', parent: 'mgmt' } },
+      { data: { id: 'dp', label: 'Data Plane (Customer VNet)', type: 'zone', zone: 'dataplane' } },
+
+      { data: { id: 'users', label: 'External Users', type: 'component', role: 'user' }, position: pos(0, -1.5) },
+      { data: { id: 'azure-lb', label: 'Azure LoadBalancer', type: 'component', role: 'infra', parent: 'shared-ingress',
+          desc: 'Single Azure LB fronting all hosted clusters' }, position: pos(-0.5, 2.5) },
+      { data: { id: 'haproxy', label: 'HAProxy (SNI routing)', type: 'component', role: 'infra', parent: 'shared-ingress',
+          desc: 'Central HAProxy with SNI-based hostname routing, shared across all hosted clusters' }, position: pos(1, 2.5) },
+      { data: { id: 'private-router', label: 'Private Router (Swift)', type: 'component', role: 'external', parent: 'mgmt',
+          desc: 'Swift-enabled pod bridging AKS and customer VNet. Routes Konnectivity and Ignition traffic via hypershift.local DNS.' }, position: pos(3, 2.5) },
+
+      { data: { id: 'kas', label: 'kube-apiserver', type: 'component', parent: 'hcp' }, position: pos(0, 5.5) },
+      { data: { id: 'etcd', label: 'etcd', type: 'component', parent: 'hcp' }, position: pos(-1, 5.5) },
+      { data: { id: 'konn-server', label: 'konnectivity-server', type: 'component', role: 'konnectivity', parent: 'hcp' }, position: pos(1.2, 7) },
+      { data: { id: 'sidecar-label', label: '(sidecar in KAS pod)', type: 'component', role: 'sidecar-label', parent: 'hcp' }, position: pos(1.2, 8) },
+      { data: { id: 'konn-agent-cp', label: 'konnectivity-agent (CP)', type: 'component', role: 'konnectivity', parent: 'hcp' }, position: pos(3.5, 5.5) },
+
+      { data: { id: 'oapi', label: 'openshift-apiserver', type: 'component', parent: 'tc' }, position: pos(3.5, 7) },
+      { data: { id: 'oauth', label: 'oauth-apiserver', type: 'component', parent: 'tc' }, position: pos(3.5, 8) },
+      { data: { id: 'cno', label: 'cluster-network-operator', type: 'component', parent: 'tc' }, position: pos(5, 7) },
+      { data: { id: 'ovn', label: 'ovnkube-control-plane', type: 'component', parent: 'tc' }, position: pos(5, 8) },
+      { data: { id: 'olm', label: 'OLM', type: 'component', parent: 'tc' }, position: pos(6.5, 7.5) },
+
+      { data: { id: 'konn-agent', label: 'konnectivity-agent', type: 'component', role: 'konnectivity', parent: 'dp' }, position: pos(1.2, 12) },
+      { data: { id: 'kubelet', label: 'kubelet', type: 'component', parent: 'dp' }, position: pos(3.5, 12) },
+      { data: { id: 'services', label: 'workload services', type: 'component', parent: 'dp' }, position: pos(5, 12) },
+      { data: { id: 'ovn-agent', label: 'OVN agents', type: 'component', parent: 'dp' }, position: pos(6.5, 12) },
+    ],
+    edges: [
+      { data: { source: 'users', target: 'azure-lb', label: 'HTTPS', flow: 'direct' } },
+      { data: { source: 'azure-lb', target: 'haproxy', flow: 'direct' } },
+      { data: { source: 'haproxy', target: 'kas', label: 'SNI routing', flow: 'direct' } },
+      { data: { source: 'haproxy', target: 'oauth', label: 'SNI routing', flow: 'direct' } },
+      { data: { source: 'kubelet', target: 'private-router', label: 'hypershift.local', flow: 'private' } },
+      { data: { source: 'konn-agent', target: 'private-router', label: 'Swift tunnel init', flow: 'tunnel-establish' } },
+      { data: { source: 'private-router', target: 'konn-server', label: 'Konnectivity Route', flow: 'private' } },
+      { data: { source: 'private-router', target: 'kas', label: 'API Route', flow: 'private' } },
+      { data: { source: 'kas', target: 'etcd', label: ':2379', flow: 'internal' } },
+      { data: { source: 'kas', target: 'konn-server', label: 'egress-selector', flow: 'tunneled' } },
+      { data: { source: 'konn-server', target: 'konn-agent', flow: 'tunnel-pipe' } },
+      { data: { source: 'konn-agent', target: 'kubelet', label: 'logs / exec', flow: 'tunneled' } },
+      { data: { source: 'konn-agent', target: 'services', label: 'webhooks', flow: 'tunneled' } },
+      { data: { source: 'konn-agent', target: 'ovn-agent', label: 'OVN interconnect', flow: 'tunneled' } },
+      { data: { source: 'oapi', target: 'konn-server', label: 'https-proxy', flow: 'tunneled' } },
+      { data: { source: 'oauth', target: 'konn-server', label: 'socks5 / https', flow: 'tunneled' } },
+      { data: { source: 'cno', target: 'konn-server', label: 'socks5', flow: 'tunneled' } },
+      { data: { source: 'ovn', target: 'konn-server', label: 'socks5', flow: 'tunneled' } },
+      { data: { source: 'olm', target: 'konn-server', label: 'socks5 (GRPC)', flow: 'tunneled' } },
+      { data: { source: 'konn-server', target: 'konn-agent-cp', label: 'APIService traffic', flow: 'tunneled' } },
+      { data: { source: 'konn-agent-cp', target: 'oapi', flow: 'tunneled' } },
+      { data: { source: 'konn-agent-cp', target: 'oauth', flow: 'tunneled' } },
+    ],
+  };
+}
+
+function azureSelfManagedTopology() {
+  return {
+    nodes: [
+      netLine('net-external', 'External / Internet', -0.5, '#e879a0'),
+      netLine('net-mgmt', 'Management Cluster Network (OpenShift on Azure)', 1.2, '#60a5fa'),
+      netLine('net-hcp', 'HCP Pod Network', 4, '#f59e0b'),
+      netLine('net-customer', 'Customer VNet', 9.8, '#34d399'),
+
+      { data: { id: 'mgmt', label: 'Management Cluster (OpenShift on Azure)', type: 'zone', zone: 'mgmt' } },
+      { data: { id: 'hcp', label: 'Hosted Control Plane Namespace', type: 'zone', zone: 'hcp', parent: 'mgmt' } },
+      { data: { id: 'tc', label: 'Tunnel consumers (via proxy sidecars)', type: 'zone', zone: 'tunnel-consumers', parent: 'hcp' } },
+      { data: { id: 'dp', label: 'Data Plane (Customer VNet)', type: 'zone', zone: 'dataplane' } },
+
+      { data: { id: 'users', label: 'External Users', type: 'component', role: 'user' }, position: pos(2, -1.5) },
+      { data: { id: 'mc-ingress', label: 'MC Ingress Controller', type: 'component', role: 'infra', parent: 'mgmt' }, position: pos(1.5, 2.5) },
+
+      { data: { id: 'kas', label: 'kube-apiserver', type: 'component', parent: 'hcp' }, position: pos(0, 5.5) },
+      { data: { id: 'etcd', label: 'etcd', type: 'component', parent: 'hcp' }, position: pos(-1, 5.5) },
+      { data: { id: 'konn-server', label: 'konnectivity-server', type: 'component', role: 'konnectivity', parent: 'hcp' }, position: pos(1.2, 7) },
+      { data: { id: 'sidecar-label', label: '(sidecar in KAS pod)', type: 'component', role: 'sidecar-label', parent: 'hcp' }, position: pos(1.2, 8) },
+      { data: { id: 'konn-agent-cp', label: 'konnectivity-agent (CP)', type: 'component', role: 'konnectivity', parent: 'hcp' }, position: pos(3.5, 5.5) },
+
+      { data: { id: 'oapi', label: 'openshift-apiserver', type: 'component', parent: 'tc' }, position: pos(3.5, 7) },
+      { data: { id: 'oauth', label: 'oauth-apiserver', type: 'component', parent: 'tc' }, position: pos(3.5, 8) },
+      { data: { id: 'cno', label: 'cluster-network-operator', type: 'component', parent: 'tc' }, position: pos(5, 7) },
+      { data: { id: 'ovn', label: 'ovnkube-control-plane', type: 'component', parent: 'tc' }, position: pos(5, 8) },
+      { data: { id: 'olm', label: 'OLM', type: 'component', parent: 'tc' }, position: pos(6.5, 7.5) },
+
+      { data: { id: 'konn-agent', label: 'konnectivity-agent', type: 'component', role: 'konnectivity', parent: 'dp' }, position: pos(1.2, 11) },
+      { data: { id: 'kubelet', label: 'kubelet', type: 'component', parent: 'dp' }, position: pos(3.5, 11) },
+      { data: { id: 'services', label: 'workload services', type: 'component', parent: 'dp' }, position: pos(5, 11) },
+    ],
+    edges: [
+      { data: { source: 'users', target: 'mc-ingress', label: 'External DNS', flow: 'direct' } },
+      { data: { source: 'kubelet', target: 'mc-ingress', label: 'External DNS', flow: 'direct' } },
+      { data: { source: 'konn-agent', target: 'mc-ingress', label: 'tunnel init', flow: 'tunnel-establish' } },
+      { data: { source: 'mc-ingress', target: 'kas', label: 'Route', flow: 'direct' } },
+      { data: { source: 'mc-ingress', target: 'oauth', label: 'Route', flow: 'direct' } },
+      { data: { source: 'mc-ingress', target: 'konn-server', label: 'Route :8091', flow: 'direct' } },
+      { data: { source: 'kas', target: 'etcd', label: ':2379', flow: 'internal' } },
+      { data: { source: 'kas', target: 'konn-server', label: 'egress-selector', flow: 'tunneled' } },
+      { data: { source: 'konn-server', target: 'konn-agent', flow: 'tunnel-pipe' } },
+      { data: { source: 'konn-agent', target: 'kubelet', label: 'logs / exec', flow: 'tunneled' } },
+      { data: { source: 'konn-agent', target: 'services', label: 'webhooks', flow: 'tunneled' } },
+      { data: { source: 'oapi', target: 'konn-server', label: 'https-proxy', flow: 'tunneled' } },
+      { data: { source: 'oauth', target: 'konn-server', label: 'socks5 / https', flow: 'tunneled' } },
+      { data: { source: 'cno', target: 'konn-server', label: 'socks5', flow: 'tunneled' } },
+      { data: { source: 'ovn', target: 'konn-server', label: 'socks5', flow: 'tunneled' } },
+      { data: { source: 'olm', target: 'konn-server', label: 'socks5 (GRPC)', flow: 'tunneled' } },
+      { data: { source: 'konn-server', target: 'konn-agent-cp', label: 'APIService traffic', flow: 'tunneled' } },
+      { data: { source: 'konn-agent-cp', target: 'oapi', flow: 'tunneled' } },
+      { data: { source: 'konn-agent-cp', target: 'oauth', flow: 'tunneled' } },
+    ],
+  };
+}
+
+function agentNodeportTopology() {
+  return {
+    nodes: [
+      netLine('net-external', 'External Network', -0.5, '#e879a0'),
+      netLine('net-mgmt', 'Management Cluster Network', 1.2, '#60a5fa'),
+      netLine('net-hcp', 'HCP Pod Network', 4, '#f59e0b'),
+      netLine('net-customer', 'Bare Metal / Customer Network', 9.8, '#34d399'),
+
+      { data: { id: 'mgmt', label: 'Management Cluster (Bare Metal / On-Prem)', type: 'zone', zone: 'mgmt' } },
+      { data: { id: 'hcp', label: 'Hosted Control Plane Namespace', type: 'zone', zone: 'hcp', parent: 'mgmt' } },
+      { data: { id: 'tc', label: 'Tunnel consumers', type: 'zone', zone: 'tunnel-consumers', parent: 'hcp' } },
+      { data: { id: 'dp', label: 'Data Plane (Bare Metal Nodes)', type: 'zone', zone: 'dataplane' } },
+
+      { data: { id: 'users', label: 'External Users', type: 'component', role: 'user' }, position: pos(1, -1.5) },
+      { data: { id: 'mgmt-node', label: 'Management Node (10.0.0.100)', type: 'component', role: 'infra', parent: 'mgmt',
+          desc: 'NodePorts exposed on management cluster node IPs' }, position: pos(1.5, 2.5) },
+
+      { data: { id: 'kas', label: 'kube-apiserver', type: 'component', parent: 'hcp' }, position: pos(0, 5.5) },
+      { data: { id: 'etcd', label: 'etcd', type: 'component', parent: 'hcp' }, position: pos(-1, 5.5) },
+      { data: { id: 'konn-server', label: 'konnectivity-server', type: 'component', role: 'konnectivity', parent: 'hcp' }, position: pos(1.2, 7) },
+      { data: { id: 'sidecar-label', label: '(sidecar in KAS pod)', type: 'component', role: 'sidecar-label', parent: 'hcp' }, position: pos(1.2, 8) },
+      { data: { id: 'ignition', label: 'ignition-server', type: 'component', parent: 'hcp',
+          desc: 'Serves ignition configs for node bootstrapping, exposed via NodePort :8443' }, position: pos(-1, 7) },
+      { data: { id: 'konn-agent-cp', label: 'konnectivity-agent (CP)', type: 'component', role: 'konnectivity', parent: 'hcp' }, position: pos(3.5, 5.5) },
+
+      { data: { id: 'oapi', label: 'openshift-apiserver', type: 'component', parent: 'tc' }, position: pos(3.5, 7) },
+      { data: { id: 'oauth', label: 'oauth-apiserver', type: 'component', parent: 'tc' }, position: pos(3.5, 8) },
+
+      { data: { id: 'konn-agent', label: 'konnectivity-agent', type: 'component', role: 'konnectivity', parent: 'dp' }, position: pos(1.2, 11) },
+      { data: { id: 'kubelet', label: 'kubelet', type: 'component', parent: 'dp' }, position: pos(3.5, 11) },
+      { data: { id: 'services', label: 'workload services', type: 'component', parent: 'dp' }, position: pos(5, 11) },
+    ],
+    edges: [
+      { data: { source: 'users', target: 'mgmt-node', label: 'NodePort :30000', flow: 'direct' } },
+      { data: { source: 'kubelet', target: 'mgmt-node', label: 'NodePort :30000', flow: 'direct' } },
+      { data: { source: 'konn-agent', target: 'mgmt-node', label: 'NodePort :8091', flow: 'tunnel-establish' } },
+      { data: { source: 'mgmt-node', target: 'kas', label: 'KAS NodePort', flow: 'direct' } },
+      { data: { source: 'mgmt-node', target: 'oauth', label: 'OAuth NodePort', flow: 'direct' } },
+      { data: { source: 'mgmt-node', target: 'konn-server', label: 'Konn NodePort', flow: 'direct' } },
+      { data: { source: 'mgmt-node', target: 'ignition', label: 'Ignition :8443', flow: 'direct' } },
+      { data: { source: 'kas', target: 'etcd', label: ':2379', flow: 'internal' } },
+      { data: { source: 'kas', target: 'konn-server', label: 'egress-selector', flow: 'tunneled' } },
+      { data: { source: 'konn-server', target: 'konn-agent', flow: 'tunnel-pipe' } },
+      { data: { source: 'konn-agent', target: 'kubelet', label: 'logs / exec', flow: 'tunneled' } },
+      { data: { source: 'konn-agent', target: 'services', label: 'webhooks', flow: 'tunneled' } },
+      { data: { source: 'oapi', target: 'konn-server', label: 'https-proxy', flow: 'tunneled' } },
+      { data: { source: 'oauth', target: 'konn-server', label: 'socks5 / https', flow: 'tunneled' } },
+      { data: { source: 'konn-server', target: 'konn-agent-cp', label: 'APIService traffic', flow: 'tunneled' } },
+      { data: { source: 'konn-agent-cp', target: 'oapi', flow: 'tunneled' } },
+      { data: { source: 'konn-agent-cp', target: 'oauth', flow: 'tunneled' } },
+    ],
+  };
+}
+
+const TOPOLOGIES = {
+  'aws-public': awsPublicTopology,
+  'aws-public-extdns': awsPublicExtDnsTopology,
+  'aws-private': awsPrivateTopology,
+  'azure-aro-hcp': azureAroHcpTopology,
+  'azure-self-managed': azureSelfManagedTopology,
+  'agent-nodeport': agentNodeportTopology,
+};
+
+// ── App ──
+
+let cy;
+
+function renderTopology(key) {
+  const topo = TOPOLOGIES[key]();
+
+  if (cy) cy.destroy();
+
+  cy = cytoscape({
+    container: document.getElementById('cy'),
+    elements: { nodes: topo.nodes, edges: topo.edges },
+    style: STYLES,
+    layout: { name: 'preset' },
+    minZoom: 0.3,
+    maxZoom: 3,
+    wheelSensitivity: 0.3,
+  });
+
+  cy.fit(undefined, 50);
+
+  const tooltip = document.getElementById('tooltip');
+
+  cy.on('mouseover', 'node[type="component"]', (e) => {
+    const node = e.target;
+    if (node.data('role') === 'sidecar-label') return;
+
+    const connected = node.connectedEdges().connectedNodes();
+    const neighborhood = node.connectedEdges().union(connected).union(node);
+
+    cy.elements().addClass('dimmed');
+    neighborhood.removeClass('dimmed').addClass('highlighted');
+    neighborhood.parents().removeClass('dimmed');
+
+    const desc = node.data('desc');
+    if (desc) {
+      tooltip.querySelector('.tt-title').textContent = node.data('label');
+      tooltip.querySelector('.tt-desc').textContent = desc;
+      tooltip.style.display = 'block';
+    }
+  });
+
+  cy.on('mousemove', 'node[type="component"]', (e) => {
+    if (tooltip.style.display === 'block') {
+      tooltip.style.left = (e.originalEvent.clientX + 14) + 'px';
+      tooltip.style.top = (e.originalEvent.clientY + 14) + 'px';
+    }
+  });
+
+  cy.on('mouseout', 'node[type="component"]', () => {
+    cy.elements().removeClass('dimmed').removeClass('highlighted');
+    tooltip.style.display = 'none';
+  });
+}
+
+document.getElementById('topology-select').addEventListener('change', (e) => {
+  renderTopology(e.target.value);
+});
+
+document.getElementById('btn-fit').addEventListener('click', () => {
+  cy.fit(undefined, 50);
+});
+
+document.getElementById('btn-export').addEventListener('click', () => {
+  const png = cy.png({ output: 'blob', bg: '#0f1117', scale: 3, full: true });
+  const url = URL.createObjectURL(png);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `hypershift-network-${document.getElementById('topology-select').value}.png`;
+  a.click();
+  URL.revokeObjectURL(url);
+});
+
+renderTopology('aws-public');
+</script>
+</body>
+</html>

--- a/docs/content/reference/network-topology.md
+++ b/docs/content/reference/network-topology.md
@@ -1,0 +1,35 @@
+---
+title: Network Topology
+---
+
+# Network Topology
+
+Interactive diagrams showing HyperShift network connectivity across platforms and topology variants.
+Select a topology from the dropdown to explore how control plane and data plane components communicate,
+which flows traverse the Konnectivity tunnel, and how services are published.
+
+<iframe src="network-topology-viewer.html" width="100%" height="800" frameborder="0" style="border: 1px solid #ccc; border-radius: 4px;"></iframe>
+
+## Available Topologies
+
+| Topology | Platform | Description |
+|----------|----------|-------------|
+| AWS Public | AWS | Public endpoints via Route (KAS, OAuth, Konnectivity) and S3 (Ignition) |
+| AWS Public + ExternalDNS | AWS | Same as public but with ExternalDNS managing DNS records for service endpoints |
+| AWS Private | AWS | Private endpoints via PrivateLink; KAS accessible only within VPC |
+| Azure ARO HCP | Azure | Managed Azure with shared ingress via HAProxy, Swift networking for pods |
+| Azure Self-Managed | Azure | Self-managed Azure with Route-based service publishing |
+| Agent (NodePort) | Bare Metal | Agent/bare-metal platform using NodePort for all service endpoints |
+
+## Edge Legend
+
+- **Blue (solid)** — Direct network flow (e.g., client to KAS, KAS to etcd)
+- **Amber (solid)** — Flow tunneled through Konnectivity (e.g., KAS to kubelet, metrics scraping)
+- **Green (dashed)** — Konnectivity tunnel establishment (agent connects to server)
+- **Purple (solid)** — PrivateLink / private network flow
+- **Gray (solid)** — Internal cluster communication
+
+## Related
+
+- [Konnectivity](konnectivity.md) — architecture and troubleshooting for the Konnectivity tunnel
+- [Service Publishing Strategies](service-publishing-strategies.md) — how HCP services are exposed per platform

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
     - 'Global Pull Secret': how-to/common/global-pull-secret.md
     - 'HCP Networking Requirements': how-to/common/hcp-networking-requirements.md
     - how-to/common/multi-arch-on-hcp.md
+  - 'Cluster Capabilities': how-to/cluster-capabilities.md
   - how-to/metrics-sets.md
   - 'Configure OCP components':
     - how-to/configure-ocp-components/index.md
@@ -366,6 +367,7 @@ nav:
   - 'HO/CPO Release Process': contribute/release-process.md
   - 'OCP Branching Tasks': contribute/branch-process.md
   - 'Custom Images': contribute/custom-images.md
+  - 'Add a Capability': contribute/add-a-capability.md
   - 'Onboard a Platform': contribute/onboard-a-platform.md
   - 'Run Tests': contribute/run-tests.md
   - 'Develop in Cluster': contribute/develop_in_cluster.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -343,6 +343,7 @@ nav:
     - "Agent": reference/infrastructure/agent.md
   - reference/index.md
   - reference/konnectivity.md
+  - 'Network Topology': reference/network-topology.md
   - 'Manifests':
     - reference/manifests/index.md
     - 'IBM Cloud':


### PR DESCRIPTION
## Summary

- Add interactive Cytoscape.js network topology viewer showing HyperShift connectivity across 6 platform/topology variants
- Covers AWS (public, public+ExternalDNS, private), Azure (ARO HCP, self-managed), and Agent (NodePort)
- Visualizes Konnectivity tunnel flows, network boundary layers, service publishing, and PrivateLink paths
- Includes topology selector dropdown, hover details, and PNG export
- Embedded via iframe in a new Reference > Network Topology documentation page

## Test plan

- [ ] Run `cd docs && mkdocs serve` and verify the Network Topology page loads
- [ ] Confirm all 6 topology variants render correctly
- [ ] Verify hover interactions show edge/node details
- [ ] Verify PNG export button works
- [ ] Check nav link appears in Reference section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Cluster Capabilities Guide**: Added documentation explaining how to enable/disable optional OpenShift components at HostedCluster creation time via CLI or manifest configuration.
* **Add a Capability Guide**: New contributor guide for implementing new optional capabilities.
* **Interactive Network Topology Viewer**: Added an interactive visualization tool for exploring HyperShift network topologies across platforms and deployment scenarios.
* **Network Topology Reference**: New reference documentation describing network connectivity patterns and edge types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->