### PR TITLE
AUTOSCALE-681: remove TechPreviewNoUpgrade gate from karpenter upgrade test

### DIFF
--- a/test/e2e/karpenter_control_plane_upgrade_test.go
+++ b/test/e2e/karpenter_control_plane_upgrade_test.go
@@ -22,10 +22,7 @@ import (
 )
 
 func TestKarpenterUpgradeControlPlane(t *testing.T) {
-	e2eutil.AtLeast(t, e2eutil.Version419)
-	if os.Getenv("TECH_PREVIEW_NO_UPGRADE") != "true" {
-		t.Skipf("Only tested when CI sets TECH_PREVIEW_NO_UPGRADE=true and the Hypershift Operator is installed with --tech-preview-no-upgrade")
-	}
+	e2eutil.AtLeast(t, e2eutil.Version422)
 	if globalOpts.Platform != hyperv1.AWSPlatform {
 		t.Skip("test only supported on platform AWS")
 	}


### PR DESCRIPTION
## What this PR does / why we need it:

AutoNode/Karpenter is no longer behind `TechPreviewNoUpgrade` in 5.0, so the
`TECH_PREVIEW_NO_UPGRADE=true` env check in `TestKarpenterUpgradeControlPlane`
is stale. The test is unconditionally skipped in any CI job that doesn't set
this env var, meaning the upgrade test never runs in the standard periodic jobs.

This removes the gate so the test can run in non-techpreview CI configurations.

Also bumps the version requirement to 4.22 to match `TestKarpenter`.

## Which issue(s) this PR fixes:

N/A

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

Assisted-by: Cursor Agent

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Increased the minimum e2e utility requirement for Karpenter control plane upgrade tests.
  * Removed a conditional skip, simplifying test execution flow.
  * Tests now explicitly target the AWS platform for upgrade validation.
  * Subtests use isolated copies of cluster fixtures to reduce shared-state flakiness.
  * Certain checks now re-fetch cluster state before asserting to improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->