### PR TITLE
OCPBUGS-55621: Replace konnectivity Dial with DialContext in konnectivity-https-proxy/cmd.go

### DIFF
--- a/konnectivity-https-proxy/cmd.go
+++ b/konnectivity-https-proxy/cmd.go
@@ -1,6 +1,7 @@
 package konnectivityhttpsproxy
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
@@ -151,7 +152,6 @@ func NewStartCommand() *cobra.Command {
 				l.V(4).Info("Should proxy", "url", u)
 				return u, nil
 			},
-			Dial:        konnectivityDialer.Dial,
 			DialContext: konnectivityDialer.DialContext,
 		}
 		if httpsProxyURL != "" {
@@ -175,12 +175,13 @@ func NewStartCommand() *cobra.Command {
 }
 
 type dialFunc func(network, addr string) (net.Conn, error)
+type dialContextFunc func(ctx context.Context, network, addr string) (net.Conn, error)
 type dialRequestFunc func(req *http.Request, network, addr string) (net.Conn, error)
 
-func dialDirectFunc(httpProxy *goproxy.ProxyHttpServer) dialFunc {
-	// NOTE: the function signature is determined by the goproxy library, it requires the deprecated version
-	// nolint:staticcheck
-	return httpProxy.Tr.Dial
+func dialDirectFunc(httpProxy *goproxy.ProxyHttpServer) dialContextFunc {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return httpProxy.Tr.DialContext(ctx, network, addr)
+	}
 }
 
 func dialThroughProxyFunc(httpProxy *goproxy.ProxyHttpServer, proxyURL string, proxyURLUser *url.Userinfo) dialFunc {
@@ -219,14 +220,14 @@ func addBasicAuthHeader(proxyUser *url.Userinfo) func(req *http.Request) {
 	}
 }
 
-func connectDialFunc(shouldDialDirect func(*url.URL) (bool, error), dialDirectly dialFunc, dialThroughProxy dialFunc) dialRequestFunc {
+func connectDialFunc(shouldDialDirect func(*url.URL) (bool, error), dialDirectly dialContextFunc, dialThroughProxy dialFunc) dialRequestFunc {
 	return func(req *http.Request, network, addr string) (net.Conn, error) {
 		shouldDialDirectly, err := shouldDialDirect(req.URL)
 		if err != nil {
 			return nil, err
 		}
 		if shouldDialDirectly {
-			return dialDirectly(network, addr)
+			return dialDirectly(req.Context(), network, addr)
 		}
 		return dialThroughProxy(network, addr)
 	}

--- a/konnectivity-https-proxy/cmd.go
+++ b/konnectivity-https-proxy/cmd.go
@@ -179,9 +179,7 @@ type dialContextFunc func(ctx context.Context, network, addr string) (net.Conn, 
 type dialRequestFunc func(req *http.Request, network, addr string) (net.Conn, error)
 
 func dialDirectFunc(httpProxy *goproxy.ProxyHttpServer) dialContextFunc {
-	return func(ctx context.Context, network, addr string) (net.Conn, error) {
-		return httpProxy.Tr.DialContext(ctx, network, addr)
-	}
+	return httpProxy.Tr.DialContext
 }
 
 func dialThroughProxyFunc(httpProxy *goproxy.ProxyHttpServer, proxyURL string, proxyURLUser *url.Userinfo) dialFunc {

--- a/konnectivity-https-proxy/cmd_test.go
+++ b/konnectivity-https-proxy/cmd_test.go
@@ -1,8 +1,11 @@
 package konnectivityhttpsproxy
 
 import (
+	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -10,6 +13,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"github.com/elazarl/goproxy"
 	"golang.org/x/net/http/httpproxy"
 )
 
@@ -97,6 +101,116 @@ func TestShouldDialDirectFunc(t *testing.T) {
 			result, err := f(tc.requestURL)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(result).To(Equal(tc.expectedDialDirectly))
+		})
+	}
+}
+
+func TestDialDirectFunc(t *testing.T) {
+	t.Run("When dialing with a valid listener it should connect successfully", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+		g.Expect(err).NotTo(HaveOccurred())
+		defer listener.Close()
+
+		httpProxy := goproxy.NewProxyHttpServer()
+		httpProxy.Tr = &http.Transport{
+			DialContext: (&net.Dialer{}).DialContext,
+		}
+
+		dialFn := dialDirectFunc(httpProxy)
+		conn, err := dialFn(t.Context(), "tcp", listener.Addr().String())
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(conn).NotTo(BeNil())
+		conn.Close()
+	})
+
+	t.Run("When the transport DialContext fails it should return an error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		expectedErr := errors.New("dial failed")
+		httpProxy := goproxy.NewProxyHttpServer()
+		httpProxy.Tr = &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return nil, expectedErr
+			},
+		}
+
+		dialFn := dialDirectFunc(httpProxy)
+		conn, err := dialFn(t.Context(), "tcp", "127.0.0.1:1")
+		g.Expect(err).To(MatchError(expectedErr))
+		g.Expect(conn).To(BeNil())
+	})
+}
+
+func TestConnectDialFunc(t *testing.T) {
+	lookupErr := errors.New("lookup failed")
+
+	tests := []struct {
+		name               string
+		shouldDialDirect   bool
+		shouldDialDirectErr error
+		expectDialDirect   bool
+		expectDialProxy    bool
+		expectErr          error
+	}{
+		{
+			name:             "When shouldDialDirect returns true it should dial directly with request context",
+			shouldDialDirect: true,
+			expectDialDirect: true,
+		},
+		{
+			name:            "When shouldDialDirect returns false it should dial through proxy",
+			expectDialProxy: true,
+		},
+		{
+			name:                "When shouldDialDirect returns an error it should propagate the error",
+			shouldDialDirectErr: lookupErr,
+			expectErr:           lookupErr,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			type contextKey string
+			reqCtx := context.WithValue(t.Context(), contextKey("test"), "value")
+			req, err := http.NewRequestWithContext(reqCtx, "CONNECT", "https://example.com:443", nil)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			directCalled := false
+			proxyCalled := false
+			var capturedCtx context.Context
+
+			dialDirectly := func(ctx context.Context, network, addr string) (net.Conn, error) {
+				directCalled = true
+				capturedCtx = ctx
+				return nil, nil
+			}
+			dialThroughProxy := func(network, addr string) (net.Conn, error) {
+				proxyCalled = true
+				return nil, nil
+			}
+			shouldDialDirect := func(u *url.URL) (bool, error) {
+				return tc.shouldDialDirect, tc.shouldDialDirectErr
+			}
+
+			f := connectDialFunc(shouldDialDirect, dialDirectly, dialThroughProxy)
+			conn, err := f(req, "tcp", "example.com:443")
+
+			if tc.expectErr != nil {
+				g.Expect(err).To(MatchError(tc.expectErr))
+				g.Expect(conn).To(BeNil())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			g.Expect(directCalled).To(Equal(tc.expectDialDirect))
+			g.Expect(proxyCalled).To(Equal(tc.expectDialProxy))
+			if tc.expectDialDirect {
+				g.Expect(capturedCtx).To(Equal(reqCtx))
+				g.Expect(capturedCtx.Value(contextKey("test"))).To(Equal("value"))
+			}
 		})
 	}
 }

