### PR TITLE
OCPBUGS-86329: cpo: turn off cluster-api crdmigrator controller

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-api/deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/cluster-api/deployment.yaml
@@ -28,6 +28,7 @@ spec:
         - --leader-elect-lease-duration=137s
         - --leader-elect-retry-period=26s
         - --leader-elect-renew-deadline=107s
+        - --skip-crd-migration-phases=StorageVersionMigration,CleanupManagedFields
         env:
         - name: MY_NAMESPACE
           valueFrom:

--- a/hypershift-operator/controllers/hostedcluster/testdata/cluster-api/zz_fixture_TestReconcileComponents.yaml
+++ b/hypershift-operator/controllers/hostedcluster/testdata/cluster-api/zz_fixture_TestReconcileComponents.yaml
@@ -68,6 +68,7 @@ spec:
         - --leader-elect-lease-duration=137s
         - --leader-elect-retry-period=26s
         - --leader-elect-renew-deadline=107s
+        - --skip-crd-migration-phases=StorageVersionMigration,CleanupManagedFields
         env:
         - name: MY_NAMESPACE
           valueFrom:


### PR DESCRIPTION
We do not provide the RBAC necessary to make this controller function, and we do not want or need its behavior. Turn off the controller by skipping all phases in order to remove lots of serious-looking 401 spam from logs that misleads humans and agents analyzing the logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted control plane operator deployment configuration to skip certain CRD migration phases during controller startup, altering startup migration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->