### PR TITLE
OCPBUGS-84327: Product-cli missing controller-runtime logger initialization causes noisy warning

### DIFF
--- a/product-cli/main.go
+++ b/product-cli/main.go
@@ -28,14 +28,19 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap/zapcore"
 )
 
-func main() {
-	ctrl.SetLogger(zap.New(zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
+func newLogger(opts ...zap.Opts) logr.Logger {
+	return zap.New(append([]zap.Opts{zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
 		o.EncodeTime = zapcore.RFC3339TimeEncoder
-	})))
+	})}, opts...)...)
+}
+
+func main() {
+	ctrl.SetLogger(newLogger())
 	cmd := &cobra.Command{
 		Use:              "hcp",
 		SilenceUsage:     true,

--- a/product-cli/main.go
+++ b/product-cli/main.go
@@ -25,10 +25,17 @@ import (
 	"github.com/openshift/hypershift/product-cli/cmd/create"
 	"github.com/openshift/hypershift/product-cli/cmd/destroy"
 
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
 	"github.com/spf13/cobra"
+	"go.uber.org/zap/zapcore"
 )
 
 func main() {
+	ctrl.SetLogger(zap.New(zap.JSONEncoder(func(o *zapcore.EncoderConfig) {
+		o.EncodeTime = zapcore.RFC3339TimeEncoder
+	})))
 	cmd := &cobra.Command{
 		Use:              "hcp",
 		SilenceUsage:     true,

--- a/product-cli/main_test.go
+++ b/product-cli/main_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestNewLogger(t *testing.T) {
+	t.Run("When creating a new logger it should produce JSON output with RFC3339 timestamps", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := newLogger(zap.WriteTo(&buf))
+
+		logger.Info("test message", "key", "value")
+
+		var entry map[string]interface{}
+		if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+			t.Fatalf("expected JSON log output, got error: %v\nraw output: %s", err, buf.String())
+		}
+
+		ts, ok := entry["ts"].(string)
+		if !ok {
+			t.Fatalf("expected string 'ts' field, got: %v", entry["ts"])
+		}
+		if _, err := time.Parse(time.RFC3339, ts); err != nil {
+			t.Errorf("expected RFC3339 timestamp, got %q: %v", ts, err)
+		}
+
+		if msg, _ := entry["msg"].(string); msg != "test message" {
+			t.Errorf("expected msg 'test message', got %q", msg)
+		}
+
+		if v, _ := entry["key"].(string); v != "value" {
+			t.Errorf("expected key 'value', got %q", v)
+		}
+	})
+}


### PR DESCRIPTION
## What this PR does / why we need it:
product-cli/main.go does not initialize the controller-runtime logger, while the hypershift CLI (main.go) properly initializes it at line 43 with ctrl.SetLogger(zap.New(...)). This causes a noisy warning to be emitted during operations like create infra when using the product-cli:

[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
The hypershift CLI does not produce this warning because the logger is properly initialized.

Added "ctrl.SetLogger(zap.New(...))." to the product-cli/main.go to fix the above mentioned issue.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes : https://redhat.atlassian.net/browse/OCPBUGS-84327

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CLI now initializes structured JSON logging at startup, improving machine-readability and consistency of log output.
  * Timestamps in logs use RFC3339 formatting for better interoperability and easier correlation across systems.
  * Result: clearer, more parseable logs to aid debugging and monitoring of CLI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->