### PR TITLE
OCPBUGS-56376: Honor spec.configuration.apiServer.encryption in HostedCluster

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -4883,54 +4883,8 @@ func (r *HostedClusterReconciler) reconcileKubevirtPlatformDefaultSettings(ctx c
 		}
 	}
 
-	if hc.Spec.SecretEncryption == nil ||
-		len(hc.Spec.SecretEncryption.Type) == 0 ||
-		(hc.Spec.SecretEncryption.Type == hyperv1.AESCBC &&
-			(hc.Spec.SecretEncryption.AESCBC == nil || len(hc.Spec.SecretEncryption.AESCBC.ActiveKey.Name) == 0)) {
-
-		logger.Info("no etcd encryption key configuration found; adding", "hostedCluster name", hc.Name, "hostedCluster namespace", hc.Namespace)
-		etcdEncSec := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: hc.Namespace,
-				Name:      hc.Name + etcdEncKeyPostfix,
-			},
-		}
-
-		_, err := createOrUpdate(ctx, r.Client, etcdEncSec, func() error {
-			// don't override existing key just in case something weird happened
-			_, exists := etcdEncSec.Data[hyperv1.AESCBCKeySecretKey]
-			if exists {
-				return nil
-			}
-
-			generatedKey := make([]byte, 32)
-			_, err := rand.Read(generatedKey)
-			if err != nil {
-				return fmt.Errorf("failed to generate the etcd encryption key; %w", err)
-			}
-
-			if etcdEncSec.Data == nil {
-				etcdEncSec.Data = map[string][]byte{}
-			}
-			etcdEncSec.Data[hyperv1.AESCBCKeySecretKey] = generatedKey
-			etcdEncSec.Type = corev1.SecretTypeOpaque
-
-			ownerRef := config.OwnerRefFrom(hc)
-			ownerRef.ApplyTo(etcdEncSec)
-			return nil
-		})
-		if err != nil {
-			return fmt.Errorf("failed to create ETCD SecretEncryption key for KubeVirt platform HostedCluster: %w", err)
-		}
-
-		hc.Spec.SecretEncryption = &hyperv1.SecretEncryptionSpec{
-			Type: hyperv1.AESCBC,
-			AESCBC: &hyperv1.AESCBCSpec{
-				ActiveKey: corev1.LocalObjectReference{
-					Name: etcdEncSec.Name,
-				},
-			},
-		}
+	if err := r.ensureAESCBCEncryptionKey(ctx, hc, createOrUpdate, logger); err != nil {
+		return fmt.Errorf("KubeVirt platform: %w", err)
 	}
 
 	// Reconcile management infrastructure annotation
