### PR TITLE
WIP: NO-JIRA: stream karpenter pod logs during HC teardown

### DIFF
--- a/test/e2e/util/hypershift_framework.go
+++ b/test/e2e/util/hypershift_framework.go
@@ -556,6 +556,13 @@ func teardownHostedCluster(t *testing.T, ctx context.Context, hc *hyperv1.Hosted
 	// Save off any error so that we can continue with the teardown
 	dumpErr := dumpCluster(ctx, t, true)
 
+	// Stream karpenter pod logs in the background so we capture the teardown
+	// window. Point-in-time dumps miss this because the pods are killed during
+	// HC deletion, before the retry dump runs.
+	cpNamespace := manifests.HostedControlPlaneNamespace(hc.Namespace, hc.Name)
+	stopStreaming := streamHCPPodLogs(ctx, t, cpNamespace, artifactDir)
+	defer stopStreaming()
+
 	// Try repeatedly to destroy the cluster gracefully. For each failure, dump
 	// the current cluster to help debug teardown lifecycle issues.
 	destroyAttempt := 1

--- a/test/e2e/util/teardown_log_streamer.go
+++ b/test/e2e/util/teardown_log_streamer.go
@@ -1,0 +1,105 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeclient "k8s.io/client-go/kubernetes"
+
+	"github.com/openshift/hypershift/cmd/util"
+)
+
+// streamHCPPodLogs starts background goroutines that follow logs from
+// karpenter-related pods in the given HCP namespace. This captures the
+// teardown window — the period between HC deletion and pod termination —
+// which point-in-time dumps miss because the pods are dead by the time
+// the retry dump runs.
+//
+// Returns a stop function that cancels all streams and waits for the
+// goroutines to exit. The caller must invoke it (typically via defer).
+func streamHCPPodLogs(ctx context.Context, t *testing.T, namespace, artifactDir string) func() {
+	streamCtx, cancel := context.WithCancel(ctx)
+	noop := func() { cancel() }
+
+	cfg, err := util.GetConfig()
+	if err != nil {
+		t.Logf("Teardown log streaming: failed to get rest config: %v", err)
+		return noop
+	}
+
+	kc, err := kubeclient.NewForConfig(cfg)
+	if err != nil {
+		t.Logf("Teardown log streaming: failed to create kubeclient: %v", err)
+		return noop
+	}
+
+	logDir := filepath.Join(artifactDir, "teardown-logs")
+	if err := os.MkdirAll(logDir, 0755); err != nil {
+		t.Logf("Teardown log streaming: failed to create directory: %v", err)
+		return noop
+	}
+
+	selectors := []string{"app=karpenter", "app=karpenter-operator"}
+
+	var wg sync.WaitGroup
+	started := 0
+	for _, sel := range selectors {
+		pods, err := kc.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: sel,
+		})
+		if err != nil {
+			t.Logf("Teardown log streaming: failed to list pods (selector=%s): %v", sel, err)
+			continue
+		}
+		for i := range pods.Items {
+			pod := &pods.Items[i]
+			for _, container := range pod.Spec.Containers {
+				wg.Add(1)
+				started++
+				go followContainerLog(streamCtx, t, &wg, kc, namespace, pod.Name, container.Name, logDir)
+			}
+		}
+	}
+
+	if started == 0 {
+		t.Logf("Teardown log streaming: no karpenter pods found in %s, skipping", namespace)
+		return noop
+	}
+
+	t.Logf("Teardown log streaming: following %d container(s) in %s", started, namespace)
+	return func() {
+		cancel()
+		wg.Wait()
+	}
+}
+
+func followContainerLog(ctx context.Context, t *testing.T, wg *sync.WaitGroup, kc kubeclient.Interface, namespace, podName, containerName, logDir string) {
+	defer wg.Done()
+
+	fileName := filepath.Join(logDir, fmt.Sprintf("%s-%s.log", podName, containerName))
+	f, err := os.Create(fileName)
+	if err != nil {
+		t.Logf("Teardown log streaming: failed to create log file %s: %v", fileName, err)
+		return
+	}
+	defer f.Close()
+
+	stream, err := kc.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
+		Container: containerName,
+		Follow:    true,
+	}).Stream(ctx)
+	if err != nil {
+		t.Logf("Teardown log streaming: failed to stream logs for %s/%s: %v", podName, containerName, err)
+		return
+	}
+	defer stream.Close()
+
+	io.Copy(f, stream)
+}


### PR DESCRIPTION
## What this PR does / why we need it:

Point-in-time dumps miss the teardown window because karpenter pods are killed during HC deletion before the retry dump runs. Start Follow streams on karpenter-operator and karpenter pods before the destroy loop so the full finalizer-cleanup sequence is captured in teardown-logs/.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Real-time streaming of hosted control plane pod logs during teardown so logs are captured continuously rather than only in point-in-time dumps.
  * New background log-streaming utilities to collect per-pod/container log files into teardown artifacts for improved diagnostics and faster root-cause analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->