### PR TITLE
CNTRLPLANE-3329: Extend EFS-backed build cache to lint, verify, and envtest workflows

### DIFF
--- a/.github/actions/warm-go-cache/action.yaml
+++ b/.github/actions/warm-go-cache/action.yaml
@@ -9,5 +9,5 @@ runs:
         if [ -d /cache/go-build ]; then
           mkdir -p /tmp/go-build-cache && \
           timeout 120 cp -a /cache/go-build/. /tmp/go-build-cache/ || \
-          echo "Warning: failed to copy EFS cache, proceeding without cache"
+          echo "::warning::Failed to copy EFS cache, proceeding without cache"
         fi

--- a/.github/workflows/envtest-kube-reusable.yaml
+++ b/.github/workflows/envtest-kube-reusable.yaml
@@ -49,8 +49,6 @@ jobs:
     if: needs.changes.outputs.should_run == 'true'
     runs-on: arc-runner-set
     timeout-minutes: 15
-    env:
-      GOCACHE: /tmp/go-build-cache
     strategy:
       fail-fast: false
       matrix:
@@ -59,12 +57,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Warm Go build cache from EFS
-        run: |
-          if [ -d /cache/go-build ]; then
-            mkdir -p /tmp/go-build-cache
-            cp -a /cache/go-build/. /tmp/go-build-cache/
-          fi
+      - uses: ./.github/actions/warm-go-cache
       - run: make test-envtest-kube ENVTEST_KUBE_VERSIONS="${{ matrix.version }}"
 
   conclusion:

--- a/.github/workflows/envtest-kube-reusable.yaml
+++ b/.github/workflows/envtest-kube-reusable.yaml
@@ -62,7 +62,8 @@ jobs:
       - name: Warm Go build cache from EFS
         run: |
           if [ -d /cache/go-build ]; then
-            cp -a /cache/go-build /tmp/go-build-cache
+            mkdir -p /tmp/go-build-cache
+            cp -a /cache/go-build/. /tmp/go-build-cache/
           fi
       - run: make test-envtest-kube ENVTEST_KUBE_VERSIONS="${{ matrix.version }}"
 

--- a/.github/workflows/envtest-kube-reusable.yaml
+++ b/.github/workflows/envtest-kube-reusable.yaml
@@ -49,8 +49,6 @@ jobs:
     if: needs.changes.outputs.should_run == 'true'
     runs-on: arc-runner-set
     timeout-minutes: 15
-    env:
-      GOCACHE: /tmp/go-build-cache
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/envtest-kube-reusable.yaml
+++ b/.github/workflows/envtest-kube-reusable.yaml
@@ -49,6 +49,8 @@ jobs:
     if: needs.changes.outputs.should_run == 'true'
     runs-on: arc-runner-set
     timeout-minutes: 15
+    env:
+      GOCACHE: /tmp/go-build-cache
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/envtest-kube-reusable.yaml
+++ b/.github/workflows/envtest-kube-reusable.yaml
@@ -49,6 +49,8 @@ jobs:
     if: needs.changes.outputs.should_run == 'true'
     runs-on: arc-runner-set
     timeout-minutes: 15
+    env:
+      GOCACHE: /tmp/go-build-cache
     strategy:
       fail-fast: false
       matrix:
@@ -57,6 +59,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Warm Go build cache from EFS
+        run: |
+          if [ -d /cache/go-build ]; then
+            cp -a /cache/go-build /tmp/go-build-cache
+          fi
       - run: make test-envtest-kube ENVTEST_KUBE_VERSIONS="${{ matrix.version }}"
 
   conclusion:

--- a/.github/workflows/envtest-ocp-reusable.yaml
+++ b/.github/workflows/envtest-ocp-reusable.yaml
@@ -49,8 +49,6 @@ jobs:
     if: needs.changes.outputs.should_run == 'true'
     runs-on: arc-runner-set
     timeout-minutes: 15
-    env:
-      GOCACHE: /tmp/go-build-cache
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/envtest-ocp-reusable.yaml
+++ b/.github/workflows/envtest-ocp-reusable.yaml
@@ -49,6 +49,8 @@ jobs:
     if: needs.changes.outputs.should_run == 'true'
     runs-on: arc-runner-set
     timeout-minutes: 15
+    env:
+      GOCACHE: /tmp/go-build-cache
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/envtest-ocp-reusable.yaml
+++ b/.github/workflows/envtest-ocp-reusable.yaml
@@ -49,8 +49,6 @@ jobs:
     if: needs.changes.outputs.should_run == 'true'
     runs-on: arc-runner-set
     timeout-minutes: 15
-    env:
-      GOCACHE: /tmp/go-build-cache
     strategy:
       fail-fast: false
       matrix:
