### PR TITLE
CNTRLPLANE-3381: CPO: Surface cloud resource deletion timeout as a status condition

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -315,6 +315,8 @@ const (
 
 	CloudResourcesCleanupSkippedReason = "CloudResourcesCleanupSkipped"
 
+	CloudResourcesDeletionTimedOutReason = "CloudResourcesDeletionTimedOut"
+
 	DataPlaneConnectionNoKonnectivityAgentPodsNotFoundReason = "KonnectivityAgentPodsNotFound"
 
 	DataPlaneConnectionLogsAccessFailedReason = "LogsAccessFailed"

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2423,7 +2423,9 @@ func (r *HostedControlPlaneReconciler) removeCloudResources(ctx context.Context,
 	if resourcesDestroyedCond != nil && resourcesDestroyedCond.Status == metav1.ConditionFalse &&
 		(resourcesDestroyedCond.Reason == string(hyperv1.CloudResourcesCleanupSkippedReason) ||
 			resourcesDestroyedCond.Reason == string(hyperv1.CloudResourcesDeletionTimedOutReason)) {
-		log.Info("Cleanup has been skipped", "reason", resourcesDestroyedCond.Message)
+		log.Info("Cloud resource cleanup reached terminal state",
+			"reason", resourcesDestroyedCond.Reason,
+			"message", resourcesDestroyedCond.Message)
 		return true, nil
 	}
 

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2419,9 +2419,10 @@ func (r *HostedControlPlaneReconciler) removeCloudResources(ctx context.Context,
 		return true, nil
 	}
 
-	// check if cleanup has been skipped
+	// check if cleanup has been skipped or timed out
 	if resourcesDestroyedCond != nil && resourcesDestroyedCond.Status == metav1.ConditionFalse &&
-		resourcesDestroyedCond.Reason == string(hyperv1.CloudResourcesCleanupSkippedReason) {
+		(resourcesDestroyedCond.Reason == string(hyperv1.CloudResourcesCleanupSkippedReason) ||
+			resourcesDestroyedCond.Reason == string(hyperv1.CloudResourcesDeletionTimedOutReason)) {
 		log.Info("Cleanup has been skipped", "reason", resourcesDestroyedCond.Message)
 		return true, nil
 	}
@@ -2441,6 +2442,19 @@ func (r *HostedControlPlaneReconciler) removeCloudResources(ctx context.Context,
 
 		if timeElapsed > resourceDeletionTimeout {
 			log.Info("Giving up on resource deletion after timeout", "timeElapsed", duration.ShortHumanDuration(timeElapsed))
+			message := fmt.Sprintf("Giving up on cloud resource deletion after %s", duration.ShortHumanDuration(timeElapsed))
+			if resourcesDestroyedCond != nil && resourcesDestroyedCond.Message != "" {
+				message = fmt.Sprintf("%s (last status: %s)", message, resourcesDestroyedCond.Message)
+			}
+			meta.SetStatusCondition(&hcp.Status.Conditions, metav1.Condition{
+				Type:    string(hyperv1.CloudResourcesDestroyed),
+				Status:  metav1.ConditionFalse,
+				Reason:  string(hyperv1.CloudResourcesDeletionTimedOutReason),
+				Message: message,
+			})
+			if err := r.Status().Update(ctx, hcp); err != nil {
+				return false, fmt.Errorf("failed to update cloud resources destroyed condition: %w", err)
+			}
 			return true, nil
 		}
 		return false, nil

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -2831,6 +2831,12 @@ func TestRemoveCloudResources(t *testing.T) {
 				Client: c,
 			}
 
+			var originalCloudResourcesCond *metav1.Condition
+			if cond := meta.FindStatusCondition(tc.hcp.Status.Conditions, string(hyperv1.CloudResourcesDestroyed)); cond != nil {
+				copied := *cond
+				originalCloudResourcesCond = &copied
+			}
+
 			ctx := ctrl.LoggerInto(t.Context(), zapr.NewLogger(zaptest.NewLogger(t)))
 			done, err := r.removeCloudResources(ctx, tc.hcp)
 
@@ -2850,11 +2856,19 @@ func TestRemoveCloudResources(t *testing.T) {
 				g.Expect(condition.Reason).To(Equal(tc.expectedCondition.Reason))
 				g.Expect(condition.Message).To(ContainSubstring("Giving up on cloud resource deletion"))
 
-				prevCond := meta.FindStatusCondition(tc.hcp.Status.Conditions, string(hyperv1.CloudResourcesDestroyed))
-				if prevCond != nil && prevCond.Message != "" && prevCond.Reason != string(hyperv1.CloudResourcesDeletionTimedOutReason) {
+				if originalCloudResourcesCond != nil &&
+					originalCloudResourcesCond.Message != "" &&
+					originalCloudResourcesCond.Reason != string(hyperv1.CloudResourcesDeletionTimedOutReason) {
 					g.Expect(condition.Message).To(ContainSubstring("last status:"))
-					g.Expect(condition.Message).To(ContainSubstring(prevCond.Message))
+					g.Expect(condition.Message).To(ContainSubstring(originalCloudResourcesCond.Message))
 				}
+			}
+
+			if tc.cvoDeployment != nil {
+				updatedCVO := &appsv1.Deployment{}
+				g.Expect(c.Get(ctx, client.ObjectKeyFromObject(tc.cvoDeployment), updatedCVO)).To(Succeed())
+				g.Expect(updatedCVO.Spec.Replicas).ToNot(BeNil())
+				g.Expect(*updatedCVO.Spec.Replicas).To(Equal(int32(0)))
 			}
 		})
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -2638,3 +2638,224 @@ func TestEtcdStatefulSetCondition(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoveCloudResources(t *testing.T) {
+	t.Parallel()
+	testNamespace := "test-namespace"
+
+	testCases := []struct {
+		name              string
+		hcp               *hyperv1.HostedControlPlane
+		cvoDeployment     *appsv1.Deployment
+		expectedDone      bool
+		expectedError     bool
+		expectedCondition *metav1.Condition
+	}{
+		{
+			name: "When CloudResourcesDestroyed is True, it should return done",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: testNamespace,
+				},
+				Status: hyperv1.HostedControlPlaneStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(hyperv1.CloudResourcesDestroyed),
+							Status: metav1.ConditionTrue,
+							Reason: hyperv1.AsExpectedReason,
+						},
+					},
+				},
+			},
+			expectedDone: true,
+		},
+		{
+			name: "When CloudResourcesDestroyed reason is CloudResourcesCleanupSkipped, it should return done",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: testNamespace,
+				},
+				Status: hyperv1.HostedControlPlaneStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    string(hyperv1.CloudResourcesDestroyed),
+							Status:  metav1.ConditionFalse,
+							Reason:  string(hyperv1.CloudResourcesCleanupSkippedReason),
+							Message: "Cleanup was skipped by annotation",
+						},
+					},
+				},
+			},
+			expectedDone: true,
+		},
+		{
+			name: "When CloudResourcesDestroyed reason is CloudResourcesDeletionTimedOut, it should return done",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: testNamespace,
+				},
+				Status: hyperv1.HostedControlPlaneStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    string(hyperv1.CloudResourcesDestroyed),
+							Status:  metav1.ConditionFalse,
+							Reason:  string(hyperv1.CloudResourcesDeletionTimedOutReason),
+							Message: "Giving up on cloud resource deletion after 10m",
+						},
+					},
+				},
+			},
+			expectedDone: true,
+		},
+		{
+			name: "When CVO is scaled down and deletion has timed out, it should set CloudResourcesDeletionTimedOut condition",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: testNamespace,
+				},
+				Status: hyperv1.HostedControlPlaneStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(hyperv1.CVOScaledDown),
+							Status:             metav1.ConditionTrue,
+							Reason:             "CVOScaledDown",
+							LastTransitionTime: metav1.NewTime(time.Now().Add(-15 * time.Minute)),
+						},
+					},
+				},
+			},
+			expectedDone: true,
+			expectedCondition: &metav1.Condition{
+				Type:   string(hyperv1.CloudResourcesDestroyed),
+				Status: metav1.ConditionFalse,
+				Reason: string(hyperv1.CloudResourcesDeletionTimedOutReason),
+			},
+		},
+		{
+			name: "When CVO is scaled down and deletion has timed out with existing condition, it should include last status in message",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: testNamespace,
+				},
+				Status: hyperv1.HostedControlPlaneStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(hyperv1.CVOScaledDown),
+							Status:             metav1.ConditionTrue,
+							Reason:             "CVOScaledDown",
+							LastTransitionTime: metav1.NewTime(time.Now().Add(-15 * time.Minute)),
+						},
+						{
+							Type:               string(hyperv1.CloudResourcesDestroyed),
+							Status:             metav1.ConditionFalse,
+							Reason:             "InProgress",
+							Message:            "Deleting load balancers",
+							LastTransitionTime: metav1.NewTime(time.Now().Add(-15 * time.Minute)),
+						},
+					},
+				},
+			},
+			expectedDone: true,
+			expectedCondition: &metav1.Condition{
+				Type:   string(hyperv1.CloudResourcesDestroyed),
+				Status: metav1.ConditionFalse,
+				Reason: string(hyperv1.CloudResourcesDeletionTimedOutReason),
+			},
+		},
+		{
+			name: "When CVO is scaled down and deletion has not timed out, it should return not done",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: testNamespace,
+				},
+				Status: hyperv1.HostedControlPlaneStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(hyperv1.CVOScaledDown),
+							Status:             metav1.ConditionTrue,
+							Reason:             "CVOScaledDown",
+							LastTransitionTime: metav1.NewTime(time.Now().Add(-5 * time.Minute)),
+						},
+					},
+				},
+			},
+			expectedDone: false,
+		},
+		{
+			name: "When CVO deployment exists with replicas, it should scale it down",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: testNamespace,
+				},
+			},
+			cvoDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-version-operator",
+					Namespace: testNamespace,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](1),
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas: 1,
+				},
+			},
+			expectedDone: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			objs := []client.Object{tc.hcp}
+			if tc.cvoDeployment != nil {
+				objs = append(objs, tc.cvoDeployment)
+			}
+
+			c := fake.NewClientBuilder().
+				WithScheme(api.Scheme).
+				WithObjects(objs...).
+				WithStatusSubresource(&hyperv1.HostedControlPlane{}).
+				Build()
+
+			r := &HostedControlPlaneReconciler{
+				Client: c,
+			}
+
+			ctx := ctrl.LoggerInto(t.Context(), zapr.NewLogger(zaptest.NewLogger(t)))
+			done, err := r.removeCloudResources(ctx, tc.hcp)
+
+			if tc.expectedError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+			g.Expect(done).To(Equal(tc.expectedDone))
+
+			if tc.expectedCondition != nil {
+				updatedHCP := &hyperv1.HostedControlPlane{}
+				g.Expect(c.Get(ctx, client.ObjectKeyFromObject(tc.hcp), updatedHCP)).To(Succeed())
+				condition := meta.FindStatusCondition(updatedHCP.Status.Conditions, tc.expectedCondition.Type)
+				g.Expect(condition).ToNot(BeNil())
+				g.Expect(condition.Status).To(Equal(tc.expectedCondition.Status))
+				g.Expect(condition.Reason).To(Equal(tc.expectedCondition.Reason))
+				g.Expect(condition.Message).To(ContainSubstring("Giving up on cloud resource deletion"))
+
+				prevCond := meta.FindStatusCondition(tc.hcp.Status.Conditions, string(hyperv1.CloudResourcesDestroyed))
+				if prevCond != nil && prevCond.Message != "" && prevCond.Reason != string(hyperv1.CloudResourcesDeletionTimedOutReason) {
+					g.Expect(condition.Message).To(ContainSubstring("last status:"))
+					g.Expect(condition.Message).To(ContainSubstring(prevCond.Message))
+				}
+			}
+		})
+	}
+}

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -315,6 +315,8 @@ const (
 
 	CloudResourcesCleanupSkippedReason = "CloudResourcesCleanupSkipped"
 
+	CloudResourcesDeletionTimedOutReason = "CloudResourcesDeletionTimedOut"
+
 	DataPlaneConnectionNoKonnectivityAgentPodsNotFoundReason = "KonnectivityAgentPodsNotFound"
 
 	DataPlaneConnectionLogsAccessFailedReason = "LogsAccessFailed"


### PR DESCRIPTION
## Summary

- Add `CloudResourcesDeletionTimedOutReason` constant to the API
- Set `CloudResourcesDestroyed` condition to `False` with reason `CloudResourcesDeletionTimedOut` when the CPO deletion timeout is exceeded, including elapsed time and last known status in the message
- Handle the new reason in the cleanup-skipped check so the CPO does not re-enter cleanup after a timeout

## Context

When the CPO gives up on deleting cloud resources after a timeout, it only emits a log message. This behavior is not exposed through any status condition, making it invisible to users and to the hypershift-operator unless someone is actively tailing CPO logs. This change surfaces the timeout as a first-class condition for automated monitoring and OCM integration.

Identified during a debugging session investigating cluster deletion issues in the managed Azure service (ARO HCP).

## Jira

https://issues.redhat.com/browse/CNTRLPLANE-3381

## Test plan

- [ ] Verify `CloudResourcesDestroyed` condition is set to `False` with reason `CloudResourcesDeletionTimedOut` when deletion times out
- [ ] Verify condition message includes timeout duration and last known status
- [ ] Verify subsequent reconciles treat the timed-out state the same as cleanup-skipped
- [ ] `make test` passes
- [ ] `make build` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Treats cloud resource deletion timeouts as a completed/skipped cleanup case, records a clear timeout status message (including prior status when available), and ensures related controllers are scaled down during cleanup.
* **Tests**
  * Added unit tests covering timeout handling, skipped/done status transitions, scaling behavior, and status message composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->