### PR TITLE
OCPBUGS-86075: docs(nodepool): fixing incomplete stuck node drain documentation in section Scaling To Zero

### DIFF
--- a/docs/content/how-to/automated-machine-management/nodepool-lifecycle.md
+++ b/docs/content/how-to/automated-machine-management/nodepool-lifecycle.md
@@ -73,8 +73,12 @@ Node(s) can become stuck when removing all Nodes from a cluster (scaling NodePoo
 
 Several conditions can prevent Node(s) from being drained successfully:
 
-- The hosted cluster contains `PodDisruptionBudgets` that require at least 
-- The hosted cluster contains pods that use `PersistentVolumes``
+- The hosted cluster contains `PodDisruptionBudgets` that require at least one healthy pod, preventing eviction when there are no other nodes to reschedule onto.
+- The hosted cluster contains pods that use `PersistentVolumes` that cannot be detached from the node.
+
+!!! important
+
+    This is expected behavior. When all nodes are removed simultaneously, pods protected by PodDisruptionBudgets cannot be evicted because the PDB constraints cannot be satisfied with no remaining nodes. As a result, the drain operation blocks indefinitely. Configure `nodeDrainTimeout` to ensure nodes are eventually removed after a bounded period.
 
 #### Prevention
 
@@ -82,5 +86,20 @@ To prevent Nodes from becoming stuck when scaling down, set the `.spec.nodeDrain
 
 This forces Nodes to be removed once the timeout specified in the field has been reached, regardless of whether the node can be drained or the volumes can be detached successfully.
 
+```
+apiVersion: hypershift.openshift.io/v1beta1
+kind: NodePool
+metadata:
+  name: example
+  namespace: clusters
+spec:
+  nodeDrainTimeout: 30m
+  nodeVolumeDetachTimeout: 10m
+  # ...other fields...
+```
+
 !!! note
-    See the [Hypershift API reference page](../../reference/api.md) for more details.
+
+    See the [HyperShift API reference page](../../reference/api.md) for more details on these fields.
+
+    For an alternative approach that skips draining entirely via machine annotations, see [Scaling down data plane to Zero](scale-to-zero-dataplane.md).

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -5870,8 +5870,12 @@ Node(s) can become stuck when removing all Nodes from a cluster (scaling NodePoo
 
 Several conditions can prevent Node(s) from being drained successfully:
 
-- The hosted cluster contains `PodDisruptionBudgets` that require at least 
-- The hosted cluster contains pods that use `PersistentVolumes``
+- The hosted cluster contains `PodDisruptionBudgets` that require at least one healthy pod, preventing eviction when there are no other nodes to reschedule onto.
+- The hosted cluster contains pods that use `PersistentVolumes` that cannot be detached from the node.
+
+!!! important
+
+    This is expected behavior. When all nodes are removed simultaneously, pods protected by PodDisruptionBudgets cannot be evicted because the PDB constraints cannot be satisfied with no remaining nodes. As a result, the drain operation blocks indefinitely. Configure `nodeDrainTimeout` to ensure nodes are eventually removed after a bounded period.
 
 #### Prevention
 
@@ -5879,8 +5883,23 @@ To prevent Nodes from becoming stuck when scaling down, set the `.spec.nodeDrain
 
 This forces Nodes to be removed once the timeout specified in the field has been reached, regardless of whether the node can be drained or the volumes can be detached successfully.
 
+```
+apiVersion: hypershift.openshift.io/v1beta1
+kind: NodePool
+metadata:
+  name: example
+  namespace: clusters
+spec:
+  nodeDrainTimeout: 30m
+  nodeVolumeDetachTimeout: 10m
+  # ...other fields...
+```
+
 !!! note
-    See the Hypershift API reference page for more details.
+
+    See the HyperShift API reference page for more details on these fields.
+
+    For an alternative approach that skips draining entirely via machine annotations, see Scaling down data plane to Zero.
 
 
 ---


### PR DESCRIPTION

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:
As a part of this PR below has been fixed in upstream document of **NodePool lifecycle** in **Scaling To Zero** section :
 - Complete truncated bullet points for PodDisruptionBudgets and PersistentVolumes conditions.
 -  Add important admonition explaining expected behavior during simultaneous node removal.
 -  Include YAML example for nodeDrainTimeout and nodeVolumeDetachTimeout fields. 
 - Fix HyperShift casing and add cross-reference to scale-to-zero docs.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes : https://redhat.atlassian.net/browse/OCPBUGS-86075

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote NodePool scale-down guidance to clarify why node drains can become blocked and what triggers this behavior.
  * Added an explicit important note that drains may block indefinitely when all nodes are removed at once.
  * Expanded prevention guidance with a concrete configuration example to increase node drain and volume-detach timeouts.
  * Added a note describing an alternative annotation-based approach that avoids draining.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->