### PR TITLE
CNTRLPLANE-3329: Add nightly CronJob to warm EFS-backed Go build cache

### DIFF
--- a/hack/github-actions-runner/cache-warming-cronjob.yaml
+++ b/hack/github-actions-runner/cache-warming-cronjob.yaml
@@ -18,9 +18,18 @@ spec:
       template:
         spec:
           restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           containers:
             - name: cache-warmer
               image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-gh-actions-runner:latest
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
               command:
                 - /bin/bash
                 - -c

--- a/hack/github-actions-runner/cache-warming-cronjob.yaml
+++ b/hack/github-actions-runner/cache-warming-cronjob.yaml
@@ -37,8 +37,11 @@ spec:
                   echo "=== Compiling all test binaries ==="
                   go test -c -o /dev/null ./... 2>/dev/null || true
 
+                  echo "=== Cleaning stale cache entries (older than 7 days) ==="
+                  find /cache/go-build -type f -mtime +7 -delete
+                  find /cache/go-build -type d -empty -delete
+
                   echo "=== Syncing build cache to PV ==="
-                  rm -rf /cache/go-build/*
                   cp -a "${GOCACHE}"/* /cache/go-build/
 
                   echo "=== Cache warming complete ==="

--- a/hack/github-actions-runner/cache-warming-cronjob.yaml
+++ b/hack/github-actions-runner/cache-warming-cronjob.yaml
@@ -48,7 +48,7 @@ spec:
 
                   echo "=== Cleaning stale cache entries (older than 7 days) ==="
                   find /cache/go-build -type f -mtime +7 -delete
-                  find /cache/go-build -type d -empty -delete
+                  find /cache/go-build -mindepth 1 -type d -empty -delete
 
                   echo "=== Syncing build cache to PV ==="
                   cp -a "${GOCACHE}"/* /cache/go-build/

--- a/hack/github-actions-runner/cache-warming-cronjob.yaml
+++ b/hack/github-actions-runner/cache-warming-cronjob.yaml
@@ -1,0 +1,66 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: go-cache-warmer
+  namespace: arc-runners
+  labels:
+    app.kubernetes.io/component: cache-warmer
+    app.kubernetes.io/part-of: arc-runner-set
+spec:
+  schedule: "0 2 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 3600
+      backoffLimit: 1
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: cache-warmer
+              image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-gh-actions-runner:latest
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -euo pipefail
+
+                  echo "=== Cloning openshift/hypershift main branch ==="
+                  git clone --depth 1 --branch main https://github.com/openshift/hypershift.git /tmp/hypershift
+                  cd /tmp/hypershift
+
+                  echo "=== Compiling all packages ==="
+                  go build ./...
+
+                  echo "=== Compiling all test binaries ==="
+                  go test -c -o /dev/null ./... 2>/dev/null || true
+
+                  echo "=== Syncing build cache to PV ==="
+                  rm -rf /cache/go-build/*
+                  cp -a "${GOCACHE}"/* /cache/go-build/
+
+                  echo "=== Cache warming complete ==="
+                  du -sh /cache/go-build/
+              env:
+                - name: GOCACHE
+                  value: /tmp/go-build-cache
+                - name: GOMODCACHE
+                  value: /tmp/go-mod-cache
+                - name: HOME
+                  value: /tmp
+              resources:
+                requests:
+                  cpu: "4"
+                  memory: "16Gi"
+                limits:
+                  cpu: "4"
+                  memory: "16Gi"
+              volumeMounts:
+                - name: go-cache
+                  mountPath: /cache/go-build
+          volumes:
+            - name: go-cache
+              persistentVolumeClaim:
+                claimName: go-cache-pvc


### PR DESCRIPTION
## What this PR does / why we need it:

The EFS-backed PV mounted on ARC runner pods is empty until something
populates it. This PR adds a Kubernetes CronJob that runs nightly at
2 AM UTC to compile all Go packages and test binaries from `main`, then
syncs the resulting build cache to the shared PV.

Once populated, every CI run copies from this pre-warmed cache instead
of compiling from scratch, eliminating ~2-3.5 min of overhead per shard.

### How it works:
1. Clones `openshift/hypershift` main branch (shallow, depth 1)
2. Runs `go build ./...` and `go test -c ./...` to compile everything
3. Copies the build cache from local tmpdir to the EFS PV
4. Runner pods (mounted read-only) pick up the cache on their next run

### CronJob details:
- Schedule: `0 2 * * *` (2 AM UTC daily)
- Concurrency: `Forbid` (no overlapping runs)
- Deadline: 1 hour timeout
- Resources: 4 CPU / 16Gi (matches runner pods)
- Uses the same runner image as CI pods

## Which issue(s) this PR fixes:

Fixes https://redhat.atlassian.net/browse/CNTRLPLANE-3329

## Special notes for your reviewer:

- This CronJob can be applied to the cluster independently of the other
  PRs (#8493, #8494, #8495). In fact, it should be applied first so the
  cache is warm before runners start using it.
- After merging, apply with: `oc apply -f hack/github-actions-runner/cache-warming-cronjob.yaml`
- To test immediately: `oc create job --from=cronjob/go-cache-warmer go-cache-warmer-manual -n arc-runners`

## Checklist:

- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a daily CronJob that pre-populates the Go build cache during off-hours to reduce build latency.
  * Job restricts concurrent runs, enforces execution timeouts, limited job history, retry/backoff controls, and resource limits to protect cluster stability.
  * Container runtime is hardened; the job prunes stale cache entries, syncs cache to persistent storage, and reports disk usage to maintain storage health.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->