### PR TITLE
CNTRLPLANE-2939: Coordinate CRD lifecycle with Cluster CAPI Operator

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -46,6 +46,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/errors"
@@ -1050,21 +1051,28 @@ func ensureUnmanagedCRDs(ctx context.Context, out io.Writer, c crclient.Client, 
 // 2. status.currentRevision == status.desiredRevision
 // The generation parameter must be the metadata.generation returned by the SSA patch
 // to avoid false positives from reading a stale object.
+//
+// Uses unstructured access for status.observedRevisionGeneration because the field
+// may not be present in the vendored operatorv1alpha1.ClusterAPIStatus type.
 func waitForCAPIOperatorSync(ctx context.Context, out io.Writer, c crclient.Client, generation int64) error {
 	waitCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
 	fmt.Fprintf(out, "Waiting for Cluster CAPI Operator to sync...\n")
 	return wait.PollUntilContextCancel(waitCtx, 2*time.Second, true, func(ctx context.Context) (bool, error) {
-		clusterAPI := &operatorv1alpha1.ClusterAPI{}
-		if err := c.Get(ctx, crclient.ObjectKey{Name: "cluster"}, clusterAPI); err != nil {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(operatorv1alpha1.GroupVersion.WithKind("ClusterAPI"))
+		if err := c.Get(ctx, crclient.ObjectKey{Name: "cluster"}, obj); err != nil {
 			return false, fmt.Errorf("failed to get ClusterAPI config: %w", err)
 		}
 
-		if clusterAPI.Status.ObservedRevisionGeneration < generation {
+		observedGen, _, _ := unstructured.NestedInt64(obj.Object, "status", "observedRevisionGeneration")
+		if observedGen < generation {
 			return false, nil
 		}
-		if clusterAPI.Status.CurrentRevision == "" || clusterAPI.Status.CurrentRevision != clusterAPI.Status.DesiredRevision {
+		currentRevision, _, _ := unstructured.NestedString(obj.Object, "status", "currentRevision")
+		desiredRevision, _, _ := unstructured.NestedString(obj.Object, "status", "desiredRevision")
+		if currentRevision == "" || currentRevision != desiredRevision {
 			return false, nil
 		}
 

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -37,6 +37,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	imageapi "github.com/openshift/api/image/v1"
+	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -49,6 +50,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/discovery"
 	"k8s.io/utils/ptr"
 	"k8s.io/utils/set"
 
@@ -423,6 +425,36 @@ func InstallHyperShiftOperator(ctx context.Context, out io.Writer, opts Options)
 	crds, objects, err := hyperShiftOperatorManifests(ctx, client, opts)
 	if err != nil {
 		return err
+	}
+
+	// Validate all CRDs via dry-run before applying
+	if err := dryRunValidateCRDs(ctx, out, crds); err != nil {
+		return err
+	}
+
+	// Coordinate with Cluster CAPI Operator if the ClusterAPI API is available.
+	// This is done after dry-run so the ClusterAPI config is not mutated if CRDs
+	// cannot be applied.
+	config, err := util.GetConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get kubernetes config: %w", err)
+	}
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return fmt.Errorf("failed to create discovery client: %w", err)
+	}
+	registered, err := isClusterAPIRegistered(discoveryClient)
+	if err != nil {
+		return err
+	}
+	if registered {
+		fmt.Fprintf(out, "ClusterAPI API detected, coordinating with Cluster CAPI Operator\n")
+		if err := ensureUnmanagedCRDs(ctx, out, client, crds); err != nil {
+			return err
+		}
+		if err := waitForCAPIOperatorSync(ctx, out, client); err != nil {
+			return err
+		}
 	}
 
 	err = apply(ctx, out, crds)
@@ -925,6 +957,133 @@ func isAzurePlatformEnabled(platformsToInstall []string) bool {
 		}
 	}
 	return false
+}
+
+// groupVersionDiscoverer is a subset of discovery.ServerResourcesInterface
+// used for checking if a specific API group version has a given resource.
+type groupVersionDiscoverer interface {
+	ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error)
+}
+
+// isClusterAPIRegistered checks whether the ClusterAPI API resource (clusterapis)
+// is served on the management cluster via the discovery API. This indicates that the
+// cluster knows about the ClusterAPI config type, independent of whether a config
+// instance exists.
+func isClusterAPIRegistered(discoveryClient groupVersionDiscoverer) (bool, error) {
+	apis, err := discoveryClient.ServerResourcesForGroupVersion(operatorv1alpha1.GroupVersion.String())
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to discover API resources for %s: %w", operatorv1alpha1.GroupVersion, err)
+	}
+	if apis != nil {
+		for _, api := range apis.APIResources {
+			if api.Kind == "ClusterAPI" {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// ensureUnmanagedCRDs ensures the singleton ClusterAPI config resource exists and has
+// HyperShift's CAPI CRD names listed in unmanagedCustomResourceDefinitions. This tells
+// the Cluster CAPI Operator to skip these CRDs during its own installation.
+// Server-Side Apply is used so the API server handles create-or-update atomically and
+// merges set entries across field owners without conflicts.
+func ensureUnmanagedCRDs(ctx context.Context, out io.Writer, client crclient.Client, capiCRDs []crclient.Object) error {
+	// Collect CAPI CRD names (groups ending in .cluster.x-k8s.io)
+	capiCRDNames := set.New[string]()
+	for _, crd := range capiCRDs {
+		name := crd.GetName()
+		if strings.HasSuffix(name, ".cluster.x-k8s.io") {
+			capiCRDNames.Insert(name)
+		}
+	}
+	if capiCRDNames.Len() == 0 {
+		return nil
+	}
+
+	clusterAPI := &operatorv1alpha1.ClusterAPI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: &operatorv1alpha1.ClusterAPISpec{
+			UnmanagedCustomResourceDefinitions: capiCRDNames.SortedList(),
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := hyperapi.YamlSerializer.Encode(clusterAPI, &buf); err != nil {
+		return fmt.Errorf("failed to encode ClusterAPI config: %w", err)
+	}
+	if err := client.Patch(ctx, clusterAPI, crclient.RawPatch(types.ApplyPatchType, buf.Bytes()),
+		crclient.ForceOwnership, crclient.FieldOwner("hypershift"),
+	); err != nil {
+		return fmt.Errorf("failed to apply ClusterAPI config: %w", err)
+	}
+	fmt.Fprintf(out, "Applied ClusterAPI config with %d unmanaged CRDs\n", capiCRDNames.Len())
+	return nil
+}
+
+// waitForCAPIOperatorSync waits for the Cluster CAPI Operator to fully reconcile after
+// unmanaged CRDs are set in the ClusterAPI config. It polls until:
+// 1. status.observedRevisionGeneration >= metadata.generation
+// 2. status.currentRevision == status.desiredRevision
+func waitForCAPIOperatorSync(ctx context.Context, out io.Writer, c crclient.Client) error {
+	waitCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	fmt.Fprintf(out, "Waiting for Cluster CAPI Operator to sync...\n")
+	return wait.PollUntilContextCancel(waitCtx, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+		clusterAPI := &operatorv1alpha1.ClusterAPI{}
+		if err := c.Get(ctx, crclient.ObjectKey{Name: "cluster"}, clusterAPI); err != nil {
+			return false, fmt.Errorf("failed to get ClusterAPI config: %w", err)
+		}
+
+		if clusterAPI.Status.ObservedRevisionGeneration < clusterAPI.Generation {
+			return false, nil
+		}
+		if clusterAPI.Status.CurrentRevision == "" || clusterAPI.Status.CurrentRevision != clusterAPI.Status.DesiredRevision {
+			return false, nil
+		}
+
+		fmt.Fprintf(out, "Cluster CAPI Operator synced successfully\n")
+		return true, nil
+	})
+}
+
+// dryRunValidateCRDs validates all CRDs through the API server's admission webhooks
+// using server-side dry-run. This catches malformed CRDs, webhook rejections, and
+// schema conflicts before any CRDs are persisted.
+func dryRunValidateCRDs(ctx context.Context, out io.Writer, crds []crclient.Object) error {
+	client, err := util.GetClient()
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+	for _, crd := range crds {
+		var objectBytes bytes.Buffer
+		if err := hyperapi.YamlSerializer.Encode(crd, &objectBytes); err != nil {
+			errs = append(errs, fmt.Errorf("failed to encode CRD %s: %w", crd.GetName(), err))
+			continue
+		}
+		// Use a deep copy so the dry-run response (which includes managedFields)
+		// does not mutate the original CRD objects passed to apply().
+		crdCopy := crd.DeepCopyObject().(crclient.Object)
+		if err := client.Patch(ctx, crdCopy, crclient.RawPatch(types.ApplyPatchType, objectBytes.Bytes()),
+			crclient.ForceOwnership, crclient.FieldOwner("hypershift"), crclient.DryRunAll,
+		); err != nil {
+			errs = append(errs, fmt.Errorf("dry-run validation failed for CRD %s: %w", crd.GetName(), err))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("CRD dry-run validation failed:\n%w", errors.NewAggregate(errs))
+	}
+	fmt.Fprintf(out, "All %d CRDs passed dry-run validation\n", len(crds))
+	return nil
 }
 
 // setupMonitoring creates the Prometheus resources for monitoring

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -17,6 +17,7 @@ package install
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -449,11 +450,14 @@ func InstallHyperShiftOperator(ctx context.Context, out io.Writer, opts Options)
 	}
 	if registered {
 		fmt.Fprintf(out, "ClusterAPI API detected, coordinating with Cluster CAPI Operator\n")
-		if err := ensureUnmanagedCRDs(ctx, out, client, crds); err != nil {
+		generation, err := ensureUnmanagedCRDs(ctx, out, client, crds)
+		if err != nil {
 			return err
 		}
-		if err := waitForCAPIOperatorSync(ctx, out, client); err != nil {
-			return err
+		if generation > 0 {
+			if err := waitForCAPIOperatorSync(ctx, out, client, generation); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -992,8 +996,9 @@ func isClusterAPIRegistered(discoveryClient groupVersionDiscoverer) (bool, error
 // the Cluster CAPI Operator to skip these CRDs during its own installation.
 // Server-Side Apply is used so the API server handles create-or-update atomically and
 // merges set entries across field owners without conflicts.
-func ensureUnmanagedCRDs(ctx context.Context, out io.Writer, client crclient.Client, capiCRDs []crclient.Object) error {
-	// Collect CAPI CRD names (groups ending in .cluster.x-k8s.io)
+// Returns the metadata.generation of the applied ClusterAPI resource so the caller
+// can wait for the CAPI Operator to reconcile this specific version.
+func ensureUnmanagedCRDs(ctx context.Context, out io.Writer, c crclient.Client, capiCRDs []crclient.Object) (int64, error) {
 	capiCRDNames := set.New[string]()
 	for _, crd := range capiCRDs {
 		name := crd.GetName()
@@ -1002,7 +1007,24 @@ func ensureUnmanagedCRDs(ctx context.Context, out io.Writer, client crclient.Cli
 		}
 	}
 	if capiCRDNames.Len() == 0 {
-		return nil
+		return 0, nil
+	}
+
+	// Build the SSA patch payload as a map so only the fields we intend to own
+	// are included. ApplyConfiguration types for operator/v1alpha1 are not yet
+	// available in openshift/client-go.
+	patchData, err := json.Marshal(map[string]any{
+		"apiVersion": operatorv1alpha1.GroupVersion.String(),
+		"kind":       "ClusterAPI",
+		"metadata": map[string]any{
+			"name": "cluster",
+		},
+		"spec": map[string]any{
+			"unmanagedCustomResourceDefinitions": capiCRDNames.SortedList(),
+		},
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to marshal ClusterAPI config: %w", err)
 	}
 
 	clusterAPI := &operatorv1alpha1.ClusterAPI{
@@ -1013,25 +1035,22 @@ func ensureUnmanagedCRDs(ctx context.Context, out io.Writer, client crclient.Cli
 			UnmanagedCustomResourceDefinitions: capiCRDNames.SortedList(),
 		},
 	}
-
-	var buf bytes.Buffer
-	if err := hyperapi.YamlSerializer.Encode(clusterAPI, &buf); err != nil {
-		return fmt.Errorf("failed to encode ClusterAPI config: %w", err)
-	}
-	if err := client.Patch(ctx, clusterAPI, crclient.RawPatch(types.ApplyPatchType, buf.Bytes()),
+	if err := c.Patch(ctx, clusterAPI, crclient.RawPatch(types.ApplyPatchType, patchData),
 		crclient.ForceOwnership, crclient.FieldOwner("hypershift"),
 	); err != nil {
-		return fmt.Errorf("failed to apply ClusterAPI config: %w", err)
+		return 0, fmt.Errorf("failed to apply ClusterAPI config: %w", err)
 	}
 	fmt.Fprintf(out, "Applied ClusterAPI config with %d unmanaged CRDs\n", capiCRDNames.Len())
-	return nil
+	return clusterAPI.Generation, nil
 }
 
 // waitForCAPIOperatorSync waits for the Cluster CAPI Operator to fully reconcile after
 // unmanaged CRDs are set in the ClusterAPI config. It polls until:
-// 1. status.observedRevisionGeneration >= metadata.generation
+// 1. status.observedRevisionGeneration >= generation (from the patch response)
 // 2. status.currentRevision == status.desiredRevision
-func waitForCAPIOperatorSync(ctx context.Context, out io.Writer, c crclient.Client) error {
+// The generation parameter must be the metadata.generation returned by the SSA patch
+// to avoid false positives from reading a stale object.
+func waitForCAPIOperatorSync(ctx context.Context, out io.Writer, c crclient.Client, generation int64) error {
 	waitCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
@@ -1042,7 +1061,7 @@ func waitForCAPIOperatorSync(ctx context.Context, out io.Writer, c crclient.Clie
 			return false, fmt.Errorf("failed to get ClusterAPI config: %w", err)
 		}
 
-		if clusterAPI.Status.ObservedRevisionGeneration < clusterAPI.Generation {
+		if clusterAPI.Status.ObservedRevisionGeneration < generation {
 			return false, nil
 		}
 		if clusterAPI.Status.CurrentRevision == "" || clusterAPI.Status.CurrentRevision != clusterAPI.Status.DesiredRevision {

--- a/cmd/install/install_test.go
+++ b/cmd/install/install_test.go
@@ -739,7 +739,7 @@ func TestEnsureUnmanagedCRDs(t *testing.T) {
 			}
 			client := builder.Build()
 
-			err := ensureUnmanagedCRDs(t.Context(), io.Discard, client, tc.crds)
+			_, err := ensureUnmanagedCRDs(t.Context(), io.Discard, client, tc.crds)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			if tc.expectNoChange {
@@ -767,12 +767,13 @@ func TestEnsureUnmanagedCRDs(t *testing.T) {
 
 func TestWaitForCAPIOperatorSync(t *testing.T) {
 	tests := []struct {
-		name          string
-		config        *operatorv1alpha1.ClusterAPI
-		expectSuccess bool
+		name            string
+		config          *operatorv1alpha1.ClusterAPI
+		patchGeneration int64
+		expectSuccess   bool
 	}{
 		{
-			name: "When revision controller has observed the generation and installer has applied it should succeed",
+			name: "When revision controller has observed the patch generation and installer has applied it should succeed",
 			config: &operatorv1alpha1.ClusterAPI{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "cluster",
@@ -787,14 +788,15 @@ func TestWaitForCAPIOperatorSync(t *testing.T) {
 					},
 				},
 			},
-			expectSuccess: true,
+			patchGeneration: 2,
+			expectSuccess:   true,
 		},
 		{
-			name: "When observedRevisionGeneration is ahead of generation it should succeed",
+			name: "When observedRevisionGeneration is ahead of patch generation it should succeed",
 			config: &operatorv1alpha1.ClusterAPI{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "cluster",
-					Generation: 2,
+					Generation: 3,
 				},
 				Status: operatorv1alpha1.ClusterAPIStatus{
 					ObservedRevisionGeneration: 3,
@@ -805,10 +807,11 @@ func TestWaitForCAPIOperatorSync(t *testing.T) {
 					},
 				},
 			},
-			expectSuccess: true,
+			patchGeneration: 2,
+			expectSuccess:   true,
 		},
 		{
-			name: "When revision controller has not observed the generation it should time out",
+			name: "When revision controller has not observed the patch generation it should time out",
 			config: &operatorv1alpha1.ClusterAPI{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "cluster",
@@ -823,7 +826,27 @@ func TestWaitForCAPIOperatorSync(t *testing.T) {
 					},
 				},
 			},
-			expectSuccess: false,
+			patchGeneration: 3,
+			expectSuccess:   false,
+		},
+		{
+			name: "When reading a stale object from before the patch it should time out",
+			config: &operatorv1alpha1.ClusterAPI{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "cluster",
+					Generation: 1,
+				},
+				Status: operatorv1alpha1.ClusterAPIStatus{
+					ObservedRevisionGeneration: 1,
+					DesiredRevision:            "rev-1",
+					CurrentRevision:            "rev-1",
+					Revisions: []operatorv1alpha1.ClusterAPIInstallerRevision{
+						{Name: "rev-1", Revision: 1, ContentID: "content-1"},
+					},
+				},
+			},
+			patchGeneration: 2,
+			expectSuccess:   false,
 		},
 		{
 			name: "When currentRevision does not match desiredRevision it should time out",
@@ -842,7 +865,8 @@ func TestWaitForCAPIOperatorSync(t *testing.T) {
 					},
 				},
 			},
-			expectSuccess: false,
+			patchGeneration: 2,
+			expectSuccess:   false,
 		},
 		{
 			name: "When currentRevision is empty it should time out",
@@ -859,7 +883,8 @@ func TestWaitForCAPIOperatorSync(t *testing.T) {
 					},
 				},
 			},
-			expectSuccess: false,
+			patchGeneration: 1,
+			expectSuccess:   false,
 		},
 	}
 
@@ -875,7 +900,7 @@ func TestWaitForCAPIOperatorSync(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 			defer cancel()
 
-			err := waitForCAPIOperatorSync(ctx, io.Discard, client)
+			err := waitForCAPIOperatorSync(ctx, io.Discard, client, tc.patchGeneration)
 			if tc.expectSuccess {
 				g.Expect(err).ToNot(HaveOccurred())
 			} else {

--- a/cmd/install/install_test.go
+++ b/cmd/install/install_test.go
@@ -23,6 +23,8 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/set"
 
@@ -766,123 +768,72 @@ func TestEnsureUnmanagedCRDs(t *testing.T) {
 }
 
 func TestWaitForCAPIOperatorSync(t *testing.T) {
+	clusterAPIGVK := schema.GroupVersionKind{
+		Group:   operatorv1alpha1.GroupVersion.Group,
+		Version: operatorv1alpha1.GroupVersion.Version,
+		Kind:    "ClusterAPI",
+	}
+
+	makeConfig := func(t *testing.T, generation, observedRevisionGeneration int64, currentRevision, desiredRevision string) *unstructured.Unstructured {
+		t.Helper()
+		g := NewGomegaWithT(t)
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(clusterAPIGVK)
+		obj.SetName("cluster")
+		obj.SetGeneration(generation)
+		status := map[string]any{
+			"observedRevisionGeneration": observedRevisionGeneration,
+			"desiredRevision":            desiredRevision,
+			"revisions": []any{
+				map[string]any{"name": desiredRevision, "revision": observedRevisionGeneration, "contentID": "content"},
+			},
+		}
+		if currentRevision != "" {
+			status["currentRevision"] = currentRevision
+		}
+		g.Expect(unstructured.SetNestedField(obj.Object, status, "status")).To(Succeed())
+		return obj
+	}
+
 	tests := []struct {
 		name            string
-		config          *operatorv1alpha1.ClusterAPI
+		config          *unstructured.Unstructured
 		patchGeneration int64
 		expectSuccess   bool
 	}{
 		{
-			name: "When revision controller has observed the patch generation and installer has applied it should succeed",
-			config: &operatorv1alpha1.ClusterAPI{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "cluster",
-					Generation: 2,
-				},
-				Status: operatorv1alpha1.ClusterAPIStatus{
-					ObservedRevisionGeneration: 2,
-					DesiredRevision:            "rev-2",
-					CurrentRevision:            "rev-2",
-					Revisions: []operatorv1alpha1.ClusterAPIInstallerRevision{
-						{Name: "rev-2", Revision: 2, ContentID: "content-2"},
-					},
-				},
-			},
+			name:            "When revision controller has observed the patch generation and installer has applied it should succeed",
+			config:          makeConfig(t, 2, 2, "rev-2", "rev-2"),
 			patchGeneration: 2,
 			expectSuccess:   true,
 		},
 		{
-			name: "When observedRevisionGeneration is ahead of patch generation it should succeed",
-			config: &operatorv1alpha1.ClusterAPI{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "cluster",
-					Generation: 3,
-				},
-				Status: operatorv1alpha1.ClusterAPIStatus{
-					ObservedRevisionGeneration: 3,
-					DesiredRevision:            "rev-3",
-					CurrentRevision:            "rev-3",
-					Revisions: []operatorv1alpha1.ClusterAPIInstallerRevision{
-						{Name: "rev-3", Revision: 3, ContentID: "content-3"},
-					},
-				},
-			},
+			name:            "When observedRevisionGeneration is ahead of patch generation it should succeed",
+			config:          makeConfig(t, 3, 3, "rev-3", "rev-3"),
 			patchGeneration: 2,
 			expectSuccess:   true,
 		},
 		{
-			name: "When revision controller has not observed the patch generation it should time out",
-			config: &operatorv1alpha1.ClusterAPI{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "cluster",
-					Generation: 3,
-				},
-				Status: operatorv1alpha1.ClusterAPIStatus{
-					ObservedRevisionGeneration: 2,
-					DesiredRevision:            "rev-2",
-					CurrentRevision:            "rev-2",
-					Revisions: []operatorv1alpha1.ClusterAPIInstallerRevision{
-						{Name: "rev-2", Revision: 2, ContentID: "content-2"},
-					},
-				},
-			},
+			name:            "When revision controller has not observed the patch generation it should time out",
+			config:          makeConfig(t, 3, 2, "rev-2", "rev-2"),
 			patchGeneration: 3,
 			expectSuccess:   false,
 		},
 		{
-			name: "When reading a stale object from before the patch it should time out",
-			config: &operatorv1alpha1.ClusterAPI{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "cluster",
-					Generation: 1,
-				},
-				Status: operatorv1alpha1.ClusterAPIStatus{
-					ObservedRevisionGeneration: 1,
-					DesiredRevision:            "rev-1",
-					CurrentRevision:            "rev-1",
-					Revisions: []operatorv1alpha1.ClusterAPIInstallerRevision{
-						{Name: "rev-1", Revision: 1, ContentID: "content-1"},
-					},
-				},
-			},
+			name:            "When reading a stale object from before the patch it should time out",
+			config:          makeConfig(t, 1, 1, "rev-1", "rev-1"),
 			patchGeneration: 2,
 			expectSuccess:   false,
 		},
 		{
-			name: "When currentRevision does not match desiredRevision it should time out",
-			config: &operatorv1alpha1.ClusterAPI{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "cluster",
-					Generation: 2,
-				},
-				Status: operatorv1alpha1.ClusterAPIStatus{
-					ObservedRevisionGeneration: 2,
-					DesiredRevision:            "rev-2",
-					CurrentRevision:            "rev-1",
-					Revisions: []operatorv1alpha1.ClusterAPIInstallerRevision{
-						{Name: "rev-1", Revision: 1, ContentID: "content-1"},
-						{Name: "rev-2", Revision: 2, ContentID: "content-2"},
-					},
-				},
-			},
+			name:            "When currentRevision does not match desiredRevision it should time out",
+			config:          makeConfig(t, 2, 2, "rev-1", "rev-2"),
 			patchGeneration: 2,
 			expectSuccess:   false,
 		},
 		{
-			name: "When currentRevision is empty it should time out",
-			config: &operatorv1alpha1.ClusterAPI{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       "cluster",
-					Generation: 1,
-				},
-				Status: operatorv1alpha1.ClusterAPIStatus{
-					ObservedRevisionGeneration: 1,
-					DesiredRevision:            "rev-1",
-					Revisions: []operatorv1alpha1.ClusterAPIInstallerRevision{
-						{Name: "rev-1", Revision: 1, ContentID: "content-1"},
-					},
-				},
-			},
+			name:            "When currentRevision is empty it should time out",
+			config:          makeConfig(t, 1, 1, "", "rev-1"),
 			patchGeneration: 1,
 			expectSuccess:   false,
 		},
@@ -891,10 +842,22 @@ func TestWaitForCAPIOperatorSync(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
+			// Use an interceptor to return the unstructured object directly,
+			// bypassing the fake client's typed round-trip which would drop
+			// the observedRevisionGeneration field not present in the vendored type.
+			config := tc.config
 			client := fake.NewClientBuilder().
 				WithScheme(hyperapi.Scheme).
-				WithObjects(tc.config).
-				WithStatusSubresource(&operatorv1alpha1.ClusterAPI{}).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, c crclient.WithWatch, key crclient.ObjectKey, obj crclient.Object, opts ...crclient.GetOption) error {
+						u, ok := obj.(*unstructured.Unstructured)
+						if !ok {
+							return c.Get(ctx, key, obj, opts...)
+						}
+						u.Object = config.DeepCopy().Object
+						return nil
+					},
+				}).
 				Build()
 
 			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)

--- a/cmd/install/install_test.go
+++ b/cmd/install/install_test.go
@@ -1,22 +1,34 @@
 package install
 
 import (
+	"context"
+	"io"
 	"io/fs"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	crdassets "github.com/openshift/hypershift/cmd/install/assets/crds"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/sharedingress"
+	hyperapi "github.com/openshift/hypershift/support/api"
+
+	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/set"
 
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func TestOptions_Validate(t *testing.T) {
@@ -547,6 +559,327 @@ func TestHyperShiftOperatorManifests_SharedIngress(t *testing.T) {
 				g.Expect(hasSharedIngressNamespace).To(BeFalse(), "expected shared ingress namespace to not be present")
 				g.Expect(hasSharedIngressClusterRole).To(BeFalse(), "expected shared ingress ClusterRole to not be present")
 				g.Expect(hasSharedIngressClusterRoleBinding).To(BeFalse(), "expected shared ingress ClusterRoleBinding to not be present")
+			}
+		})
+	}
+}
+
+// fakeDiscovery implements discovery.ServerResourcesInterface for testing.
+type fakeDiscovery struct {
+	resources []*metav1.APIResourceList
+}
+
+func (f *fakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	for _, rl := range f.resources {
+		if rl.GroupVersion == groupVersion {
+			return rl, nil
+		}
+	}
+	return nil, &apierrors.StatusError{
+		ErrStatus: metav1.Status{
+			Status: metav1.StatusFailure,
+			Reason: metav1.StatusReasonNotFound,
+		},
+	}
+}
+
+func TestIsClusterAPIRegistered(t *testing.T) {
+	tests := []struct {
+		name           string
+		resources      []*metav1.APIResourceList
+		expectedResult bool
+	}{
+		{
+			name: "When ClusterAPI API is registered it should detect CCAPIO presence",
+			resources: []*metav1.APIResourceList{
+				{
+					GroupVersion: "operator.openshift.io/v1alpha1",
+					APIResources: []metav1.APIResource{
+						{Name: "imagecontentsourcepolicies", Kind: "ImageContentSourcePolicy"},
+						{Name: "clusterapis", Kind: "ClusterAPI"},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name:           "When ClusterAPI API is not registered it should skip CCAPIO coordination",
+			resources:      nil,
+			expectedResult: false,
+		},
+		{
+			name: "When operator.openshift.io/v1alpha1 exists but ClusterAPI kind is not present it should return false",
+			resources: []*metav1.APIResourceList{
+				{
+					GroupVersion: "operator.openshift.io/v1alpha1",
+					APIResources: []metav1.APIResource{
+						{Name: "imagecontentsourcepolicies", Kind: "ImageContentSourcePolicy"},
+					},
+				},
+			},
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			disco := &fakeDiscovery{resources: tc.resources}
+
+			registered, err := isClusterAPIRegistered(disco)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(registered).To(Equal(tc.expectedResult))
+		})
+	}
+}
+
+func TestEnsureUnmanagedCRDs(t *testing.T) {
+	capiCRDs := []crclient.Object{
+		&apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "clusters.cluster.x-k8s.io"}},
+		&apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "machines.cluster.x-k8s.io"}},
+		&apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "nodepools.hypershift.openshift.io"}},
+	}
+
+	// ssaInterceptor converts SSA Patch calls into Create/Update for the fake client,
+	// which does not support ApplyPatchType natively.
+	ssaInterceptor := interceptor.Funcs{
+		Patch: func(ctx context.Context, c crclient.WithWatch, obj crclient.Object, patch crclient.Patch, opts ...crclient.PatchOption) error {
+			if patch.Type() != types.ApplyPatchType {
+				return c.Patch(ctx, obj, patch, opts...)
+			}
+			existing := obj.DeepCopyObject().(crclient.Object)
+			err := c.Get(ctx, crclient.ObjectKeyFromObject(obj), existing)
+			if apierrors.IsNotFound(err) {
+				return c.Create(ctx, obj)
+			}
+			if err != nil {
+				return err
+			}
+			obj.SetResourceVersion(existing.GetResourceVersion())
+			return c.Update(ctx, obj)
+		},
+	}
+
+	tests := []struct {
+		name             string
+		existingConfig   *operatorv1alpha1.ClusterAPI
+		crds             []crclient.Object
+		expectedCRDNames []string
+		expectNoChange   bool
+	}{
+		{
+			name:           "When ClusterAPI config does not exist it should create it with unmanaged CRDs",
+			existingConfig: nil,
+			crds:           capiCRDs,
+			expectedCRDNames: []string{
+				"clusters.cluster.x-k8s.io",
+				"machines.cluster.x-k8s.io",
+			},
+		},
+		{
+			name: "When ClusterAPI config exists it should apply unmanaged CRDs",
+			existingConfig: &operatorv1alpha1.ClusterAPI{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: &operatorv1alpha1.ClusterAPISpec{
+					UnmanagedCustomResourceDefinitions: []string{
+						"clusters.cluster.x-k8s.io",
+						"machinesets.cluster.x-k8s.io",
+					},
+				},
+			},
+			crds: capiCRDs,
+			// SSA with listType=set would merge entries from different field owners on a real
+			// API server. Since the fake client cannot simulate set-based merge semantics,
+			// this test verifies that HyperShift's apply succeeds and contains its own entries.
+			expectedCRDNames: []string{
+				"clusters.cluster.x-k8s.io",
+				"machines.cluster.x-k8s.io",
+			},
+		},
+		{
+			name: "When all CRDs already listed it should apply idempotently",
+			existingConfig: &operatorv1alpha1.ClusterAPI{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: &operatorv1alpha1.ClusterAPISpec{
+					UnmanagedCustomResourceDefinitions: []string{
+						"clusters.cluster.x-k8s.io",
+						"machines.cluster.x-k8s.io",
+					},
+				},
+			},
+			crds: capiCRDs,
+			expectedCRDNames: []string{
+				"clusters.cluster.x-k8s.io",
+				"machines.cluster.x-k8s.io",
+			},
+		},
+		{
+			name:           "When populating unmanaged CRDs it should only include CAPI CRDs",
+			existingConfig: nil,
+			crds: []crclient.Object{
+				&apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "nodepools.hypershift.openshift.io"}},
+				&apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "hostedclusters.hypershift.openshift.io"}},
+			},
+			expectNoChange: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			builder := fake.NewClientBuilder().
+				WithScheme(hyperapi.Scheme).
+				WithInterceptorFuncs(ssaInterceptor)
+			if tc.existingConfig != nil {
+				builder = builder.WithObjects(tc.existingConfig)
+			}
+			client := builder.Build()
+
+			err := ensureUnmanagedCRDs(t.Context(), io.Discard, client, tc.crds)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			if tc.expectNoChange {
+				config := &operatorv1alpha1.ClusterAPI{}
+				err := client.Get(t.Context(), crclient.ObjectKey{Name: "cluster"}, config)
+				if tc.existingConfig == nil {
+					g.Expect(err).To(HaveOccurred(), "expected no ClusterAPI config to be created")
+					return
+				}
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(config.Spec).ToNot(BeNil())
+				g.Expect(config.Spec.UnmanagedCustomResourceDefinitions).
+					To(ConsistOf(tc.existingConfig.Spec.UnmanagedCustomResourceDefinitions))
+				return
+			}
+
+			config := &operatorv1alpha1.ClusterAPI{}
+			err = client.Get(t.Context(), crclient.ObjectKey{Name: "cluster"}, config)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(config.Spec).ToNot(BeNil())
+			g.Expect(config.Spec.UnmanagedCustomResourceDefinitions).To(ConsistOf(tc.expectedCRDNames))
+		})
+	}
+}
+
+func TestWaitForCAPIOperatorSync(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        *operatorv1alpha1.ClusterAPI
+		expectSuccess bool
+	}{
+		{
+			name: "When revision controller has observed the generation and installer has applied it should succeed",
+			config: &operatorv1alpha1.ClusterAPI{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "cluster",
+					Generation: 2,
+				},
+				Status: operatorv1alpha1.ClusterAPIStatus{
+					ObservedRevisionGeneration: 2,
+					DesiredRevision:            "rev-2",
+					CurrentRevision:            "rev-2",
+					Revisions: []operatorv1alpha1.ClusterAPIInstallerRevision{
+						{Name: "rev-2", Revision: 2, ContentID: "content-2"},
+					},
+				},
+			},
+			expectSuccess: true,
+		},
+		{
+			name: "When observedRevisionGeneration is ahead of generation it should succeed",
+			config: &operatorv1alpha1.ClusterAPI{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "cluster",
+					Generation: 2,
+				},
+				Status: operatorv1alpha1.ClusterAPIStatus{
+					ObservedRevisionGeneration: 3,
+					DesiredRevision:            "rev-3",
+					CurrentRevision:            "rev-3",
+					Revisions: []operatorv1alpha1.ClusterAPIInstallerRevision{
+						{Name: "rev-3", Revision: 3, ContentID: "content-3"},
+					},
+				},
+			},
+			expectSuccess: true,
+		},
+		{
+			name: "When revision controller has not observed the generation it should time out",
+			config: &operatorv1alpha1.ClusterAPI{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "cluster",
+					Generation: 3,
+				},
+				Status: operatorv1alpha1.ClusterAPIStatus{
+					ObservedRevisionGeneration: 2,
+					DesiredRevision:            "rev-2",
+					CurrentRevision:            "rev-2",
+					Revisions: []operatorv1alpha1.ClusterAPIInstallerRevision{
+						{Name: "rev-2", Revision: 2, ContentID: "content-2"},
+					},
+				},
+			},
+			expectSuccess: false,
+		},
+		{
+			name: "When currentRevision does not match desiredRevision it should time out",
+			config: &operatorv1alpha1.ClusterAPI{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "cluster",
+					Generation: 2,
+				},
+				Status: operatorv1alpha1.ClusterAPIStatus{
+					ObservedRevisionGeneration: 2,
+					DesiredRevision:            "rev-2",
+					CurrentRevision:            "rev-1",
+					Revisions: []operatorv1alpha1.ClusterAPIInstallerRevision{
+						{Name: "rev-1", Revision: 1, ContentID: "content-1"},
+						{Name: "rev-2", Revision: 2, ContentID: "content-2"},
+					},
+				},
+			},
+			expectSuccess: false,
+		},
+		{
+			name: "When currentRevision is empty it should time out",
+			config: &operatorv1alpha1.ClusterAPI{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "cluster",
+					Generation: 1,
+				},
+				Status: operatorv1alpha1.ClusterAPIStatus{
+					ObservedRevisionGeneration: 1,
+					DesiredRevision:            "rev-1",
+					Revisions: []operatorv1alpha1.ClusterAPIInstallerRevision{
+						{Name: "rev-1", Revision: 1, ContentID: "content-1"},
+					},
+				},
+			},
+			expectSuccess: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			client := fake.NewClientBuilder().
+				WithScheme(hyperapi.Scheme).
+				WithObjects(tc.config).
+				WithStatusSubresource(&operatorv1alpha1.ClusterAPI{}).
+				Build()
+
+			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+			defer cancel()
+
+			err := waitForCAPIOperatorSync(ctx, io.Discard, client)
+			if tc.expectSuccess {
+				g.Expect(err).ToNot(HaveOccurred())
+			} else {
+				g.Expect(err).To(HaveOccurred())
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Backport of #7996 to release-4.22
- Coordinates CRD lifecycle with the Cluster CAPI Operator during `hypershift install` by setting unmanaged CRDs in the ClusterAPI singleton config and waiting for the operator to reconcile
- Uses unstructured access for `status.observedRevisionGeneration` because the field is not present in the vendored `operatorv1alpha1.ClusterAPIStatus` type on release-4.22

## Changes from main
The `waitForCAPIOperatorSync` function reads the ClusterAPI object as `unstructured.Unstructured` instead of the typed struct, extracting `observedRevisionGeneration`, `currentRevision`, and `desiredRevision` via `unstructured.NestedInt64`/`NestedString`. Tests use `interceptor.Funcs` to return unstructured objects directly, bypassing the fake client's typed round-trip.

## Test plan
- [x] Unit tests pass (`go test ./cmd/install/ -v`)
- [x] Build succeeds (`go build ./cmd/install/`)
- [ ] E2E: `hypershift install` on a cluster with Cluster CAPI Operator deployed