### PR TITLE
NO-JIRA: Test docs deploy preview

### DIFF
--- a/docs/content/how-to/ci/docs-preview.md
+++ b/docs/content/how-to/ci/docs-preview.md
@@ -11,7 +11,7 @@ The preview system uses two separate workflows for security, following the reusa
 
 GitHub shows a **View deployment** link in the PR timeline via the `docs-preview` environment.
 
-The preview is available at `https://pr-<number>.hypershift.pages.dev`.
+The preview is available at `https://pr-<number>.hypershift.pages.dev`. Previews are automatically cleaned up by Cloudflare's branch retention policy.
 
 ## Configuration
 

--- a/docs/content/how-to/ci/docs-preview.md
+++ b/docs/content/how-to/ci/docs-preview.md
@@ -24,6 +24,10 @@ The deploy workflow requires two secrets configured on the `docs-preview` GitHub
 | `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account ID |
 | `CLOUDFLARE_API_TOKEN` | API token with Cloudflare Pages edit permissions |
 
+## Troubleshooting
+
+If the preview link doesn't appear on your PR, check that the Docs Build workflow completed successfully. The Docs Deploy workflow triggers automatically after a successful build.
+
 ## Local Preview
 
 To preview documentation locally:


### PR DESCRIPTION
## Summary

- Minor docs clarification to test the docs deploy preview workflow after merging #8488

## Test plan

- [ ] Verify Docs Build workflow triggers and succeeds
- [ ] Verify Docs Deploy Preview workflow triggers and creates a deployment status
- [ ] Verify preview link appears on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Cloudflare Pages preview URLs (pr-<number>.pages.dev) are cleaned up automatically via branch retention policy.
  * Added a Troubleshooting note: if a preview link is missing on a PR, verify the Docs Build workflow succeeded before expecting a Docs Deploy preview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->