### PR TITLE
OCPBUGS-86025: Close HTTP response bodies to prevent goroutine and connection leaks

### DIFF
--- a/support/konnectivityproxy/dialer.go
+++ b/support/konnectivityproxy/dialer.go
@@ -328,6 +328,7 @@ func (p *konnectivityProxy) DialContext(ctx context.Context, network string, req
 	}
 	if res.StatusCode != http.StatusOK {
 		log.Info("Status code was not 200", "statusCode", res.StatusCode)
+		res.Body.Close()
 		_ = konnectivityConnection.Close()
 		return nil, fmt.Errorf("proxy error from %s while dialing %s: %v", konnectivityServerAddress, requestAddress, res.Status)
 	}
@@ -335,6 +336,7 @@ func (p *konnectivityProxy) DialContext(ctx context.Context, network string, req
 	// for TLS. In TLS, the client speaks first, so we know there's no unbuffered data, but we can double-check.
 	if br.Buffered() > 0 {
 		log.Info("The response contained buffered data, none expected")
+		res.Body.Close()
 		_ = konnectivityConnection.Close()
 		return nil, fmt.Errorf("unexpected %d bytes of buffered data from CONNECT proxy %q",
 			br.Buffered(), konnectivityServerAddress)

--- a/support/konnectivityproxy/proxy_dialer.go
+++ b/support/konnectivityproxy/proxy_dialer.go
@@ -61,6 +61,7 @@ func (hpd *httpProxyDialer) Dial(network string, addr string) (net.Conn, error) 
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
 		conn.Close()
 		f := strings.SplitN(resp.Status, " ", 2)
 		return nil, errors.New(f[1])


### PR DESCRIPTION
## What this PR does / why we need it:

Adds `defer resp.Body.Close()` to `healthCheckKASEndpoint` and explicit `resp.Body.Close()` on error paths in the two CONNECT tunnel dialers, where HTTP response bodies are not closed after use. Without closing, each unclosed response leaks ~3 goroutines and holds an open TCP connection. In `healthCheckKASEndpoint` (called from the HCP reconcile loop every ~10s), this accumulates ~26,000 leaked goroutines/day and ~200MB memory/day, potentially causing CPO pods to OOM on long-running management clusters.

**Files changed:**
- `control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go` — `healthCheckKASEndpoint`
- `support/konnectivityproxy/dialer.go` — `KonnectivityDialer.DialContext`
- `support/konnectivityproxy/proxy_dialer.go` — `httpProxyDialer.Dial`

All three were identified via the `bodyclose` linter (`golangci-lint`).

## Which issue(s) this PR fixes:

Fixes https://redhat.atlassian.net/browse/OCPBUGS-86025

## Special notes for your reviewer:

- `healthCheckKASEndpoint`: uses `defer resp.Body.Close()` — standard pattern for a regular HTTP GET.
- The two konnectivity dialers use explicit `resp.Body.Close()` on error paths only. These are CONNECT tunnels where the response body *is* the tunnel connection — a `defer` would close the tunnel on the success return path.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP response body leaks in health check monitoring operations to prevent resource exhaustion.
  * Fixed HTTP response body leaks in proxy connection handling during error scenarios to ensure proper resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->