### PR TITLE
AUTOSCALE-681: various karpenter and karpenterupgrade test fixes

### DIFF
--- a/test/e2e/karpenter_control_plane_upgrade_test.go
+++ b/test/e2e/karpenter_control_plane_upgrade_test.go
@@ -70,7 +70,7 @@ func TestKarpenterUpgradeControlPlane(t *testing.T) {
 
 		nodes := e2eutil.WaitForReadyNodesByLabels(t, ctx, guestClient, hostedCluster.Spec.Platform.Type, int32(replicas), nodeLabels)
 		nodeClaims := waitForReadyNodeClaims(t, ctx, guestClient, len(nodes))
-		waitForReadyKarpenterPods(t, ctx, guestClient, nodes, replicas)
+		waitForReadyKarpenterPods(t, ctx, guestClient, nodes, replicas, map[string]string{"app": "web-app"})
 
 		preUpgradeOSImage := nodes[0].Status.NodeInfo.OSImage
 		t.Logf("Pre-upgrade node: %s, OS image: %s", nodes[0].Name, preUpgradeOSImage)
@@ -127,7 +127,7 @@ func TestKarpenterUpgradeControlPlane(t *testing.T) {
 		)
 
 		t.Logf("Waiting for Karpenter pods to schedule on the new node")
-		waitForReadyKarpenterPods(t, ctx, guestClient, nodes, replicas)
+		waitForReadyKarpenterPods(t, ctx, guestClient, nodes, replicas, map[string]string{"app": "web-app"})
 
 		nodeClaims = waitForReadyNodeClaims(t, ctx, guestClient, len(nodes))
 

--- a/test/e2e/karpenter_control_plane_upgrade_test.go
+++ b/test/e2e/karpenter_control_plane_upgrade_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestKarpenterUpgradeControlPlane(t *testing.T) {
-	e2eutil.AtLeast(t, e2eutil.Version422)
+	e2eutil.ShouldRunKarpenterTests(t)
 	if globalOpts.Platform != hyperv1.AWSPlatform {
 		t.Skip("test only supported on platform AWS")
 	}

--- a/test/e2e/karpenter_test.go
+++ b/test/e2e/karpenter_test.go
@@ -315,7 +315,8 @@ func testARM64Provisioning(ctx context.Context, guestClient crclient.Client, hos
 			{Key: "kubernetes.io/arch", Operator: corev1.NodeSelectorOpIn, Values: []string{"arm64"}},
 			{Key: karpenterv1.CapacityTypeLabelKey, Operator: corev1.NodeSelectorOpIn, Values: []string{karpenterv1.CapacityTypeOnDemand}},
 		}
-		armWorkLoads := testWorkload("arm-app", 1, map[string]string{karpenterv1.NodePoolLabelKey: armNodePool.Name})
+		// quay.io/openshift/origin-pod does not support arm64
+		armWorkLoads := testWorkloadWithImage("arm-app", 1, map[string]string{karpenterv1.NodePoolLabelKey: armNodePool.Name}, "quay.io/hypershift/sleep:multiarch")
 
 		t.Cleanup(func() {
 			_ = guestClient.Delete(ctx, armWorkLoads)
@@ -1760,6 +1761,10 @@ func baseNodePool(name, nodeClassName string) *karpenterv1.NodePool {
 }
 
 func testWorkload(name string, replicas int32, nodeSelector map[string]string) *appsv1.Deployment {
+	return testWorkloadWithImage(name, replicas, nodeSelector, "quay.io/openshift/origin-pod:4.22.0")
+}
+
+func testWorkloadWithImage(name string, replicas int32, nodeSelector map[string]string, image string) *appsv1.Deployment {
 	appLabel := map[string]string{"app": name}
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1787,7 +1792,7 @@ func testWorkload(name string, replicas int32, nodeSelector map[string]string) *
 					},
 					Containers: []corev1.Container{{
 						Name:  name,
-						Image: "quay.io/openshift/origin-pod:4.22.0",
+						Image: image,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("250m"),

--- a/test/e2e/karpenter_test.go
+++ b/test/e2e/karpenter_test.go
@@ -334,7 +334,7 @@ func testARM64Provisioning(ctx context.Context, guestClient crclient.Client, hos
 		}
 
 		nodes := e2eutil.WaitForReadyNodesByLabels(t, ctx, guestClient, hostedCluster.Spec.Platform.Type, 1, armNodeLabels)
-		waitForReadyKarpenterPods(t, ctx, guestClient, nodes, 1)
+		waitForReadyKarpenterPods(t, ctx, guestClient, nodes, 1, map[string]string{"app": "arm-app"})
 
 		g.Expect(guestClient.Delete(ctx, armNodePool)).To(Succeed())
 		t.Logf("Deleted ARM64 NodePool")
@@ -1514,12 +1514,12 @@ func testBillingConsolidationAndPDB(ctx context.Context, mgtClient, guestClient 
 	}
 }
 
-func waitForReadyKarpenterPods(t *testing.T, ctx context.Context, client crclient.Client, nodes []corev1.Node, n int) []corev1.Pod {
+func waitForReadyKarpenterPods(t *testing.T, ctx context.Context, client crclient.Client, nodes []corev1.Node, n int, podLabels map[string]string) []corev1.Pod {
 	pods := &corev1.PodList{}
 	waitTimeout := 20 * time.Minute
 	e2eutil.EventuallyObjects(t, ctx, "Pods to be scheduled on provisioned Karpenter nodes",
 		func(ctx context.Context) ([]*corev1.Pod, error) {
-			err := client.List(ctx, pods, crclient.InNamespace("default"))
+			err := client.List(ctx, pods, crclient.InNamespace("default"), crclient.MatchingLabels(podLabels))
 			items := make([]*corev1.Pod, len(pods.Items))
 			for i := range pods.Items {
 				items[i] = &pods.Items[i]


### PR DESCRIPTION
## What this PR does / why we need it:

Scope `waitForReadyKarpenterPods` to workload labels: The function listed all pods in the default namespace, which picked up pods from other parallel subtests running concurrently. This caused count mismatches and wrong-node assertions. Now each caller passes its workload's app label so it only sees its own pods.

Use correct version gate for `TestKarpenterUpgradeControlPlane`: Switch from `AtLeast(Version422)` to `ShouldRunKarpenterTests`, which is the standard gate used by the other karpenter tests and respects the `RUN_KARPENTER_TESTS` env var.

Use arm-compatible image in ARM64 test: `quay.io/openshift/origin-pod` is amd64-only and can't actually run on arm nodes. Use `quay.io/hypershift/sleep:multiarch` (multi-arch) for the arm test via a new `testWorkloadWithImage` helper.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

I was unaware of https://github.com/openshift/hypershift/pull/8466 when I merged https://github.com/openshift/hypershift/pull/8498. This PR reconciles that.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Gate Karpenter upgrade test with environment-aware runner to skip when not applicable
  * Add pod label filtering (e.g., app=web-app) to Karpenter readiness checks before and after upgrades
  * Generalize readiness helper to accept label selectors for more precise verification
  * Add ARM64 workload handling and configurable test workload images for broader platform coverage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->