### PR TITLE
NO-JIRA: fix(e2e): lower pull secret in-place propagation test gate to 4.22

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -2011,7 +2011,7 @@ func EnsureGlobalPullSecret(t *testing.T, ctx context.Context, mgmtClient crclie
 		// Verify that in-place management-cluster pull secret updates propagate to the guest cluster
 		// without triggering a NodePool rollout.
 		t.Run("When management-cluster hostedCluster.Spec.PullSecret is updated in-place it should propagate to guest without rollout", func(t *testing.T) {
-			CPOAtLeast(t, Version423, entryHostedCluster)
+			CPOAtLeast(t, Version422, entryHostedCluster)
 			g := NewWithT(t)
 			t.Logf("Reading management-cluster pull secret %s/%s", entryHostedCluster.Namespace, entryHostedCluster.Spec.PullSecret.Name)
 			mgmtSecret := &corev1.Secret{}


### PR DESCRIPTION
## Summary
- Lower the `CPOAtLeast` gate on the pull secret in-place propagation e2e test from `Version423` to `Version422`, since the CP pull-secret watches were backported to release-4.22 via [#8408](https://github.com/openshift/hypershift/pull/8408)

## Test plan
- [ ] The test should now run on 4.22+ clusters instead of being skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated version compatibility check in end-to-end test validation for pull secret propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->