### PR TITLE
OCPBUGS-78988: bump go builder and ubi images

### DIFF
--- a/Containerfile.control-plane
+++ b/Containerfile.control-plane
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.7-1773318690 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778054913 AS builder
 
 WORKDIR /hypershift
 
@@ -7,7 +7,7 @@ COPY --chown=default . .
 RUN make control-plane-operator \
   && make control-plane-pki-operator
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1773204619
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1777857961
 COPY --from=builder /hypershift/bin/control-plane-operator /usr/bin/control-plane-operator
 COPY --from=builder /hypershift/bin/control-plane-pki-operator /usr/bin/control-plane-pki-operator
 

--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.7-1773318690 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778054913 AS builder
 
 WORKDIR /hypershift
 
@@ -10,7 +10,7 @@ RUN make hypershift \
   && make product-cli \
   && make karpenter-operator
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1773204619
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1777857961
 COPY --from=builder /hypershift/bin/hypershift \
   /hypershift/bin/hypershift-no-cgo \
   /hypershift/bin/hcp \


### PR DESCRIPTION
## What this PR does / why we need it:

bump go builder and base ubi images to the latest available versions.
