### PR TITLE
CNTRLPLANE-3384: Remove unconditional low-quality log messages from controllers

### DIFF
--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
@@ -129,8 +129,6 @@ func (r *PrivateServiceObserver) SetupWithManager(ctx context.Context, mgr ctrl.
 }
 
 func (r *PrivateServiceObserver) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.log.Info("reconciling")
-
 	// Fetch the Service
 	svc, err := r.clientset.CoreV1().Services(req.Namespace).Get(ctx, req.Name, metav1.GetOptions{})
 	if err != nil {
@@ -181,7 +179,6 @@ func (r *PrivateServiceObserver) Reconcile(ctx context.Context, req ctrl.Request
 	}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile AWSEndpointService: %w", err)
 	}
-	r.log.Info("reconcile complete", "request", req)
 	return ctrl.Result{}, nil
 }
 
@@ -412,8 +409,6 @@ func (r *AWSEndpointServiceReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, fmt.Errorf("logger not found: %w", err)
 	}
 
-	log.Info("reconciling")
-
 	// Fetch the AWSEndpointService
 	obj := &hyperv1.AWSEndpointService{
 		ObjectMeta: metav1.ObjectMeta{
@@ -548,7 +543,6 @@ func (r *AWSEndpointServiceReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 	}
 
-	log.Info("reconciliation complete")
 	// always requeue to catch and report out of band changes in AWS
 	// NOTICE: if the RequeueAfter interval is short enough, it could result in hitting some AWS request limits.
 	return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil

--- a/control-plane-operator/controllers/gcpprivateserviceconnect/observer.go
+++ b/control-plane-operator/controllers/gcpprivateserviceconnect/observer.go
@@ -64,8 +64,6 @@ func (r *GCPPrivateServiceObserver) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, nil
 	}
 
-	r.log.Info("reconciling")
-
 	// Fetch the Service
 	svc := &corev1.Service{}
 	if err := r.Get(ctx, req.NamespacedName, svc); err != nil {
@@ -114,7 +112,6 @@ func (r *GCPPrivateServiceObserver) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile GCPPrivateServiceConnect: %w", err)
 	}
 
-	r.log.Info("reconcile complete", "request", req, "loadBalancerIP", loadBalancerIP)
 	return ctrl.Result{}, nil
 }
 

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/drainer/drainer.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/drainer/drainer.go
@@ -43,7 +43,6 @@ type Reconciler struct {
 
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling")
 
 	node := &corev1.Node{}
 	err := r.guestClusterClient.Get(ctx, req.NamespacedName, node)

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/globalps/globalps.go
@@ -47,9 +47,6 @@ type Reconciler struct {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req crreconcile.Request) (crreconcile.Result, error) {
-	log := ctrl.LoggerFrom(ctx)
-	log.Info("reconciling global pull secret")
-
 	// Reconcile GlobalPullSecret
 	if err := r.reconcileGlobalPullSecret(ctx); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile global pull secret: %w", err)
@@ -77,7 +74,6 @@ func (r *Reconciler) reconcileGlobalPullSecret(ctx context.Context) error {
 		ok                          bool
 	)
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("reconciling global pull secret")
 
 	// Create ServiceAccount for global-pull-secret-syncer
 	serviceAccount := manifests.GlobalPullSecretServiceAccount()
@@ -180,9 +176,6 @@ func (r *Reconciler) reconcileGlobalPullSecret(ctx context.Context) error {
 }
 
 func reconcileDaemonSet(ctx context.Context, daemonSet *appsv1.DaemonSet, globalPullSecretName string, originalPullSecretName string, configSeed string, c crclient.Client, createOrUpdate upsert.CreateOrUpdateFN, hccoImage string) error {
-	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling global pull secret daemon set")
-
 	if _, err := createOrUpdate(ctx, c, daemonSet, func() error {
 		daemonSet.Spec = appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/hcpstatus/hcpstatus.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/hcpstatus/hcpstatus.go
@@ -99,7 +99,6 @@ func findClusterOperatorStatusCondition(conditions []configv1.ClusterOperatorSta
 
 func (h *hcpStatusReconciler) reconcile(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling hosted cluster version conditions")
 
 	var clusterVersion configv1.ClusterVersion
 	err := h.hostedClusterClient.Get(ctx, crclient.ObjectKey{Name: "version"}, &clusterVersion)

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/inplaceupgrader/inplaceupgrader.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/inplaceupgrader/inplaceupgrader.go
@@ -71,7 +71,6 @@ type Reconciler struct {
 
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling")
 
 	// Fetch the MachineSet.
 	machineSet := &capiv1.MachineSet{}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/machine/machine.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/machine/machine.go
@@ -32,7 +32,6 @@ const (
 
 func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling")
 
 	hcp := &hyperv1.HostedControlPlane{}
 	if err := r.client.Get(ctx, r.hcpKey, hcp); err != nil {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/node/node.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/node/node.go
@@ -36,7 +36,6 @@ type reconciler struct {
 
 func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling")
 
 	node := &corev1.Node{}
 	if err := r.guestClusterClient.Get(ctx, req.NamespacedName, node); err != nil {

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/nodecount/controller.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/nodecount/controller.go
@@ -27,7 +27,6 @@ type reconciler struct {
 
 func (r *reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling")
 
 	var hcp hypershiftv1beta1.HostedControlPlane
 	if err := r.lister.Get(ctx, client.ObjectKey{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas/admissionpolicies.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas/admissionpolicies.go
@@ -20,7 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -61,9 +60,6 @@ var (
 // ReconcileKASValidatingAdmissionPolicies will create ValidatingAdmissionPolicies which block certain resources
 // from being updated/deleted from the DataPlane side.
 func ReconcileKASValidatingAdmissionPolicies(ctx context.Context, hcp *hyperv1.HostedControlPlane, client client.Client, createOrUpdate upsert.CreateOrUpdateFN) error {
-	log := ctrl.LoggerFrom(ctx)
-	log.Info("reconciling validating admission policies")
-
 	if err := reconcileConfigValidatingAdmissionPolicy(ctx, hcp, client, createOrUpdate); err != nil {
 		return fmt.Errorf("failed to reconcile Config Validating Admission Policy: %v", err)
 	}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/admissionpolicies.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/registry/admissionpolicies.go
@@ -38,9 +38,6 @@ var (
 )
 
 func ReconcileRegistryConfigValidatingAdmissionPolicies(ctx context.Context, hcp *hyperv1.HostedControlPlane, client client.Client, createOrUpdate upsert.CreateOrUpdateFN) error {
-	log := ctrl.LoggerFrom(ctx)
-	log.Info("reconciling image registry config validating admission policies")
-
 	if err := reconcileRegistryConfigManagementStateValidatingAdmissionPolicy(ctx, hcp, client, createOrUpdate); err != nil {
 		return fmt.Errorf("failed to reconcile ManagementState Validating Admission Policy: %v", err)
 	}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -319,7 +319,6 @@ func Setup(ctx context.Context, opts *operator.HostedClusterConfigOperatorConfig
 
 func (r *reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling")
 
 	hcp := manifests.HostedControlPlane(r.hcpNamespace, r.hcpName)
 	if err := r.cpClient.Get(ctx, client.ObjectKeyFromObject(hcp), hcp); err != nil {

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -339,7 +339,6 @@ func pauseHostedControlPlane(ctx context.Context, c client.Client, hcp *hyperv1.
 
 func (r *HostedClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("reconciling")
 
 	// Look up the HostedCluster instance to reconcile
 	hcluster := &hyperv1.HostedCluster{}

--- a/hypershift-operator/controllers/hostedclustersizing/hostedclustersizing_validation_controller.go
+++ b/hypershift-operator/controllers/hostedclustersizing/hostedclustersizing_validation_controller.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	metav1applyconfigurations "k8s.io/client-go/applyconfigurations/meta/v1"
 
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -27,9 +26,6 @@ type validator struct {
 }
 
 func (r *validator) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling")
-
 	config := schedulingv1alpha1.ClusterSizingConfiguration{}
 	if err := r.lister.Get(ctx, request.NamespacedName, &config); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get cluster sizing configuration %s: %w", request.NamespacedName.String(), err)

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -181,7 +181,6 @@ func (r *NodePoolReconciler) managedResources() []client.Object {
 
 func (r *NodePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling")
 
 	// Fetch the nodePool instance
 	nodePool := &hyperv1.NodePool{}

--- a/hypershift-operator/controllers/platform/aws/controller.go
+++ b/hypershift-operator/controllers/platform/aws/controller.go
@@ -265,8 +265,6 @@ func (r *AWSEndpointServiceReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("no logger found: %w", err)
 	}
-	log.Info("reconciling")
-
 	// Fetch the AWSEndpointService
 	obj := &hyperv1.AWSEndpointService{
 		ObjectMeta: metav1.ObjectMeta{
@@ -373,7 +371,6 @@ func (r *AWSEndpointServiceReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 	}
 
-	log.Info("reconciliation complete")
 	// always requeue to catch and report out of band changes in AWS
 	// NOTICE: if the RequeueAfter interval is short enough, it could result in hitting some AWS request limits.
 	return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil

--- a/hypershift-operator/controllers/scheduler/aws/autoscaler.go
+++ b/hypershift-operator/controllers/scheduler/aws/autoscaler.go
@@ -342,8 +342,6 @@ func (r *RequestServingNodeAutoscaler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, nil
 	}
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling")
-
 	podList := &corev1.PodList{}
 	if err := r.List(ctx, podList, client.InNamespace(placeholderNamespace), client.HasLabels{PlaceholderLabel}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to list placeholder pods: %w", err)

--- a/hypershift-operator/controllers/scheduler/azure/controller.go
+++ b/hypershift-operator/controllers/scheduler/azure/controller.go
@@ -67,7 +67,6 @@ func (r *Scheduler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resul
 	}
 
 	if !hc.DeletionTimestamp.IsZero() {
-		log.Info("hostedcluster is being deleted, aborting reconcile")
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
## Summary

- Remove unconditional `log.Info("Reconciling")`, `log.Info("reconciliation complete")`, and equivalent messages from 18 controllers across the CPO and HO
- Clean up unused variables and imports resulting from the removal

## Context

These log messages provide no actionable information and are emitted on every reconcile invocation, including frequent re-queues. controller-runtime already provides reconcile lifecycle tracing at debug verbosity. In management clusters running many HostedClusters (e.g., ARO HCP), this produces significant log noise that obscures meaningful events during incident investigation.

Identified during a debugging session investigating cluster deletion issues in the managed Azure service (ARO HCP).

## Jira

https://issues.redhat.com/browse/CNTRLPLANE-3384

## Test plan

- [ ] Verify no meaningful or conditional log messages were removed
- [ ] Verify unused variables and imports are cleaned up
- [ ] `make test` passes
- [ ] `make build` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced verbose informational logging across multiple controllers and providers to declutter logs and make operational output more concise without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->