### PR TITLE
NO-JIRA: Add managed ingress DNS support for AWS hosted control planes

### DIFF
--- a/api/hypershift/v1beta1/aws.go
+++ b/api/hypershift/v1beta1/aws.go
@@ -309,6 +309,21 @@ type AWSCloudProviderConfig struct {
 	VPC string `json:"vpc"`
 }
 
+// AWSIngressDNSManagement specifies whether the control plane operator manages
+// Route53 hosted zones for ingress DNS in the customer's AWS account.
+type AWSIngressDNSManagement string
+
+const (
+	// AWSIngressDNSUnmanaged means the control plane operator does not create
+	// public/private ingress hosted zones. Only the .hypershift.local zone is managed.
+	AWSIngressDNSUnmanaged AWSIngressDNSManagement = "Unmanaged"
+
+	// AWSIngressDNSManaged means the control plane operator creates public and private
+	// Route53 hosted zones for ingress, creates a DNSEndpoint CR for NS delegation,
+	// and creates an _acme-challenge CNAME for cert-manager DNS01 CNAME-follow.
+	AWSIngressDNSManaged AWSIngressDNSManagement = "Managed"
+)
+
 // AWSEndpointAccessType specifies the publishing scope of cluster endpoints.
 type AWSEndpointAccessType string
 
