### PR TITLE
CNTRLPLANE-3329: Use fuse-overlayfs for build cache instead of full copy

### DIFF
--- a/.github/actions/warm-go-cache/action.yaml
+++ b/.github/actions/warm-go-cache/action.yaml
@@ -1,13 +1,13 @@
 name: 'Warm Go build cache'
-description: 'Set GOCACHE and optionally warm from EFS-backed PV'
+description: 'Set GOCACHE to the EFS-backed PV mount (read-only) or a writable fallback'
 runs:
   using: composite
   steps:
     - shell: bash
       run: |
-        echo "GOCACHE=/tmp/go-build-cache" >> "$GITHUB_ENV"
         if [ -d /cache/go-build ]; then
-          mkdir -p /tmp/go-build-cache && \
-          timeout 120 cp -a /cache/go-build/. /tmp/go-build-cache/ || \
-          echo "::warning::Failed to copy EFS cache, proceeding without cache"
+          echo "GOCACHE=/cache/go-build" >> "$GITHUB_ENV"
+        else
+          mkdir -p /tmp/go-build-cache
+          echo "GOCACHE=/tmp/go-build-cache" >> "$GITHUB_ENV"
         fi

--- a/.github/actions/warm-go-cache/action.yaml
+++ b/.github/actions/warm-go-cache/action.yaml
@@ -1,13 +1,22 @@
 name: 'Warm Go build cache'
-description: 'Set GOCACHE to the EFS-backed PV mount (read-only) or a writable fallback'
+description: 'Set GOCACHE via fuse-overlayfs over the EFS-backed PV or a writable fallback'
 runs:
   using: composite
   steps:
     - shell: bash
       run: |
-        if [ -d /cache/go-build ]; then
-          echo "GOCACHE=/cache/go-build" >> "$GITHUB_ENV"
-        else
-          mkdir -p /tmp/go-build-cache
-          echo "GOCACHE=/tmp/go-build-cache" >> "$GITHUB_ENV"
+        mkdir -p /tmp/go-build-cache
+        mounted=false
+        if [ -d /cache/go-build ] && command -v fuse-overlayfs >/dev/null 2>&1 && [ -e /dev/fuse ]; then
+          mkdir -p /tmp/go-cache-upper /tmp/go-cache-work
+          if fuse-overlayfs -o lowerdir=/cache/go-build,upperdir=/tmp/go-cache-upper,workdir=/tmp/go-cache-work /tmp/go-build-cache; then
+            mounted=true
+          else
+            echo "::warning::fuse-overlayfs mount failed, falling back to copy"
+          fi
         fi
+        if [ "$mounted" = "false" ] && [ -d /cache/go-build ]; then
+          timeout 120 cp -a /cache/go-build/. /tmp/go-build-cache/ || \
+            echo "::warning::Failed to copy EFS cache, proceeding without cache"
+        fi
+        echo "GOCACHE=/tmp/go-build-cache" >> "$GITHUB_ENV"

--- a/Dockerfile.github-actions-runner
+++ b/Dockerfile.github-actions-runner
@@ -11,6 +11,7 @@ RUN apt-get update && \
         curl \
         ca-certificates \
         python3-pip \
+        fuse-overlayfs \
     && rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH


### PR DESCRIPTION
## Summary

- Adds `fuse-overlayfs` to the GitHub Actions runner image
- Replaces the per-job `cp -a` of the entire EFS cache with a fuse-overlayfs mount that gives Go a writable view over the read-only EFS PVC with zero copy overhead
- Reads hit the EFS mount directly, writes go to a tmpfs upper layer
- Falls back to `cp -a` if fuse-overlayfs or `/dev/fuse` is unavailable, and to an empty cache if both fail
- On OpenShift 4.15+, `/dev/fuse` is available to unprivileged pods without cluster config changes

## Context

Benchmarking with `contrib/ci/gha-cache-timing.sh` showed that all cached workflows (lint, verify, unit tests, envtest) got **slower** after the EFS cache was introduced (May 13-18) compared to before:

| Job | Before (May 8-12) | After (May 19-21) | Delta |
|-----|-------------------|--------------------|-------|
| lint / Lint | 7m46s | 9m26s | +1m40s |
| verify / Verify | 11m19s | 12m44s | +1m25s |
| test / Unit Tests (avg) | 6m30s | 8m44s | +2m14s |
| envtest (avg) | 8m33s | 10m54s | +2m21s |

The `timeout 120 cp -a /cache/go-build/. /tmp/go-build-cache/` in the warm-go-cache action was copying the full cache on every job start, negating the compilation time savings. Pointing `GOCACHE` directly at the read-only mount doesn't work either — Go fails hard if it can't write to its cache directory.

## Test plan

- [ ] CI passes on this PR (falls back to `cp -a` since the new runner image isn't built yet)
- [ ] After new runner image is deployed: verify fuse-overlayfs mount succeeds in job logs
- [ ] Compare job durations against pre-cache baseline (May 8-12) using `contrib/ci/gha-cache-timing.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Go build cache handling in CI: runner environment now supports an overlay-based read-mostly cache with a writable fallback.
  * The cache location is always initialized and exposed to builds.
  * CI will attempt to warm from remote storage (with a timed copy fallback) and will safely proceed without cache if warming or mounting fails.
  * Runner image now includes overlay tooling to enable overlay mounts when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->