### PR TITLE
OCPBUGS-84969: fix(e2e): wait for Karpenter node cleanup in parallel tests to prevent vCPU flake

### DIFF
--- a/test/e2e/karpenter_test.go
+++ b/test/e2e/karpenter_test.go
@@ -672,9 +672,11 @@ func testNodeClassVersionField(ctx context.Context, mgtClient, guestClient crcli
 				instanceID, instance.MetadataOptions.HttpTokens, instance.MetadataOptions.HttpEndpoint, *instance.MetadataOptions.HttpPutResponseHopLimit)
 		}
 
-		// Trigger cleanup; the t.Cleanup handles final deletion.
+		// Trigger cleanup and wait for nodes to fully terminate so stale
+		// NodeClaims don't leak vCPUs into subsequent sequential tests.
 		g.Expect(guestClient.Delete(ctx, testWorkLoads)).To(Succeed())
 		g.Expect(guestClient.Delete(ctx, testNodePool)).To(Succeed())
+		_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, guestClient, hostedCluster.Spec.Platform.Type, 0, testNodeLabels)
 
 		// Verify that a version exceeding the allowed n-3 skew sets SupportedVersionSkew=False.
 		skewMajor, skewMinor, err := supportedversion.PreviousMinorVersion(cpVersion, 4)
@@ -887,6 +889,12 @@ func testCapacityReservation(ctx context.Context, mgtClient, guestClient crclien
 		g.Expect(aws.ToString(instance.CapacityReservationId)).To(Equal(crID),
 			"instance %s should have been launched into capacity reservation %s", instanceID, crID)
 		t.Logf("Instance %s correctly launched into capacity reservation %s", instanceID, crID)
+
+		// Delete workload and NodePool, then wait for nodes to fully terminate
+		// so stale NodeClaims don't leak vCPUs into subsequent sequential tests.
+		g.Expect(guestClient.Delete(ctx, crWorkload)).To(Succeed())
+		g.Expect(guestClient.Delete(ctx, crNodePool)).To(Succeed())
+		_ = e2eutil.WaitForReadyNodesByLabels(t, ctx, guestClient, hostedCluster.Spec.Platform.Type, 0, crNodeLabels)
 	}
 }
 


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes a 50% flake rate in `TestKarpenter/Main/Billing_vCPUs,_consolidation,_and_cluster_deletion_with_blocking_PDB` across all e2e-aws runs.

`testCapacityReservation` and `testNodeClassVersionField` provision Karpenter nodes but only rely on `t.Cleanup` for deletion without waiting for nodes to fully terminate. When the sequential `testBillingConsolidationAndPDB` runs next and asserts `AutoNode.VCPUs=0`, stale NodeClaims from these parallel tests cause the assertion to fail with `AutoNode.VCPUs=4, want 0` (one lingering t3.xlarge = 4 vCPUs).

This adds explicit `WaitForReadyNodesByLabels(..., 0, ...)` calls after deleting workloads and NodePools, matching the pattern already used by `testARM64Provisioning` and `testInstanceProfileAnnotation`.

## Which issue(s) this PR fixes:

6 out of 12 e2e-aws runs in the last 24h failed due to this flake, blocking unrelated PRs (#8385, #8396, #8404, #8409).

https://redhat.atlassian.net/browse/OCPBUGS-84969

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test flow to ensure explicit cleanup of managed resources and full node termination before running subsequent checks, preventing resource leakage and improving overall test reliability across multiple test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->