### PR TITLE
CNTRLPLANE-3584: Add kube-scheduler ServiceMonitor with CA-signed serving certs

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1587,6 +1587,13 @@ func (r *HostedControlPlaneReconciler) reconcileOLMAndMiscCerts(ctx context.Cont
 		return fmt.Errorf("failed to reconcile olm operator serving cert: %w", err)
 	}
 
+	schedulerServerSecret := manifests.SchedulerServerCertSecret(hcp.Namespace)
+	if _, err := createOrUpdate(ctx, r, schedulerServerSecret, func() error {
+		return pki.ReconcileSchedulerServerSecret(schedulerServerSecret, rootCASecret, p.OwnerRef)
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile scheduler serving cert: %w", err)
+	}
+
 	cvoServerCert := manifests.ClusterVersionOperatorServerCertSecret(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r, cvoServerCert, func() error {
 		return pki.ReconcileCVOServerSecret(cvoServerCert, rootCASecret, p.OwnerRef)

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/pki.go
@@ -272,6 +272,8 @@ func KASMachineBootstrapClientCertSecret(ns string) *corev1.Secret {
 
 func KCMServerCertSecret(ns string) *corev1.Secret { return secretFor(ns, "kcm-server") }
 
+func SchedulerServerCertSecret(ns string) *corev1.Secret { return secretFor(ns, "scheduler-server") }
+
 func ServiceAccountSigningKeySecret(ns string) *corev1.Secret { return secretFor(ns, "sa-signing-key") }
 
 func OpenShiftAPIServerCertSecret(ns string) *corev1.Secret {

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/scheduler.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/scheduler.go
@@ -1,0 +1,19 @@
+package pki
+
+import (
+	"fmt"
+
+	"github.com/openshift/hypershift/support/config"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func ReconcileSchedulerServerSecret(secret, ca *corev1.Secret, ownerRef config.OwnerRef) error {
+	dnsNames := []string{
+		fmt.Sprintf("kube-scheduler.%s.svc", secret.Namespace),
+		fmt.Sprintf("kube-scheduler.%s.svc.cluster.local", secret.Namespace),
+		"kube-scheduler",
+		"localhost",
+	}
+	return reconcileSignedCertWithAddresses(secret, ca, ownerRef, "kube-scheduler", []string{"openshift"}, X509UsageClientServerAuth, dnsNames, nil)
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/scheduler_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/scheduler_test.go
@@ -1,0 +1,76 @@
+package pki
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/support/certs"
+	"github.com/openshift/hypershift/support/config"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestReconcileSchedulerServerSecret(t *testing.T) {
+	t.Parallel()
+
+	t.Run("When secret is empty it should generate a valid cert", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		ca := createTestCA(t)
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "scheduler-server",
+				Namespace: "test-namespace",
+			},
+		}
+
+		err := ReconcileSchedulerServerSecret(secret, ca, config.OwnerRef{})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(secret.Data[corev1.TLSCertKey]).ToNot(BeEmpty())
+		g.Expect(secret.Data[corev1.TLSPrivateKeyKey]).ToNot(BeEmpty())
+	})
+
+	t.Run("When secret already has a valid cert it should not regenerate", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		ca := createTestCA(t)
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "scheduler-server",
+				Namespace: "test-namespace",
+			},
+		}
+
+		err := ReconcileSchedulerServerSecret(secret, ca, config.OwnerRef{})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		initialCert := make([]byte, len(secret.Data[corev1.TLSCertKey]))
+		copy(initialCert, secret.Data[corev1.TLSCertKey])
+
+		err = ReconcileSchedulerServerSecret(secret, ca, config.OwnerRef{})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(secret.Data[corev1.TLSCertKey]).To(Equal(initialCert))
+	})
+}
+
+func createTestCA(t *testing.T) *corev1.Secret {
+	t.Helper()
+	g := NewWithT(t)
+
+	caSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "root-ca",
+			Namespace: "test-namespace",
+		},
+	}
+	err := ReconcileRootCA(caSecret, config.OwnerRef{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(caSecret.Data[certs.CASignerCertMapKey]).ToNot(BeEmpty())
+	g.Expect(caSecret.Data[certs.CASignerKeyMapKey]).ToNot(BeEmpty())
+
+	return caSecret
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/AROSwift/zz_fixture_TestControlPlaneComponents_kube_scheduler_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/AROSwift/zz_fixture_TestControlPlaneComponents_kube_scheduler_controlplanecomponent.yaml
@@ -25,3 +25,9 @@ status:
   - group: ""
     kind: Secret
     name: kube-scheduler-kubeconfig
+  - group: ""
+    kind: Service
+    name: kube-scheduler
+  - group: monitoring.coreos.com
+    kind: ServiceMonitor
+    name: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/AROSwift/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/AROSwift/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
@@ -27,7 +27,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cert-work,tmp-dir
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 022a8a3ab4d55cfe
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
@@ -78,7 +78,8 @@ spec:
       containers:
       - args:
         - --config=/etc/kubernetes/config/config.json
-        - --cert-dir=/var/run/kubernetes
+        - --tls-cert-file=/etc/kubernetes/certs/tls.crt
+        - --tls-private-key-file=/etc/kubernetes/certs/tls.key
         - --secure-port=10259
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
@@ -199,6 +200,10 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         name: kube-scheduler
+        ports:
+        - containerPort: 10259
+          name: client
+          protocol: TCP
         resources:
           requests:
             cpu: 25m
@@ -207,8 +212,8 @@ spec:
           readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - mountPath: /var/run/kubernetes
-          name: cert-work
+        - mountPath: /etc/kubernetes/certs
+          name: serving-cert
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeconfig
         - mountPath: /etc/kubernetes/config
@@ -241,8 +246,10 @@ spec:
           defaultMode: 420
           name: kube-scheduler
         name: scheduler-config
-      - emptyDir: {}
-        name: cert-work
+      - name: serving-cert
+        secret:
+          defaultMode: 416
+          secretName: scheduler-server
       - name: kubeconfig
         secret:
           defaultMode: 416

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/AROSwift/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/AROSwift/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kube-scheduler
+  name: kube-scheduler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilyPolicy: PreferDualStack
+  ports:
+  - name: client
+    port: 10259
+    protocol: TCP
+    targetPort: client
+  selector:
+    app: kube-scheduler
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/AROSwift/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/AROSwift/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
@@ -1,0 +1,49 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations:
+    hypershift.openshift.io/metrics-endpoint: https
+    hypershift.openshift.io/metrics-job: kube-scheduler
+    hypershift.openshift.io/metrics-namespace: openshift-kube-scheduler
+    hypershift.openshift.io/metrics-service: kube-scheduler
+  name: kube-scheduler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  endpoints:
+  - metricRelabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    relabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    scheme: https
+    targetPort: client
+    tlsConfig:
+      ca:
+        configMap:
+          key: ca.crt
+          name: root-ca
+      cert:
+        secret:
+          key: tls.crt
+          name: metrics-client
+      keySecret:
+        key: tls.key
+        name: metrics-client
+      serverName: kube-scheduler
+  namespaceSelector:
+    matchNames:
+    - hcp-namespace
+  selector:
+    matchLabels:
+      app: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/GCP/zz_fixture_TestControlPlaneComponents_kube_scheduler_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/GCP/zz_fixture_TestControlPlaneComponents_kube_scheduler_controlplanecomponent.yaml
@@ -25,3 +25,9 @@ status:
   - group: ""
     kind: Secret
     name: kube-scheduler-kubeconfig
+  - group: ""
+    kind: Service
+    name: kube-scheduler
+  - group: monitoring.coreos.com
+    kind: ServiceMonitor
+    name: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/GCP/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/GCP/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
@@ -27,7 +27,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cert-work,tmp-dir
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 022a8a3ab4d55cfe
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
@@ -78,7 +78,8 @@ spec:
       containers:
       - args:
         - --config=/etc/kubernetes/config/config.json
-        - --cert-dir=/var/run/kubernetes
+        - --tls-cert-file=/etc/kubernetes/certs/tls.crt
+        - --tls-private-key-file=/etc/kubernetes/certs/tls.key
         - --secure-port=10259
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
@@ -198,6 +199,10 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         name: kube-scheduler
+        ports:
+        - containerPort: 10259
+          name: client
+          protocol: TCP
         resources:
           requests:
             cpu: 25m
@@ -211,8 +216,8 @@ spec:
           runAsNonRoot: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - mountPath: /var/run/kubernetes
-          name: cert-work
+        - mountPath: /etc/kubernetes/certs
+          name: serving-cert
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeconfig
         - mountPath: /etc/kubernetes/config
@@ -251,8 +256,10 @@ spec:
           defaultMode: 420
           name: kube-scheduler
         name: scheduler-config
-      - emptyDir: {}
-        name: cert-work
+      - name: serving-cert
+        secret:
+          defaultMode: 416
+          secretName: scheduler-server
       - name: kubeconfig
         secret:
           defaultMode: 416

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/GCP/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/GCP/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kube-scheduler
+  name: kube-scheduler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilyPolicy: PreferDualStack
+  ports:
+  - name: client
+    port: 10259
+    protocol: TCP
+    targetPort: client
+  selector:
+    app: kube-scheduler
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/GCP/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/GCP/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
@@ -1,0 +1,49 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations:
+    hypershift.openshift.io/metrics-endpoint: https
+    hypershift.openshift.io/metrics-job: kube-scheduler
+    hypershift.openshift.io/metrics-namespace: openshift-kube-scheduler
+    hypershift.openshift.io/metrics-service: kube-scheduler
+  name: kube-scheduler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  endpoints:
+  - metricRelabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    relabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    scheme: https
+    targetPort: client
+    tlsConfig:
+      ca:
+        configMap:
+          key: ca.crt
+          name: root-ca
+      cert:
+        secret:
+          key: tls.crt
+          name: metrics-client
+      keySecret:
+        key: tls.key
+        name: metrics-client
+      serverName: kube-scheduler
+  namespaceSelector:
+    matchNames:
+    - hcp-namespace
+  selector:
+    matchLabels:
+      app: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_scheduler_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_scheduler_controlplanecomponent.yaml
@@ -25,3 +25,9 @@ status:
   - group: ""
     kind: Secret
     name: kube-scheduler-kubeconfig
+  - group: ""
+    kind: Service
+    name: kube-scheduler
+  - group: monitoring.coreos.com
+    kind: ServiceMonitor
+    name: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
@@ -27,7 +27,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cert-work,tmp-dir
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 022a8a3a40ea5fe1
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
@@ -78,7 +78,8 @@ spec:
       containers:
       - args:
         - --config=/etc/kubernetes/config/config.json
-        - --cert-dir=/var/run/kubernetes
+        - --tls-cert-file=/etc/kubernetes/certs/tls.crt
+        - --tls-private-key-file=/etc/kubernetes/certs/tls.key
         - --secure-port=10259
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
@@ -199,6 +200,10 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         name: kube-scheduler
+        ports:
+        - containerPort: 10259
+          name: client
+          protocol: TCP
         resources:
           requests:
             cpu: 25m
@@ -207,8 +212,8 @@ spec:
           readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - mountPath: /var/run/kubernetes
-          name: cert-work
+        - mountPath: /etc/kubernetes/certs
+          name: serving-cert
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeconfig
         - mountPath: /etc/kubernetes/config
@@ -241,8 +246,10 @@ spec:
           defaultMode: 420
           name: kube-scheduler
         name: scheduler-config
-      - emptyDir: {}
-        name: cert-work
+      - name: serving-cert
+        secret:
+          defaultMode: 416
+          secretName: scheduler-server
       - name: kubeconfig
         secret:
           defaultMode: 416

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kube-scheduler
+  name: kube-scheduler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilyPolicy: PreferDualStack
+  ports:
+  - name: client
+    port: 10259
+    protocol: TCP
+    targetPort: client
+  selector:
+    app: kube-scheduler
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/IBMCloud/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
@@ -1,0 +1,49 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations:
+    hypershift.openshift.io/metrics-endpoint: https
+    hypershift.openshift.io/metrics-job: kube-scheduler
+    hypershift.openshift.io/metrics-namespace: openshift-kube-scheduler
+    hypershift.openshift.io/metrics-service: kube-scheduler
+  name: kube-scheduler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  endpoints:
+  - metricRelabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    relabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    scheme: https
+    targetPort: client
+    tlsConfig:
+      ca:
+        configMap:
+          key: ca.crt
+          name: root-ca
+      cert:
+        secret:
+          key: tls.crt
+          name: metrics-client
+      keySecret:
+        key: tls.key
+        name: metrics-client
+      serverName: kube-scheduler
+  namespaceSelector:
+    matchNames:
+    - hcp-namespace
+  selector:
+    matchLabels:
+      app: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_controlplanecomponent.yaml
@@ -25,3 +25,9 @@ status:
   - group: ""
     kind: Secret
     name: kube-scheduler-kubeconfig
+  - group: ""
+    kind: Service
+    name: kube-scheduler
+  - group: monitoring.coreos.com
+    kind: ServiceMonitor
+    name: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
@@ -27,7 +27,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cert-work,tmp-dir
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 022a8a3ab4d55cfe
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
@@ -78,7 +78,8 @@ spec:
       containers:
       - args:
         - --config=/etc/kubernetes/config/config.json
-        - --cert-dir=/var/run/kubernetes
+        - --tls-cert-file=/etc/kubernetes/certs/tls.crt
+        - --tls-private-key-file=/etc/kubernetes/certs/tls.key
         - --secure-port=10259
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
@@ -198,6 +199,10 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         name: kube-scheduler
+        ports:
+        - containerPort: 10259
+          name: client
+          protocol: TCP
         resources:
           requests:
             cpu: 25m
@@ -206,8 +211,8 @@ spec:
           readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - mountPath: /var/run/kubernetes
-          name: cert-work
+        - mountPath: /etc/kubernetes/certs
+          name: serving-cert
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeconfig
         - mountPath: /etc/kubernetes/config
@@ -240,8 +245,10 @@ spec:
           defaultMode: 420
           name: kube-scheduler
         name: scheduler-config
-      - emptyDir: {}
-        name: cert-work
+      - name: serving-cert
+        secret:
+          defaultMode: 416
+          secretName: scheduler-server
       - name: kubeconfig
         secret:
           defaultMode: 416

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kube-scheduler
+  name: kube-scheduler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilyPolicy: PreferDualStack
+  ports:
+  - name: client
+    port: 10259
+    protocol: TCP
+    targetPort: client
+  selector:
+    app: kube-scheduler
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
@@ -1,0 +1,49 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations:
+    hypershift.openshift.io/metrics-endpoint: https
+    hypershift.openshift.io/metrics-job: kube-scheduler
+    hypershift.openshift.io/metrics-namespace: openshift-kube-scheduler
+    hypershift.openshift.io/metrics-service: kube-scheduler
+  name: kube-scheduler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  endpoints:
+  - metricRelabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    relabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    scheme: https
+    targetPort: client
+    tlsConfig:
+      ca:
+        configMap:
+          key: ca.crt
+          name: root-ca
+      cert:
+        secret:
+          key: tls.crt
+          name: metrics-client
+      keySecret:
+        key: tls.key
+        name: metrics-client
+      serverName: kube-scheduler
+  namespaceSelector:
+    matchNames:
+    - hcp-namespace
+  selector:
+    matchLabels:
+      app: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_controlplanecomponent.yaml
@@ -25,3 +25,9 @@ status:
   - group: ""
     kind: Secret
     name: kube-scheduler-kubeconfig
+  - group: ""
+    kind: Service
+    name: kube-scheduler
+  - group: monitoring.coreos.com
+    kind: ServiceMonitor
+    name: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_deployment.yaml
@@ -27,7 +27,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: cert-work,tmp-dir
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
         component.hypershift.openshift.io/config-hash: 022a8a3ab4d55cfe
         hypershift.openshift.io/release-image: quay.io/openshift-release-dev/ocp-release:4.16.10-x86_64
       labels:
@@ -78,7 +78,8 @@ spec:
       containers:
       - args:
         - --config=/etc/kubernetes/config/config.json
-        - --cert-dir=/var/run/kubernetes
+        - --tls-cert-file=/etc/kubernetes/certs/tls.crt
+        - --tls-private-key-file=/etc/kubernetes/certs/tls.key
         - --secure-port=10259
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
@@ -199,6 +200,10 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         name: kube-scheduler
+        ports:
+        - containerPort: 10259
+          name: client
+          protocol: TCP
         resources:
           requests:
             cpu: 25m
@@ -207,8 +212,8 @@ spec:
           readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - mountPath: /var/run/kubernetes
-          name: cert-work
+        - mountPath: /etc/kubernetes/certs
+          name: serving-cert
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeconfig
         - mountPath: /etc/kubernetes/config
@@ -241,8 +246,10 @@ spec:
           defaultMode: 420
           name: kube-scheduler
         name: scheduler-config
-      - emptyDir: {}
-        name: cert-work
+      - name: serving-cert
+        secret:
+          defaultMode: 416
+          secretName: scheduler-server
       - name: kubeconfig
         secret:
           defaultMode: 416

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kube-scheduler
+  name: kube-scheduler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilyPolicy: PreferDualStack
+  ports:
+  - name: client
+    port: 10259
+    protocol: TCP
+    targetPort: client
+  selector:
+    app: kube-scheduler
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/kube-scheduler/zz_fixture_TestControlPlaneComponents_kube_scheduler_servicemonitor.yaml
@@ -1,0 +1,49 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations:
+    hypershift.openshift.io/metrics-endpoint: https
+    hypershift.openshift.io/metrics-job: kube-scheduler
+    hypershift.openshift.io/metrics-namespace: openshift-kube-scheduler
+    hypershift.openshift.io/metrics-service: kube-scheduler
+  name: kube-scheduler
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+spec:
+  endpoints:
+  - metricRelabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    relabelings:
+    - action: replace
+      replacement: ""
+      targetLabel: _id
+    scheme: https
+    targetPort: client
+    tlsConfig:
+      ca:
+        configMap:
+          key: ca.crt
+          name: root-ca
+      cert:
+        secret:
+          key: tls.crt
+          name: metrics-client
+      keySecret:
+        key: tls.key
+        name: metrics-client
+      serverName: kube-scheduler
+  namespaceSelector:
+    matchNames:
+    - hcp-namespace
+  selector:
+    matchLabels:
+      app: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-scheduler/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-scheduler/deployment.yaml
@@ -20,7 +20,8 @@ spec:
       containers:
       - args:
         - --config=/etc/kubernetes/config/config.json
-        - --cert-dir=/var/run/kubernetes
+        - --tls-cert-file=/etc/kubernetes/certs/tls.crt
+        - --tls-private-key-file=/etc/kubernetes/certs/tls.key
         - --secure-port=10259
         - --authentication-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
@@ -41,13 +42,17 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         name: kube-scheduler
+        ports:
+        - containerPort: 10259
+          name: client
+          protocol: TCP
         resources:
           requests:
             cpu: 25m
             memory: 150Mi
         volumeMounts:
-        - mountPath: /var/run/kubernetes
-          name: cert-work
+        - mountPath: /etc/kubernetes/certs
+          name: serving-cert
         - mountPath: /etc/kubernetes/kubeconfig
           name: kubeconfig
         - mountPath: /etc/kubernetes/config
@@ -57,8 +62,10 @@ spec:
           defaultMode: 420
           name: kube-scheduler
         name: scheduler-config
-      - emptyDir: {}
-        name: cert-work
+      - name: serving-cert
+        secret:
+          defaultMode: 416
+          secretName: scheduler-server
       - name: kubeconfig
         secret:
           defaultMode: 416

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-scheduler/service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-scheduler/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kube-scheduler
+  name: kube-scheduler
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilyPolicy: PreferDualStack
+  ports:
+  - name: client
+    port: 10259
+    protocol: TCP
+    targetPort: client
+  selector:
+    app: kube-scheduler
+  sessionAffinity: None
+  type: ClusterIP

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-scheduler/servicemonitor.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/kube-scheduler/servicemonitor.yaml
@@ -1,0 +1,29 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kube-scheduler
+  annotations:
+    hypershift.openshift.io/metrics-job: kube-scheduler
+    hypershift.openshift.io/metrics-namespace: openshift-kube-scheduler
+    hypershift.openshift.io/metrics-service: kube-scheduler
+    hypershift.openshift.io/metrics-endpoint: https
+spec:
+  endpoints:
+  - scheme: https
+    targetPort: client
+    tlsConfig:
+      ca:
+        configMap:
+          key: ca.crt
+          name: root-ca
+      cert:
+        secret:
+          key: tls.crt
+          name: metrics-client
+      keySecret:
+        key: tls.key
+        name: metrics-client
+      serverName: kube-scheduler
+  selector:
+    matchLabels:
+      app: kube-scheduler

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/component.go
@@ -40,6 +40,10 @@ func NewComponent() component.ControlPlaneComponent {
 			"kubeconfig.yaml",
 			component.WithAdaptFunction(adaptKubeconfig),
 		).
+		WithManifestAdapter(
+			"servicemonitor.yaml",
+			component.WithAdaptFunction(adaptServiceMonitor),
+		).
 		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{}).
 		Build()
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/component_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/component_test.go
@@ -1,0 +1,35 @@
+package scheduler
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestKubeSchedulerOptions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("When IsRequestServing is called it should return false", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		ks := &kubeScheduler{}
+		g.Expect(ks.IsRequestServing()).To(BeFalse())
+	})
+
+	t.Run("When MultiZoneSpread is called it should return true", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		ks := &kubeScheduler{}
+		g.Expect(ks.MultiZoneSpread()).To(BeTrue())
+	})
+
+	t.Run("When NeedsManagementKASAccess is called it should return false", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		ks := &kubeScheduler{}
+		g.Expect(ks.NeedsManagementKASAccess()).To(BeFalse())
+	})
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/servicemonitor.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/servicemonitor.go
@@ -1,0 +1,19 @@
+package scheduler
+
+import (
+	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/metrics"
+	"github.com/openshift/hypershift/support/util"
+
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+)
+
+func adaptServiceMonitor(cpContext component.WorkloadContext, sm *prometheusoperatorv1.ServiceMonitor) error {
+	sm.Spec.NamespaceSelector = prometheusoperatorv1.NamespaceSelector{
+		MatchNames: []string{sm.Namespace},
+	}
+	sm.Spec.Endpoints[0].MetricRelabelConfigs = metrics.SchedulerRelabelConfigs(cpContext.MetricsSet)
+	util.ApplyClusterIDLabel(&sm.Spec.Endpoints[0], cpContext.HCP.Spec.ClusterID)
+
+	return nil
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/servicemonitor_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kube_scheduler/servicemonitor_test.go
@@ -1,0 +1,110 @@
+package scheduler
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	component "github.com/openshift/hypershift/support/controlplane-component"
+	"github.com/openshift/hypershift/support/metrics"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	prometheusoperatorv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+)
+
+func TestAdaptServiceMonitor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		metricsSet metrics.MetricsSet
+		clusterID  string
+		validate   func(*testing.T, *prometheusoperatorv1.ServiceMonitor, error)
+	}{
+		{
+			name:       "When service monitor is adapted it should set namespace selector",
+			metricsSet: metrics.MetricsSetTelemetry,
+			clusterID:  "test-cluster-id",
+			validate: func(t *testing.T, sm *prometheusoperatorv1.ServiceMonitor, err error) {
+				g := NewWithT(t)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(sm.Spec.NamespaceSelector.MatchNames).To(Equal([]string{"test-namespace"}))
+			},
+		},
+		{
+			name:       "When service monitor is adapted it should apply cluster ID label",
+			metricsSet: metrics.MetricsSetAll,
+			clusterID:  "cluster-abc-123",
+			validate: func(t *testing.T, sm *prometheusoperatorv1.ServiceMonitor, err error) {
+				g := NewWithT(t)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(sm.Spec.Endpoints).To(HaveLen(1))
+
+				relabelConfigs := sm.Spec.Endpoints[0].RelabelConfigs
+				foundClusterIDLabel := false
+				for _, config := range relabelConfigs {
+					if config.TargetLabel == "_id" && config.Replacement != nil && *config.Replacement == "cluster-abc-123" {
+						foundClusterIDLabel = true
+						break
+					}
+				}
+				g.Expect(foundClusterIDLabel).To(BeTrue(), "cluster ID label should be applied")
+			},
+		},
+		{
+			name:       "When metrics set is Telemetry it should drop all metrics",
+			metricsSet: metrics.MetricsSetTelemetry,
+			clusterID:  "test-cluster",
+			validate: func(t *testing.T, sm *prometheusoperatorv1.ServiceMonitor, err error) {
+				g := NewWithT(t)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(sm.Spec.Endpoints).To(HaveLen(1))
+
+				g.Expect(sm.Spec.Endpoints[0].MetricRelabelConfigs).To(HaveLen(2))
+				g.Expect(sm.Spec.Endpoints[0].MetricRelabelConfigs[0].Action).To(Equal("drop"))
+				g.Expect(sm.Spec.Endpoints[0].MetricRelabelConfigs[0].Regex).To(Equal(".*"))
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: "test-namespace",
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					ClusterID: tc.clusterID,
+				},
+			}
+
+			cpContext := component.WorkloadContext{
+				Context:    t.Context(),
+				HCP:        hcp,
+				MetricsSet: tc.metricsSet,
+			}
+
+			sm := &prometheusoperatorv1.ServiceMonitor{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-scheduler",
+					Namespace: "test-namespace",
+				},
+				Spec: prometheusoperatorv1.ServiceMonitorSpec{
+					Endpoints: []prometheusoperatorv1.Endpoint{
+						{
+							Port: "metrics",
+						},
+					},
+				},
+			}
+
+			err := adaptServiceMonitor(cpContext, sm)
+			tc.validate(t, sm, err)
+		})
+	}
+}

