### PR TITLE
CNTRLPLANE-3372: Add AI SBOM enforcement to PR workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,6 +31,7 @@ Fixes
 ## AI Assistance
 <!--
 Declare AI tool usage. Use `none` if no AI tools were used.
+If you use Claude Code with the ai-helpers plugin, run /ai-sbom:generate to fill this in automatically.
 See: https://github.com/openshift-eng/ai-helpers/blob/main/plugins/ai-sbom/docs/AI_SBOM.md
 -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,3 +27,13 @@ Fixes
 - [ ] Relevant issues have been referenced.
 - [ ] This change includes docs. 
 - [ ] This change includes unit tests.
+
+## AI Assistance
+<!--
+Declare AI tool usage. Use `none` if no AI tools were used.
+See: https://github.com/openshift-eng/ai-helpers/blob/main/plugins/ai-sbom/docs/AI_SBOM.md
+-->
+
+```ai-assisted
+none
+```

--- a/.github/workflows/ai-sbom-reusable.yaml
+++ b/.github/workflows/ai-sbom-reusable.yaml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
       - run: hack/verify-ai-sbom.sh
         env:

--- a/.github/workflows/ai-sbom-reusable.yaml
+++ b/.github/workflows/ai-sbom-reusable.yaml
@@ -1,0 +1,20 @@
+name: AI SBOM (Reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  ai-sbom:
+    name: AI SBOM
+    runs-on: arc-runner-set
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - run: hack/verify-ai-sbom.sh
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}

--- a/.github/workflows/ai-sbom.yaml
+++ b/.github/workflows/ai-sbom.yaml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
       - run: hack/verify-ai-sbom.sh
         env:

--- a/.github/workflows/ai-sbom.yaml
+++ b/.github/workflows/ai-sbom.yaml
@@ -6,8 +6,20 @@ on:
       - main
       - release-4.22
 
+permissions:
+  contents: read
+
+# TODO: switch to reusable workflow before merging:
+#   uses: openshift/hypershift/.github/workflows/ai-sbom-reusable.yaml@main
 jobs:
   ai-sbom:
-    uses: openshift/hypershift/.github/workflows/ai-sbom-reusable.yaml@agentic-sbom
-    permissions:
-      contents: read
+    name: AI SBOM
+    runs-on: arc-runner-set
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - run: hack/verify-ai-sbom.sh
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}

--- a/.github/workflows/ai-sbom.yaml
+++ b/.github/workflows/ai-sbom.yaml
@@ -6,21 +6,8 @@ on:
       - main
       - release-4.22
 
-permissions:
-  contents: read
-
-# TODO: switch to reusable workflow before merging:
-#   uses: openshift/hypershift/.github/workflows/ai-sbom-reusable.yaml@main
 jobs:
   ai-sbom:
-    name: AI SBOM
-    runs-on: arc-runner-set
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-          persist-credentials: false
-      - run: hack/verify-ai-sbom.sh
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
+    uses: openshift/hypershift/.github/workflows/ai-sbom-reusable.yaml@main
+    permissions:
+      contents: read

--- a/.github/workflows/ai-sbom.yaml
+++ b/.github/workflows/ai-sbom.yaml
@@ -1,0 +1,13 @@
+name: AI SBOM
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release-4.22
+
+jobs:
+  ai-sbom:
+    uses: openshift/hypershift/.github/workflows/ai-sbom-reusable.yaml@main
+    permissions:
+      contents: read

--- a/.github/workflows/ai-sbom.yaml
+++ b/.github/workflows/ai-sbom.yaml
@@ -2,6 +2,11 @@ name: AI SBOM
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
     branches:
       - main
       - release-4.22

--- a/.github/workflows/ai-sbom.yaml
+++ b/.github/workflows/ai-sbom.yaml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   ai-sbom:
-    uses: openshift/hypershift/.github/workflows/ai-sbom-reusable.yaml@main
+    uses: openshift/hypershift/.github/workflows/ai-sbom-reusable.yaml@agentic-sbom
     permissions:
       contents: read

