### PR TITLE
OCPBUGS-85763: Fix metrics-proxy deployment failure due to dots in volume names

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/metrics_proxy/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/metrics_proxy/deployment.go
@@ -3,6 +3,7 @@ package metricsproxy
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/metrics"
@@ -121,8 +122,9 @@ func certVolumesFromMonitors(cpContext component.WorkloadContext, namespace stri
 
 	for _, name := range names {
 		ref := refs[name]
+		volName := sanitizeVolumeName(name)
 		vol := corev1.Volume{
-			Name: name,
+			Name: volName,
 		}
 
 		if ref.isSecret {
@@ -144,12 +146,19 @@ func certVolumesFromMonitors(cpContext component.WorkloadContext, namespace stri
 
 		volumes = append(volumes, vol)
 		mounts = append(mounts, corev1.VolumeMount{
-			Name:      name,
+			Name:      volName,
 			MountPath: certBasePath + "/" + name,
 		})
 	}
 
 	return volumes, mounts, nil
+}
+
+// sanitizeVolumeName converts a resource name into a valid Kubernetes volume
+// name by replacing dots with dashes. Kubernetes volume names must conform to
+// DNS label rules which do not allow dots.
+func sanitizeVolumeName(name string) string {
+	return strings.ReplaceAll(name, ".", "-")
 }
 
 // collectSecretOrConfigMapRef adds a SecretOrConfigMap reference to the refs map.

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/metrics_proxy/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/metrics_proxy/deployment_test.go
@@ -309,6 +309,38 @@ func TestCertVolumesFromMonitors(t *testing.T) {
 		}
 	})
 
+	t.Run("When resource names contain dots, it should sanitize volume names but preserve mount paths", func(t *testing.T) {
+		t.Parallel()
+
+		sm := newServiceMonitorWithTLS("cno", namespace, &prometheusoperatorv1.TLSConfig{
+			SafeTLSConfig: prometheusoperatorv1.SafeTLSConfig{
+				CA: prometheusoperatorv1.SecretOrConfigMap{
+					ConfigMap: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "openshift-service-ca.crt"},
+						Key:                  "service-ca.crt",
+					},
+				},
+			},
+		})
+
+		cpContext := newCertVolumeTestContext(namespace, scheme, sm)
+		volumes, mounts := assertCertVolumeCount(t, cpContext, namespace, 1, 1)
+
+		if volumes[0].Name != "openshift-service-ca-crt" {
+			t.Errorf("expected sanitized volume name openshift-service-ca-crt, got %s", volumes[0].Name)
+		}
+		if mounts[0].Name != "openshift-service-ca-crt" {
+			t.Errorf("expected sanitized mount name openshift-service-ca-crt, got %s", mounts[0].Name)
+		}
+		expectedPath := certBasePath + "/openshift-service-ca.crt"
+		if mounts[0].MountPath != expectedPath {
+			t.Errorf("expected mount path to preserve dots %q, got %q", expectedPath, mounts[0].MountPath)
+		}
+		if volumes[0].VolumeSource.ConfigMap.Name != "openshift-service-ca.crt" {
+			t.Errorf("expected ConfigMap source name to preserve original name, got %s", volumes[0].VolumeSource.ConfigMap.Name)
+		}
+	})
+
 	t.Run("When PodMonitor has no TLS config, it should be skipped", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Summary

- Sanitize Kubernetes volume names derived from Secret/ConfigMap resource names by replacing dots with dashes to comply with RFC 1123 DNS label rules
- Preserve the original resource name in ConfigMap/Secret source references and mount paths so file path resolution in scrape configs remains correct
- Add test coverage for the dot-sanitization behavior

## Details

The `certVolumesFromMonitors` function in the metrics-proxy component lists all ServiceMonitors and PodMonitors in the HCP namespace and collects their TLS certificate references to create volumes. It used the resource names directly as Kubernetes volume names, which fails validation when a resource name contains dots (e.g., `openshift-service-ca.crt`).

On a 4.22 ROSA HCP cluster with metrics forwarding enabled, the `audit-webhook` ServiceMonitor references a ConfigMap named `openshift-service-ca.crt` in its TLS CA config, causing the metrics-proxy Deployment to be rejected by the API server with:
```
Deployment.apps "metrics-proxy" is invalid: spec.template.spec.volumes[8].name: Invalid value: "openshift-service-ca.crt": must not contain dots
```

Fixes https://issues.redhat.com/browse/OCPBUGS-85763

## Test plan

- [x] Existing unit tests pass (no regressions in volume deduplication, optional flags, mount paths)
- [x] New test case verifies dots are replaced with dashes in volume/mount names while preserving original names in ConfigMap source and mount paths
- [ ] Manual verification on a 4.22 ROSA HCP cluster with `hypershift.openshift.io/enable-metrics-forwarding: "true"` annotation — metrics-proxy deployment should be created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metrics proxy deployment to properly handle resource names containing dots by sanitizing Kubernetes volume names, ensuring more reliable configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->