### PR TITLE
OCPBUGS-59142: fix ValidReleaseImage condition message to show minor version

### DIFF
--- a/support/supportedversion/version.go
+++ b/support/supportedversion/version.go
@@ -182,11 +182,11 @@ func IsValidReleaseVersion(version, currentVersion, maxSupportedVersion, minSupp
 	}
 
 	if normalizedVersion.Minor > normalizedMax.Minor {
-		return fmt.Errorf("the latest version supported is: %q. Attempting to use: %q", displayMax, version)
+		return fmt.Errorf("the latest version supported is: %q. Attempting to use: %q", trimVersion(displayMax.String()), version)
 	}
 
 	if normalizedVersion.Minor < normalizedMin.Minor {
-		return fmt.Errorf("the minimum version supported for platform %s is: %q. Attempting to use: %q", string(platformType), minSupportedVersion, version)
+		return fmt.Errorf("the minimum version supported for platform %s is: %q. Attempting to use: %q", string(platformType), trimVersion(minSupportedVersion.String()), version)
 	}
 
 	return nil

--- a/support/supportedversion/version_test.go
+++ b/support/supportedversion/version_test.go
@@ -104,6 +104,7 @@ func TestIsValidReleaseVersion(t *testing.T) {
 		minVersionSupported    *semver.Version
 		networkType            hyperv1.NetworkType
 		expectError            bool
+		expectedMessage        string
 		platform               hyperv1.PlatformType
 	}{
 		{
@@ -125,6 +126,7 @@ func TestIsValidReleaseVersion(t *testing.T) {
 			latestVersionSupported: v("4.22.0"),
 			minVersionSupported:    v("4.14.0"),
 			expectError:            true,
+			expectedMessage:        "\"4.22\"",
 			platform:               hyperv1.NonePlatform,
 		},
 		{
@@ -162,6 +164,7 @@ func TestIsValidReleaseVersion(t *testing.T) {
 			latestVersionSupported: v("4.12.0"),
 			minVersionSupported:    v("4.10.0"),
 			expectError:            true,
+			expectedMessage:        "\"4.10\"",
 			platform:               hyperv1.NonePlatform,
 		},
 		{
@@ -294,6 +297,9 @@ func TestIsValidReleaseVersion(t *testing.T) {
 			err := IsValidReleaseVersion(test.nextVersion, test.currentVersion, test.latestVersionSupported, test.minVersionSupported, test.networkType, test.platform)
 			if test.expectError {
 				g.Expect(err).To(HaveOccurred())
+				if test.expectedMessage != "" {
+					g.Expect(err.Error()).To(ContainSubstring(test.expectedMessage))
+				}
 				return
 			}
 			g.Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
## What this PR does / why we need it:

The ValidReleaseImage condition error messages displayed the full semver version (e.g. "4.18.0") for the max and min supported versions, misleading users into thinking only that specific patch version was supported. This change uses `trimVersion()` to strip the ".0" patch suffix so the message shows "4.18" instead, making it clear that any patch version within the minor release is valid.

**Before:** `the latest version supported is: "4.18.0". Attempting to use: "4.19.0"`
**After:** `the latest version supported is: "4.18". Attempting to use: "4.19.0"`

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/OCPBUGS-59142

## Special notes for your reviewer:

The fix applies `trimVersion()` (which already exists in the same file) to two error messages in `IsValidReleaseVersion()`:
- Line 185: max supported version message
- Line 189: min supported version message

Tested on a ROSA cluster by lowering `LatestSupportedVersion` to 4.18.0, creating a HostedCluster with a 4.19 release image, and confirming the updated message.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve OCPBUGS-59142`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Version validation error messages now display supported version bounds more concisely by trimming redundant trailing zeros for clearer user-facing text.
* **Tests**
  * Updated tests to assert the improved error message content for relevant failing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->