--- a/support/metrics/sets.go
+++ b/support/metrics/sets.go
@@ -52,6 +52,7 @@ type MetricsSetConfig struct {
 	OLM                             []prometheusoperatorv1.RelabelConfig `json:"olm,omitempty"`
 	CatalogOperator                 []prometheusoperatorv1.RelabelConfig `json:"catalogOperator,omitempty"`
 	RegistryOperator                []prometheusoperatorv1.RelabelConfig `json:"registryOperator,omitempty"`
+	KubeScheduler                   []prometheusoperatorv1.RelabelConfig `json:"kubeScheduler,omitempty"`
 	NodeTuningOperator              []prometheusoperatorv1.RelabelConfig `json:"nodeTuningOperator,omitempty"`
 
 	// HyperShift components
@@ -222,6 +223,23 @@ func KASRelabelConfigs(set MetricsSet) []prometheusoperatorv1.RelabelConfig {
 				SourceLabels: []prometheusoperatorv1.LabelName{"__name__", "le"},
 			},
 		}
+	}
+}
+
+func SchedulerRelabelConfigs(set MetricsSet) []prometheusoperatorv1.RelabelConfig {
+	switch set {
+	case MetricsSetTelemetry:
+		return []prometheusoperatorv1.RelabelConfig{
+			{
+				Action:       "drop",
+				Regex:        ".*",
+				SourceLabels: []prometheusoperatorv1.LabelName{"__name__"},
+			},
+		}
+	case MetricsSetSRE:
+		return sreMetricsSetConfig.KubeScheduler
+	default:
+		return nil
 	}
 }
 


