### PR TITLE
OCPBUGS-54790: Move packageserver PDB from guest cluster to management cluster

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -189,6 +189,15 @@ spec:
           rm -f /var/payload/release-manifests/0000_03_marketplace-operator_02_operatorhub.cr.yaml
           cat > /var/payload/release-manifests/0000_01_cleanup.yaml <<EOF
           ---
+          apiVersion: policy/v1
+          kind: PodDisruptionBudget
+          metadata:
+            name: packageserver-pdb
+            namespace: openshift-operator-lifecycle-manager
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
           apiVersion: apiextensions.k8s.io/v1
           kind: CustomResourceDefinition
           metadata:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -152,6 +152,7 @@ spec:
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.service.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.servicemonitor.yaml
+          rm -f /var/payload/release-manifests/0000_50_olm_00-packageserver.pdb.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-collect-profiles.cronjob.yaml

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -200,6 +200,15 @@ spec:
           rm -f /var/payload/release-manifests/0000_03_marketplace-operator_02_operatorhub.cr.yaml
           cat > /var/payload/release-manifests/0000_01_cleanup.yaml <<EOF
           ---
+          apiVersion: policy/v1
+          kind: PodDisruptionBudget
+          metadata:
+            name: packageserver-pdb
+            namespace: openshift-operator-lifecycle-manager
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
           apiVersion: apiextensions.k8s.io/v1
           kind: CustomResourceDefinition
           metadata:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -163,6 +163,7 @@ spec:
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.service.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.servicemonitor.yaml
+          rm -f /var/payload/release-manifests/0000_50_olm_00-packageserver.pdb.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-collect-profiles.cronjob.yaml

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -152,6 +152,7 @@ spec:
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.service.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.servicemonitor.yaml
+          rm -f /var/payload/release-manifests/0000_50_olm_00-packageserver.pdb.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-collect-profiles.cronjob.yaml

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -187,6 +187,15 @@ spec:
           rm -f /var/payload/release-manifests/0000_03_marketplace-operator_02_operatorhub.cr.yaml
           cat > /var/payload/release-manifests/0000_01_cleanup.yaml <<EOF
           ---
+          apiVersion: policy/v1
+          kind: PodDisruptionBudget
+          metadata:
+            name: packageserver-pdb
+            namespace: openshift-operator-lifecycle-manager
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
           apiVersion: apps/v1
           kind: Deployment
           metadata:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -189,6 +189,15 @@ spec:
           rm -f /var/payload/release-manifests/0000_03_marketplace-operator_02_operatorhub.cr.yaml
           cat > /var/payload/release-manifests/0000_01_cleanup.yaml <<EOF
           ---
+          apiVersion: policy/v1
+          kind: PodDisruptionBudget
+          metadata:
+            name: packageserver-pdb
+            namespace: openshift-operator-lifecycle-manager
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
           apiVersion: apiextensions.k8s.io/v1
           kind: CustomResourceDefinition
           metadata:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -152,6 +152,7 @@ spec:
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.service.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.servicemonitor.yaml
+          rm -f /var/payload/release-manifests/0000_50_olm_00-packageserver.pdb.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-collect-profiles.cronjob.yaml

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -189,6 +189,15 @@ spec:
           rm -f /var/payload/release-manifests/0000_03_marketplace-operator_02_operatorhub.cr.yaml
           cat > /var/payload/release-manifests/0000_01_cleanup.yaml <<EOF
           ---
+          apiVersion: policy/v1
+          kind: PodDisruptionBudget
+          metadata:
+            name: packageserver-pdb
+            namespace: openshift-operator-lifecycle-manager
+            annotations:
+              include.release.openshift.io/ibm-cloud-managed: "true"
+              release.openshift.io/delete: "true"
+          ---
           apiVersion: apiextensions.k8s.io/v1
           kind: CustomResourceDefinition
           metadata:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-version-operator/zz_fixture_TestControlPlaneComponents_cluster_version_operator_deployment.yaml
@@ -152,6 +152,7 @@ spec:
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.service.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_06-psm-operator.servicemonitor.yaml
+          rm -f /var/payload/release-manifests/0000_50_olm_00-packageserver.pdb.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-olm-operator.deployment.yaml
           rm -f /var/payload/release-manifests/0000_50_olm_07-collect-profiles.cronjob.yaml

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/AROSwift/zz_fixture_TestControlPlaneComponents_packageserver_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/AROSwift/zz_fixture_TestControlPlaneComponents_packageserver_controlplanecomponent.yaml
@@ -18,3 +18,7 @@ status:
     reason: WaitingForRolloutComplete
     status: "False"
     type: RolloutComplete
