### PR TITLE
OCPBUGS-85192: Add retry logic for Azure DNS cleanup in hcp destroy

### DIFF
--- a/cmd/cluster/azure/destroy.go
+++ b/cmd/cluster/azure/destroy.go
@@ -43,6 +43,7 @@ func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.AzurePlatform.ResourceGroupName, "resource-group-name", opts.AzurePlatform.ResourceGroupName, "The name of the resource group containing the HostedCluster infrastructure resources that need to be destroyed.")
 	cmd.Flags().BoolVar(&opts.AzurePlatform.PreserveResourceGroup, "preserve-resource-group", opts.AzurePlatform.PreserveResourceGroup, "When true, the managed/main resource group will not be deleted during cluster destroy. Only cluster-specific resources within the resource group will be cleaned up.")
 	cmd.Flags().StringVar(&opts.AzurePlatform.DNSZoneRGName, "dns-zone-rg-name", opts.AzurePlatform.DNSZoneRGName, util.DNSZoneRGNameDestroyDescription)
+	cmd.Flags().DurationVar(&opts.AzurePlatform.AzureInfraGracePeriod, "azure-infra-grace-period", azureinfra.DefaultInfraGracePeriod, util.AzureInfraGracePeriodDescription)
 
 	_ = cmd.MarkFlagRequired("azure-creds")
 	_ = cmd.MarkFlagRequired("dns-zone-rg-name")
@@ -176,6 +177,7 @@ func destroyPlatformSpecifics(ctx context.Context, o *core.DestroyOptions) error
 		Cloud:                 o.AzurePlatform.Cloud,
 		ResourceGroupName:     o.AzurePlatform.ResourceGroupName,
 		PreserveResourceGroup: o.AzurePlatform.PreserveResourceGroup,
+		AzureInfraGracePeriod: o.AzurePlatform.AzureInfraGracePeriod,
 	}
 	return destroyInfraOptions.Run(ctx, o.Log)
 }

