### PR TITLE
OCPBUGS-86296: Propagate management cluster proxy env vars to konnectivity sidecar

### DIFF
--- a/support/controlplane-component/konnectivity-container.go
+++ b/support/controlplane-component/konnectivity-container.go
@@ -224,7 +224,25 @@ func (opts KonnectivityContainerOptions) buildContainer(hcp *hyperv1.HostedContr
 		}
 	}
 
+	// When connecting directly to cloud APIs, dialDirectWithProxy() reads
+	// HTTPS_PROXY from the process environment. Propagate the management
+	// cluster's proxy env vars so that path can reach cloud endpoints.
+	if opts.connectsDirectlyToCloudAPIs() {
+		proxy.SetEnvVars(&container.Env)
+	}
+
 	return container
+}
+
+func (opts KonnectivityContainerOptions) connectsDirectlyToCloudAPIs() bool {
+	switch opts.Mode {
+	case HTTPS:
+		return ptr.Deref(opts.HTTPSOptions.ConnectDirectlyToCloudAPIs, false)
+	case Socks5:
+		return ptr.Deref(opts.Socks5Options.ConnectDirectlyToCloudAPIs, false)
+	default:
+		return false
+	}
 }
 
 func (opts KonnectivityContainerOptions) buildVolumes(proxyAdditionalCAs []corev1.VolumeProjection) []corev1.Volume {

--- a/support/controlplane-component/konnectivity-container_test.go
+++ b/support/controlplane-component/konnectivity-container_test.go
@@ -1,0 +1,174 @@
+package controlplanecomponent
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+func findEnvVar(envVars []corev1.EnvVar, name string) *corev1.EnvVar {
+	for i := range envVars {
+		if envVars[i].Name == name {
+			return &envVars[i]
+		}
+	}
+	return nil
+}
+
+func TestBuildContainer(t *testing.T) {
+	hcp := &hyperv1.HostedControlPlane{}
+
+	tests := []struct {
+		name            string
+		opts            KonnectivityContainerOptions
+		proxyEnvs       map[string]string
+		expectProxyVars bool
+	}{
+		{
+			name: "When ConnectDirectlyToCloudAPIs is true and management proxy is configured it should set proxy env vars",
+			opts: KonnectivityContainerOptions{
+				Mode: HTTPS,
+				HTTPSOptions: HTTPSOptions{
+					ConnectDirectlyToCloudAPIs: ptr.To(true),
+				},
+			},
+			proxyEnvs: map[string]string{
+				"HTTP_PROXY":  "http://proxy.mgmt.example.com:3128",
+				"HTTPS_PROXY": "https://proxy.mgmt.example.com:3129",
+				"NO_PROXY":    "localhost,10.0.0.0/8",
+			},
+			expectProxyVars: true,
+		},
+		{
+			name: "When ConnectDirectlyToCloudAPIs is true for Socks5 mode it should set proxy env vars",
+			opts: KonnectivityContainerOptions{
+				Mode: Socks5,
+				Socks5Options: Socks5Options{
+					ConnectDirectlyToCloudAPIs: ptr.To(true),
+				},
+			},
+			proxyEnvs: map[string]string{
+				"HTTP_PROXY":  "http://proxy.mgmt.example.com:3128",
+				"HTTPS_PROXY": "https://proxy.mgmt.example.com:3129",
+				"NO_PROXY":    "localhost,10.0.0.0/8",
+			},
+			expectProxyVars: true,
+		},
+		{
+			name: "When ConnectDirectlyToCloudAPIs is false it should not set proxy env vars",
+			opts: KonnectivityContainerOptions{
+				Mode: HTTPS,
+				HTTPSOptions: HTTPSOptions{
+					ConnectDirectlyToCloudAPIs: ptr.To(false),
+				},
+			},
+			proxyEnvs: map[string]string{
+				"HTTP_PROXY":  "http://proxy.mgmt.example.com:3128",
+				"HTTPS_PROXY": "https://proxy.mgmt.example.com:3129",
+				"NO_PROXY":    "localhost,10.0.0.0/8",
+			},
+			expectProxyVars: false,
+		},
+		{
+			name: "When ConnectDirectlyToCloudAPIs is not set it should not set proxy env vars",
+			opts: KonnectivityContainerOptions{
+				Mode: HTTPS,
+			},
+			proxyEnvs: map[string]string{
+				"HTTP_PROXY":  "http://proxy.mgmt.example.com:3128",
+				"HTTPS_PROXY": "https://proxy.mgmt.example.com:3129",
+				"NO_PROXY":    "localhost,10.0.0.0/8",
+			},
+			expectProxyVars: false,
+		},
+		{
+			name: "When ConnectDirectlyToCloudAPIs is true but no management proxy is configured it should not add proxy env vars",
+			opts: KonnectivityContainerOptions{
+				Mode: HTTPS,
+				HTTPSOptions: HTTPSOptions{
+					ConnectDirectlyToCloudAPIs: ptr.To(true),
+				},
+			},
+			proxyEnvs:       map[string]string{},
+			expectProxyVars: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			t.Setenv("HTTP_PROXY", "")
+			t.Setenv("HTTPS_PROXY", "")
+			t.Setenv("NO_PROXY", "")
+
+			for k, v := range tt.proxyEnvs {
+				t.Setenv(k, v)
+			}
+
+			container := tt.opts.buildContainer(hcp, "test-image:latest", nil)
+
+			g.Expect(findEnvVar(container.Env, "KUBECONFIG")).NotTo(BeNil(), "KUBECONFIG should always be set")
+
+			if tt.expectProxyVars {
+				httpProxy := findEnvVar(container.Env, "HTTP_PROXY")
+				g.Expect(httpProxy).NotTo(BeNil(), "HTTP_PROXY should be set")
+				g.Expect(httpProxy.Value).To(Equal(tt.proxyEnvs["HTTP_PROXY"]))
+
+				httpsProxy := findEnvVar(container.Env, "HTTPS_PROXY")
+				g.Expect(httpsProxy).NotTo(BeNil(), "HTTPS_PROXY should be set")
+				g.Expect(httpsProxy.Value).To(Equal(tt.proxyEnvs["HTTPS_PROXY"]))
+
+				noProxy := findEnvVar(container.Env, "NO_PROXY")
+				g.Expect(noProxy).NotTo(BeNil(), "NO_PROXY should be set")
+				g.Expect(noProxy.Value).To(ContainSubstring("kube-apiserver"), "NO_PROXY should include kube-apiserver")
+				for _, entry := range strings.Split(tt.proxyEnvs["NO_PROXY"], ",") {
+					g.Expect(noProxy.Value).To(ContainSubstring(entry), "NO_PROXY should preserve original entry %q", entry)
+				}
+			} else {
+				g.Expect(findEnvVar(container.Env, "HTTP_PROXY")).To(BeNil(), "HTTP_PROXY should not be set")
+				g.Expect(findEnvVar(container.Env, "HTTPS_PROXY")).To(BeNil(), "HTTPS_PROXY should not be set")
+				g.Expect(findEnvVar(container.Env, "NO_PROXY")).To(BeNil(), "NO_PROXY should not be set")
+			}
+		})
+	}
+}
+
+func TestBuildContainerDualMode(t *testing.T) {
+	g := NewGomegaWithT(t)
+	hcp := &hyperv1.HostedControlPlane{}
+
+	t.Setenv("HTTP_PROXY", "http://proxy.mgmt.example.com:3128")
+	t.Setenv("HTTPS_PROXY", "https://proxy.mgmt.example.com:3129")
+	t.Setenv("NO_PROXY", "localhost")
+
+	// Simulate what injectKonnectivityContainer does for Dual mode:
+	// it builds the HTTPS container first, then the Socks5 container.
+	opts := KonnectivityContainerOptions{
+		Mode: Dual,
+		HTTPSOptions: HTTPSOptions{
+			ConnectDirectlyToCloudAPIs: ptr.To(true),
+		},
+	}
+
+	opts.Mode = HTTPS
+	httpsContainer := opts.buildContainer(hcp, "test-image:latest", nil)
+
+	opts.Mode = Socks5
+	socks5Container := opts.buildContainer(hcp, "test-image:latest", nil)
+
+	g.Expect(findEnvVar(httpsContainer.Env, "HTTP_PROXY")).NotTo(BeNil(),
+		"HTTPS container should have HTTP_PROXY because ConnectDirectlyToCloudAPIs is set on HTTPSOptions")
+	g.Expect(findEnvVar(httpsContainer.Env, "HTTPS_PROXY")).NotTo(BeNil(),
+		"HTTPS container should have HTTPS_PROXY")
+
+	g.Expect(findEnvVar(socks5Container.Env, "HTTP_PROXY")).To(BeNil(),
+		"Socks5 container should not have HTTP_PROXY because ConnectDirectlyToCloudAPIs is not set on Socks5Options")
+	g.Expect(findEnvVar(socks5Container.Env, "HTTPS_PROXY")).To(BeNil(),
+		"Socks5 container should not have HTTPS_PROXY")
+}

