### PR TITLE
OCPBUGS-85011: fix(cpo): use check-first pattern for EBS CSI operator serving cert

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1684,6 +1684,27 @@ func (r *HostedControlPlaneReconciler) reconcileAWSPlatformCerts(ctx context.Con
 		return fmt.Errorf("failed to reconcile %s secret: %w", awsPodIdentityWebhookServingCert.Name, err)
 	}
 
+	awsEBSCsiDriverOperatorMetricsService := manifests.AWSEBSCsiDriverOperatorMetricsService(hcp.Namespace)
+	if err := r.Get(ctx, client.ObjectKeyFromObject(awsEBSCsiDriverOperatorMetricsService), awsEBSCsiDriverOperatorMetricsService); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to retrieve aws-ebs-csi-driver-operator-metrics service: %w", err)
+		}
+	}
+
+	if hasServiceCAAnnotation := doesServiceHaveServiceCAAnnotation(awsEBSCsiDriverOperatorMetricsService); !hasServiceCAAnnotation {
+		awsEBSCsiDriverOperatorServingCert := manifests.AWSEBSCsiDriverOperatorServingCert(hcp.Namespace)
+
+		if err := removeServiceCASecret(ctx, r.Client, awsEBSCsiDriverOperatorServingCert); err != nil {
+			return fmt.Errorf("failed to remove service CA secret for aws-ebs-csi-driver-operator: %w", err)
+		}
+
+		if _, err := createOrUpdate(ctx, r, awsEBSCsiDriverOperatorServingCert, func() error {
+			return pki.ReconcileAWSEBSCsiDriverOperatorMetricsServingCertSecret(awsEBSCsiDriverOperatorServingCert, rootCASecret, p.OwnerRef)
+		}); err != nil {
+			return fmt.Errorf("failed to reconcile aws ebs csi driver operator serving cert: %w", err)
+		}
+	}
+
 	awsEBSCsiDriverControllerMetricsService := manifests.AWSEBSCsiDriverControllerMetricsService(hcp.Namespace)
 	if err := r.Get(ctx, client.ObjectKeyFromObject(awsEBSCsiDriverControllerMetricsService), awsEBSCsiDriverControllerMetricsService); err != nil {
 		if !apierrors.IsNotFound(err) {

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/aws_ebs_csi_driver_operator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/aws_ebs_csi_driver_operator.go
@@ -1,0 +1,15 @@
+package manifests
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func AWSEBSCsiDriverOperatorMetricsService(namespace string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws-ebs-csi-driver-operator-metrics",
+			Namespace: namespace,
+		},
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -380,6 +380,10 @@ func AzureFileCsiDriverControllerMetricsServingCert(ns string) *corev1.Secret {
 	return secretFor(ns, "azure-file-csi-driver-controller-metrics-serving-cert")
 }
 
+func AWSEBSCsiDriverOperatorServingCert(ns string) *corev1.Secret {
+	return secretFor(ns, "aws-ebs-csi-driver-operator-serving-cert")
+}
+
 func AWSEBSCsiDriverControllerMetricsServingCert(ns string) *corev1.Secret {
 	return secretFor(ns, "aws-ebs-csi-driver-controller-metrics-serving-cert")
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/aws_ebs_csi_driver_operator.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/aws_ebs_csi_driver_operator.go
@@ -1,0 +1,19 @@
+package pki
+
+import (
+	"fmt"
+
+	"github.com/openshift/hypershift/support/config"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func ReconcileAWSEBSCsiDriverOperatorMetricsServingCertSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+	dnsNames := []string{
+		fmt.Sprintf("aws-ebs-csi-driver-operator-metrics.%s.svc", secret.Namespace),
+		fmt.Sprintf("aws-ebs-csi-driver-operator-metrics.%s.svc.cluster.local", secret.Namespace),
+		"aws-ebs-csi-driver-operator-metrics",
+		"localhost",
+	}
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "aws-ebs-csi-driver-operator-metrics", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/aws_ebs_csi_driver_operator_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/aws_ebs_csi_driver_operator_test.go
@@ -1,0 +1,108 @@
+package pki
+
+import (
+	"testing"
+
+	"github.com/openshift/hypershift/support/certs"
+	"github.com/openshift/hypershift/support/config"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+)
+
+func TestReconcileAWSEBSCsiDriverOperatorMetricsServingCertSecret(t *testing.T) {
+	namespace := "test-namespace"
+
+	ownerRef := config.OwnerRef{
+		Reference: &metav1.OwnerReference{
+			APIVersion: "v1",
+			Kind:       "HostedControlPlane",
+			Name:       "test-hcp",
+			UID:        types.UID("test-uid"),
+			Controller: ptr.To(true),
+		},
+	}
+
+	ca := &corev1.Secret{}
+	ca.Name = "test-ca"
+	ca.Namespace = namespace
+	if err := reconcileSelfSignedCA(ca, ownerRef, "test-org", "test-ca"); err != nil {
+		t.Fatalf("failed to create CA: %v", err)
+	}
+
+	t.Run("When reconciling with a valid CA it should generate a cert with correct DNS names and subject", func(t *testing.T) {
+		secret := &corev1.Secret{}
+		secret.Name = "aws-ebs-csi-driver-operator-serving-cert"
+		secret.Namespace = namespace
+
+		if err := ReconcileAWSEBSCsiDriverOperatorMetricsServingCertSecret(secret, ca, ownerRef); err != nil {
+			t.Fatalf("failed to reconcile cert: %v", err)
+		}
+
+		if secret.Data == nil {
+			t.Fatal("secret data is nil")
+		}
+
+		if _, ok := secret.Data[corev1.TLSCertKey]; !ok {
+			t.Fatal("secret missing tls.crt")
+		}
+
+		if _, ok := secret.Data[corev1.TLSPrivateKeyKey]; !ok {
+			t.Fatal("secret missing tls.key")
+		}
+
+		cert, err := certs.PemToCertificate(secret.Data[corev1.TLSCertKey])
+		if err != nil {
+			t.Fatalf("failed to parse certificate: %v", err)
+		}
+
+		expectedDNSNames := map[string]bool{
+			"aws-ebs-csi-driver-operator-metrics." + namespace + ".svc":               true,
+			"aws-ebs-csi-driver-operator-metrics." + namespace + ".svc.cluster.local": true,
+			"aws-ebs-csi-driver-operator-metrics":                                     true,
+			"localhost":                                                               true,
+		}
+
+		if len(cert.DNSNames) != len(expectedDNSNames) {
+			t.Errorf("expected %d DNS names, got %d", len(expectedDNSNames), len(cert.DNSNames))
+		}
+
+		for _, name := range cert.DNSNames {
+			if !expectedDNSNames[name] {
+				t.Errorf("unexpected DNS name: %s", name)
+			}
+		}
+
+		expectedCN := "aws-ebs-csi-driver-operator-metrics"
+		if cert.Subject.CommonName != expectedCN {
+			t.Errorf("expected CN %s, got %s", expectedCN, cert.Subject.CommonName)
+		}
+
+		if len(cert.Subject.Organization) == 0 || cert.Subject.Organization[0] != "openshift" {
+			t.Errorf("expected Organization [openshift], got %v", cert.Subject.Organization)
+		}
+	})
+
+	t.Run("When reconciling the serving cert twice it should produce the same certificate", func(t *testing.T) {
+		secret := &corev1.Secret{}
+		secret.Name = "aws-ebs-csi-driver-operator-serving-cert"
+		secret.Namespace = namespace
+
+		if err := ReconcileAWSEBSCsiDriverOperatorMetricsServingCertSecret(secret, ca, ownerRef); err != nil {
+			t.Fatalf("first reconcile failed: %v", err)
+		}
+
+		firstCert := make([]byte, len(secret.Data[corev1.TLSCertKey]))
+		copy(firstCert, secret.Data[corev1.TLSCertKey])
+
+		if err := ReconcileAWSEBSCsiDriverOperatorMetricsServingCertSecret(secret, ca, ownerRef); err != nil {
+			t.Fatalf("second reconcile failed: %v", err)
+		}
+
+		if string(firstCert) != string(secret.Data[corev1.TLSCertKey]) {
+			t.Error("expected idempotent reconciliation to produce the same certificate")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

CPO now only generates the EBS CSI driver operator serving cert when service-ca is not managing it - allowing the ebs csi driver operator to run on non-OpenShift AWS clusters. 

## Problem

The aws-ebs-csi-driver-operator deployment mounts a TLS serving cert from secret aws-ebs-csi-driver-operator-serving-cert. On OpenShift, the [service-ca operator](https://github.com/openshift/service-ca-operator) generates this cert automatically for services annotated with service.beta.kubernetes.io/serving-cert-secret-name. On non-OpenShift management clusters (e.g. EKS), the service-ca operator does not exist, so the secret is never created and the operator pod fails to start with FailedMount.

Without the EBS CSI driver operator, no CSI driver pods are deployed on the data plane, blocking PersistentVolume support on the guest cluster.

The CPO already handles the analogous case for the EBS CSI driver controller metrics cert (commit [acebcc919](https://github.com/openshift/hypershift/commit/acebcc919)), but the operator serving cert was not covered.

## Fix

Use the same pattern already used by the AWS EBS CSI driver **controller** metrics cert (introduced in #7538).

## Note

This is an iteration on [hypershift/pull/8357](https://github.com/openshift/hypershift/pull/8357) following a revert [here](https://github.com/openshift/hypershift/pull/8417).

This time, we're not patching the service and try to always own the certificate generation (ARO-style), but only create the cert if service-ca is not present. This fixes the reconciliation fights over the service detected by conformance-e2e. The conformance-e2e now pass. 

## Test plan

- [x] Unit tests pass (`go test ./control-plane-operator/controllers/hostedcontrolplane/pki/... -run AWSEBS`)
- [x] Build succeeds
- [x] Pre-commit hooks pass
- [x] Verify on non-OpenShift management cluster
- [x] `/payload-with-prs openshift/hypershift#THIS_PR periodic-ci-openshift-hypershift-main-periodics-e2e-aws-ovn-conformance`

Supersedes revert PR: #8417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a headless metrics Service and a serving-cert Secret manifest for the AWS EBS CSI driver.
  * Added reconciliation to create/sign the metrics serving certificate.

* **Bug Fixes**
  * Only remove service-CA–generated serving cert when the Service lacks the service-ca annotation.
  * Return errors on failures when removing service-CA secrets or reconciling serving certs.

* **Tests**
  * Added unit tests validating issued TLS cert contents, DNS names, and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->