### PR TITLE
OCPBUGS-85084: fix(ci): use explicit lease in dependabot commit fix push

### DIFF
--- a/.github/workflows/dependabot-commit-fix-reusable.yaml
+++ b/.github/workflows/dependabot-commit-fix-reusable.yaml
@@ -31,6 +31,7 @@ jobs:
       - name: Rewrite commit body
         env:
           HEAD_BRANCH: ${{ inputs.head_branch }}
+          HEAD_SHA: ${{ inputs.head_sha }}
         run: |
           SUBJECT=$(git log -1 --format='%s')
           BODY=$(git log -1 --format='%b')
@@ -70,4 +71,4 @@ jobs:
           git config user.name "dependabot[bot]"
           git config user.email "49699333+dependabot[bot]@users.noreply.github.com"
           git commit --amend -F /tmp/commit-msg.txt
-          git push --force-with-lease origin HEAD:"${HEAD_BRANCH}"
+          git push "--force-with-lease=${HEAD_BRANCH}:${HEAD_SHA}" origin HEAD:"${HEAD_BRANCH}"


### PR DESCRIPTION
## Summary

- Fix `--force-with-lease` push failure ("stale info") in the dependabot commit message fix workflow
- Use explicit lease form `--force-with-lease=<ref>:<expected-sha>` instead of relying on local tracking refs that don't exist in the shallow detached HEAD clone created by `actions/checkout`

## Root Cause Analysis

The `dependabot-commit-fix-reusable.yaml` workflow (introduced in #8435) rewrites dependabot commit messages to pass gitlint, then pushes the amended commit. **Every push has failed** since the workflow was introduced.

**Why it fails:**

1. `actions/checkout` with `ref: <SHA>` + `fetch-depth: 2` creates a **shallow clone in detached HEAD** state
2. In this state, git has no remote tracking branches (no `refs/remotes/origin/<branch>`)
3. `--force-with-lease` without an explicit expected value needs the local remote-tracking ref to compare against the current remote state
4. Since no tracking ref exists, git reports `(stale info)` and rejects the push

**Evidence:** All 6 workflow runs triggered by dependabot Gitlint failures on 2026-05-08 failed with the same error:
```
! [rejected] HEAD -> dependabot/go_modules/... (stale info)
error: failed to push some refs to 'https://github.com/openshift/hypershift'
```

**Fix:** Use `--force-with-lease=${HEAD_BRANCH}:${HEAD_SHA}` which explicitly provides the expected remote SHA, bypassing the need for local tracking refs. Verified empirically by reproducing the exact `actions/checkout` shallow clone scenario locally.

## Test plan

- [ ] Trigger a dependabot rebase on an existing PR (`@dependabot rebase` on #8460) to re-run Gitlint → fix workflow chain
- [ ] Verify the fix workflow completes successfully (push succeeds)
- [ ] Verify the dependabot commit message is rewritten correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Validation

- Run `@dependabot rebase` at https://github.com/openshift/hypershift/pull/8460 once this PR got merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the reliability of automated commit processing in continuous integration workflows by refining version control push operations with more precise specifications for handling code updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->