### PR TITLE
OCPBUGS-85825: [release-4.20] Add KAS readiness sidecar to OAS, OAuth API Server, and OLM packageserver

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/AROSwift/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/AROSwift/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
@@ -196,6 +196,32 @@ spec:
           name: work-logs
         - mountPath: /tmp
           name: tmp-dir
+      - command:
+        - /bin/bash
+        - -c
+        - sleep infinity
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: kas-readiness-check
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - curl -kfs https://kube-apiserver:6443/livez > /dev/null
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         command:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/IBMCloud/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/IBMCloud/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
@@ -196,6 +196,32 @@ spec:
           name: work-logs
         - mountPath: /tmp
           name: tmp-dir
+      - command:
+        - /bin/bash
+        - -c
+        - sleep infinity
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: kas-readiness-check
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - curl -kfs https://kube-apiserver:2040/livez > /dev/null
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         command:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
@@ -196,6 +196,32 @@ spec:
           name: work-logs
         - mountPath: /tmp
           name: tmp-dir
+      - command:
+        - /bin/bash
+        - -c
+        - sleep infinity
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: kas-readiness-check
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - curl -kfs https://kube-apiserver:6443/livez > /dev/null
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         command:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
@@ -196,6 +196,32 @@ spec:
           name: work-logs
         - mountPath: /tmp
           name: tmp-dir
+      - command:
+        - /bin/bash
+        - -c
+        - sleep infinity
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: kas-readiness-check
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - curl -kfs https://kube-apiserver:6443/livez > /dev/null
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         command:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/AROSwift/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/AROSwift/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
@@ -198,6 +198,32 @@ spec:
           name: work-logs
         - mountPath: /tmp
           name: tmp-dir
+      - command:
+        - /bin/bash
+        - -c
+        - sleep infinity
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: kas-readiness-check
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - curl -kfs https://kube-apiserver:6443/livez > /dev/null
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         - --resolve-from-guest-cluster-dns=true

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/IBMCloud/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/IBMCloud/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
@@ -198,6 +198,32 @@ spec:
           name: work-logs
         - mountPath: /tmp
           name: tmp-dir
+      - command:
+        - /bin/bash
+        - -c
+        - sleep infinity
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: kas-readiness-check
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - curl -kfs https://kube-apiserver:2040/livez > /dev/null
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         - --resolve-from-guest-cluster-dns=true

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
@@ -198,6 +198,32 @@ spec:
           name: work-logs
         - mountPath: /tmp
           name: tmp-dir
+      - command:
+        - /bin/bash
+        - -c
+        - sleep infinity
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: kas-readiness-check
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - curl -kfs https://kube-apiserver:6443/livez > /dev/null
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         - --resolve-from-guest-cluster-dns=true

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_deployment.yaml
@@ -198,6 +198,32 @@ spec:
           name: work-logs
         - mountPath: /tmp
           name: tmp-dir
+      - command:
+        - /bin/bash
+        - -c
+        - sleep infinity
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: kas-readiness-check
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - curl -kfs https://kube-apiserver:6443/livez > /dev/null
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         - --resolve-from-guest-cluster-dns=true

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/AROSwift/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/AROSwift/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
@@ -143,6 +143,32 @@ spec:
         - mountPath: /etc/openshift/kubeconfig
           name: kubeconfig
           readOnly: true
+      - command:
+        - /bin/bash
+        - -c
+        - sleep infinity
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: kas-readiness-check
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - curl -kfs https://kube-apiserver:6443/livez > /dev/null
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         command:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/IBMCloud/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/IBMCloud/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
@@ -143,6 +143,32 @@ spec:
         - mountPath: /etc/openshift/kubeconfig
           name: kubeconfig
           readOnly: true
+      - command:
+        - /bin/bash
+        - -c
+        - sleep infinity
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: kas-readiness-check
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - curl -kfs https://kube-apiserver:2040/livez > /dev/null
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         command:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
@@ -143,6 +143,32 @@ spec:
         - mountPath: /etc/openshift/kubeconfig
           name: kubeconfig
           readOnly: true
+      - command:
+        - /bin/bash
+        - -c
+        - sleep infinity
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: kas-readiness-check
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - curl -kfs https://kube-apiserver:6443/livez > /dev/null
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         command:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
@@ -143,6 +143,32 @@ spec:
         - mountPath: /etc/openshift/kubeconfig
           name: kubeconfig
           readOnly: true
