### PR TITLE
NO-JIRA: Update GHA docs for reusable workflow pattern

### DIFF
--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -42,3 +42,27 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy site --project-name=hypershift --branch=pr-${{ steps.pr.outputs.number }} --commit-dirty=true
+      - name: Create PR deployment status
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          if ! [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+            echo "Invalid PR number: '${PR_NUMBER}'"
+            exit 1
+          fi
+          DEPLOY_ENV="docs-preview/pr-${PR_NUMBER}"
+          ENV_URL="https://pr-${PR_NUMBER}.hypershift.pages.dev"
+
+          DEPLOY_ID=$(echo '{"ref":"'"${HEAD_SHA}"'","environment":"'"${DEPLOY_ENV}"'","auto_merge":false,"required_contexts":[]}' \
+            | gh api "repos/${{ github.repository }}/deployments" --input - --jq '.id')
+          if ! [[ "${DEPLOY_ID}" =~ ^[0-9]+$ ]]; then
+            echo "Failed to create deployment. DEPLOY_ID='${DEPLOY_ID}'"
+            exit 1
+          fi
+
+          gh api "repos/${{ github.repository }}/deployments/${DEPLOY_ID}/statuses" \
+            -f state="success" \
+            -f environment_url="${ENV_URL}" \
+            -f description="Docs preview for PR #${PR_NUMBER}"

--- a/docs/content/how-to/ci/docs-preview.md
+++ b/docs/content/how-to/ci/docs-preview.md
@@ -1,13 +1,13 @@
 # Documentation Preview
 
-When a pull request modifies files under `docs/`, a GitHub Actions workflow automatically builds the documentation and deploys a preview to Cloudflare Pages.
+When a pull request modifies files under `docs/`, GitHub Actions workflows automatically build the documentation and deploy a preview to Cloudflare Pages.
 
 ## How It Works
 
-The workflow uses `pull_request_target` with two jobs to securely handle fork PRs:
+The preview system uses two separate workflows for security, following the reusable workflow pattern described in [GitHub Actions Workflows](github-actions.md):
 
-1. **Build** — checks out the PR code and builds the docs with MkDocs in strict mode. This job has no access to secrets.
-2. **Deploy** — downloads the built artifact and deploys it to Cloudflare Pages. This job has access to the `docs-preview` environment secrets but never executes PR code.
+1. **Docs Build** (`.github/workflows/docs-build.yaml`) — triggers on `pull_request` for changes under `docs/`. The caller delegates to `docs-build-reusable.yaml@main`, which checks out the PR code, builds with MkDocs in strict mode, and uploads the built site as an artifact. This workflow has no access to secrets.
+2. **Docs Deploy** (`.github/workflows/docs-deploy.yaml`) — triggers via `workflow_run` when the Docs Build workflow completes successfully. It downloads the built artifact and deploys to Cloudflare Pages. This workflow has access to the `docs-preview` environment secrets but never executes PR code.
 
 GitHub shows a **View deployment** link in the PR timeline via the `docs-preview` environment.
 
@@ -15,9 +15,9 @@ The preview is available at `https://pr-<number>.hypershift.pages.dev`.
 
 ## Configuration
 
-The workflow is defined in `.github/workflows/docs-preview.yaml` and runs on self-hosted ARC runners.
+The workflows run on self-hosted ARC runners.
 
-It requires two secrets configured on the `docs-preview` GitHub Environment:
+The deploy workflow requires two secrets configured on the `docs-preview` GitHub Environment:
 
 | Secret | Description |
 |--------|-------------|

--- a/docs/content/how-to/ci/github-actions.md
+++ b/docs/content/how-to/ci/github-actions.md
@@ -1,0 +1,93 @@
+# GitHub Actions Workflows
+
+HyperShift uses GitHub Actions for lightweight CI checks that run on every pull request. These workflows complement the heavier Prow-based e2e tests by providing fast feedback on code quality, formatting, and documentation.
+
+## Reusable Workflow Architecture
+
+All GHA workflows follow a **caller + reusable** pattern:
+
+- **Caller workflow** (e.g., `lint.yaml`) — defines triggers (`pull_request`, branch filters) and delegates to a reusable workflow pinned at `@main`.
+- **Reusable workflow** (e.g., `lint-reusable.yaml`) — contains the actual job steps. Triggered via `workflow_call` and optionally on `push` to `main` for post-merge runs.
+
+```mermaid
+flowchart LR
+    subgraph "Caller (lint.yaml)"
+        A["on: pull_request"] --> B["uses: ...lint-reusable.yaml@main"]
+    end
+
+    subgraph "Reusable (lint-reusable.yaml)"
+        B --> C["on: workflow_call"]
+        C --> D["Checkout + Run lint"]
+    end
+```
+
+This pattern provides:
+
+- **Consistency** — all PR and push workflows share the same job definitions.
+- **Maintainability** — job logic is defined once in the reusable workflow and updated in a single place.
+- **Security** — callers pin reusable workflows to `@main`, reducing the risk of PRs altering reusable job logic. Caller workflows are protected by branch protection rules and CODEOWNERS.
+
+## Workflows
+
+All workflows run on self-hosted ARC runners and target the `main` and `release-4.22` branches.
+
+### Code Quality
+
+| Caller | Reusable | Purpose |
+|--------|----------|---------|
+| `codespell.yaml` | `codespell-reusable.yaml` | Spell checking across the codebase |
+| `gitlint.yaml` | `gitlint-reusable.yaml` | Commit message format validation |
+| `lint.yaml` | `lint-reusable.yaml` | Go linting via `golangci-lint` |
+| `verify.yaml` | `verify-reusable.yaml` | Full verification (`make verify`) |
+
+### Testing
+
+| Caller | Reusable | Purpose |
+|--------|----------|---------|
+| `test.yaml` | `test-reusable.yaml` | Unit tests with race detection and Codecov upload |
+| `envtest-ocp.yaml` | `envtest-ocp-reusable.yaml` | CRD validation tests against OpenShift k8s versions |
+| `envtest-kube.yaml` | `envtest-kube-reusable.yaml` | CRD validation tests against vanilla k8s versions |
+
+### Documentation
+
+| Caller | Reusable | Purpose |
+|--------|----------|---------|
+| `docs-build.yaml` | `docs-build-reusable.yaml` | Build MkDocs site in strict mode |
+
+The `docs-deploy.yaml` workflow is not a reusable workflow pair — it triggers via `workflow_run` after the Docs Build completes to deploy the preview. See [Documentation Preview](docs-preview.md) for details.
+
+### Other
+
+| Caller | Reusable | Purpose |
+|--------|----------|---------|
+| `cpo-container-sync.yaml` | `cpo-container-sync-reusable.yaml` | Validate CPO container image references are in sync |
+| `dependabot-commit-fix.yaml` | `dependabot-commit-fix-reusable.yaml` | Rewrite dependabot commit messages to pass gitlint |
+
+The `sync-community-fork.yaml` workflow runs on push to `main` only (not on PRs) and does not use the reusable pattern. See [Sync Community Fork](sync-community-fork.md) for details.
+
+## Adding a New Workflow
+
+To add a new GHA workflow:
+
+1. Create the reusable workflow (e.g., `my-check-reusable.yaml`) with `on: workflow_call`.
+2. Create the caller workflow (e.g., `my-check.yaml`) that uses the reusable workflow pinned at `@main`.
+3. Add branch filters for `main` and any active release branches.
+4. Use `arc-runner-set` as the runner.
+
+Example caller:
+
+```yaml
+name: My Check
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release-4.22
+
+jobs:
+  my-check:
+    uses: openshift/hypershift/.github/workflows/my-check-reusable.yaml@main
+    permissions:
+      contents: read
+```

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -11862,14 +11862,14 @@ Understanding the CI infrastructure helps when:
 
 # Documentation Preview
 
-When a pull request modifies files under `docs/`, a GitHub Actions workflow automatically builds the documentation and deploys a preview to Cloudflare Pages.
+When a pull request modifies files under `docs/`, GitHub Actions workflows automatically build the documentation and deploy a preview to Cloudflare Pages.
 
 ## How It Works
 
-The workflow uses `pull_request_target` with two jobs to securely handle fork PRs:
+The preview system uses two separate workflows for security, following the reusable workflow pattern described in GitHub Actions Workflows:
 
-1. **Build** — checks out the PR code and builds the docs with MkDocs in strict mode. This job has no access to secrets.
-2. **Deploy** — downloads the built artifact and deploys it to Cloudflare Pages. This job has access to the `docs-preview` environment secrets but never executes PR code.
+1. **Docs Build** (`.github/workflows/docs-build.yaml`) — triggers on `pull_request` for changes under `docs/`. The caller delegates to `docs-build-reusable.yaml@main`, which checks out the PR code, builds with MkDocs in strict mode, and uploads the built site as an artifact. This workflow has no access to secrets.
+2. **Docs Deploy** (`.github/workflows/docs-deploy.yaml`) — triggers via `workflow_run` when the Docs Build workflow completes successfully. It downloads the built artifact and deploys to Cloudflare Pages. This workflow has access to the `docs-preview` environment secrets but never executes PR code.
 
 GitHub shows a **View deployment** link in the PR timeline via the `docs-preview` environment.
 
@@ -11877,9 +11877,9 @@ The preview is available at `https://pr-<number>.hypershift.pages.dev`.
 
 ## Configuration
 
-The workflow is defined in `.github/workflows/docs-preview.yaml` and runs on self-hosted ARC runners.
+The workflows run on self-hosted ARC runners.
 
-It requires two secrets configured on the `docs-preview` GitHub Environment:
+The deploy workflow requires two secrets configured on the `docs-preview` GitHub Environment:
 
 | Secret | Description |
 |--------|-------------|
@@ -11897,6 +11897,105 @@ mkdocs serve
 ```
 
 Then open http://127.0.0.1:8000.
+
+
+---
+
+## Source: docs/content/how-to/ci/github-actions.md
+
+# GitHub Actions Workflows
+
+HyperShift uses GitHub Actions for lightweight CI checks that run on every pull request. These workflows complement the heavier Prow-based e2e tests by providing fast feedback on code quality, formatting, and documentation.
+
+## Reusable Workflow Architecture
+
+All GHA workflows follow a **caller + reusable** pattern:
+
+- **Caller workflow** (e.g., `lint.yaml`) — defines triggers (`pull_request`, branch filters) and delegates to a reusable workflow pinned at `@main`.
+- **Reusable workflow** (e.g., `lint-reusable.yaml`) — contains the actual job steps. Triggered via `workflow_call` and optionally on `push` to `main` for post-merge runs.
+
+```mermaid
+flowchart LR
+    subgraph "Caller (lint.yaml)"
+        A["on: pull_request"] --> B["uses: ...lint-reusable.yaml@main"]
+    end
+
+    subgraph "Reusable (lint-reusable.yaml)"
+        B --> C["on: workflow_call"]
+        C --> D["Checkout + Run lint"]
+    end
+```
+
+This pattern provides:
+
+- **Consistency** — all PR and push workflows share the same job definitions.
+- **Maintainability** — job logic is defined once in the reusable workflow and updated in a single place.
+- **Security** — callers pin reusable workflows to `@main`, reducing the risk of PRs altering reusable job logic. Caller workflows are protected by branch protection rules and CODEOWNERS.
+
+## Workflows
+
+All workflows run on self-hosted ARC runners and target the `main` and `release-4.22` branches.
+
+### Code Quality
+
+| Caller | Reusable | Purpose |
+|--------|----------|---------|
+| `codespell.yaml` | `codespell-reusable.yaml` | Spell checking across the codebase |
+| `gitlint.yaml` | `gitlint-reusable.yaml` | Commit message format validation |
+| `lint.yaml` | `lint-reusable.yaml` | Go linting via `golangci-lint` |
+| `verify.yaml` | `verify-reusable.yaml` | Full verification (`make verify`) |
+
+### Testing
+
+| Caller | Reusable | Purpose |
+|--------|----------|---------|
+| `test.yaml` | `test-reusable.yaml` | Unit tests with race detection and Codecov upload |
+| `envtest-ocp.yaml` | `envtest-ocp-reusable.yaml` | CRD validation tests against OpenShift k8s versions |
+| `envtest-kube.yaml` | `envtest-kube-reusable.yaml` | CRD validation tests against vanilla k8s versions |
+
+### Documentation
+
+| Caller | Reusable | Purpose |
+|--------|----------|---------|
+| `docs-build.yaml` | `docs-build-reusable.yaml` | Build MkDocs site in strict mode |
+
+The `docs-deploy.yaml` workflow is not a reusable workflow pair — it triggers via `workflow_run` after the Docs Build completes to deploy the preview. See Documentation Preview for details.
+
+### Other
+
+| Caller | Reusable | Purpose |
+|--------|----------|---------|
+| `cpo-container-sync.yaml` | `cpo-container-sync-reusable.yaml` | Validate CPO container image references are in sync |
+| `dependabot-commit-fix.yaml` | `dependabot-commit-fix-reusable.yaml` | Rewrite dependabot commit messages to pass gitlint |
+
+The `sync-community-fork.yaml` workflow runs on push to `main` only (not on PRs) and does not use the reusable pattern. See Sync Community Fork for details.
+
+## Adding a New Workflow
+
+To add a new GHA workflow:
+
+1. Create the reusable workflow (e.g., `my-check-reusable.yaml`) with `on: workflow_call`.
+2. Create the caller workflow (e.g., `my-check.yaml`) that uses the reusable workflow pinned at `@main`.
+3. Add branch filters for `main` and any active release branches.
+4. Use `arc-runner-set` as the runner.
+
+Example caller:
+
+```yaml
+name: My Check
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release-4.22
+
+jobs:
+  my-check:
+    uses: openshift/hypershift/.github/workflows/my-check-reusable.yaml@main
+    permissions:
+      contents: read
+```
 
 
 ---

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -73,6 +73,8 @@ nav:
     - how-to/ci/ci-infrastructure.md
     - how-to/ci/checking-ci.md
     - 'Documentation Preview': how-to/ci/docs-preview.md
+    - 'GitHub Actions Workflows': how-to/ci/github-actions.md
+    - 'Sync Community Fork': how-to/ci/sync-community-fork.md
   - 'Common':
     - how-to/common/exposing-services-from-hcp.md
     - 'Global Pull Secret': how-to/common/global-pull-secret.md

--- a/hack/github-actions-runner/README.md
+++ b/hack/github-actions-runner/README.md
@@ -14,9 +14,11 @@ runner pods that pick up GitHub Actions jobs and terminate after completion.
 ### How It Works
 
 When a PR is opened against `openshift/hypershift`, GitHub triggers the workflow
-files defined in `.github/workflows/`. Each workflow file (e.g., `lint.yaml`,
-`codespell.yaml`) specifies `runs-on: arc-runner-set`, which tells GitHub to
-route the job to our self-hosted runners instead of GitHub-hosted runners.
+files defined in `.github/workflows/`. All workflows follow a **caller + reusable**
+pattern: each caller workflow (e.g., `lint.yaml`) delegates to a reusable workflow
+(e.g., `lint-reusable.yaml`) pinned at `@main` via `uses:`. The reusable workflow
+contains the actual job steps and specifies `runs-on: arc-runner-set`, which tells
+GitHub to route the job to our self-hosted runners instead of GitHub-hosted runners.
 
 **Note:** These runners are scoped to the `openshift/hypershift` repository
 only (via `githubConfigUrl` in the Helm values). PRs in other OpenShift repos
@@ -42,7 +44,8 @@ connection to GitHub's Actions service — essentially saying "I'm here, send me
 jobs."
 
 **Phase 2 — Job matching (on every PR):**
-When a PR triggers a workflow, GitHub reads the workflow YAML and sees
+When a PR triggers a workflow, the caller workflow delegates to the reusable
+workflow pinned at `@main`. GitHub reads the reusable workflow YAML and sees
 `runs-on: arc-runner-set`. It checks its registry of runners and finds one
 registered under that label for `openshift/hypershift`. It queues the job for
 that runner set. The Listener — already connected — receives the job
@@ -61,7 +64,7 @@ arrow — everything flows outbound from the cluster to GitHub:
 sequenceDiagram
     participant Dev as Developer
     participant GH as GitHub API<br/>(api.github.com)
-    participant WF as Workflow YAML<br/>(.github/workflows/*.yaml)
+    participant WF as Workflow YAML<br/>(.github/workflows/*-reusable.yaml)
     participant Listener as ARC Listener<br/>(arc-systems namespace)
     participant Controller as ARC Controller<br/>(arc-systems namespace)
     participant Runner as Runner Pod<br/>(arc-runners namespace)
@@ -77,7 +80,7 @@ sequenceDiagram
     rect rgb(255, 248, 240)
         Note over Dev,GH: Phase 2: Job Matching (on PR)
         Dev->>GH: Opens / updates PR
-        GH->>WF: Evaluates workflow triggers<br/>(on: pull_request)
+        GH->>WF: Evaluates caller triggers<br/>(on: pull_request)<br/>Caller delegates to reusable@main
         WF->>GH: Creates jobs with<br/>runs-on: arc-runner-set
         GH->>GH: Matches label to registered<br/>runner scale set
         GH-->>Listener: Job notification delivered<br/>over existing long-poll<br/>(no inbound connection needed)
@@ -406,18 +409,49 @@ spec:
 
 ## Using the Runners in Workflows
 
-Reference the runner label `arc-runner-set` in your GitHub Actions workflow:
+All HyperShift workflows use a caller + reusable pattern. The caller defines
+triggers and delegates to a reusable workflow pinned at `@main`. The reusable
+workflow contains the job steps and `runs-on: arc-runner-set`.
+
+**Caller workflow** (e.g., `my-check.yaml`):
 
 ```yaml
+name: My Check
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release-4.22
+
 jobs:
-  build:
+  my-check:
+    uses: openshift/hypershift/.github/workflows/my-check-reusable.yaml@main
+    permissions:
+      contents: read
+```
+
+**Reusable workflow** (e.g., `my-check-reusable.yaml`):
+
+```yaml
+name: My Check (Reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  my-check:
     runs-on: arc-runner-set
     steps:
       - uses: actions/checkout@v4
-      - run: go version
-      - run: oc version --client
-      - run: make build
+      - run: make my-check
 ```
+
+This pattern ensures PRs cannot modify the workflow code they execute under
+(the reusable workflow is resolved from `@main`, not from the PR branch).
 
 ## Verification
 


### PR DESCRIPTION
## Summary
- Update `hack/github-actions-runner/README.md` to reflect the caller + reusable workflow pattern adopted across all GHA workflows
- Add new MkDocs page documenting all GHA workflows and the reusable architecture
- Update docs-preview page to reference the current docs-build + docs-deploy split

## Test plan
- [ ] Docs Build GHA workflow triggers on this PR
- [ ] Docs Deploy Preview deploys successfully
- [ ] Preview site renders the new GitHub Actions Workflows page correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed GitHub Actions CI docs covering caller+reusable workflow patterns, workflow examples, and a new how-to page for docs previews.
  * Updated site navigation and runner README to show standardized workflow usage and runner guidance.

* **Improvements**
  * Introduced a two-step docs preview flow (build + deploy) and enhanced deployment status reporting for preview environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->