### PR TITLE
NO-JIRA: docs: detail release branch e2e config steps in branch-process guide

### DIFF
--- a/docs/content/contribute/branch-process.md
+++ b/docs/content/contribute/branch-process.md
@@ -78,9 +78,15 @@ So, we need to check over the Step registry config and make sure that the hypers
 
 [Example Release Repo PR](https://github.com/openshift/release/pull/59120/files)
 
-We should also ensure that the latest release branch is using the Hypershift Operator and e2e from main.
+We should also ensure that the latest release branch is using the Hypershift Operator and e2e from main. Specifically, the release branch CI config should import `hypershift-tests` as a pre-built base image from the `hypershift` namespace rather than building it from `Dockerfile.e2e` in the release branch source. This ensures the e2e binary comes from main and keeps release branch configs consistent. The changes needed are:
 
-[Example Release Branch PR](https://github.com/openshift/release/pull/69341/files)
+1. Add `hypershift-tests` to the `base_images` section (namespace: `hypershift`, tag: `latest`)
+2. Remove the `Dockerfile.e2e` entry from the `images` section
+3. Remove `hypershift-tests` from the promotion exclusion list (since it is no longer built)
+
+[Example Release Branch PR (4.21)](https://github.com/openshift/release/pull/69341/files)
+
+[Example Release Branch PR (4.22)](https://github.com/openshift/release/pull/78912/files)
 
 ---
 

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -87,9 +87,15 @@ So, we need to check over the Step registry config and make sure that the hypers
 
 Example Release Repo PR
 
-We should also ensure that the latest release branch is using the Hypershift Operator and e2e from main.
+We should also ensure that the latest release branch is using the Hypershift Operator and e2e from main. Specifically, the release branch CI config should import `hypershift-tests` as a pre-built base image from the `hypershift` namespace rather than building it from `Dockerfile.e2e` in the release branch source. This ensures the e2e binary comes from main and keeps release branch configs consistent. The changes needed are:
 
-Example Release Branch PR
+1. Add `hypershift-tests` to the `base_images` section (namespace: `hypershift`, tag: `latest`)
+2. Remove the `Dockerfile.e2e` entry from the `images` section
+3. Remove `hypershift-tests` from the promotion exclusion list (since it is no longer built)
+
+Example Release Branch PR (4.21)
+
+Example Release Branch PR (4.22)
 
 ---
 


### PR DESCRIPTION
## Summary
- Expands the branch-process docs to explain the specific CI config changes needed when setting up a release branch to use pre-built `hypershift-tests` from main
- Lists the 3 concrete changes: adding base image, removing Dockerfile build, updating promotion exclusions
- Adds the 4.22 PR (openshift/release#78912) as an additional example alongside the existing 4.21 one

## Test plan
- [ ] Verify docs render correctly on hypershift.pages.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated branch process documentation with expanded guidance on OpenShift/Release configuration and CI alignment for release branches
  * Clarified steps for configuring latest release branch base images and updated image promotion settings
  * Added reference examples and updated release branch instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->