--- a/hack/verify-ai-sbom.sh
+++ b/hack/verify-ai-sbom.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SPEC_URL="https://github.com/openshift-eng/ai-helpers/blob/main/plugins/ai-sbom/docs/AI_SBOM.md"
+
+if [[ -z "${PR_BODY:-}" ]]; then
+  echo "ERROR: PR_BODY environment variable is not set."
+  echo "This script must be run in CI with the PR description passed via PR_BODY."
+  exit 1
+fi
+
+if ! echo "$PR_BODY" | grep -q '```ai-assisted'; then
+  echo "ERROR: PR description is missing the AI Assistance declaration."
+  echo ""
+  echo "Every PR must include an ai-assisted block in the description."
+  echo "Add one of the following to your PR body:"
+  echo ""
+  echo "  For AI-assisted PRs:"
+  echo ""
+  echo '    ## AI Assistance'
+  echo ""
+  echo '    ```ai-assisted'
+  echo '    Tool: <tool-name> <tool-version>'
+  echo '    Model: <model-id>'
+  echo ''
+  echo '    Skills used:'
+  echo '    - <skill>@<version> (<source-repo>@<commit-sha>) — <description>'
+  echo '    ```'
+  echo ""
+  echo "  For non-AI PRs:"
+  echo ""
+  echo '    ## AI Assistance'
+  echo ""
+  echo '    ```ai-assisted'
+  echo '    none'
+  echo '    ```'
+  echo ""
+  echo "See: ${SPEC_URL}"
+  exit 1
+fi
+
+block=$(echo "$PR_BODY" | sed -n '/```ai-assisted/,/```/{/```ai-assisted/d;/```/d;p;}')
+
+trimmed=$(echo "$block" | sed '/^[[:space:]]*$/d')
+
+if [[ -z "$trimmed" ]]; then
+  echo "ERROR: ai-assisted block is empty."
+  echo "It must contain either 'none' or the required fields (Tool, Model, Skills used)."
+  echo "See: ${SPEC_URL}"
+  exit 1
+fi
+
+if echo "$trimmed" | grep -qx 'none'; then
+  echo "OK: PR declares no AI assistance."
+  exit 0
+fi
+
+errors=()
+if ! echo "$block" | grep -q '^Tool:'; then
+  errors+=("Tool")
+fi
+if ! echo "$block" | grep -q '^Model:'; then
+  errors+=("Model")
+fi
+if ! echo "$block" | grep -q '^Skills used:'; then
+  errors+=("Skills used")
+fi
+
+if [[ ${#errors[@]} -gt 0 ]]; then
+  echo "ERROR: ai-assisted block is missing required fields: ${errors[*]}"
+  echo "See: ${SPEC_URL}"
+  exit 1
+fi
+
+echo "OK: AI Assistance declaration is valid."


### PR DESCRIPTION
## What this PR does / why we need it:

Adds a CI check that validates PR descriptions contain an `ai-assisted` code fence block declaring AI tool usage. This provides transparency into which AI tools and skills contributed to code changes.

Every PR must include an AI Assistance section with either:
- A full SBOM block (`Tool`, `Model`, `Skills used`) for AI-assisted PRs
- `none` for non-AI PRs

The format spec lives in [openshift-eng/ai-helpers](https://github.com/openshift-eng/ai-helpers/blob/main/plugins/ai-sbom/docs/AI_SBOM.md). The `ai-sbom` plugin includes a generator skill that can produce the block automatically from Claude Code sessions.

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/CNTRLPLANE-3372

## Special notes for your reviewer:

- The validation script (`hack/verify-ai-sbom.sh`) reads the PR body via `$PR_BODY` env var
- Follows the existing reusable workflow pattern (`ai-sbom.yaml` calls `ai-sbom-reusable.yaml`)
- PR template defaults to `none` so existing workflows aren't disrupted
- The format spec and generator tooling are in [openshift-eng/ai-helpers#441](https://github.com/openshift-eng/ai-helpers/pull/441)

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

## AI Assistance

```ai-assisted
Tool: Claude Code 2.1.128
Model: claude-opus-4-6

Skills used:
- superpowers:brainstorming@5.0.7 (anthropics/claude-plugins-official@a01a135f) — Collaborative design and spec creation
- example-skills:skill-creator@b0cbd3df1533 (anthropics/skills@b0cbd3df1533) — Guided skill creation process
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the pull request template to include a unit-test checkbox and an AI assistance disclosure section.
  * Added CI checks that validate PR AI-disclosure entries, ensuring a declared AI-assisted block is present and contains required fields (or explicitly states "none").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->