### PR TITLE
OCPSTRAT-1677: fix(cpo): increase NTH default workers from 10 to 20

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-node-termination-handler/AROSwift/zz_fixture_TestControlPlaneComponents_aws_node_termination_handler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-node-termination-handler/AROSwift/zz_fixture_TestControlPlaneComponents_aws_node_termination_handler_deployment.yaml
@@ -100,7 +100,7 @@ spec:
           value: info
         - name: WEBHOOK_URL
         - name: WORKERS
-          value: "10"
+          value: "20"
         - name: METADATA_TRIES
           value: "3"
         - name: KUBERNETES_SERVICE_HOST

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-node-termination-handler/GCP/zz_fixture_TestControlPlaneComponents_aws_node_termination_handler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-node-termination-handler/GCP/zz_fixture_TestControlPlaneComponents_aws_node_termination_handler_deployment.yaml
@@ -100,7 +100,7 @@ spec:
           value: info
         - name: WEBHOOK_URL
         - name: WORKERS
-          value: "10"
+          value: "20"
         - name: METADATA_TRIES
           value: "3"
         - name: KUBERNETES_SERVICE_HOST

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-node-termination-handler/IBMCloud/zz_fixture_TestControlPlaneComponents_aws_node_termination_handler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-node-termination-handler/IBMCloud/zz_fixture_TestControlPlaneComponents_aws_node_termination_handler_deployment.yaml
@@ -100,7 +100,7 @@ spec:
           value: info
         - name: WEBHOOK_URL
         - name: WORKERS
-          value: "10"
+          value: "20"
         - name: METADATA_TRIES
           value: "3"
         - name: KUBERNETES_SERVICE_HOST

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-node-termination-handler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_aws_node_termination_handler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-node-termination-handler/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_aws_node_termination_handler_deployment.yaml
@@ -100,7 +100,7 @@ spec:
           value: info
         - name: WEBHOOK_URL
         - name: WORKERS
-          value: "10"
+          value: "20"
         - name: METADATA_TRIES
           value: "3"
         - name: KUBERNETES_SERVICE_HOST

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-node-termination-handler/zz_fixture_TestControlPlaneComponents_aws_node_termination_handler_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/aws-node-termination-handler/zz_fixture_TestControlPlaneComponents_aws_node_termination_handler_deployment.yaml
@@ -100,7 +100,7 @@ spec:
           value: info
         - name: WEBHOOK_URL
         - name: WORKERS
-          value: "10"
+          value: "20"
         - name: METADATA_TRIES
           value: "3"
         - name: KUBERNETES_SERVICE_HOST

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/aws-node-termination-handler/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/aws-node-termination-handler/deployment.yaml
@@ -62,7 +62,7 @@ spec:
         - name: WEBHOOK_URL
           value: ""
         - name: WORKERS
-          value: "10"
+          value: "20"
         - name: METADATA_TRIES
           value: "3"
         - name: KUBERNETES_SERVICE_HOST


### PR DESCRIPTION
## Summary

- Increases the AWS Node Termination Handler default `WORKERS` from 10 to 20

Scale evaluation showed that 10 workers caps graceful spot termination handling at ~80-100 concurrent interruptions. At 100 nodes, the SQS-to-drain pipeline reaches the 2-minute AWS notice window boundary — any pods with non-zero `terminationGracePeriodSeconds` cause ungraceful terminations.

Increasing to 20 extends safe coverage to ~150-200 concurrent spot interruptions with negligible resource overhead (idle goroutines), better matching common ROSA HCP cluster sizes. Clusters running 300+ spot nodes should tune `WORKERS` explicitly per the scale evaluation sizing formula.

Related https://github.com/aws/aws-node-termination-handler/pull/1278

## Test plan

- [ ] Deploy a HostedCluster with spot NodePools and verify the NTH deployment has `WORKERS=20`
- [ ] Simulate concurrent spot interruptions at ~100 nodes and verify all drains complete within the 2-minute window

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated worker configuration for AWS Node Termination Handler, increasing capacity from 10 to 20 workers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->