--- a/cmd/cluster/core/destroy.go
+++ b/cmd/cluster/core/destroy.go
@@ -65,6 +65,7 @@ type AzurePlatformDestroyOptions struct {
 	PreserveResourceGroup bool
 	Cloud                 string
 	DNSZoneRGName         string
+	AzureInfraGracePeriod time.Duration
 }
 
 type PowerVSPlatformDestroyOptions struct {

--- a/cmd/infra/azure/destroy.go
+++ b/cmd/infra/azure/destroy.go
@@ -2,8 +2,11 @@ package azure
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"slices"
 	"strings"
+	"time"
 
 	"github.com/openshift/hypershift/cmd/log"
 	"github.com/openshift/hypershift/cmd/util"
@@ -15,10 +18,68 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 
+	"k8s.io/apimachinery/pkg/util/wait"
+
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
+
+// nonRetriableError matches the Azure SDK's errorinfo.NonRetriable interface
+// for use with errors.As without importing the internal package.
+type nonRetriableError interface {
+	error
+	NonRetriable()
+}
+
+const (
+	DefaultInfraGracePeriod         = 5 * time.Minute
+	defaultRetryInterval            = 10 * time.Second
+	fallbackAzureResourceAPIVersion = "2021-04-01"
+)
+
+// resourceDeleter abstracts Azure resource listing and deletion for testability.
+type resourceDeleter interface {
+	ListByResourceGroup(ctx context.Context, resourceGroup string) ([]resourceToDelete, error)
+	DeleteByID(ctx context.Context, id string, apiVersion string) error
+}
+
+// azureResourceDeleter wraps *armresources.Client to implement resourceDeleter.
+type azureResourceDeleter struct {
+	client *armresources.Client
+}
+
+func (a *azureResourceDeleter) ListByResourceGroup(ctx context.Context, resourceGroup string) ([]resourceToDelete, error) {
+	pager := a.client.NewListByResourceGroupPager(resourceGroup, nil)
+	var resources []resourceToDelete
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list resources in resource group %s: %w", resourceGroup, err)
+		}
+		for _, resource := range page.Value {
+			if resource.ID == nil || resource.Name == nil || resource.Type == nil {
+				continue
+			}
+			resources = append(resources, resourceToDelete{
+				id:           *resource.ID,
+				apiVersion:   getAPIVersionForResourceType(*resource.Type),
+				name:         *resource.Name,
+				resourceType: *resource.Type,
+			})
+		}
+	}
+	return resources, nil
+}
+
+func (a *azureResourceDeleter) DeleteByID(ctx context.Context, id string, apiVersion string) error {
+	poller, err := a.client.BeginDeleteByID(ctx, id, apiVersion, nil)
+	if err != nil {
+		return err
+	}
+	_, err = poller.PollUntilDone(ctx, nil)
+	return err
+}
 
 type DestroyInfraOptions struct {
 	Name                  string
@@ -29,6 +90,9 @@ type DestroyInfraOptions struct {
 	ResourceGroupName     string
 	PreserveResourceGroup bool
 	Cloud                 string
+	AzureInfraGracePeriod time.Duration
+
+	retryInterval time.Duration // test-only: overrides defaultRetryInterval for faster test execution
 }
 
 func NewDestroyCommand() *cobra.Command {
@@ -50,6 +114,7 @@ func NewDestroyCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.Name, "name", opts.Name, "A name for the cluster")
 	cmd.Flags().StringVar(&opts.ResourceGroupName, "resource-group-name", opts.ResourceGroupName, "The name of the resource group containing the HostedCluster infrastructure resources that need to be destroyed.")
 	cmd.Flags().BoolVar(&opts.PreserveResourceGroup, "preserve-resource-group", opts.PreserveResourceGroup, "When true, the managed/main resource group will not be deleted during cluster destroy. Only cluster-specific resources within the resource group will be cleaned up.")
+	cmd.Flags().DurationVar(&opts.AzureInfraGracePeriod, "azure-infra-grace-period", DefaultInfraGracePeriod, util.AzureInfraGracePeriodDescription)
 
 	_ = cmd.MarkFlagRequired("infra-id")
 	_ = cmd.MarkFlagRequired("azure-creds")
@@ -57,6 +122,9 @@ func NewDestroyCommand() *cobra.Command {
 
 	logger := log.Log
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := opts.Validate(); err != nil {
+			return err
+		}
 		if err := opts.Run(cmd.Context(), logger); err != nil {
 			logger.Error(err, "Failed to destroy infrastructure")
 			return err
@@ -92,6 +160,7 @@ func BindDestroyProductFlags(opts *DestroyInfraOptions, flags *pflag.FlagSet) {
 	// Resource group
 	flags.StringVar(&opts.ResourceGroupName, "resource-group-name", opts.ResourceGroupName, util.ResourceGroupNameDescription)
 	flags.BoolVar(&opts.PreserveResourceGroup, "preserve-resource-group", opts.PreserveResourceGroup, util.PreserveResourceGroupDescription)
+	flags.DurationVar(&opts.AzureInfraGracePeriod, "azure-infra-grace-period", DefaultInfraGracePeriod, util.AzureInfraGracePeriodDescription)
 }
 
 // Validate validates the DestroyInfraOptions before running the destroy operation.
@@ -104,6 +173,9 @@ func (o *DestroyInfraOptions) Validate() error {
 	}
 	if o.CredentialsFile == "" && o.Credentials == nil {
 		return fmt.Errorf("azure-creds is required")
+	}
+	if o.AzureInfraGracePeriod < 0 {
+		return fmt.Errorf("azure-infra-grace-period must be >= 0")
 	}
 	return nil
 }
@@ -140,12 +212,14 @@ func (o *DestroyInfraOptions) Run(ctx context.Context, logger logr.Logger) error
 		return fmt.Errorf("failed to create new resources client: %w", err)
 	}
 
-	mainResourceGroup := o.GetResourceGroupName()
+	mainResourceGroup := o.getResourceGroupName()
+
+	deleter := &azureResourceDeleter{client: resourcesClient}
 
 	// Handle main resource group based on preserve flag
 	if o.PreserveResourceGroup {
 		logger.Info("Preserving main resource group, deleting only cluster-specific resources", "resource-group", mainResourceGroup)
-		if err := o.deleteClusterResourcesInGroup(ctx, logger, resourcesClient, mainResourceGroup); err != nil {
+		if err := o.retryDeleteClusterResources(ctx, logger, deleter, mainResourceGroup); err != nil {
 			return fmt.Errorf("failed to delete cluster resources in resource group %s: %w", mainResourceGroup, err)
 		}
 		logger.Info("Successfully cleaned up cluster resources, resource group preserved", "resource-group", mainResourceGroup)
@@ -191,7 +265,12 @@ func (o *DestroyInfraOptions) Run(ctx context.Context, logger logr.Logger) error
 	return nil
 }
 
-// resourceToDelete represents a resource to be deleted with its ID, API version, and type.
+func (o *DestroyInfraOptions) isClusterResource(name string) bool {
+	return strings.Contains(name, o.InfraID) ||
+		strings.HasPrefix(name, o.Name+"-azurecluster.")
+}
+
+// resourceToDelete is an internal transfer object for resource deletion operations.
 type resourceToDelete struct {
 	id           string
 	apiVersion   string
@@ -199,71 +278,89 @@ type resourceToDelete struct {
 	resourceType string
 }
 
-// deleteClusterResourcesInGroup deletes cluster-specific resources within a resource group
-// while preserving the resource group itself and any non-cluster resources.
-// Resources are identified as cluster-specific if they contain the infraID in their name OR
-// if they match the cluster naming pattern (e.g., {name}-azurecluster.{baseDomain} for DNS zones).
-// Resources are deleted in dependency order to avoid conflicts.
-func (o *DestroyInfraOptions) deleteClusterResourcesInGroup(ctx context.Context, logger logr.Logger, resourcesClient *armresources.Client, resourceGroupName string) error {
-	// List all resources in the resource group
-	pager := resourcesClient.NewListByResourceGroupPager(resourceGroupName, nil)
+func (o *DestroyInfraOptions) retryDeleteClusterResources(ctx context.Context, logger logr.Logger, deleter resourceDeleter, resourceGroupName string) error {
+	gracePeriod := o.AzureInfraGracePeriod
+	retryInterval := o.retryInterval
+	if retryInterval == 0 {
+		retryInterval = defaultRetryInterval
+	}
 
-	var resourcesToDelete []resourceToDelete
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to list resources in resource group %s: %w", resourceGroupName, err)
+	infraCtx, cancel := context.WithTimeout(ctx, gracePeriod)
+	defer cancel()
+
+	logger.Info("Starting cluster resource cleanup with retry", "resource-group", resourceGroupName, "grace-period", gracePeriod)
+
+	pollErr := wait.PollUntilContextCancel(infraCtx, retryInterval, true, func(pollCtx context.Context) (bool, error) {
+		err := o.deleteClusterResourcesInGroup(pollCtx, logger, deleter, resourceGroupName)
+		if err == nil {
+			return true, nil
 		}
 
-		for _, resource := range page.Value {
-			if resource.ID == nil || resource.Name == nil || resource.Type == nil {
-				continue
-			}
+		var nre nonRetriableError
+		if errors.As(err, &nre) {
+			return false, err
+		}
 
-			// Only delete resources that are cluster-specific
-			// Resources are identified as cluster-specific if they contain the InfraID OR
-			// if they match the cluster naming pattern (e.g., {name}-azurecluster.{baseDomain} for DNS zones)
-			isClusterResource := strings.Contains(*resource.Name, o.InfraID) ||
-				strings.HasPrefix(*resource.Name, o.Name+"-azurecluster.")
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) && respErr.StatusCode == 429 {
+			logger.Info("Azure API throttling detected, will retry", "error", err.Error())
+		} else {
+			logger.Info("Error during cluster resource cleanup, will retry", "error", err.Error())
+		}
+		return false, nil
+	})
 
-			if isClusterResource {
-				apiVersion := getAPIVersionForResourceType(*resource.Type)
-				resourcesToDelete = append(resourcesToDelete, resourceToDelete{
-					id:           *resource.ID,
-					apiVersion:   apiVersion,
-					name:         *resource.Name,
-					resourceType: *resource.Type,
-				})
-				logger.Info("Marking cluster resource for deletion", "resource", *resource.Name, "id", *resource.ID, "type", *resource.Type)
-			} else {
-				logger.Info("Preserving non-cluster resource", "resource", *resource.Name)
+	if pollErr != nil {
+		if errors.Is(pollErr, context.DeadlineExceeded) {
+			// Use the parent ctx (not infraCtx) since infraCtx is the one that timed out.
+			listCtx, listCancel := context.WithTimeout(ctx, 30*time.Second)
+			defer listCancel()
+			remaining, listErr := deleter.ListByResourceGroup(listCtx, resourceGroupName)
+			if listErr == nil {
+				for _, r := range remaining {
+					if o.isClusterResource(r.name) {
+						logger.Info("Cluster resource still exists after timeout", "resource-id", r.id, "resource-type", r.resourceType)
+					}
+				}
 			}
+			return fmt.Errorf("timed out after %s waiting for cluster resource cleanup in resource group %s: %w", gracePeriod, resourceGroupName, pollErr)
+		}
+		return pollErr
+	}
+	return nil
+}
+
+func (o *DestroyInfraOptions) deleteClusterResourcesInGroup(ctx context.Context, logger logr.Logger, deleter resourceDeleter, resourceGroupName string) error {
+	allResources, err := deleter.ListByResourceGroup(ctx, resourceGroupName)
+	if err != nil {
+		return err
+	}
+
+	var resourcesToDelete []resourceToDelete
+	for _, resource := range allResources {
+		if o.isClusterResource(resource.name) {
+			resourcesToDelete = append(resourcesToDelete, resource)
+			logger.Info("Marking cluster resource for deletion", "resource", resource.name, "id", resource.id, "type", resource.resourceType)
+		} else {
+			logger.Info("Preserving non-cluster resource", "resource", resource.name)
 		}
 	}
 
-	// Sort resources by deletion priority to handle basic dependencies
 	sortResourcesByDeletionOrder(resourcesToDelete)
 
-	// Delete the identified cluster resources in order
 	var deletionErrors []error
 	successfulDeletions := 0
 
 	for _, resource := range resourcesToDelete {
 		logger.Info("Deleting cluster resource", "resource-id", resource.id, "resource-type", resource.resourceType)
-		poller, err := resourcesClient.BeginDeleteByID(ctx, resource.id, resource.apiVersion, nil)
-		if err != nil {
-			if strings.Contains(err.Error(), "ResourceNotFound") {
+		if err := deleter.DeleteByID(ctx, resource.id, resource.apiVersion); err != nil {
+			var respErr *azcore.ResponseError
+			if errors.As(err, &respErr) && respErr.StatusCode == 404 {
 				logger.Info("Resource not found, skipping", "resource-id", resource.id)
 				continue
 			}
-			logger.Error(err, "Failed to start deletion for resource, continuing with remaining resources", "resource-id", resource.id, "resource-name", resource.name)
-			deletionErrors = append(deletionErrors, fmt.Errorf("failed to start deletion for resource %s (%s): %w", resource.name, resource.id, err))
-			continue
-		}
-
-		if _, err = poller.PollUntilDone(ctx, nil); err != nil {
-			logger.Error(err, "Failed to complete deletion for resource, continuing with remaining resources", "resource-id", resource.id, "resource-name", resource.name)
-			deletionErrors = append(deletionErrors, fmt.Errorf("failed to complete deletion for resource %s (%s): %w", resource.name, resource.id, err))
+			logger.Error(err, "Failed to delete resource, continuing with remaining resources", "resource-id", resource.id, "resource-name", resource.name)
+			deletionErrors = append(deletionErrors, fmt.Errorf("failed to delete resource %s (%s): %w", resource.name, resource.id, err))
 			continue
 		}
 		logger.Info("Successfully deleted cluster resource", "resource-id", resource.id)
@@ -272,33 +369,33 @@ func (o *DestroyInfraOptions) deleteClusterResourcesInGroup(ctx context.Context,
 
 	logger.Info("Cluster resource cleanup summary", "resources-deleted", successfulDeletions, "total-resources", len(resourcesToDelete), "errors", len(deletionErrors))
 
-	// If there were any deletion errors, log them
 	if len(deletionErrors) > 0 {
-		logger.Info("Some resources failed to delete, but continuing with destroy operation", "failed-count", len(deletionErrors))
-		for i, err := range deletionErrors {
-			logger.Error(err, "Deletion error", "error-number", i+1)
-		}
-		// Return nil to allow the destroy operation to continue
-		// The errors have been logged for user visibility
+		// If any deletion returns a NonRetriable error (e.g., auth/permission failure),
+		// errors.As in the retry loop will match it in the joined error and stop retrying.
+		// This is correct because such errors typically affect all resources equally.
+		// A resource-specific NonRetriable error would also stop retries for other resources,
+		// which is an acceptable trade-off to avoid masking systemic failures.
+		return errors.Join(deletionErrors...)
 	}
 
 	return nil
 }
 
-// sortResourcesByDeletionOrder sorts resources so that dependencies are deleted before their dependents.
-// The deletion order is:
-// 1. Virtual network links (child resources)
+// sortResourcesByDeletionOrder sorts resources so that child/dependent resources are deleted
+// before their parents. The deletion order is:
+// 1. Virtual network links (child of DNS zones)
 // 2. Virtual machines
 // 3. Network interfaces
 // 4. Load balancers
 // 5. Public IP addresses
 // 6. Disks
-// 7. Network security groups
-// 8. Virtual networks
-// 9. Private DNS zones (parent resources)
-// 10. Storage accounts
-// 11. Managed identities
-// 12. Everything else
+// 7. Subnets (child of virtual networks)
+// 8. Network security groups
+// 9. Virtual networks
+// 10. Private DNS zones
+// 11. Storage accounts
+// 12. Managed identities
+// 13. Everything else
 func sortResourcesByDeletionOrder(resources []resourceToDelete) {
 	priority := func(resourceType string) int {
 		switch {
@@ -314,29 +411,26 @@ func sortResourcesByDeletionOrder(resources []resourceToDelete) {
 			return 5
 		case strings.Contains(resourceType, "disks"):
 			return 6
-		case strings.Contains(resourceType, "networkSecurityGroups"):
+		case strings.Contains(resourceType, "subnets"):
 			return 7
-		case strings.Contains(resourceType, "virtualNetworks"):
+		case strings.Contains(resourceType, "networkSecurityGroups"):
 			return 8
-		case strings.Contains(resourceType, "privateDnsZones") && !strings.Contains(resourceType, "virtualNetworkLinks"):
+		case strings.Contains(resourceType, "virtualNetworks") && !strings.Contains(resourceType, "virtualNetworkLinks"):
 			return 9
-		case strings.Contains(resourceType, "storageAccounts"):
+		case strings.Contains(resourceType, "privateDnsZones") && !strings.Contains(resourceType, "virtualNetworkLinks"):
 			return 10
-		case strings.Contains(resourceType, "userAssignedIdentities"):
+		case strings.Contains(resourceType, "storageAccounts"):
 			return 11
+		case strings.Contains(resourceType, "userAssignedIdentities"):
+			return 12
 		default:
 			return 99
 		}
 	}
 
-	// Sort by priority (lower number = delete first)
-	for i := 0; i < len(resources); i++ {
-		for j := i + 1; j < len(resources); j++ {
-			if priority(resources[i].resourceType) > priority(resources[j].resourceType) {
-				resources[i], resources[j] = resources[j], resources[i]
-			}
-		}
-	}
+	slices.SortFunc(resources, func(a, b resourceToDelete) int {
+		return priority(a.resourceType) - priority(b.resourceType)
+	})
 }
 
 // getAPIVersionForResourceType returns the appropriate API version for a given Azure resource type.
@@ -349,6 +443,7 @@ func getAPIVersionForResourceType(resourceType string) string {
 		"Microsoft.Network/networkInterfaces":                   "2023-11-01",
 		"Microsoft.Network/networkSecurityGroups":               "2023-11-01",
 		"Microsoft.Network/virtualNetworks":                     "2023-11-01",
+		"Microsoft.Network/virtualNetworks/subnets":             "2023-11-01",
 		"Microsoft.Network/privateDnsZones":                     "2020-06-01",
 		"Microsoft.Network/privateDnsZones/virtualNetworkLinks": "2020-06-01",
 		"Microsoft.Compute/virtualMachines":                     "2024-03-01",
@@ -363,13 +458,13 @@ func getAPIVersionForResourceType(resourceType string) string {
 	}
 
 	// Default to a common API version that works for most resource types
-	return "2021-04-01"
+	return fallbackAzureResourceAPIVersion
 }
 
-// GetResourceGroupName returns the resource group name to use for destroy operations.
+// getResourceGroupName returns the resource group name to use for destroy operations.
 // If a custom resource group name was provided, it is returned; otherwise, the default
 // name format of {name}-{infraID} is used.
-func (o *DestroyInfraOptions) GetResourceGroupName() string {
+func (o *DestroyInfraOptions) getResourceGroupName() string {
 	if len(o.ResourceGroupName) > 0 {
 		return o.ResourceGroupName
 	}

--- a/cmd/infra/azure/destroy_test.go
+++ b/cmd/infra/azure/destroy_test.go
@@ -1,10 +1,443 @@
 package azure
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
 	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
+	"github.com/go-logr/logr"
 )
 
+// mockResourceDeleter implements the resourceDeleter interface for testing.
+type mockResourceDeleter struct {
+	listFunc   func(ctx context.Context, rg string) ([]resourceToDelete, error)
+	deleteFunc func(ctx context.Context, id string, apiVersion string) error
+}
+
+func (m *mockResourceDeleter) ListByResourceGroup(ctx context.Context, rg string) ([]resourceToDelete, error) {
+	return m.listFunc(ctx, rg)
+}
+
+func (m *mockResourceDeleter) DeleteByID(ctx context.Context, id string, apiVersion string) error {
+	return m.deleteFunc(ctx, id, apiVersion)
+}
+
+func TestDeleteClusterResourcesInGroup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("When all deletions succeed on first pass it should return no error", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		mock := &mockResourceDeleter{
+			listFunc: func(_ context.Context, _ string) ([]resourceToDelete, error) {
+				return []resourceToDelete{
+					{id: "/sub/rg/dns-zone-1", apiVersion: "2020-06-01", name: "zone-abc123", resourceType: "Microsoft.Network/privateDnsZones"},
+				}, nil
+			},
+			deleteFunc: func(_ context.Context, _ string, _ string) error {
+				return nil
+			},
+		}
+
+		opts := &DestroyInfraOptions{
+			Name:    "test-cluster",
+			InfraID: "abc123",
+		}
+
+		err := opts.deleteClusterResourcesInGroup(context.Background(), logr.Discard(), mock, "test-rg")
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("When a deletion fails it should return an error", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		mock := &mockResourceDeleter{
+			listFunc: func(_ context.Context, _ string) ([]resourceToDelete, error) {
+				return []resourceToDelete{
+					{id: "/sub/rg/dns-zone-1", apiVersion: "2020-06-01", name: "zone-abc123", resourceType: "Microsoft.Network/privateDnsZones"},
+				}, nil
+			},
+			deleteFunc: func(_ context.Context, _ string, _ string) error {
+				return fmt.Errorf("deletion failed: child resources still exist")
+			},
+		}
+
+		opts := &DestroyInfraOptions{
+			Name:    "test-cluster",
+			InfraID: "abc123",
+		}
+
+		err := opts.deleteClusterResourcesInGroup(context.Background(), logr.Discard(), mock, "test-rg")
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("child resources still exist"))
+	})
+
+	t.Run("When a resource is not found it should skip and continue", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		mock := &mockResourceDeleter{
+			listFunc: func(_ context.Context, _ string) ([]resourceToDelete, error) {
+				return []resourceToDelete{
+					{id: "/sub/rg/zone-1", apiVersion: "2020-06-01", name: "zone-abc123", resourceType: "Microsoft.Network/privateDnsZones"},
+					{id: "/sub/rg/zone-2", apiVersion: "2020-06-01", name: "zone2-abc123", resourceType: "Microsoft.Network/privateDnsZones"},
+				}, nil
+			},
+			deleteFunc: func(_ context.Context, id string, _ string) error {
+				if id == "/sub/rg/zone-1" {
+					return &azcore.ResponseError{
+						ErrorCode:  "ResourceNotFound",
+						StatusCode: http.StatusNotFound,
+					}
+				}
+				return nil
+			},
+		}
+
+		opts := &DestroyInfraOptions{
+			Name:    "test-cluster",
+			InfraID: "abc123",
+		}
+
+		err := opts.deleteClusterResourcesInGroup(context.Background(), logr.Discard(), mock, "test-rg")
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+
+	t.Run("When multiple deletions fail it should return all errors", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		mock := &mockResourceDeleter{
+			listFunc: func(_ context.Context, _ string) ([]resourceToDelete, error) {
+				return []resourceToDelete{
+					{id: "/sub/rg/zone-1", apiVersion: "2020-06-01", name: "zone-abc123", resourceType: "Microsoft.Network/privateDnsZones"},
+					{id: "/sub/rg/zone-2", apiVersion: "2020-06-01", name: "zone2-abc123", resourceType: "Microsoft.Network/privateDnsZones"},
+				}, nil
+			},
+			deleteFunc: func(_ context.Context, id string, _ string) error {
+				if id == "/sub/rg/zone-1" {
+					return fmt.Errorf("first deletion failed")
+				}
+				return fmt.Errorf("second deletion failed")
+			},
+		}
+
+		opts := &DestroyInfraOptions{
+			Name:    "test-cluster",
+			InfraID: "abc123",
+		}
+
+		err := opts.deleteClusterResourcesInGroup(context.Background(), logr.Discard(), mock, "test-rg")
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("first deletion failed"))
+		g.Expect(err.Error()).To(ContainSubstring("second deletion failed"))
+	})
+
+	t.Run("When a resource matches the azurecluster prefix it should be deleted", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		var deletedIDs []string
+		mock := &mockResourceDeleter{
+			listFunc: func(_ context.Context, _ string) ([]resourceToDelete, error) {
+				return []resourceToDelete{
+					{id: "/sub/rg/azurecluster-resource", apiVersion: "2020-06-01", name: "test-cluster-azurecluster.example.com", resourceType: "Microsoft.Network/privateDnsZones"},
+				}, nil
+			},
+			deleteFunc: func(_ context.Context, id string, _ string) error {
+				deletedIDs = append(deletedIDs, id)
+				return nil
+			},
+		}
+
+		opts := &DestroyInfraOptions{
+			Name:    "test-cluster",
+			InfraID: "xyz999",
+		}
+
+		err := opts.deleteClusterResourcesInGroup(context.Background(), logr.Discard(), mock, "test-rg")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(deletedIDs).To(ContainElement("/sub/rg/azurecluster-resource"))
+	})
+
+	t.Run("When listing resources fails it should return the error", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		mock := &mockResourceDeleter{
+			listFunc: func(_ context.Context, _ string) ([]resourceToDelete, error) {
+				return nil, fmt.Errorf("failed to list resources")
+			},
+			deleteFunc: func(_ context.Context, _ string, _ string) error {
+				t.Fatal("deleteFunc should not be called")
+				return nil
+			},
+		}
+
+		opts := &DestroyInfraOptions{
+			Name:    "test-cluster",
+			InfraID: "abc123",
+		}
+
+		err := opts.deleteClusterResourcesInGroup(context.Background(), logr.Discard(), mock, "test-rg")
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("failed to list resources"))
+	})
+
+	t.Run("When a resource does not match cluster patterns it should be preserved", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		mock := &mockResourceDeleter{
+			listFunc: func(_ context.Context, _ string) ([]resourceToDelete, error) {
+				return []resourceToDelete{
+					{id: "/sub/rg/other-resource", apiVersion: "2020-06-01", name: "unrelated-resource", resourceType: "Microsoft.Network/privateDnsZones"},
+				}, nil
+			},
+			deleteFunc: func(_ context.Context, _ string, _ string) error {
+				t.Fatal("deleteFunc should not be called for non-cluster resources")
+				return nil
+			},
+		}
+
+		opts := &DestroyInfraOptions{
+			Name:    "test-cluster",
+			InfraID: "abc123",
+		}
+
+		err := opts.deleteClusterResourcesInGroup(context.Background(), logr.Discard(), mock, "test-rg")
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+}
+
+func TestRetryDeleteClusterResources(t *testing.T) {
+	t.Parallel()
+
+	t.Run("When DNS zone deletion fails on first pass it should succeed on retry", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		callCount := 0
+		mock := &mockResourceDeleter{
+			listFunc: func(_ context.Context, _ string) ([]resourceToDelete, error) {
+				callCount++
+				if callCount == 1 {
+					return []resourceToDelete{
+						{id: "/sub/rg/vnetlink-1", apiVersion: "2020-06-01", name: "link-abc123", resourceType: "Microsoft.Network/privateDnsZones/virtualNetworkLinks"},
+						{id: "/sub/rg/dns-zone-1", apiVersion: "2020-06-01", name: "zone-abc123", resourceType: "Microsoft.Network/privateDnsZones"},
+					}, nil
+				}
+				// Second pass: vnet link is gone, only zone remains
+				return []resourceToDelete{
+					{id: "/sub/rg/dns-zone-1", apiVersion: "2020-06-01", name: "zone-abc123", resourceType: "Microsoft.Network/privateDnsZones"},
+				}, nil
+			},
+			deleteFunc: func(_ context.Context, id string, _ string) error {
+				if id == "/sub/rg/dns-zone-1" && callCount == 1 {
+					return fmt.Errorf("child resources still exist")
+				}
+				return nil
+			},
+		}
+
+		opts := &DestroyInfraOptions{
+			Name:                  "test-cluster",
+			InfraID:               "abc123",
+			AzureInfraGracePeriod: 5 * time.Second,
+			retryInterval:         100 * time.Millisecond,
+		}
+
+		err := opts.retryDeleteClusterResources(context.Background(), logr.Discard(), mock, "test-rg")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(callCount).To(BeNumerically(">=", 2))
+	})
+
+	t.Run("When a non-retriable error occurs it should stop retrying immediately", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		callCount := 0
+		mock := &mockResourceDeleter{
+			listFunc: func(_ context.Context, _ string) ([]resourceToDelete, error) {
+				callCount++
+				return []resourceToDelete{
+					{id: "/sub/rg/zone-1", apiVersion: "2020-06-01", name: "zone-abc123", resourceType: "Microsoft.Network/privateDnsZones"},
+				}, nil
+			},
+			deleteFunc: func(_ context.Context, _ string, _ string) error {
+				return &testNonRetriableError{msg: "authentication failed"}
+			},
+		}
+
+		opts := &DestroyInfraOptions{
+			Name:                  "test-cluster",
+			InfraID:               "abc123",
+			AzureInfraGracePeriod: 5 * time.Second,
+			retryInterval:         100 * time.Millisecond,
+		}
+
+		err := opts.retryDeleteClusterResources(context.Background(), logr.Discard(), mock, "test-rg")
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("authentication failed"))
+		g.Expect(callCount).To(Equal(1))
+	})
+
+	t.Run("When timeout is exceeded it should return a wrapped error with resource group name", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		mock := &mockResourceDeleter{
+			listFunc: func(_ context.Context, _ string) ([]resourceToDelete, error) {
+				return []resourceToDelete{
+					{id: "/sub/rg/zone-1", apiVersion: "2020-06-01", name: "zone-abc123", resourceType: "Microsoft.Network/privateDnsZones"},
+				}, nil
+			},
+			deleteFunc: func(_ context.Context, _ string, _ string) error {
+				return fmt.Errorf("child resources still exist")
+			},
+		}
+
+		opts := &DestroyInfraOptions{
+			Name:                  "test-cluster",
+			InfraID:               "abc123",
+			AzureInfraGracePeriod: 500 * time.Millisecond,
+			retryInterval:         100 * time.Millisecond,
+		}
+
+		err := opts.retryDeleteClusterResources(context.Background(), logr.Discard(), mock, "test-rg")
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("timed out"))
+		g.Expect(err.Error()).To(ContainSubstring("test-rg"))
+		g.Expect(errors.Is(err, context.DeadlineExceeded)).To(BeTrue())
+	})
+
+	t.Run("When Azure API returns 429 throttling it should retry", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		callCount := 0
+		mock := &mockResourceDeleter{
+			listFunc: func(_ context.Context, _ string) ([]resourceToDelete, error) {
+				callCount++
+				if callCount <= 2 {
+					return []resourceToDelete{
+						{id: "/sub/rg/zone-1", apiVersion: "2020-06-01", name: "zone-abc123", resourceType: "Microsoft.Network/privateDnsZones"},
+					}, nil
+				}
+				return nil, nil
+			},
+			deleteFunc: func(_ context.Context, _ string, _ string) error {
+				if callCount <= 1 {
+					return &azcore.ResponseError{
+						StatusCode: 429,
+						ErrorCode:  "TooManyRequests",
+					}
+				}
+				return nil
+			},
+		}
+
+		opts := &DestroyInfraOptions{
+			Name:                  "test-cluster",
+			InfraID:               "abc123",
+			AzureInfraGracePeriod: 5 * time.Second,
+			retryInterval:         100 * time.Millisecond,
+		}
+
+		err := opts.retryDeleteClusterResources(context.Background(), logr.Discard(), mock, "test-rg")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(callCount).To(BeNumerically(">=", 2))
+	})
+
+	t.Run("When grace period is zero it should attempt deletion once without retries", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		callCount := 0
+		mock := &mockResourceDeleter{
+			listFunc: func(_ context.Context, _ string) ([]resourceToDelete, error) {
+				callCount++
+				return []resourceToDelete{
+					{id: "/sub/rg/zone-1", apiVersion: "2020-06-01", name: "zone-abc123", resourceType: "Microsoft.Network/privateDnsZones"},
+				}, nil
+			},
+			deleteFunc: func(_ context.Context, _ string, _ string) error {
+				return nil
+			},
+		}
+
+		opts := &DestroyInfraOptions{
+			Name:                  "test-cluster",
+			InfraID:               "abc123",
+			AzureInfraGracePeriod: 0,
+			retryInterval:         100 * time.Millisecond,
+		}
+
+		err := opts.retryDeleteClusterResources(context.Background(), logr.Discard(), mock, "test-rg")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(callCount).To(Equal(1))
+	})
+
+	t.Run("When retrying it should re-list resources on each pass", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		listCallCount := 0
+		deleteCallCount := 0
+		mock := &mockResourceDeleter{
+			listFunc: func(_ context.Context, _ string) ([]resourceToDelete, error) {
+				listCallCount++
+				if listCallCount <= 2 {
+					return []resourceToDelete{
+						{id: "/sub/rg/zone-1", apiVersion: "2020-06-01", name: "zone-abc123", resourceType: "Microsoft.Network/privateDnsZones"},
+					}, nil
+				}
+				return nil, nil
+			},
+			deleteFunc: func(_ context.Context, _ string, _ string) error {
+				deleteCallCount++
+				if deleteCallCount <= 2 {
+					return fmt.Errorf("still deleting")
+				}
+				return nil
+			},
+		}
+
+		opts := &DestroyInfraOptions{
+			Name:                  "test-cluster",
+			InfraID:               "abc123",
+			AzureInfraGracePeriod: 5 * time.Second,
+			retryInterval:         100 * time.Millisecond,
+		}
+
+		err := opts.retryDeleteClusterResources(context.Background(), logr.Discard(), mock, "test-rg")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(listCallCount).To(BeNumerically(">=", 2))
+	})
+}
+
+// testNonRetriableError implements the nonRetriableError interface for testing.
+var _ nonRetriableError = (*testNonRetriableError)(nil)
+
+type testNonRetriableError struct {
+	msg string
+}
+
+func (e *testNonRetriableError) Error() string { return e.msg }
+func (e *testNonRetriableError) NonRetriable() {}
+
 func TestSortResourcesByDeletionOrder(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name          string
 		resources     []resourceToDelete
@@ -24,22 +457,24 @@ func TestSortResourcesByDeletionOrder(t *testing.T) {
 				"Microsoft.Compute/virtualMachines",                     // 2
 				"Microsoft.Network/networkInterfaces",                   // 3
 				"Microsoft.Network/loadBalancers",                       // 4
-				"Microsoft.Storage/storageAccounts",                     // 10
+				"Microsoft.Storage/storageAccounts",                     // 11
 			},
 		},
 		{
-			name: "When network resources are provided it should put vnet before dns zones but after nsg",
+			name: "When network resources are provided it should put subnets before vnets and vnets before dns zones",
 			resources: []resourceToDelete{
 				{id: "1", name: "dns", resourceType: "Microsoft.Network/privateDnsZones"},
 				{id: "2", name: "vnet", resourceType: "Microsoft.Network/virtualNetworks"},
 				{id: "3", name: "nsg", resourceType: "Microsoft.Network/networkSecurityGroups"},
 				{id: "4", name: "identity", resourceType: "Microsoft.ManagedIdentity/userAssignedIdentities"},
+				{id: "5", name: "subnet", resourceType: "Microsoft.Network/virtualNetworks/subnets"},
 			},
 			expectedOrder: []string{
-				"Microsoft.Network/networkSecurityGroups",          // 7
-				"Microsoft.Network/virtualNetworks",                // 8
-				"Microsoft.Network/privateDnsZones",                // 9
-				"Microsoft.ManagedIdentity/userAssignedIdentities", // 11
+				"Microsoft.Network/virtualNetworks/subnets",        // 7
+				"Microsoft.Network/networkSecurityGroups",          // 8
+				"Microsoft.Network/virtualNetworks",                // 9
+				"Microsoft.Network/privateDnsZones",                // 10
+				"Microsoft.ManagedIdentity/userAssignedIdentities", // 12
 			},
 		},
 		{
@@ -57,18 +492,21 @@ func TestSortResourcesByDeletionOrder(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
 			sortResourcesByDeletionOrder(tt.resources)
 
 			for i, expected := range tt.expectedOrder {
-				if tt.resources[i].resourceType != expected {
-					t.Errorf("position %d: got %s, expected %s", i, tt.resources[i].resourceType, expected)
-				}
+				g.Expect(tt.resources[i].resourceType).To(Equal(expected))
 			}
 		})
 	}
 }
 
 func TestGetAPIVersionForResourceType(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name         string
 		resourceType string
@@ -138,15 +576,52 @@ func TestGetAPIVersionForResourceType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
 			result := getAPIVersionForResourceType(tt.resourceType)
-			if result != tt.expected {
-				t.Errorf("getAPIVersionForResourceType(%s) = %s, expected %s", tt.resourceType, result, tt.expected)
-			}
+			g.Expect(result).To(Equal(tt.expected))
 		})
 	}
 }
 
