### PR TITLE
OCPBUGS-78539: re-add crash toleration for dns-operator during upgrades

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -139,6 +139,12 @@ var (
 		// Allow 1 restart for token-minter sidecar race condition: https://issues.redhat.com/browse/GCP-441
 		// TODO(GCP-447): Remove this toleration once token-minter is injected as a native sidecar init container.
 		"gcp-cloud-controller-manager": 1,
+		// During minor version upgrades the controlplane-manager rolls out the new dns-operator
+		// before CVO applies the updated ClusterRole on the hosted cluster. The 4.22 dns-operator
+		// requires NetworkPolicy and APIServer RBAC that doesn't exist in 4.21, so it crash-loops
+		// until CVO catches up. This is a deterministic ordering issue, not a race.
+		// See https://issues.redhat.com/browse/OCPBUGS-78539
+		"dns-operator": 5,
 	}
 )
 


### PR DESCRIPTION
## Summary

- Re-adds the temporary e2e crash toleration for `dns-operator` that was removed in #7994
- The toleration was removed because same-version tests passed once RBAC manifests reached the 4.22 payload
- However, during **minor version upgrades** (4.21→4.22), the controlplane-manager rolls out the new dns-operator before CVO applies the updated ClusterRole on the hosted cluster, causing deterministic crash-loops

## Root Cause

The 4.22 `cluster-dns-operator` added two new RBAC requirements:
- `networkpolicies.networking.k8s.io` (PR openshift/cluster-dns-operator#468, [NE-2500](https://redhat.atlassian.net/browse/NE-2500))
- `apiservers.config.openshift.io` (PR openshift/cluster-dns-operator#466, OCPBUGS-62178)

During a 4.21→4.22 upgrade, the 4.21 ClusterRole lacks these permissions. The controlplane-manager deploys the 4.22 binary before CVO applies the updated ClusterRole, so the dns-operator crashes until CVO catches up. This is a deterministic ordering issue — the deployment rollout is not gated on CVO progress.

## Why the toleration was prematurely removed

PR #7994 removed the toleration because the dns-operator RBAC manifests had landed in the 4.22 nightly payload, making same-version CI tests (`e2e-aks-4-22`, `e2e-aws-4-22`) pass. The upgrade path (4.21→4.22) was not validated before removal.

## References

- https://redhat.atlassian.net/browse/OCPBUGS-78539
- Reverts #7994 (partially — re-adds the toleration)
- Original toleration: #7978
- Regression surfaced in: openshift/release#73748

## Test plan

- [ ] Verify `TestUpgradeControlPlane/Main/EnsureNoCrashingPods` passes on 4.21→4.22 upgrade jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability during minor version upgrades by increasing crash-restart tolerance for the dns-operator, allowing transient restarts without prolonged outages. This reduces temporary crash-loops, minimizes service interruptions during control plane rollout, and speeds automatic recovery so services resume more quickly after upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->