@@ -60,12 +58,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Warm Go build cache from EFS
-        run: |
-          if [ -d /cache/go-build ]; then
-            mkdir -p /tmp/go-build-cache
-            cp -a /cache/go-build/. /tmp/go-build-cache/
-          fi
+      - uses: ./.github/actions/warm-go-cache
       - run: make test-envtest-ocp ENVTEST_OCP_K8S_VERSIONS="${{ matrix.version }}"
 
   conclusion:

--- a/.github/workflows/envtest-ocp-reusable.yaml
+++ b/.github/workflows/envtest-ocp-reusable.yaml
@@ -49,6 +49,8 @@ jobs:
     if: needs.changes.outputs.should_run == 'true'
     runs-on: arc-runner-set
     timeout-minutes: 15
+    env:
+      GOCACHE: /tmp/go-build-cache
     strategy:
       fail-fast: false
       matrix:
@@ -58,6 +60,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Warm Go build cache from EFS
+        run: |
+          if [ -d /cache/go-build ]; then
+            cp -a /cache/go-build /tmp/go-build-cache
+          fi
       - run: make test-envtest-ocp ENVTEST_OCP_K8S_VERSIONS="${{ matrix.version }}"
 
   conclusion:

--- a/.github/workflows/envtest-ocp-reusable.yaml
+++ b/.github/workflows/envtest-ocp-reusable.yaml
@@ -63,7 +63,8 @@ jobs:
       - name: Warm Go build cache from EFS
         run: |
           if [ -d /cache/go-build ]; then
-            cp -a /cache/go-build /tmp/go-build-cache
+            mkdir -p /tmp/go-build-cache
+            cp -a /cache/go-build/. /tmp/go-build-cache/
           fi
       - run: make test-envtest-ocp ENVTEST_OCP_K8S_VERSIONS="${{ matrix.version }}"
 

--- a/.github/workflows/lint-reusable.yaml
+++ b/.github/workflows/lint-reusable.yaml
@@ -25,7 +25,8 @@ jobs:
       - name: Warm Go build cache from EFS
         run: |
           if [ -d /cache/go-build ]; then
-            cp -a /cache/go-build /tmp/go-build-cache
+            mkdir -p /tmp/go-build-cache
+            cp -a /cache/go-build/. /tmp/go-build-cache/
           fi
       - name: Use pre-built lint tools
         run: |

--- a/.github/workflows/lint-reusable.yaml
+++ b/.github/workflows/lint-reusable.yaml
@@ -11,6 +11,8 @@ jobs:
     name: Lint
     runs-on: arc-runner-set
     timeout-minutes: 60
+    env:
+      GOCACHE: /tmp/go-build-cache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/lint-reusable.yaml
+++ b/.github/workflows/lint-reusable.yaml
@@ -11,8 +11,6 @@ jobs:
     name: Lint
     runs-on: arc-runner-set
     timeout-minutes: 60
-    env:
-      GOCACHE: /tmp/go-build-cache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -22,12 +20,7 @@ jobs:
           if [ -n "${{ github.base_ref }}" ]; then
             git fetch origin "${{ github.base_ref }}:${{ github.base_ref }}"
           fi
-      - name: Warm Go build cache from EFS
-        run: |
-          if [ -d /cache/go-build ]; then
-            mkdir -p /tmp/go-build-cache
-            cp -a /cache/go-build/. /tmp/go-build-cache/
-          fi
+      - uses: ./.github/actions/warm-go-cache
       - name: Use pre-built lint tools
         run: |
           if [ -d /opt/lint-tools ]; then

--- a/.github/workflows/lint-reusable.yaml
+++ b/.github/workflows/lint-reusable.yaml
@@ -11,6 +11,8 @@ jobs:
     name: Lint
     runs-on: arc-runner-set
     timeout-minutes: 60
+    env:
+      GOCACHE: /tmp/go-build-cache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -19,6 +21,11 @@ jobs:
       - run: |
           if [ -n "${{ github.base_ref }}" ]; then
             git fetch origin "${{ github.base_ref }}:${{ github.base_ref }}"
+          fi
+      - name: Warm Go build cache from EFS
+        run: |
+          if [ -d /cache/go-build ]; then
+            cp -a /cache/go-build /tmp/go-build-cache
           fi
       - name: Use pre-built lint tools
         run: |

--- a/.github/workflows/lint-reusable.yaml
+++ b/.github/workflows/lint-reusable.yaml
@@ -11,8 +11,6 @@ jobs:
     name: Lint
     runs-on: arc-runner-set
     timeout-minutes: 60