--- a/support/konnectivityproxy/dialer_test.go
+++ b/support/konnectivityproxy/dialer_test.go
@@ -1,8 +1,15 @@
 package konnectivityproxy
 
 import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -271,6 +278,151 @@ func TestKonnectivityHealthEndRetryPreventsStubbornFlag(t *testing.T) {
 	if !kh.beginRetry() {
 		t.Error("expected retry to be allowed after endRetry and interval")
 	}
+}
+
+// startTCPEchoServer starts a TCP server that echoes back anything it receives.
+// All accepted connections inherit a deadline so io.Copy never blocks indefinitely.
+func startTCPEchoServer(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start echo server: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				if err := conn.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+					return
+				}
+				if _, err := io.Copy(conn, conn); err != nil {
+					return
+				}
+			}()
+		}
+	}()
+	return ln
+}
+
+// startConnectProxy starts an HTTP CONNECT proxy that increments connectCount
+// for every successful tunnel. Relay goroutines are bounded by per-connection
+// deadlines so they cannot outlive the test.
+func startConnectProxy(t *testing.T, connectCount *atomic.Int32) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start proxy server: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodConnect {
+				http.Error(w, "only CONNECT supported", http.StatusMethodNotAllowed)
+				return
+			}
+			connectCount.Add(1)
+
+			target, err := net.DialTimeout("tcp", r.Host, 5*time.Second)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadGateway)
+				return
+			}
+			defer target.Close()
+			if err := target.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			w.WriteHeader(http.StatusOK)
+			hijacker, ok := w.(http.Hijacker)
+			if !ok {
+				http.Error(w, "hijack not supported", http.StatusInternalServerError)
+				return
+			}
+			client, _, err := hijacker.Hijack()
+			if err != nil {
+				return
+			}
+			defer client.Close()
+			if err := client.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+				return
+			}
+
+			done := make(chan struct{}, 2)
+			relay := func(dst, src net.Conn) {
+				io.Copy(dst, src) //nolint:errcheck // relay best-effort; deadline bounds lifetime
+				done <- struct{}{}
+			}
+			go relay(target, client)
+			go relay(client, target)
+			<-done
+		}),
+	}
+	t.Cleanup(func() { srv.Close() })
+	go func() { _ = srv.Serve(ln) }()
+	return ln
+}
+
+func TestDialDirectWithProxy(t *testing.T) {
+	const testTimeout = 5 * time.Second
+
+	t.Run("When HTTPS_PROXY is set it should route through the proxy", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		t.Setenv("HTTP_PROXY", "")
+		t.Setenv("HTTPS_PROXY", "")
+		t.Setenv("NO_PROXY", "")
+		echo := startTCPEchoServer(t)
+		var connectCount atomic.Int32
+		proxyLn := startConnectProxy(t, &connectCount)
+		t.Setenv("HTTPS_PROXY", fmt.Sprintf("http://%s", proxyLn.Addr().String()))
+
+		p := &konnectivityProxy{}
+		conn, err := p.dialDirectWithProxy("tcp", echo.Addr().String())
+		g.Expect(err).NotTo(HaveOccurred(), "dialDirectWithProxy should succeed")
+		defer conn.Close()
+		g.Expect(conn.SetDeadline(time.Now().Add(testTimeout))).To(Succeed())
+
+		msg := []byte("hello")
+		_, err = conn.Write(msg)
+		g.Expect(err).NotTo(HaveOccurred(), "write should succeed")
+		buf := make([]byte, len(msg))
+		_, err = io.ReadFull(conn, buf)
+		g.Expect(err).NotTo(HaveOccurred(), "read should succeed")
+		g.Expect(string(buf)).To(Equal(string(msg)))
+		g.Expect(connectCount.Load()).To(Equal(int32(1)), "proxy should receive 1 CONNECT request")
+	})
+
+	t.Run("When HTTPS_PROXY is not set it should connect directly", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		echo := startTCPEchoServer(t)
+		var connectCount atomic.Int32
+		startConnectProxy(t, &connectCount)
+		t.Setenv("HTTPS_PROXY", "")
+		t.Setenv("HTTP_PROXY", "")
+		t.Setenv("NO_PROXY", "")
+
+		p := &konnectivityProxy{}
+		conn, err := p.dialDirectWithProxy("tcp", echo.Addr().String())
+		g.Expect(err).NotTo(HaveOccurred(), "dialDirectWithProxy should succeed")
+		defer conn.Close()
+		g.Expect(conn.SetDeadline(time.Now().Add(testTimeout))).To(Succeed())
+
+		msg := []byte("hello")
+		_, err = conn.Write(msg)
+		g.Expect(err).NotTo(HaveOccurred(), "write should succeed")
+		buf := make([]byte, len(msg))
+		_, err = io.ReadFull(conn, buf)
+		g.Expect(err).NotTo(HaveOccurred(), "read should succeed")
+		g.Expect(string(buf)).To(Equal(string(msg)))
+		g.Expect(connectCount.Load()).To(Equal(int32(0)), "proxy should receive 0 CONNECT requests")
+	})
 }
 
 func TestIsCloudAPI(t *testing.T) {


### PR DESCRIPTION
## Summary

- The konnectivity sidecar's `dialDirectWithProxy()` reads `HTTPS_PROXY` from the process environment to route cloud API calls through the management cluster's outbound proxy when `ConnectDirectlyToCloudAPIs` is enabled. The sidecar container spec never set these env vars, so cloud API calls fail on management clusters that require a proxy for outbound access.
- Add `proxy.SetEnvVars()` in `buildContainer()` conditioned on `ConnectDirectlyToCloudAPIs` — the only code path that needs the management cluster proxy env vars. This follows the same pattern used by other CPO-managed containers (KCM, CCO, CAPI provider, etc.).
- Add network-level tests for `dialDirectWithProxy()` with a real TCP echo server and HTTP CONNECT proxy to verify the proxy routing behavior end-to-end.

## Test plan

- [ ] Unit tests pass: `go test ./support/controlplane-component/... ./support/konnectivityproxy/...`
- [ ] Tests pass with race detector: `go test -race ./support/controlplane-component/... ./support/konnectivityproxy/...`
- [ ] `make verify` passes
- [ ] Deploy a private HCP cluster on a management cluster with an outbound proxy and verify ingress-operator can reach cloud APIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Konnectivity now conditionally propagates proxy environment variables when direct cloud-API connectivity is enabled, with safe defaults for unset or unsupported proxy modes.

* **Tests**
  * Added comprehensive unit and integration tests covering HTTPS, SOCKS5, dual-mode proxy behavior, preservation of NO_PROXY entries, presence of kubeconfig, and CONNECT-proxy dialing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->