### PR TITLE
AUTOSCALE-685: Stop controllers fighting over HCP Status() updates 

### DIFF
--- a/client/applyconfiguration/hypershift/v1beta1/clusterversionstatus.go
+++ b/client/applyconfiguration/hypershift/v1beta1/clusterversionstatus.go
@@ -27,7 +27,7 @@ type ClusterVersionStatusApplyConfiguration struct {
 	Desired            *v1.Release            `json:"desired,omitempty"`
 	History            []v1.UpdateHistory     `json:"history,omitempty"`
 	ObservedGeneration *int64                 `json:"observedGeneration,omitempty"`
-	AvailableUpdates   []v1.Release           `json:"availableUpdates,omitempty"`
+	AvailableUpdates   []v1.Release           `json:"availableUpdates,omitzero"`
 	ConditionalUpdates []v1.ConditionalUpdate `json:"conditionalUpdates,omitempty"`
 }
 

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -16,6 +16,8 @@ import (
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hypershiftv1beta1applyconfigurations "github.com/openshift/hypershift/client/applyconfiguration/hypershift/v1beta1"
+	hypershiftclient "github.com/openshift/hypershift/client/clientset/clientset"
 	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/ignition"
@@ -116,6 +118,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/duration"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	metav1applyconfigurations "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/workqueue"
@@ -156,6 +159,7 @@ const (
 
 type HostedControlPlaneReconciler struct {
 	client.Client
+	HypershiftClient hypershiftclient.Interface
 
 	GVKAccessChecker component.GVKAccessChecker
 
@@ -1957,31 +1961,38 @@ func (r *HostedControlPlaneReconciler) cleanupOldPKIOperatorDeployment(ctx conte
 	return nil
 }
 
+func (r *HostedControlPlaneReconciler) applyHCPStatusCondition(ctx context.Context, hcp *hyperv1.HostedControlPlane, fieldManager string, managedTypes sets.Set[string], updated ...*metav1applyconfigurations.ConditionApplyConfiguration) error {
+	cfg := hypershiftv1beta1applyconfigurations.HostedControlPlane(hcp.Name, hcp.Namespace).
+		WithStatus(hypershiftv1beta1applyconfigurations.HostedControlPlaneStatus().
+			WithConditions(conditions.SSAConditions(hcp.Status.Conditions, managedTypes, updated...)...))
+	_, err := r.HypershiftClient.HypershiftV1beta1().HostedControlPlanes(hcp.Namespace).ApplyStatus(
+		ctx, cfg, metav1.ApplyOptions{FieldManager: fieldManager, Force: true})
+	return err
+}
+
 func (r *HostedControlPlaneReconciler) reconcileValidIDPConfigurationCondition(ctx context.Context, hcp *hyperv1.HostedControlPlane, releaseImageProvider imageprovider.ReleaseImageProvider, oauthHost string, oauthPort int32) error {
 	p := oauth.NewOAuthServerParams(hcp, releaseImageProvider, oauthHost, oauthPort, r.SetDefaultSecurityContext)
 
-	// Report any IDP configuration errors as a condition on the HCP
-	new := metav1.Condition{
-		Type:    string(hyperv1.ValidIDPConfiguration),
-		Status:  metav1.ConditionTrue,
-		Reason:  "IDPConfigurationValid",
-		Message: "Identity provider configuration is valid",
-	}
+	cond := metav1applyconfigurations.Condition().
+		WithType(string(hyperv1.ValidIDPConfiguration)).
+		WithStatus(metav1.ConditionTrue).
+		WithReason("IDPConfigurationValid").
+		WithMessage("Identity provider configuration is valid")
+
 	if _, _, err := oauth.ConvertIdentityProviders(ctx, p.IdentityProviders(), p.OauthConfigOverrides, r, hcp.Namespace); err != nil {
-		// Report the error in a condition on the HCP
 		r.Log.Error(err, "failed to initialize identity providers")
-		new = metav1.Condition{
-			Type:    string(hyperv1.ValidIDPConfiguration),
-			Status:  metav1.ConditionFalse,
-			Reason:  "IDPConfigurationError",
-			Message: fmt.Sprintf("failed to initialize identity providers: %v", err),
-		}
+		cond.
+			WithStatus(metav1.ConditionFalse).
+			WithReason("IDPConfigurationError").
+			WithMessage(fmt.Sprintf("failed to initialize identity providers: %v", err))
 	}
-	// Update the condition on the HCP if it has changed
-	if meta.SetStatusCondition(&hcp.Status.Conditions, new) {
-		if err := r.Status().Update(ctx, hcp); err != nil {
-			return fmt.Errorf("failed to update valid IDP configuration condition: %w", err)
-		}
+
+	if !conditions.ConditionChanged(hcp.Status.Conditions, cond) {
+		return nil
+	}
+	managed := sets.New[string](string(hyperv1.ValidIDPConfiguration))
+	if err := r.applyHCPStatusCondition(ctx, hcp, "hostedcontrolplane-idp", managed, cond); err != nil {
+		return fmt.Errorf("failed to apply valid IDP configuration condition: %w", err)
 	}
 	return nil
 }
@@ -2497,14 +2508,14 @@ func (r *HostedControlPlaneReconciler) removeCloudResources(ctx context.Context,
 			if resourcesDestroyedCond != nil && resourcesDestroyedCond.Message != "" {
 				message = fmt.Sprintf("%s (last status: %s)", message, resourcesDestroyedCond.Message)
 			}
-			meta.SetStatusCondition(&hcp.Status.Conditions, metav1.Condition{
-				Type:    string(hyperv1.CloudResourcesDestroyed),
-				Status:  metav1.ConditionFalse,
-				Reason:  string(hyperv1.CloudResourcesDeletionTimedOutReason),
-				Message: message,
-			})
-			if err := r.Status().Update(ctx, hcp); err != nil {
-				return false, fmt.Errorf("failed to update cloud resources destroyed condition: %w", err)
+			managed := sets.New[string](string(hyperv1.CloudResourcesDestroyed))
+			cond := metav1applyconfigurations.Condition().
+				WithType(string(hyperv1.CloudResourcesDestroyed)).
+				WithStatus(metav1.ConditionFalse).
+				WithReason(string(hyperv1.CloudResourcesDeletionTimedOutReason)).
+				WithMessage(message)
+			if err := r.applyHCPStatusCondition(ctx, hcp, "hostedcontrolplane-cloud-resources", managed, cond); err != nil {
+				return false, fmt.Errorf("failed to apply cloud resources destroyed condition: %w", err)
 			}
 			return true, nil
 		}
@@ -2529,15 +2540,14 @@ func (r *HostedControlPlaneReconciler) removeCloudResources(ctx context.Context,
 		return false, nil
 	}
 	if cvoScaledDownCond == nil || cvoScaledDownCond.Status != metav1.ConditionTrue {
-		cvoScaledDownCond = &metav1.Condition{
-			Type:               string(hyperv1.CVOScaledDown),
-			Status:             metav1.ConditionTrue,
-			Reason:             "CVOScaledDown",
-			LastTransitionTime: metav1.Now(),
-		}
-		meta.SetStatusCondition(&hcp.Status.Conditions, *cvoScaledDownCond)
-		if err := r.Status().Update(ctx, hcp); err != nil {
-			return false, fmt.Errorf("failed to set CVO scaled down condition: %w", err)
+		managed := sets.New[string](string(hyperv1.CVOScaledDown))
+		cond := metav1applyconfigurations.Condition().
+			WithType(string(hyperv1.CVOScaledDown)).
+			WithStatus(metav1.ConditionTrue).
+			WithReason("CVOScaledDown").
+			WithLastTransitionTime(metav1.Now())
+		if err := r.applyHCPStatusCondition(ctx, hcp, "hostedcontrolplane-cvo-scaledown", managed, cond); err != nil {
+			return false, fmt.Errorf("failed to apply CVO scaled down condition: %w", err)
 		}
 	}
 	return false, nil

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -13,6 +13,7 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/api/util/ipnet"
+	hypershiftfake "github.com/openshift/hypershift/client/clientset/clientset/fake"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/infra"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
@@ -732,6 +733,7 @@ func TestEventHandling(t *testing.T) {
 
 	r := &HostedControlPlaneReconciler{
 		Client:                        c,
+		HypershiftClient:              hypershiftfake.NewSimpleClientset(hcp.DeepCopy()),
 		ManagementClusterCapabilities: &fakecapabilities.FakeSupportAllCapabilities{},
 		ReleaseProvider:               mockedProviderWithOpenshiftImageRegistryOverrides,
 		UserReleaseProvider:           &fakereleaseprovider.FakeReleaseProvider{},
@@ -2836,8 +2838,11 @@ func TestRemoveCloudResources(t *testing.T) {
 				WithStatusSubresource(&hyperv1.HostedControlPlane{}).
 				Build()
 
+			fakeHypershiftClient := hypershiftfake.NewSimpleClientset(tc.hcp.DeepCopy())
+
 			r := &HostedControlPlaneReconciler{
-				Client: c,
+				Client:           c,
+				HypershiftClient: fakeHypershiftClient,
 			}
 
 			var originalCloudResourcesCond *metav1.Condition
@@ -2857,8 +2862,8 @@ func TestRemoveCloudResources(t *testing.T) {
 			g.Expect(done).To(Equal(tc.expectedDone))
 
 			if tc.expectedCondition != nil {
-				updatedHCP := &hyperv1.HostedControlPlane{}
-				g.Expect(c.Get(ctx, client.ObjectKeyFromObject(tc.hcp), updatedHCP)).To(Succeed())
+				updatedHCP, getErr := fakeHypershiftClient.HypershiftV1beta1().HostedControlPlanes(tc.hcp.Namespace).Get(ctx, tc.hcp.Name, metav1.GetOptions{})
+				g.Expect(getErr).ToNot(HaveOccurred())
 				condition := meta.FindStatusCondition(updatedHCP.Status.Conditions, tc.expectedCondition.Type)
 				g.Expect(condition).ToNot(BeNil())
 				g.Expect(condition.Status).To(Equal(tc.expectedCondition.Status))

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/hcpstatus/hcpstatus.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/hcpstatus/hcpstatus.go
@@ -3,17 +3,21 @@ package hcpstatus
 import (
 	"context"
 	"fmt"
-	"reflect"
+	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hypershiftv1beta1applyconfigurations "github.com/openshift/hypershift/client/applyconfiguration/hypershift/v1beta1"
+	hypershiftclient "github.com/openshift/hypershift/client/clientset/clientset"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/operator"
+	"github.com/openshift/hypershift/support/conditions"
 	"github.com/openshift/hypershift/support/releaseinfo"
 
 	configv1 "github.com/openshift/api/config/v1"
 
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	metav1applyconfigurations "k8s.io/client-go/applyconfigurations/meta/v1"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -25,8 +29,24 @@ import (
 
 const ControllerName = "hcpstatus"
 
+var managedConditions = sets.New[string](
+	string(hyperv1.ClusterVersionFailing),
+	string(hyperv1.ClusterVersionReleaseAccepted),
+	string(hyperv1.ClusterVersionRetrievedUpdates),
+	string(hyperv1.ClusterVersionProgressing),
+	string(hyperv1.ClusterVersionUpgradeable),
+	string(hyperv1.ClusterVersionAvailable),
+)
+
 func Setup(ctx context.Context, opts *operator.HostedClusterConfigOperatorConfig) error {
+	hypershiftClient, err := hypershiftclient.NewForConfig(opts.CPCluster.GetConfig())
+	if err != nil {
+		return fmt.Errorf("failed to create hypershift client: %w", err)
+	}
 	r := &hcpStatusReconciler{
+		hcpName:             opts.HCPName,
+		hcpNamespace:        opts.Namespace,
+		hypershiftClient:    hypershiftClient,
 		mgtClusterClient:    opts.CPCluster.GetClient(),
 		hostedClusterClient: opts.Manager.GetClient(),
 		releaseProvider:     opts.ReleaseProvider,
@@ -58,9 +78,11 @@ func Setup(ctx context.Context, opts *operator.HostedClusterConfigOperatorConfig
 }
 
 type hcpStatusReconciler struct {
-	mgtClusterClient    crclient.Client
-	hostedClusterClient crclient.Client
-	releaseProvider     releaseinfo.Provider
+	hcpName, hcpNamespace string
+	hypershiftClient      hypershiftclient.Interface
+	mgtClusterClient      crclient.Client
+	hostedClusterClient   crclient.Client
+	releaseProvider       releaseinfo.Provider
 }
 
 func (h *hcpStatusReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
@@ -69,56 +91,46 @@ func (h *hcpStatusReconciler) Reconcile(ctx context.Context, req reconcile.Reque
 	if err := h.mgtClusterClient.Get(ctx, req.NamespacedName, hcp); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get hcp %s: %w", req, err)
 	}
-	originalHCP := hcp.DeepCopy()
-	if err := h.reconcile(ctx, hcp); err != nil {
-		return reconcile.Result{}, err
-	}
 
-	if !reflect.DeepEqual(hcp.Status, originalHCP.Status) {
-		log.Info("Updating HCP status with new configuration and version status")
-		if err := h.mgtClusterClient.Status().Update(ctx, hcp); err != nil {
-			return reconcile.Result{}, fmt.Errorf("failed to update hcp: %w", err)
-		}
-		log.Info("Successfully updated HCP status")
-	}
-
-	return reconcile.Result{}, nil
-}
-
-// findClusterOperatorStatusCondition is identical to meta.FindStatusCondition except that it works on config1.ClusterOperatorStatusCondition instead of
-// metav1.StatusCondition
-func findClusterOperatorStatusCondition(conditions []configv1.ClusterOperatorStatusCondition, conditionType configv1.ClusterStatusConditionType) *configv1.ClusterOperatorStatusCondition {
-	for i := range conditions {
-		if conditions[i].Type == conditionType {
-			return &conditions[i]
-		}
-	}
-
-	return nil
-}
-
-func (h *hcpStatusReconciler) reconcile(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
-	log := ctrl.LoggerFrom(ctx)
+	statusCfg := hypershiftv1beta1applyconfigurations.HostedControlPlaneStatus()
+	var reconcileErr error
 
 	var clusterVersion configv1.ClusterVersion
-	err := h.hostedClusterClient.Get(ctx, crclient.ObjectKey{Name: "version"}, &clusterVersion)
-	// We check err in loop below to build conditions with ConditionUnknown status for all types.
+	cvErr := h.hostedClusterClient.Get(ctx, crclient.ObjectKey{Name: "version"}, &clusterVersion)
 
-	if err == nil {
-		hcp.Status.VersionStatus = &hyperv1.ClusterVersionStatus{
-			Desired:            clusterVersion.Status.Desired,
-			History:            clusterVersion.Status.History,
-			ObservedGeneration: clusterVersion.Status.ObservedGeneration,
-			AvailableUpdates:   clusterVersion.Status.AvailableUpdates,
-			ConditionalUpdates: clusterVersion.Status.ConditionalUpdates,
-		}
-		//lint:ignore SA1019 populate the deprecated property until we can drop it in a later API version
-		hcp.Status.Version = hcp.Status.VersionStatus.Desired.Version
-		//lint:ignore SA1019 populate the deprecated property until we can drop it in a later API version
-		hcp.Status.ReleaseImage = hcp.Status.VersionStatus.Desired.Image
+	if cvErr == nil {
+		versionStatus := hypershiftv1beta1applyconfigurations.ClusterVersionStatus().
+			WithDesired(clusterVersion.Status.Desired).
+			WithHistory(clusterVersion.Status.History...).
+			WithObservedGeneration(clusterVersion.Status.ObservedGeneration).
+			WithAvailableUpdates(clusterVersion.Status.AvailableUpdates...).
+			WithConditionalUpdates(clusterVersion.Status.ConditionalUpdates...)
+		ensureRequiredSlices(versionStatus)
+		statusCfg.
+			WithVersionStatus(versionStatus).
+			//lint:ignore SA1019 populate the deprecated property until we can drop it in a later API version
+			WithVersion(clusterVersion.Status.Desired.Version).
+			//lint:ignore SA1019 populate the deprecated property until we can drop it in a later API version
+			WithReleaseImage(clusterVersion.Status.Desired.Image)
+	} else if hcp.Status.VersionStatus != nil {
+		// Preserve existing version fields so that SSA doesn't drop them
+		// when the ClusterVersion read fails transiently.
+		versionStatus := hypershiftv1beta1applyconfigurations.ClusterVersionStatus().
+			WithDesired(hcp.Status.VersionStatus.Desired).
+			WithHistory(hcp.Status.VersionStatus.History...).
+			WithObservedGeneration(hcp.Status.VersionStatus.ObservedGeneration).
+			WithAvailableUpdates(hcp.Status.VersionStatus.AvailableUpdates...).
+			WithConditionalUpdates(hcp.Status.VersionStatus.ConditionalUpdates...)
+		ensureRequiredSlices(versionStatus)
+		statusCfg.
+			WithVersionStatus(versionStatus).
+			//lint:ignore SA1019 populate the deprecated property until we can drop it in a later API version
+			WithVersion(hcp.Status.VersionStatus.Desired.Version).
+			//lint:ignore SA1019 populate the deprecated property until we can drop it in a later API version
+			WithReleaseImage(hcp.Status.VersionStatus.Desired.Image)
 	}
 
-	cvoConditions := map[hyperv1.ConditionType]*configv1.ClusterOperatorStatusCondition{
+	cvoConditionTypes := map[hyperv1.ConditionType]*configv1.ClusterOperatorStatusCondition{
 		hyperv1.ClusterVersionFailing:          findClusterOperatorStatusCondition(clusterVersion.Status.Conditions, "Failing"),
 		hyperv1.ClusterVersionReleaseAccepted:  findClusterOperatorStatusCondition(clusterVersion.Status.Conditions, "ReleaseAccepted"),
 		hyperv1.ClusterVersionRetrievedUpdates: findClusterOperatorStatusCondition(clusterVersion.Status.Conditions, configv1.RetrievedUpdates),
@@ -127,60 +139,119 @@ func (h *hcpStatusReconciler) reconcile(ctx context.Context, hcp *hyperv1.Hosted
 		hyperv1.ClusterVersionAvailable:        findClusterOperatorStatusCondition(clusterVersion.Status.Conditions, configv1.OperatorAvailable),
 	}
 
-	for conditionType, condition := range cvoConditions {
-		var hcpCVOCondition metav1.Condition
-		// Set unknown status.
-		var unknownStatusMessage string
-		if condition == nil {
-			unknownStatusMessage = "Condition not found in the CVO."
-		}
-		if err != nil {
-			unknownStatusMessage = fmt.Sprintf("failed to get clusterVersion: %v", err)
-		}
+	var conditionUpdates []*metav1applyconfigurations.ConditionApplyConfiguration
+	for conditionType, condition := range cvoConditionTypes {
+		applyCond := metav1applyconfigurations.Condition().
+			WithType(string(conditionType)).
+			WithObservedGeneration(hcp.Generation)
 
-		hcpCVOCondition = metav1.Condition{
-			Type:               string(conditionType),
-			Status:             metav1.ConditionUnknown,
-			Reason:             hyperv1.StatusUnknownReason,
-			Message:            unknownStatusMessage,
-			ObservedGeneration: hcp.Generation,
-		}
-
-		if err == nil && condition != nil {
-			// Bubble up info from CVO.
+		if cvErr != nil {
+			applyCond.
+				WithStatus(metav1.ConditionUnknown).
+				WithReason(hyperv1.StatusUnknownReason).
+				WithMessage(fmt.Sprintf("failed to get clusterVersion: %v", cvErr))
+		} else if condition == nil {
+			status := metav1.ConditionUnknown
+			reason := hyperv1.StatusUnknownReason
+			if conditionType == hyperv1.ClusterVersionUpgradeable {
+				status = metav1.ConditionTrue
+				reason = hyperv1.FromClusterVersionReason
+			}
+			applyCond.
+				WithStatus(status).
+				WithReason(reason).
+				WithMessage("Condition not found in the CVO.")
+		} else {
 			reason := condition.Reason
-			// reason is not required in ClusterOperatorStatusCondition, but it's in metav1.conditions.
-			// So we need to make sure the input does not break the KAS expectation.
 			if reason == "" {
 				reason = hyperv1.FromClusterVersionReason
 			}
-			hcpCVOCondition = metav1.Condition{
-				Type:               string(conditionType),
-				Status:             metav1.ConditionStatus(condition.Status),
-				Reason:             reason,
-				Message:            condition.Message,
-				ObservedGeneration: hcp.Generation,
-			}
+			applyCond.
+				WithStatus(metav1.ConditionStatus(condition.Status)).
+				WithReason(reason).
+				WithMessage(condition.Message)
 		}
 
-		// If CVO has no Upgradeable condition, consider the HCP upgradable according to the CVO
-		if conditionType == hyperv1.ClusterVersionUpgradeable &&
-			condition == nil {
-			hcpCVOCondition.Status = metav1.ConditionTrue
-			hcpCVOCondition.Reason = hyperv1.FromClusterVersionReason
+		existingCondition := findCondition(hcp.Status.Conditions, string(conditionType))
+		if existingCondition != nil && existingCondition.Status == *applyCond.Status {
+			applyCond.WithLastTransitionTime(existingCondition.LastTransitionTime)
+		} else {
+			applyCond.WithLastTransitionTime(metav1.NewTime(time.Now()))
 		}
 
-		meta.SetStatusCondition(&hcp.Status.Conditions, hcpCVOCondition)
+		conditionUpdates = append(conditionUpdates, applyCond)
 	}
+
+	statusCfg.WithConditions(conditions.SSAConditions(hcp.Status.Conditions, managedConditions, conditionUpdates...)...)
 
 	var authentication configv1.Authentication
-	if err = h.hostedClusterClient.Get(ctx, crclient.ObjectKey{Name: "cluster"}, &authentication); err != nil {
-		return fmt.Errorf("failed to get Authentication resource \"cluster\": %w", err)
-	}
-	hcp.Status.Configuration = &hyperv1.ConfigurationStatus{
-		Authentication: authentication.Status,
+	if err := h.hostedClusterClient.Get(ctx, crclient.ObjectKey{Name: "cluster"}, &authentication); err != nil {
+		reconcileErr = fmt.Errorf("failed to get Authentication resource \"cluster\": %w", err)
+		// Preserve existing Configuration so that SSA doesn't drop a field
+		// this manager previously owned.
+		if hcp.Status.Configuration != nil {
+			statusCfg.WithConfiguration(
+				hypershiftv1beta1applyconfigurations.ConfigurationStatus().
+					WithAuthentication(sanitizeAuthenticationStatus(hcp.Status.Configuration.Authentication)),
+			)
+		}
+	} else {
+		statusCfg.WithConfiguration(
+			hypershiftv1beta1applyconfigurations.ConfigurationStatus().
+				WithAuthentication(sanitizeAuthenticationStatus(authentication.Status)),
+		)
 	}
 
-	log.Info("Finished reconciling configuration and version status")
+	cfg := hypershiftv1beta1applyconfigurations.HostedControlPlane(h.hcpName, h.hcpNamespace)
+	cfg.Status = statusCfg
+	log.Info("Applying HCP status with configuration and version status")
+	if _, err := h.hypershiftClient.HypershiftV1beta1().HostedControlPlanes(h.hcpNamespace).ApplyStatus(
+		ctx, cfg, metav1.ApplyOptions{FieldManager: ControllerName, Force: true},
+	); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to apply hcp status: %w", err)
+	}
+	log.Info("Successfully applied HCP status")
+
+	if reconcileErr != nil {
+		return reconcile.Result{}, reconcileErr
+	}
+	return reconcile.Result{}, nil
+}
+
+// ensureRequiredSlices ensures that +required slice fields on ClusterVersionStatus
+// are non-nil. The generated apply configuration uses omitempty, so a nil slice is
+// omitted from the JSON payload — but the API server rejects a missing +required
+// field within a parent struct that IS present.
+func ensureRequiredSlices(vs *hypershiftv1beta1applyconfigurations.ClusterVersionStatusApplyConfiguration) {
+	if vs.AvailableUpdates == nil {
+		vs.AvailableUpdates = []configv1.Release{}
+	}
+}
+
+// sanitizeAuthenticationStatus returns a copy of the AuthenticationStatus with nil
+// slices replaced by empty slices. The OIDCClients field uses json:"oidcClients"
+// without omitempty, so a nil slice serializes as null which the API server rejects.
+func sanitizeAuthenticationStatus(status configv1.AuthenticationStatus) configv1.AuthenticationStatus {
+	if status.OIDCClients == nil {
+		status.OIDCClients = []configv1.OIDCClientStatus{}
+	}
+	return status
+}
+
+func findClusterOperatorStatusCondition(conditions []configv1.ClusterOperatorStatusCondition, conditionType configv1.ClusterStatusConditionType) *configv1.ClusterOperatorStatusCondition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}
+
+func findCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
 	return nil
 }

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hypershiftv1beta1applyconfigurations "github.com/openshift/hypershift/client/applyconfiguration/hypershift/v1beta1"
+	hypershiftclient "github.com/openshift/hypershift/client/clientset/clientset"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/azure"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/cloud/openstack"
@@ -48,6 +50,7 @@ import (
 	hyperapi "github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/capabilities"
+	"github.com/openshift/hypershift/support/conditions"
 	"github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/globalconfig"
 	"github.com/openshift/hypershift/support/k8sutil"
@@ -77,6 +80,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	metav1applyconfigurations "k8s.io/client-go/applyconfigurations/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
@@ -133,9 +137,10 @@ exec /bin/azure-cloud-node-manager \
 `
 
 type reconciler struct {
-	client         client.Client
-	uncachedClient client.Client
-	clientSet      *clientset.Clientset
+	client           client.Client
+	uncachedClient   client.Client
+	clientSet        *clientset.Clientset
+	hypershiftClient hypershiftclient.Interface
 	upsert.CreateOrUpdateProvider
 	platformType              hyperv1.PlatformType
 	rootCA                    string
@@ -207,10 +212,16 @@ func Setup(ctx context.Context, opts *operator.HostedClusterConfigOperatorConfig
 		return fmt.Errorf("failed to initialize kubeClient from config: %w", err)
 	}
 
+	hypershiftClient, err := hypershiftclient.NewForConfig(opts.CPCluster.GetConfig())
+	if err != nil {
+		return fmt.Errorf("failed to create hypershift client: %w", err)
+	}
+
 	c, err := controller.New(ControllerName, opts.Manager, controller.Options{Reconciler: &reconciler{
 		client:                    opts.Manager.GetClient(),
 		uncachedClient:            uncachedClient,
 		clientSet:                 clientset,
+		hypershiftClient:          hypershiftClient,
 		CreateOrUpdateProvider:    opts.TargetCreateOrUpdateProvider,
 		platformType:              opts.PlatformType,
 		rootCA:                    opts.InitialCA,
@@ -567,12 +578,22 @@ func (r *reconciler) reconcileClusterRecovery(ctx context.Context, log logr.Logg
 		condition.Message = "Hosted cluster recovery finished"
 	}
 
-	meta.SetStatusCondition(&hcp.Status.Conditions, *condition)
 	log.Info("setting condition", "type", condition.Type, "status", condition.Status, "message", condition.Message)
-	if err := r.cpClient.Status().Update(ctx, hcp); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to update status on hcp for hosted cluster recovery: %w. Condition error message: %v", err, condition.Message)
+	managed := sets.New[string](string(hyperv1.HostedClusterRestoredFromBackup))
+	applyCond := metav1applyconfigurations.Condition().
+		WithType(condition.Type).
+		WithStatus(condition.Status).
+		WithReason(condition.Reason).
+		WithMessage(condition.Message)
+	cfg := hypershiftv1beta1applyconfigurations.HostedControlPlane(hcp.Name, hcp.Namespace).
+		WithStatus(hypershiftv1beta1applyconfigurations.HostedControlPlaneStatus().
+			WithConditions(conditions.SSAConditions(hcp.Status.Conditions, managed, applyCond)...))
+	if _, err := r.hypershiftClient.HypershiftV1beta1().HostedControlPlanes(hcp.Namespace).ApplyStatus(
+		ctx, cfg, metav1.ApplyOptions{FieldManager: "hcco-resources-recovery", Force: true},
+	); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to apply status on hcp for hosted cluster recovery: %w. Condition error message: %v", err, condition.Message)
 	}
-	log.Info("successfully updated hcp status with recovery condition")
+	log.Info("successfully applied hcp status with recovery condition")
 
 	if !finished {
 		return ctrl.Result{RequeueAfter: 120 * time.Second}, nil
@@ -1619,20 +1640,20 @@ func (r *reconciler) reconcileDataPlaneConnectionAvailable(ctx context.Context, 
 		condition.Status = metav1.ConditionUnknown
 		condition.Reason = hyperv1.ReconcileErrorReason
 		condition.Message = "Unable to count worker nodes: " + err.Error()
-		return r.patchHCPStatusCondition(ctx, hcp, condition)
+		return r.applyHCPStatusCondition(ctx, hcp, condition)
 	}
 	if totalNodes == 0 {
 		condition.Status = metav1.ConditionUnknown
 		condition.Reason = hyperv1.DataPlaneConnectionNoWorkerNodesAvailableReason
 		condition.Message = "No worker nodes available"
-		return r.patchHCPStatusCondition(ctx, hcp, condition)
+		return r.applyHCPStatusCondition(ctx, hcp, condition)
 	}
 	var podList corev1.PodList
 	if err := r.uncachedClient.List(ctx, &podList,
 		client.MatchingLabels{"app": "konnectivity-agent"}, client.InNamespace("kube-system")); err != nil {
 		condition.Reason = hyperv1.ReconciliationErrorReason
 		condition.Message = "Couldn't list konnectivity-agent PODs in kube-system namespace: " + err.Error()
-		return r.patchHCPStatusCondition(ctx, hcp, condition)
+		return r.applyHCPStatusCondition(ctx, hcp, condition)
 	}
 
 	logsFound := false
@@ -1667,7 +1688,7 @@ func (r *reconciler) reconcileDataPlaneConnectionAvailable(ctx context.Context, 
 		}
 	}
 
-	return r.patchHCPStatusCondition(ctx, hcp, condition)
+	return r.applyHCPStatusCondition(ctx, hcp, condition)
 }
 
 // getKASHealthCheckEndpoint returns the appropriate KAS health check endpoint based on the platform type.
@@ -1679,18 +1700,30 @@ func getKASHealthCheckEndpoint(platformType hyperv1.PlatformType) string {
 	return "/version"
 }
 
-// patchHCPStatusCondition patches the HostedControlPlane status with the provided condition.
-// It only performs the API call if the condition actually changed.
-func (r *reconciler) patchHCPStatusCondition(ctx context.Context, hcp *hyperv1.HostedControlPlane, condition *metav1.Condition) error {
+var connectionConditions = sets.New[string](
+	string(hyperv1.DataPlaneConnectionAvailable),
+	string(hyperv1.ControlPlaneConnectionAvailable),
+)
+
+func (r *reconciler) applyHCPStatusCondition(ctx context.Context, hcp *hyperv1.HostedControlPlane, condition *metav1.Condition) error {
 	log := ctrl.LoggerFrom(ctx)
-	originalHCP := hcp.DeepCopy()
-	if !meta.SetStatusCondition(&hcp.Status.Conditions, *condition) {
-		return nil // No status change; avoid unnecessary API call.
+	applyCond := metav1applyconfigurations.Condition().
+		WithType(condition.Type).
+		WithStatus(condition.Status).
+		WithReason(condition.Reason).
+		WithMessage(condition.Message)
+	if !conditions.ConditionChanged(hcp.Status.Conditions, applyCond) {
+		return nil
 	}
-	if err := r.cpClient.Status().Patch(ctx, hcp, client.MergeFrom(originalHCP)); err != nil {
-		return fmt.Errorf("failed to update HostedControlPlane status with %s condition: %w", condition.Type, err)
+	cfg := hypershiftv1beta1applyconfigurations.HostedControlPlane(hcp.Name, hcp.Namespace).
+		WithStatus(hypershiftv1beta1applyconfigurations.HostedControlPlaneStatus().
+			WithConditions(conditions.SSAConditions(hcp.Status.Conditions, connectionConditions, applyCond)...))
+	if _, err := r.hypershiftClient.HypershiftV1beta1().HostedControlPlanes(hcp.Namespace).ApplyStatus(
+		ctx, cfg, metav1.ApplyOptions{FieldManager: "hcco-resources-connection", Force: true},
+	); err != nil {
+		return fmt.Errorf("failed to apply HostedControlPlane status with %s condition: %w", condition.Type, err)
 	}
-	log.Info(string(condition.Type) + " condition updated")
+	log.Info(condition.Type + " condition updated")
 	return nil
 }
 
@@ -1816,12 +1849,12 @@ func (r *reconciler) reconcileControlPlaneConnectionAvailable(ctx context.Contex
 	if err != nil {
 		condition.Reason = hyperv1.ReconcileErrorReason
 		condition.Message = "Unable to count worker nodes: " + err.Error()
-		return r.patchHCPStatusCondition(ctx, hcp, condition)
+		return r.applyHCPStatusCondition(ctx, hcp, condition)
 	}
 	if totalNodes == 0 {
 		condition.Reason = hyperv1.ControlPlaneConnectionNoWorkerNodesAvailableReason
 		condition.Message = "No worker nodes available to verify control plane connectivity"
-		return r.patchHCPStatusCondition(ctx, hcp, condition)
+		return r.applyHCPStatusCondition(ctx, hcp, condition)
 	}
 
 	// Get the connectivity check ConfigMap
@@ -1832,13 +1865,13 @@ func (r *reconciler) reconcileControlPlaneConnectionAvailable(ctx context.Contex
 			condition.Reason = hyperv1.ControlPlaneConnectionConfigMapNotFoundReason
 			condition.Message = fmt.Sprintf("Connectivity check ConfigMap %s/%s not found; the hosted cluster config operator may not have reconciled it yet",
 				manifests.KASConnectionCheckerNamespace, manifests.KASConnectionCheckerConfigMapName)
-			return r.patchHCPStatusCondition(ctx, hcp, condition)
+			return r.applyHCPStatusCondition(ctx, hcp, condition)
 		}
 		// This should not happen as we are started by the CPO after the configmap should be created
 		condition.Reason = hyperv1.ReconcileErrorReason
 		condition.Message = fmt.Sprintf("Failed to get connectivity check ConfigMap %s/%s: %v",
 			manifests.KASConnectionCheckerNamespace, manifests.KASConnectionCheckerConfigMapName, err)
-		return r.patchHCPStatusCondition(ctx, hcp, condition)
+		return r.applyHCPStatusCondition(ctx, hcp, condition)
 	}
 
 	// Check the lastSucceeded timestamp
@@ -1847,7 +1880,7 @@ func (r *reconciler) reconcileControlPlaneConnectionAvailable(ctx context.Contex
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = hyperv1.ControlPlaneConnectionKASAccessFailedReason
 		condition.Message = "Data plane to control plane connection is not available: no successful connectivity check recorded"
-		return r.patchHCPStatusCondition(ctx, hcp, condition)
+		return r.applyHCPStatusCondition(ctx, hcp, condition)
 	}
 
 	lastSucceeded, err := time.Parse(time.RFC3339, lastSucceededStr)
@@ -1855,20 +1888,20 @@ func (r *reconciler) reconcileControlPlaneConnectionAvailable(ctx context.Contex
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = hyperv1.ControlPlaneConnectionKASAccessFailedReason
 		condition.Message = fmt.Sprintf("Data plane to control plane connection is not available: failed to parse lastSucceeded timestamp: %v", err)
-		return r.patchHCPStatusCondition(ctx, hcp, condition)
+		return r.applyHCPStatusCondition(ctx, hcp, condition)
 	}
 
 	if time.Since(lastSucceeded) > 5*time.Minute {
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = hyperv1.ControlPlaneConnectionCheckStaleReason
 		condition.Message = fmt.Sprintf("Data plane to control plane connection is not available: last successful check was at %s, which is older than 5 minutes", lastSucceededStr)
-		return r.patchHCPStatusCondition(ctx, hcp, condition)
+		return r.applyHCPStatusCondition(ctx, hcp, condition)
 	}
 
 	condition.Status = metav1.ConditionTrue
 	condition.Reason = hyperv1.AsExpectedReason
 	condition.Message = hyperv1.AllIsWellMessage
-	return r.patchHCPStatusCondition(ctx, hcp, condition)
+	return r.applyHCPStatusCondition(ctx, hcp, condition)
 }
 
 func (r *reconciler) reconcileOpenshiftAPIServerAPIServices(ctx context.Context, hcp *hyperv1.HostedControlPlane) error {
@@ -2724,12 +2757,20 @@ func (r *reconciler) destroyCloudResources(ctx context.Context, hcp *hyperv1.Hos
 		Message: message,
 	}
 
-	originalHCP := hcp.DeepCopy()
-	meta.SetStatusCondition(&hcp.Status.Conditions, *resourcesDestroyedCond)
-
-	if !equality.Semantic.DeepEqual(hcp, originalHCP) {
-		if err := r.cpClient.Status().Update(ctx, hcp); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to set resources destroyed condition: %w", err)
+	applyCond := metav1applyconfigurations.Condition().
+		WithType(resourcesDestroyedCond.Type).
+		WithStatus(resourcesDestroyedCond.Status).
+		WithReason(resourcesDestroyedCond.Reason).
+		WithMessage(resourcesDestroyedCond.Message)
+	if conditions.ConditionChanged(hcp.Status.Conditions, applyCond) {
+		managed := sets.New[string](string(hyperv1.CloudResourcesDestroyed))
+		cfg := hypershiftv1beta1applyconfigurations.HostedControlPlane(hcp.Name, hcp.Namespace).
+			WithStatus(hypershiftv1beta1applyconfigurations.HostedControlPlaneStatus().
+				WithConditions(conditions.SSAConditions(hcp.Status.Conditions, managed, applyCond)...))
+		if _, err := r.hypershiftClient.HypershiftV1beta1().HostedControlPlanes(hcp.Namespace).ApplyStatus(
+			ctx, cfg, metav1.ApplyOptions{FieldManager: "hcco-resources-cloud-destroy", Force: true},
+		); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to apply resources destroyed condition: %w", err)
 		}
 	}
 

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hypershiftfake "github.com/openshift/hypershift/client/clientset/clientset/fake"
 	cpomanifests "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/api"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/kas"
@@ -176,6 +177,7 @@ func TestReconcileErrorHandling(t *testing.T) {
 			platformType:           hyperv1.NonePlatform,
 			clusterSignerCA:        "foobar",
 			cpClient:               fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(cpObjects...).WithStatusSubresource(&hyperv1.HostedControlPlane{}).Build(),
+			hypershiftClient:       hypershiftfake.NewSimpleClientset(fakeHCP()),
 			hcpName:                "foo",
 			hcpNamespace:           "bar",
 			releaseProvider: &fakereleaseprovider.FakeReleaseProvider{
@@ -210,6 +212,7 @@ func TestReconcileErrorHandling(t *testing.T) {
 			platformType:           hyperv1.NonePlatform,
 			clusterSignerCA:        "foobar",
 			cpClient:               fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(cpObjects...).Build(),
+			hypershiftClient:       hypershiftfake.NewSimpleClientset(fakeHCP()),
 			hcpName:                "foo",
 			hcpNamespace:           "bar",
 			releaseProvider: &fakereleaseprovider.FakeReleaseProvider{
@@ -817,21 +820,23 @@ func TestDestroyCloudResources(t *testing.T) {
 		g.Expect(len(pods.Items)).To(Equal(0))
 	}
 
-	verifyDoneCond := func(g *WithT, c client.Client) {
+	verifyDoneCond := func(g *WithT, hcpClient *hypershiftfake.Clientset) {
 		hcp := fakeHostedControlPlane()
-		err := c.Get(t.Context(), client.ObjectKeyFromObject(hcp), hcp)
+		updated, err := hcpClient.HypershiftV1beta1().HostedControlPlanes(hcp.Namespace).Get(t.Context(), hcp.Name, metav1.GetOptions{})
 		g.Expect(err).ToNot(HaveOccurred())
-		cond := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.CloudResourcesDestroyed))
+		cond := meta.FindStatusCondition(updated.Status.Conditions, string(hyperv1.CloudResourcesDestroyed))
 		g.Expect(cond).ToNot(BeNil())
+		g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 	}
 
-	verifyNotDoneCond := func(g *WithT, c client.Client) {
+	verifyNotDoneCond := func(g *WithT, hcpClient *hypershiftfake.Clientset) {
 		hcp := fakeHostedControlPlane()
-		err := c.Get(t.Context(), client.ObjectKeyFromObject(hcp), hcp)
+		updated, err := hcpClient.HypershiftV1beta1().HostedControlPlanes(hcp.Namespace).Get(t.Context(), hcp.Name, metav1.GetOptions{})
 		g.Expect(err).ToNot(HaveOccurred())
-		cond := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.CloudResourcesDestroyed))
+		cond := meta.FindStatusCondition(updated.Status.Conditions, string(hyperv1.CloudResourcesDestroyed))
 		g.Expect(cond).ToNot(BeNil())
 		g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		g.Expect(cond.Reason).ToNot(Equal("NotDone"), "condition should have been updated from its seeded value")
 	}
 
 	tests := []struct {
@@ -937,10 +942,12 @@ func TestDestroyCloudResources(t *testing.T) {
 				},
 			}
 			cpClient := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(fakeHCP, kasDeployment).WithStatusSubresource(&hyperv1.HostedControlPlane{}).Build()
+			fakeHypershiftClient := hypershiftfake.NewSimpleClientset(fakeHCP.DeepCopy())
 			r := &reconciler{
 				client:                 guestClient,
 				uncachedClient:         uncachedClient,
 				cpClient:               cpClient,
+				hypershiftClient:       fakeHypershiftClient,
 				CreateOrUpdateProvider: &simpleCreateOrUpdater{},
 				cleanupTracker:         supportutil.NewCleanupTracker(),
 			}
@@ -951,9 +958,9 @@ func TestDestroyCloudResources(t *testing.T) {
 				test.verify(g, guestClient, uncachedClient)
 			}
 			if test.verifyDoneCond {
-				verifyDoneCond(g, cpClient)
+				verifyDoneCond(g, fakeHypershiftClient)
 			} else {
-				verifyNotDoneCond(g, cpClient)
+				verifyNotDoneCond(g, fakeHypershiftClient)
 			}
 		})
 	}
@@ -2505,9 +2512,11 @@ func Test_reconciler_reconcileDataPlaneConnectionAvailable(t *testing.T) {
 			podList := &corev1.PodList{
 				Items: tt.pods,
 			}
+			fakeHypershiftClient := hypershiftfake.NewSimpleClientset(tt.hcp.DeepCopy())
 			r.client = fake.NewClientBuilder().WithLists(nodeList).Build()
 			r.uncachedClient = fake.NewClientBuilder().WithLists(podList).Build()
 			r.cpClient = fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(tt.hcp).WithStatusSubresource(&hyperv1.HostedControlPlane{}).Build()
+			r.hypershiftClient = fakeHypershiftClient
 			r.GetPodLogs = tt.mockedGetPodLogs
 
 			gotErr := r.reconcileDataPlaneConnectionAvailable(ctx, tt.hcp, log)
@@ -2521,8 +2530,12 @@ func Test_reconciler_reconcileDataPlaneConnectionAvailable(t *testing.T) {
 				t.Fatal("reconcileDataPlaneConnectionAvailable() succeeded unexpectedly")
 			}
 			if tt.expectedCondition != nil {
+				updated, err := fakeHypershiftClient.HypershiftV1beta1().HostedControlPlanes(tt.hcp.Namespace).Get(ctx, tt.hcp.Name, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("failed to get HCP: %v", err)
+				}
 				found := false
-				for _, c := range tt.hcp.Status.Conditions {
+				for _, c := range updated.Status.Conditions {
 					if tt.expectedCondition.Type == c.Type &&
 						tt.expectedCondition.Message == c.Message &&
 						tt.expectedCondition.Status == c.Status &&
@@ -2531,7 +2544,7 @@ func Test_reconciler_reconcileDataPlaneConnectionAvailable(t *testing.T) {
 					}
 				}
 				if !found {
-					t.Fatal("couldn't find expected condition")
+					t.Fatalf("couldn't find expected condition. Expected: %+v, Got: %+v", tt.expectedCondition, updated.Status.Conditions)
 				}
 			}
 		})
@@ -2673,8 +2686,10 @@ func Test_reconciler_reconcileControlPlaneConnectionAvailable(t *testing.T) {
 			}
 			nodeList := &corev1.NodeList{Items: tt.nodes}
 
+			fakeHypershiftClient := hypershiftfake.NewSimpleClientset(tt.hcp.DeepCopy())
 			r.client = fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(objects...).WithLists(nodeList).Build()
 			r.cpClient = fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(tt.hcp).WithStatusSubresource(&hyperv1.HostedControlPlane{}).Build()
+			r.hypershiftClient = fakeHypershiftClient
 
 			gotErr := r.reconcileControlPlaneConnectionAvailable(ctx, tt.hcp)
 			if gotErr != nil {
@@ -2687,8 +2702,12 @@ func Test_reconciler_reconcileControlPlaneConnectionAvailable(t *testing.T) {
 				t.Fatal("reconcileControlPlaneConnectionAvailable() succeeded unexpectedly")
 			}
 			if tt.expectedCondition != nil {
+				updated, err := fakeHypershiftClient.HypershiftV1beta1().HostedControlPlanes(tt.hcp.Namespace).Get(ctx, tt.hcp.Name, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("failed to get HCP: %v", err)
+				}
 				found := false
-				for _, c := range tt.hcp.Status.Conditions {
+				for _, c := range updated.Status.Conditions {
 					if tt.expectedCondition.Type == c.Type &&
 						tt.expectedCondition.Message == c.Message &&
 						tt.expectedCondition.Status == c.Status &&
@@ -2697,7 +2716,7 @@ func Test_reconciler_reconcileControlPlaneConnectionAvailable(t *testing.T) {
 					}
 				}
 				if !found {
-					t.Fatalf("couldn't find expected condition. Expected: %+v, Got: %+v", tt.expectedCondition, tt.hcp.Status.Conditions)
+					t.Fatalf("couldn't find expected condition. Expected: %+v, Got: %+v", tt.expectedCondition, updated.Status.Conditions)
 				}
 			}
 		})
@@ -3244,11 +3263,13 @@ func TestReconcileDeletion(t *testing.T) {
 
 			guestClient := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(tt.existingObjects...).Build()
 			cpClient := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(tt.hcp).WithStatusSubresource(&hyperv1.HostedControlPlane{}).Build()
+			fakeHypershiftClient := hypershiftfake.NewSimpleClientset(tt.hcp.DeepCopy())
 
 			r := &reconciler{
 				client:                 guestClient,
 				uncachedClient:         fake.NewClientBuilder().WithScheme(api.Scheme).Build(),
 				cpClient:               cpClient,
+				hypershiftClient:       fakeHypershiftClient,
 				CreateOrUpdateProvider: &simpleCreateOrUpdater{},
 				cleanupTracker:         supportutil.NewCleanupTracker(),
 			}
@@ -3298,8 +3319,10 @@ func TestReconcileDeletion(t *testing.T) {
 
 			if tt.expectCloudCleanup {
 				// When cloud cleanup is triggered, verify it ran by checking the CloudResourcesDestroyed condition was set
-				// The condition is set by destroyCloudResources regardless of whether resources remain
-				condition := meta.FindStatusCondition(tt.hcp.Status.Conditions, string(hyperv1.CloudResourcesDestroyed))
+				// The condition is set by destroyCloudResources regardless of whether resources remain (read from typed client since SSA writes go there)
+				updatedHCP, getErr := fakeHypershiftClient.HypershiftV1beta1().HostedControlPlanes(tt.hcp.Namespace).Get(t.Context(), tt.hcp.Name, metav1.GetOptions{})
+				g.Expect(getErr).ToNot(HaveOccurred())
+				condition := meta.FindStatusCondition(updatedHCP.Status.Conditions, string(hyperv1.CloudResourcesDestroyed))
 				g.Expect(condition).ToNot(BeNil(), "CloudResourcesDestroyed condition should be set when cleanup is triggered")
 				g.Expect(condition.Status).To(Equal(metav1.ConditionTrue), "CloudResourcesDestroyed should be true when all resources are cleaned up")
 				g.Expect(condition.Reason).ToNot(BeEmpty(), "CloudResourcesDestroyed condition should have a reason")
@@ -3503,11 +3526,13 @@ func TestReconcileClusterRecovery(t *testing.T) {
 
 			cpClient := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(tt.hcp).WithStatusSubresource(&hyperv1.HostedControlPlane{}).Build()
 			uncachedClient := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(tt.uncachedObjects...).Build()
+			fakeHypershiftClient := hypershiftfake.NewSimpleClientset(tt.hcp.DeepCopy())
 
 			r := &reconciler{
 				client:                 fake.NewClientBuilder().WithScheme(api.Scheme).Build(),
 				uncachedClient:         uncachedClient,
 				cpClient:               cpClient,
+				hypershiftClient:       fakeHypershiftClient,
 				CreateOrUpdateProvider: &simpleCreateOrUpdater{},
 			}
 
@@ -3526,8 +3551,8 @@ func TestReconcileClusterRecovery(t *testing.T) {
 			}
 
 			if tt.expectCondition {
-				updatedHCP := &hyperv1.HostedControlPlane{}
-				g.Expect(cpClient.Get(t.Context(), client.ObjectKeyFromObject(tt.hcp), updatedHCP)).To(Succeed())
+				updatedHCP, getErr := fakeHypershiftClient.HypershiftV1beta1().HostedControlPlanes(tt.hcp.Namespace).Get(t.Context(), tt.hcp.Name, metav1.GetOptions{})
+				g.Expect(getErr).ToNot(HaveOccurred())
 
 				cond := meta.FindStatusCondition(updatedHCP.Status.Conditions, string(hyperv1.HostedClusterRestoredFromBackup))
 				g.Expect(cond).ToNot(BeNil(), "recovery condition should be set")

--- a/control-plane-operator/main.go
+++ b/control-plane-operator/main.go
@@ -522,6 +522,7 @@ func NewStartCommand() *cobra.Command {
 
 		if err := (&hostedcontrolplane.HostedControlPlaneReconciler{
 			Client:                                  mgr.GetClient(),
+			HypershiftClient:                        hcpClient,
 			GVKAccessChecker:                        component.NewGVKAccessCache(mgr.GetAPIReader()),
 			ManagementClusterCapabilities:           mgmtClusterCaps,
 			ReleaseProvider:                         cpReleaseProvider,

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -20,3 +20,10 @@ kube::codegen::gen_client \
     --versioned-name clientset \
     --boilerplate "../${SCRIPT_ROOT}/boilerplate.go.txt" \
     .
+
+# applyconfiguration-gen puts omitempty on all fields, but AvailableUpdates is
+# +required in the CRD schema. omitempty omits empty slices from JSON, causing
+# the API server to reject SSA applies with "Required value". omitzero (Go 1.24+)
+# omits only nil — an empty slice serializes as [].
+sed -i 's/"availableUpdates,omitempty"/"availableUpdates,omitzero"/' \
+    ../client/applyconfiguration/hypershift/v1beta1/clusterversionstatus.go

--- a/hypershift-operator/controllers/etcdbackup/reconciler.go
+++ b/hypershift-operator/controllers/etcdbackup/reconciler.go
@@ -8,7 +8,10 @@ import (
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hypershiftv1beta1applyconfigurations "github.com/openshift/hypershift/client/applyconfiguration/hypershift/v1beta1"
+	hypershiftclient "github.com/openshift/hypershift/client/clientset/clientset"
 	"github.com/openshift/hypershift/hypershift-operator/featuregate"
+	"github.com/openshift/hypershift/support/conditions"
 	supportconfig "github.com/openshift/hypershift/support/config"
 	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/releaseinfo"
@@ -24,6 +27,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	metav1applyconfigurations "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
@@ -78,6 +83,7 @@ const (
 // etcd snapshot and upload Jobs in the HyperShift Operator namespace.
 type HCPEtcdBackupReconciler struct {
 	client.Client
+	HypershiftClient        hypershiftclient.Interface
 	OperatorNamespace       string
 	ReleaseProvider         releaseinfo.ProviderWithOpenShiftImageRegistryOverrides
 	HypershiftOperatorImage string
@@ -299,9 +305,19 @@ func (r *HCPEtcdBackupReconciler) setCondition(backup *hyperv1.HCPEtcdBackup, co
 // updateHCPBackupCondition sets a condition on the HostedControlPlane to bubble
 // up the etcd backup status. The HC controller propagates this to the HostedCluster.
 func (r *HCPEtcdBackupReconciler) updateHCPBackupCondition(ctx context.Context, hcp *hyperv1.HostedControlPlane, condition metav1.Condition) error {
-	condition.ObservedGeneration = hcp.Generation
-	meta.SetStatusCondition(&hcp.Status.Conditions, condition)
-	return r.Status().Update(ctx, hcp)
+	managed := sets.New[string](condition.Type)
+	applyCond := metav1applyconfigurations.Condition().
+		WithType(condition.Type).
+		WithStatus(condition.Status).
+		WithObservedGeneration(hcp.Generation).
+		WithReason(condition.Reason).
+		WithMessage(condition.Message)
+	cfg := hypershiftv1beta1applyconfigurations.HostedControlPlane(hcp.Name, hcp.Namespace).
+		WithStatus(hypershiftv1beta1applyconfigurations.HostedControlPlaneStatus().
+			WithConditions(conditions.SSAConditions(hcp.Status.Conditions, managed, applyCond)...))
+	_, err := r.HypershiftClient.HypershiftV1beta1().HostedControlPlanes(hcp.Namespace).ApplyStatus(
+		ctx, cfg, metav1.ApplyOptions{FieldManager: "etcd-backup", Force: true})
+	return err
 }
 
 // updateHostedClusterBackupURL persists the snapshot URL in the HostedCluster

--- a/hypershift-operator/controllers/etcdbackup/reconciler_test.go
+++ b/hypershift-operator/controllers/etcdbackup/reconciler_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hypershiftfake "github.com/openshift/hypershift/client/clientset/clientset/fake"
 	"github.com/openshift/hypershift/hypershift-operator/featuregate"
 	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/releaseinfo"
@@ -72,8 +73,17 @@ func newReconciler(objs ...client.Object) *HCPEtcdBackupReconciler {
 		WithStatusSubresource(&hyperv1.HCPEtcdBackup{}, &hyperv1.HostedControlPlane{}, &hyperv1.HostedCluster{}).
 		Build()
 
+	var hypershiftObjs []runtime.Object
+	for _, obj := range objs {
+		switch obj.(type) {
+		case *hyperv1.HostedControlPlane, *hyperv1.HostedCluster, *hyperv1.HCPEtcdBackup:
+			hypershiftObjs = append(hypershiftObjs, obj.DeepCopyObject())
+		}
+	}
+
 	return &HCPEtcdBackupReconciler{
 		Client:                  fakeClient,
+		HypershiftClient:        hypershiftfake.NewSimpleClientset(hypershiftObjs...),
 		OperatorNamespace:       testHONamespace,
 		ReleaseProvider:         &fakeReleaseProvider{},
 		HypershiftOperatorImage: "quay.io/hypershift/hypershift:latest",
@@ -817,9 +827,9 @@ func TestHandleJobStatus(t *testing.T) {
 		g.Expect(updated.Status.Conditions[0].Reason).To(Equal(hyperv1.BackupSucceededReason))
 		g.Expect(updated.Status.SnapshotURL).To(Equal("s3://my-bucket/backups/test/snapshot.db"))
 
-		// Verify HCP condition was set
-		updatedHCP := &hyperv1.HostedControlPlane{}
-		g.Expect(r.Get(context.Background(), types.NamespacedName{Name: testHCPName, Namespace: testHCPNamespace}, updatedHCP)).To(Succeed())
+		// Verify HCP condition was set (read from typed client since SSA writes go there)
+		updatedHCP, getErr := r.HypershiftClient.HypershiftV1beta1().HostedControlPlanes(testHCPNamespace).Get(context.Background(), testHCPName, metav1.GetOptions{})
+		g.Expect(getErr).ToNot(HaveOccurred())
 		hcpCond := meta.FindStatusCondition(updatedHCP.Status.Conditions, string(hyperv1.EtcdBackupSucceeded))
 		g.Expect(hcpCond).ToNot(BeNil())
 		g.Expect(hcpCond.Status).To(Equal(metav1.ConditionTrue))
@@ -1411,9 +1421,9 @@ func TestReconcileHappyPath(t *testing.T) {
 		g.Expect(updated.Status.Conditions[0].Reason).To(Equal(hyperv1.BackupInProgressReason))
 		g.Expect(updated.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
 
-		// Verify HCP condition was set
-		updatedHCP := &hyperv1.HostedControlPlane{}
-		g.Expect(r.Get(ctx, types.NamespacedName{Name: testHCPName, Namespace: testHCPNamespace}, updatedHCP)).To(Succeed())
+		// Verify HCP condition was set (read from typed client since SSA writes go there)
+		updatedHCP, getErr := r.HypershiftClient.HypershiftV1beta1().HostedControlPlanes(testHCPNamespace).Get(ctx, testHCPName, metav1.GetOptions{})
+		g.Expect(getErr).ToNot(HaveOccurred())
 		hcpCond := meta.FindStatusCondition(updatedHCP.Status.Conditions, string(hyperv1.EtcdBackupSucceeded))
 		g.Expect(hcpCond).ToNot(BeNil())
 		g.Expect(hcpCond.Status).To(Equal(metav1.ConditionFalse))

--- a/hypershift-operator/main.go
+++ b/hypershift-operator/main.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hypershiftclient "github.com/openshift/hypershift/client/clientset/clientset"
 	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
 	pkiconfig "github.com/openshift/hypershift/control-plane-pki-operator/config"
 	etcdrecovery "github.com/openshift/hypershift/etcd-recovery"
@@ -766,8 +767,13 @@ func setupSupportControllers(mgr ctrl.Manager, opts *StartOptions, mgmtClusterCa
 	}
 
 	if featuregate.Gate().Enabled(featuregate.HCPEtcdBackup) {
+		hclient, err := hypershiftclient.NewForConfig(mgr.GetConfig())
+		if err != nil {
+			return fmt.Errorf("unable to create hypershift client for etcd backup controller: %w", err)
+		}
 		etcdBackupReconciler := &etcdbackup.HCPEtcdBackupReconciler{
 			Client:                  mgr.GetClient(),
+			HypershiftClient:        hclient,
 			OperatorNamespace:       opts.Namespace,
 			ReleaseProvider:         registryProvider.ReleaseProvider,
 			HypershiftOperatorImage: operatorImage,

--- a/ignition-server/cmd/start.go
+++ b/ignition-server/cmd/start.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hypershiftclient "github.com/openshift/hypershift/client/clientset/clientset"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/nodepool"
 	"github.com/openshift/hypershift/ignition-server/controllers"
 	hyperapi "github.com/openshift/hypershift/support/api"
@@ -156,10 +157,16 @@ func setUpPayloadStoreReconciler(ctx context.Context, registryOverrides map[stri
 		OpenShiftImageRegistryOverrides: util.ConvertImageRegistryOverrideStringToMap(os.Getenv("OPENSHIFT_IMG_OVERRIDES")),
 	}
 
+	hcpClient, err := hypershiftclient.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create hypershift client: %w", err)
+	}
+
 	if err = (&controllers.TokenSecretReconciler{
 		Client:       mgr.GetClient(),
 		PayloadStore: payloadStore,
 		IgnitionProvider: &controllers.LocalIgnitionProvider{
+			HypershiftClient: hcpClient,
 			ReleaseProvider: &releaseinfo.ProviderWithOpenShiftImageRegistryOverridesDecorator{
 				Delegate: &releaseinfo.RegistryMirrorProviderDecorator{
 					Delegate: &releaseinfo.CachedProvider{

--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -17,11 +17,14 @@ import (
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hypershiftv1beta1applyconfigurations "github.com/openshift/hypershift/client/applyconfiguration/hypershift/v1beta1"
+	hypershiftclient "github.com/openshift/hypershift/client/clientset/clientset"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/common"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/certs"
+	"github.com/openshift/hypershift/support/conditions"
 	"github.com/openshift/hypershift/support/k8sutil"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/releaseinfo/registryclient"
@@ -29,9 +32,10 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	metav1applyconfigurations "k8s.io/client-go/applyconfigurations/meta/v1"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -56,10 +60,11 @@ import (
 // non-conflicting ports. This effort is not yet justified by any performance
 // measurements.
 type LocalIgnitionProvider struct {
-	Client          client.Client
-	ReleaseProvider releaseinfo.ProviderWithOpenShiftImageRegistryOverrides
-	CloudProvider   hyperv1.PlatformType
-	Namespace       string
+	Client           client.Client
+	HypershiftClient hypershiftclient.Interface
+	ReleaseProvider  releaseinfo.ProviderWithOpenShiftImageRegistryOverrides
+	CloudProvider    hyperv1.PlatformType
+	Namespace        string
 
 	// WorkDir is the base working directory for contents extracted from a
 	// release payload. Usually this would map to a volume mount.
@@ -766,25 +771,33 @@ func (r *LocalIgnitionProvider) reconcileValidReleaseInfoCondition(ctx context.C
 
 	hostedControlPlane := hcpList.Items[0]
 
+	managedTypes := sets.New[string](string(hyperv1.IgnitionServerValidReleaseInfo))
+
+	var condition *metav1applyconfigurations.ConditionApplyConfiguration
 	if len(releaseImageProvider.GetMissingImages()) == 0 {
-		meta.SetStatusCondition(&hostedControlPlane.Status.Conditions, metav1.Condition{
-			Type:               string(hyperv1.IgnitionServerValidReleaseInfo),
-			Status:             metav1.ConditionTrue,
-			Reason:             hyperv1.AsExpectedReason,
-			Message:            hyperv1.AllIsWellMessage,
-			ObservedGeneration: hostedControlPlane.Generation,
-		})
+		condition = metav1applyconfigurations.Condition().
+			WithType(string(hyperv1.IgnitionServerValidReleaseInfo)).
+			WithStatus(metav1.ConditionTrue).
+			WithReason(hyperv1.AsExpectedReason).
+			WithMessage(hyperv1.AllIsWellMessage).
+			WithObservedGeneration(hostedControlPlane.Generation).
+			WithLastTransitionTime(metav1.Now())
 	} else {
-		meta.SetStatusCondition(&hostedControlPlane.Status.Conditions, metav1.Condition{
-			Type:               string(hyperv1.IgnitionServerValidReleaseInfo),
-			Status:             metav1.ConditionFalse,
-			Reason:             hyperv1.MissingReleaseImagesReason,
-			Message:            strings.Join(releaseImageProvider.GetMissingImages(), ", "),
-			ObservedGeneration: hostedControlPlane.Generation,
-		})
+		condition = metav1applyconfigurations.Condition().
+			WithType(string(hyperv1.IgnitionServerValidReleaseInfo)).
+			WithStatus(metav1.ConditionFalse).
+			WithReason(hyperv1.MissingReleaseImagesReason).
+			WithMessage(strings.Join(releaseImageProvider.GetMissingImages(), ", ")).
+			WithObservedGeneration(hostedControlPlane.Generation).
+			WithLastTransitionTime(metav1.Now())
 	}
 
-	return r.Client.Status().Update(ctx, &hostedControlPlane)
+	cfg := hypershiftv1beta1applyconfigurations.HostedControlPlane(hostedControlPlane.Name, hostedControlPlane.Namespace).
+		WithStatus(hypershiftv1beta1applyconfigurations.HostedControlPlaneStatus().
+			WithConditions(conditions.SSAConditions(hostedControlPlane.Status.Conditions, managedTypes, condition)...))
+	_, err := r.HypershiftClient.HypershiftV1beta1().HostedControlPlanes(hostedControlPlane.Namespace).ApplyStatus(
+		ctx, cfg, metav1.ApplyOptions{FieldManager: "ignition-server", Force: true})
+	return err
 }
 
 // copyFile copies a file named src to dst, preserving attributes.

--- a/ignition-server/controllers/local_ignitionprovider_test.go
+++ b/ignition-server/controllers/local_ignitionprovider_test.go
@@ -15,6 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hypershiftfake "github.com/openshift/hypershift/client/clientset/clientset/fake"
 	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 
 	corev1 "k8s.io/api/core/v1"
@@ -1237,9 +1238,17 @@ func TestReconcileValidReleaseInfoCondition(t *testing.T) {
 			g := NewWithT(t)
 
 			fakeClient := newFakeClientWithScheme(tt.objects...)
+
+			var runtimeObjects []runtime.Object
+			for _, obj := range tt.objects {
+				runtimeObjects = append(runtimeObjects, obj.DeepCopyObject())
+			}
+			fakeHypershiftClient := hypershiftfake.NewSimpleClientset(runtimeObjects...)
+
 			provider := &LocalIgnitionProvider{
-				Client:    fakeClient,
-				Namespace: tt.namespace,
+				Client:           fakeClient,
+				HypershiftClient: fakeHypershiftClient,
+				Namespace:        tt.namespace,
 			}
 
 			// Build a SimpleReleaseImageProvider with controlled missing images.
@@ -1258,9 +1267,9 @@ func TestReconcileValidReleaseInfoCondition(t *testing.T) {
 			}
 			g.Expect(err).NotTo(HaveOccurred())
 
-			// Verify the condition was set on the HostedControlPlane.
-			hcpList := &hyperv1.HostedControlPlaneList{}
-			g.Expect(fakeClient.List(t.Context(), hcpList, client.InNamespace(tt.namespace))).To(Succeed())
+			// Verify the condition was set on the HostedControlPlane via the typed client.
+			hcpList, listErr := fakeHypershiftClient.HypershiftV1beta1().HostedControlPlanes(tt.namespace).List(t.Context(), metav1.ListOptions{})
+			g.Expect(listErr).NotTo(HaveOccurred())
 			g.Expect(hcpList.Items).To(HaveLen(1))
 
 			cond := meta.FindStatusCondition(hcpList.Items[0].Status.Conditions, string(hyperv1.IgnitionServerValidReleaseInfo))

--- a/support/conditions/ssa.go
+++ b/support/conditions/ssa.go
@@ -1,0 +1,102 @@
+package conditions
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	metav1applyconfigurations "k8s.io/client-go/applyconfigurations/meta/v1"
+)
+
+// ConditionChanged reports whether applying the given condition would change
+// anything relative to the existing conditions. It mirrors the change-detection
+// logic of meta.SetStatusCondition: a condition is "changed" if it's new or if
+// its Status, Reason, Message, or ObservedGeneration differ from the existing one.
+func ConditionChanged(existing []metav1.Condition, updated *metav1applyconfigurations.ConditionApplyConfiguration) bool {
+	if updated.Type == nil {
+		return true
+	}
+	for i := range existing {
+		if existing[i].Type != *updated.Type {
+			continue
+		}
+		if updated.Status != nil && existing[i].Status != *updated.Status {
+			return true
+		}
+		if updated.Reason != nil && existing[i].Reason != *updated.Reason {
+			return true
+		}
+		if updated.Message != nil && existing[i].Message != *updated.Message {
+			return true
+		}
+		if updated.ObservedGeneration != nil && existing[i].ObservedGeneration != *updated.ObservedGeneration {
+			return true
+		}
+		return false
+	}
+	return true
+}
+
+// SSAConditions builds the full list of condition apply configurations needed for
+// a Server-Side Apply call. With SSA, a field manager that previously declared
+// ownership of a condition type will lose that condition if it's omitted from a
+// subsequent apply. This helper merges the caller's updated conditions with any
+// existing managed conditions that aren't being updated, preventing accidental removal.
+//
+// Panics on programmer error (precedent: hostedclustersizing_controller.go, which
+// this was extracted from): if an updated condition has no Type, or if it specifies
+// a Type not in managedTypes.
+func SSAConditions(
+	existing []metav1.Condition,
+	managedTypes sets.Set[string],
+	updated ...*metav1applyconfigurations.ConditionApplyConfiguration,
+) []*metav1applyconfigurations.ConditionApplyConfiguration {
+	updatedTypes := sets.New[string]()
+	for _, condition := range updated {
+		if condition.Type == nil {
+			panic(fmt.Errorf("programmer error: must set a type for condition: %#v", condition))
+		}
+		if !managedTypes.Has(*condition.Type) {
+			panic(fmt.Errorf("programmer error: attempting to set unmanaged condition type %q", *condition.Type))
+		}
+		updatedTypes.Insert(*condition.Type)
+	}
+	result := append([]*metav1applyconfigurations.ConditionApplyConfiguration{}, updated...)
+	for _, condition := range existing {
+		if !updatedTypes.Has(condition.Type) && managedTypes.Has(condition.Type) {
+			result = append(result, metav1applyconfigurations.Condition().
+				WithType(condition.Type).
+				WithStatus(condition.Status).
+				WithObservedGeneration(condition.ObservedGeneration).
+				WithLastTransitionTime(condition.LastTransitionTime).
+				WithReason(condition.Reason).
+				WithMessage(condition.Message),
+			)
+		}
+	}
+	// Ensure LastTransitionTime is set on every condition — it's a required field
+	// on metav1.Condition and the API server rejects SSA applies that omit it.
+	for _, cond := range result {
+		if cond.LastTransitionTime != nil {
+			continue
+		}
+		// Preserve existing transition time when status hasn't changed.
+		for i := range existing {
+			if existing[i].Type == *cond.Type && cond.Status != nil && existing[i].Status == *cond.Status {
+				cond.LastTransitionTime = &existing[i].LastTransitionTime
+				break
+			}
+		}
+		if cond.LastTransitionTime == nil {
+			now := metav1.NewTime(time.Now())
+			cond.LastTransitionTime = &now
+		}
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return *result[i].Type < *result[j].Type
+	})
+	return result
+}

--- a/support/conditions/ssa_test.go
+++ b/support/conditions/ssa_test.go
@@ -1,0 +1,365 @@
+package conditions
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	metav1applyconfigurations "k8s.io/client-go/applyconfigurations/meta/v1"
+)
+
+func TestConditionChanged(t *testing.T) {
+	existing := []metav1.Condition{
+		{
+			Type:               "Ready",
+			Status:             metav1.ConditionTrue,
+			Reason:             "AllGood",
+			Message:            "everything is fine",
+			ObservedGeneration: 5,
+		},
+	}
+
+	t.Run("When condition is identical to existing, it should return false", func(t *testing.T) {
+		g := NewWithT(t)
+		updated := metav1applyconfigurations.Condition().
+			WithType("Ready").
+			WithStatus(metav1.ConditionTrue).
+			WithReason("AllGood").
+			WithMessage("everything is fine").
+			WithObservedGeneration(5)
+		g.Expect(ConditionChanged(existing, updated)).To(BeFalse())
+	})
+
+	t.Run("When status differs, it should return true", func(t *testing.T) {
+		g := NewWithT(t)
+		updated := metav1applyconfigurations.Condition().
+			WithType("Ready").
+			WithStatus(metav1.ConditionFalse).
+			WithReason("AllGood").
+			WithMessage("everything is fine")
+		g.Expect(ConditionChanged(existing, updated)).To(BeTrue())
+	})
+
+	t.Run("When reason differs, it should return true", func(t *testing.T) {
+		g := NewWithT(t)
+		updated := metav1applyconfigurations.Condition().
+			WithType("Ready").
+			WithStatus(metav1.ConditionTrue).
+			WithReason("DifferentReason").
+			WithMessage("everything is fine")
+		g.Expect(ConditionChanged(existing, updated)).To(BeTrue())
+	})
+
+	t.Run("When message differs, it should return true", func(t *testing.T) {
+		g := NewWithT(t)
+		updated := metav1applyconfigurations.Condition().
+			WithType("Ready").
+			WithStatus(metav1.ConditionTrue).
+			WithReason("AllGood").
+			WithMessage("different message")
+		g.Expect(ConditionChanged(existing, updated)).To(BeTrue())
+	})
+
+	t.Run("When observedGeneration differs, it should return true", func(t *testing.T) {
+		g := NewWithT(t)
+		updated := metav1applyconfigurations.Condition().
+			WithType("Ready").
+			WithStatus(metav1.ConditionTrue).
+			WithReason("AllGood").
+			WithMessage("everything is fine").
+			WithObservedGeneration(6)
+		g.Expect(ConditionChanged(existing, updated)).To(BeTrue())
+	})
+
+	t.Run("When condition type does not exist yet, it should return true", func(t *testing.T) {
+		g := NewWithT(t)
+		updated := metav1applyconfigurations.Condition().
+			WithType("NewCondition").
+			WithStatus(metav1.ConditionTrue).
+			WithReason("New")
+		g.Expect(ConditionChanged(existing, updated)).To(BeTrue())
+	})
+
+	t.Run("When existing is empty, it should return true", func(t *testing.T) {
+		g := NewWithT(t)
+		updated := metav1applyconfigurations.Condition().
+			WithType("Ready").
+			WithStatus(metav1.ConditionTrue).
+			WithReason("AllGood")
+		g.Expect(ConditionChanged(nil, updated)).To(BeTrue())
+	})
+
+	t.Run("When only some fields are set on updated and they match, it should return false", func(t *testing.T) {
+		g := NewWithT(t)
+		updated := metav1applyconfigurations.Condition().
+			WithType("Ready").
+			WithStatus(metav1.ConditionTrue).
+			WithReason("AllGood")
+		g.Expect(ConditionChanged(existing, updated)).To(BeFalse())
+	})
+}
+
+func TestSSAConditions(t *testing.T) {
+	oldTime := metav1.NewTime(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	t.Run("When an updated condition has the same status as existing, it should preserve the existing LastTransitionTime", func(t *testing.T) {
+		g := NewWithT(t)
+
+		existing := []metav1.Condition{
+			{
+				Type:               "Ready",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: oldTime,
+				Reason:             "OldReason",
+				Message:            "old message",
+			},
+		}
+		managed := sets.New[string]("Ready")
+		updated := metav1applyconfigurations.Condition().
+			WithType("Ready").
+			WithStatus(metav1.ConditionTrue).
+			WithReason("NewReason").
+			WithMessage("new message")
+
+		result := SSAConditions(existing, managed, updated)
+
+		g.Expect(result).To(HaveLen(1))
+		g.Expect(*result[0].LastTransitionTime).To(Equal(oldTime))
+		g.Expect(*result[0].Reason).To(Equal("NewReason"))
+	})
+
+	t.Run("When an updated condition has a different status from existing, it should set LastTransitionTime to now", func(t *testing.T) {
+		g := NewWithT(t)
+
+		existing := []metav1.Condition{
+			{
+				Type:               "Ready",
+				Status:             metav1.ConditionFalse,
+				LastTransitionTime: oldTime,
+				Reason:             "OldReason",
+			},
+		}
+		managed := sets.New[string]("Ready")
+		updated := metav1applyconfigurations.Condition().
+			WithType("Ready").
+			WithStatus(metav1.ConditionTrue).
+			WithReason("NowReady")
+
+		before := time.Now()
+		result := SSAConditions(existing, managed, updated)
+		after := time.Now()
+
+		g.Expect(result).To(HaveLen(1))
+		g.Expect(result[0].LastTransitionTime).NotTo(BeNil())
+		g.Expect(result[0].LastTransitionTime.Time).To(BeTemporally(">=", before))
+		g.Expect(result[0].LastTransitionTime.Time).To(BeTemporally("<=", after))
+	})
+
+	t.Run("When a condition is brand new with no existing match, it should set LastTransitionTime to now", func(t *testing.T) {
+		g := NewWithT(t)
+
+		managed := sets.New[string]("Ready")
+		updated := metav1applyconfigurations.Condition().
+			WithType("Ready").
+			WithStatus(metav1.ConditionTrue).
+			WithReason("FirstTime")
+
+		before := time.Now()
+		result := SSAConditions(nil, managed, updated)
+		after := time.Now()
+
+		g.Expect(result).To(HaveLen(1))
+		g.Expect(result[0].LastTransitionTime).NotTo(BeNil())
+		g.Expect(result[0].LastTransitionTime.Time).To(BeTemporally(">=", before))
+		g.Expect(result[0].LastTransitionTime.Time).To(BeTemporally("<=", after))
+	})
+
+	t.Run("When the caller explicitly sets LastTransitionTime, it should not be overridden", func(t *testing.T) {
+		g := NewWithT(t)
+
+		callerTime := metav1.NewTime(time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC))
+
+		existing := []metav1.Condition{
+			{
+				Type:               "Ready",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: oldTime,
+				Reason:             "OldReason",
+			},
+		}
+		managed := sets.New[string]("Ready")
+		updated := metav1applyconfigurations.Condition().
+			WithType("Ready").
+			WithStatus(metav1.ConditionFalse).
+			WithReason("NowFailing").
+			WithLastTransitionTime(callerTime)
+
+		result := SSAConditions(existing, managed, updated)
+
+		g.Expect(result).To(HaveLen(1))
+		g.Expect(*result[0].LastTransitionTime).To(Equal(callerTime))
+	})
+
+	t.Run("When the caller sets LastTransitionTime and status is unchanged, it should still use caller's value", func(t *testing.T) {
+		g := NewWithT(t)
+
+		callerTime := metav1.NewTime(time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC))
+
+		existing := []metav1.Condition{
+			{
+				Type:               "Ready",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: oldTime,
+				Reason:             "OldReason",
+			},
+		}
+		managed := sets.New[string]("Ready")
+		updated := metav1applyconfigurations.Condition().
+			WithType("Ready").
+			WithStatus(metav1.ConditionTrue).
+			WithReason("StillReady").
+			WithLastTransitionTime(callerTime)
+
+		result := SSAConditions(existing, managed, updated)
+
+		g.Expect(result).To(HaveLen(1))
+		g.Expect(*result[0].LastTransitionTime).To(Equal(callerTime))
+	})
+
+	t.Run("When there are existing managed conditions not in updated, it should carry them forward with their LastTransitionTime", func(t *testing.T) {
+		g := NewWithT(t)
+
+		existing := []metav1.Condition{
+			{
+				Type:               "Ready",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: oldTime,
+				Reason:             "AllGood",
+				Message:            "everything is fine",
+			},
+			{
+				Type:               "Degraded",
+				Status:             metav1.ConditionFalse,
+				LastTransitionTime: oldTime,
+				Reason:             "NotDegraded",
+				Message:            "not degraded",
+			},
+		}
+		managed := sets.New[string]("Ready", "Degraded")
+		updated := metav1applyconfigurations.Condition().
+			WithType("Ready").
+			WithStatus(metav1.ConditionTrue).
+			WithReason("StillGood")
+
+		result := SSAConditions(existing, managed, updated)
+
+		g.Expect(result).To(HaveLen(2))
+		// Sorted by type: Degraded, Ready
+		g.Expect(*result[0].Type).To(Equal("Degraded"))
+		g.Expect(*result[0].LastTransitionTime).To(Equal(oldTime))
+		g.Expect(*result[1].Type).To(Equal("Ready"))
+		g.Expect(*result[1].LastTransitionTime).To(Equal(oldTime))
+	})
+
+	t.Run("When results contain multiple conditions, it should sort them by type", func(t *testing.T) {
+		g := NewWithT(t)
+
+		managed := sets.New[string]("Zebra", "Alpha", "Middle")
+		z := metav1applyconfigurations.Condition().WithType("Zebra").WithStatus(metav1.ConditionTrue).WithReason("R")
+		a := metav1applyconfigurations.Condition().WithType("Alpha").WithStatus(metav1.ConditionTrue).WithReason("R")
+		m := metav1applyconfigurations.Condition().WithType("Middle").WithStatus(metav1.ConditionTrue).WithReason("R")
+
+		result := SSAConditions(nil, managed, z, a, m)
+
+		g.Expect(result).To(HaveLen(3))
+		g.Expect(*result[0].Type).To(Equal("Alpha"))
+		g.Expect(*result[1].Type).To(Equal("Middle"))
+		g.Expect(*result[2].Type).To(Equal("Zebra"))
+	})
+
+	t.Run("When an updated condition has no Type, it should panic", func(t *testing.T) {
+		g := NewWithT(t)
+
+		managed := sets.New[string]("Ready")
+		noType := metav1applyconfigurations.Condition().WithStatus(metav1.ConditionTrue)
+
+		g.Expect(func() {
+			SSAConditions(nil, managed, noType)
+		}).To(PanicWith(MatchError(ContainSubstring("must set a type"))))
+	})
+
+	t.Run("When an updated condition has a type not in managedTypes, it should panic", func(t *testing.T) {
+		g := NewWithT(t)
+
+		managed := sets.New[string]("Ready")
+		unmanaged := metav1applyconfigurations.Condition().
+			WithType("SomethingElse").
+			WithStatus(metav1.ConditionTrue)
+
+		g.Expect(func() {
+			SSAConditions(nil, managed, unmanaged)
+		}).To(PanicWith(MatchError(ContainSubstring("unmanaged condition type"))))
+	})
+
+	t.Run("When existing has unmanaged conditions, it should not include them in result", func(t *testing.T) {
+		g := NewWithT(t)
+
+		existing := []metav1.Condition{
+			{
+				Type:               "Ready",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: oldTime,
+				Reason:             "OK",
+			},
+			{
+				Type:               "OtherControllerCondition",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: oldTime,
+				Reason:             "SomeoneElse",
+			},
+		}
+		managed := sets.New[string]("Ready")
+		updated := metav1applyconfigurations.Condition().
+			WithType("Ready").
+			WithStatus(metav1.ConditionFalse).
+			WithReason("Failing")
+
+		result := SSAConditions(existing, managed, updated)
+
+		g.Expect(result).To(HaveLen(1))
+		g.Expect(*result[0].Type).To(Equal("Ready"))
+	})
+
+	t.Run("When no updated conditions are provided, it should carry forward all existing managed conditions", func(t *testing.T) {
+		g := NewWithT(t)
+
+		existing := []metav1.Condition{
+			{
+				Type:               "Ready",
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: oldTime,
+				Reason:             "OK",
+				Message:            "ready",
+			},
+			{
+				Type:               "Degraded",
+				Status:             metav1.ConditionFalse,
+				LastTransitionTime: oldTime,
+				Reason:             "NotDegraded",
+				Message:            "not degraded",
+			},
+		}
+		managed := sets.New[string]("Ready", "Degraded")
+
+		result := SSAConditions(existing, managed)
+
+		g.Expect(result).To(HaveLen(2))
+		// Carried forward with their original LastTransitionTime
+		for _, cond := range result {
+			g.Expect(*cond.LastTransitionTime).To(Equal(oldTime))
+		}
+	})
+}


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:
- We have multiple controllers writing to the HCP's status object with `Update()` calls, which replaces the entire object 
- Depending on what the controller performing the Update() understands and sees, and when it performs the update, that potentially blows away fields like `vcpus` from the autonode status that we added here: https://github.com/openshift/hypershift/pull/8265/ 
- This just replaces the Status().Update() calls with calls to Patch calls that use client.MergeFrom() so that the full object updates don't wipe other controllers' status update
- Testing this explicitly is unpleasant without some kind of refactor, the parts controllers that write the status aren't set up for easy testing, but it's observably possible the issue can happen because of the use of `Update()` calls across multiple controllers on the same object 

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Status-condition updates across control-plane, ignition server, and backup controllers now use server-side apply for more reliable, conflict-resistant status synchronization.

* **New Features**
  * Added reusable SSA condition helpers to build, merge, and preserve condition fields consistently.
  * Controllers now use a typed Hypershift client to apply status updates.

* **Chores / Tests**
  * Tests updated to validate status condition changes via the typed Hypershift API surface.
* **Chores**
  * Startup wiring updated to construct and inject the Hypershift client; codegen post-processing adjusted for apply-configuration generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->