### PR TITLE
OCPBUGS-85243: Set aws-load-balancer-scheme on public HCP router service

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/infra/infra_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/infra_test.go
@@ -1475,7 +1475,8 @@ func TestReconcileHCPRouterServices(t *testing.T) {
 				Name:      "router",
 				Namespace: namespace,
 				Annotations: map[string]string{
-					"service.beta.kubernetes.io/aws-load-balancer-type": "nlb",
+					"service.beta.kubernetes.io/aws-load-balancer-type":   "nlb",
+					"service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing",
 				},
 				Labels: map[string]string{"app": "private-router"},
 			},
@@ -1497,6 +1498,7 @@ func TestReconcileHCPRouterServices(t *testing.T) {
 		return publicService(append(m, func(s *corev1.Service) {
 			s.Name = "private-router"
 			s.Annotations["service.beta.kubernetes.io/aws-load-balancer-internal"] = "true"
+			delete(s.Annotations, "service.beta.kubernetes.io/aws-load-balancer-scheme")
 		})...)
 	}
 	withCrossZoneAnnotation := func(svc *corev1.Service) {

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_AWS_PublicAndPrivate_Route.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_AWS_PublicAndPrivate_Route.yaml
@@ -286,6 +286,7 @@ services:
       annotations:
         service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
         service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+        service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
         service.beta.kubernetes.io/aws-load-balancer-type: nlb
       labels:
         app: private-router

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_AWS_Public_Route.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/testdata/zz_fixture_TestReconcileInfrastructure_AWS_Public_Route.yaml
@@ -239,6 +239,7 @@ services:
       loadBalancer: {}
   - metadata:
       annotations:
+        service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
         service.beta.kubernetes.io/aws-load-balancer-type: nlb
       labels:
         app: private-router

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router.go
@@ -29,6 +29,15 @@ func ReconcileRouterService(svc *corev1.Service, internal, crossZoneLoadBalancin
 		svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
 		if internal {
 			svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-internal"] = "true"
+			delete(svc.Annotations, "service.beta.kubernetes.io/aws-load-balancer-scheme")
+		} else {
+			delete(svc.Annotations, "service.beta.kubernetes.io/aws-load-balancer-internal")
+			// The AWS Load Balancer Controller (used on EKS) defaults to scheme=internal:
+			//   https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/service/annotations/
+			// The in-tree AWS cloud provider (used on OpenShift) defaults to internet-facing:
+			//   https://cloud-provider-aws.sigs.k8s.io/service_controller/
+			// Set the annotation explicitly so the public router works on both.
+			svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-scheme"] = "internet-facing"
 		}
 		if crossZoneLoadBalancingEnabled {
 			// In-tree AWS cloud provider annotation for cross-zone load balancing (OpenShift management clusters).

--- a/control-plane-operator/controllers/hostedcontrolplane/ingress/router_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/ingress/router_test.go
@@ -3,6 +3,8 @@ package ingress
 import (
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/support/netutil"
 
@@ -53,6 +55,69 @@ func TestReconcileRouterServiceAnnotations(t *testing.T) {
 	}
 	if got := svc.Annotations["service.beta.kubernetes.io/aws-load-balancer-target-node-labels"]; got != targetNodesLabel {
 		t.Fatalf("expected target node labels annotation to be '%s', got %q", targetNodesLabel, got)
+	}
+}
+
+// When reconciling an external (non-internal) AWS router service
+// it should set aws-load-balancer-scheme to internet-facing.
+func TestReconcileRouterService_WhenExternalAWS_ItShouldSetInternetFacingScheme(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	hcp := &hyperv1.HostedControlPlane{}
+	hcp.Spec.Platform.Type = hyperv1.AWSPlatform
+
+	svc := &corev1.Service{}
+
+	err := ReconcileRouterService(svc, false /* internal */, true /* cross-zone */, hcp)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(svc.Annotations).To(HaveKeyWithValue(
+		"service.beta.kubernetes.io/aws-load-balancer-scheme", "internet-facing"))
+	g.Expect(svc.Annotations).ToNot(HaveKey(
+		"service.beta.kubernetes.io/aws-load-balancer-internal"))
+}
+
+func TestReconcileRouterService_WhenSwitchingMode_ItShouldRemoveConflictingAnnotation(t *testing.T) {
+	tests := []struct {
+		name         string
+		internal     bool
+		preExisting  map[string]string
+		expectKey    string
+		expectValue  string
+		expectAbsent string
+	}{
+		{
+			name:         "When switching from internal to external it should remove the internal annotation",
+			internal:     false,
+			preExisting:  map[string]string{"service.beta.kubernetes.io/aws-load-balancer-internal": "true"},
+			expectKey:    "service.beta.kubernetes.io/aws-load-balancer-scheme",
+			expectValue:  "internet-facing",
+			expectAbsent: "service.beta.kubernetes.io/aws-load-balancer-internal",
+		},
+		{
+			name:         "When switching from external to internal it should remove the scheme annotation",
+			internal:     true,
+			preExisting:  map[string]string{"service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing"},
+			expectKey:    "service.beta.kubernetes.io/aws-load-balancer-internal",
+			expectValue:  "true",
+			expectAbsent: "service.beta.kubernetes.io/aws-load-balancer-scheme",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			hcp := &hyperv1.HostedControlPlane{}
+			hcp.Spec.Platform.Type = hyperv1.AWSPlatform
+
+			svc := &corev1.Service{}
+			svc.Annotations = tt.preExisting
+
+			err := ReconcileRouterService(svc, tt.internal, true /* cross-zone */, hcp)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(svc.Annotations).To(HaveKeyWithValue(tt.expectKey, tt.expectValue))
+			g.Expect(svc.Annotations).ToNot(HaveKey(tt.expectAbsent))
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Set `service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing` on the public HCP router service so it creates an internet-facing NLB on both OpenShift (in-tree cloud provider) and EKS (AWS Load Balancer Controller) management clusters
- Clean up mutually exclusive annotations (`aws-load-balancer-internal` vs `aws-load-balancer-scheme`) when switching between internal and external

## Problem

The AWS Load Balancer Controller (used on EKS) defaults to `scheme=internal` when `aws-load-balancer-scheme` is not set ([docs](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/service/annotations/)). The in-tree AWS cloud provider (used on OpenShift) defaults to `internet-facing` ([docs](https://cloud-provider-aws.sigs.k8s.io/service_controller/)).

For `PublicAndPrivate` clusters using `type: Route` with explicit hostnames, HyperShift deploys a dedicated HCP router with a public LoadBalancer service. Without the scheme annotation, this NLB is created as internal on EKS, making KAS and OAuth unreachable from outside the VPC.

## Test plan

- [x] Existing unit tests updated to verify `internet-facing` annotation on public services
- [x] New tests for external scheme and internal-to-external switching
- [x] Verified internal services do NOT get the scheme annotation
- [x] Deploy PublicAndPrivate HCP on EKS and verify public router NLB is internet-facing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AWS load balancer annotation handling so external routers are marked internet-facing, internal routers use the internal-LB annotation, and conflicting scheme annotations are removed during transitions.

* **Tests**
  * Added tests covering external vs internal AWS annotation behavior and mode-switching scenarios; updated fixtures to reflect the expected scheme for public/private routers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->