### PR TITLE
CNTRLPLANE-3329: Replace actions/cache with EFS-backed build cache in unit tests

### DIFF
--- a/.github/actions/warm-go-cache/action.yaml
+++ b/.github/actions/warm-go-cache/action.yaml
@@ -8,6 +8,6 @@ runs:
         echo "GOCACHE=/tmp/go-build-cache" >> "$GITHUB_ENV"
         if [ -d /cache/go-build ]; then
           mkdir -p /tmp/go-build-cache && \
-          cp -a /cache/go-build/. /tmp/go-build-cache/ || \
+          timeout 120 cp -a /cache/go-build/. /tmp/go-build-cache/ || \
           echo "Warning: failed to copy EFS cache, proceeding without cache"
         fi

--- a/.github/actions/warm-go-cache/action.yaml
+++ b/.github/actions/warm-go-cache/action.yaml
@@ -1,0 +1,13 @@
+name: 'Warm Go build cache'
+description: 'Set GOCACHE and optionally warm from EFS-backed PV'
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        echo "GOCACHE=/tmp/go-build-cache" >> "$GITHUB_ENV"
+        if [ -d /cache/go-build ]; then
+          mkdir -p /tmp/go-build-cache && \
+          cp -a /cache/go-build/. /tmp/go-build-cache/ || \
+          echo "Warning: failed to copy EFS cache, proceeding without cache"
+        fi

--- a/.github/workflows/test-reusable.yaml
+++ b/.github/workflows/test-reusable.yaml
@@ -86,12 +86,11 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
-      - name: Restore Go build cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: /tmp/go-build-cache
-          key: go-build-${{ matrix.shard }}-${{ hashFiles('go.mod') }}-${{ github.sha }}
-          restore-keys: go-build-${{ matrix.shard }}-${{ hashFiles('go.mod') }}-
+      - name: Warm Go build cache from EFS
+        run: |
+          if [ -d /cache/go-build ]; then
+            cp -a /cache/go-build /tmp/go-build-cache
+          fi
       - name: Run tests
         run: make test-shard TEST_PACKAGES="${{ matrix.packages }}" COVER_PROFILE="cover-${{ matrix.shard }}.out"
       - name: Upload to Codecov

--- a/.github/workflows/test-reusable.yaml
+++ b/.github/workflows/test-reusable.yaml
@@ -73,7 +73,6 @@ jobs:
           - shard: other
             packages: ./karpenter-operator/... ./control-plane-pki-operator/... ./contrib/... ./ignition-server/... ./pkg/... ./dnsresolver/... ./product-cli/... ./client/... ./test/integration/... ./test/e2e/util/... ./test/util/... ./availability-prober/... ./konnectivity-socks5-proxy/... ./konnectivity-https-proxy/... ./kubernetes-default-proxy/... ./kubevirtexternalinfra/... ./etcd-defrag/... ./etcd-backup/... ./etcd-recovery/... ./etcd-upload/... ./kas-bootstrap/... ./sharedingress-config-generator/... ./sync-fg-configmap/... ./sync-global-pullsecret/... ./token-minter/...
     env:
-      GOCACHE: /tmp/go-build-cache
       GOMODCACHE: /tmp/go-mod-cache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -86,12 +85,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
-      - name: Warm Go build cache from EFS
-        run: |
-          if [ -d /cache/go-build ]; then
-            mkdir -p /tmp/go-build-cache
-            cp -a /cache/go-build/. /tmp/go-build-cache/
-          fi
+      - uses: ./.github/actions/warm-go-cache
       - name: Run tests
         run: make test-shard TEST_PACKAGES="${{ matrix.packages }}" COVER_PROFILE="cover-${{ matrix.shard }}.out"
       - name: Upload to Codecov

--- a/.github/workflows/test-reusable.yaml
+++ b/.github/workflows/test-reusable.yaml
@@ -89,7 +89,8 @@ jobs:
       - name: Warm Go build cache from EFS
         run: |
           if [ -d /cache/go-build ]; then
-            cp -a /cache/go-build /tmp/go-build-cache
+            mkdir -p /tmp/go-build-cache
+            cp -a /cache/go-build/. /tmp/go-build-cache/
           fi
       - name: Run tests
         run: make test-shard TEST_PACKAGES="${{ matrix.packages }}" COVER_PROFILE="cover-${{ matrix.shard }}.out"

--- a/.github/workflows/test-reusable.yaml
+++ b/.github/workflows/test-reusable.yaml
@@ -73,6 +73,7 @@ jobs:
           - shard: other
             packages: ./karpenter-operator/... ./control-plane-pki-operator/... ./contrib/... ./ignition-server/... ./pkg/... ./dnsresolver/... ./product-cli/... ./client/... ./test/integration/... ./test/e2e/util/... ./test/util/... ./availability-prober/... ./konnectivity-socks5-proxy/... ./konnectivity-https-proxy/... ./kubernetes-default-proxy/... ./kubevirtexternalinfra/... ./etcd-defrag/... ./etcd-backup/... ./etcd-recovery/... ./etcd-upload/... ./kas-bootstrap/... ./sharedingress-config-generator/... ./sync-fg-configmap/... ./sync-global-pullsecret/... ./token-minter/...
     env:
+      GOCACHE: /tmp/go-build-cache
       GOMODCACHE: /tmp/go-mod-cache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## What this PR does / why we need it:

`actions/cache` adds ~2-3.5 min overhead per shard (upload/download) on every
CI run. This PR replaces the `actions/cache` step in `test-reusable.yaml` with
a conditional copy from the EFS-backed PV mount at `/cache/go-build`.

The cache is copied to a local tmpdir (`/tmp/go-build-cache`) at job start,
which is already set as `GOCACHE` in the workflow. If the EFS mount is not
present (e.g. before the Helm values PR is merged, or during mount issues),
the step silently skips and CI runs without a cache — same as today.

## Which issue(s) this PR fixes:

Fixes https://redhat.atlassian.net/browse/CNTRLPLANE-3329

## Special notes for your reviewer:

- Depends on PR #8493 (Helm values update to mount the PVC on runner pods).
  However, because the cache step is conditional (`if [ -d /cache/go-build ]`),
  this PR can be merged in any order without breaking CI.
- The `GOCACHE` and `GOMODCACHE` env vars at the job level are unchanged.
- Follow-up PR will extend EFS caching to lint, verify, and envtest workflows.

## Checklist:

- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now pre-warms a local Go build cache via a dedicated warming step before running tests, replacing the previous direct cache restore to improve reliability and speed of unit-test runs.
  * Test sharding and test-reporting behavior remain unchanged; overall effect is faster, more stable CI unit-test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->