### PR TITLE
OCPBUGS-85577: Update external-dns image from 1.1.0-3 to 1.2.1

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -63,9 +63,9 @@ import (
 )
 
 const (
-	// ExternalDNSImage - This is specifically tag 1.1.0-3 from https://catalog.redhat.com/software/containers/edo/external-dns-rhel8/61d4c35023156829b87a434a?container-tabs=overview&tag=1.1.0-3&push_date=1671131187000
+	// ExternalDNSImage - This is specifically tag 1.2.1 from https://catalog.redhat.com/software/containers/edo/external-dns-rhel8/61d4c35023156829b87a434a
 	// TODO this needs to be updated to a multi-arch image including Arm - https://issues.redhat.com/browse/NE-1298
-	ExternalDNSImage = "registry.redhat.io/edo/external-dns-rhel8@sha256:638fb6b5fc348f5cf52b9800d3d8e9f5315078fc9b1e57e800cb0a4a50f1b4b9"
+	ExternalDNSImage = "registry.redhat.io/edo/external-dns-rhel8@sha256:9f60c682b44497d9736a04991c0d2b3485d477f6c89a87c4a44a211a3d1f3cd4"
 )
 
 var HyperShiftImage = fmt.Sprintf("%s:%s", config.HypershiftImageBase, config.HypershiftImageTag)


### PR DESCRIPTION
## Summary

- Update the hardcoded ExternalDNS image from tag `1.1.0-3` (December 2022) to `1.2.1` (April 2026)
- The previous image was ~3.5 years behind the latest available version

## Description

The `ExternalDNSImage` constant in `cmd/install/install.go` pins a specific digest of `registry.redhat.io/edo/external-dns-rhel8`. The old digest corresponded to tag `1.1.0-3`, published December 2022. The new digest corresponds to tag `1.2.1`, the latest available version.

Note: all available versions remain amd64-only — the existing TODO for multi-arch/Arm support ([NE-1298](https://redhat.atlassian.net/browse/NE-1298)) is unchanged.

## Test plan

- [ ] Verify `go build ./cmd/install/...` passes
- [ ] Verify unit tests pass
- [ ] Confirm the new digest resolves correctly: `skopeo inspect docker://registry.redhat.io/edo/external-dns-rhel8@sha256:9f60c682b44497d9736a04991c0d2b3485d477f6c89a87c4a44a211a3d1f3cd4`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the external-dns image reference to version 1.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->