### PR TITLE
CNTRLPLANE-3430: Make HA break-glass credentials test infraless

### DIFF
--- a/test/e2e/create_cluster_test.go
+++ b/test/e2e/create_cluster_test.go
@@ -154,6 +154,7 @@ func TestCreateCluster(t *testing.T) {
 // each individual KAS pod rather than through the service load balancer.
 func TestCreateClusterHABreakGlassCredentials(t *testing.T) {
 	t.Parallel()
+	e2eutil.AtLeast(t, e2eutil.Version423)
 
 	ctx, cancel := context.WithCancel(testContext)
 	defer cancel()
@@ -162,12 +163,83 @@ func TestCreateClusterHABreakGlassCredentials(t *testing.T) {
 	clusterOpts.ControlPlaneAvailabilityPolicy = string(hyperv1.HighlyAvailable)
 	clusterOpts.NodePoolReplicas = 0
 
+	// On non-OpenShift management clusters (e.g. AKS, GKE) there is no default
+	// router to auto-generate route hostnames. Set explicit hostnames on all
+	// Route-type services so the CPO can resolve infrastructure readiness.
+	// LoadBalancer-type services are left to the cloud LB controller, which
+	// provisions external IPs on every CI management cluster.
+	clusterOpts.BeforeApply = func(o crclient.Object) {
+		hc, ok := o.(*hyperv1.HostedCluster)
+		if !ok {
+			return
+		}
+		for i := range hc.Spec.Services {
+			svc := &hc.Spec.Services[i]
+			if svc.ServicePublishingStrategy.Type != hyperv1.Route {
+				continue
+			}
+			if svc.ServicePublishingStrategy.Route != nil && svc.ServicePublishingStrategy.Route.Hostname != "" {
+				continue
+			}
+			svc.ServicePublishingStrategy.Route = &hyperv1.RoutePublishingStrategy{
+				Hostname: fmt.Sprintf("%s.%s", strings.ToLower(string(svc.Service)), hc.Spec.DNS.BaseDomain),
+			}
+		}
+	}
+
 	e2eutil.NewHypershiftTest(t, ctx, func(t *testing.T, g Gomega, mgtClient crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+		controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
+
+		// Fail fast if control plane pods can't schedule, rather than waiting
+		// for the full WaitForGuestClient timeout with a generic error.
+		e2eutil.EventuallyObjects(t, ctx, "at least one KAS pod to be scheduled",
+			func(ctx context.Context) ([]*corev1.Pod, error) {
+				podList := &corev1.PodList{}
+				err := mgtClient.List(ctx, podList,
+					crclient.InNamespace(controlPlaneNamespace),
+					crclient.MatchingLabels{"app": "kube-apiserver"},
+				)
+				if err != nil {
+					return nil, err
+				}
+				pods := make([]*corev1.Pod, len(podList.Items))
+				for i := range podList.Items {
+					pods[i] = &podList.Items[i]
+				}
+				return pods, nil
+			},
+			[]e2eutil.Predicate[[]*corev1.Pod]{
+				func(pods []*corev1.Pod) (done bool, reasons string, err error) {
+					if len(pods) == 0 {
+						return false, "no KAS pods found yet", nil
+					}
+					for _, pod := range pods {
+						for _, cond := range pod.Status.Conditions {
+							if cond.Type == corev1.PodScheduled && cond.Status == corev1.ConditionTrue {
+								return true, "", nil
+							}
+						}
+					}
+					var msgs []string
+					for _, pod := range pods {
+						for _, cond := range pod.Status.Conditions {
+							if cond.Type == corev1.PodScheduled {
+								msgs = append(msgs, fmt.Sprintf("%s: %s", pod.Name, cond.Message))
+							}
+						}
+					}
+					if len(msgs) > 0 {
+						return false, fmt.Sprintf("KAS pods not scheduled: %s", strings.Join(msgs, "; ")), nil
+					}
+					return false, "KAS pods pending, scheduling conditions not yet set", nil
+				},
+			},
+			nil, // no per-pod predicates; the group predicate handles scheduling detection
+			e2eutil.WithTimeout(10*time.Minute),
+		)
+
 		// Wait for guest API to be reachable (SelfSubjectReview only, no nodes needed)
 		_ = e2eutil.WaitForGuestClient(t, ctx, mgtClient, hostedCluster)
-
-		// Assert that KAS deployment has 3 ready replicas to guard against false-positive passes
-		controlPlaneNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 		e2eutil.EventuallyObject(t, ctx, "KAS deployment to have 3 ready replicas",
 			func(ctx context.Context) (*appsv1.Deployment, error) {
 				deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
@@ -205,7 +277,7 @@ func TestCreateClusterHABreakGlassCredentials(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred(), "couldn't create guest clients")
 
 		integration.RunTestControlPlanePKIOperatorBreakGlassCredentials(t, testContext, hostedCluster, mgmtClients, guestClients)
-	}).Execute(&clusterOpts, globalOpts.Platform, globalOpts.ArtifactDir, "ha-break-glass-creds", globalOpts.ServiceAccountSigningKey)
+	}).Execute(&clusterOpts, hyperv1.NonePlatform, globalOpts.ArtifactDir, "ha-break-glass-creds", globalOpts.ServiceAccountSigningKey)
 }
 
 // TODO(alberto): rename this e2e to drop TestCreateCluster prefix after merging https://github.com/openshift/release/pull/66655

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -353,7 +353,9 @@ func WaitForGuestClient(t testing.TB, ctx context.Context, client crclient.Clien
 	guestConfig.QPS = -1
 	guestConfig.Burst = -1
 
-	connectTimeout := 10 * time.Minute
+	// 15 minutes accounts for cloud LB provisioning (3-5 min on Azure/AWS)
+	// plus time for the guest API server to become reachable.
+	connectTimeout := 15 * time.Minute
 	if timeoutOverride := os.Getenv("GUEST_CONNECT_TIMEOUT"); timeoutOverride != "" {
 		connectTimeout, err = time.ParseDuration(timeoutOverride)
 		if err != nil {

--- a/test/integration/control_plane_pki_operator.go
+++ b/test/integration/control_plane_pki_operator.go
@@ -139,24 +139,37 @@ func validateCertificateAuth(t *testing.T, ctx context.Context, root *rest.Confi
 	t.Log("validating that the client certificate provides the appropriate access")
 	breakGlassTenantClient := clientForCertKey(t, root, crt, key)
 
-	t.Log("issuing SSR to identify the subject we are given using the client certificate")
-	response, err := breakGlassTenantClient.AuthenticationV1().SelfSubjectReviews().Create(ctx, &authenticationv1.SelfSubjectReview{}, metav1.CreateOptions{})
-	if err != nil {
-		if apierrors.IsUnauthorized(err) {
-			t.Logf("got an unauthorized error for SSR, debugging certificates")
-			t.Logf("client certificate: %s", string(crt))
-			caBundle, err := mgmtDebugClient.Get(ctx, cpomanifests.TotalClientCABundle("").Name, metav1.GetOptions{})
-			if err != nil {
-				t.Logf("failed to get total client CA bundle: %v", err)
-			}
+	// Poll the SSR until KAS trusts the break-glass signer CA. On NonePlatform
+	// clusters, the test framework skips the full cluster-readiness gate, so KAS
+	// may be serving before the control-plane-pki-operator has reconciled the
+	// break-glass signer CA into the client-ca trust bundle. All errors are
+	// retried: Unauthorized means the CA hasn't been reconciled yet, while
+	// transient connection errors (DNS resolution, connection refused, TLS
+	// handshake) mean the KAS endpoint isn't fully reachable yet. The 5-minute
+	// timeout bounds the total retry window.
+	t.Log("polling SSR to confirm that the client certificate is authorized")
+	var response *authenticationv1.SelfSubjectReview
+	if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		response, err = breakGlassTenantClient.AuthenticationV1().SelfSubjectReviews().Create(ctx, &authenticationv1.SelfSubjectReview{}, metav1.CreateOptions{})
+		if err != nil {
+			t.Logf("SSR attempt failed (will retry): %v", err)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		t.Logf("SSR did not succeed within timeout, debugging certificates")
+		t.Logf("client certificate: %s", string(crt))
+		if caBundle, getErr := mgmtDebugClient.Get(ctx, cpomanifests.TotalClientCABundle("").Name, metav1.GetOptions{}); getErr != nil {
+			t.Logf("failed to get total client CA bundle: %v", getErr)
+		} else {
 			t.Logf("server total certificate trust bundle: %s", string(caBundle.Data[certs.CASignerCertMapKey]))
-			caBundle, err = mgmtDebugClient.Get(ctx, pkimanifests.TotalKASClientCABundle("").Name, metav1.GetOptions{})
-			if err != nil {
-				t.Logf("failed to get KAS total client CA bundle: %v", err)
-			}
+		}
+		if caBundle, getErr := mgmtDebugClient.Get(ctx, pkimanifests.TotalKASClientCABundle("").Name, metav1.GetOptions{}); getErr != nil {
+			t.Logf("failed to get KAS total client CA bundle: %v", getErr)
+		} else {
 			t.Logf("KAS certificate trust bundle: %s", string(caBundle.Data[certs.OCPCASignerCertMapKey]))
 		}
-		t.Fatalf("could not send SSR: %v", err)
+		t.Fatalf("break-glass client certificate not authorized within timeout: %v", err)
 	}
 
 	t.Log("ensuring that the SSR identifies the client certificate as having system:masters power and correct username")


### PR DESCRIPTION
## Summary

- Make `TestCreateClusterHABreakGlassCredentials` work on non-OpenShift management clusters (e.g. AKS) by setting explicit hostnames on Route-type services in `BeforeApply`, so the CPO can resolve infrastructure readiness without a default ingress domain.
- Add early KAS pod scheduling failure detection (10-minute timeout) to fail fast under resource pressure instead of waiting for the full `WaitForGuestClient` timeout.
- Skip the test on release versions < 4.23 via `e2eutil.AtLeast(t, e2eutil.Version423)` because older CPO versions lack the `LoadBalancer.Hostname` bypass fix (merged in PR #8663).
- Poll SSR in `validateCertificateAuth` instead of failing immediately on Unauthorized, allowing time for the control-plane-pki-operator to reconcile the break-glass signer CA into the client-ca trust bundle.

**Depends on:** https://github.com/openshift/hypershift/pull/8663

## Test plan

- [ ] `e2e-aks-4-22`: test should be **skipped** (not failed) due to `AtLeast(Version423)`
- [ ] `e2e-aks` (4.23+): test should pass as before
- [ ] `e2e-aws`: test should pass (cloud LB provisions external endpoints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)