### PR TITLE
OCPBUGS-84857: bump go builder and ubi images

### DIFF
--- a/Containerfile.control-plane
+++ b/Containerfile.control-plane
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.7-1773318690 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778054913 AS builder
 ARG COMMIT_HASH
 
 WORKDIR /hypershift
@@ -8,7 +8,7 @@ COPY --chown=default . .
 RUN make control-plane-operator \
   && make control-plane-pki-operator
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1773204619
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1777857961
 COPY --from=builder /hypershift/bin/control-plane-operator /usr/bin/control-plane-operator
 COPY --from=builder /hypershift/bin/control-plane-pki-operator /usr/bin/control-plane-pki-operator
 

--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.7-1773318690 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778054913 AS builder
 ARG COMMIT_HASH
 
 WORKDIR /hypershift
@@ -11,7 +11,7 @@ RUN make hypershift \
   && make product-cli \
   && make karpenter-operator
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1773204619
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1777857961
 COPY --from=builder /hypershift/bin/hypershift \
   /hypershift/bin/hypershift-no-cgo \
   /hypershift/bin/hcp \


### PR DESCRIPTION
## What this PR does / why we need it:

Bump go builder and base UBI images to the latest available versions.

## Special notes for your reviewer:

We need to bump this on `release-4.22`, starting on main.

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated base container images for control plane and operator components to newer stable releases. These updates are infrastructure-level and are not expected to change product behavior or public APIs. No functional differences were introduced; runtime behavior and configuration remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->