### PR TITLE
OCPBUGS-86008: Gate Route watch on management cluster capability

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/cmd.go
+++ b/control-plane-operator/hostedclusterconfigoperator/cmd.go
@@ -33,12 +33,14 @@ import (
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/spotremediation"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/operator"
 	hyperapi "github.com/openshift/hypershift/support/api"
+	"github.com/openshift/hypershift/support/capabilities"
 	"github.com/openshift/hypershift/support/labelenforcingclient"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/supportedversion"
 	"github.com/openshift/hypershift/support/upsert"
 	"github.com/openshift/hypershift/support/util"
 
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -222,6 +224,19 @@ func (o *HostedClusterConfigOperator) Run(ctx context.Context) error {
 	}
 	cfg := operator.CfgFromFile(o.TargetKubeconfig)
 	cpConfig := ctrl.GetConfigOrDie()
+
+	// Detect the management cluster capabilities once at startup so controllers can
+	// gate optional behavior (e.g. watching route.openshift.io Routes) without each
+	// having to build its own discovery client.
+	cpDiscoveryClient, err := discovery.NewDiscoveryClientForConfig(cpConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create management cluster discovery client: %w", err)
+	}
+	mgmtClusterCaps, err := capabilities.DetectManagementClusterCapabilities(cpDiscoveryClient)
+	if err != nil {
+		return fmt.Errorf("failed to detect management cluster capabilities: %w", err)
+	}
+
 	mgr := operator.Mgr(ctx, cfg, cpConfig, o.Namespace, o.HostedControlPlaneName)
 	mgr.GetLogger().Info("Starting hosted-cluster-config-operator", "version", supportedversion.String())
 	cpCluster, err := cluster.New(cpConfig, func(opt *cluster.Options) {
@@ -302,27 +317,28 @@ func (o *HostedClusterConfigOperator) Run(ctx context.Context) error {
 			APIClient: apiReadingClient,
 		},
 
-		Config:                cpConfig,
-		TargetConfig:          cfg,
-		KubevirtInfraConfig:   kubevirtInfraConfig,
-		Manager:               mgr,
-		Namespace:             o.Namespace,
-		HCPName:               o.HostedControlPlaneName,
-		InitialCA:             string(o.initialCA),
-		ClusterSignerCA:       string(o.clusterSignerCA),
-		ControllerFuncs:       controllersToRun,
-		Versions:              versions,
-		PlatformType:          hyperv1.PlatformType(o.platformType),
-		CPCluster:             cpCluster,
-		Logger:                ctrl.Log.WithName("hypershift-operator"),
-		ReleaseProvider:       releaseProvider,
-		KonnectivityAddress:   o.KonnectivityAddress,
-		KonnectivityPort:      o.KonnectivityPort,
-		OAuthAddress:          o.OAuthAddress,
-		OAuthPort:             o.OAuthPort,
-		OperateOnReleaseImage: os.Getenv("OPERATE_ON_RELEASE_IMAGE"),
-		EnableCIDebugOutput:   o.enableCIDebugOutput,
-		ImageMetaDataProvider: imageMetaDataProvider,
+		Config:                        cpConfig,
+		TargetConfig:                  cfg,
+		KubevirtInfraConfig:           kubevirtInfraConfig,
+		Manager:                       mgr,
+		Namespace:                     o.Namespace,
+		HCPName:                       o.HostedControlPlaneName,
+		InitialCA:                     string(o.initialCA),
+		ClusterSignerCA:               string(o.clusterSignerCA),
+		ControllerFuncs:               controllersToRun,
+		Versions:                      versions,
+		PlatformType:                  hyperv1.PlatformType(o.platformType),
+		CPCluster:                     cpCluster,
+		Logger:                        ctrl.Log.WithName("hypershift-operator"),
+		ReleaseProvider:               releaseProvider,
+		KonnectivityAddress:           o.KonnectivityAddress,
+		KonnectivityPort:              o.KonnectivityPort,
+		OAuthAddress:                  o.OAuthAddress,
+		OAuthPort:                     o.OAuthPort,
+		OperateOnReleaseImage:         os.Getenv("OPERATE_ON_RELEASE_IMAGE"),
+		EnableCIDebugOutput:           o.enableCIDebugOutput,
+		ImageMetaDataProvider:         imageMetaDataProvider,
+		ManagementClusterCapabilities: mgmtClusterCaps,
 	}
 	configmetrics.Register(mgr.GetCache())
 	return operatorConfig.Start(ctx)

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -310,8 +310,12 @@ func Setup(ctx context.Context, opts *operator.HostedClusterConfigOperatorConfig
 	}
 
 	// Watch metrics-proxy Route on the control plane cluster for hostname changes.
-	if err := c.Watch(source.Kind[client.Object](opts.CPCluster.GetCache(), &routev1.Route{}, eventHandler())); err != nil {
-		return fmt.Errorf("failed to watch Route: %w", err)
+	// Skip when the management cluster does not expose the route.openshift.io API
+	// (non-OpenShift management cluster); otherwise the watch fails and HCCO does not start.
+	if opts.ManagementClusterCapabilities.Has(capabilities.CapabilityRoute) {
+		if err := c.Watch(source.Kind[client.Object](opts.CPCluster.GetCache(), &routev1.Route{}, eventHandler())); err != nil {
+			return fmt.Errorf("failed to watch Route: %w", err)
+		}
 	}
 
 	// Watch HostedControlPlane namespace pull-secret on the control plane cluster so guest pull secrets

--- a/control-plane-operator/hostedclusterconfigoperator/operator/config.go
+++ b/control-plane-operator/hostedclusterconfigoperator/operator/config.go
@@ -56,29 +56,30 @@ func cacheLabelSelector() labels.Selector {
 type ControllerSetupFunc func(context.Context, *HostedClusterConfigOperatorConfig) error
 
 type HostedClusterConfigOperatorConfig struct {
-	Manager                      ctrl.Manager
-	Config                       *rest.Config
-	TargetConfig                 *rest.Config
-	KubevirtInfraConfig          *rest.Config
-	TargetCreateOrUpdateProvider upsert.CreateOrUpdateProvider
-	CPCluster                    cluster.Cluster
-	Logger                       logr.Logger
-	Versions                     map[string]string
-	HCPName                      string
-	Namespace                    string
-	InitialCA                    string
-	ClusterSignerCA              string
-	Controllers                  []string
-	PlatformType                 hyperv1.PlatformType
-	ControllerFuncs              map[string]ControllerSetupFunc
-	ReleaseProvider              releaseinfo.Provider
-	KonnectivityAddress          string
-	KonnectivityPort             int32
-	OAuthAddress                 string
-	OAuthPort                    int32
-	OperateOnReleaseImage        string
-	EnableCIDebugOutput          bool
-	ImageMetaDataProvider        util.ImageMetadataProvider
+	Manager                       ctrl.Manager
+	Config                        *rest.Config
+	TargetConfig                  *rest.Config
+	KubevirtInfraConfig           *rest.Config
+	TargetCreateOrUpdateProvider  upsert.CreateOrUpdateProvider
+	CPCluster                     cluster.Cluster
+	Logger                        logr.Logger
+	Versions                      map[string]string
+	HCPName                       string
+	Namespace                     string
+	InitialCA                     string
+	ClusterSignerCA               string
+	Controllers                   []string
+	PlatformType                  hyperv1.PlatformType
+	ControllerFuncs               map[string]ControllerSetupFunc
+	ReleaseProvider               releaseinfo.Provider
+	KonnectivityAddress           string
+	KonnectivityPort              int32
+	OAuthAddress                  string
+	OAuthPort                     int32
+	OperateOnReleaseImage         string
+	EnableCIDebugOutput           bool
+	ImageMetaDataProvider         util.ImageMetadataProvider
+	ManagementClusterCapabilities capabilities.CapabiltyChecker
 
 	kubeClient kubeclient.Interface
 }


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

The hosted-cluster-config-operator unconditionally watches route.openshift.io/v1 Routes against the management cluster to react to hostname changes on the metrics-proxy Route. On management clusters that do not expose the Routes API (e.g. non-OpenShift management clusters) this watch fails during controller setup and prevents HCCO from starting.

Detect the management cluster Route capability using the existing `capabilities.DetectManagementClusterCapabilities` helper and only register the watch when route.openshift.io is registered. This mirrors the pattern already used in other parts of the code.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes  #OCPBUGS-86008

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operator now performs a one-time management-cluster capability detection at startup.

* **Bug Fixes**
  * Skips watches for unsupported APIs, preventing startup failures when resources aren’t available.
  * Only monitors Route resources when the management cluster reports Route support, reducing errors and improving stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->