### PR TITLE
NO-JIRA: fix(ci): use PR base SHA for api-lint diff in GHA

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,3 +23,5 @@ jobs:
             touch hack/tools/bin/golangci-lint hack/tools/bin/kube-api-linter.so
           fi
       - run: make lint
+        env:
+          PULL_BASE_SHA: ${{ github.event.pull_request.base.sha }}


### PR DESCRIPTION
## Summary

- Set `PULL_BASE_SHA` to `github.event.pull_request.base.sha` in the lint GHA workflow, matching the pattern already used by `gitlint.yaml`
- Without this, the Makefile defaults `PULL_BASE_SHA` to `origin/main`, causing `api-lint` to diff release-4.22 PRs against main instead of the target branch
- This broke all release-4.22 lint runs after PR #8166 (merged Apr 30) changed AutoNode/Karpenter fields on main — every lint run since then has failed:
  - PR #8388: 2 runs, both failed
  - PR #8408: 3 runs, all failed

## Root cause

The `api-lint` target runs `--new-from-rev=${PULL_BASE_SHA}`. The Makefile defaults:
```makefile
UPSTREAM_REMOTE ?= $(shell git remote -v | grep 'openshift/hypershift.*fetch' | head -1 | cut -f1)
PULL_BASE_SHA ?= $(if $(UPSTREAM_REMOTE),$(UPSTREAM_REMOTE)/main,main)
```

In GHA, `UPSTREAM_REMOTE` resolves to `origin`, so `PULL_BASE_SHA` becomes `origin/main`. For release-4.22 PRs, the diff sees divergent lines as "new" and flags them.

## Test plan

- [ ] This PR's own lint check should pass (it targets release-4.22, so api-lint will diff against the release-4.22 base SHA instead of origin/main)
- [ ] Verify PRs targeting main still work (github.event.pull_request.base.sha resolves to main's HEAD for those PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)