+  resources:
+  - group: policy
+    kind: PodDisruptionBudget
+    name: packageserver-pdb

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/AROSwift/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/AROSwift/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: packageserver-pdb
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  selector:
+    matchLabels:
+      app: packageserver
+  unhealthyPodEvictionPolicy: AlwaysAllow
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/GCP/zz_fixture_TestControlPlaneComponents_packageserver_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/GCP/zz_fixture_TestControlPlaneComponents_packageserver_controlplanecomponent.yaml
@@ -18,3 +18,7 @@ status:
     reason: WaitingForRolloutComplete
     status: "False"
     type: RolloutComplete
+  resources:
+  - group: policy
+    kind: PodDisruptionBudget
+    name: packageserver-pdb

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/GCP/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/GCP/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: packageserver-pdb
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  selector:
+    matchLabels:
+      app: packageserver
+  unhealthyPodEvictionPolicy: AlwaysAllow
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/IBMCloud/zz_fixture_TestControlPlaneComponents_packageserver_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/IBMCloud/zz_fixture_TestControlPlaneComponents_packageserver_controlplanecomponent.yaml
@@ -18,3 +18,7 @@ status:
     reason: WaitingForRolloutComplete
     status: "False"
     type: RolloutComplete
+  resources:
+  - group: policy
+    kind: PodDisruptionBudget
+    name: packageserver-pdb

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/IBMCloud/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/IBMCloud/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: packageserver-pdb
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  selector:
+    matchLabels:
+      app: packageserver
+  unhealthyPodEvictionPolicy: AlwaysAllow
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_packageserver_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_packageserver_controlplanecomponent.yaml
@@ -18,3 +18,7 @@ status:
     reason: WaitingForRolloutComplete
     status: "False"
     type: RolloutComplete
+  resources:
+  - group: policy
+    kind: PodDisruptionBudget
+    name: packageserver-pdb

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: packageserver-pdb
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  selector:
+    matchLabels:
+      app: packageserver
+  unhealthyPodEvictionPolicy: AlwaysAllow
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/zz_fixture_TestControlPlaneComponents_packageserver_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/zz_fixture_TestControlPlaneComponents_packageserver_controlplanecomponent.yaml
@@ -18,3 +18,7 @@ status:
     reason: WaitingForRolloutComplete
     status: "False"
     type: RolloutComplete
+  resources:
+  - group: policy
+    kind: PodDisruptionBudget
+    name: packageserver-pdb

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/zz_fixture_TestControlPlaneComponents_packageserver_pdb_poddisruptionbudget.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: packageserver-pdb
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  selector:
+    matchLabels:
+      app: packageserver
+  unhealthyPodEvictionPolicy: AlwaysAllow
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/packageserver/pdb.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/packageserver/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: packageserver-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: packageserver

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment.go
@@ -22,6 +22,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -148,6 +149,7 @@ var (
 		"0000_50_olm_06-psm-operator.deployment.ibm-cloud-managed.yaml",
 		"0000_50_olm_06-psm-operator.service.yaml",
 		"0000_50_olm_06-psm-operator.servicemonitor.yaml",
+		"0000_50_olm_00-packageserver.pdb.yaml",
 		"0000_50_olm_07-olm-operator.deployment.ibm-cloud-managed.yaml",
 		"0000_50_olm_07-olm-operator.deployment.yaml",
 		"0000_50_olm_07-collect-profiles.cronjob.yaml",
@@ -266,6 +268,7 @@ func resourcesToRemove(platformType hyperv1.PlatformType) []client.Object {
 	switch platformType {
 	case hyperv1.IBMCloudPlatform, hyperv1.PowerVSPlatform:
 		return []client.Object{
+			&policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Name: "packageserver-pdb", Namespace: "openshift-operator-lifecycle-manager"}},
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "network-operator", Namespace: "openshift-network-operator"}},
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "default-account-cluster-network-operator"}},
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "cluster-node-tuning-operator", Namespace: "openshift-cluster-node-tuning-operator"}},
@@ -273,6 +276,7 @@ func resourcesToRemove(platformType hyperv1.PlatformType) []client.Object {
 		}
 	default:
 		return []client.Object{
+			&policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Name: "packageserver-pdb", Namespace: "openshift-operator-lifecycle-manager"}},
 			&apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "machineconfigs.machineconfiguration.openshift.io"}},
 			&apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: "machineconfigpools.machineconfiguration.openshift.io"}},
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "network-operator", Namespace: "openshift-network-operator"}},

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cvo/deployment_test.go
@@ -110,6 +110,15 @@ func TestPreparePayloadScript(t *testing.T) {
 				g.Expect(script).To(ContainSubstring("0000_01_cleanup.yaml"))
 			},
 		},
