### PR TITLE
OCPBUGS-85084: fix(ci): rewrite dependabot commit messages to pass gitlint

### DIFF
--- a/.github/workflows/dependabot-commit-fix-reusable.yaml
+++ b/.github/workflows/dependabot-commit-fix-reusable.yaml
@@ -1,0 +1,73 @@
+name: Fix Dependabot Commit Messages (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      head_sha:
+        description: "The commit SHA to check out and amend"
+        required: true
+        type: string
+      head_branch:
+        description: "The branch to push the amended commit to"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  fix-commit-message:
+    name: Fix dependabot commit body
+    runs-on: arc-runner-set
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.head_sha }}
+          fetch-depth: 2
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Rewrite commit body
+        env:
+          HEAD_BRANCH: ${{ inputs.head_branch }}
+        run: |
+          SUBJECT=$(git log -1 --format='%s')
+          BODY=$(git log -1 --format='%b')
+
+          # Extract "Updates `lib` from X to Y" lines (sed -nE avoids grep exit-code 1 under set -eo pipefail)
+          UPDATES=$(printf '%s\n' "$BODY" | \
+            sed -nE 's/^Updates `([^`]+)` from (.+) to (.+)$/\1|\2|\3/p')
+
+          SIGNOFF=$(printf '%s\n' "$BODY" | grep '^Signed-off-by:' | head -1 || true)
+          BODY_NO_SIGNOFF=$(printf '%s\n' "$BODY" | sed '/^Signed-off-by:/d')
+
+          if [ -z "$UPDATES" ]; then
+            echo "No Updates lines found, falling back to fold wrapping"
+            WRAPPED=$(printf '%s\n' "$BODY_NO_SIGNOFF" | fold -s -w 140 | sed 's/[[:space:]]*$//')
+            if [ "$BODY_NO_SIGNOFF" = "$WRAPPED" ]; then
+              echo "Body already compliant, nothing to fix."
+              exit 0
+            fi
+            NEW_BODY="$WRAPPED"
+          else
+            NEW_BODY=""
+            while IFS='|' read -r lib source target; do
+              short=$(basename "$lib")
+              NEW_BODY+="- ${short}: ${source} => ${target}"$'\n'
+            done <<< "$UPDATES"
+          fi
+
+          {
+            echo "$SUBJECT"
+            echo ""
+            echo "$NEW_BODY"
+            if [ -n "$SIGNOFF" ]; then
+              echo "$SIGNOFF"
+            fi
+          } > /tmp/commit-msg.txt
+
+          git config user.name "dependabot[bot]"
+          git config user.email "49699333+dependabot[bot]@users.noreply.github.com"
+          git commit --amend -F /tmp/commit-msg.txt
+          git push --force-with-lease origin HEAD:"${HEAD_BRANCH}"

--- a/.github/workflows/dependabot-commit-fix.yaml
+++ b/.github/workflows/dependabot-commit-fix.yaml
@@ -1,0 +1,21 @@
+name: Fix Dependabot Commit Messages
+
+on:
+  workflow_run:
+    workflows: ["Gitlint"]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  fix-commit-message:
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]'
+    uses: openshift/hypershift/.github/workflows/dependabot-commit-fix-reusable.yaml@main
+    with:
+      head_sha: ${{ github.event.workflow_run.head_sha }}
+      head_branch: ${{ github.event.workflow_run.head_branch }}
+    permissions:
+      contents: write
+      actions: read


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that triggers via `workflow_run` after the Gitlint check fails for dependabot PRs
- Parses the commit body to extract library names and version ranges, then reconstructs a clean message that passes gitlint validation
- Fixes the systemic issue where all dependabot PRs fail CI due to auto-generated body lines exceeding `body-max-line-length=140`
- Follows the repo's caller + reusable `@main` workflow pattern for consistency and security

Related: [OCPBUGS-85084](https://redhat.atlassian.net/browse/OCPBUGS-85084) | [dependabot-core#2445](https://github.com/dependabot/dependabot-core/issues/2445)

### Structure

| File | Role |
|------|------|
| `dependabot-commit-fix.yaml` | Caller — triggers on `workflow_run` (Gitlint failure + dependabot actor), delegates to reusable `@main` |
| `dependabot-commit-fix-reusable.yaml` | Reusable — receives `head_sha` and `head_branch` as inputs, rewrites the commit body and pushes |

### Flow

1. Dependabot opens PR → Gitlint runs → **fails** (body lines exceed 140 chars)
2. `dependabot-commit-fix.yaml` triggers → calls reusable workflow
3. Reusable checks out the exact commit (`head_sha`), parses `Updates` lines, reconstructs clean body
4. Pushes amended commit → Gitlint re-runs → **passes**

### Example

Current dependabot commit (fails gitlint, 476 chars on one line):
```
Bumps the azure-github-dependencies group with 4 updates in the / directory: [github.com/Azure/azure-sdk-for-go/sdk/azidentity](https://github.com/Azure/azure-sdk-for-go), ...
```

After this workflow rewrites it:
```
build(deps): bump the azure-github-dependencies group

- azidentity: 1.8.2 => 1.9.0
- armstorage: 1.7.0 => 1.8.0
- azkeys: 1.3.0 => 1.4.0
- msi-dataplane: 1.1.0 => 1.2.0

Signed-off-by: dependabot[bot] <support@github.com>
```

cc @bryan-cox

## Test plan

- [x] Verify gitlint passes on reconstructed single-dep message (tested locally ✅)
- [x] Verify gitlint passes on reconstructed multi-dep message (tested locally ✅)
- [x] Verify fallback fold path passes gitlint with no duplicate Signed-off-by (tested locally ✅)
- [x] YAML validation passes on both workflow files
- [ ] Merge and wait for next dependabot PR to validate end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)