-    env:
-      GOCACHE: /tmp/go-build-cache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/test-reusable.yaml
+++ b/.github/workflows/test-reusable.yaml
@@ -73,7 +73,6 @@ jobs:
           - shard: other
             packages: ./karpenter-operator/... ./control-plane-pki-operator/... ./contrib/... ./ignition-server/... ./pkg/... ./dnsresolver/... ./product-cli/... ./client/... ./test/integration/... ./test/e2e/util/... ./test/util/... ./availability-prober/... ./konnectivity-socks5-proxy/... ./konnectivity-https-proxy/... ./kubernetes-default-proxy/... ./kubevirtexternalinfra/... ./etcd-defrag/... ./etcd-backup/... ./etcd-recovery/... ./etcd-upload/... ./kas-bootstrap/... ./sharedingress-config-generator/... ./sync-fg-configmap/... ./sync-global-pullsecret/... ./token-minter/...
     env:
-      GOCACHE: /tmp/go-build-cache
       GOMODCACHE: /tmp/go-mod-cache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/verify-reusable.yaml
+++ b/.github/workflows/verify-reusable.yaml
@@ -11,6 +11,8 @@ jobs:
     name: Verify
     runs-on: arc-runner-set
     timeout-minutes: 60
+    env:
+      GOCACHE: /tmp/go-build-cache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/verify-reusable.yaml
+++ b/.github/workflows/verify-reusable.yaml
@@ -11,10 +11,17 @@ jobs:
     name: Verify
     runs-on: arc-runner-set
     timeout-minutes: 60
+    env:
+      GOCACHE: /tmp/go-build-cache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Warm Go build cache from EFS
+        run: |
+          if [ -d /cache/go-build ]; then
+            cp -a /cache/go-build /tmp/go-build-cache
+          fi
       - run: make generate update
       - run: make staticcheck
       - run: make fmt

--- a/.github/workflows/verify-reusable.yaml
+++ b/.github/workflows/verify-reusable.yaml
@@ -20,7 +20,8 @@ jobs:
       - name: Warm Go build cache from EFS
         run: |
           if [ -d /cache/go-build ]; then
-            cp -a /cache/go-build /tmp/go-build-cache
+            mkdir -p /tmp/go-build-cache
+            cp -a /cache/go-build/. /tmp/go-build-cache/
           fi
       - run: make generate update
       - run: make staticcheck

--- a/.github/workflows/verify-reusable.yaml
+++ b/.github/workflows/verify-reusable.yaml
@@ -11,8 +11,6 @@ jobs:
     name: Verify
     runs-on: arc-runner-set
     timeout-minutes: 60
-    env:
-      GOCACHE: /tmp/go-build-cache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/verify-reusable.yaml
+++ b/.github/workflows/verify-reusable.yaml
@@ -11,18 +11,11 @@ jobs:
     name: Verify
     runs-on: arc-runner-set
     timeout-minutes: 60
-    env:
-      GOCACHE: /tmp/go-build-cache
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Warm Go build cache from EFS
-        run: |
-          if [ -d /cache/go-build ]; then
-            mkdir -p /tmp/go-build-cache
-            cp -a /cache/go-build/. /tmp/go-build-cache/
-          fi
+      - uses: ./.github/actions/warm-go-cache
       - run: make generate update
       - run: make staticcheck
       - run: make fmt


### PR DESCRIPTION
## What this PR does / why we need it:

Extends the EFS-backed Go build cache to all Go-based CI workflows beyond
unit tests. Each workflow now includes a conditional step that copies the
shared cache from `/cache/go-build` to a local tmpdir, setting `GOCACHE`
to use it. This eliminates cold compilation overhead across all CI jobs.

Workflows updated:
- `lint-reusable.yaml`
- `verify-reusable.yaml`
- `envtest-ocp-reusable.yaml`
- `envtest-kube-reusable.yaml`

If the EFS mount is not present, the step silently skips and CI runs
without a cache — no functional change from today's behavior.

## Which issue(s) this PR fixes:

Fixes https://redhat.atlassian.net/browse/CNTRLPLANE-3329

## Special notes for your reviewer:

- Depends on PR #8493 (Helm values — mount PVC on runner pods) and
  PR #8494 (unit test workflow update). Can be merged in any order due
  to the conditional cache step.
- `docs-build-reusable.yaml` is not included — it uses Python/mkdocs
  and does not benefit from Go build cache.
- The same conditional pattern (`if [ -d /cache/go-build ]`) is used
  consistently across all workflows.

## Checklist:

- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a reusable job-local Go build cache warming step and set the job cache location to /tmp/go-build-cache.
  * Integrated the cache-warming step into verification, lint, and envtest (Kubernetes and OCP) workflows.
  * Updated cache-warming failure output to emit a GitHub Actions-formatted warning when pre-seeding from shared storage fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->