### PR TITLE
OCPBUGS-85778: Fix NodePool reconciliation failure when updating mirrored immutable ConfigMaps

### DIFF
--- a/hypershift-operator/controllers/nodepool/nto.go
+++ b/hypershift-operator/controllers/nodepool/nto.go
@@ -116,6 +116,10 @@ func (r *NodePoolReconciler) reconcileMirroredConfigs(ctx context.Context, logr 
 				Name:      netutil.ShortenName(mirroredConfig.Name, nodePool.Name, validation.LabelValueMaxLength),
 				Namespace: controlPlaneNamespace},
 		}
+		if err := r.deleteImmutableConfigMapIfNeeded(ctx, logr, cm, nodePool.Name); err != nil {
+			return err
+		}
+		cm.SetResourceVersion("")
 		if result, err := r.CreateOrUpdate(ctx, r.Client, cm, func() error {
 			return mutateMirroredConfig(cm, mirroredConfig, nodePool)
 		}); err != nil {
@@ -193,7 +197,7 @@ func reconcilePerformanceProfileConfigMap(performanceProfileConfigMap *corev1.Co
 }
 
 func mutateMirroredConfig(cm *corev1.ConfigMap, mirroredConfig *MirrorConfig, nodePool *hyperv1.NodePool) error {
-	cm.Immutable = ptr.To(true)
+	cm.Immutable = ptr.To(false)
 	if cm.Annotations == nil {
 		cm.Annotations = make(map[string]string)
 	}
@@ -205,6 +209,21 @@ func mutateMirroredConfig(cm *corev1.ConfigMap, mirroredConfig *MirrorConfig, no
 	cm.Labels = labels.Merge(cm.Labels, mirroredConfig.Labels)
 	cm.Data = mirroredConfig.Data
 	return nil
+}
+
+func (r *NodePoolReconciler) deleteImmutableConfigMapIfNeeded(ctx context.Context, log logr.Logger, cm *corev1.ConfigMap, nodePoolName string) error {
+	_, err := k8sutil.DeleteIfNeededWithPredicate(ctx, r.Client, cm, func(existing *corev1.ConfigMap) bool {
+		if existing.Labels[NTOMirroredConfigLabel] != "true" || existing.Labels[hyperv1.NodePoolLabel] != nodePoolName {
+			return false
+		}
+		if existing.Immutable != nil && *existing.Immutable {
+			log.Info("deleting immutable mirrored ConfigMap to recreate as mutable",
+				"configMap", client.ObjectKeyFromObject(existing).String())
+			return true
+		}
+		return false
+	})
+	return err
 }
 
 func (r *NodePoolReconciler) getTuningConfig(ctx context.Context,

--- a/hypershift-operator/controllers/nodepool/nto_test.go
+++ b/hypershift-operator/controllers/nodepool/nto_test.go
@@ -553,7 +553,7 @@ func TestReconcileMirroredConfigs(t *testing.T) {
 			existingConfigsInHcpNs: nil,
 			expectedMirroredConfigs: []corev1.ConfigMap{
 				{
-					Immutable: ptr.To(true),
+					Immutable: ptr.To(false),
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      netutil.ShortenName("foo", npName, validation.LabelValueMaxLength),
 						Namespace: hcpNamespace,
@@ -602,7 +602,7 @@ func TestReconcileMirroredConfigs(t *testing.T) {
 			},
 			expectedMirroredConfigs: []corev1.ConfigMap{
 				{
-					Immutable: ptr.To(true),
+					Immutable: ptr.To(false),
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      netutil.ShortenName("foo", npName, validation.LabelValueMaxLength),
 						Namespace: hcpNamespace,
@@ -652,7 +652,172 @@ func TestReconcileMirroredConfigs(t *testing.T) {
 			existingConfigsInHcpNs: nil,
 			expectedMirroredConfigs: []corev1.ConfigMap{
 				{
+					Immutable: ptr.To(false),
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      netutil.ShortenName("bar", npName, validation.LabelValueMaxLength),
+						Namespace: hcpNamespace,
+						Labels: map[string]string{
+							NTOMirroredConfigLabel:      "true",
+							nodePoolAnnotation:          npName,
+							KubeletConfigConfigMapLabel: "true",
+						},
+					},
+					Data: map[string]string{
+						TokenSecretConfigKey: kubeletConfig1,
+					},
+				},
+			},
+		},
+		{
+			name:                  "When an immutable mirrored ConfigMap exists and data changes, it should delete and recreate as mutable",
+			nodePool:              np,
+			controlPlaneNamespace: hcpNamespace,
+			configsToBeMirrored: []*MirrorConfig{
+				{
+					ConfigMap: &corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "bar",
+							Namespace: npNamespace,
+						},
+						Data: map[string]string{
+							TokenSecretConfigKey: kubeletConfig1,
+						},
+					},
+					Labels: map[string]string{
+						KubeletConfigConfigMapLabel: "true",
+					},
+				},
+			},
+			existingConfigsInHcpNs: []client.Object{
+				&corev1.ConfigMap{
 					Immutable: ptr.To(true),
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      netutil.ShortenName("bar", npName, validation.LabelValueMaxLength),
+						Namespace: hcpNamespace,
+						Labels: map[string]string{
+							NTOMirroredConfigLabel:      "true",
+							nodePoolAnnotation:          npName,
+							KubeletConfigConfigMapLabel: "true",
+						},
+					},
+					Data: map[string]string{
+						TokenSecretConfigKey: "old-data",
+					},
+				},
+			},
+			expectedMirroredConfigs: []corev1.ConfigMap{
+				{
+					Immutable: ptr.To(false),
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      netutil.ShortenName("bar", npName, validation.LabelValueMaxLength),
+						Namespace: hcpNamespace,
+						Labels: map[string]string{
+							NTOMirroredConfigLabel:      "true",
+							nodePoolAnnotation:          npName,
+							KubeletConfigConfigMapLabel: "true",
+						},
+					},
+					Data: map[string]string{
+						TokenSecretConfigKey: kubeletConfig1,
+					},
+				},
+			},
+		},
+		{
+			name:                  "When an immutable mirrored ConfigMap belongs to a different NodePool, it should not be deleted",
+			nodePool:              np,
+			controlPlaneNamespace: hcpNamespace,
+			configsToBeMirrored: []*MirrorConfig{
+				{
+					ConfigMap: &corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "bar",
+							Namespace: npNamespace,
+						},
+						Data: map[string]string{
+							TokenSecretConfigKey: kubeletConfig1,
+						},
+					},
+					Labels: map[string]string{
+						KubeletConfigConfigMapLabel: "true",
+					},
+				},
+			},
+			existingConfigsInHcpNs: []client.Object{
+				&corev1.ConfigMap{
+					Immutable: ptr.To(true),
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      netutil.ShortenName("bar", npName, validation.LabelValueMaxLength),
+						Namespace: hcpNamespace,
+						Labels: map[string]string{
+							NTOMirroredConfigLabel:      "true",
+							nodePoolAnnotation:          "other-nodepool",
+							KubeletConfigConfigMapLabel: "true",
+						},
+					},
+					Data: map[string]string{
+						TokenSecretConfigKey: "old-data",
+					},
+				},
+			},
+			expectedMirroredConfigs: []corev1.ConfigMap{
+				{
+					Immutable: ptr.To(false),
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      netutil.ShortenName("bar", npName, validation.LabelValueMaxLength),
+						Namespace: hcpNamespace,
+						Labels: map[string]string{
+							NTOMirroredConfigLabel:      "true",
+							nodePoolAnnotation:          npName,
+							KubeletConfigConfigMapLabel: "true",
+						},
+					},
+					Data: map[string]string{
+						TokenSecretConfigKey: kubeletConfig1,
+					},
+				},
+			},
+		},
+		{
+			name:                  "When an existing mirrored ConfigMap is already mutable, it should not be deleted",
+			nodePool:              np,
+			controlPlaneNamespace: hcpNamespace,
+			configsToBeMirrored: []*MirrorConfig{
+				{
+					ConfigMap: &corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "bar",
+							Namespace: npNamespace,
+						},
+						Data: map[string]string{
+							TokenSecretConfigKey: kubeletConfig1,
+						},
+					},
+					Labels: map[string]string{
+						KubeletConfigConfigMapLabel: "true",
+					},
+				},
+			},
+			existingConfigsInHcpNs: []client.Object{
+				&corev1.ConfigMap{
+					Immutable: ptr.To(false),
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      netutil.ShortenName("bar", npName, validation.LabelValueMaxLength),
+						Namespace: hcpNamespace,
+						Labels: map[string]string{
+							NTOMirroredConfigLabel:      "true",
+							nodePoolAnnotation:          npName,
+							KubeletConfigConfigMapLabel: "true",
+						},
+					},
+					Data: map[string]string{
+						TokenSecretConfigKey: "old-data",
+					},
+				},
+			},
+			expectedMirroredConfigs: []corev1.ConfigMap{
+				{
+					Immutable: ptr.To(false),
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      netutil.ShortenName("bar", npName, validation.LabelValueMaxLength),
 						Namespace: hcpNamespace,


### PR DESCRIPTION
## What this PR does / why we need it:

When multiple NodePools reference the same kubelet ConfigMap and the source ConfigMap is modified after mirroring, the nodepool-controller's NTO reconciliation fails because mirrored ConfigMaps are created with `immutable: true`. Kubernetes rejects in-place updates to immutable ConfigMaps, causing NodePools to get stuck in `UpdatingConfig=True` with:

```
failed to reconcile mirrored ConfigMap: data: Forbidden: field is immutable when `immutable` is set
```

This PR:
- Removes the `immutable: true` flag from `mutateMirroredConfig` so newly created mirrored ConfigMaps are mutable
- Adds `deleteImmutableConfigMapIfNeeded` to `reconcileMirroredConfigs` to handle migration — existing immutable mirrored ConfigMaps are deleted before `CreateOrUpdate` recreates them as mutable
- This mirrors the parallel fix already applied on the CPO/HCCO side (commit bbd8f63d9, PR #6726) which fixed Stage 2 (HCP namespace → guest cluster), while this PR fixes Stage 1 (user namespace → HCP namespace)

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/OCPBUGS-85778

## Special notes for your reviewer:

- Tested on a live KubeVirt HCP cluster (OCP 4.21.9 management, 4.18.30 guest) with two NodePools sharing the same `custom-kubelet` ConfigMap
- Bug reproduced: both NodePools stuck in `UpdatingConfig=True` with immutable field error
- After deploying patched operator image: mirrored ConfigMaps recreated as mutable, reconciliation succeeded, no new errors

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented reconciliation failures by removing immutable ConfigMaps and recreating them as mutable so updates apply reliably.
  * Ensured mirrored ConfigMaps are set mutable during reconciliation to allow safe updates.

* **Tests**
  * Updated tests to expect mutable mirrored ConfigMaps and to validate recreation behavior when immutable configs are encountered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->