-func TestGetResourceGroupName(t *testing.T) {
+func TestDestroyValidate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("When negative grace period is provided it should return an error", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		opts := &DestroyInfraOptions{
+			Name:                  "test-cluster",
+			InfraID:               "abc123",
+			CredentialsFile:       "/tmp/creds",
+			AzureInfraGracePeriod: -1 * time.Second,
+		}
+
+		err := opts.Validate()
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("azure-infra-grace-period must be >= 0"))
+	})
+
+	t.Run("When zero grace period is provided it should not return an error", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		opts := &DestroyInfraOptions{
+			Name:            "test-cluster",
+			InfraID:         "abc123",
+			CredentialsFile: "/tmp/creds",
+		}
+
+		err := opts.Validate()
+		g.Expect(err).ToNot(HaveOccurred())
+	})
+}
+
+func TestDestroyGetResourceGroupName(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		opts     DestroyInfraOptions
@@ -183,10 +658,11 @@ func TestGetResourceGroupName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := tt.opts.GetResourceGroupName()
-			if result != tt.expected {
-				t.Errorf("GetResourceGroupName() = %v, expected %v", result, tt.expected)
-			}
+			t.Parallel()
+			g := NewWithT(t)
+
+			result := tt.opts.getResourceGroupName()
+			g.Expect(result).To(Equal(tt.expected))
 		})
 	}
 }

