### PR TITLE
CNTRLPLANE-3329: Mount EFS-backed Go build cache PV on ARC runner pods

### DIFF
--- a/hack/github-actions-runner/values.yaml
+++ b/hack/github-actions-runner/values.yaml
@@ -10,6 +10,10 @@ template:
       - name: runner
         image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-gh-actions-runner:latest
         command: ["/home/runner/run.sh"]
+        volumeMounts:
+          - name: go-cache
+            mountPath: /cache/go-build
+            readOnly: true
         resources:
           requests:
             cpu: "4"
@@ -17,6 +21,11 @@ template:
           limits:
             cpu: "4"
             memory: "16Gi"
+    volumes:
+      - name: go-cache
+        persistentVolumeClaim:
+          claimName: go-cache-pvc
+          readOnly: true
     topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
## What this PR does / why we need it:

`actions/cache` adds ~2-3.5 min overhead per shard (upload/download) on every
CI run. To eliminate this, we are migrating to an EFS-backed PersistentVolume
that provides a shared Go build cache to all ARC runner pods.

This PR adds a read-only volume mount for the EFS-backed PVC (`go-cache-pvc`)
to the ARC runner pod template in `values.yaml`, mounting the shared cache at
`/cache/go-build`. This is the infrastructure wiring step — follow-up PRs will
update the workflow files to copy from this cache and remove `actions/cache`.

Infrastructure already provisioned on the ARC hosted cluster:
- EFS filesystem with mount target configured
- IAM role with EFS CSI driver policy attached
- AWS EFS CSI Driver Operator installed and running
- StorageClass, PV, and PVC created and bound in `arc-runners` namespace

## Which issue(s) this PR fixes:

Fixes https://redhat.atlassian.net/browse/CNTRLPLANE-3329

## Special notes for your reviewer:

- This change alone does **not** modify CI behavior — the mount is added but
  no workflow uses it yet.
- The PVC is mounted read-only, so runner pods cannot corrupt the shared cache.
- A nightly CronJob (separate from this PR) will warm the cache with read-write
  access.
- Follow-up PRs will: (1) update `test-reusable.yaml` to use the cache and
  remove `actions/cache`, (2) extend caching to lint, verify, and envtest
  workflows.

## Checklist:

- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.