### PR TITLE
NO-JIRA: Skip TestKarpenter for releases < 4.22

### DIFF
--- a/test/e2e/karpenter_test.go
+++ b/test/e2e/karpenter_test.go
@@ -49,7 +49,7 @@ import (
 )
 
 func TestKarpenter(t *testing.T) {
-	e2eutil.AtLeast(t, e2eutil.Version419)
+	e2eutil.AtLeast(t, e2eutil.Version422)
 	if globalOpts.Platform != hyperv1.AWSPlatform {
 		t.Skip("test only supported on platform AWS")
 	}


### PR DESCRIPTION
## Summary

- Skip `TestKarpenter` e2e suite for releases < 4.22. Karpenter is only supported from 4.22 onwards.
- Unblock `periodic-ci-openshift-hypershift-release-4.20-periodics-e2e-aws-ovn` and `periodic-ci-openshift-hypershift-release-4.19-periodics-e2e-aws-ovn` failing since April 30

## Test plan

- [x] Verify e2e tests compile with `go build -tags e2e ./test/e2e/`
- [ ] Verify 4.20/4.19 periodic jobs start passing (Karpenter tests will be skipped)
- [ ] Verify 4.22+ periodic jobs still run Karpenter tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Raised the minimum end-to-end test environment version requirement from 4.19 to 4.22. This affects execution of AWS Karpenter end-to-end tests and ensures they run only on environments meeting the new version threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->