### PR TITLE
*: proposed follow-ups after cluster deletion investigation

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -252,6 +252,12 @@ const (
 	// **False / AutoNodeProgressing** means AutoNode is being enabled or disabled — the operation is in progress.
 	// **False / AutoNodeNotConfigured** means AutoNode is not configured in the spec and all Karpenter components have been removed.
 	AutoNodeEnabled ConditionType = "AutoNodeEnabled"
+
+	// HostedClusterDeleting indicates whether the HostedCluster is being deleted and
+	// provides first-class visibility into which phase of deletion the cluster is in.
+	// **False / AsExpected** means the cluster is not being deleted.
+	// **True** means deletion is in progress; the Reason and Message indicate the current phase.
+	HostedClusterDeleting ConditionType = "HostedClusterDeleting"
 )
 
 // Reasons.
@@ -336,6 +342,15 @@ const (
 	AutoNodeNotConfiguredReason    = "AutoNodeNotConfigured"
 	AutoNodeProgressingReason      = "AutoNodeProgressing"
 	AutoNodeEvaluationFailedReason = "AutoNodeEvaluationFailed"
+
+	// HostedClusterDeleting reasons.
+	DeletionWaitingForNodePoolDeletionReason        = "WaitingForNodePoolDeletion"
+	DeletionWaitingForCAPIClusterDeletionReason     = "WaitingForCAPIClusterDeletion"
+	DeletionWaitingForEndpointServiceDeletionReason = "WaitingForEndpointServiceDeletion"
+	DeletionWaitingForPrivateConnectDeletionReason  = "WaitingForPrivateConnectDeletion"
+	DeletionWaitingForControlPlaneDeletionReason    = "WaitingForControlPlaneDeletion"
+	DeletionWaitingForNamespaceDeletionReason       = "WaitingForNamespaceDeletion"
+	DeletionCompletedReason                         = "DeletionCompleted"
 )
 
 // Messages.

--- a/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -315,6 +315,8 @@ const (
 
 	CloudResourcesCleanupSkippedReason = "CloudResourcesCleanupSkipped"
 
+	CloudResourcesDeletionTimedOutReason = "CloudResourcesDeletionTimedOut"
+
 	DataPlaneConnectionNoKonnectivityAgentPodsNotFoundReason = "KonnectivityAgentPodsNotFound"
 
 	DataPlaneConnectionLogsAccessFailedReason = "LogsAccessFailed"

--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
@@ -129,7 +129,6 @@ func (r *PrivateServiceObserver) SetupWithManager(ctx context.Context, mgr ctrl.
 }
 
 func (r *PrivateServiceObserver) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.log.Info("reconciling")
 
 	// Fetch the Service
 	svc, err := r.clientset.CoreV1().Services(req.Namespace).Get(ctx, req.Name, metav1.GetOptions{})
@@ -181,7 +180,6 @@ func (r *PrivateServiceObserver) Reconcile(ctx context.Context, req ctrl.Request
 	}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile AWSEndpointService: %w", err)
 	}
-	r.log.Info("reconcile complete", "request", req)
 	return ctrl.Result{}, nil
 }
 
@@ -412,8 +410,6 @@ func (r *AWSEndpointServiceReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, fmt.Errorf("logger not found: %w", err)
 	}
 
