### PR TITLE
OCPBUGS-81312: fix(cpo): use KubeAPIServerDNSName for OAuth LoginURL when set

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config.go
@@ -3,6 +3,9 @@ package oauth
 import (
 	"encoding/json"
 	"fmt"
+	"net"
+	"net/url"
+	"strconv"
 	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -68,11 +71,23 @@ func adaptOAuthConfig(cpContext component.WorkloadContext, cfg *osinv1.OsinServe
 	cfg.ServingInfo.MinTLSVersion = config.MinTLSVersion(configuration.GetTLSSecurityProfile())
 	cfg.ServingInfo.CipherSuites = config.CipherSuites(configuration.GetTLSSecurityProfile())
 
-	masterUrl := fmt.Sprintf("https://%s:%d", cpContext.InfraStatus.OAuthHost, cpContext.InfraStatus.OAuthPort)
+	masterUrl := (&url.URL{
+		Scheme: "https",
+		Host:   net.JoinHostPort(cpContext.InfraStatus.OAuthHost, strconv.Itoa(int(cpContext.InfraStatus.OAuthPort))),
+	}).String()
 	controlPlaneEndpoint := cpContext.HCP.Status.ControlPlaneEndpoint
 	cfg.OAuthConfig.MasterURL = masterUrl
 	cfg.OAuthConfig.MasterPublicURL = masterUrl
-	cfg.OAuthConfig.LoginURL = fmt.Sprintf("https://%s:%d", controlPlaneEndpoint.Host, controlPlaneEndpoint.Port)
+
+	loginHost := controlPlaneEndpoint.Host
+	if customDNS := cpContext.HCP.Spec.KubeAPIServerDNSName; len(customDNS) > 0 {
+		loginHost = customDNS
+	}
+	cfg.OAuthConfig.LoginURL = (&url.URL{
+		Scheme: "https",
+		Host:   net.JoinHostPort(loginHost, strconv.Itoa(int(controlPlaneEndpoint.Port))),
+	}).String()
+
 	// loginURLOverride can be used to specify an override for the oauth config login url. The need for this arises
 	// when the login a provider uses doesn't conform to the standard login url in hypershift. The only supported use case
 	// for this is IBMCloud Red Hat Openshift

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/config_test.go
@@ -1,0 +1,125 @@
+package oauth
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/infra"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+
+	osinv1 "github.com/openshift/api/osin/v1"
+)
+
+func TestAdaptOAuthConfig(t *testing.T) {
+	testCases := []struct {
+		name              string
+		oauthHost         string
+		oauthPort         int32
+		cpEndpointHost    string
+		cpEndpointPort    int32
+		kasDNSName        string
+		loginURLOverride  string
+		expectedLoginURL  string
+		expectedMasterURL string
+	}{
+		{
+			name:              "When no custom DNS is set, it should use the control plane endpoint for LoginURL",
+			oauthHost:         "oauth.example.com",
+			oauthPort:         443,
+			cpEndpointHost:    "api.example.com",
+			cpEndpointPort:    6443,
+			expectedLoginURL:  "https://api.example.com:6443",
+			expectedMasterURL: "https://oauth.example.com:443",
+		},
+		{
+			name:              "When KubeAPIServerDNSName is set, it should use the custom DNS name for LoginURL",
+			oauthHost:         "oauth.example.com",
+			oauthPort:         443,
+			cpEndpointHost:    "10.0.0.1",
+			cpEndpointPort:    6443,
+			kasDNSName:        "api.custom.example.com",
+			expectedLoginURL:  "https://api.custom.example.com:6443",
+			expectedMasterURL: "https://oauth.example.com:443",
+		},
+		{
+			name:              "When control plane endpoint is an IP and no custom DNS is set, it should use the IP for LoginURL",
+			oauthHost:         "10.0.0.2",
+			oauthPort:         443,
+			cpEndpointHost:    "10.0.0.1",
+			cpEndpointPort:    6443,
+			expectedLoginURL:  "https://10.0.0.1:6443",
+			expectedMasterURL: "https://10.0.0.2:443",
+		},
+		{
+			name:              "When login URL override annotation is set, it should take precedence over KubeAPIServerDNSName",
+			oauthHost:         "oauth.example.com",
+			oauthPort:         443,
+			cpEndpointHost:    "10.0.0.1",
+			cpEndpointPort:    6443,
+			kasDNSName:        "api.custom.example.com",
+			loginURLOverride:  "https://ibm.override.example.com:6443",
+			expectedLoginURL:  "https://ibm.override.example.com:6443",
+			expectedMasterURL: "https://oauth.example.com:443",
+		},
+		{
+			name:              "When control plane endpoint is an IPv6 address, it should bracket it in the LoginURL",
+			oauthHost:         "oauth.example.com",
+			oauthPort:         443,
+			cpEndpointHost:    "2001:db8::1",
+			cpEndpointPort:    6443,
+			expectedLoginURL:  "https://[2001:db8::1]:6443",
+			expectedMasterURL: "https://oauth.example.com:443",
+		},
+		{
+			name:              "When OAuth host is an IPv6 address, it should bracket it in the MasterURL",
+			oauthHost:         "2001:db8::2",
+			oauthPort:         443,
+			cpEndpointHost:    "api.example.com",
+			cpEndpointPort:    6443,
+			expectedLoginURL:  "https://api.example.com:6443",
+			expectedMasterURL: "https://[2001:db8::2]:443",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			hcp := &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					KubeAPIServerDNSName: tc.kasDNSName,
+				},
+				Status: hyperv1.HostedControlPlaneStatus{
+					ControlPlaneEndpoint: hyperv1.APIEndpoint{
+						Host: tc.cpEndpointHost,
+						Port: tc.cpEndpointPort,
+					},
+				},
+			}
+			if tc.loginURLOverride != "" {
+				hcp.Annotations = map[string]string{
+					hyperv1.OauthLoginURLOverrideAnnotation: tc.loginURLOverride,
+				}
+			}
+
+			cpContext := component.WorkloadContext{
+				HCP: hcp,
+				InfraStatus: infra.InfrastructureStatus{
+					OAuthHost: tc.oauthHost,
+					OAuthPort: tc.oauthPort,
+				},
+			}
+
+			cfg := &osinv1.OsinServerConfig{}
+			cfg.OAuthConfig = osinv1.OAuthConfig{}
+
+			adaptOAuthConfig(cpContext, cfg)
+
+			g.Expect(cfg.OAuthConfig.LoginURL).To(Equal(tc.expectedLoginURL))
+			g.Expect(cfg.OAuthConfig.MasterURL).To(Equal(tc.expectedMasterURL))
+			g.Expect(cfg.OAuthConfig.MasterPublicURL).To(Equal(tc.expectedMasterURL))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- When `spec.kubeAPIServerDNSName` is set, the OAuth token display page now shows the custom FQDN in `oc login --server=` instead of the LoadBalancer IP address
- The IBMCloud login URL override annotation retains highest priority
- Adds unit tests for `adaptOAuthConfig` covering all LoginURL derivation paths

Fixes: https://issues.redhat.com/browse/OCPBUGS-81312

## Details

The OAuth server config's `LoginURL` determines the `--server=` value shown on the token display page (the "Copy login command" page in the console). Previously, `LoginURL` always used `ControlPlaneEndpoint.Host`, which is derived from the infrastructure LoadBalancer status and resolves to an IP when the LB ingress only has an IP address (common with MetalLB and on-premises environments).

When a user configures `spec.kubeAPIServerDNSName` to set a custom FQDN for accessing the API server, this FQDN was correctly used for the custom kubeconfig but was not reflected in the OAuth token display page. Users would see `oc login --server=https://10.x.x.x:6443` instead of `oc login --server=https://api.custom.example.com:6443`.

This change makes `adaptOAuthConfig` prefer `KubeAPIServerDNSName` for the `LoginURL` host when set, while preserving the existing IBMCloud login URL override annotation (`oauth.hypershift.openshift.io/login-url-override`) as the highest-priority override.

## Test plan
- [x] Unit tests pass (`go test ./control-plane-operator/controllers/hostedcontrolplane/v2/oauth/... -v`)
- [ ] Verify on a HCP cluster with `KubeAPIServerDNSName` set that the token display page shows the FQDN
- [ ] Verify behaviour is unchanged when `KubeAPIServerDNSName` is not set
- [ ] Verify IBMCloud login URL override annotation still takes precedence


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth login URL generation now uses the control-plane host and port, respects a customized control‑plane DNS name and explicit login‑URL overrides, and correctly handles IPv4 and IPv6 formats.

* **Tests**
  * Added comprehensive tests validating OAuth URL generation across DNS overrides, annotation precedence, IP endpoints, and IPv6 formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->