### PR TITLE
OCPBUGS-76530: Fix intermittent etcd peer communication failures

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/pki/etcd.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/etcd.go
@@ -45,6 +45,9 @@ func ReconcileEtcdPeerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef
 	dnsNames := []string{
 		fmt.Sprintf("*.etcd-discovery.%s.svc", secret.Namespace),
 		fmt.Sprintf("*.etcd-discovery.%s.svc.cluster.local", secret.Namespace),
+		// etcd-client uses a ClusterIP service (not headless), so it does not create per-pod
+		// PTR records and cannot cause reverse DNS ambiguity during peer TLS verification.
+		// TODO(OCPBUGS-86648): move IPs to the ips parameter of reconcileSignedCertWithKeysAndAddresses.
 		"127.0.0.1",
 		"::1",
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/etcd_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/etcd_test.go
@@ -1,0 +1,81 @@
+package pki
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/support/certs"
+	"github.com/openshift/hypershift/support/config"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestReconcileEtcdPeerSecret(t *testing.T) {
+	t.Parallel()
+
+	caCfg := certs.CertCfg{
+		IsCA:    true,
+		Subject: pkix.Name{CommonName: "etcd-signer", OrganizationalUnit: []string{"openshift"}},
+	}
+	caKey, caCert, err := certs.GenerateSelfSignedCertificate(&caCfg)
+	if err != nil {
+		t.Fatalf("failed to generate CA: %v", err)
+	}
+	caSecret := &corev1.Secret{
+		Data: map[string][]byte{
+			certs.CASignerCertMapKey: certs.CertToPem(caCert),
+			certs.CASignerKeyMapKey:  certs.PrivateKeyToPem(caKey),
+		},
+	}
+
+	t.Run("When reconciling etcd peer secret it should include etcd-discovery SANs", func(t *testing.T) {
+		g := NewWithT(t)
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "clusters-test",
+			},
+		}
+
+		err := ReconcileEtcdPeerSecret(secret, caSecret, config.OwnerRef{})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		certData := secret.Data[EtcdPeerCrtKey]
+		g.Expect(certData).ToNot(BeEmpty())
+
+		cert, err := certs.PemToCertificate(certData)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(cert.DNSNames).To(ContainElements(
+			"*.etcd-discovery.clusters-test.svc",
+			"*.etcd-discovery.clusters-test.svc.cluster.local",
+			// TODO(OCPBUGS-86648): assert on cert.IPAddresses instead once IPs are moved out of dnsNames.
+			"127.0.0.1",
+			"::1",
+		))
+		g.Expect(cert.DNSNames).ToNot(ContainElement(ContainSubstring("etcd-client")))
+	})
+
+	t.Run("When reconciling etcd peer secret it should have client and server auth usage", func(t *testing.T) {
+		g := NewWithT(t)
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "clusters-test",
+			},
+		}
+
+		err := ReconcileEtcdPeerSecret(secret, caSecret, config.OwnerRef{})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		cert, err := certs.PemToCertificate(secret.Data[EtcdPeerCrtKey])
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(cert.ExtKeyUsage).To(ContainElements(
+			x509.ExtKeyUsageClientAuth,
+			x509.ExtKeyUsageServerAuth,
+		))
+	})
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/AROSwift/zz_fixture_TestControlPlaneComponents_etcd_client_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/AROSwift/zz_fixture_TestControlPlaneComponents_etcd_client_service.yaml
@@ -14,7 +14,6 @@ metadata:
     uid: ""
   resourceVersion: "1"
 spec:
-  clusterIP: None
   ports:
   - name: etcd-client
     port: 2379

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/GCP/zz_fixture_TestControlPlaneComponents_etcd_client_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/GCP/zz_fixture_TestControlPlaneComponents_etcd_client_service.yaml
@@ -14,7 +14,6 @@ metadata:
     uid: ""
   resourceVersion: "1"
 spec:
-  clusterIP: None
   ports:
   - name: etcd-client
     port: 2379

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/IBMCloud/zz_fixture_TestControlPlaneComponents_etcd_client_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/IBMCloud/zz_fixture_TestControlPlaneComponents_etcd_client_service.yaml
@@ -14,7 +14,6 @@ metadata:
     uid: ""
   resourceVersion: "1"
 spec:
-  clusterIP: None
   ports:
   - name: etcd-client
     port: 2379

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_etcd_client_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_etcd_client_service.yaml
@@ -14,7 +14,6 @@ metadata:
     uid: ""
   resourceVersion: "1"
 spec:
-  clusterIP: None
   ports:
   - name: etcd-client
     port: 2379

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_etcd_client_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_etcd_client_service.yaml
@@ -14,7 +14,6 @@ metadata:
     uid: ""
   resourceVersion: "1"
 spec:
-  clusterIP: None
   ports:
   - name: etcd-client
     port: 2379

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/etcd/service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/etcd/service.yaml
@@ -5,7 +5,6 @@ metadata:
     app: etcd
   name: etcd-client
 spec:
-  clusterIP: None
   ports:
   - name: etcd-client
     port: 2379


### PR DESCRIPTION
## What this PR does / why we need it:

Both `etcd-discovery` and `etcd-client` were headless services selecting the same etcd pods (`app: etcd`), causing CoreDNS to register two PTR records per pod IP. The etcd peer certificate only included `*.etcd-discovery` wildcard SANs, so when Go's `getnameinfo()` non-deterministically returned the `etcd-client` PTR record during peer TLS verification, the SAN check failed and peer connections were rejected (~50% of attempts).

This PR switches the `etcd-client` service from headless (`clusterIP: None`) to a regular ClusterIP service, which eliminates the per-pod PTR records that caused the reverse DNS ambiguity. With this change, only `etcd-discovery` creates per-pod PTR records, so peer TLS verification consistently resolves to the correct SAN.

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/OCPBUGS-76530

## Special notes for your reviewer:

- The `etcd-client` service is switched from headless to ClusterIP — this removes per-pod PTR records and resolves the dual-PTR ambiguity
- etcd-client SANs are intentionally not added to the peer cert since they are no longer needed with the ClusterIP change
- A unit test explicitly asserts that etcd-client SANs are absent from the peer certificate
- The ClusterIP change was originally authored by @csrwng in #8612 and incorporated here
- This is a HyperShift-specific issue — standalone OCP etcd uses static pods with node IPs, no dual headless services
- Tech debt tracked in [OCPBUGS-86648](https://issues.redhat.com/browse/OCPBUGS-86648): IPs (`127.0.0.1`, `::1`) are currently passed in `dnsNames` instead of `ips`

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

Authored by Vimal Solanki