@@ -414,6 +429,20 @@ type AWSPlatformSpec struct {
 	//
 	// +optional
 	SharedVPC *AWSSharedVPC `json:"sharedVPC,omitempty"`
+
+	// ingressDNSManagement specifies whether the control plane operator manages
+	// Route53 hosted zones for ingress DNS in the customer's AWS account.
+	// When set to "Managed", the CPO creates public and private ingress zones,
+	// a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+	// cert-manager DNS01 CNAME-follow.
+	// When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+	//
+	// +kubebuilder:validation:Enum=Unmanaged;Managed
+	// +kubebuilder:default=Unmanaged
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="ingressDNSManagement is immutable"
+	// +immutable
+	// +optional
+	IngressDNSManagement AWSIngressDNSManagement `json:"ingressDNSManagement,omitempty"`
 
 	// terminationHandlerQueueURL specifies the SQS queue URL for EC2 spot interruption events.
 	// This is required when using spot instances (marketType: Spot) in NodePools to enable

--- a/api/hypershift/v1beta1/endpointservice_types.go
+++ b/api/hypershift/v1beta1/endpointservice_types.go
@@ -25,6 +25,10 @@ const (
 	// created in the guest VPC
 	AWSEndpointAvailable ConditionType = "AWSEndpointAvailable"
 
+	// AWSIngressDNSAvailable indicates whether the Route53 ingress DNS zones
+	// and records have been successfully created in the customer's AWS account.
+	AWSIngressDNSAvailable ConditionType = "AWSIngressDNSAvailable"
+
 	AWSSuccessReason string = "AWSSuccess"
 	AWSErrorReason   string = "AWSError"
 )
@@ -92,6 +96,18 @@ type AWSEndpointServiceStatus struct {
 	// SecurityGroupID is the ID of the security group.
 	// +optional
 	SecurityGroupID string `json:"securityGroupID,omitempty"`
+
+	// ingressPublicZoneID is the Route53 hosted zone ID for the public ingress zone
+	// created when IngressDNSManagement is Managed.
+	// +optional
+	// +kubebuilder:validation:MaxLength=32
+	IngressPublicZoneID string `json:"ingressPublicZoneID,omitempty"`
+
+	// ingressPrivateZoneID is the Route53 hosted zone ID for the private ingress zone
+	// created when IngressDNSManagement is Managed.
+	// +optional
+	// +kubebuilder:validation:MaxLength=32
+	IngressPrivateZoneID string `json:"ingressPrivateZoneID,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/hypershift/v1beta1/endpointservice_types.go
+++ b/api/hypershift/v1beta1/endpointservice_types.go
@@ -60,7 +60,7 @@ type AWSEndpointServiceStatus struct {
 	// exist, then the Available condition will be false, reason AWSErrorReason,
 	// and the error reported in the message.
 	//
-	// Current condition types are: "Available"
+	// Current condition types are: "AWSEndpointServiceAvailable", "AWSEndpointAvailable", "AWSIngressDNSAvailable"
 	// +optional
 	// +listType=map
 	// +listMapKey=type

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/awsendpointservices.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/awsendpointservices.hypershift.openshift.io/AAA_ungated.yaml
@@ -178,6 +178,18 @@ spec:
                   management VPC
                 maxLength: 255
                 type: string
+              ingressPrivateZoneID:
+                description: |-
+                  ingressPrivateZoneID is the Route53 hosted zone ID for the private ingress zone
+                  created when IngressDNSManagement is Managed.
+                maxLength: 32
+                type: string
+              ingressPublicZoneID:
+                description: |-
+                  ingressPublicZoneID is the Route53 hosted zone ID for the public ingress zone
+                  created when IngressDNSManagement is Managed.
+                maxLength: 32
+                type: string
               securityGroupID:
                 description: |-
                   securityGroupID is the ID for the VPC endpoint SecurityGroup

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -4031,6 +4031,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -4022,6 +4022,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -4042,6 +4042,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -4354,6 +4354,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -4494,6 +4494,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -4485,6 +4485,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
@@ -4022,6 +4022,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -4087,6 +4087,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -4044,6 +4044,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -4040,6 +4040,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -4098,6 +4098,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -4022,6 +4022,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSAdherence.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSAdherence.yaml
@@ -4062,6 +4062,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -3911,6 +3911,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -3902,6 +3902,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -3922,6 +3922,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -4234,6 +4234,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -4374,6 +4374,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -4365,6 +4365,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
@@ -3902,6 +3902,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -3967,6 +3967,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -3924,6 +3924,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -3920,6 +3920,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -3978,6 +3978,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -3902,6 +3902,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSAdherence.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSAdherence.yaml
@@ -3942,6 +3942,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/client/applyconfiguration/hypershift/v1beta1/awsplatformspec.go
+++ b/client/applyconfiguration/hypershift/v1beta1/awsplatformspec.go
@@ -24,16 +24,17 @@ import (
 // AWSPlatformSpecApplyConfiguration represents a declarative configuration of the AWSPlatformSpec type for use
 // with apply.
 type AWSPlatformSpecApplyConfiguration struct {
-	Region                      *string                                   `json:"region,omitempty"`
-	CloudProviderConfig         *AWSCloudProviderConfigApplyConfiguration `json:"cloudProviderConfig,omitempty"`
-	ServiceEndpoints            []AWSServiceEndpointApplyConfiguration    `json:"serviceEndpoints,omitempty"`
-	RolesRef                    *AWSRolesRefApplyConfiguration            `json:"rolesRef,omitempty"`
-	ResourceTags                []AWSResourceTagApplyConfiguration        `json:"resourceTags,omitempty"`
-	EndpointAccess              *hypershiftv1beta1.AWSEndpointAccessType  `json:"endpointAccess,omitempty"`
-	AdditionalAllowedPrincipals []string                                  `json:"additionalAllowedPrincipals,omitempty"`
-	MultiArch                   *bool                                     `json:"multiArch,omitempty"`
-	SharedVPC                   *AWSSharedVPCApplyConfiguration           `json:"sharedVPC,omitempty"`
-	TerminationHandlerQueueURL  *string                                   `json:"terminationHandlerQueueURL,omitempty"`
+	Region                      *string                                    `json:"region,omitempty"`
+	CloudProviderConfig         *AWSCloudProviderConfigApplyConfiguration  `json:"cloudProviderConfig,omitempty"`
+	ServiceEndpoints            []AWSServiceEndpointApplyConfiguration     `json:"serviceEndpoints,omitempty"`
+	RolesRef                    *AWSRolesRefApplyConfiguration             `json:"rolesRef,omitempty"`
+	ResourceTags                []AWSResourceTagApplyConfiguration         `json:"resourceTags,omitempty"`
+	EndpointAccess              *hypershiftv1beta1.AWSEndpointAccessType   `json:"endpointAccess,omitempty"`
+	AdditionalAllowedPrincipals []string                                   `json:"additionalAllowedPrincipals,omitempty"`
+	MultiArch                   *bool                                      `json:"multiArch,omitempty"`
+	SharedVPC                   *AWSSharedVPCApplyConfiguration            `json:"sharedVPC,omitempty"`
+	IngressDNSManagement        *hypershiftv1beta1.AWSIngressDNSManagement `json:"ingressDNSManagement,omitempty"`
+	TerminationHandlerQueueURL  *string                                    `json:"terminationHandlerQueueURL,omitempty"`
 }
 
 // AWSPlatformSpecApplyConfiguration constructs a declarative configuration of the AWSPlatformSpec type for use with
@@ -123,6 +124,14 @@ func (b *AWSPlatformSpecApplyConfiguration) WithMultiArch(value bool) *AWSPlatfo
 // If called multiple times, the SharedVPC field is set to the value of the last call.
 func (b *AWSPlatformSpecApplyConfiguration) WithSharedVPC(value *AWSSharedVPCApplyConfiguration) *AWSPlatformSpecApplyConfiguration {
 	b.SharedVPC = value
+	return b
+}
+
+// WithIngressDNSManagement sets the IngressDNSManagement field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the IngressDNSManagement field is set to the value of the last call.
+func (b *AWSPlatformSpecApplyConfiguration) WithIngressDNSManagement(value hypershiftv1beta1.AWSIngressDNSManagement) *AWSPlatformSpecApplyConfiguration {
+	b.IngressDNSManagement = &value
 	return b
 }
 

--- a/cmd/infra/aws/delegating_client.go
+++ b/cmd/infra/aws/delegating_client.go
@@ -559,6 +559,15 @@ type route53Client struct {
 func (c *route53Client) ChangeResourceRecordSets(ctx context.Context, input *route53.ChangeResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ChangeResourceRecordSetsOutput, error) {
 	return c.controlPlaneOperator.route53Client.ChangeResourceRecordSets(ctx, input, optFns...)
 }
+func (c *route53Client) CreateHostedZone(ctx context.Context, input *route53.CreateHostedZoneInput, optFns ...func(*route53.Options)) (*route53.CreateHostedZoneOutput, error) {
+	return c.controlPlaneOperator.route53Client.CreateHostedZone(ctx, input, optFns...)
+}
+func (c *route53Client) DeleteHostedZone(ctx context.Context, input *route53.DeleteHostedZoneInput, optFns ...func(*route53.Options)) (*route53.DeleteHostedZoneOutput, error) {
+	return c.controlPlaneOperator.route53Client.DeleteHostedZone(ctx, input, optFns...)
+}
+func (c *route53Client) GetHostedZone(ctx context.Context, input *route53.GetHostedZoneInput, optFns ...func(*route53.Options)) (*route53.GetHostedZoneOutput, error) {
+	return c.controlPlaneOperator.route53Client.GetHostedZone(ctx, input, optFns...)
+}
 func (c *route53Client) ListHostedZones(ctx context.Context, input *route53.ListHostedZonesInput, optFns ...func(*route53.Options)) (*route53.ListHostedZonesOutput, error) {
 	return c.controlPlaneOperator.route53Client.ListHostedZones(ctx, input, optFns...)
 }

--- a/cmd/infra/aws/delegatingclientgenerator/main.go
+++ b/cmd/infra/aws/delegatingclientgenerator/main.go
@@ -395,11 +395,9 @@ var extendedAPIs = map[string][]string{
 	},
 	"route53": {
 		"AssociateVPCWithHostedZone",
-		"CreateHostedZone",
 		"CreateVPCAssociationAuthorization",
-		"DeleteHostedZone",
 		"DisassociateVPCFromHostedZone",
-		"GetHostedZone",
+		"ListHostedZonesByName",
 		"ListHostedZonesByVPC",
 	},
 	"ec2": {

--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -695,6 +695,9 @@ func controlPlaneOperatorPolicy(hostedZone string, sharedVPC bool) policyBinding
 						"ec2:DeleteVpcEndpoints",
 						"ec2:CreateTags",
 						"route53:ListHostedZones",
+						"route53:CreateHostedZone",
+						"route53:DeleteHostedZone",
+						"route53:GetHostedZone",
 						"ec2:CreateSecurityGroup",
 						"ec2:AuthorizeSecurityGroupIngress",
 						"ec2:AuthorizeSecurityGroupEgress",
@@ -735,6 +738,8 @@ func sharedVPCRoute53Role(allowedRoles []string) sharedVPCPolicyBinding {
             "Action": [
                 "route53:ListHostedZones",
                 "route53:ListHostedZonesByName",
+                "route53:CreateHostedZone",
+                "route53:DeleteHostedZone",
                 "route53:ChangeTagsForResource",
                 "route53:GetAccountLimit",
                 "route53:GetChange",

--- a/cmd/infra/aws/iam.go
+++ b/cmd/infra/aws/iam.go
@@ -657,8 +657,7 @@ func ingressPermPolicy(publicZone, privateZone string, sharedVPC bool) policyBin
 	}
 }
 
-func controlPlaneOperatorPolicy(hostedZone string, sharedVPC bool) policyBinding {
-	hostedZone = ensureHostedZonePrefix(hostedZone)
+func controlPlaneOperatorPolicy(_ string, sharedVPC bool) policyBinding {
 	var policy string
 	if sharedVPC {
 		policy = `{
@@ -683,7 +682,7 @@ func controlPlaneOperatorPolicy(hostedZone string, sharedVPC bool) policyBinding
 			]
 		}`
 	} else {
-		policy = fmt.Sprintf(`{
+		policy = `{
 			"Version": "2012-10-17",
 			"Statement": [
 				{
@@ -695,6 +694,7 @@ func controlPlaneOperatorPolicy(hostedZone string, sharedVPC bool) policyBinding
 						"ec2:DeleteVpcEndpoints",
 						"ec2:CreateTags",
 						"route53:ListHostedZones",
+						"route53:ListHostedZonesByName",
 						"route53:CreateHostedZone",
 						"route53:DeleteHostedZone",
 						"route53:GetHostedZone",
@@ -715,10 +715,10 @@ func controlPlaneOperatorPolicy(hostedZone string, sharedVPC bool) policyBinding
 						"route53:ChangeResourceRecordSets",
 						"route53:ListResourceRecordSets"
 					],
-					"Resource": "arn:aws:route53:::%s"
+					"Resource": "arn:aws:route53:::hostedzone/*"
 				}
 			]
-		}`, hostedZone)
+		}`
 	}
 	return policyBinding{
 		name:                 "control-plane-operator",

--- a/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.aws.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.aws.testsuite.yaml
@@ -315,6 +315,80 @@ tests:
             route: {}
     expectedError: "ingressDNSManagement is immutable"
 
+  - name: When pre-existing HC without ingressDNSManagement is updated it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: AWS
+          aws:
+            region: us-east-1
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: AWS
+          aws:
+            region: us-east-1
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.16.0-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+
   - name: When ingressDNSManagement is unchanged on update it should pass
     initial: |
       apiVersion: hypershift.openshift.io/v1beta1

--- a/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.aws.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.aws.testsuite.yaml
@@ -1,0 +1,392 @@
+apiVersion: apiextensions.k8s.io/v1
+name: "HostedCluster AWS validation"
+crdName: hostedclusters.hypershift.openshift.io
+version: v1beta1
+tests:
+  onCreate:
+  - name: When ingressDNSManagement is Managed it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: AWS
+          aws:
+            region: us-east-1
+            ingressDNSManagement: Managed
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+
+  - name: When ingressDNSManagement is Unmanaged it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: AWS
+          aws:
+            region: us-east-1
+            ingressDNSManagement: Unmanaged
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+
+  - name: When ingressDNSManagement is omitted it should default to Unmanaged
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: AWS
+          aws:
+            region: us-east-1
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+
+  - name: When ingressDNSManagement is an invalid value it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: AWS
+          aws:
+            region: us-east-1
+            ingressDNSManagement: InvalidValue
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    expectedError: "Unsupported value"
+
+  onUpdate:
+  - name: When ingressDNSManagement is changed from Managed to Unmanaged it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: AWS
+          aws:
+            region: us-east-1
+            ingressDNSManagement: Managed
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: AWS
+          aws:
+            region: us-east-1
+            ingressDNSManagement: Unmanaged
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    expectedError: "ingressDNSManagement is immutable"
+
+  - name: When ingressDNSManagement is changed from Unmanaged to Managed it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: AWS
+          aws:
+            region: us-east-1
+            ingressDNSManagement: Unmanaged
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: AWS
+          aws:
+            region: us-east-1
+            ingressDNSManagement: Managed
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    expectedError: "ingressDNSManagement is immutable"
+
+  - name: When ingressDNSManagement is unchanged on update it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: AWS
+          aws:
+            region: us-east-1
+            ingressDNSManagement: Managed
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: AWS
+          aws:
+            region: us-east-1
+            ingressDNSManagement: Managed
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.16.0-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/awsendpointservices.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/awsendpointservices.crd.yaml
@@ -180,6 +180,18 @@ spec:
                   management VPC
                 maxLength: 255
                 type: string
+              ingressPrivateZoneID:
+                description: |-
+                  ingressPrivateZoneID is the Route53 hosted zone ID for the private ingress zone
+                  created when IngressDNSManagement is Managed.
+                maxLength: 32
+                type: string
+              ingressPublicZoneID:
+                description: |-
+                  ingressPublicZoneID is the Route53 hosted zone ID for the public ingress zone
+                  created when IngressDNSManagement is Managed.
+                maxLength: 32
+                type: string
               securityGroupID:
                 description: |-
                   securityGroupID is the ID for the VPC endpoint SecurityGroup

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
@@ -4873,6 +4873,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
@@ -4523,6 +4523,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -4744,6 +4744,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
@@ -4753,6 +4753,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
@@ -4403,6 +4403,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -4624,6 +4624,22 @@ spec:
                         - PublicAndPrivate
                         - Private
                         type: string
+                      ingressDNSManagement:
+                        default: Unmanaged
+                        description: |-
+                          ingressDNSManagement specifies whether the control plane operator manages
+                          Route53 hosted zones for ingress DNS in the customer's AWS account.
+                          When set to "Managed", the CPO creates public and private ingress zones,
+                          a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+                          cert-manager DNS01 CNAME-follow.
+                          When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+                        enum:
+                        - Unmanaged
+                        - Managed
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ingressDNSManagement is immutable
+                          rule: self == oldSelf
                       multiArch:
                         default: false
                         description: |-

--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
@@ -34,6 +34,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -58,6 +60,12 @@ const (
 	defaultResync               = 10 * time.Hour
 	externalPrivateServiceLabel = "hypershift.openshift.io/external-private-service"
 )
+
+var dnsEndpointGVK = schema.GroupVersionKind{
+	Group:   "externaldns.k8s.io",
+	Version: "v1alpha1",
+	Kind:    "DNSEndpoint",
+}
 
 // PrivateServiceObserver watches a given Service type LB and reconciles
 // an awsEndpointService CR representation for it.
@@ -790,6 +798,32 @@ func (r *AWSEndpointServiceReconciler) reconcileAWSEndpointService(ctx context.C
 	awsEndpointService.Status.DNSNames = fqdns
 	awsEndpointService.Status.DNSZoneID = zoneID
 
+	if awsEndpointService.Name == manifests.PrivateRouterService("").Name &&
+		hcp.Spec.Platform.AWS != nil &&
+		hcp.Spec.Platform.AWS.IngressDNSManagement == hyperv1.AWSIngressDNSManaged {
+		dnsResult, err := reconcileIngressDNS(ctx, route53Client, hcp,
+			awsEndpointService.Status.IngressPublicZoneID,
+			awsEndpointService.Status.IngressPrivateZoneID)
+		if err != nil {
+			log.Error(err, "failed to reconcile ingress DNS")
+			setIngressDNSCondition(&awsEndpointService.Status.Conditions, metav1.ConditionFalse, hyperv1.AWSErrorReason, err.Error())
+			return err
+		}
+
+		awsEndpointService.Status.IngressPublicZoneID = dnsResult.PublicZoneID
+		awsEndpointService.Status.IngressPrivateZoneID = dnsResult.PrivateZoneID
+
+		if len(dnsResult.NSRecords) > 0 {
+			if err := r.reconcileDNSEndpoint(ctx, hcp, dnsResult.IngressDNS, dnsResult.NSRecords); err != nil {
+				log.Error(err, "failed to reconcile DNSEndpoint for ingress DNS")
+				setIngressDNSCondition(&awsEndpointService.Status.Conditions, metav1.ConditionFalse, hyperv1.AWSErrorReason, err.Error())
+				return err
+			}
+		}
+
+		setIngressDNSCondition(&awsEndpointService.Status.Conditions, metav1.ConditionTrue, hyperv1.AWSSuccessReason, "")
+	}
+
 	if isPublic, externalNames := netutil.IsPublicHCP(hcp), hcpExternalNames(hcp); !isPublic && len(externalNames) > 0 {
 		// only if not public and external names are configured, create services of type ExternalName so external-dns
 		// can create records for them
@@ -1100,6 +1134,28 @@ func (r *AWSEndpointServiceReconciler) delete(ctx context.Context, awsEndpointSe
 		log.Info("security group deleted", "id", awsEndpointService.Status.SecurityGroupID)
 	}
 
+	if awsEndpointService.Status.IngressPublicZoneID != "" || awsEndpointService.Status.IngressPrivateZoneID != "" {
+		if err := cleanupIngressDNS(ctx, route53Client,
+			awsEndpointService.Status.IngressPublicZoneID,
+			awsEndpointService.Status.IngressPrivateZoneID); err != nil {
+			return false, fmt.Errorf("failed to clean up ingress DNS zones: %w", err)
+		}
+		log.Info("ingress DNS zones cleaned up")
+
+		for _, ref := range awsEndpointService.OwnerReferences {
+			if ref.Kind == "HostedControlPlane" {
+				ep := &unstructured.Unstructured{}
+				ep.SetGroupVersionKind(dnsEndpointGVK)
+				ep.SetName(dnsEndpointName(ref.Name))
+				ep.SetNamespace(awsEndpointService.Namespace)
+				if err := r.Delete(ctx, ep); err != nil && !apierrors.IsNotFound(err) {
+					log.Info("Failed to delete DNSEndpoint during cleanup", "name", ep.GetName(), "error", err.Error())
+				}
+				break
+			}
+		}
+	}
+
 	zoneID := awsEndpointService.Status.DNSZoneID
 
 	for _, fqdn := range awsEndpointService.Status.DNSNames {
@@ -1211,4 +1267,81 @@ func equalIPRanges(a, b []ec2types.IpRange) bool {
 		}
 	}
 	return true
+}
+
+func setIngressDNSCondition(conditions *[]metav1.Condition, status metav1.ConditionStatus, reason, message string) {
+	meta.SetStatusCondition(conditions, metav1.Condition{
+		Type:    string(hyperv1.AWSIngressDNSAvailable),
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+	})
+}
+
+func dnsEndpointName(hcpName string) string {
+	return hcpName + "-ingress-delegation"
+}
+
+func trimDNSName(dnsName string) string {
+	return strings.TrimSuffix(dnsName, ".")
+}
+
+func trimNameservers(nameservers []string) []string {
+	result := make([]string, len(nameservers))
+	for i, ns := range nameservers {
+		result[i] = strings.TrimSuffix(ns, ".")
+	}
+	return result
+}
+
+func (r *AWSEndpointServiceReconciler) reconcileDNSEndpoint(
+	ctx context.Context,
+	hcp *hyperv1.HostedControlPlane,
+	ingressDNSName string,
+	nameservers []string,
+) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	dnsName := trimDNSName(ingressDNSName)
+	trimmed := trimNameservers(nameservers)
+	nsTargets := make([]interface{}, len(trimmed))
+	for i, ns := range trimmed {
+		nsTargets[i] = ns
+	}
+
+	dnsEndpoint := &unstructured.Unstructured{}
+	dnsEndpoint.SetGroupVersionKind(dnsEndpointGVK)
+	dnsEndpoint.SetName(dnsEndpointName(hcp.Name))
+	dnsEndpoint.SetNamespace(hcp.Namespace)
+
+	result, err := r.CreateOrUpdate(ctx, r, dnsEndpoint, func() error {
+		if err := controllerutil.SetControllerReference(hcp, dnsEndpoint, r.Scheme()); err != nil {
+			return fmt.Errorf("failed to set controller reference on DNSEndpoint: %w", err)
+		}
+		dnsEndpoint.Object["spec"] = map[string]interface{}{
+			"endpoints": []interface{}{
+				map[string]interface{}{
+					"dnsName":    dnsName,
+					"recordType": "NS",
+					"targets":    nsTargets,
+					"recordTTL":  float64(300),
+				},
+			},
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to reconcile DNSEndpoint: %w", err)
+	}
+
+	if result != controllerutil.OperationResultNone {
+		log.Info("Reconciled DNSEndpoint",
+			"result", result,
+			"name", dnsEndpoint.GetName(),
+			"namespace", dnsEndpoint.GetNamespace(),
+			"dnsName", dnsName,
+			"nameservers", nameservers)
+	}
+
+	return nil
 }

--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
@@ -1142,17 +1142,29 @@ func (r *AWSEndpointServiceReconciler) delete(ctx context.Context, awsEndpointSe
 		}
 		log.Info("ingress DNS zones cleaned up")
 
-		for _, ref := range awsEndpointService.OwnerReferences {
-			if ref.Kind == "HostedControlPlane" {
-				ep := &unstructured.Unstructured{}
-				ep.SetGroupVersionKind(dnsEndpointGVK)
-				ep.SetName(dnsEndpointName(ref.Name))
-				ep.SetNamespace(awsEndpointService.Namespace)
-				if err := r.Delete(ctx, ep); err != nil && !apierrors.IsNotFound(err) {
-					log.Info("Failed to delete DNSEndpoint during cleanup", "name", ep.GetName(), "error", err.Error())
+		var hcpName string
+		hcpList := &hyperv1.HostedControlPlaneList{}
+		if err := r.List(ctx, hcpList, &client.ListOptions{Namespace: awsEndpointService.Namespace}); err == nil && len(hcpList.Items) == 1 {
+			hcpName = hcpList.Items[0].Name
+		}
+		if hcpName == "" {
+			for _, ref := range awsEndpointService.OwnerReferences {
+				if ref.Kind == "HostedControlPlane" {
+					hcpName = ref.Name
+					break
 				}
-				break
 			}
+		}
+		if hcpName != "" {
+			ep := &unstructured.Unstructured{}
+			ep.SetGroupVersionKind(dnsEndpointGVK)
+			ep.SetName(dnsEndpointName(hcpName))
+			ep.SetNamespace(awsEndpointService.Namespace)
+			if err := r.Delete(ctx, ep); err != nil && !apierrors.IsNotFound(err) {
+				log.Info("Failed to delete DNSEndpoint during cleanup", "name", ep.GetName(), "error", err.Error())
+			}
+		} else {
+			log.Info("Could not determine HCP name for DNSEndpoint cleanup, skipping")
 		}
 	}
 

--- a/control-plane-operator/controllers/awsprivatelink/dns.go
+++ b/control-plane-operator/controllers/awsprivatelink/dns.go
@@ -1,0 +1,308 @@
+package awsprivatelink
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"strings"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/awsapi"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type ingressDNSResult struct {
+	PublicZoneID  string
+	PrivateZoneID string
+	NSRecords     []string
+	IngressDNS    string
+}
+
+func ingressDNSName(hcp *hyperv1.HostedControlPlane) string {
+	prefix := hcp.Name
+	if hcp.Spec.DNS.BaseDomainPrefix != nil && *hcp.Spec.DNS.BaseDomainPrefix != "" {
+		prefix = *hcp.Spec.DNS.BaseDomainPrefix
+	}
+	return fmt.Sprintf("%s.%s", prefix, hcp.Spec.DNS.BaseDomain)
+}
+
+func callerReference(hcp *hyperv1.HostedControlPlane, zoneName string) string {
+	h := sha256.Sum256([]byte(fmt.Sprintf("%s/%s/%s", hcp.Namespace, hcp.Name, zoneName)))
+	return fmt.Sprintf("%x", h[:16])
+}
+
+func createOrGetPublicHostedZone(ctx context.Context, client awsapi.ROUTE53API, name, callerRef string) (string, []string, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	output, err := client.CreateHostedZone(ctx, &route53.CreateHostedZoneInput{
+		Name:            aws.String(name),
+		CallerReference: aws.String(callerRef),
+		HostedZoneConfig: &route53types.HostedZoneConfig{
+			Comment: aws.String("Public ingress zone managed by HyperShift"),
+		},
+	})
+	if err != nil {
+		var alreadyExists *route53types.HostedZoneAlreadyExists
+		if !errors.As(err, &alreadyExists) {
+			return "", nil, fmt.Errorf("failed to create public hosted zone %s: %w", name, err)
+		}
+		log.Info("Public hosted zone already exists, looking up", "name", name)
+		zoneID, lookupErr := lookupIngressZoneID(ctx, client, name, false)
+		if lookupErr != nil {
+			return "", nil, fmt.Errorf("failed to lookup existing public zone %s: %w", name, lookupErr)
+		}
+		getOutput, getErr := client.GetHostedZone(ctx, &route53.GetHostedZoneInput{
+			Id: aws.String(zoneID),
+		})
+		if getErr != nil {
+			return "", nil, fmt.Errorf("failed to get public zone %s: %w", zoneID, getErr)
+		}
+		var ns []string
+		if getOutput.DelegationSet != nil {
+			ns = getOutput.DelegationSet.NameServers
+		}
+		return zoneID, ns, nil
+	}
+
+	zoneID := cleanZoneID(aws.ToString(output.HostedZone.Id))
+	var ns []string
+	if output.DelegationSet != nil {
+		ns = output.DelegationSet.NameServers
+	}
+	log.Info("Created public hosted zone", "name", name, "zoneID", zoneID)
+	return zoneID, ns, nil
+}
+
+func createOrGetPrivateHostedZone(ctx context.Context, client awsapi.ROUTE53API, name, callerRef, vpcID, region string) (string, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	output, err := client.CreateHostedZone(ctx, &route53.CreateHostedZoneInput{
+		Name:            aws.String(name),
+		CallerReference: aws.String(callerRef),
+		HostedZoneConfig: &route53types.HostedZoneConfig{
+			Comment:     aws.String("Private ingress zone managed by HyperShift"),
+			PrivateZone: true,
+		},
+		VPC: &route53types.VPC{
+			VPCId:     aws.String(vpcID),
+			VPCRegion: route53types.VPCRegion(region),
+		},
+	})
+	if err != nil {
+		var alreadyExists *route53types.HostedZoneAlreadyExists
+		if !errors.As(err, &alreadyExists) {
+			return "", fmt.Errorf("failed to create private hosted zone %s: %w", name, err)
+		}
+		log.Info("Private hosted zone already exists, looking up", "name", name)
+		zoneID, lookupErr := lookupIngressZoneID(ctx, client, name, true)
+		if lookupErr != nil {
+			return "", fmt.Errorf("failed to lookup existing private zone %s: %w", name, lookupErr)
+		}
+		getOutput, getErr := client.GetHostedZone(ctx, &route53.GetHostedZoneInput{
+			Id: aws.String(zoneID),
+		})
+		if getErr != nil {
+			return "", fmt.Errorf("failed to get private zone %s: %w", zoneID, getErr)
+		}
+		vpcAssociated := false
+		for _, v := range getOutput.VPCs {
+			if aws.ToString(v.VPCId) == vpcID {
+				vpcAssociated = true
+				break
+			}
+		}
+		if !vpcAssociated {
+			log.Info("Private zone not associated with expected VPC, associating", "zoneID", zoneID, "vpcID", vpcID)
+			_, assocErr := client.AssociateVPCWithHostedZone(ctx, &route53.AssociateVPCWithHostedZoneInput{
+				HostedZoneId: aws.String(zoneID),
+				VPC: &route53types.VPC{
+					VPCId:     aws.String(vpcID),
+					VPCRegion: route53types.VPCRegion(region),
+				},
+			})
+			if assocErr != nil {
+				return "", fmt.Errorf("failed to associate VPC %s with private zone %s: %w", vpcID, zoneID, assocErr)
+			}
+		}
+		return zoneID, nil
+	}
+
+	zoneID := cleanZoneID(aws.ToString(output.HostedZone.Id))
+	log.Info("Created private hosted zone", "name", name, "zoneID", zoneID)
+	return zoneID, nil
+}
+
+func lookupIngressZoneID(ctx context.Context, client awsapi.ROUTE53API, name string, privateZone bool) (string, error) {
+	normalizedName := strings.TrimSuffix(name, ".")
+	resp, err := client.ListHostedZonesByName(ctx, &route53.ListHostedZonesByNameInput{
+		DNSName: aws.String(normalizedName),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to list hosted zones by name: %w", err)
+	}
+	for _, zone := range resp.HostedZones {
+		zoneName := strings.TrimSuffix(aws.ToString(zone.Name), ".")
+		if zoneName != normalizedName {
+			break
+		}
+		isPrivate := zone.Config != nil && zone.Config.PrivateZone
+		if isPrivate == privateZone {
+			return cleanZoneID(aws.ToString(zone.Id)), nil
+		}
+	}
+	return "", fmt.Errorf("hosted zone %s (private=%v) not found", name, privateZone)
+}
+
+func createACMEChallengeRecord(ctx context.Context, client awsapi.ROUTE53API, publicZoneID, ingressDNS, baseDomain string) error {
+	recordName := fmt.Sprintf("_acme-challenge.apps.%s", ingressDNS)
+	target := fmt.Sprintf("_acme-challenge.%s", baseDomain)
+	return CreateRecord(ctx, client, publicZoneID, recordName, target, route53types.RRTypeCname)
+}
+
+func reconcileIngressDNS(ctx context.Context, route53Client awsapi.ROUTE53API, hcp *hyperv1.HostedControlPlane, existingPublicZoneID, existingPrivateZoneID string) (*ingressDNSResult, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	if hcp.Spec.Platform.AWS == nil {
+		return nil, fmt.Errorf("AWS platform spec is nil")
+	}
+	if hcp.Spec.DNS.BaseDomain == "" {
+		return nil, fmt.Errorf("DNS baseDomain is required")
+	}
+
+	ingressDNS := ingressDNSName(hcp)
+	log.Info("Reconciling ingress DNS", "ingressDNS", ingressDNS)
+
+	result := &ingressDNSResult{
+		IngressDNS:    ingressDNS,
+		PublicZoneID:  existingPublicZoneID,
+		PrivateZoneID: existingPrivateZoneID,
+	}
+
+	if existingPublicZoneID == "" {
+		publicCallerRef := callerReference(hcp, ingressDNS+"-public")
+		zoneID, ns, err := createOrGetPublicHostedZone(ctx, route53Client, ingressDNS, publicCallerRef)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create public ingress zone: %w", err)
+		}
+		result.PublicZoneID = zoneID
+		result.NSRecords = ns
+	} else {
+		getOutput, err := route53Client.GetHostedZone(ctx, &route53.GetHostedZoneInput{
+			Id: aws.String(existingPublicZoneID),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get existing public zone %s: %w", existingPublicZoneID, err)
+		}
+		if getOutput.DelegationSet != nil {
+			result.NSRecords = getOutput.DelegationSet.NameServers
+		}
+	}
+
+	if existingPrivateZoneID == "" {
+		awsSpec := hcp.Spec.Platform.AWS
+		vpcID := ""
+		if awsSpec.CloudProviderConfig != nil {
+			vpcID = awsSpec.CloudProviderConfig.VPC
+		}
+		if vpcID == "" {
+			return nil, fmt.Errorf("VPC ID is required for private ingress zone creation")
+		}
+		privateCallerRef := callerReference(hcp, ingressDNS+"-private")
+		zoneID, err := createOrGetPrivateHostedZone(ctx, route53Client, ingressDNS, privateCallerRef, vpcID, awsSpec.Region)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create private ingress zone: %w", err)
+		}
+		result.PrivateZoneID = zoneID
+	}
+
+	if err := createACMEChallengeRecord(ctx, route53Client, result.PublicZoneID, ingressDNS, hcp.Spec.DNS.BaseDomain); err != nil {
+		return nil, fmt.Errorf("failed to create ACME challenge record: %w", err)
+	}
+
+	log.Info("Ingress DNS reconciliation complete",
+		"publicZoneID", result.PublicZoneID,
+		"privateZoneID", result.PrivateZoneID,
+		"nsRecords", result.NSRecords)
+
+	return result, nil
+}
+
+func cleanupIngressDNSZone(ctx context.Context, client awsapi.ROUTE53API, zoneID string) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	var changes []route53types.Change
+	input := &route53.ListResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+	}
+	for {
+		resp, err := client.ListResourceRecordSets(ctx, input)
+		if err != nil {
+			var noSuchZone *route53types.NoSuchHostedZone
+			if errors.As(err, &noSuchZone) {
+				log.Info("Zone already deleted", "zoneID", zoneID)
+				return nil
+			}
+			return fmt.Errorf("failed to list records in zone %s: %w", zoneID, err)
+		}
+		for _, record := range resp.ResourceRecordSets {
+			if record.Type == route53types.RRTypeSoa || record.Type == route53types.RRTypeNs {
+				continue
+			}
+			changes = append(changes, route53types.Change{
+				Action:            route53types.ChangeActionDelete,
+				ResourceRecordSet: &record,
+			})
+		}
+		if !resp.IsTruncated {
+			break
+		}
+		input.StartRecordName = resp.NextRecordName
+		input.StartRecordType = resp.NextRecordType
+		input.StartRecordIdentifier = resp.NextRecordIdentifier
+	}
+
+	if len(changes) > 0 {
+		_, err := client.ChangeResourceRecordSets(ctx, &route53.ChangeResourceRecordSetsInput{
+			HostedZoneId: aws.String(zoneID),
+			ChangeBatch:  &route53types.ChangeBatch{Changes: changes},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to delete records in zone %s: %w", zoneID, err)
+		}
+		log.Info("Deleted custom records from zone", "zoneID", zoneID, "count", len(changes))
+	}
+
+	_, err := client.DeleteHostedZone(ctx, &route53.DeleteHostedZoneInput{
+		Id: aws.String(zoneID),
+	})
+	if err != nil {
+		var noSuchZone *route53types.NoSuchHostedZone
+		if errors.As(err, &noSuchZone) {
+			return nil
+		}
+		return fmt.Errorf("failed to delete zone %s: %w", zoneID, err)
+	}
+
+	log.Info("Deleted hosted zone", "zoneID", zoneID)
+	return nil
+}
+
+func cleanupIngressDNS(ctx context.Context, client awsapi.ROUTE53API, publicZoneID, privateZoneID string) error {
+	if publicZoneID != "" {
+		if err := cleanupIngressDNSZone(ctx, client, publicZoneID); err != nil {
+			return fmt.Errorf("failed to cleanup public ingress zone: %w", err)
+		}
+	}
+	if privateZoneID != "" {
+		if err := cleanupIngressDNSZone(ctx, client, privateZoneID); err != nil {
+			return fmt.Errorf("failed to cleanup private ingress zone: %w", err)
+		}
+	}
+	return nil
+}

--- a/control-plane-operator/controllers/awsprivatelink/dns.go
+++ b/control-plane-operator/controllers/awsprivatelink/dns.go
@@ -63,6 +63,9 @@ func createOrGetPublicHostedZone(ctx context.Context, client awsapi.ROUTE53API, 
 		if getErr != nil {
 			return "", nil, fmt.Errorf("failed to get public zone %s: %w", zoneID, getErr)
 		}
+		if getOutput.HostedZone == nil || aws.ToString(getOutput.HostedZone.CallerReference) != callerRef {
+			return "", nil, fmt.Errorf("public zone %s exists but has unexpected CallerReference, refusing to adopt", zoneID)
+		}
 		var ns []string
 		if getOutput.DelegationSet != nil {
 			ns = getOutput.DelegationSet.NameServers
@@ -109,6 +112,9 @@ func createOrGetPrivateHostedZone(ctx context.Context, client awsapi.ROUTE53API,
 		})
 		if getErr != nil {
 			return "", fmt.Errorf("failed to get private zone %s: %w", zoneID, getErr)
+		}
+		if getOutput.HostedZone == nil || aws.ToString(getOutput.HostedZone.CallerReference) != callerRef {
+			return "", fmt.Errorf("private zone %s exists but has unexpected CallerReference, refusing to adopt", zoneID)
 		}
 		vpcAssociated := false
 		for _, v := range getOutput.VPCs {
@@ -204,12 +210,50 @@ func reconcileIngressDNS(ctx context.Context, route53Client awsapi.ROUTE53API, h
 		}
 	}
 
-	if existingPrivateZoneID == "" {
-		awsSpec := hcp.Spec.Platform.AWS
-		vpcID := ""
-		if awsSpec.CloudProviderConfig != nil {
-			vpcID = awsSpec.CloudProviderConfig.VPC
+	awsSpec := hcp.Spec.Platform.AWS
+	vpcID := ""
+	if awsSpec.CloudProviderConfig != nil {
+		vpcID = awsSpec.CloudProviderConfig.VPC
+	}
+
+	if existingPrivateZoneID != "" {
+		getOutput, err := route53Client.GetHostedZone(ctx, &route53.GetHostedZoneInput{
+			Id: aws.String(existingPrivateZoneID),
+		})
+		if err != nil {
+			var noSuchZone *route53types.NoSuchHostedZone
+			if errors.As(err, &noSuchZone) {
+				log.Info("Existing private zone no longer exists, will recreate", "zoneID", existingPrivateZoneID)
+				existingPrivateZoneID = ""
+				result.PrivateZoneID = ""
+			} else {
+				return nil, fmt.Errorf("failed to validate existing private zone %s: %w", existingPrivateZoneID, err)
+			}
+		} else if vpcID != "" {
+			vpcAssociated := false
+			for _, v := range getOutput.VPCs {
+				if aws.ToString(v.VPCId) == vpcID {
+					vpcAssociated = true
+					break
+				}
+			}
+			if !vpcAssociated {
+				log.Info("Existing private zone missing VPC association, re-associating", "zoneID", existingPrivateZoneID, "vpcID", vpcID)
+				_, assocErr := route53Client.AssociateVPCWithHostedZone(ctx, &route53.AssociateVPCWithHostedZoneInput{
+					HostedZoneId: aws.String(existingPrivateZoneID),
+					VPC: &route53types.VPC{
+						VPCId:     aws.String(vpcID),
+						VPCRegion: route53types.VPCRegion(awsSpec.Region),
+					},
+				})
+				if assocErr != nil {
+					return nil, fmt.Errorf("failed to re-associate VPC %s with private zone %s: %w", vpcID, existingPrivateZoneID, assocErr)
+				}
+			}
 		}
+	}
+
+	if existingPrivateZoneID == "" {
 		if vpcID == "" {
 			return nil, fmt.Errorf("VPC ID is required for private ingress zone creation")
 		}

--- a/control-plane-operator/controllers/awsprivatelink/dns_test.go
+++ b/control-plane-operator/controllers/awsprivatelink/dns_test.go
@@ -120,7 +120,7 @@ func TestCreateOrGetPublicHostedZone(t *testing.T) {
 			expectNS:     []string{"ns-1.awsdns.com", "ns-2.awsdns.com"},
 		},
 		{
-			name: "When zone already exists it should look it up and return zone ID and NS records",
+			name: "When zone already exists with matching CallerReference it should return zone ID and NS records",
 			setupMock: func(m *awsapi.MockROUTE53API) {
 				m.EXPECT().CreateHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 					nil, &route53types.HostedZoneAlreadyExists{Message: aws.String("exists")},
@@ -141,7 +141,8 @@ func TestCreateOrGetPublicHostedZone(t *testing.T) {
 				m.EXPECT().GetHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 					&route53.GetHostedZoneOutput{
 						HostedZone: &route53types.HostedZone{
-							Id: aws.String("/hostedzone/Z456"),
+							Id:              aws.String("/hostedzone/Z456"),
+							CallerReference: aws.String("callerref"),
 						},
 						DelegationSet: &route53types.DelegationSet{
 							NameServers: []string{"ns-3.awsdns.com"},
@@ -151,6 +152,37 @@ func TestCreateOrGetPublicHostedZone(t *testing.T) {
 			},
 			expectZoneID: "Z456",
 			expectNS:     []string{"ns-3.awsdns.com"},
+		},
+		{
+			name: "When zone already exists with mismatched CallerReference it should refuse to adopt",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().CreateHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					nil, &route53types.HostedZoneAlreadyExists{Message: aws.String("exists")},
+				)
+				m.EXPECT().ListHostedZonesByName(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.ListHostedZonesByNameOutput{
+						HostedZones: []route53types.HostedZone{
+							{
+								Id:   aws.String("/hostedzone/ZOTHER"),
+								Name: aws.String("test.example.com."),
+								Config: &route53types.HostedZoneConfig{
+									PrivateZone: false,
+								},
+							},
+						},
+					}, nil,
+				)
+				m.EXPECT().GetHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.GetHostedZoneOutput{
+						HostedZone: &route53types.HostedZone{
+							Id:              aws.String("/hostedzone/ZOTHER"),
+							CallerReference: aws.String("someone-elses-ref"),
+						},
+					}, nil,
+				)
+			},
+			expectError:   true,
+			errorContains: "unexpected CallerReference",
 		},
 		{
 			name: "When create fails with non-exists error it should return the error",
@@ -209,7 +241,7 @@ func TestCreateOrGetPrivateHostedZone(t *testing.T) {
 			expectZoneID: "ZPRIV1",
 		},
 		{
-			name: "When zone already exists with correct VPC it should look it up and return zone ID",
+			name: "When zone already exists with correct VPC and matching CallerReference it should return zone ID",
 			setupMock: func(m *awsapi.MockROUTE53API) {
 				m.EXPECT().CreateHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 					nil, &route53types.HostedZoneAlreadyExists{Message: aws.String("exists")},
@@ -229,7 +261,10 @@ func TestCreateOrGetPrivateHostedZone(t *testing.T) {
 				)
 				m.EXPECT().GetHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 					&route53.GetHostedZoneOutput{
-						HostedZone: &route53types.HostedZone{Id: aws.String("/hostedzone/ZPRIV2")},
+						HostedZone: &route53types.HostedZone{
+							Id:              aws.String("/hostedzone/ZPRIV2"),
+							CallerReference: aws.String("callerref"),
+						},
 						VPCs: []route53types.VPC{
 							{VPCId: aws.String("vpc-123"), VPCRegion: route53types.VPCRegionUsEast1},
 						},
@@ -259,7 +294,10 @@ func TestCreateOrGetPrivateHostedZone(t *testing.T) {
 				)
 				m.EXPECT().GetHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 					&route53.GetHostedZoneOutput{
-						HostedZone: &route53types.HostedZone{Id: aws.String("/hostedzone/ZPRIV3")},
+						HostedZone: &route53types.HostedZone{
+							Id:              aws.String("/hostedzone/ZPRIV3"),
+							CallerReference: aws.String("callerref"),
+						},
 						VPCs: []route53types.VPC{
 							{VPCId: aws.String("vpc-other"), VPCRegion: route53types.VPCRegionUsEast1},
 						},
@@ -381,15 +419,57 @@ func TestReconcileIngressDNS(t *testing.T) {
 			},
 		},
 		{
-			name:              "When both zones already exist it should skip creation and fetch NS records",
+			name:              "When both zones already exist it should validate and fetch NS records",
 			hcp:               baseHCP(),
 			existingPublicID:  "ZPUB-EXISTING",
 			existingPrivateID: "ZPRIV-EXISTING",
 			setupMock: func(m *awsapi.MockROUTE53API) {
-				m.EXPECT().GetHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-					&route53.GetHostedZoneOutput{
-						HostedZone:    &route53types.HostedZone{Id: aws.String("ZPUB-EXISTING")},
-						DelegationSet: &route53types.DelegationSet{NameServers: []string{"ns-existing.awsdns.com"}},
+				m.EXPECT().GetHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, input *route53.GetHostedZoneInput, _ ...func(*route53.Options)) (*route53.GetHostedZoneOutput, error) {
+						if aws.ToString(input.Id) == "ZPUB-EXISTING" {
+							return &route53.GetHostedZoneOutput{
+								HostedZone:    &route53types.HostedZone{Id: aws.String("ZPUB-EXISTING")},
+								DelegationSet: &route53types.DelegationSet{NameServers: []string{"ns-existing.awsdns.com"}},
+							}, nil
+						}
+						return &route53.GetHostedZoneOutput{
+							HostedZone: &route53types.HostedZone{Id: aws.String("ZPRIV-EXISTING")},
+							VPCs: []route53types.VPC{
+								{VPCId: aws.String("vpc-123"), VPCRegion: route53types.VPCRegionUsEast1},
+							},
+						}, nil
+					},
+				).Times(2)
+				m.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.ChangeResourceRecordSetsOutput{}, nil,
+				)
+			},
+			validateResult: func(g *GomegaWithT, result *ingressDNSResult) {
+				g.Expect(result.PublicZoneID).To(Equal("ZPUB-EXISTING"))
+				g.Expect(result.PrivateZoneID).To(Equal("ZPRIV-EXISTING"))
+				g.Expect(result.NSRecords).To(Equal([]string{"ns-existing.awsdns.com"}))
+			},
+		},
+		{
+			name:              "When existing private zone is deleted it should recreate it",
+			hcp:               baseHCP(),
+			existingPublicID:  "ZPUB-EXISTING",
+			existingPrivateID: "ZPRIV-GONE",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().GetHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, input *route53.GetHostedZoneInput, _ ...func(*route53.Options)) (*route53.GetHostedZoneOutput, error) {
+						if aws.ToString(input.Id) == "ZPUB-EXISTING" {
+							return &route53.GetHostedZoneOutput{
+								HostedZone:    &route53types.HostedZone{Id: aws.String("ZPUB-EXISTING")},
+								DelegationSet: &route53types.DelegationSet{NameServers: []string{"ns-existing.awsdns.com"}},
+							}, nil
+						}
+						return nil, &route53types.NoSuchHostedZone{Message: aws.String("not found")}
+					},
+				).Times(2)
+				m.EXPECT().CreateHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.CreateHostedZoneOutput{
+						HostedZone: &route53types.HostedZone{Id: aws.String("/hostedzone/ZPRIV-NEW")},
 					}, nil,
 				)
 				m.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -398,7 +478,7 @@ func TestReconcileIngressDNS(t *testing.T) {
 			},
 			validateResult: func(g *GomegaWithT, result *ingressDNSResult) {
 				g.Expect(result.PublicZoneID).To(Equal("ZPUB-EXISTING"))
-				g.Expect(result.PrivateZoneID).To(Equal("ZPRIV-EXISTING"))
+				g.Expect(result.PrivateZoneID).To(Equal("ZPRIV-NEW"))
 				g.Expect(result.NSRecords).To(Equal([]string{"ns-existing.awsdns.com"}))
 			},
 		},

--- a/control-plane-operator/controllers/awsprivatelink/dns_test.go
+++ b/control-plane-operator/controllers/awsprivatelink/dns_test.go
@@ -1,0 +1,596 @@
+package awsprivatelink
+
+import (
+	"context"
+	"testing"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/awsapi"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIngressDNSName(t *testing.T) {
+	tests := []struct {
+		name     string
+		hcp      *hyperv1.HostedControlPlane
+		expected string
+	}{
+		{
+			name: "When BaseDomainPrefix is nil it should use HCP name as prefix",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-cluster"},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					DNS: hyperv1.DNSSpec{
+						BaseDomain: "example.com",
+					},
+				},
+			},
+			expected: "my-cluster.example.com",
+		},
+		{
+			name: "When BaseDomainPrefix is set it should use the prefix",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-cluster"},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					DNS: hyperv1.DNSSpec{
+						BaseDomain:       "example.com",
+						BaseDomainPrefix: aws.String("custom"),
+					},
+				},
+			},
+			expected: "custom.example.com",
+		},
+		{
+			name: "When BaseDomainPrefix is empty string it should use HCP name as prefix",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-cluster"},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					DNS: hyperv1.DNSSpec{
+						BaseDomain:       "example.com",
+						BaseDomainPrefix: aws.String(""),
+					},
+				},
+			},
+			expected: "my-cluster.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(ingressDNSName(tt.hcp)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestCallerReference(t *testing.T) {
+	g := NewWithT(t)
+
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cluster",
+			Namespace: "clusters",
+		},
+	}
+
+	t.Run("When called with same inputs it should return the same reference", func(t *testing.T) {
+		ref1 := callerReference(hcp, "zone-name")
+		ref2 := callerReference(hcp, "zone-name")
+		g.Expect(ref1).To(Equal(ref2))
+	})
+
+	t.Run("When called with different zone names it should return different references", func(t *testing.T) {
+		ref1 := callerReference(hcp, "zone-a")
+		ref2 := callerReference(hcp, "zone-b")
+		g.Expect(ref1).NotTo(Equal(ref2))
+	})
+}
+
+func TestCreateOrGetPublicHostedZone(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMock     func(*awsapi.MockROUTE53API)
+		expectZoneID  string
+		expectNS      []string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "When zone does not exist it should create it and return zone ID and NS records",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().CreateHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.CreateHostedZoneOutput{
+						HostedZone: &route53types.HostedZone{
+							Id: aws.String("/hostedzone/Z123"),
+						},
+						DelegationSet: &route53types.DelegationSet{
+							NameServers: []string{"ns-1.awsdns.com", "ns-2.awsdns.com"},
+						},
+					}, nil,
+				)
+			},
+			expectZoneID: "Z123",
+			expectNS:     []string{"ns-1.awsdns.com", "ns-2.awsdns.com"},
+		},
+		{
+			name: "When zone already exists it should look it up and return zone ID and NS records",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().CreateHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					nil, &route53types.HostedZoneAlreadyExists{Message: aws.String("exists")},
+				)
+				m.EXPECT().ListHostedZonesByName(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.ListHostedZonesByNameOutput{
+						HostedZones: []route53types.HostedZone{
+							{
+								Id:   aws.String("/hostedzone/Z456"),
+								Name: aws.String("test.example.com."),
+								Config: &route53types.HostedZoneConfig{
+									PrivateZone: false,
+								},
+							},
+						},
+					}, nil,
+				)
+				m.EXPECT().GetHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.GetHostedZoneOutput{
+						HostedZone: &route53types.HostedZone{
+							Id: aws.String("/hostedzone/Z456"),
+						},
+						DelegationSet: &route53types.DelegationSet{
+							NameServers: []string{"ns-3.awsdns.com"},
+						},
+					}, nil,
+				)
+			},
+			expectZoneID: "Z456",
+			expectNS:     []string{"ns-3.awsdns.com"},
+		},
+		{
+			name: "When create fails with non-exists error it should return the error",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().CreateHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					nil, &route53types.InvalidInput{Message: aws.String("bad input")},
+				)
+			},
+			expectError:   true,
+			errorContains: "failed to create public hosted zone",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctrl := gomock.NewController(t)
+			mockR53 := awsapi.NewMockROUTE53API(ctrl)
+			tt.setupMock(mockR53)
+
+			zoneID, ns, err := createOrGetPublicHostedZone(context.Background(), mockR53, "test.example.com", "callerref")
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				if tt.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tt.errorContains))
+				}
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(zoneID).To(Equal(tt.expectZoneID))
+				g.Expect(ns).To(Equal(tt.expectNS))
+			}
+		})
+	}
+}
+
+func TestCreateOrGetPrivateHostedZone(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMock     func(*awsapi.MockROUTE53API)
+		expectZoneID  string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "When zone does not exist it should create it and return zone ID",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().CreateHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.CreateHostedZoneOutput{
+						HostedZone: &route53types.HostedZone{
+							Id: aws.String("/hostedzone/ZPRIV1"),
+						},
+					}, nil,
+				)
+			},
+			expectZoneID: "ZPRIV1",
+		},
+		{
+			name: "When zone already exists with correct VPC it should look it up and return zone ID",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().CreateHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					nil, &route53types.HostedZoneAlreadyExists{Message: aws.String("exists")},
+				)
+				m.EXPECT().ListHostedZonesByName(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.ListHostedZonesByNameOutput{
+						HostedZones: []route53types.HostedZone{
+							{
+								Id:   aws.String("/hostedzone/ZPRIV2"),
+								Name: aws.String("test.example.com."),
+								Config: &route53types.HostedZoneConfig{
+									PrivateZone: true,
+								},
+							},
+						},
+					}, nil,
+				)
+				m.EXPECT().GetHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.GetHostedZoneOutput{
+						HostedZone: &route53types.HostedZone{Id: aws.String("/hostedzone/ZPRIV2")},
+						VPCs: []route53types.VPC{
+							{VPCId: aws.String("vpc-123"), VPCRegion: route53types.VPCRegionUsEast1},
+						},
+					}, nil,
+				)
+			},
+			expectZoneID: "ZPRIV2",
+		},
+		{
+			name: "When zone already exists without VPC association it should associate the VPC",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().CreateHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					nil, &route53types.HostedZoneAlreadyExists{Message: aws.String("exists")},
+				)
+				m.EXPECT().ListHostedZonesByName(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.ListHostedZonesByNameOutput{
+						HostedZones: []route53types.HostedZone{
+							{
+								Id:   aws.String("/hostedzone/ZPRIV3"),
+								Name: aws.String("test.example.com."),
+								Config: &route53types.HostedZoneConfig{
+									PrivateZone: true,
+								},
+							},
+						},
+					}, nil,
+				)
+				m.EXPECT().GetHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.GetHostedZoneOutput{
+						HostedZone: &route53types.HostedZone{Id: aws.String("/hostedzone/ZPRIV3")},
+						VPCs: []route53types.VPC{
+							{VPCId: aws.String("vpc-other"), VPCRegion: route53types.VPCRegionUsEast1},
+						},
+					}, nil,
+				)
+				m.EXPECT().AssociateVPCWithHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.AssociateVPCWithHostedZoneOutput{}, nil,
+				)
+			},
+			expectZoneID: "ZPRIV3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctrl := gomock.NewController(t)
+			mockR53 := awsapi.NewMockROUTE53API(ctrl)
+			tt.setupMock(mockR53)
+
+			zoneID, err := createOrGetPrivateHostedZone(context.Background(), mockR53, "test.example.com", "callerref", "vpc-123", "us-east-1")
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				if tt.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tt.errorContains))
+				}
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(zoneID).To(Equal(tt.expectZoneID))
+			}
+		})
+	}
+}
+
+func TestCreateACMEChallengeRecord(t *testing.T) {
+	t.Run("When called it should create a CNAME from _acme-challenge.apps.ingress to _acme-challenge.baseDomain", func(t *testing.T) {
+		g := NewWithT(t)
+		ctrl := gomock.NewController(t)
+		mockR53 := awsapi.NewMockROUTE53API(ctrl)
+
+		mockR53.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, input *route53.ChangeResourceRecordSetsInput, _ ...func(*route53.Options)) (*route53.ChangeResourceRecordSetsOutput, error) {
+				g.Expect(aws.ToString(input.HostedZoneId)).To(Equal("ZPUB"))
+				changes := input.ChangeBatch.Changes
+				g.Expect(changes).To(HaveLen(1))
+				g.Expect(aws.ToString(changes[0].ResourceRecordSet.Name)).To(Equal("_acme-challenge.apps.cluster.example.com"))
+				g.Expect(changes[0].ResourceRecordSet.Type).To(Equal(route53types.RRTypeCname))
+				g.Expect(changes[0].ResourceRecordSet.ResourceRecords).To(HaveLen(1))
+				g.Expect(aws.ToString(changes[0].ResourceRecordSet.ResourceRecords[0].Value)).To(Equal("_acme-challenge.example.com"))
+				return &route53.ChangeResourceRecordSetsOutput{}, nil
+			},
+		)
+
+		err := createACMEChallengeRecord(context.Background(), mockR53, "ZPUB", "cluster.example.com", "example.com")
+		g.Expect(err).NotTo(HaveOccurred())
+	})
+}
+
+func TestReconcileIngressDNS(t *testing.T) {
+	baseHCP := func() *hyperv1.HostedControlPlane {
+		return &hyperv1.HostedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-cluster",
+				Namespace: "clusters",
+			},
+			Spec: hyperv1.HostedControlPlaneSpec{
+				DNS: hyperv1.DNSSpec{
+					BaseDomain: "example.com",
+				},
+				Platform: hyperv1.PlatformSpec{
+					AWS: &hyperv1.AWSPlatformSpec{
+						Region: "us-east-1",
+						CloudProviderConfig: &hyperv1.AWSCloudProviderConfig{
+							VPC: "vpc-123",
+						},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name              string
+		hcp               *hyperv1.HostedControlPlane
+		existingPublicID  string
+		existingPrivateID string
+		setupMock         func(*awsapi.MockROUTE53API)
+		expectError       bool
+		errorContains     string
+		validateResult    func(*GomegaWithT, *ingressDNSResult)
+	}{
+		{
+			name: "When no zones exist it should create both public and private zones",
+			hcp:  baseHCP(),
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().CreateHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, input *route53.CreateHostedZoneInput, _ ...func(*route53.Options)) (*route53.CreateHostedZoneOutput, error) {
+						if input.VPC == nil {
+							return &route53.CreateHostedZoneOutput{
+								HostedZone:    &route53types.HostedZone{Id: aws.String("/hostedzone/ZPUB")},
+								DelegationSet: &route53types.DelegationSet{NameServers: []string{"ns-1.awsdns.com"}},
+							}, nil
+						}
+						return &route53.CreateHostedZoneOutput{
+							HostedZone: &route53types.HostedZone{Id: aws.String("/hostedzone/ZPRIV")},
+						}, nil
+					},
+				).Times(2)
+				m.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.ChangeResourceRecordSetsOutput{}, nil,
+				)
+			},
+			validateResult: func(g *GomegaWithT, result *ingressDNSResult) {
+				g.Expect(result.PublicZoneID).To(Equal("ZPUB"))
+				g.Expect(result.PrivateZoneID).To(Equal("ZPRIV"))
+				g.Expect(result.NSRecords).To(Equal([]string{"ns-1.awsdns.com"}))
+				g.Expect(result.IngressDNS).To(Equal("my-cluster.example.com"))
+			},
+		},
+		{
+			name:              "When both zones already exist it should skip creation and fetch NS records",
+			hcp:               baseHCP(),
+			existingPublicID:  "ZPUB-EXISTING",
+			existingPrivateID: "ZPRIV-EXISTING",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().GetHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.GetHostedZoneOutput{
+						HostedZone:    &route53types.HostedZone{Id: aws.String("ZPUB-EXISTING")},
+						DelegationSet: &route53types.DelegationSet{NameServers: []string{"ns-existing.awsdns.com"}},
+					}, nil,
+				)
+				m.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.ChangeResourceRecordSetsOutput{}, nil,
+				)
+			},
+			validateResult: func(g *GomegaWithT, result *ingressDNSResult) {
+				g.Expect(result.PublicZoneID).To(Equal("ZPUB-EXISTING"))
+				g.Expect(result.PrivateZoneID).To(Equal("ZPRIV-EXISTING"))
+				g.Expect(result.NSRecords).To(Equal([]string{"ns-existing.awsdns.com"}))
+			},
+		},
+		{
+			name: "When AWS platform spec is nil it should return an error",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-cluster", Namespace: "clusters"},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					DNS:      hyperv1.DNSSpec{BaseDomain: "example.com"},
+					Platform: hyperv1.PlatformSpec{},
+				},
+			},
+			setupMock:     func(m *awsapi.MockROUTE53API) {},
+			expectError:   true,
+			errorContains: "AWS platform spec is nil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctrl := gomock.NewController(t)
+			mockR53 := awsapi.NewMockROUTE53API(ctrl)
+			tt.setupMock(mockR53)
+
+			result, err := reconcileIngressDNS(context.Background(), mockR53, tt.hcp, tt.existingPublicID, tt.existingPrivateID)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				if tt.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tt.errorContains))
+				}
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				if tt.validateResult != nil {
+					tt.validateResult(g, result)
+				}
+			}
+		})
+	}
+}
+
+func TestCleanupIngressDNS(t *testing.T) {
+	tests := []struct {
+		name          string
+		publicZoneID  string
+		privateZoneID string
+		setupMock     func(*awsapi.MockROUTE53API)
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:          "When both zone IDs are set it should delete both zones",
+			publicZoneID:  "ZPUB",
+			privateZoneID: "ZPRIV",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.ListResourceRecordSetsOutput{
+						ResourceRecordSets: []route53types.ResourceRecordSet{
+							{Type: route53types.RRTypeSoa, Name: aws.String("soa")},
+							{Type: route53types.RRTypeNs, Name: aws.String("ns")},
+						},
+					}, nil,
+				).Times(2)
+				m.EXPECT().DeleteHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.DeleteHostedZoneOutput{}, nil,
+				).Times(2)
+			},
+		},
+		{
+			name:          "When zones have custom records it should delete records before deleting the zone",
+			publicZoneID:  "ZPUB",
+			privateZoneID: "",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.ListResourceRecordSetsOutput{
+						ResourceRecordSets: []route53types.ResourceRecordSet{
+							{Type: route53types.RRTypeSoa, Name: aws.String("soa")},
+							{Type: route53types.RRTypeCname, Name: aws.String("_acme-challenge.apps.test.example.com")},
+						},
+					}, nil,
+				)
+				m.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.ChangeResourceRecordSetsOutput{}, nil,
+				)
+				m.EXPECT().DeleteHostedZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.DeleteHostedZoneOutput{}, nil,
+				)
+			},
+		},
+		{
+			name:          "When zone is already deleted it should succeed without error",
+			publicZoneID:  "ZGONE",
+			privateZoneID: "",
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					nil, &route53types.NoSuchHostedZone{Message: aws.String("not found")},
+				)
+			},
+		},
+		{
+			name:          "When both zone IDs are empty it should be a no-op",
+			publicZoneID:  "",
+			privateZoneID: "",
+			setupMock:     func(m *awsapi.MockROUTE53API) {},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctrl := gomock.NewController(t)
+			mockR53 := awsapi.NewMockROUTE53API(ctrl)
+			tt.setupMock(mockR53)
+
+			err := cleanupIngressDNS(context.Background(), mockR53, tt.publicZoneID, tt.privateZoneID)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				if tt.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tt.errorContains))
+				}
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
+func TestLookupIngressZoneID(t *testing.T) {
+	tests := []struct {
+		name          string
+		zoneName      string
+		privateZone   bool
+		setupMock     func(*awsapi.MockROUTE53API)
+		expectZoneID  string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:        "When matching public zone exists it should return its ID",
+			zoneName:    "test.example.com",
+			privateZone: false,
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListHostedZonesByName(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.ListHostedZonesByNameOutput{
+						HostedZones: []route53types.HostedZone{
+							{
+								Id:     aws.String("/hostedzone/ZFOUND"),
+								Name:   aws.String("test.example.com."),
+								Config: &route53types.HostedZoneConfig{PrivateZone: false},
+							},
+						},
+					}, nil,
+				)
+			},
+			expectZoneID: "ZFOUND",
+		},
+		{
+			name:        "When no matching zone exists it should return an error",
+			zoneName:    "missing.example.com",
+			privateZone: false,
+			setupMock: func(m *awsapi.MockROUTE53API) {
+				m.EXPECT().ListHostedZonesByName(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53.ListHostedZonesByNameOutput{
+						HostedZones: []route53types.HostedZone{},
+					}, nil,
+				)
+			},
+			expectError:   true,
+			errorContains: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctrl := gomock.NewController(t)
+			mockR53 := awsapi.NewMockROUTE53API(ctrl)
+			tt.setupMock(mockR53)
+
+			zoneID, err := lookupIngressZoneID(context.Background(), mockR53, tt.zoneName, tt.privateZone)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				if tt.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tt.errorContains))
+				}
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(zoneID).To(Equal(tt.expectZoneID))
+			}
+		})
+	}
+}

--- a/docs/content/how-to/aws/managed-ingress-dns.md
+++ b/docs/content/how-to/aws/managed-ingress-dns.md
@@ -1,0 +1,68 @@
+# Managed Ingress DNS for AWS
+
+By default, HyperShift creates only an internal `.hypershift.local` DNS zone for hosted control planes on AWS. When managed ingress DNS is enabled, the control plane operator (CPO) creates and manages Route53 hosted zones for ingress traffic in the customer's AWS account.
+
+## What Gets Created
+
+When `IngressDNSManagement` is set to `Managed`, the CPO creates:
+
+1. **Public Route53 hosted zone** for the cluster's ingress subdomain (e.g. `my-cluster.example.com`)
+2. **Private Route53 hosted zone** associated with the cluster's VPC for internal resolution
+3. **DNSEndpoint CR** with NS records for delegation from the service provider's DNS zone to the customer's public zone
+4. **ACME challenge CNAME** (`_acme-challenge.apps.<ingress>` pointing to `_acme-challenge.<baseDomain>`) for cert-manager DNS01 validation
+
+## Prerequisites
+
+The IAM role used for Route53 access (via `SharedVPC.RolesRef.IngressARN` or the default credentials) must have the following permissions:
+
+- `route53:CreateHostedZone`
+- `route53:DeleteHostedZone`
+- `route53:GetHostedZone`
+- `route53:ListHostedZones`
+- `route53:ListResourceRecordSets`
+- `route53:ChangeResourceRecordSets`
+
+## Configuration
+
+Set `ingressDNSManagement` to `Managed` on the HostedCluster's AWS platform spec:
+
+```yaml
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  name: my-cluster
+  namespace: clusters
+spec:
+  platform:
+    type: AWS
+    aws:
+      region: us-east-1
+      ingressDNSManagement: Managed
+      # ... other AWS fields
+  dns:
+    baseDomain: example.com
+```
+
+This field is **immutable** after creation. The default value is `Unmanaged`, which preserves the existing behavior.
+
+## Monitoring
+
+The `AWSIngressDNSAvailable` condition on the `AWSEndpointService` and `HostedCluster` resources reflects the status of ingress DNS setup:
+
+```bash
+# Check AWSEndpointService condition
+oc get awsendpointservice -n clusters-my-cluster -o jsonpath='{.items[*].status.conditions}'
+
+# Check HostedCluster condition
+oc get hostedcluster my-cluster -n clusters -o jsonpath='{.status.conditions[?(@.type=="AWSIngressDNSAvailable")]}'
+```
+
+## Cleanup
+
+When the hosted cluster is deleted, the CPO automatically:
+
+1. Deletes all custom DNS records from the managed zones
+2. Deletes both the public and private hosted zones
+3. Removes the DNSEndpoint CR
+
+Zone IDs are persisted in the `AWSEndpointService` status (`ingressPublicZoneID` and `ingressPrivateZoneID`) so cleanup is reliable even across controller restarts.

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -7166,6 +7166,80 @@ This implementation provides a secure, autonomous solution that allows HostedClu
 
 ---
 
+## Source: docs/content/how-to/aws/managed-ingress-dns.md
+
+# Managed Ingress DNS for AWS
+
+By default, HyperShift creates only an internal `.hypershift.local` DNS zone for hosted control planes on AWS. When managed ingress DNS is enabled, the control plane operator (CPO) creates and manages Route53 hosted zones for ingress traffic in the customer's AWS account.
+
+## What Gets Created
+
+When `IngressDNSManagement` is set to `Managed`, the CPO creates:
+
+1. **Public Route53 hosted zone** for the cluster's ingress subdomain (e.g. `my-cluster.example.com`)
+2. **Private Route53 hosted zone** associated with the cluster's VPC for internal resolution
+3. **DNSEndpoint CR** with NS records for delegation from the service provider's DNS zone to the customer's public zone
+4. **ACME challenge CNAME** (`_acme-challenge.apps.<ingress>` pointing to `_acme-challenge.<baseDomain>`) for cert-manager DNS01 validation
+
+## Prerequisites
+
+The IAM role used for Route53 access (via `SharedVPC.RolesRef.IngressARN` or the default credentials) must have the following permissions:
+
+- `route53:CreateHostedZone`
+- `route53:DeleteHostedZone`
+- `route53:GetHostedZone`
+- `route53:ListHostedZones`
+- `route53:ListResourceRecordSets`
+- `route53:ChangeResourceRecordSets`
+
+## Configuration
+
+Set `ingressDNSManagement` to `Managed` on the HostedCluster's AWS platform spec:
+
+```yaml
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  name: my-cluster
+  namespace: clusters
+spec:
+  platform:
+    type: AWS
+    aws:
+      region: us-east-1
+      ingressDNSManagement: Managed
+      # ... other AWS fields
+  dns:
+    baseDomain: example.com
+```
+
+This field is **immutable** after creation. The default value is `Unmanaged`, which preserves the existing behavior.
+
+## Monitoring
+
+The `AWSIngressDNSAvailable` condition on the `AWSEndpointService` and `HostedCluster` resources reflects the status of ingress DNS setup:
+
+```bash
+# Check AWSEndpointService condition
+oc get awsendpointservice -n clusters-my-cluster -o jsonpath='{.items[*].status.conditions}'
+
+# Check HostedCluster condition
+oc get hostedcluster my-cluster -n clusters -o jsonpath='{.status.conditions[?(@.type=="AWSIngressDNSAvailable")]}'
+```
+
+## Cleanup
+
+When the hosted cluster is deleted, the CPO automatically:
+
+1. Deletes all custom DNS records from the managed zones
+2. Deletes both the public and private hosted zones
+3. Removes the DNSEndpoint CR
+
+Zone IDs are persisted in the `AWSEndpointService` status (`ingressPublicZoneID` and `ingressPrivateZoneID`) so cleanup is reliable even across controller restarts.
+
+
+---
+
 ## Source: docs/content/how-to/aws/other-sdn-providers.md
 
 This document explains how to create a HostedCluster that runs an SDN provider different from OVNKubernetes. The document assumes that you already have the required infrastructure in place to create HostedClusters.
@@ -33365,6 +33439,33 @@ private node communication with the control plane.</p>
 </td>
 </tr></tbody>
 </table>
+###AWSIngressDNSManagement { #hypershift.openshift.io/v1beta1.AWSIngressDNSManagement }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1beta1.AWSPlatformSpec">AWSPlatformSpec</a>)
+</p>
+<p>
+<p>AWSIngressDNSManagement specifies whether the control plane operator manages
+Route53 hosted zones for ingress DNS in the customer&rsquo;s AWS account.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Managed&#34;</p></td>
+<td><p>AWSIngressDNSManaged means the control plane operator creates public and private
+Route53 hosted zones for ingress, creates a DNSEndpoint CR for NS delegation,
+and creates an _acme-challenge CNAME for cert-manager DNS01 CNAME-follow.</p>
+</td>
+</tr><tr><td><p>&#34;Unmanaged&#34;</p></td>
+<td><p>AWSIngressDNSUnmanaged means the control plane operator does not create
+public/private ingress hosted zones. Only the .hypershift.local zone is managed.</p>
+</td>
+</tr></tbody>
+</table>
 ###AWSKMSAuthSpec { #hypershift.openshift.io/v1beta1.AWSKMSAuthSpec }
 <p>
 (<em>Appears on:</em>
@@ -33845,6 +33946,25 @@ AWSSharedVPC
 <p>sharedVPC contains fields that must be specified if the HostedCluster must use a VPC that is
 created in a different AWS account and is shared with the AWS account where the HostedCluster
 will be created.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ingressDNSManagement</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1beta1.AWSIngressDNSManagement">
+AWSIngressDNSManagement
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ingressDNSManagement specifies whether the control plane operator manages
+Route53 hosted zones for ingress DNS in the customer&rsquo;s AWS account.
+When set to &ldquo;Managed&rdquo;, the CPO creates public and private ingress zones,
+a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+cert-manager DNS01 CNAME-follow.
+When set to &ldquo;Unmanaged&rdquo; (the default), only the .hypershift.local zone is managed.</p>
 </td>
 </tr>
 <tr>
@@ -37587,6 +37707,10 @@ created in the guest VPC</p>
 </tr><tr><td><p>&#34;AWSEndpointServiceAvailable&#34;</p></td>
 <td><p>AWSEndpointServiceAvailable indicates whether the AWS Endpoint Service
 has been created for the specified NLB in the management VPC</p>
+</td>
+</tr><tr><td><p>&#34;AWSIngressDNSAvailable&#34;</p></td>
+<td><p>AWSIngressDNSAvailable indicates whether the Route53 ingress DNS zones
+and records have been successfully created in the customer&rsquo;s AWS account.</p>
 </td>
 </tr><tr><td><p>&#34;AutoNodeEnabled&#34;</p></td>
 <td><p>AutoNodeEnabled indicates whether AutoNode is configured and operational for this HostedCluster.

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1537,6 +1537,33 @@ private node communication with the control plane.</p>
 </td>
 </tr></tbody>
 </table>
+###AWSIngressDNSManagement { #hypershift.openshift.io/v1beta1.AWSIngressDNSManagement }
+<p>
+(<em>Appears on:</em>
+<a href="#hypershift.openshift.io/v1beta1.AWSPlatformSpec">AWSPlatformSpec</a>)
+</p>
+<p>
+<p>AWSIngressDNSManagement specifies whether the control plane operator manages
+Route53 hosted zones for ingress DNS in the customer&rsquo;s AWS account.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Managed&#34;</p></td>
+<td><p>AWSIngressDNSManaged means the control plane operator creates public and private
+Route53 hosted zones for ingress, creates a DNSEndpoint CR for NS delegation,
+and creates an _acme-challenge CNAME for cert-manager DNS01 CNAME-follow.</p>
+</td>
+</tr><tr><td><p>&#34;Unmanaged&#34;</p></td>
+<td><p>AWSIngressDNSUnmanaged means the control plane operator does not create
+public/private ingress hosted zones. Only the .hypershift.local zone is managed.</p>
+</td>
+</tr></tbody>
+</table>
 ###AWSKMSAuthSpec { #hypershift.openshift.io/v1beta1.AWSKMSAuthSpec }
 <p>
 (<em>Appears on:</em>
@@ -2017,6 +2044,25 @@ AWSSharedVPC
 <p>sharedVPC contains fields that must be specified if the HostedCluster must use a VPC that is
 created in a different AWS account and is shared with the AWS account where the HostedCluster
 will be created.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ingressDNSManagement</code></br>
+<em>
+<a href="#hypershift.openshift.io/v1beta1.AWSIngressDNSManagement">
+AWSIngressDNSManagement
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ingressDNSManagement specifies whether the control plane operator manages
+Route53 hosted zones for ingress DNS in the customer&rsquo;s AWS account.
+When set to &ldquo;Managed&rdquo;, the CPO creates public and private ingress zones,
+a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+cert-manager DNS01 CNAME-follow.
+When set to &ldquo;Unmanaged&rdquo; (the default), only the .hypershift.local zone is managed.</p>
 </td>
 </tr>
 <tr>
@@ -5759,6 +5805,10 @@ created in the guest VPC</p>
 </tr><tr><td><p>&#34;AWSEndpointServiceAvailable&#34;</p></td>
 <td><p>AWSEndpointServiceAvailable indicates whether the AWS Endpoint Service
 has been created for the specified NLB in the management VPC</p>
+</td>
+</tr><tr><td><p>&#34;AWSIngressDNSAvailable&#34;</p></td>
+<td><p>AWSIngressDNSAvailable indicates whether the Route53 ingress DNS zones
+and records have been successfully created in the customer&rsquo;s AWS account.</p>
 </td>
 </tr><tr><td><p>&#34;AutoNodeEnabled&#34;</p></td>
 <td><p>AutoNodeEnabled indicates whether AutoNode is configured and operational for this HostedCluster.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -131,6 +131,7 @@ nav:
       - how-to/aws/external-dns.md
       - 'Global Pull Secret': how-to/aws/global-pull-secret.md
       - 'Other SDN providers': how-to/aws/other-sdn-providers.md
+      - how-to/aws/managed-ingress-dns.md
       - how-to/aws/shared-vpc.md
       - 'Troubleshooting':
         - how-to/aws/troubleshooting/index.md

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -956,6 +956,11 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 				Message: fmt.Sprintf("error listing awsendpointservices in namespace %s: %v", hcpNamespace, err),
 			}
 			meta.SetStatusCondition(&hcluster.Status.Conditions, condition)
+			if hcluster.Spec.Platform.AWS != nil &&
+				hcluster.Spec.Platform.AWS.IngressDNSManagement == hyperv1.AWSIngressDNSManaged {
+				condition.Type = string(hyperv1.AWSIngressDNSAvailable)
+				meta.SetStatusCondition(&hcluster.Status.Conditions, condition)
+			}
 		} else {
 			meta.SetStatusCondition(&hcluster.Status.Conditions, computeAWSEndpointServiceCondition(awsEndpointServiceList, hyperv1.AWSEndpointAvailable))
 			meta.SetStatusCondition(&hcluster.Status.Conditions, computeAWSEndpointServiceCondition(awsEndpointServiceList, hyperv1.AWSEndpointServiceAvailable))

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -959,6 +959,10 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		} else {
 			meta.SetStatusCondition(&hcluster.Status.Conditions, computeAWSEndpointServiceCondition(awsEndpointServiceList, hyperv1.AWSEndpointAvailable))
 			meta.SetStatusCondition(&hcluster.Status.Conditions, computeAWSEndpointServiceCondition(awsEndpointServiceList, hyperv1.AWSEndpointServiceAvailable))
+			if hcluster.Spec.Platform.AWS != nil &&
+				hcluster.Spec.Platform.AWS.IngressDNSManagement == hyperv1.AWSIngressDNSManaged {
+				meta.SetStatusCondition(&hcluster.Status.Conditions, computeAWSEndpointServiceCondition(awsEndpointServiceList, hyperv1.AWSIngressDNSAvailable))
+			}
 		}
 	}
 

--- a/support/awsapi/route53.go
+++ b/support/awsapi/route53.go
@@ -26,6 +26,7 @@ type ROUTE53API interface {
 	DisassociateVPCFromHostedZone(ctx context.Context, input *route53.DisassociateVPCFromHostedZoneInput, optFns ...func(*route53.Options)) (*route53.DisassociateVPCFromHostedZoneOutput, error)
 	GetHostedZone(ctx context.Context, input *route53.GetHostedZoneInput, optFns ...func(*route53.Options)) (*route53.GetHostedZoneOutput, error)
 	ListHostedZones(ctx context.Context, input *route53.ListHostedZonesInput, optFns ...func(*route53.Options)) (*route53.ListHostedZonesOutput, error)
+	ListHostedZonesByName(ctx context.Context, input *route53.ListHostedZonesByNameInput, optFns ...func(*route53.Options)) (*route53.ListHostedZonesByNameOutput, error)
 	ListHostedZonesByVPC(ctx context.Context, input *route53.ListHostedZonesByVPCInput, optFns ...func(*route53.Options)) (*route53.ListHostedZonesByVPCOutput, error)
 	ListResourceRecordSets(ctx context.Context, input *route53.ListResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ListResourceRecordSetsOutput, error)
 }

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/aws.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/aws.go
@@ -309,6 +309,21 @@ type AWSCloudProviderConfig struct {
 	VPC string `json:"vpc"`
 }
 
+// AWSIngressDNSManagement specifies whether the control plane operator manages
+// Route53 hosted zones for ingress DNS in the customer's AWS account.
+type AWSIngressDNSManagement string
+
+const (
+	// AWSIngressDNSUnmanaged means the control plane operator does not create
+	// public/private ingress hosted zones. Only the .hypershift.local zone is managed.
+	AWSIngressDNSUnmanaged AWSIngressDNSManagement = "Unmanaged"
+
+	// AWSIngressDNSManaged means the control plane operator creates public and private
+	// Route53 hosted zones for ingress, creates a DNSEndpoint CR for NS delegation,
+	// and creates an _acme-challenge CNAME for cert-manager DNS01 CNAME-follow.
+	AWSIngressDNSManaged AWSIngressDNSManagement = "Managed"
+)
+
 // AWSEndpointAccessType specifies the publishing scope of cluster endpoints.
 type AWSEndpointAccessType string
 
@@ -414,6 +429,20 @@ type AWSPlatformSpec struct {
 	//
 	// +optional
 	SharedVPC *AWSSharedVPC `json:"sharedVPC,omitempty"`
+
+	// ingressDNSManagement specifies whether the control plane operator manages
+	// Route53 hosted zones for ingress DNS in the customer's AWS account.
+	// When set to "Managed", the CPO creates public and private ingress zones,
+	// a DNSEndpoint CR for NS delegation, and an _acme-challenge CNAME for
+	// cert-manager DNS01 CNAME-follow.
+	// When set to "Unmanaged" (the default), only the .hypershift.local zone is managed.
+	//
+	// +kubebuilder:validation:Enum=Unmanaged;Managed
+	// +kubebuilder:default=Unmanaged
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="ingressDNSManagement is immutable"
+	// +immutable
+	// +optional
+	IngressDNSManagement AWSIngressDNSManagement `json:"ingressDNSManagement,omitempty"`
 
 	// terminationHandlerQueueURL specifies the SQS queue URL for EC2 spot interruption events.
 	// This is required when using spot instances (marketType: Spot) in NodePools to enable

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/endpointservice_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/endpointservice_types.go
@@ -25,6 +25,10 @@ const (
 	// created in the guest VPC
 	AWSEndpointAvailable ConditionType = "AWSEndpointAvailable"
 
+	// AWSIngressDNSAvailable indicates whether the Route53 ingress DNS zones
+	// and records have been successfully created in the customer's AWS account.
+	AWSIngressDNSAvailable ConditionType = "AWSIngressDNSAvailable"
+
 	AWSSuccessReason string = "AWSSuccess"
 	AWSErrorReason   string = "AWSError"
 )
@@ -92,6 +96,18 @@ type AWSEndpointServiceStatus struct {
 	// SecurityGroupID is the ID of the security group.
 	// +optional
 	SecurityGroupID string `json:"securityGroupID,omitempty"`
+
+	// ingressPublicZoneID is the Route53 hosted zone ID for the public ingress zone
+	// created when IngressDNSManagement is Managed.
+	// +optional
+	// +kubebuilder:validation:MaxLength=32
+	IngressPublicZoneID string `json:"ingressPublicZoneID,omitempty"`
+
+	// ingressPrivateZoneID is the Route53 hosted zone ID for the private ingress zone
+	// created when IngressDNSManagement is Managed.
+	// +optional
+	// +kubebuilder:validation:MaxLength=32
+	IngressPrivateZoneID string `json:"ingressPrivateZoneID,omitempty"`
 }
 
 // +kubebuilder:object:root=true


### PR DESCRIPTION
## Summary

Adds opt-in managed ingress DNS for AWS hosted control planes, mirroring GCP's existing implementation. When `IngressDNSManagement: Managed` is set on `AWSPlatformSpec`:

- CPO creates public + private Route53 hosted zones for the ingress subdomain
- CPO creates a `DNSEndpoint` CR for NS delegation (external-dns writes NS records to the service provider's zone)
- CPO creates an `_acme-challenge` CNAME in the public ingress zone for cert-manager DNS01 CNAME-follow
- Zone IDs are persisted in `AWSEndpointServiceStatus` and a new `AWSIngressDNSAvailable` condition is surfaced on the HostedCluster

Default is `Unmanaged` (no behavior change for existing clusters). The field is immutable once set.

### Commits

1. **api**: Add `IngressDNSManagement` enum field to `AWSPlatformSpec` + status fields on `AWSEndpointServiceStatus`
2. **cpo**: Implement ingress DNS reconciliation and cleanup in the AWS private link controller
3. **iam**: Add `route53:CreateHostedZone`, `route53:DeleteHostedZone`, `route53:GetHostedZone` to self-managed IAM policies + SharedVPC Route53 role
4. **ho**: Propagate `AWSIngressDNSAvailable` condition to HostedCluster status
5. **test**: Add envtest CEL validation tests for `IngressDNSManagement` (immutability, enum, default)
6. **docs**: Add how-to guide for managed ingress DNS

### ⚠️ ROSA Managed Policy Update Required

This PR adds Route53 zone management permissions to the **self-managed** IAM policies in `cmd/infra/aws/iam.go`. However, **ROSA uses AWS managed policies** (`ROSAControlPlaneOperatorPolicy`) that are maintained by the AWS team separately.

Before this feature can be used on ROSA HCP, the following permissions must be added to `ROSAControlPlaneOperatorPolicy`:

```json
{
  "Effect": "Allow",
  "Action": [
    "route53:CreateHostedZone",
    "route53:DeleteHostedZone",
    "route53:GetHostedZone"
  ],
  "Resource": "*"
}
```

The AWS team should be engaged to update the managed policy in parallel with this PR.

## Test plan

- [x] Unit tests for all DNS functions (`dns_test.go` — 24 test cases)
- [x] Envtest CEL validation tests for `IngressDNSManagement` field (7 test cases)
- [ ] `make verify` passes
- [ ] E2E test with `IngressDNSManagement: Managed` on a real cluster
- [ ] Verify SharedVPC scenario: ingress zones created with IngressARN credentials
- [ ] Verify cleanup on HostedCluster deletion removes zones and records

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added managed ingress DNS for AWS-hosted clusters with "Managed" (immutable, default Unmanaged) and "Unmanaged" modes
  * Automatic creation/association of public/private Route53 hosted zones, ACME challenge CNAMEs, and delegated DNS endpoints; hosted-zone IDs are stored in endpoint status
  * New AWSIngressDNSAvailable condition surfaced on endpoint and HostedCluster status

* **Documentation**
  * Added guide for configuring and monitoring managed ingress DNS on AWS platforms
<!-- end of auto-generated comment: release notes by coderabbit.ai -->