### PR TITLE
NO-JIRA: Fix Azure private/topology CEL validation rules

### DIFF
--- a/api/hypershift/v1beta1/azure.go
+++ b/api/hypershift/v1beta1/azure.go
@@ -668,8 +668,7 @@ const (
 // mechanism. Currently only PrivateLink is supported; additional mechanisms (e.g., Swift) may
 // be added in the future.
 //
-// +kubebuilder:validation:XValidation:rule="self.type != 'PrivateLink' ? !has(self.privateLink) : true",message="privateLink is forbidden when type is not PrivateLink"
-// +kubebuilder:validation:XValidation:rule="self.type != 'PrivateLink' || has(self.privateLink)",message="privateLink is required when type is PrivateLink"
+// +kubebuilder:validation:XValidation:rule="self.type == 'PrivateLink' ? has(self.privateLink) : !has(self.privateLink)",message="privateLink is required when type is PrivateLink, and forbidden otherwise"
 // +union
 type AzurePrivateSpec struct {
 	// type specifies the private connectivity mechanism used for the hosted cluster's API server.

--- a/api/hypershift/v1beta1/azure.go
+++ b/api/hypershift/v1beta1/azure.go
@@ -362,7 +362,7 @@ type AzureNodePoolOSDisk struct {
 // +kubebuilder:validation:XValidation:rule="has(self.private) == has(oldSelf.private)",message="private cannot be added or removed after cluster creation"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.topology) || has(self.topology)",message="topology cannot be removed once set"
 // +kubebuilder:validation:XValidation:rule="!has(self.topology) || !has(oldSelf.topology) || (self.topology == 'Public') == (oldSelf.topology == 'Public')",message="transitions between Public and non-Public topology are not supported"
-// +kubebuilder:validation:XValidation:rule="!has(self.topology) || ((self.topology == 'Private' || self.topology == 'PublicAndPrivate') ? has(self.private) : !has(self.private))",message="private is required when topology is Private or PublicAndPrivate, and forbidden otherwise"
+// +kubebuilder:validation:XValidation:rule="has(self.topology) && (self.topology == 'Private' || self.topology == 'PublicAndPrivate') ? has(self.private) : !has(self.private)",message="private is required when topology is Private or PublicAndPrivate, and forbidden otherwise"
 // +kubebuilder:validation:XValidation:rule="!has(self.private) || self.private.type != 'PrivateLink' || self.azureAuthenticationConfig.azureAuthenticationConfigType != 'WorkloadIdentities' || has(self.azureAuthenticationConfig.workloadIdentities.controlPlaneOperator)",message="workloadIdentities.controlPlaneOperator is required when Private Link is configured with WorkloadIdentities authentication"
 type AzurePlatformSpec struct {
 	// cloud is the cloud environment identifier, valid values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33
@@ -669,6 +669,7 @@ const (
 // be added in the future.
 //
 // +kubebuilder:validation:XValidation:rule="self.type != 'PrivateLink' ? !has(self.privateLink) : true",message="privateLink is forbidden when type is not PrivateLink"
+// +kubebuilder:validation:XValidation:rule="self.type != 'PrivateLink' || has(self.privateLink)",message="privateLink is required when type is PrivateLink"
 // +union
 type AzurePrivateSpec struct {
 	// type specifies the private connectivity mechanism used for the hosted cluster's API server.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -5291,11 +5291,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -5294,6 +5294,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5428,9 +5430,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -5282,11 +5282,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -5285,6 +5285,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5419,9 +5421,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -5305,6 +5305,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5439,9 +5441,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -5302,11 +5302,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -5614,11 +5614,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -5617,6 +5617,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5751,9 +5753,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -5757,6 +5757,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5891,9 +5893,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -5754,11 +5754,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -5745,11 +5745,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -5748,6 +5748,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5882,9 +5884,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
@@ -5282,11 +5282,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
@@ -5285,6 +5285,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5419,9 +5421,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -5350,6 +5350,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5484,9 +5486,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -5347,11 +5347,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -5307,6 +5307,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5441,9 +5443,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -5304,11 +5304,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -5300,11 +5300,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -5303,6 +5303,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5437,9 +5439,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -5361,6 +5361,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5495,9 +5497,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -5358,11 +5358,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -5282,11 +5282,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -5285,6 +5285,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5419,9 +5421,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSAdherence.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSAdherence.yaml
@@ -5325,6 +5325,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5459,9 +5461,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSAdherence.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSAdherence.yaml
@@ -5322,11 +5322,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -5171,11 +5171,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/AAA_ungated.yaml
@@ -5174,6 +5174,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5308,9 +5310,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -5162,11 +5162,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -5165,6 +5165,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5299,9 +5301,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -5185,6 +5185,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5319,9 +5321,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -5182,11 +5182,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -5494,11 +5494,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDC.yaml
@@ -5497,6 +5497,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5631,9 +5633,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -5637,6 +5637,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5771,9 +5773,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -5634,11 +5634,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -5628,6 +5628,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5762,9 +5764,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -5625,11 +5625,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
@@ -5162,11 +5162,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/GCPPlatform.yaml
@@ -5165,6 +5165,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5299,9 +5301,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -5227,11 +5227,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -5230,6 +5230,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5364,9 +5366,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -5184,11 +5184,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -5187,6 +5187,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5321,9 +5323,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -5180,11 +5180,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -5183,6 +5183,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5317,9 +5319,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -5241,6 +5241,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5375,9 +5377,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -5238,11 +5238,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -5162,11 +5162,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/OpenStack.yaml
@@ -5165,6 +5165,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5299,9 +5301,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSAdherence.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSAdherence.yaml
@@ -5205,6 +5205,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5339,9 +5341,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSAdherence.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedcontrolplanes.hypershift.openshift.io/TLSAdherence.yaml
@@ -5202,11 +5202,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.azure.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.azure.testsuite.yaml
@@ -613,7 +613,7 @@ tests:
           servicePublishingStrategy:
             type: Route
             route: {}
-    expectedError: "privateLink is required when type is PrivateLink"
+    expectedError: "privateLink is required when type is PrivateLink, and forbidden otherwise"
 
   - name: When Azure PrivateLink type is set with privateLink config it should pass
     initial: |

--- a/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.azure.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/hostedclusters.hypershift.openshift.io/stable.hostedclusters.azure.testsuite.yaml
@@ -548,7 +548,7 @@ tests:
             route: {}
 
   # --- Azure PrivateLink CEL validation ---
-  - name: When Azure PrivateLink type is set without privateLink config it should pass
+  - name: When Azure PrivateLink type is set without privateLink config it should fail
     initial: |
       apiVersion: hypershift.openshift.io/v1beta1
       kind: HostedCluster
@@ -613,6 +613,7 @@ tests:
           servicePublishingStrategy:
             type: Route
             route: {}
+    expectedError: "privateLink is required when type is PrivateLink"
 
   - name: When Azure PrivateLink type is set with privateLink config it should pass
     initial: |
@@ -703,6 +704,8 @@ tests:
             topology: Private
             private:
               type: PrivateLink
+              privateLink:
+                natSubnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/nat-subnet"
             azureAuthenticationConfig:
               azureAuthenticationConfigType: WorkloadIdentities
               workloadIdentities:
@@ -769,6 +772,8 @@ tests:
             topology: Private
             private:
               type: PrivateLink
+              privateLink:
+                natSubnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/nat-subnet"
             azureAuthenticationConfig:
               azureAuthenticationConfigType: WorkloadIdentities
               workloadIdentities:
@@ -813,3 +818,140 @@ tests:
             type: Route
             route: {}
     expectedError: "workloadIdentities.controlPlaneOperator is required when Private Link is configured with WorkloadIdentities authentication"
+
+  - name: When Azure private is set without topology it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: Azure
+          azure:
+            location: eastus
+            resourceGroupName: test-rg
+            vnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet"
+            subnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet"
+            subscriptionID: "12345678-1234-5678-9012-123456789012"
+            securityGroupID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/test-nsg"
+            tenantID: "87654321-4321-8765-2109-876543210987"
+            private:
+              type: PrivateLink
+              privateLink:
+                natSubnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/nat-subnet"
+            azureAuthenticationConfig:
+              azureAuthenticationConfigType: WorkloadIdentities
+              workloadIdentities:
+                imageRegistry:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                ingress:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                file:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                disk:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                nodePoolManagement:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                cloudProvider:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                network:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                controlPlaneOperator:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    expectedError: "private is required when topology is Private or PublicAndPrivate, and forbidden otherwise"
+
+  - name: When Azure private is set with Public topology it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: HostedCluster
+      spec:
+        dns:
+          baseDomain: example.com
+        platform:
+          type: Azure
+          azure:
+            location: eastus
+            resourceGroupName: test-rg
+            vnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet"
+            subnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet"
+            subscriptionID: "12345678-1234-5678-9012-123456789012"
+            securityGroupID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/test-nsg"
+            tenantID: "87654321-4321-8765-2109-876543210987"
+            topology: Public
+            private:
+              type: PrivateLink
+              privateLink:
+                natSubnetID: "/subscriptions/12345678-1234-5678-9012-123456789012/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/nat-subnet"
+            azureAuthenticationConfig:
+              azureAuthenticationConfigType: WorkloadIdentities
+              workloadIdentities:
+                imageRegistry:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                ingress:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                file:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                disk:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                nodePoolManagement:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                cloudProvider:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                network:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+                controlPlaneOperator:
+                  clientID: "12345678-1234-5678-9012-123456789012"
+        pullSecret:
+          name: secret
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.15.11-x86_64
+        secretEncryption:
+          aescbc:
+            activeKey:
+              name: key
+          type: aescbc
+        services:
+        - service: APIServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: OAuthServer
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Konnectivity
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+        - service: Ignition
+          servicePublishingStrategy:
+            type: Route
+            route: {}
+    expectedError: "private is required when topology is Private or PublicAndPrivate, and forbidden otherwise"

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
@@ -6136,6 +6136,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -6270,9 +6272,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
@@ -6133,11 +6133,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
@@ -5786,6 +5786,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5920,9 +5922,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
@@ -5783,11 +5783,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -6004,11 +6004,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -6007,6 +6007,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -6141,9 +6143,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
@@ -6016,6 +6016,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -6150,9 +6152,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-CustomNoUpgrade.crd.yaml
@@ -6013,11 +6013,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
@@ -5663,11 +5663,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-Default.crd.yaml
@@ -5666,6 +5666,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -5800,9 +5802,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -5884,11 +5884,10 @@ spec:
                         - type
                         type: object
                         x-kubernetes-validations:
-                        - message: privateLink is forbidden when type is not PrivateLink
-                          rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
-                            : true'
-                        - message: privateLink is required when type is PrivateLink
-                          rule: self.type != 'PrivateLink' || has(self.privateLink)
+                        - message: privateLink is required when type is PrivateLink,
+                            and forbidden otherwise
+                          rule: 'self.type == ''PrivateLink'' ? has(self.privateLink)
+                            : !has(self.privateLink)'
                       resourceGroup:
                         default: default
                         description: |-

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedcontrolplanes-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -5887,6 +5887,8 @@ spec:
                         - message: privateLink is forbidden when type is not PrivateLink
                           rule: 'self.type != ''PrivateLink'' ? !has(self.privateLink)
                             : true'
+                        - message: privateLink is required when type is PrivateLink
+                          rule: self.type != 'PrivateLink' || has(self.privateLink)
                       resourceGroup:
                         default: default
                         description: |-
@@ -6021,9 +6023,9 @@ spec:
                         == ''Public'') == (oldSelf.topology == ''Public'')'
                     - message: private is required when topology is Private or PublicAndPrivate,
                         and forbidden otherwise
-                      rule: '!has(self.topology) || ((self.topology == ''Private''
-                        || self.topology == ''PublicAndPrivate'') ? has(self.private)
-                        : !has(self.private))'
+                      rule: 'has(self.topology) && (self.topology == ''Private'' ||
+                        self.topology == ''PublicAndPrivate'') ? has(self.private)
+                        : !has(self.private)'
                     - message: workloadIdentities.controlPlaneOperator is required
                         when Private Link is configured with WorkloadIdentities authentication
                       rule: '!has(self.private) || self.private.type != ''PrivateLink''

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/azure.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/azure.go
@@ -668,8 +668,7 @@ const (
 // mechanism. Currently only PrivateLink is supported; additional mechanisms (e.g., Swift) may
 // be added in the future.
 //
-// +kubebuilder:validation:XValidation:rule="self.type != 'PrivateLink' ? !has(self.privateLink) : true",message="privateLink is forbidden when type is not PrivateLink"
-// +kubebuilder:validation:XValidation:rule="self.type != 'PrivateLink' || has(self.privateLink)",message="privateLink is required when type is PrivateLink"
+// +kubebuilder:validation:XValidation:rule="self.type == 'PrivateLink' ? has(self.privateLink) : !has(self.privateLink)",message="privateLink is required when type is PrivateLink, and forbidden otherwise"
 // +union
 type AzurePrivateSpec struct {
 	// type specifies the private connectivity mechanism used for the hosted cluster's API server.

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/azure.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/azure.go
@@ -362,7 +362,7 @@ type AzureNodePoolOSDisk struct {
 // +kubebuilder:validation:XValidation:rule="has(self.private) == has(oldSelf.private)",message="private cannot be added or removed after cluster creation"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.topology) || has(self.topology)",message="topology cannot be removed once set"
 // +kubebuilder:validation:XValidation:rule="!has(self.topology) || !has(oldSelf.topology) || (self.topology == 'Public') == (oldSelf.topology == 'Public')",message="transitions between Public and non-Public topology are not supported"
-// +kubebuilder:validation:XValidation:rule="!has(self.topology) || ((self.topology == 'Private' || self.topology == 'PublicAndPrivate') ? has(self.private) : !has(self.private))",message="private is required when topology is Private or PublicAndPrivate, and forbidden otherwise"
+// +kubebuilder:validation:XValidation:rule="has(self.topology) && (self.topology == 'Private' || self.topology == 'PublicAndPrivate') ? has(self.private) : !has(self.private)",message="private is required when topology is Private or PublicAndPrivate, and forbidden otherwise"
 // +kubebuilder:validation:XValidation:rule="!has(self.private) || self.private.type != 'PrivateLink' || self.azureAuthenticationConfig.azureAuthenticationConfigType != 'WorkloadIdentities' || has(self.azureAuthenticationConfig.workloadIdentities.controlPlaneOperator)",message="workloadIdentities.controlPlaneOperator is required when Private Link is configured with WorkloadIdentities authentication"
 type AzurePlatformSpec struct {
 	// cloud is the cloud environment identifier, valid values could be found here: https://github.com/Azure/go-autorest/blob/4c0e21ca2bbb3251fe7853e6f9df6397f53dd419/autorest/azure/environments.go#L33
@@ -669,6 +669,7 @@ const (
 // be added in the future.
 //
 // +kubebuilder:validation:XValidation:rule="self.type != 'PrivateLink' ? !has(self.privateLink) : true",message="privateLink is forbidden when type is not PrivateLink"
+// +kubebuilder:validation:XValidation:rule="self.type != 'PrivateLink' || has(self.privateLink)",message="privateLink is required when type is PrivateLink"
 // +union
 type AzurePrivateSpec struct {
 	// type specifies the private connectivity mechanism used for the hosted cluster's API server.


### PR DESCRIPTION
## Description

Fix two CEL validation gaps on Azure `AzurePlatformSpec` and `AzurePrivateSpec`:

1. **`private` was settable without `topology`**: The existing rule `!has(self.topology) || (...)` short-circuited to `true` when `topology` was omitted, allowing `private` to be set without `topology`. Fixed to `has(self.topology) && (...) ? has(self.private) : !has(self.private)` — now correctly forbids `private` when `topology` is absent or `Public`.

2. **`privateLink` struct not required when `type` is `PrivateLink`**: Only the negative constraint existed (forbid `privateLink` when type is not PrivateLink). Added `self.type != 'PrivateLink' || has(self.privateLink)` to require the struct.

## Changes

- `api/hypershift/v1beta1/azure.go`: Fix topology/private CEL rule, add privateLink requirement rule
- Envtest cases: added "private without topology should fail", "private with Public topology should fail", "PrivateLink without privateLink config should fail"; fixed existing tests to include `privateLink` struct

## Test plan

- [x] `make test-envtest-ocp` — all 630 specs pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Azure topology validation tightened: private configuration is now consistently required for Private or PublicAndPrivate topologies and forbidden otherwise, preventing ambiguous or missing private settings.
  * PrivateLink validation strengthened: PrivateLink-specific settings are now required when PrivateLink is selected and disallowed for other types, reducing misconfiguration risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->