### PR TITLE
OCPBUGS-85344: Add version gates for 4.22 backward compatibility in e2e tests

### DIFF
--- a/test/e2e/karpenter_test.go
+++ b/test/e2e/karpenter_test.go
@@ -49,7 +49,7 @@ import (
 )
 
 func TestKarpenter(t *testing.T) {
-	e2eutil.AtLeast(t, e2eutil.Version422)
+	e2eutil.ShouldRunKarpenterTests(t)
 	if globalOpts.Platform != hyperv1.AWSPlatform {
 		t.Skip("test only supported on platform AWS")
 	}

--- a/test/e2e/nodepool_test.go
+++ b/test/e2e/nodepool_test.go
@@ -363,7 +363,9 @@ func executeNodePoolTest(t *testing.T, ctx context.Context, mgmtClient crclient.
 	// Validate that CAPI v1 condition messages are bubbled up during machine provisioning.
 	// This checks that the AllMachinesReady condition is populated with CAPI-derived
 	// machine-level details before machines are fully ready.
-	if nodePool.Spec.Replicas != nil && *nodePool.Spec.Replicas > 0 {
+	// The CAPI condition aggregation logic was introduced in 4.23; older operators don't produce
+	// the expected "machines are not healthy" message format during provisioning.
+	if e2eutil.IsGreaterThanOrEqualTo(e2eutil.Version423) && nodePool.Spec.Replicas != nil && *nodePool.Spec.Replicas > 0 {
 		validateCAPIConditionBubblingDuringProvisioning(t, ctx, mgmtClient, nodePool)
 	}
 
@@ -412,7 +414,8 @@ func validateNodePoolConditions(t *testing.T, ctx context.Context, client crclie
 		// to ensure CAPI v1 condition messages are properly aggregated and bubbled up.
 		// When all machines are ready and healthy, the aggregation pipeline should produce
 		// Reason=AsExpected and Message="All is well".
-		if expectedSupportedVersionSkew {
+		// The CAPI condition aggregation logic was introduced in 4.23.
+		if expectedSupportedVersionSkew && e2eutil.IsGreaterThanOrEqualTo(e2eutil.Version423) {
 			switch conditionType {
 			case hyperv1.NodePoolAllMachinesReadyConditionType, hyperv1.NodePoolAllNodesHealthyConditionType:
 				condition.Reason = hyperv1.AsExpectedReason

--- a/test/e2e/util/version.go
+++ b/test/e2e/util/version.go
@@ -114,3 +114,15 @@ func IsLessThan(version semver.Version) bool {
 func IsGreaterThanOrEqualTo(version semver.Version) bool {
 	return releaseVersion.GE(version)
 }
+
+// ShouldRunKarpenterTests skips the test unless the Karpenter v1 API is available.
+// The v1 API exists on 4.23+, but when the operator is built from main and
+// tested against a 4.22 hosted cluster, set RUN_KARPENTER_TESTS=true to
+// lower the gate to 4.22.
+func ShouldRunKarpenterTests(t *testing.T) {
+	if os.Getenv("RUN_KARPENTER_TESTS") == "true" {
+		AtLeast(t, Version422)
+	} else {
+		AtLeast(t, Version423)
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it:

The e2e test binary from main fails when run against 4.22 hosted clusters. This was discovered when https://github.com/openshift/release/pull/78912 changed the 4.22 CI config to use the pre-built e2e binary from main instead of building from the 4.22 branch.

Changes:
- **CAPI condition bubbling** (`nodepool_test.go`): Gate `validateCAPIConditionBubblingDuringProvisioning` and the AllMachinesReady/AllNodesHealthy Reason/Message checks behind `IsGreaterThanOrEqualTo(Version423)`, since the CAPI v1 condition aggregation logic only exists in 4.23+.
- **Karpenter tests** (`karpenter_test.go`): Add `ShouldRunKarpenterTests` helper that gates on 4.23 by default (the `karpenter.hypershift.openshift.io/v1` API only exists on main), but lowers the gate to 4.22 when `RUN_KARPENTER_TESTS=true` is set — for CI jobs like `e2e-aws-4-22` where the operator is built from main but tested against 4.22 clusters.

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/OCPBUGS-85344

## Special notes for your reviewer:

Depends on https://github.com/openshift/release/pull/78912 for the CI config change that switches the 4.22 branch to use the e2e binary from main.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test execution gating mechanism for Karpenter e2e tests with environment variable-based control.
  * Refined version-specific test conditions for NodePool validations to ensure proper compatibility checks.
  * Improved test preconditions to enforce minimum version requirements based on feature availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->