+      - command:
+        - /bin/bash
+        - -c
+        - sleep infinity
+        image: cli
+        imagePullPolicy: IfNotPresent
+        name: kas-readiness-check
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - curl -kfs https://kube-apiserver:6443/livez > /dev/null
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-dir
       - args:
         - run
         command:

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oapi/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oapi/deployment.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
@@ -106,6 +107,12 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 	if cpContext.HCP.Spec.AuditWebhook != nil && len(cpContext.HCP.Spec.AuditWebhook.Name) > 0 {
 		applyAuditWebhookConfigFileVolume(&deployment.Spec.Template.Spec, cpContext.HCP.Spec.AuditWebhook)
 	}
+
+	kasLivezURL := kas.InClusterKASURL(cpContext.HCP.Spec.Platform.Type) + "/livez"
+	deployment.Spec.Template.Spec.Containers = append(
+		deployment.Spec.Template.Spec.Containers,
+		util.KASReadinessCheckContainer(kasLivezURL),
+	)
 
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/deployment.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/config"
 	component "github.com/openshift/hypershift/support/controlplane-component"
@@ -74,6 +75,12 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 	if cpContext.HCP.Spec.AuditWebhook != nil && len(cpContext.HCP.Spec.AuditWebhook.Name) > 0 {
 		applyAuditWebhookConfigFileVolume(&deployment.Spec.Template.Spec, cpContext.HCP.Spec.AuditWebhook)
 	}
+
+	kasLivezURL := kas.InClusterKASURL(cpContext.HCP.Spec.Platform.Type) + "/livez"
+	deployment.Spec.Template.Spec.Containers = append(
+		deployment.Spec.Template.Spec.Containers,
+		util.KASReadinessCheckContainer(kasLivezURL),
+	)
 
 	return nil
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/olm/packageserver/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/olm/packageserver/deployment.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/kas"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/util"
 
@@ -30,5 +31,12 @@ func adaptDeployment(cpContext component.WorkloadContext, deployment *appsv1.Dep
 	if hcp.Spec.Platform.Type == hyperv1.IBMCloudPlatform && hcp.Spec.ControllerAvailabilityPolicy == hyperv1.HighlyAvailable {
 		deployment.Spec.Replicas = ptr.To[int32](2)
 	}
+
+	kasLivezURL := kas.InClusterKASURL(hcp.Spec.Platform.Type) + "/livez"
+	deployment.Spec.Template.Spec.Containers = append(
+		deployment.Spec.Template.Spec.Containers,
+		util.KASReadinessCheckContainer(kasLivezURL),
+	)
+
 	return nil
 }

--- a/support/util/containers.go
+++ b/support/util/containers.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -117,6 +118,35 @@ func AvailabilityProber(target string, image string, spec *corev1.PodSpec, o ...
 	}
 	if !reflect.DeepEqual(spec.InitContainers[0], availabilityProberContainer) {
 		spec.InitContainers[0] = availabilityProberContainer
+	}
+}
+
+// KASReadinessCheckContainer returns a sidecar container that probes the KAS /livez endpoint.
+// When KAS is unreachable, the readiness probe fails and the pod goes unready,
+// which prevents PDB from treating it as healthy during eviction decisions.
+// This uses /livez (not /readyz) to avoid a circular dependency: KAS /readyz checks
+// aggregated API servers, which include OAS and OAuth API Server.
+func KASReadinessCheckContainer(kasLivezURL string) corev1.Container {
+	return corev1.Container{
+		Name:    "kas-readiness-check",
+		Image:   "cli",
+		Command: []string{"/bin/bash", "-c", "sleep infinity"},
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"/bin/bash", "-c", fmt.Sprintf("curl -kfs %s > /dev/null", kasLivezURL)},
+				},
+			},
+			FailureThreshold: 3,
+			PeriodSeconds:    10,
+			TimeoutSeconds:   5,
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("10Mi"),
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary

Cherry-pick of #8213 to `release-4.20`.

- Adds a `kas-readiness-check` sidecar container to the OpenShift API Server (OAS), OpenShift OAuth API Server, and OLM packageserver deployments
- The sidecar has a readiness probe that checks the KAS `/livez` endpoint. When KAS is unreachable, the probe fails and the pod goes unready, preventing PDB from treating it as healthy during eviction decisions
- Uses `/livez` (not `/readyz`) to avoid a circular dependency: KAS `/readyz` checks aggregated API servers (which include OAS and OAuth API Server), so checking `/readyz` would create a bootstrap deadlock during simultaneous restart

## Which issue(s) this PR fixes

Fixes [OCPBUGS-85825](https://redhat.atlassian.net/browse/OCPBUGS-85825)