### PR TITLE
GCP-410: fix(gcp): add registry SA WIF binding for image registry GCS access

### DIFF
--- a/cmd/infra/gcp/iam-bindings.json
+++ b/cmd/infra/gcp/iam-bindings.json
@@ -9,10 +9,9 @@
         "roles/compute.networkAdmin",
         "roles/iam.serviceAccountUser"
       ],
-      "k8sServiceAccount": {
-        "namespace": "kube-system",
-        "name": "capi-gcp-controller-manager"
-      }
+      "k8sServiceAccounts": [
+        {"namespace": "kube-system", "name": "capi-gcp-controller-manager"}
+      ]
     },
     {
       "name": "ctrlplane-op",
@@ -23,10 +22,9 @@
         "roles/compute.networkAdmin",
         "roles/compute.viewer"
       ],
-      "k8sServiceAccount": {
-        "namespace": "kube-system",
-        "name": "control-plane-operator"
-      }
+      "k8sServiceAccounts": [
+        {"namespace": "kube-system", "name": "control-plane-operator"}
+      ]
     },
     {
       "name": "cloud-controller",
@@ -37,10 +35,9 @@
         "roles/compute.securityAdmin",
         "roles/compute.viewer"
       ],
-      "k8sServiceAccount": {
-        "namespace": "kube-system",
-        "name": "cloud-controller-manager"
-      }
+      "k8sServiceAccounts": [
+        {"namespace": "kube-system", "name": "cloud-controller-manager"}
+      ]
     },
     {
       "name": "gcp-pd-csi",
@@ -52,20 +49,19 @@
         "roles/iam.serviceAccountUser",
         "roles/resourcemanager.tagUser"
       ],
-      "k8sServiceAccount": {
-        "namespace": "openshift-cluster-csi-drivers",
-        "name": "gcp-pd-csi-driver-controller-sa"
-      }
+      "k8sServiceAccounts": [
+        {"namespace": "openshift-cluster-csi-drivers", "name": "gcp-pd-csi-driver-controller-sa"}
+      ]
     },
     {
       "name": "image-registry",
       "displayName": "HyperShift Image Registry Operator",
       "description": "Service account for Image Registry Operator GCS storage operations",
       "roles": ["roles/storage.admin"],
-      "k8sServiceAccount": {
-        "namespace": "openshift-image-registry",
-        "name": "cluster-image-registry-operator"
-      }
+      "k8sServiceAccounts": [
+        {"namespace": "openshift-image-registry", "name": "cluster-image-registry-operator"},
+        {"namespace": "openshift-image-registry", "name": "registry"}
+      ]
     },
     {
       "name": "cloud-network",
@@ -75,10 +71,9 @@
         "roles/compute.instanceAdmin.v1",
         "roles/compute.networkUser"
       ],
-      "k8sServiceAccount": {
-        "namespace": "openshift-cloud-network-config-controller",
-        "name": "cloud-network-config-controller"
-      }
+      "k8sServiceAccounts": [
+        {"namespace": "openshift-cloud-network-config-controller", "name": "cloud-network-config-controller"}
+      ]
     }
   ]
 }

--- a/cmd/infra/gcp/iam.go
+++ b/cmd/infra/gcp/iam.go
@@ -53,8 +53,8 @@ type ServiceAccountDefinition struct {
 	// Roles are the GCP IAM roles to assign to this GSA
 	Roles []string `json:"roles"`
 
-	// K8sServiceAccount contains the namespace and name of the K8s SA for WIF binding
-	K8sServiceAccount *K8sServiceAccountRef `json:"k8sServiceAccount,omitempty"`
+	// K8sServiceAccounts contains the namespace and name of each K8s SA for WIF binding
+	K8sServiceAccounts []K8sServiceAccountRef `json:"k8sServiceAccounts,omitempty"`
 }
 
 // K8sServiceAccountRef identifies a Kubernetes ServiceAccount for WIF binding.
@@ -365,10 +365,10 @@ func (c *IAMManager) CreateServiceAccounts(ctx context.Context) (map[string]stri
 			}
 		}
 