--- a/konnectivity-https-proxy/cmd_test.go
+++ b/konnectivity-https-proxy/cmd_test.go
@@ -147,12 +147,12 @@ func TestConnectDialFunc(t *testing.T) {
 	lookupErr := errors.New("lookup failed")
 
 	tests := []struct {
-		name               string
-		shouldDialDirect   bool
+		name                string
+		shouldDialDirect    bool
 		shouldDialDirectErr error
-		expectDialDirect   bool
-		expectDialProxy    bool
-		expectErr          error
+		expectDialDirect    bool
+		expectDialProxy     bool
+		expectErr           error
 	}{
 		{
 			name:             "When shouldDialDirect returns true it should dial directly with request context",

--- a/konnectivity-https-proxy/cmd_test.go
+++ b/konnectivity-https-proxy/cmd_test.go
@@ -191,8 +191,7 @@ func TestConnectDialFunc(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 
-			type contextKey string
-			reqCtx := context.WithValue(t.Context(), contextKey("test"), "value")
+			reqCtx := t.Context()
 			req, err := http.NewRequestWithContext(reqCtx, http.MethodConnect, "https://example.com:443", nil)
 			g.Expect(err).NotTo(HaveOccurred())
 
@@ -226,7 +225,6 @@ func TestConnectDialFunc(t *testing.T) {
 			g.Expect(proxyCalled).To(Equal(tc.expectDialProxy))
 			if tc.expectDialDirect {
 				g.Expect(capturedCtx).To(Equal(reqCtx))
-				g.Expect(capturedCtx.(context.Context).Value(contextKey("test"))).To(Equal("value"))
 			}
 		})
 	}

--- a/konnectivity-https-proxy/cmd_test.go
+++ b/konnectivity-https-proxy/cmd_test.go
@@ -106,41 +106,58 @@ func TestShouldDialDirectFunc(t *testing.T) {
 }
 
 func TestDialDirectFunc(t *testing.T) {
-	t.Run("When dialing with a valid listener it should connect successfully", func(t *testing.T) {
-		g := NewGomegaWithT(t)
+	dialErr := errors.New("dial failed")
 
-		listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
-		g.Expect(err).NotTo(HaveOccurred())
-		defer listener.Close()
-
-		httpProxy := goproxy.NewProxyHttpServer()
-		httpProxy.Tr = &http.Transport{
-			DialContext: (&net.Dialer{}).DialContext,
-		}
-
-		dialFn := dialDirectFunc(httpProxy)
-		conn, err := dialFn(t.Context(), "tcp", listener.Addr().String())
-		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(conn).NotTo(BeNil())
-		conn.Close()
-	})
-
-	t.Run("When the transport DialContext fails it should return an error", func(t *testing.T) {
-		g := NewGomegaWithT(t)
-
-		expectedErr := errors.New("dial failed")
-		httpProxy := goproxy.NewProxyHttpServer()
-		httpProxy.Tr = &http.Transport{
-			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				return nil, expectedErr
+	tests := []struct {
+		name      string
+		dialCtx   func(ctx context.Context, network, addr string) (net.Conn, error)
+		addr      func(t *testing.T) string
+		expectErr error
+	}{
+		{
+			name:    "When dialing with a valid listener it should connect successfully",
+			dialCtx: (&net.Dialer{}).DialContext,
+			addr: func(t *testing.T) string {
+				listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+				if err != nil {
+					t.Fatalf("failed to create listener: %v", err)
+				}
+				t.Cleanup(func() { listener.Close() })
+				return listener.Addr().String()
 			},
-		}
+		},
+		{
+			name: "When the transport DialContext fails it should return an error",
+			dialCtx: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return nil, dialErr
+			},
+			addr:      func(t *testing.T) string { return "127.0.0.1:1" },
+			expectErr: dialErr,
+		},
+	}
 
-		dialFn := dialDirectFunc(httpProxy)
-		conn, err := dialFn(t.Context(), "tcp", "127.0.0.1:1")
-		g.Expect(err).To(MatchError(expectedErr))
-		g.Expect(conn).To(BeNil())
-	})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			httpProxy := goproxy.NewProxyHttpServer()
+			httpProxy.Tr = &http.Transport{
+				DialContext: tc.dialCtx,
+			}
+
+			dialFn := dialDirectFunc(httpProxy)
+			conn, err := dialFn(t.Context(), "tcp", tc.addr(t))
+
+			if tc.expectErr != nil {
+				g.Expect(err).To(MatchError(tc.expectErr))
+				g.Expect(conn).To(BeNil())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(conn).NotTo(BeNil())
+				conn.Close()
+			}
+		})
+	}
 }
 
 func TestConnectDialFunc(t *testing.T) {
@@ -176,12 +193,12 @@ func TestConnectDialFunc(t *testing.T) {
 
 			type contextKey string
 			reqCtx := context.WithValue(t.Context(), contextKey("test"), "value")
-			req, err := http.NewRequestWithContext(reqCtx, "CONNECT", "https://example.com:443", nil)
+			req, err := http.NewRequestWithContext(reqCtx, http.MethodConnect, "https://example.com:443", nil)
 			g.Expect(err).NotTo(HaveOccurred())
 
 			directCalled := false
 			proxyCalled := false
-			var capturedCtx context.Context
+			var capturedCtx any
 
 			dialDirectly := func(ctx context.Context, network, addr string) (net.Conn, error) {
 				directCalled = true
@@ -209,7 +226,7 @@ func TestConnectDialFunc(t *testing.T) {
 			g.Expect(proxyCalled).To(Equal(tc.expectDialProxy))
 			if tc.expectDialDirect {
 				g.Expect(capturedCtx).To(Equal(reqCtx))
-				g.Expect(capturedCtx.Value(contextKey("test"))).To(Equal("value"))
+				g.Expect(capturedCtx.(context.Context).Value(contextKey("test"))).To(Equal("value"))
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

Replacing **deprecated** Dial with DialContext in konnectivity-https-proxy/cmd.go so that golangci-lint passes without needing nolint suppressions.
If we uncomment nolint in cmd.go its giving below error:

`  konnectivity-https-proxy/cmd.go uses the deprecated Dial field on http.Transport (deprecated since Go 1.7) instead of DialContext. A // nolint:staticcheck comment on line 182 suppresses the lint warning.`



## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes ---> https://redhat.atlassian.net/browse/OCPBUGS-55621

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * HTTPS proxy connection handling now uses context-aware networking, improving support for request timeouts and cancellations.
  * Dialing behavior updated to rely on modern connection APIs for cleaner lifecycle management and more reliable setup/teardown.

* **Tests**
  * Added unit tests validating direct vs. proxy dialing selection, successful direct dialing, and correct propagation of dialing errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->