### PR TITLE
OCPBUGS-85584: Fix stale api.openshift.com labels on HostedControlPlane

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -135,6 +135,8 @@ const (
 	useRestrictedPodSecurityLabel                              = "io.openshift.hypershift.restricted-psa"
 	defaultToControlPlaneV2Label                               = "io.openshift.hypershift.control-plane-operator.v2-isdefault"
 
+	apiOpenShiftComLabelPrefix = "api.openshift.com/"
+
 	etcdEncKeyPostfix = "-etcd-encryption-key"
 
 	jobHostedClusterNameLabel      = "hypershift.openshift.io/cluster-name"
@@ -2423,10 +2425,17 @@ func reconcileHostedControlPlane(hcp *hyperv1.HostedControlPlane, hcluster *hype
 	if hcp.Labels == nil {
 		hcp.Labels = make(map[string]string)
 	}
-	// All labels on the HostedCluster with this special prefix are copied
-	// Those are labels set by OCM
+	// These labels are managed by OCM. Delete-then-copy ensures removals
+	// on the HostedCluster (e.g., clearing limited-support) propagate to the HCP.
+	for key := range hcp.Labels {
+		if strings.HasPrefix(key, apiOpenShiftComLabelPrefix) {
+			if _, exists := hcluster.Labels[key]; !exists {
+				delete(hcp.Labels, key)
+			}
+		}
+	}
 	for key, val := range hcluster.Labels {
-		if strings.HasPrefix(key, "api.openshift.com") {
+		if strings.HasPrefix(key, apiOpenShiftComLabelPrefix) {
 			hcp.Labels[key] = val
 		}
 	}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -310,6 +310,64 @@ func TestReconcileHostedControlPlaneAdditionalTrustBundle(t *testing.T) {
 	}
 }
 
+func TestReconcileHostedControlPlaneLabelSync(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name           string
+		hcLabels       map[string]string
+		hcpLabels      map[string]string
+		expectedLabels map[string]string
+	}{
+		{
+			name:           "When HC has api.openshift.com labels, it should copy them to HCP",
+			hcLabels:       map[string]string{"api.openshift.com/limited-support": "true", "api.openshift.com/name": "test"},
+			hcpLabels:      map[string]string{},
+			expectedLabels: map[string]string{"api.openshift.com/limited-support": "true", "api.openshift.com/name": "test"},
+		},
+		{
+			name:           "When HC removes an api.openshift.com label, it should remove the stale label from HCP",
+			hcLabels:       map[string]string{"api.openshift.com/name": "test"},
+			hcpLabels:      map[string]string{"api.openshift.com/limited-support": "true", "api.openshift.com/name": "old"},
+			expectedLabels: map[string]string{"api.openshift.com/name": "test"},
+		},
+		{
+			name:           "When HC has no api.openshift.com labels, it should preserve non-api.openshift.com labels on HCP",
+			hcLabels:       map[string]string{},
+			hcpLabels:      map[string]string{"api.openshift.com/limited-support": "true", "cluster.x-k8s.io/cluster-name": "keep-me"},
+			expectedLabels: map[string]string{"cluster.x-k8s.io/cluster-name": "keep-me"},
+		},
+		{
+			name:           "When HC labels are nil, it should remove all api.openshift.com labels from HCP",
+			hcLabels:       nil,
+			hcpLabels:      map[string]string{"api.openshift.com/limited-support": "true"},
+			expectedLabels: map[string]string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			hc := &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{Labels: test.hcLabels},
+			}
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{Labels: test.hcpLabels},
+			}
+			err := reconcileHostedControlPlane(hcp, hc, false, false, func() (map[string]string, error) { return nil, nil })
+			g.Expect(err).ToNot(HaveOccurred())
+
+			for key, val := range test.expectedLabels {
+				g.Expect(hcp.Labels).To(HaveKeyWithValue(key, val))
+			}
+			for key := range hcp.Labels {
+				if strings.HasPrefix(key, apiOpenShiftComLabelPrefix) {
+					g.Expect(test.expectedLabels).To(HaveKey(key), "unexpected label %s=%s still on HCP", key, hcp.Labels[key])
+				}
+			}
+		})
+	}
+}
+
 func TestReconcileHostedControlPlaneUpgrades(t *testing.T) {
 	t.Parallel()
 	// TODO: the spec/status comparison of control plane is a weak check; the


### PR DESCRIPTION
## Summary

Fixes stale `api.openshift.com/*` labels on HostedControlPlane CRs that persist after being removed from the HostedCluster.

## Problem

The label sync in `reconcileHostedControlPlane` ([line 2426-2432](https://github.com/openshift/hypershift/blob/main/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go#L2426-L2432)) only copies labels from HC to HCP. It never removes HCP labels that were deleted from HC.

When OCM/CS removes `api.openshift.com/limited-support` from the HostedCluster (via ManifestWork when LS is cleared), the label stays on the HostedControlPlane forever.

## Reproduction (stage, 2026-05-13)

Reproduced on stage cluster `test-hcp-stable-420` (2q4jijtpbjlrtjavc29s8n54bnah70kl), MC `hs-mc-13vnfh7o0`:

1. Cluster had 1 LS reason. Both HC and HCP had `api.openshift.com/limited-support: "true"`. Correct.
2. Removed LS reason via `ocm delete`. OCM confirmed 0 LS reasons.
3. Checked HC: label cleared (CS removed via ManifestWork). Checked HCP: label still `"true"`.
4. After 60 seconds: HC still cleared, HCP still `"true"`. **Label removal never propagated.**

Also confirmed on production clusters `dai-test-hcp` and `clairp02ue1` (0 LS reasons in OCM, stale label on HCP).

## Impact

Route Monitor Operator checks this label on the HCP to skip probe creation for LS clusters. Stale labels cause RMO to permanently skip synthetic monitoring probe creation for fully supported clusters. ~60% of clusters on some RHOBS cells have no synthetic probes due to this bug.

## Fix

Before copying HC labels to HCP, remove any `api.openshift.com/*` labels from HCP that no longer exist on HC. Includes 4 unit tests covering label copy, stale removal, non-OCM label preservation, and nil HC labels.

## Jira

- [OCPBUGS-85584](https://redhat.atlassian.net/browse/OCPBUGS-85584)
- [SREP-4859](https://redhat.atlassian.net/browse/SREP-4859) (downstream impact)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Label synchronization for OpenShift API labels now removes stale labels from the target resource and tightens matching to avoid partial/prefix collisions, while still copying current labels.

* **Tests**
  * Added coverage validating label add, stale-label removal, preservation of unrelated labels, and behavior when source labels are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->