@@ -4967,11 +4921,28 @@ func (r *HostedClusterReconciler) reconcileAPIServerEncryptionConfig(ctx context
 	if hc.Spec.Configuration.APIServer.Encryption.Type != configv1.EncryptionTypeAESCBC {
 		return nil
 	}
-	if hc.Spec.SecretEncryption != nil && len(hc.Spec.SecretEncryption.Type) > 0 {
+	if hc.Spec.SecretEncryption != nil && len(hc.Spec.SecretEncryption.Type) > 0 &&
+		hc.Spec.SecretEncryption.Type != hyperv1.AESCBC {
+		logger.Info("configuration.apiServer.encryption.type is aescbc but secretEncryption is already set with a different type; secretEncryption takes precedence",
+			"apiServerEncryptionType", hc.Spec.Configuration.APIServer.Encryption.Type,
+			"secretEncryptionType", hc.Spec.SecretEncryption.Type,
+		)
+		return nil
+	}
+	if err := r.ensureAESCBCEncryptionKey(ctx, hc, createOrUpdate, logger); err != nil {
+		return fmt.Errorf("apiServer encryption config: %w", err)
+	}
+	return nil
+}
+
+func (r *HostedClusterReconciler) ensureAESCBCEncryptionKey(ctx context.Context, hc *hyperv1.HostedCluster, createOrUpdate upsert.CreateOrUpdateFN, logger logr.Logger) error {
+	if hc.Spec.SecretEncryption != nil && len(hc.Spec.SecretEncryption.Type) > 0 &&
+		!(hc.Spec.SecretEncryption.Type == hyperv1.AESCBC &&
+			(hc.Spec.SecretEncryption.AESCBC == nil || len(hc.Spec.SecretEncryption.AESCBC.ActiveKey.Name) == 0)) {
 		return nil
 	}
 
-	logger.Info("configuration.apiServer.encryption.type is aescbc but secretEncryption is not set; auto-generating key", "hostedCluster", client.ObjectKeyFromObject(hc))
+	logger.Info("no etcd encryption key configuration found; auto-generating", "hostedCluster", client.ObjectKeyFromObject(hc))
 	etcdEncSec := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: hc.Namespace,
@@ -4980,16 +4951,18 @@ func (r *HostedClusterReconciler) reconcileAPIServerEncryptionConfig(ctx context
 	}
 
 	_, err := createOrUpdate(ctx, r.Client, etcdEncSec, func() error {
+		_, exists := etcdEncSec.Data[hyperv1.AESCBCKeySecretKey]
+		if exists {
+			return nil
+		}
+		generatedKey := make([]byte, 32)
+		if _, err := rand.Read(generatedKey); err != nil {
+			return fmt.Errorf("failed to generate the etcd encryption key: %w", err)
+		}
 		if etcdEncSec.Data == nil {
 			etcdEncSec.Data = map[string][]byte{}
 		}
-		if _, exists := etcdEncSec.Data[hyperv1.AESCBCKeySecretKey]; !exists {
-			generatedKey := make([]byte, 32)
-			if _, err := rand.Read(generatedKey); err != nil {
-				return fmt.Errorf("failed to generate the etcd encryption key: %w", err)
-			}
-			etcdEncSec.Data[hyperv1.AESCBCKeySecretKey] = generatedKey
-		}
+		etcdEncSec.Data[hyperv1.AESCBCKeySecretKey] = generatedKey
 		etcdEncSec.Type = corev1.SecretTypeOpaque
 
 		ownerRef := config.OwnerRefFrom(hc)
@@ -4997,7 +4970,7 @@ func (r *HostedClusterReconciler) reconcileAPIServerEncryptionConfig(ctx context
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("failed to create ETCD SecretEncryption key from apiServer encryption config: %w", err)
+		return fmt.Errorf("failed to create ETCD SecretEncryption key: %w", err)
 	}
 
 	hc.Spec.SecretEncryption = &hyperv1.SecretEncryptionSpec{
@@ -5008,7 +4981,6 @@ func (r *HostedClusterReconciler) reconcileAPIServerEncryptionConfig(ctx context
 			},
 		},
 	}
-
 	return nil
 }
 

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -633,6 +633,11 @@ func (r *HostedClusterReconciler) reconcile(ctx context.Context, req ctrl.Reques
 
 	createOrUpdate := r.createOrUpdate(req)
 
+	// Reconcile apiServer encryption configuration
+	if err := r.reconcileAPIServerEncryptionConfig(ctx, hcluster, createOrUpdate, log); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	// Reconcile platform defaults
 	if err := r.reconcilePlatformDefaultSettings(ctx, hcluster, createOrUpdate, log); err != nil {
 		return ctrl.Result{}, err
@@ -4057,6 +4062,25 @@ func (r *HostedClusterReconciler) validateOCPConfigurations(ctx context.Context,
 		}
 	}
 
+	if hc.Spec.Configuration != nil && hc.Spec.Configuration.APIServer != nil {
+		encType := hc.Spec.Configuration.APIServer.Encryption.Type
+		encPath := field.NewPath("spec", "configuration", "apiServer", "encryption", "type")
+		switch encType {
+		case configv1.EncryptionTypeAESGCM:
+			errs = append(errs, field.Invalid(encPath, encType, "aesgcm encryption is not supported; use spec.configuration.apiServer.encryption.type aescbc or configure spec.secretEncryption with type aescbc or kms"))
+		case configv1.EncryptionTypeKMS:
+			if hc.Spec.SecretEncryption == nil ||
+				hc.Spec.SecretEncryption.Type != hyperv1.KMS ||
+				hc.Spec.SecretEncryption.KMS == nil {
+				errs = append(errs, field.Invalid(encPath, encType, "KMS encryption requires configuring spec.secretEncryption with platform-specific KMS settings"))
+			} else if hc.Spec.SecretEncryption.KMS.AWS == nil &&
+				hc.Spec.SecretEncryption.KMS.IBMCloud == nil &&
+				hc.Spec.SecretEncryption.KMS.Azure == nil {
+				errs = append(errs, field.Invalid(encPath, encType, "KMS encryption requires at least one platform-specific provider (aws, azure, or ibmcloud) in spec.secretEncryption.kms"))
+			}
+		}
+	}
+
 	return errs.ToAggregate()
 }
 
@@ -4927,6 +4951,62 @@ func (r *HostedClusterReconciler) reconcileKubevirtPlatformDefaultSettings(ctx c
 				return fmt.Errorf("failed to update hostedcluster %s annotation: %w", hc.Name, err)
 			}
 		}
+	}
+
+	return nil
+}
+
+// reconcileAPIServerEncryptionConfig honors spec.configuration.apiServer.encryption
+// by auto-generating an AESCBC key and populating spec.secretEncryption when the user
+// sets encryption.type to aescbc without configuring secretEncryption directly.
+// If secretEncryption is already set, it takes precedence (override power).
+func (r *HostedClusterReconciler) reconcileAPIServerEncryptionConfig(ctx context.Context, hc *hyperv1.HostedCluster, createOrUpdate upsert.CreateOrUpdateFN, logger logr.Logger) error {
+	if hc.Spec.Configuration == nil || hc.Spec.Configuration.APIServer == nil {
+		return nil
+	}
+	if hc.Spec.Configuration.APIServer.Encryption.Type != configv1.EncryptionTypeAESCBC {
+		return nil
+	}
+	if hc.Spec.SecretEncryption != nil && len(hc.Spec.SecretEncryption.Type) > 0 {
+		return nil
+	}
+
+	logger.Info("configuration.apiServer.encryption.type is aescbc but secretEncryption is not set; auto-generating key", "hostedCluster", client.ObjectKeyFromObject(hc))
+	etcdEncSec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: hc.Namespace,
+			Name:      hc.Name + etcdEncKeyPostfix,
+		},
+	}
+
+	_, err := createOrUpdate(ctx, r.Client, etcdEncSec, func() error {
+		if etcdEncSec.Data == nil {
+			etcdEncSec.Data = map[string][]byte{}
+		}
+		if _, exists := etcdEncSec.Data[hyperv1.AESCBCKeySecretKey]; !exists {
+			generatedKey := make([]byte, 32)
+			if _, err := rand.Read(generatedKey); err != nil {
+				return fmt.Errorf("failed to generate the etcd encryption key: %w", err)
+			}
+			etcdEncSec.Data[hyperv1.AESCBCKeySecretKey] = generatedKey
+		}
+		etcdEncSec.Type = corev1.SecretTypeOpaque
+
+		ownerRef := config.OwnerRefFrom(hc)
+		ownerRef.ApplyTo(etcdEncSec)
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create ETCD SecretEncryption key from apiServer encryption config: %w", err)
+	}
+
+	hc.Spec.SecretEncryption = &hyperv1.SecretEncryptionSpec{
+		Type: hyperv1.AESCBC,
+		AESCBC: &hyperv1.AESCBCSpec{
+			ActiveKey: corev1.LocalObjectReference{
+				Name: etcdEncSec.Name,
+			},
+		},
 	}
 
 	return nil

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -6574,11 +6574,12 @@ func TestReconcileAPIServerEncryptionConfig(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range []struct {
-		name                      string
-		hc                        *hyperv1.HostedCluster
-		expectSecretCreated       bool
-		expectSecretEncryptionSet bool
-		expectedActiveKeyName     string
+		name                          string
+		hc                            *hyperv1.HostedCluster
+		expectSecretCreated           bool
+		expectSecretEncryptionSet     bool
+		expectedActiveKeyName         string
+		expectSecretEncryptionPreserved bool
 	}{
 		{
 			name: "When configuration.apiServer.encryption.type is aescbc and secretEncryption is nil, it should generate key and set secretEncryption",
@@ -6698,6 +6699,88 @@ func TestReconcileAPIServerEncryptionConfig(t *testing.T) {
 			expectSecretCreated:       false,
 			expectSecretEncryptionSet: false,
 		},
+		{
+			name: "When secretEncryption type is aescbc but aescbc config is nil, it should generate key and set secretEncryption",
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							Encryption: configv1.APIServerEncryption{
+								Type: configv1.EncryptionTypeAESCBC,
+							},
+						},
+					},
+					SecretEncryption: &hyperv1.SecretEncryptionSpec{
+						Type: hyperv1.AESCBC,
+					},
+				},
+			},
+			expectSecretCreated:       true,
+			expectSecretEncryptionSet: true,
+			expectedActiveKeyName:     "test-cluster" + etcdEncKeyPostfix,
+		},
+		{
+			name: "When secretEncryption type is aescbc but activeKey name is empty, it should generate key and set secretEncryption",
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							Encryption: configv1.APIServerEncryption{
+								Type: configv1.EncryptionTypeAESCBC,
+							},
+						},
+					},
+					SecretEncryption: &hyperv1.SecretEncryptionSpec{
+						Type: hyperv1.AESCBC,
+						AESCBC: &hyperv1.AESCBCSpec{
+							ActiveKey: corev1.LocalObjectReference{
+								Name: "",
+							},
+						},
+					},
+				},
+			},
+			expectSecretCreated:       true,
+			expectSecretEncryptionSet: true,
+			expectedActiveKeyName:     "test-cluster" + etcdEncKeyPostfix,
+		},
+		{
+			name: "When apiServer encryption is aescbc but secretEncryption is kms, it should not override and preserve secretEncryption",
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							Encryption: configv1.APIServerEncryption{
+								Type: configv1.EncryptionTypeAESCBC,
+							},
+						},
+					},
+					SecretEncryption: &hyperv1.SecretEncryptionSpec{
+						Type: hyperv1.KMS,
+						KMS: &hyperv1.KMSSpec{
+							AWS: &hyperv1.AWSKMSSpec{
+								Region: "us-east-1",
+							},
+						},
+					},
+				},
+			},
+			expectSecretCreated:            false,
+			expectSecretEncryptionSet:      false,
+			expectSecretEncryptionPreserved: true,
+		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
@@ -6744,11 +6827,67 @@ func TestReconcileAPIServerEncryptionConfig(t *testing.T) {
 				g.Expect(testCase.hc.Spec.SecretEncryption.Type).To(Equal(hyperv1.AESCBC))
 				g.Expect(testCase.hc.Spec.SecretEncryption.AESCBC).ToNot(BeNil())
 				g.Expect(testCase.hc.Spec.SecretEncryption.AESCBC.ActiveKey.Name).To(Equal(testCase.expectedActiveKeyName))
+			} else if testCase.expectSecretEncryptionPreserved {
+				g.Expect(testCase.hc.Spec.SecretEncryption).ToNot(BeNil())
 			} else {
 				g.Expect(testCase.hc.Spec.SecretEncryption).To(BeNil())
 			}
 		})
 	}