-	log.Info("reconciling")
-
 	// Fetch the AWSEndpointService
 	obj := &hyperv1.AWSEndpointService{
 		ObjectMeta: metav1.ObjectMeta{
@@ -548,7 +544,6 @@ func (r *AWSEndpointServiceReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 	}
 
-	log.Info("reconciliation complete")
 	// always requeue to catch and report out of band changes in AWS
 	// NOTICE: if the RequeueAfter interval is short enough, it could result in hitting some AWS request limits.
 	return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil

--- a/control-plane-operator/controllers/gcpprivateserviceconnect/observer.go
+++ b/control-plane-operator/controllers/gcpprivateserviceconnect/observer.go
@@ -64,8 +64,6 @@ func (r *GCPPrivateServiceObserver) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, nil
 	}
 
-	r.log.Info("reconciling")
-
 	// Fetch the Service
 	svc := &corev1.Service{}
 	if err := r.Get(ctx, req.NamespacedName, svc); err != nil {
@@ -114,7 +112,6 @@ func (r *GCPPrivateServiceObserver) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile GCPPrivateServiceConnect: %w", err)
 	}
 
-	r.log.Info("reconcile complete", "request", req, "loadBalancerIP", loadBalancerIP)
 	return ctrl.Result{}, nil
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2431,9 +2431,10 @@ func (r *HostedControlPlaneReconciler) removeCloudResources(ctx context.Context,
 		return true, nil
 	}
 
-	// check if cleanup has been skipped
+	// check if cleanup has been skipped or timed out
 	if resourcesDestroyedCond != nil && resourcesDestroyedCond.Status == metav1.ConditionFalse &&
-		resourcesDestroyedCond.Reason == string(hyperv1.CloudResourcesCleanupSkippedReason) {
+		(resourcesDestroyedCond.Reason == string(hyperv1.CloudResourcesCleanupSkippedReason) ||
+			resourcesDestroyedCond.Reason == string(hyperv1.CloudResourcesDeletionTimedOutReason)) {
 		log.Info("Cleanup has been skipped", "reason", resourcesDestroyedCond.Message)
 		return true, nil
 	}
@@ -2453,6 +2454,19 @@ func (r *HostedControlPlaneReconciler) removeCloudResources(ctx context.Context,
 
 		if timeElapsed > resourceDeletionTimeout {
 			log.Info("Giving up on resource deletion after timeout", "timeElapsed", duration.ShortHumanDuration(timeElapsed))
+			message := fmt.Sprintf("Giving up on cloud resource deletion after %s", duration.ShortHumanDuration(timeElapsed))
+			if resourcesDestroyedCond != nil && resourcesDestroyedCond.Message != "" {
+				message = fmt.Sprintf("%s (last status: %s)", message, resourcesDestroyedCond.Message)
+			}
+			meta.SetStatusCondition(&hcp.Status.Conditions, metav1.Condition{
+				Type:    string(hyperv1.CloudResourcesDestroyed),
+				Status:  metav1.ConditionFalse,
+				Reason:  string(hyperv1.CloudResourcesDeletionTimedOutReason),
+				Message: message,
+			})
+			if err := r.Status().Update(ctx, hcp); err != nil {
+				return false, fmt.Errorf("failed to update cloud resources destroyed condition: %w", err)
+			}
 			return true, nil
 		}
 		return false, nil

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/drainer/drainer.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/drainer/drainer.go
@@ -43,7 +43,6 @@ type Reconciler struct {
 
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling")
 
 	node := &corev1.Node{}
 	err := r.guestClusterClient.Get(ctx, req.NamespacedName, node)

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps.go
@@ -47,8 +47,6 @@ type Reconciler struct {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req crreconcile.Request) (crreconcile.Result, error) {
-	log := ctrl.LoggerFrom(ctx)
-	log.Info("reconciling global pull secret")
 
 	// Reconcile GlobalPullSecret
 	if err := r.reconcileGlobalPullSecret(ctx); err != nil {
@@ -77,7 +75,6 @@ func (r *Reconciler) reconcileGlobalPullSecret(ctx context.Context) error {
 		ok                          bool
 	)
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("reconciling global pull secret")
 
 	// Create ServiceAccount for global-pull-secret-syncer
 	serviceAccount := manifests.GlobalPullSecretServiceAccount()
@@ -180,8 +177,6 @@ func (r *Reconciler) reconcileGlobalPullSecret(ctx context.Context) error {
 }
 
 func reconcileDaemonSet(ctx context.Context, daemonSet *appsv1.DaemonSet, globalPullSecretName string, originalPullSecretName string, configSeed string, c crclient.Client, createOrUpdate upsert.CreateOrUpdateFN, hccoImage string) error {
-	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling global pull secret daemon set")
 
 	if _, err := createOrUpdate(ctx, c, daemonSet, func() error {
 		daemonSet.Spec = appsv1.DaemonSetSpec{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/hcpstatus/hcpstatus.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/hcpstatus/hcpstatus.go
@@ -99,7 +99,6 @@ func findClusterOperatorStatusCondition(conditions []configv1.ClusterOperatorSta
 
 func (h *hcpStatusReconciler) reconcile(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling hosted cluster version conditions")
 
 	var clusterVersion configv1.ClusterVersion
 	err := h.hostedClusterClient.Get(ctx, crclient.ObjectKey{Name: "version"}, &clusterVersion)

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/inplaceupgrader/inplaceupgrader.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/inplaceupgrader/inplaceupgrader.go
@@ -71,7 +71,6 @@ type Reconciler struct {
 
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling")
 
 	// Fetch the MachineSet.
 	machineSet := &capiv1.MachineSet{}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/machine/machine.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/machine/machine.go
@@ -32,7 +32,6 @@ const (
 
 func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling")
 
 	hcp := &hyperv1.HostedControlPlane{}
 	if err := r.client.Get(ctx, r.hcpKey, hcp); err != nil {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/node/node.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/node/node.go
@@ -36,7 +36,6 @@ type reconciler struct {
 
 func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling")
 
 	node := &corev1.Node{}
 	if err := r.guestClusterClient.Get(ctx, req.NamespacedName, node); err != nil {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/nodecount/controller.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/nodecount/controller.go
@@ -27,7 +27,6 @@ type reconciler struct {
 
 func (r *reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling")
 
 	var hcp hypershiftv1beta1.HostedControlPlane
 	if err := r.lister.Get(ctx, client.ObjectKey{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas/admissionpolicies.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas/admissionpolicies.go
@@ -20,7 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -61,9 +60,6 @@ var (
 // ReconcileKASValidatingAdmissionPolicies will create ValidatingAdmissionPolicies which block certain resources
 // from being updated/deleted from the DataPlane side.
 func ReconcileKASValidatingAdmissionPolicies(ctx context.Context, hcp *hyperv1.HostedControlPlane, client client.Client, createOrUpdate upsert.CreateOrUpdateFN) error {
-	log := ctrl.LoggerFrom(ctx)
-	log.Info("reconciling validating admission policies")
-
 	if err := reconcileConfigValidatingAdmissionPolicy(ctx, hcp, client, createOrUpdate); err != nil {
 		return fmt.Errorf("failed to reconcile Config Validating Admission Policy: %v", err)
 	}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/admissionpolicies.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/admissionpolicies.go
@@ -38,9 +38,6 @@ var (
 )
 
 func ReconcileRegistryConfigValidatingAdmissionPolicies(ctx context.Context, hcp *hyperv1.HostedControlPlane, client client.Client, createOrUpdate upsert.CreateOrUpdateFN) error {
-	log := ctrl.LoggerFrom(ctx)
-	log.Info("reconciling image registry config validating admission policies")
-
 	if err := reconcileRegistryConfigManagementStateValidatingAdmissionPolicy(ctx, hcp, client, createOrUpdate); err != nil {
 		return fmt.Errorf("failed to reconcile ManagementState Validating Admission Policy: %v", err)
 	}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -318,7 +318,6 @@ func Setup(ctx context.Context, opts *operator.HostedClusterConfigOperatorConfig
 
 func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling")
 
 	hcp := manifests.HostedControlPlane(r.hcpNamespace, r.hcpName)
 	if err := r.cpClient.Get(ctx, client.ObjectKeyFromObject(hcp), hcp); err != nil {

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -37716,6 +37716,12 @@ When this is false for too long and there&rsquo;s no clear indication in the &ld
 <td><p>HostedClusterDegraded indicates whether the HostedCluster is encountering
 an error that may require user intervention to resolve.</p>
 </td>
+</tr><tr><td><p>&#34;HostedClusterDeleting&#34;</p></td>
+<td><p>HostedClusterDeleting indicates whether the HostedCluster is being deleted and
+provides first-class visibility into which phase of deletion the cluster is in.
+<strong>False / AsExpected</strong> means the cluster is not being deleted.
+<strong>True</strong> means deletion is in progress; the Reason and Message indicate the current phase.</p>
+</td>
 </tr><tr><td><p>&#34;HostedClusterDestroyed&#34;</p></td>
 <td><p>HostedClusterDestroyed indicates that a hosted has finished destroying and that it is waiting for a destroy grace period to go away.
 The grace period is determined by the hypershift.openshift.io/destroy-grace-period annotation in the HostedCluster if present.</p>

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -5888,6 +5888,12 @@ When this is false for too long and there&rsquo;s no clear indication in the &ld
 <td><p>HostedClusterDegraded indicates whether the HostedCluster is encountering
 an error that may require user intervention to resolve.</p>
 </td>
+</tr><tr><td><p>&#34;HostedClusterDeleting&#34;</p></td>
+<td><p>HostedClusterDeleting indicates whether the HostedCluster is being deleted and
+provides first-class visibility into which phase of deletion the cluster is in.
+<strong>False / AsExpected</strong> means the cluster is not being deleted.
+<strong>True</strong> means deletion is in progress; the Reason and Message indicate the current phase.</p>
+</td>
 </tr><tr><td><p>&#34;HostedClusterDestroyed&#34;</p></td>
 <td><p>HostedClusterDestroyed indicates that a hosted has finished destroying and that it is waiting for a destroy grace period to go away.
 The grace period is determined by the hypershift.openshift.io/destroy-grace-period annotation in the HostedCluster if present.</p>

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -338,7 +338,6 @@ func pauseHostedControlPlane(ctx context.Context, c client.Client, hcp *hyperv1.
 
 func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("reconciling")
 
 	// Look up the HostedCluster instance to reconcile
 	hcluster := &hyperv1.HostedCluster{}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -490,6 +490,20 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
+	// Ensure HostedClusterDeleting condition always exists.
+	if meta.FindStatusCondition(hcluster.Status.Conditions, string(hyperv1.HostedClusterDeleting)) == nil {
+		meta.SetStatusCondition(&hcluster.Status.Conditions, metav1.Condition{
+			Type:               string(hyperv1.HostedClusterDeleting),
+			Status:             metav1.ConditionFalse,
+			Reason:             hyperv1.AsExpectedReason,
+			Message:            "HostedCluster is not being deleted",
+			ObservedGeneration: hcluster.Generation,
+		})
+		if err := r.Client.Status().Update(ctx, hcluster); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to initialize HostedClusterDeleting condition: %w", err)
+		}
+	}
+
 	// If deleted, clean up and return early.
 	if !hcluster.DeletionTimestamp.IsZero() {
 		// This new condition is necessary for OCM personnel to report any cloud dangling objects to the user.
@@ -3337,6 +3351,22 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 	controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hc.Namespace, hc.Name)
 	log := ctrl.LoggerFrom(ctx)
 
+	setDeletionProgress := func(reason, message string) error {
+		condition := metav1.Condition{
+			Type:               string(hyperv1.HostedClusterDeleting),
+			Status:             metav1.ConditionTrue,
+			Reason:             reason,
+			Message:            message,
+			ObservedGeneration: hc.Generation,
+		}
+		old := meta.FindStatusCondition(hc.Status.Conditions, string(hyperv1.HostedClusterDeleting))
+		if old != nil && old.Reason == condition.Reason && old.Message == condition.Message {
+			return nil
+		}
+		meta.SetStatusCondition(&hc.Status.Conditions, condition)
+		return r.Client.Status().Update(ctx, hc)
+	}
+
 	// Unpause CAPI cluster to allow deletion to proceed
 	if err := pauseCAPICluster(ctx, r.Client, hc, false); err != nil {
 		return false, err
@@ -3393,6 +3423,10 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 
 		if exists {
 			log.Info("Waiting for cluster deletion", "clusterName", hc.Spec.InfraID, "controlPlaneNamespace", controlPlaneNamespace)
+			if err := setDeletionProgress(hyperv1.DeletionWaitingForCAPIClusterDeletionReason,
+				fmt.Sprintf("Waiting for CAPI cluster %s/%s to be deleted", controlPlaneNamespace, hc.Spec.InfraID)); err != nil {
+				return false, fmt.Errorf("failed to update deletion progress: %w", err)
+			}
 			return false, nil
 		} else {
 			// once infra is deleted remove finalizers.
@@ -3432,6 +3466,10 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 		}
 		if exists {
 			log.Info("Waiting for awsendpointservice deletion", "controlPlaneNamespace", controlPlaneNamespace)
+			if err := setDeletionProgress(hyperv1.DeletionWaitingForEndpointServiceDeletionReason,
+				fmt.Sprintf("Waiting for AWS endpoint services in %s to be deleted", controlPlaneNamespace)); err != nil {
+				return false, fmt.Errorf("failed to update deletion progress: %w", err)
+			}
 			return false, nil
 		}
 	}
@@ -3443,6 +3481,10 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 		}
 		if exists {
 			log.Info("Waiting for gcpprivateserviceconnect deletion", "controlPlaneNamespace", controlPlaneNamespace)
+			if err := setDeletionProgress(hyperv1.DeletionWaitingForPrivateConnectDeletionReason,
+				fmt.Sprintf("Waiting for GCP Private Service Connect resources in %s to be deleted", controlPlaneNamespace)); err != nil {
+				return false, fmt.Errorf("failed to update deletion progress: %w", err)
+			}
 			return false, nil
 		}
 	}
@@ -3474,6 +3516,10 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 	}
 	if exists {
 		log.Info("Waiting for hostedcontrolplane deletion", "controlPlaneNamespace", controlPlaneNamespace)
+		if err := setDeletionProgress(hyperv1.DeletionWaitingForControlPlaneDeletionReason,
+			fmt.Sprintf("Waiting for HostedControlPlane %s/%s to be deleted", controlPlaneNamespace, hc.Name)); err != nil {
+			return false, fmt.Errorf("failed to update deletion progress: %w", err)
+		}
 		return false, nil
 	}
 
@@ -3484,6 +3530,9 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 	r.KubevirtInfraClients.Delete(hc.Spec.InfraID)
 
 	if skipNSDeletion := hc.Annotations[hyperv1.SkipControlPlaneNamespaceDeletionAnnotation]; skipNSDeletion == "true" {
+		if err := setDeletionProgress(hyperv1.DeletionCompletedReason, "Deletion completed (namespace deletion skipped)"); err != nil {
+			return false, fmt.Errorf("failed to update deletion progress: %w", err)
+		}
 		return true, nil
 	}
 
@@ -3496,10 +3545,45 @@ func (r *HostedClusterReconciler) delete(ctx context.Context, hc *hyperv1.Hosted
 		return false, err
 	}
 	if exists {
-		log.Info("Waiting for namespace deletion", "controlPlaneNamespace", controlPlaneNamespace)
+		message := fmt.Sprintf("Waiting for namespace %s to be deleted", controlPlaneNamespace)
+
+		// Fetch the namespace to inspect its phase and conditions
+		ns := &corev1.Namespace{}
+		if getErr := r.Client.Get(ctx, types.NamespacedName{Name: controlPlaneNamespace}, ns); getErr == nil {
+			message = fmt.Sprintf("Waiting for namespace %s to be deleted (phase: %s)", controlPlaneNamespace, ns.Status.Phase)
+			var details []string
+			for _, cond := range ns.Status.Conditions {
+				switch cond.Type {
+				case corev1.NamespaceContentRemaining,
+					corev1.NamespaceFinalizersRemaining,
+					corev1.NamespaceDeletionContentFailure:
+					if cond.Status == corev1.ConditionTrue {
+						details = append(details, fmt.Sprintf("%s: %s", cond.Type, cond.Message))
+						log.Info("Namespace deletion blocked",
+							"controlPlaneNamespace", controlPlaneNamespace,
+							"conditionType", cond.Type,
+							"reason", cond.Reason,
+							"message", cond.Message,
+						)
+					}
+				}
+			}
+			if len(details) > 0 {
+				message = fmt.Sprintf("Waiting for namespace %s to be deleted (phase: %s): %s",
+					controlPlaneNamespace, ns.Status.Phase, strings.Join(details, "; "))
+			}
+		}
+
+		log.Info(message, "controlPlaneNamespace", controlPlaneNamespace)
+		if err := setDeletionProgress(hyperv1.DeletionWaitingForNamespaceDeletionReason, message); err != nil {
+			return false, fmt.Errorf("failed to update deletion progress: %w", err)
+		}
 		return false, nil
 	}
 
+	if err := setDeletionProgress(hyperv1.DeletionCompletedReason, "Deletion completed"); err != nil {
+		return false, fmt.Errorf("failed to update deletion progress: %w", err)
+	}
 	return true, nil
 }
 

--- a/hypershift-operator/controllers/hostedclustersizing/hostedclustersizing_validation_controller.go
+++ b/hypershift-operator/controllers/hostedclustersizing/hostedclustersizing_validation_controller.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	metav1applyconfigurations "k8s.io/client-go/applyconfigurations/meta/v1"
 
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -27,9 +26,6 @@ type validator struct {
 }
 
 func (r *validator) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling")
-
 	config := schedulingv1alpha1.ClusterSizingConfiguration{}
 	if err := r.lister.Get(ctx, request.NamespacedName, &config); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get cluster sizing configuration %s: %w", request.NamespacedName.String(), err)

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -180,7 +180,6 @@ func (r *NodePoolReconciler) managedResources() []client.Object {
 
 func (r *NodePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling")
 
 	// Fetch the nodePool instance
 	nodePool := &hyperv1.NodePool{}

--- a/hypershift-operator/controllers/platform/aws/controller.go
+++ b/hypershift-operator/controllers/platform/aws/controller.go
@@ -264,8 +264,6 @@ func (r *AWSEndpointServiceReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("no logger found: %w", err)
 	}
-	log.Info("reconciling")
-
 	// Fetch the AWSEndpointService
 	obj := &hyperv1.AWSEndpointService{
 		ObjectMeta: metav1.ObjectMeta{
@@ -372,7 +370,6 @@ func (r *AWSEndpointServiceReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 	}
 
-	log.Info("reconciliation complete")
 	// always requeue to catch and report out of band changes in AWS
 	// NOTICE: if the RequeueAfter interval is short enough, it could result in hitting some AWS request limits.
 	return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil

--- a/hypershift-operator/controllers/scheduler/aws/autoscaler.go
+++ b/hypershift-operator/controllers/scheduler/aws/autoscaler.go
@@ -342,8 +342,6 @@ func (r *RequestServingNodeAutoscaler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, nil
 	}
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling")
-
 	podList := &corev1.PodList{}
 	if err := r.List(ctx, podList, client.InNamespace(placeholderNamespace), client.HasLabels{PlaceholderLabel}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to list placeholder pods: %w", err)

--- a/hypershift-operator/controllers/scheduler/azure/controller.go
+++ b/hypershift-operator/controllers/scheduler/azure/controller.go
@@ -67,7 +67,6 @@ func (r *Scheduler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resul
 	}
 
 	if !hc.DeletionTimestamp.IsZero() {
-		log.Info("hostedcluster is being deleted, aborting reconcile")
 		return ctrl.Result{}, nil
 	}
 

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -252,6 +252,12 @@ const (
 	// **False / AutoNodeProgressing** means AutoNode is being enabled or disabled — the operation is in progress.
 	// **False / AutoNodeNotConfigured** means AutoNode is not configured in the spec and all Karpenter components have been removed.
 	AutoNodeEnabled ConditionType = "AutoNodeEnabled"
+
+	// HostedClusterDeleting indicates whether the HostedCluster is being deleted and
+	// provides first-class visibility into which phase of deletion the cluster is in.
+	// **False / AsExpected** means the cluster is not being deleted.
+	// **True** means deletion is in progress; the Reason and Message indicate the current phase.
+	HostedClusterDeleting ConditionType = "HostedClusterDeleting"
 )
 
 // Reasons.
@@ -336,6 +342,15 @@ const (
 	AutoNodeNotConfiguredReason    = "AutoNodeNotConfigured"
 	AutoNodeProgressingReason      = "AutoNodeProgressing"
 	AutoNodeEvaluationFailedReason = "AutoNodeEvaluationFailed"
+
+	// HostedClusterDeleting reasons.
+	DeletionWaitingForNodePoolDeletionReason        = "WaitingForNodePoolDeletion"
+	DeletionWaitingForCAPIClusterDeletionReason     = "WaitingForCAPIClusterDeletion"
+	DeletionWaitingForEndpointServiceDeletionReason = "WaitingForEndpointServiceDeletion"
+	DeletionWaitingForPrivateConnectDeletionReason  = "WaitingForPrivateConnectDeletion"
+	DeletionWaitingForControlPlaneDeletionReason    = "WaitingForControlPlaneDeletion"
+	DeletionWaitingForNamespaceDeletionReason       = "WaitingForNamespaceDeletion"
+	DeletionCompletedReason                         = "DeletionCompleted"
 )
 
 // Messages.

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -315,6 +315,8 @@ const (
 
 	CloudResourcesCleanupSkippedReason = "CloudResourcesCleanupSkipped"
 
+	CloudResourcesDeletionTimedOutReason = "CloudResourcesDeletionTimedOut"
+
 	DataPlaneConnectionNoKonnectivityAgentPodsNotFoundReason = "KonnectivityAgentPodsNotFound"
 
 	DataPlaneConnectionLogsAccessFailedReason = "LogsAccessFailed"


### PR DESCRIPTION
control-plane-operator: signal that we're giving up on deletion

When the CPO decides to give up on deleting cloud resources, it emits a
log but otherwise does not expose this behavior through conditions,
making it hard to know that this happened.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

hypershift-operator: emit deletion progress condition

Instead of putting deletion progress into logs, where it's hard to
notice and spammy, present a user-facing condition that tracks the
phases. While doing that, improve the Namespace deletion code to be more
verbose. No top-level Namespace deletion condition seems to exist, so
cherry-pick a few we know are useful to highlight. We can always add
more later.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

*: remove low-quality logs

These log messages provide no clear information and are emitted
unconditionally, leading any log period from their controllers to be
full of them.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an explicit "deleting" HostedCluster status condition and richer deletion progress updates that report each deletion phase and include namespace phase and blocker details.

* **Bug Fixes**
  * Cloud resource deletion timeouts are surfaced as a distinct status to stop indefinite retries and reflect timeout state.

* **Chores**
  * Removed redundant informational log messages to reduce control-plane log noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->