### PR TITLE
ACM-33601: use the latest ubi9 nginx image

### DIFF
--- a/Containerfile.cli
+++ b/Containerfile.cli
@@ -19,7 +19,7 @@ RUN make product-cli-release && \
     # Remove raw binaries, keep only tar.gz files \
     find ./bin -type f ! -name "*.tar.gz" -delete
 
-FROM registry.redhat.io/ubi9/nginx-124:1-1767745334
+FROM registry.redhat.io/ubi9/nginx-124:latest
 
 COPY --from=builder /hypershift/bin/ /opt/app-root/src/
 


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

It is recommended to use the latest instead of `registry.redhat.io/ubi9/nginx-124:1-1767745334` so that the build always stays current with security fixes.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container base image to the latest version to ensure current dependencies and improvements are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->