+}
+
+func TestReconcileAPIServerEncryptionConfig_Idempotency(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	hc := &hyperv1.HostedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "test",
+		},
+		Spec: hyperv1.HostedClusterSpec{
+			Configuration: &hyperv1.ClusterConfiguration{
+				APIServer: &configv1.APIServerSpec{
+					Encryption: configv1.APIServerEncryption{
+						Type: configv1.EncryptionTypeAESCBC,
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(api.Scheme).
+		WithObjects(hc).
+		Build()
+
+	r := &HostedClusterReconciler{
+		Client: fakeClient,
+	}
+
+	logger := zap.New(zap.UseDevMode(true), zap.Level(zapcore.InfoLevel))
+
+	err := r.reconcileAPIServerEncryptionConfig(t.Context(), hc, ctrl.CreateOrUpdate, logger)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	secret := &corev1.Secret{}
+	err = fakeClient.Get(t.Context(), crclient.ObjectKey{
+		Namespace: hc.Namespace,
+		Name:      hc.Name + etcdEncKeyPostfix,
+	}, secret)
+	g.Expect(err).ToNot(HaveOccurred())
+	firstKey := make([]byte, len(secret.Data[hyperv1.AESCBCKeySecretKey]))
+	copy(firstKey, secret.Data[hyperv1.AESCBCKeySecretKey])
+
+	err = r.reconcileAPIServerEncryptionConfig(t.Context(), hc, ctrl.CreateOrUpdate, logger)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = fakeClient.Get(t.Context(), crclient.ObjectKey{
+		Namespace: hc.Namespace,
+		Name:      hc.Name + etcdEncKeyPostfix,
+	}, secret)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(secret.Data[hyperv1.AESCBCKeySecretKey]).To(Equal(firstKey))
 }
 
 func TestValidateOCPConfigurationsEncryption(t *testing.T) {

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -6569,3 +6569,380 @@ func TestComputeEndpointServiceCondition(t *testing.T) {
 		})
 	}
 }
+
+func TestReconcileAPIServerEncryptionConfig(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name                      string
+		hc                        *hyperv1.HostedCluster
+		expectSecretCreated       bool
+		expectSecretEncryptionSet bool
+		expectedActiveKeyName     string
+	}{
+		{
+			name: "When configuration.apiServer.encryption.type is aescbc and secretEncryption is nil, it should generate key and set secretEncryption",
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							Encryption: configv1.APIServerEncryption{
+								Type: configv1.EncryptionTypeAESCBC,
+							},
+						},
+					},
+				},
+			},
+			expectSecretCreated:       true,
+			expectSecretEncryptionSet: true,
+			expectedActiveKeyName:     "test-cluster" + etcdEncKeyPostfix,
+		},
+		{
+			name: "When configuration.apiServer.encryption.type is aescbc and secretEncryption is already set, it should not override",
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							Encryption: configv1.APIServerEncryption{
+								Type: configv1.EncryptionTypeAESCBC,
+							},
+						},
+					},
+					SecretEncryption: &hyperv1.SecretEncryptionSpec{
+						Type: hyperv1.AESCBC,
+						AESCBC: &hyperv1.AESCBCSpec{
+							ActiveKey: corev1.LocalObjectReference{
+								Name: "custom-key",
+							},
+						},
+					},
+				},
+			},
+			expectSecretCreated:       false,
+			expectSecretEncryptionSet: true,
+			expectedActiveKeyName:     "custom-key",
+		},
+		{
+			name: "When configuration.apiServer.encryption.type is aescbc and secretEncryption has empty type, it should generate key and set secretEncryption",
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							Encryption: configv1.APIServerEncryption{
+								Type: configv1.EncryptionTypeAESCBC,
+							},
+						},
+					},
+					SecretEncryption: &hyperv1.SecretEncryptionSpec{},
+				},
+			},
+			expectSecretCreated:       true,
+			expectSecretEncryptionSet: true,
+			expectedActiveKeyName:     "test-cluster" + etcdEncKeyPostfix,
+		},
+		{
+			name: "When configuration is nil, it should be a no-op",
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test",
+				},
+				Spec: hyperv1.HostedClusterSpec{},
+			},
+			expectSecretCreated:       false,
+			expectSecretEncryptionSet: false,
+		},
+		{
+			name: "When configuration.apiServer.encryption.type is identity, it should be a no-op",
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							Encryption: configv1.APIServerEncryption{
+								Type: configv1.EncryptionTypeIdentity,
+							},
+						},
+					},
+				},
+			},
+			expectSecretCreated:       false,
+			expectSecretEncryptionSet: false,
+		},
+		{
+			name: "When configuration.apiServer is nil, it should be a no-op",
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Configuration: &hyperv1.ClusterConfiguration{},
+				},
+			},
+			expectSecretCreated:       false,
+			expectSecretEncryptionSet: false,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(api.Scheme).
+				WithObjects(testCase.hc).
+				Build()
+
+			r := &HostedClusterReconciler{
+				Client: fakeClient,
+			}
+
+			logger := zap.New(zap.UseDevMode(true), zap.Level(zapcore.InfoLevel))
+			err := r.reconcileAPIServerEncryptionConfig(t.Context(), testCase.hc, ctrl.CreateOrUpdate, logger)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			if testCase.expectSecretCreated {
+				secret := &corev1.Secret{}
+				err := fakeClient.Get(t.Context(), crclient.ObjectKey{
+					Namespace: testCase.hc.Namespace,
+					Name:      testCase.hc.Name + etcdEncKeyPostfix,
+				}, secret)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(secret.Data).To(HaveKey(hyperv1.AESCBCKeySecretKey))
+				g.Expect(secret.Data[hyperv1.AESCBCKeySecretKey]).To(HaveLen(32))
+			} else {
+				secret := &corev1.Secret{}
+				err := fakeClient.Get(t.Context(), crclient.ObjectKey{
+					Namespace: testCase.hc.Namespace,
+					Name:      testCase.hc.Name + etcdEncKeyPostfix,
+				}, secret)
+				g.Expect(errors2.IsNotFound(err)).To(BeTrue())
+				if testCase.expectedActiveKeyName != "" && testCase.expectedActiveKeyName != testCase.hc.Name+etcdEncKeyPostfix {
+					err = fakeClient.Get(t.Context(), crclient.ObjectKey{
+						Namespace: testCase.hc.Namespace,
+						Name:      testCase.expectedActiveKeyName,
+					}, secret)
+					g.Expect(errors2.IsNotFound(err)).To(BeTrue())
+				}
+			}
+
+			if testCase.expectSecretEncryptionSet {
+				g.Expect(testCase.hc.Spec.SecretEncryption).ToNot(BeNil())
+				g.Expect(testCase.hc.Spec.SecretEncryption.Type).To(Equal(hyperv1.AESCBC))
+				g.Expect(testCase.hc.Spec.SecretEncryption.AESCBC).ToNot(BeNil())
+				g.Expect(testCase.hc.Spec.SecretEncryption.AESCBC.ActiveKey.Name).To(Equal(testCase.expectedActiveKeyName))
+			} else {
+				g.Expect(testCase.hc.Spec.SecretEncryption).To(BeNil())
+			}
+		})
+	}
+}
+
+func TestValidateOCPConfigurationsEncryption(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name      string
+		hc        *hyperv1.HostedCluster
+		expectErr bool
+		errSubstr string
+	}{
+		{
+			name: "When encryption type is aesgcm, it should return an error",
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							Encryption: configv1.APIServerEncryption{
+								Type: configv1.EncryptionTypeAESGCM,
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+			errSubstr: "aesgcm encryption is not supported",
+		},
+		{
+			name: "When encryption type is KMS without secretEncryption, it should return an error",
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							Encryption: configv1.APIServerEncryption{
+								Type: configv1.EncryptionTypeKMS,
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+			errSubstr: "KMS encryption requires configuring spec.secretEncryption",
+		},
+		{
+			name: "When encryption type is KMS with secretEncryption set, it should not return an error",
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							Encryption: configv1.APIServerEncryption{
+								Type: configv1.EncryptionTypeKMS,
+							},
+						},
+					},
+					SecretEncryption: &hyperv1.SecretEncryptionSpec{
+						Type: hyperv1.KMS,
+						KMS: &hyperv1.KMSSpec{
+							Provider: hyperv1.AWS,
+							AWS: &hyperv1.AWSKMSSpec{
+								Region: "us-east-1",
+								ActiveKey: hyperv1.AWSKMSKeyEntry{
+									ARN: "arn:aws:kms:us-east-1:000000000000:key/00000000-0000-0000-0000-000000000000",
+								},
+								Auth: hyperv1.AWSKMSAuthSpec{
+									AWSKMSRoleARN: "arn:aws:iam::000000000000:role/test-role",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "When encryption type is KMS with secretEncryption type mismatch, it should return an error",
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							Encryption: configv1.APIServerEncryption{
+								Type: configv1.EncryptionTypeKMS,
+							},
+						},
+					},
+					SecretEncryption: &hyperv1.SecretEncryptionSpec{
+						Type: hyperv1.AESCBC,
+					},
+				},
+			},
+			expectErr: true,
+			errSubstr: "KMS encryption requires configuring spec.secretEncryption",
+		},
+		{
+			name: "When encryption type is KMS with nil kms config, it should return an error",
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							Encryption: configv1.APIServerEncryption{
+								Type: configv1.EncryptionTypeKMS,
+							},
+						},
+					},
+					SecretEncryption: &hyperv1.SecretEncryptionSpec{
+						Type: hyperv1.KMS,
+					},
+				},
+			},
+			expectErr: true,
+			errSubstr: "KMS encryption requires configuring spec.secretEncryption",
+		},
+		{
+			name: "When encryption type is KMS with provider set but provider-specific config nil, it should return an error",
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							Encryption: configv1.APIServerEncryption{
+								Type: configv1.EncryptionTypeKMS,
+							},
+						},
+					},
+					SecretEncryption: &hyperv1.SecretEncryptionSpec{
+						Type: hyperv1.KMS,
+						KMS: &hyperv1.KMSSpec{
+							Provider: hyperv1.AWS,
+						},
+					},
+				},
+			},
+			expectErr: true,
+			errSubstr: "KMS encryption requires at least one platform-specific provider",
+		},
+		{
+			name: "When encryption type is aescbc, it should not return an error",
+			hc: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Configuration: &hyperv1.ClusterConfiguration{
+						APIServer: &configv1.APIServerSpec{
+							Encryption: configv1.APIServerEncryption{
+								Type: configv1.EncryptionTypeAESCBC,
+							},
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(api.Scheme).
+				Build()
+
+			r := &HostedClusterReconciler{
+				Client: fakeClient,
+			}
+
+			err := r.validateOCPConfigurations(t.Context(), testCase.hc, fakeClient)
+			if testCase.expectErr {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(testCase.errSubstr))
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it:

When a user sets `spec.configuration.apiServer.encryption.type: aescbc` on a
HostedCluster, the field is copied to the HostedControlPlane but never consumed
by the CPO's KAS component. Only `spec.secretEncryption` is wired into the KAS
deployment, making the `apiServer.encryption` config a silent no-op. 

This PR adds `reconcileAPIServerEncryptionConfig()` which auto-generates a
32-byte AESCBC key and populates `spec.secretEncryption` when
`configuration.apiServer.encryption.type` is `aescbc` and `secretEncryption`
is not already set. If `secretEncryption` is already configured, it takes
precedence (override power). This follows the same pattern used by KubeVirt
platform defaults.

Also adds validation in `validateOCPConfigurations()` for unsupported encryption
types: `aesgcm` returns an error (not supported in HyperShift), and `KMS`
returns an error when `secretEncryption` is not configured with platform-specific
KMS settings.

## Which issue(s) this PR fixes:

Fixes https://redhat.atlassian.net/browse/OCPBUGS-56376

## Special notes for your reviewer:

- The auto-generation logic reuses the exact same pattern as KubeVirt's
  `reconcileKubevirtPlatformDefaultSettings()` (same secret name, same
  `createOrUpdate` idempotency, same owner ref).
- The new function runs before `reconcilePlatformDefaultSettings()` so it is
  platform-agnostic. For KubeVirt clusters, if the new code generates a key,
  the existing KubeVirt code sees `secretEncryption` already set and skips.
- Existing clusters with the misconfiguration will get encryption enabled on
  the next reconcile — this is the intended behavior and what customers expect.

## Checklist:

- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-generates a 32-byte opaque AESCBC etcd encryption secret, sets it as the active key, and updates secretEncryption to AESCBC when API server encryption is AESCBC and secretEncryption is unset; preserves existing secretEncryption.

* **Validation**
  * Rejects AESGCM as unsupported. Requires secretEncryption to be configured for KMS and at least one platform-specific KMS provider (AWS/Azure/IBM Cloud).

* **Tests**
  * Added unit tests for reconciliation and validation of API server encryption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