+		{
+			name:         "When called, it should omit the packageserver PDB manifest from the payload",
+			platformType: hyperv1.AWSPlatform,
+			oauthEnabled: true,
+			featureSet:   configv1.Default,
+			assertions: func(g Gomega, script string) {
+				g.Expect(script).To(ContainSubstring("rm -f /var/payload/release-manifests/0000_50_olm_00-packageserver.pdb.yaml"))
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -135,6 +144,7 @@ func TestResourcesToRemove(t *testing.T) {
 			name:         "When platform is IBMCloud, it should return IBM-specific resources without CRDs",
 			platformType: hyperv1.IBMCloudPlatform,
 			assertions: func(g Gomega, resources []string) {
+				g.Expect(resources).To(ContainElement("packageserver-pdb"))
 				g.Expect(resources).To(ContainElement("network-operator"))
 				g.Expect(resources).To(ContainElement("default-account-cluster-network-operator"))
 				g.Expect(resources).To(ContainElement("cluster-node-tuning-operator"))
@@ -158,6 +168,7 @@ func TestResourcesToRemove(t *testing.T) {
 			name:         "When platform is AWS (default), it should return the full list including CRDs and storage operators",
 			platformType: hyperv1.AWSPlatform,
 			assertions: func(g Gomega, resources []string) {
+				g.Expect(resources).To(ContainElement("packageserver-pdb"))
 				g.Expect(resources).To(ContainElement("machineconfigs.machineconfiguration.openshift.io"))
 				g.Expect(resources).To(ContainElement("machineconfigpools.machineconfiguration.openshift.io"))
 				g.Expect(resources).To(ContainElement("network-operator"))

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/olm/packageserver/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/olm/packageserver/component.go
@@ -33,6 +33,10 @@ func (r *packageServer) NeedsManagementKASAccess() bool {
 func NewComponent() component.ControlPlaneComponent {
 	return component.NewDeploymentComponent(ComponentName, &packageServer{}).
 		WithAdaptFunction(adaptDeployment).
+		WithManifestAdapter(
+			"pdb.yaml",
+			component.AdaptPodDisruptionBudget(),
+		).
 		InjectKonnectivityContainer(component.KonnectivityContainerOptions{
 			Mode: component.Socks5,
 		}).

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/olm/packageserver/component_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/olm/packageserver/component_test.go
@@ -1,0 +1,16 @@
+package packageserver
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestNewComponent(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	component := NewComponent()
+	g.Expect(component).ToNot(BeNil())
+	g.Expect(component.Name()).To(Equal("packageserver"))
+}


### PR DESCRIPTION
## What this PR does / why we need it:

The packageserver PodDisruptionBudget was being created in the guest cluster's
`openshift-operator-lifecycle-manager` namespace by CVO. However, packageserver
pods run on the management cluster in the `clusters-<hosted-cluster>` namespace,
making the guest cluster PDB ineffective.

This PR:
- Prevents CVO from creating the packageserver PDB in the guest cluster (via `manifestsToOmit`)
- Cleans up the orphaned PDB on existing clusters during upgrade (via `resourcesToRemove`)
- Creates the PDB in the management cluster namespace using the cpov2 framework

## Which issue(s) this PR fixes:

Fixes OCPBUGS-54790

## Special notes for your reviewer:

The PDB cleanup applies to all platforms (both IBM/PowerVS and default) since
packageserver runs on the management cluster regardless of platform.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added a PodDisruptionBudget for the packageserver (minAvailable: 1) to improve availability during disruptions and ensure it is managed as part of lifecycle operations.

* **Tests**
  * Added a unit test validating the packageserver component is created and named "packageserver".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->