### PR DESCRIPTION
## What this PR does / why we need it:

Adds a ServiceMonitor for kube-scheduler to enable Prometheus metrics scraping with proper mTLS authentication.

Previously, kube-scheduler auto-generated self-signed serving certificates via `--cert-dir=/var/run/kubernetes`. Prometheus could not verify the scheduler's identity using the cluster's root CA, and no ServiceMonitor existed.

This PR:
- Creates a CA-signed serving certificate (`scheduler-server`) for kube-scheduler, following the KCM pattern
- Replaces the self-signed cert (emptyDir) with the CA-signed cert (secret volume) in the deployment
- Adds a `kube-scheduler` Service exposing port 10259
- Adds a ServiceMonitor with mTLS config (root-ca for server verification, metrics-client for client auth)
- Adds `SchedulerRelabelConfigs()` for SRE metrics set support

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/CNTRLPLANE-3584

## Special notes for your reviewer:

Follows the same pattern as kube-controller-manager's ServiceMonitor setup.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TLS serving certificate provisioning for the kube-scheduler with secret-backed cert/key mounting, Deployment switched to explicit cert/key flags, and a ClusterIP Service exposing port 10259.
  * ServiceMonitor added to scrape scheduler metrics over TLS using configured CA and client credentials.

* **Metrics**
  * Added kube-scheduler relabel config support to metrics configuration.

* **Tests**
  * Unit tests covering scheduler certificate reconciliation, ServiceMonitor adaptation, and scheduler component defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->