### PR TITLE
NO-JIRA: fix(e2e): use public multi-arch image for ARM64 karpenter test

### DIFF
--- a/test/e2e/karpenter_test.go
+++ b/test/e2e/karpenter_test.go
@@ -316,7 +316,7 @@ func testARM64Provisioning(ctx context.Context, guestClient crclient.Client, hos
 			{Key: karpenterv1.CapacityTypeLabelKey, Operator: corev1.NodeSelectorOpIn, Values: []string{karpenterv1.CapacityTypeOnDemand}},
 		}
 		// quay.io/openshift/origin-pod does not support arm64
-		armWorkLoads := testWorkloadWithImage("arm-app", 1, map[string]string{karpenterv1.NodePoolLabelKey: armNodePool.Name}, "quay.io/hypershift/sleep:multiarch")
+		armWorkLoads := testWorkloadWithImage("arm-app", 1, map[string]string{karpenterv1.NodePoolLabelKey: armNodePool.Name}, "registry.access.redhat.com/ubi10/ubi-minimal:10.1")
 
 		t.Cleanup(func() {
 			_ = guestClient.Delete(ctx, armWorkLoads)
@@ -1802,6 +1802,7 @@ func testWorkloadWithImage(name string, replicas int32, nodeSelector map[string]
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: ptr.To(false),
 						},
+						Command: []string{"/bin/sh", "-c", "sleep infinity"},
 					}},
 					NodeSelector: nodeSelector,
 				},


### PR DESCRIPTION
quay.io/hypershift/sleep:multiarch is a private image that requires auth not available in CI pull secrets, causing ImagePullBackOff. Use registry.k8s.io/pause:3.10 which is public and multi-arch.

See rehearsals failures here: https://github.com/openshift/release/pull/79262

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated ARM64 provisioning tests to use a different container image to improve cross-architecture validation and test reliability.
  * Modified the test workload to run a persistent, long-lived process so pods remain running throughout end-to-end tests, reducing flakiness and improving stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->