-		// Create WIF binding if K8s SA is specified (with retry for IAM propagation)
-		if def.K8sServiceAccount != nil {
-			err := c.retryWithExponentialBackoff(ctx, fmt.Sprintf("createWIFBinding-%s", def.Name), func() error {
-				return c.createWorkloadIdentityBinding(ctx, email, def.K8sServiceAccount)
+		// Create WIF bindings for each K8s SA (with retry for IAM propagation)
+		for i, k8sSA := range def.K8sServiceAccounts {
+			err := c.retryWithExponentialBackoff(ctx, fmt.Sprintf("createWIFBinding-%s-%d", def.Name, i), func() error {
+				return c.createWorkloadIdentityBinding(ctx, email, &k8sSA)
 			})
 			if err != nil {
 				return nil, fmt.Errorf("failed to create WIF binding for %s: %w", def.Name, err)

--- a/cmd/infra/gcp/iam.go
+++ b/cmd/infra/gcp/iam.go
@@ -25,9 +25,9 @@ const (
 	// defaultOIDCAudience is the default audience for OIDC providers.
 	defaultOIDCAudience = "openshift"
 
-	// iamPropagationTimeout is the maximum time to wait for IAM eventual consistency.
-	// GCP IAM changes typically propagate in 5-30 seconds, we allow 60 seconds to be safe.
-	iamPropagationTimeout = 60 * time.Second
+	// iamPropagationTimeout is the maximum time to wait for IAM eventual consistency and rate limit recovery.
+	// GCP IAM changes typically propagate in 5-30 seconds; 120 seconds gives room for rate limit backoff.
+	iamPropagationTimeout = 120 * time.Second
 
 	// iamPropagationInitialBackoff is the initial backoff duration for IAM retry operations.
 	iamPropagationInitialBackoff = 2 * time.Second
@@ -348,8 +348,13 @@ func (c *IAMManager) CreateServiceAccounts(ctx context.Context) (map[string]stri
 	for _, def := range definitions {
 		c.logger.Info("Processing service account", "name", def.Name)
 
-		// Create the GSA
-		email, err := c.createServiceAccount(ctx, def)
+		// Create the GSA (with retry for rate limiting)
+		var email string
+		err = c.retryWithExponentialBackoff(ctx, fmt.Sprintf("createServiceAccount-%s", def.Name), func() error {
+			var createErr error
+			email, createErr = c.createServiceAccount(ctx, def)
+			return createErr
+		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create service account %s: %w", def.Name, err)
 		}
@@ -708,6 +713,9 @@ func isTransientIAMError(err error) bool {
 		switch apiErr.Code {
 		case 404:
 			// Not found - resource may not have propagated yet
+			return true
+		case 429:
+			// Rate limited - retry after backoff
 			return true
 		case 400:
 			// Bad request - sometimes occurs during IAM propagation

--- a/cmd/infra/gcp/iam_test.go
+++ b/cmd/infra/gcp/iam_test.go
@@ -366,6 +366,26 @@ func TestLoadServiceAccountDefinitions(t *testing.T) {
 		g.Expect(cloudNetworkDef).NotTo(BeNil(), "expected to find cloud-network service account definition")
 		g.Expect(cloudNetworkDef.Roles).NotTo(BeEmpty())
 	})
+
+	t.Run("When loading image-registry definition it should have both operator and server K8s SAs", func(t *testing.T) {
+		g := NewWithT(t)
+		definitions, err := loadServiceAccountDefinitions()
+		g.Expect(err).NotTo(HaveOccurred())
+
+		var imageRegistryDef *ServiceAccountDefinition
+		for i := range definitions {
+			if definitions[i].Name == "image-registry" {
+				imageRegistryDef = &definitions[i]
+				break
+			}
+		}
+		g.Expect(imageRegistryDef).NotTo(BeNil(), "expected to find image-registry service account definition")
+		g.Expect(imageRegistryDef.K8sServiceAccounts).To(HaveLen(2), "image-registry should have 2 K8s SA bindings")
+		g.Expect(imageRegistryDef.K8sServiceAccounts).To(ContainElements(
+			K8sServiceAccountRef{Namespace: "openshift-image-registry", Name: "cluster-image-registry-operator"},
+			K8sServiceAccountRef{Namespace: "openshift-image-registry", Name: "registry"},
+		))
+	})
 }
 
 func TestIsAlreadyExistsError(t *testing.T) {

--- a/cmd/infra/gcp/iam_test.go
+++ b/cmd/infra/gcp/iam_test.go
@@ -1,6 +1,7 @@
 package gcp
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"google.golang.org/api/cloudresourcemanager/v1"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iam/v1"
 )
 
@@ -386,6 +388,57 @@ func TestLoadServiceAccountDefinitions(t *testing.T) {
 			K8sServiceAccountRef{Namespace: "openshift-image-registry", Name: "registry"},
 		))
 	})
+}
+
+func TestIsTransientIAMError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "When error is nil it should return false",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "When error is a 429 rate limit error it should return true",
+			err:      &googleapi.Error{Code: 429, Message: "A quota has been reached"},
+			expected: true,
+		},
+		{
+			name:     "When error is a 404 not found error it should return true",
+			err:      &googleapi.Error{Code: 404, Message: "Not found"},
+			expected: true,
+		},
+		{
+			name:     "When error is a 403 permission error it should return true",
+			err:      &googleapi.Error{Code: 403, Message: "Permission denied"},
+			expected: true,
+		},
+		{
+			name:     "When error is a 403 non-permission error it should return false",
+			err:      &googleapi.Error{Code: 403, Message: "Forbidden"},
+			expected: false,
+		},
+		{
+			name:     "When error is a 500 server error it should return false",
+			err:      &googleapi.Error{Code: 500, Message: "Internal server error"},
+			expected: false,
+		},
+		{
+			name:     "When error is a non-googleapi error it should return false",
+			err:      fmt.Errorf("some other error"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(isTransientIAMError(tt.err)).To(Equal(tt.expected))
+		})
+	}
 }
 
 func TestIsAlreadyExistsError(t *testing.T) {


### PR DESCRIPTION
## Summary

- The image registry **server** pod runs as the `registry` ServiceAccount in `openshift-image-registry`, not as `cluster-image-registry-operator`. Without a WIF binding for `registry`, its projected token exchange fails with `iam.serviceAccounts.getAccessToken denied` when accessing GCS storage.
- Rename `k8sServiceAccount` (singular object) to `k8sServiceAccounts` (array) in `iam-bindings.json` and update the Go struct/loop to support multiple WIF bindings per GSA.
- Add `registry` SA to the `image-registry` entry, matching upstream `openshift/cluster-image-registry-operator`'s `CredentialsRequest` which lists both `cluster-image-registry-operator` and `registry` under `serviceAccountNames`.
- Wrap `createServiceAccount` with the existing `retryWithExponentialBackoff` helper and classify HTTP 429 responses as transient in `isTransientIAMError`, so rate limit errors during infra setup are retried rather than failing immediately. Increase `iamPropagationTimeout` to 120s to give the backoff enough room to succeed after the GCP per-minute SA creation quota resets.

## Test plan

- [x] `go build ./cmd/infra/gcp/...` passes
- [x] `go test ./cmd/infra/gcp/...` passes (new tests verify `image-registry` has 2 K8s SA entries and that 429 is treated as a transient error)
- [x] `go vet ./cmd/infra/gcp/...` passes
- [ ] Create a GCP HCP cluster and verify the image registry pod can access GCS without `getAccessToken denied` errors
- [ ] Verify `e2e-v2-gke` no longer fails intermittently with `Service accounts created per minute per project` 429 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support for multiple Kubernetes service accounts per GCP service account.

* **Improvements**
  * Increased IAM propagation timeout from 60s to 120s.
  * Enhanced handling of rate limiting in IAM operations.
  * Improved retry logic for service account creation and binding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->