--- a/cmd/util/azure_flag_descriptions.go
+++ b/cmd/util/azure_flag_descriptions.go
@@ -66,6 +66,7 @@ const (
 
 	// Destroy options
 	PreserveResourceGroupDescription = "Keep the resource group after cluster deletion. Only cluster-specific resources within the group will be removed."
+	AzureInfraGracePeriodDescription = "Timeout for retrying Azure resource cleanup when using --preserve-resource-group. Set to 0 to disable retries."
 
 	// Destroy-specific location and resource group descriptions
 	LocationDestroyDescription          = "Azure region of the cluster. Inferred from the HostedCluster if it exists; only required if the cluster resource has already been deleted."

--- a/product-cli/cmd/cluster/azure/destroy.go
+++ b/product-cli/cmd/cluster/azure/destroy.go
@@ -3,6 +3,7 @@ package azure
 import (
 	hypershiftazure "github.com/openshift/hypershift/cmd/cluster/azure"
 	"github.com/openshift/hypershift/cmd/cluster/core"
+	azureinfra "github.com/openshift/hypershift/cmd/infra/azure"
 	"github.com/openshift/hypershift/cmd/util"
 
 	"github.com/spf13/cobra"
@@ -21,6 +22,7 @@ func NewDestroyCommand(opts *core.DestroyOptions) *cobra.Command {
 	cmd.Flags().StringVar(&opts.AzurePlatform.ResourceGroupName, "resource-group-name", opts.AzurePlatform.ResourceGroupName, util.ResourceGroupNameDestroyDescription)
 	cmd.Flags().BoolVar(&opts.AzurePlatform.PreserveResourceGroup, "preserve-resource-group", opts.AzurePlatform.PreserveResourceGroup, util.PreserveResourceGroupDescription)
 	cmd.Flags().StringVar(&opts.AzurePlatform.DNSZoneRGName, "dns-zone-rg-name", opts.AzurePlatform.DNSZoneRGName, util.DNSZoneRGNameDestroyDescription)
+	cmd.Flags().DurationVar(&opts.AzurePlatform.AzureInfraGracePeriod, "azure-infra-grace-period", azureinfra.DefaultInfraGracePeriod, util.AzureInfraGracePeriodDescription)
 
 	_ = cmd.MarkFlagRequired("azure-creds")
 	_ = cmd.MarkFlagRequired("dns-zone-rg-name")

--- a/test-plan/test-pr-8454.md
+++ b/test-plan/test-pr-8454.md
@@ -1,0 +1,657 @@
+# Test Plan: PR #8454 — OCPBUGS-85192: Add retry logic for Azure DNS cleanup in `hcp destroy`
+
+## PR Summary
+
+**Title:** OCPBUGS-85192: Add retry logic for Azure DNS cleanup in hcp destroy
+**Labels:** area/platform/azure, area/cli, jira/valid-bug
+
+### Key Changes
+
+- **Retry loop** with `wait.PollUntilContextCancel` for Azure resource cleanup when using `--preserve-resource-group`, mirroring the AWS destroy path's retry pattern
+- **`resourceDeleter` interface** abstracting `ListByResourceGroup` + `DeleteByID` for testability
+- **`NonRetriable` error detection** via structural typing — stops retrying on permanent failures (auth errors, invalid requests)
+- **Error propagation** — deletion failures are now returned as joined errors instead of being silently swallowed
+- **`--azure-infra-grace-period` flag** (default 5m) controlling retry timeout
+- **Deletion order improvements** — subnets now correctly ordered before virtual networks; uses `slices.SortFunc` instead of manual bubble sort
+- **`getResourceGroupName` unexported** (was `GetResourceGroupName`)
+
+### Changed Files
+
+| File | Change |
+|------|--------|
+| `cmd/infra/azure/destroy.go` | Core implementation: interface, retry loop, error propagation, deletion order |
+| `cmd/infra/azure/destroy_test.go` | 19 unit tests (6 new retry tests, plus migrated to gomega) |
+| `cmd/cluster/azure/destroy.go` | Wire `--azure-infra-grace-period` flag |
+| `cmd/cluster/core/destroy.go` | Add `AzureInfraGracePeriod` field to `AzurePlatformDestroyOptions` |
+
+## Prerequisites
+
+### Infrastructure Requirements
+
+- **Azure subscription** with contributor access
+- **Azure credentials file** (`azure-creds`) with service principal or workload identity
+- **Management cluster** (AWS or Azure) with HyperShift operator installed
+- **DNS zone resource group** (`dns-zone-rg-name`) for the base domain
+- **Custom resource group** (recommended) to test `--preserve-resource-group` path
+
+### Tools & Versions
+
+- `hcp` CLI built from PR branch (`make build` or `make hypershift`)
+- `az` CLI (Azure CLI) for manual resource verification
+- `kubectl` / `oc` for cluster management
+- `jq` for JSON parsing
+
+### Environment Setup
+
+```bash
+# Set common variables
+export AZURE_CREDS="/path/to/azure-credentials.json"
+export CLUSTER_NAME="dns-retry-test"
+export INFRA_ID="<will be set after cluster creation>"
+export LOCATION="eastus"
+export RESOURCE_GROUP_NAME="${CLUSTER_NAME}-custom-rg"
+export DNS_ZONE_RG="<your-dns-zone-resource-group>"
+export BASE_DOMAIN="<your-base-domain>"
+
+# Build the CLI from PR branch
+git checkout investigate-azure-cli
+make build
+```
+
+> **IMPORTANT:** Every step in every scenario must include explicit verification. Do not proceed to the next step until the current step's verification passes.
+
+### Safety: Retry Loop and Process Management
+
+The `--preserve-resource-group` path enters a retry loop that polls every 10 seconds for up to 5 minutes (default). When running destroy commands that will fail (e.g., invalid/dummy credentials, nonexistent resources), **always pass `--azure-infra-grace-period 0s`** to prevent the command from blocking for the full grace period.
+
+**Do NOT use `pkill -f` with broad patterns** like `pkill -f "hypershift destroy"` to kill stuck commands. The `-f` flag matches against full command-line strings, which can match the calling process (e.g., a CI agent, test runner, or shell) if the command string appears in its arguments. Use `timeout` to bound command execution instead:
+
+```bash
+# SAFE: use timeout to bound execution
+timeout 30s bin/hypershift destroy infra azure ... 2>&1
+
+# SAFE: use --azure-infra-grace-period 0s to prevent retries
+bin/hypershift destroy infra azure ... --azure-infra-grace-period 0s 2>&1
+
+# DANGEROUS: pkill -f can match and kill the calling process
+pkill -f "hypershift destroy infra azure"  # DO NOT USE
+```
+
+For scenarios that validate flag parsing or help text (no real Azure calls), use `--help` or `--azure-infra-grace-period 0s`. For scenarios against real infrastructure, the default 5m grace period is appropriate since the retry loop will exit as soon as cleanup succeeds.
+
+## Test Scenarios
+
+### Scenario 1: Baseline — `hcp destroy` without `--preserve-resource-group`
+
+**Purpose:** Verify no regression on the default (non-preserve) destroy path.
+
+**Steps:**
+
+1. Create an Azure HyperShift cluster:
+   ```bash
+   bin/hcp create cluster azure \
+     --name ${CLUSTER_NAME} \
+     --azure-creds ${AZURE_CREDS} \
+     --location ${LOCATION} \
+     --dns-zone-rg-name ${DNS_ZONE_RG} \
+     --base-domain ${BASE_DOMAIN} \
+     --release-image <OCP_RELEASE_IMAGE>
+   ```
+   **Verify:** Command exits 0. HostedCluster resource exists:
+   ```bash
+   oc get hostedcluster -n clusters ${CLUSTER_NAME} -o jsonpath='{.metadata.name}'
+   # Expected: dns-retry-test
+   ```
+
+2. Wait for the cluster to become available:
+   ```bash
+   oc get hostedcluster -n clusters ${CLUSTER_NAME} -w
+   ```
+   **Verify:** HostedCluster status shows `Available=True`:
+   ```bash
+   oc get hostedcluster -n clusters ${CLUSTER_NAME} -o jsonpath='{.status.conditions[?(@.type=="Available")].status}'
+   # Expected: True
+   ```
+
+3. Record resource groups before destroy:
+   ```bash
+   export INFRA_ID=$(oc get hostedcluster -n clusters ${CLUSTER_NAME} -o jsonpath='{.spec.infraID}')
+   az group list --query "[?starts_with(name, '${CLUSTER_NAME}')]" -o table
+   ```
+   **Verify:** At least the main resource group (`${CLUSTER_NAME}-${INFRA_ID}`) exists. Note all resource group names for post-destroy verification.
+
+4. Destroy without preserve flag:
+   ```bash
+   bin/hcp destroy cluster azure \
+     --name ${CLUSTER_NAME} \
+     --azure-creds ${AZURE_CREDS} \
+     --dns-zone-rg-name ${DNS_ZONE_RG}
+   ```
+   **Verify:** Command exits 0. Logs do NOT contain `"Starting cluster resource cleanup with retry"` (this message only appears in the `--preserve-resource-group` path).
+
+5. Verify all resource groups are deleted:
+   ```bash
+   az group list --query "[?starts_with(name, '${CLUSTER_NAME}')]" -o table
+   ```
+   **Verify:** Returns empty — all resource groups (`{name}-{infraID}`, `{name}-vnet-{infraID}`, `{name}-nsg-{infraID}`) are gone.
+
+6. Verify the HostedCluster resource is removed:
+   ```bash
+   oc get hostedcluster -n clusters ${CLUSTER_NAME} 2>&1
+   ```
+   **Verify:** Returns `NotFound` error.
+
+---
+
+### Scenario 2: `--preserve-resource-group` with clean resources (happy path)
+
+**Purpose:** Verify the retry loop works end-to-end when all resources delete successfully on first pass.
+
+**Steps:**
+
+1. Create a custom resource group:
+   ```bash
+   az group create --name ${RESOURCE_GROUP_NAME} --location ${LOCATION}
+   ```
+   **Verify:** Resource group exists:
+   ```bash
+   az group show --name ${RESOURCE_GROUP_NAME} --query "properties.provisioningState" -o tsv
+   # Expected: Succeeded
+   ```
+
+2. Create an Azure HyperShift cluster using the custom resource group:
+   ```bash
+   bin/hcp create cluster azure \
+     --name ${CLUSTER_NAME} \
+     --azure-creds ${AZURE_CREDS} \
+     --location ${LOCATION} \
+     --dns-zone-rg-name ${DNS_ZONE_RG} \
+     --base-domain ${BASE_DOMAIN} \
+     --resource-group-name ${RESOURCE_GROUP_NAME} \
+     --release-image <OCP_RELEASE_IMAGE>
+   ```
+   **Verify:** Command exits 0. HostedCluster resource exists:
+   ```bash
+   oc get hostedcluster -n clusters ${CLUSTER_NAME} -o jsonpath='{.metadata.name}'
+   # Expected: dns-retry-test
+   ```
+
+3. Wait for the cluster to become available and record the infra ID:
+   ```bash
+   oc get hostedcluster -n clusters ${CLUSTER_NAME} -w
+   export INFRA_ID=$(oc get hostedcluster -n clusters ${CLUSTER_NAME} -o jsonpath='{.spec.infraID}')
+   ```
+   **Verify:** HostedCluster status shows `Available=True` and infra ID is non-empty:
+   ```bash
+   oc get hostedcluster -n clusters ${CLUSTER_NAME} -o jsonpath='{.status.conditions[?(@.type=="Available")].status}'
+   # Expected: True
+   echo "InfraID: ${INFRA_ID}"
+   # Expected: non-empty string
+   ```
+
+4. List resources before destroy — record the resource list for comparison:
+   ```bash
+   az resource list --resource-group ${RESOURCE_GROUP_NAME} -o table
+   ```
+   **Verify:** Cluster-specific resources exist (resources containing `${INFRA_ID}` or matching `${CLUSTER_NAME}-azurecluster.*`):
+   ```bash
+   az resource list --resource-group ${RESOURCE_GROUP_NAME} \
+     --query "[?contains(name, '${INFRA_ID}') || starts_with(name, '${CLUSTER_NAME}-azurecluster')]" -o table
+   # Expected: At least one resource listed
+   ```
+
+5. Destroy with preserve flag:
+   ```bash
+   bin/hcp destroy cluster azure \
+     --name ${CLUSTER_NAME} \
+     --azure-creds ${AZURE_CREDS} \
+     --dns-zone-rg-name ${DNS_ZONE_RG} \
+     --preserve-resource-group 2>&1 | tee /tmp/destroy-output.log
+   ```
+   **Verify:** Command exits 0. Check log contains expected messages:
+   ```bash
+   grep "Starting cluster resource cleanup with retry" /tmp/destroy-output.log
+   # Expected: Match found — retry loop was entered
+   grep "grace-period" /tmp/destroy-output.log
+   # Expected: grace-period=5m0s (default)
+   grep "Successfully cleaned up cluster resources, resource group preserved" /tmp/destroy-output.log
+   # Expected: Match found — cleanup completed successfully
+   ```
+
+6. Verify resource group still exists:
+   ```bash
+   az group show --name ${RESOURCE_GROUP_NAME} --query "properties.provisioningState" -o tsv
+   ```
+   **Verify:** Returns `Succeeded` — resource group was preserved.
+
+7. Verify no cluster-specific resources remain:
+   ```bash
+   az resource list --resource-group ${RESOURCE_GROUP_NAME} \
+     --query "[?contains(name, '${INFRA_ID}') || starts_with(name, '${CLUSTER_NAME}-azurecluster')]" -o table
+   ```
+   **Verify:** Returns empty — all cluster resources were deleted.
+
+8. Verify additional resource groups (vnet, nsg) were deleted:
+   ```bash
+   az group show --name "${CLUSTER_NAME}-vnet-${INFRA_ID}" 2>&1
+   az group show --name "${CLUSTER_NAME}-nsg-${INFRA_ID}" 2>&1
+   ```
+   **Verify:** Both return `ResourceGroupNotFound` — additional resource groups are always deleted regardless of `--preserve-resource-group`.
+
+---
+
+### Scenario 3: `--preserve-resource-group` with DNS zone + active vnet links (retry scenario)
+
+**Purpose:** This is the core bug scenario from OCPBUGS-85192. When virtualNetworkLinks are being deleted asynchronously, the first DNS zone deletion attempt fails. The retry loop should re-list resources and succeed on a subsequent pass.
+
+**Steps:**
+
+1. Create a cluster in a custom resource group (same setup as Scenario 2 steps 1-3).
+   **Verify:** Same as Scenario 2 steps 1-3 — cluster is available, infra ID is set.
+
+2. Verify DNS resources exist before destroying:
+   ```bash
+   az resource list --resource-group ${RESOURCE_GROUP_NAME} \
+     --query "[?type=='Microsoft.Network/privateDnsZones' || type=='Microsoft.Network/privateDnsZones/virtualNetworkLinks']" -o table
+   ```
+   **Verify:** At least one privateDnsZone and one virtualNetworkLink are listed. Record the count for comparison.
+
+3. Verify deletion order expectations — list resources with types:
+   ```bash
+   az resource list --resource-group ${RESOURCE_GROUP_NAME} \
+     --query "[?contains(name, '${INFRA_ID}')].[name, type]" -o table
+   ```
+   **Verify:** Note which resource types exist. virtualNetworkLinks should be deleted before privateDnsZones (priority 1 vs 10 in the deletion order).
+
+4. Destroy with preserve flag, capturing output:
+   ```bash
+   bin/hcp destroy cluster azure \
+     --name ${CLUSTER_NAME} \
+     --azure-creds ${AZURE_CREDS} \
+     --dns-zone-rg-name ${DNS_ZONE_RG} \
+     --preserve-resource-group 2>&1 | tee /tmp/destroy-output.log
+   ```
+   **Verify:** Command exits 0.
+
+5. Verify the retry loop started:
+   ```bash
+   grep "Starting cluster resource cleanup with retry" /tmp/destroy-output.log
+   ```
+   **Verify:** Match found.
+
+6. Verify resources were marked for deletion in correct order:
+   ```bash
+   grep "Marking cluster resource for deletion" /tmp/destroy-output.log
+   ```
+   **Verify:** virtualNetworkLinks appear in the log before privateDnsZones. Each cluster-specific resource from step 3 is listed.
+
+7. Check whether retries occurred:
+   ```bash
+   grep -c "will retry" /tmp/destroy-output.log
+   ```
+   **Verify:** Count >= 0 (may succeed on first pass if Azure-side deletion is fast). If retries did occur, also check:
+   ```bash
+   grep "Error during cluster resource cleanup, will retry" /tmp/destroy-output.log
+   # Expected: Shows the transient error (e.g., "child resources still exist")
+   ```
+
+8. Verify cleanup summary:
+   ```bash
+   grep "Cluster resource cleanup summary" /tmp/destroy-output.log
+   ```
+   **Verify:** `resources-deleted` count matches the number of cluster-specific resources from step 3. `errors` count is 0.
+
+9. Verify completion message:
+   ```bash
+   grep "Successfully cleaned up cluster resources, resource group preserved" /tmp/destroy-output.log
+   ```
+   **Verify:** Match found.
+
+10. Verify no orphaned resources remain:
+    ```bash
+    az resource list --resource-group ${RESOURCE_GROUP_NAME} \
+      --query "[?contains(name, '${INFRA_ID}') || starts_with(name, '${CLUSTER_NAME}-azurecluster')]" -o table
+    ```
+    **Verify:** Returns empty — no cluster-specific resources remain.
+
+11. Verify no orphaned DNS zones or vnet links:
+    ```bash
+    az network private-dns zone list \
+      --resource-group ${RESOURCE_GROUP_NAME} \
+      --query "[?contains(name, '${INFRA_ID}') || starts_with(name, '${CLUSTER_NAME}-azurecluster')]" -o table
+    ```
+    **Verify:** Returns empty.
+
+---
+
+### Scenario 4: `--azure-infra-grace-period` flag validation
+
+**Purpose:** Verify the new flag works correctly with various values.
+
+**Steps:**
+
+1. **Negative value — should fail validation:**
+   ```bash
+   bin/hcp destroy cluster azure \
+     --name ${CLUSTER_NAME} \
+     --azure-creds ${AZURE_CREDS} \
+     --dns-zone-rg-name ${DNS_ZONE_RG} \
+     --preserve-resource-group \
+     --azure-infra-grace-period -1s 2>&1
+   ```
+   **Verify:** Command exits non-zero. Error output contains `"azure-infra-grace-period must be >= 0"`.
+
+2. **Verify flag appears in help text for all command paths:**
+   ```bash
+   bin/hcp destroy cluster azure --help 2>&1 | grep "azure-infra-grace-period"
+   bin/hcp destroy infra azure --help 2>&1 | grep "azure-infra-grace-period"
+   bin/hypershift destroy infra azure --help 2>&1 | grep "azure-infra-grace-period"
+   ```
+   **Verify:** All three commands show the `--azure-infra-grace-period` flag with description matching `AzureInfraGracePeriodDescription`.
+
+3. **Zero value — single attempt, no retries (run against real infrastructure only):**
+
+   > **WARNING:** This step requires a real cluster from a prior scenario. Do NOT run destroy commands with `--preserve-resource-group` against dummy credentials or nonexistent resources without `--azure-infra-grace-period 0s` — the retry loop will block for the full grace period (default 5 minutes) retrying auth failures every 10 seconds.
+
+   ```bash
+   bin/hcp destroy cluster azure \
+     --name ${CLUSTER_NAME} \
+     --azure-creds ${AZURE_CREDS} \
+     --dns-zone-rg-name ${DNS_ZONE_RG} \
+     --preserve-resource-group \
+     --azure-infra-grace-period 0s 2>&1 | tee /tmp/destroy-zero-grace.log
+   ```
+   **Verify:** Log shows the zero value. If deletion succeeds on first pass, command exits 0. If deletion fails, command exits non-zero with a timeout error (context expires immediately after the first immediate poll):
+   ```bash
+   grep "grace-period" /tmp/destroy-zero-grace.log
+   # Expected: grace-period=0s
+   ```
+
+4. **Custom and default values (verify via log output from real-infrastructure scenarios):**
+
+   Rather than running separate destroy commands for each value, verify grace period parsing from the log output of other scenarios:
+
+   - **Default (5m):** Check logs from Scenario 2 or 3 (which use the default):
+     ```bash
+     grep "grace-period" /tmp/destroy-output.log
+     # Expected: grace-period=5m0s
+     ```
+   - **Custom (2m):** Check logs from Scenario 5 (which uses `--azure-infra-grace-period 2m`):
+     ```bash
+     grep "grace-period" /tmp/destroy-infra-output.log
+     # Expected: grace-period=2m0s
+     ```
+
+   **Verify:** Each log shows the expected grace period value.
+
+---
+
+### Scenario 5: `hcp infra destroy azure` (direct infra destroy command)
+
+**Purpose:** Verify the flag is also wired in the `hcp infra destroy azure` command path.
+
+**Steps:**
+
+1. Ensure a cluster exists with a known infra ID (from a previous create, or set up a new one).
+   **Verify:** `${INFRA_ID}` is set and non-empty.
+
+2. List resources before destroy:
+   ```bash
+   az resource list --resource-group ${RESOURCE_GROUP_NAME} \
+     --query "[?contains(name, '${INFRA_ID}')]" -o table
+   ```
+   **Verify:** Cluster-specific resources exist.
+
+3. Run with preserve and custom grace period:
+   ```bash
+   bin/hypershift destroy infra azure \
+     --name ${CLUSTER_NAME} \
+     --infra-id ${INFRA_ID} \
+     --azure-creds ${AZURE_CREDS} \
+     --preserve-resource-group \
+     --azure-infra-grace-period 2m 2>&1 | tee /tmp/destroy-infra-output.log
+   ```
+   **Verify:** Command exits 0.
+
+4. Verify retry loop used the custom grace period:
+   ```bash
+   grep "grace-period" /tmp/destroy-infra-output.log
+   ```
+   **Verify:** Shows `grace-period=2m0s`.
+
+5. Verify retry log messages appear (same pattern as Scenario 2):
+   ```bash
+   grep "Starting cluster resource cleanup with retry" /tmp/destroy-infra-output.log
+   grep "Successfully cleaned up cluster resources, resource group preserved" /tmp/destroy-infra-output.log
+   ```
+   **Verify:** Both messages appear.
+
+6. Verify resource group preserved and cluster resources deleted:
+   ```bash
+   az group show --name ${RESOURCE_GROUP_NAME} --query "properties.provisioningState" -o tsv
+   # Expected: Succeeded
+   az resource list --resource-group ${RESOURCE_GROUP_NAME} \
+     --query "[?contains(name, '${INFRA_ID}')]" -o table
+   # Expected: empty
+   ```
+   **Verify:** Resource group exists, no cluster-specific resources remain.
+
+---
+
+### Scenario 6: Repeated create/destroy cycles (regression test for original bug)
+
+**Purpose:** The original bug manifests after repeated create/destroy cycles — orphaned DNS zones accumulate. Verify this no longer happens.
+
+**Steps:**
+
+1. Create a custom resource group:
+   ```bash
+   az group create --name ${RESOURCE_GROUP_NAME} --location ${LOCATION}
+   ```
+   **Verify:** Resource group exists with `provisioningState=Succeeded`.
+
+2. **Cycle 1 — Create:**
+   ```bash
+   bin/hcp create cluster azure \
+     --name ${CLUSTER_NAME} \
+     --azure-creds ${AZURE_CREDS} \
+     --location ${LOCATION} \
+     --dns-zone-rg-name ${DNS_ZONE_RG} \
+     --base-domain ${BASE_DOMAIN} \
+     --resource-group-name ${RESOURCE_GROUP_NAME} \
+     --release-image <OCP_RELEASE_IMAGE>
+   ```
+   **Verify:** Cluster is available (`Available=True`). Record infra ID.
+
+3. **Cycle 1 — Destroy:**
+   ```bash
+   bin/hcp destroy cluster azure \
+     --name ${CLUSTER_NAME} \
+     --azure-creds ${AZURE_CREDS} \
+     --dns-zone-rg-name ${DNS_ZONE_RG} \
+     --preserve-resource-group 2>&1 | tee /tmp/destroy-cycle1.log
+   ```
+   **Verify:** Command exits 0. Check no orphaned resources:
+   ```bash
+   az resource list --resource-group ${RESOURCE_GROUP_NAME} \
+     --query "[?contains(name, '${INFRA_ID}')]" -o table
+   # Expected: empty
+   az network private-dns zone list \
+     --resource-group ${RESOURCE_GROUP_NAME} -o table
+   # Expected: no cluster-specific DNS zones remain
+   ```
+
+4. **Cycle 2 — Create** (new cluster in same resource group):
+   ```bash
+   bin/hcp create cluster azure \
+     --name ${CLUSTER_NAME} \
+     --azure-creds ${AZURE_CREDS} \
+     --location ${LOCATION} \
+     --dns-zone-rg-name ${DNS_ZONE_RG} \
+     --base-domain ${BASE_DOMAIN} \
+     --resource-group-name ${RESOURCE_GROUP_NAME} \
+     --release-image <OCP_RELEASE_IMAGE>
+   ```
+   **Verify:** Cluster is available. Record new infra ID (will differ from cycle 1).
+
+5. **Cycle 2 — Destroy:**
+   ```bash
+   export INFRA_ID=$(oc get hostedcluster -n clusters ${CLUSTER_NAME} -o jsonpath='{.spec.infraID}')
+   bin/hcp destroy cluster azure \
+     --name ${CLUSTER_NAME} \
+     --azure-creds ${AZURE_CREDS} \
+     --dns-zone-rg-name ${DNS_ZONE_RG} \
+     --preserve-resource-group 2>&1 | tee /tmp/destroy-cycle2.log
+   ```
+   **Verify:** Command exits 0. Check no orphaned resources from either cycle:
+   ```bash
+   az resource list --resource-group ${RESOURCE_GROUP_NAME} -o table
+   # Expected: no cluster-specific resources from cycle 1 OR cycle 2
+   az network private-dns zone list \
+     --resource-group ${RESOURCE_GROUP_NAME} -o table
+   # Expected: no orphaned DNS zones from either cycle
+   ```
+
+6. **Cycle 3 — Repeat** steps 4-5 once more.
+   **Verify:** Same checks as cycle 2. No accumulation of orphaned resources across any cycle.
+
+7. Final verification — count all remaining resources in the group:
+   ```bash
+   az resource list --resource-group ${RESOURCE_GROUP_NAME} --query "length(@)"
+   ```
+   **Verify:** Count equals only the non-cluster resources (if any were pre-existing). No DNS zones, vnet links, or other cluster resources from any cycle remain.
+
+---
+
+### Scenario 7: Private topology cluster
+
+**Purpose:** Verify retry works correctly for private Azure topology clusters, which have additional DNS resources (PLS, Private Endpoint, additional DNS zones and vnet links).
+
+**Steps:**
+
+1. Create a custom resource group:
+   ```bash
+   az group create --name ${RESOURCE_GROUP_NAME} --location ${LOCATION}
+   ```
+   **Verify:** Resource group exists with `provisioningState=Succeeded`.
+
+2. Create a private Azure HyperShift cluster:
+   ```bash
+   bin/hcp create cluster azure \
+     --name ${CLUSTER_NAME} \
+     --azure-creds ${AZURE_CREDS} \
+     --location ${LOCATION} \
+     --dns-zone-rg-name ${DNS_ZONE_RG} \
+     --base-domain ${BASE_DOMAIN} \
+     --resource-group-name ${RESOURCE_GROUP_NAME} \
+     --endpoint-access Private \
+     --release-image <OCP_RELEASE_IMAGE>
+   ```
+   **Verify:** Command exits 0. HostedCluster resource exists.
+
+3. Wait for the cluster to become available:
+   ```bash
+   oc get hostedcluster -n clusters ${CLUSTER_NAME} -w
+   export INFRA_ID=$(oc get hostedcluster -n clusters ${CLUSTER_NAME} -o jsonpath='{.spec.infraID}')
+   ```
+   **Verify:** `Available=True`. Infra ID is non-empty.
+
+4. Verify private DNS resources exist (should have more DNS zones/links than public topology):
+   ```bash
+   az resource list --resource-group ${RESOURCE_GROUP_NAME} \
+     --query "[?type=='Microsoft.Network/privateDnsZones' || type=='Microsoft.Network/privateDnsZones/virtualNetworkLinks' || type=='Microsoft.Network/privateEndpoints' || type=='Microsoft.Network/privateLinkServices']" -o table
+   ```
+   **Verify:** Multiple private DNS zones, vnet links, and optionally private endpoints/link services exist. Record the count and types for comparison after destroy.
+
+5. Destroy with preserve flag:
+   ```bash
+   bin/hcp destroy cluster azure \
+     --name ${CLUSTER_NAME} \
+     --azure-creds ${AZURE_CREDS} \
+     --dns-zone-rg-name ${DNS_ZONE_RG} \
+     --preserve-resource-group 2>&1 | tee /tmp/destroy-private-output.log
+   ```
+   **Verify:** Command exits 0.
+
+6. Verify retry loop entered and completed:
+   ```bash
+   grep "Starting cluster resource cleanup with retry" /tmp/destroy-private-output.log
+   grep "Successfully cleaned up cluster resources, resource group preserved" /tmp/destroy-private-output.log
+   ```
+   **Verify:** Both messages appear.
+
+7. Verify deletion order in logs — vnet links deleted before DNS zones:
+   ```bash
+   grep "Deleting cluster resource" /tmp/destroy-private-output.log
+   ```
+   **Verify:** Resources of type `virtualNetworkLinks` appear before `privateDnsZones` in the deletion sequence.
+
+8. Verify resource group preserved:
+   ```bash
+   az group show --name ${RESOURCE_GROUP_NAME} --query "properties.provisioningState" -o tsv
+   ```
+   **Verify:** Returns `Succeeded`.
+
+9. Verify no orphaned cluster resources remain:
+   ```bash
+   az resource list --resource-group ${RESOURCE_GROUP_NAME} \
+     --query "[?contains(name, '${INFRA_ID}') || starts_with(name, '${CLUSTER_NAME}-azurecluster')]" -o table
+   ```
+   **Verify:** Returns empty — all cluster-specific resources (including private topology resources) are cleaned up.
+
+10. Verify no orphaned private DNS resources:
+    ```bash
+    az network private-dns zone list \
+      --resource-group ${RESOURCE_GROUP_NAME} \
+      --query "[?contains(name, '${INFRA_ID}') || starts_with(name, '${CLUSTER_NAME}-azurecluster')]" -o table
+    ```
+    **Verify:** Returns empty.
+
+## Regression Testing
+
+### Related Features to Verify
+
+- [ ] `hcp destroy cluster azure` without `--preserve-resource-group` still works (Scenario 1)
+- [ ] Additional resource groups (vnet, nsg) are still deleted regardless of `--preserve-resource-group`
+- [ ] `hcp create cluster azure --resource-group-name` validation (verifies resource group exists)
+- [ ] RBAC cleanup still runs before infra destruction (`destroyPlatformSpecifics` calls `rbacManager.CleanupRoleAssignments` before `destroyInfraOptions.Run`)
+- [ ] `hcp infra destroy azure` direct command path (Scenario 5)
+
+### Unit Test Verification
+
+```bash
+# Run all azure infra destroy tests
+go test -v -count=1 ./cmd/infra/azure/... 2>&1 | tail -30
+# Verify: 19 tests pass (PASS), 0 failures
+
+# Run just the new retry tests
+go test -v -count=1 -run 'TestRetryDeleteClusterResources' ./cmd/infra/azure/...
+# Verify: 6 subtests pass
+
+# Run just the deletion order tests
+go test -v -count=1 -run 'TestSortResourcesByDeletionOrder' ./cmd/infra/azure/...
+# Verify: 3 subtests pass
+
+# Run validation tests
+go test -v -count=1 -run 'TestDestroyValidate' ./cmd/infra/azure/...
+# Verify: 2 subtests pass (negative grace period rejected, zero accepted)
+
+# Full build + lint + verify
+make verify
+# Verify: exits 0 with no lint errors and all checks passing
+```
+
+### CI Jobs
+
+- [ ] `/test e2e-aks` — Azure AKS-based E2E (general regression). **Verify:** Job passes.
+- [ ] `/test e2e-azure-v2-self-managed` — Azure self-managed E2E (if available). **Verify:** Job passes.
+- [ ] Standard presubmit jobs should pass. **Verify:** All required checks green on the PR.
+
+## Notes
+
+- The retry loop uses `wait.PollUntilContextCancel` with `immediate=true`, meaning it attempts the first deletion pass immediately without waiting for the retry interval
+- The `resourceDeleter` interface encapsulates both `BeginDeleteByID` and `PollUntilDone` into a single `DeleteByID` call, simplifying the retry logic
+- The `nonRetriableError` interface is defined locally to avoid importing the Azure SDK's internal `errorinfo` package — it matches the same structural typing pattern
+- The `retryInterval` field is test-only (unexported, zero-value means use `defaultRetryInterval` of 10s)
+- Deletion order now includes subnets (priority 7), inserted between disks (6) and NSGs (8)
+- `GetResourceGroupName` was unexported to `getResourceGroupName` — verify no external callers existed (it was only used internally)


### PR DESCRIPTION
## Summary

- Add retry loop with `wait.PollUntilContextCancel` for Azure resource cleanup when using `--preserve-resource-group`, mirroring the AWS destroy path's retry pattern
- Introduce `resourceDeleter` interface for testable resource deletion with mock-based unit tests
- Detect `NonRetriable` errors via structural typing to stop retrying on permanent failures (auth errors, invalid requests)
- Return joined errors instead of silently swallowing deletion failures, and log remaining resources on timeout

## Test plan

- [x] 19 unit tests pass (`go test -v ./cmd/infra/azure/...`), including 6 new retry behavior tests
- [x] Gitlint validation passes (`make run-gitlint`)
- [ ] `/test e2e-aks` — verify no regression on Azure E2E
- [ ] Manual test: `hcp destroy azure --preserve-resource-group` with DNS zone having active vnet links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --azure-infra-grace-period (default 5m) to control a retrying grace period for Azure infra destruction; negative values rejected, zero disables retries.
  * Preserve-resource-group cleanup now retries transient failures until success or timeout.

* **Bug Fixes**
  * Aggregates per-resource deletion errors and stops retries on non-retriable failures for more reliable cleanup.

* **Tests**
  * Expanded tests for retries, error handling, re-listing, ordering, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## AI Assistance

```ai-assisted
Tool: Claude Code 2.1.131
Model: claude-opus-4-6

Skills used:
- personal-claude-skills:tdd@0.1.0 (bryan-cox/personal-claude-skills@cd96dea7) — Test-driven development with vertical slicing
- superpowers:verification-before-completion@5.1.0 (anthropics/claude-plugins-official@a01a135f) — Evidence-based completion verification
- superpowers:finishing-a-development-branch@5.1.0 (anthropics/claude-plugins-official@a01a135f) — Branch completion and PR workflow
- ai-helpers:code-review:pre-commit-review@0.0.7 (openshift-eng/ai-helpers@74735316) — Multi-dimensional code review with Go and HyperShift profile
- ai-helpers:ai-sbom:generate@0.0.1 (openshift-eng/ai-helpers@b56bad09) — AI SBOM declaration generation
- repo:git-commit-format — Conventional commit formatting
- user:restructure-hypershift-commits — Component-based commit restructuring
```