### PR TITLE
OCPBUGS-86661: Konnectivity retry proxy connection on timeout

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/catalog-operator/AROSwift/zz_fixture_TestControlPlaneComponents_catalog_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/catalog-operator/AROSwift/zz_fixture_TestControlPlaneComponents_catalog_operator_deployment.yaml
@@ -144,6 +144,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/catalog-operator/GCP/zz_fixture_TestControlPlaneComponents_catalog_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/catalog-operator/GCP/zz_fixture_TestControlPlaneComponents_catalog_operator_deployment.yaml
@@ -154,6 +154,13 @@ spec:
             - ALL
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/catalog-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_catalog_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/catalog-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_catalog_operator_deployment.yaml
@@ -144,6 +144,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/catalog-operator/ModernTLS/zz_fixture_TestControlPlaneComponents_catalog_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/catalog-operator/ModernTLS/zz_fixture_TestControlPlaneComponents_catalog_operator_deployment.yaml
@@ -144,6 +144,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/catalog-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_catalog_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/catalog-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_catalog_operator_deployment.yaml
@@ -144,6 +144,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/catalog-operator/zz_fixture_TestControlPlaneComponents_catalog_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/catalog-operator/zz_fixture_TestControlPlaneComponents_catalog_operator_deployment.yaml
@@ -144,6 +144,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_network_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/AROSwift/zz_fixture_TestControlPlaneComponents_cluster_network_operator_deployment.yaml
@@ -224,6 +224,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_network_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/GCP/zz_fixture_TestControlPlaneComponents_cluster_network_operator_deployment.yaml
@@ -238,6 +238,13 @@ spec:
             - ALL
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_network_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_cluster_network_operator_deployment.yaml
@@ -222,6 +222,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/ModernTLS/zz_fixture_TestControlPlaneComponents_cluster_network_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/ModernTLS/zz_fixture_TestControlPlaneComponents_cluster_network_operator_deployment.yaml
@@ -221,6 +221,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_network_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_cluster_network_operator_deployment.yaml
@@ -221,6 +221,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/zz_fixture_TestControlPlaneComponents_cluster_network_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/cluster-network-operator/zz_fixture_TestControlPlaneComponents_cluster_network_operator_deployment.yaml
@@ -221,6 +221,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/AROSwift/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/AROSwift/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
@@ -142,6 +142,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/GCP/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/GCP/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
@@ -149,6 +149,13 @@ spec:
             - ALL
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
@@ -137,6 +137,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/ModernTLS/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/ModernTLS/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
@@ -139,6 +139,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
@@ -139,6 +139,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/ingress-operator/zz_fixture_TestControlPlaneComponents_ingress_operator_deployment.yaml
@@ -139,6 +139,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/AROSwift/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/AROSwift/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
@@ -200,6 +200,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8092
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
@@ -228,6 +235,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/GCP/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/GCP/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
@@ -215,6 +215,13 @@ spec:
             - ALL
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8092
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
@@ -248,6 +255,13 @@ spec:
             - ALL
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/IBMCloud/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/IBMCloud/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
@@ -200,6 +200,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8092
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
@@ -228,6 +235,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/ModernTLS/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/ModernTLS/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
@@ -200,6 +200,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8092
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
@@ -228,6 +235,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
@@ -200,6 +200,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8092
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
@@ -228,6 +235,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/oauth-openshift/zz_fixture_TestControlPlaneComponents_oauth_openshift_deployment.yaml
@@ -200,6 +200,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8092
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig
@@ -228,6 +235,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-operator/AROSwift/zz_fixture_TestControlPlaneComponents_olm_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-operator/AROSwift/zz_fixture_TestControlPlaneComponents_olm_operator_deployment.yaml
@@ -140,6 +140,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-operator/GCP/zz_fixture_TestControlPlaneComponents_olm_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-operator/GCP/zz_fixture_TestControlPlaneComponents_olm_operator_deployment.yaml
@@ -150,6 +150,13 @@ spec:
             - ALL
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_olm_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-operator/IBMCloud/zz_fixture_TestControlPlaneComponents_olm_operator_deployment.yaml
@@ -140,6 +140,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-operator/ModernTLS/zz_fixture_TestControlPlaneComponents_olm_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-operator/ModernTLS/zz_fixture_TestControlPlaneComponents_olm_operator_deployment.yaml
@@ -140,6 +140,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_olm_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-operator/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_olm_operator_deployment.yaml
@@ -140,6 +140,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-operator/zz_fixture_TestControlPlaneComponents_olm_operator_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/olm-operator/zz_fixture_TestControlPlaneComponents_olm_operator_deployment.yaml
@@ -140,6 +140,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/AROSwift/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/AROSwift/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
@@ -236,6 +236,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/GCP/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/GCP/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
@@ -256,6 +256,13 @@ spec:
             - ALL
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/IBMCloud/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/IBMCloud/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
@@ -236,6 +236,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/ModernTLS/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/ModernTLS/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
@@ -236,6 +236,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
@@ -236,6 +236,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-apiserver/zz_fixture_TestControlPlaneComponents_openshift_apiserver_deployment.yaml
@@ -236,6 +236,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/AROSwift/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/AROSwift/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_controlplanecomponent.yaml
@@ -8,14 +8,13 @@ spec: {}
 status:
   conditions:
   - lastTransitionTime: null
-    message: openshift-oauth-apiserver Deployment Available condition not found
+    message: deployments.apps "openshift-oauth-apiserver" not found
     reason: NotFound
     status: "False"
     type: Available
   - lastTransitionTime: null
-    message: 'Waiting for deployment openshift-oauth-apiserver rollout to finish:
-      0 out of 3 new replicas have been updated'
-    reason: WaitingForRolloutComplete
+    message: 'Waiting for Dependencies: konnectivity-agent'
+    reason: WaitingForDependencies
     status: "False"
     type: RolloutComplete
   resources:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/GCP/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/GCP/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_controlplanecomponent.yaml
@@ -8,14 +8,13 @@ spec: {}
 status:
   conditions:
   - lastTransitionTime: null
-    message: openshift-oauth-apiserver Deployment Available condition not found
+    message: deployments.apps "openshift-oauth-apiserver" not found
     reason: NotFound
     status: "False"
     type: Available
   - lastTransitionTime: null
-    message: 'Waiting for deployment openshift-oauth-apiserver rollout to finish:
-      0 out of 3 new replicas have been updated'
-    reason: WaitingForRolloutComplete
+    message: 'Waiting for Dependencies: konnectivity-agent'
+    reason: WaitingForDependencies
     status: "False"
     type: RolloutComplete
   resources:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/IBMCloud/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/IBMCloud/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_controlplanecomponent.yaml
@@ -8,14 +8,13 @@ spec: {}
 status:
   conditions:
   - lastTransitionTime: null
-    message: openshift-oauth-apiserver Deployment Available condition not found
+    message: deployments.apps "openshift-oauth-apiserver" not found
     reason: NotFound
     status: "False"
     type: Available
   - lastTransitionTime: null
-    message: 'Waiting for deployment openshift-oauth-apiserver rollout to finish:
-      0 out of 3 new replicas have been updated'
-    reason: WaitingForRolloutComplete
+    message: 'Waiting for Dependencies: konnectivity-agent'
+    reason: WaitingForDependencies
     status: "False"
     type: RolloutComplete
   resources:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/ModernTLS/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/ModernTLS/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_controlplanecomponent.yaml
@@ -8,14 +8,13 @@ spec: {}
 status:
   conditions:
   - lastTransitionTime: null
-    message: openshift-oauth-apiserver Deployment Available condition not found
+    message: deployments.apps "openshift-oauth-apiserver" not found
     reason: NotFound
     status: "False"
     type: Available
   - lastTransitionTime: null
-    message: 'Waiting for deployment openshift-oauth-apiserver rollout to finish:
-      0 out of 3 new replicas have been updated'
-    reason: WaitingForRolloutComplete
+    message: 'Waiting for Dependencies: konnectivity-agent'
+    reason: WaitingForDependencies
     status: "False"
     type: RolloutComplete
   resources:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_controlplanecomponent.yaml
@@ -8,14 +8,13 @@ spec: {}
 status:
   conditions:
   - lastTransitionTime: null
-    message: openshift-oauth-apiserver Deployment Available condition not found
+    message: deployments.apps "openshift-oauth-apiserver" not found
     reason: NotFound
     status: "False"
     type: Available
   - lastTransitionTime: null
-    message: 'Waiting for deployment openshift-oauth-apiserver rollout to finish:
-      0 out of 3 new replicas have been updated'
-    reason: WaitingForRolloutComplete
+    message: 'Waiting for Dependencies: konnectivity-agent'
+    reason: WaitingForDependencies
     status: "False"
     type: RolloutComplete
   resources:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/openshift-oauth-apiserver/zz_fixture_TestControlPlaneComponents_openshift_oauth_apiserver_controlplanecomponent.yaml
@@ -8,14 +8,13 @@ spec: {}
 status:
   conditions:
   - lastTransitionTime: null
-    message: openshift-oauth-apiserver Deployment Available condition not found
+    message: deployments.apps "openshift-oauth-apiserver" not found
     reason: NotFound
     status: "False"
     type: Available
   - lastTransitionTime: null
-    message: 'Waiting for deployment openshift-oauth-apiserver rollout to finish:
-      0 out of 3 new replicas have been updated'
-    reason: WaitingForRolloutComplete
+    message: 'Waiting for Dependencies: konnectivity-agent'
+    reason: WaitingForDependencies
     status: "False"
     type: RolloutComplete
   resources:

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/AROSwift/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/AROSwift/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
@@ -185,6 +185,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/GCP/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/GCP/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
@@ -200,6 +200,13 @@ spec:
             - ALL
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/IBMCloud/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/IBMCloud/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
@@ -185,6 +185,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/ModernTLS/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/ModernTLS/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
@@ -184,6 +184,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
@@ -185,6 +185,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/packageserver/zz_fixture_TestControlPlaneComponents_packageserver_deployment.yaml
@@ -185,6 +185,13 @@ spec:
             memory: 30Mi
         securityContext:
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 30
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          tcpSocket:
+            port: 8090
+          timeoutSeconds: 1
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/kubernetes/secrets/kubeconfig

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/component_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth/component_test.go
@@ -1,4 +1,4 @@
-package packageserver
+package oauth
 
 import (
 	"testing"

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/component.go
@@ -2,6 +2,7 @@ package oapi
 
 import (
 	kasv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/kas"
+	konnectivityagent "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/konnectivity_agent"
 	oapiv2 "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/v2/oapi"
 	component "github.com/openshift/hypershift/support/controlplane-component"
 	"github.com/openshift/hypershift/support/podspec"
@@ -46,7 +47,7 @@ func NewComponent() component.ControlPlaneComponent {
 			"pdb.yaml",
 			component.AdaptPodDisruptionBudget(),
 		).
-		WithDependencies(oapiv2.ComponentName).
+		WithDependencies(oapiv2.ComponentName, konnectivityagent.ComponentName).
 		InjectAvailabilityProberContainer(podspec.AvailabilityProberOpts{}).
 		InjectKonnectivityContainer(component.KonnectivityContainerOptions{
 			Mode: component.Socks5,

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/component_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/oauth_apiserver/component_test.go
@@ -135,3 +135,12 @@ func TestPredicate(t *testing.T) {
 		})
 	}
 }
+
+func TestNewComponent(t *testing.T) {
+	t.Run("When creating component it should build successfully", func(t *testing.T) {
+		g := NewWithT(t)
+		component := NewComponent()
+		g.Expect(component).ToNot(BeNil())
+		g.Expect(component.Name()).To(Equal(ComponentName))
+	})
+}

--- a/konnectivity-socks5-proxy/guard.go
+++ b/konnectivity-socks5-proxy/guard.go
@@ -1,0 +1,266 @@
+package konnectivitysocks5proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/openshift/hypershift/support/konnectivityproxy"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/armon/go-socks5"
+	"github.com/go-logr/logr"
+)
+
+const (
+	defaultKonnectivityHost = "konnectivity-server-local"
+	defaultKonnectivityPort = 8090
+	konnectivityDialTimeout = 5 * time.Second
+)
+
+// coreGuardBackoffConfig holds exponential backoff parameters for konnectivity bootstrap and serve retries.
+type coreGuardBackoffConfig struct {
+	initialDelay time.Duration
+	factor       float64
+	jitter       float64
+	steps        int
+	cap          time.Duration
+}
+
+func (c coreGuardBackoffConfig) waitBackoff() wait.Backoff {
+	return wait.Backoff{
+		Duration: c.initialDelay,
+		Factor:   c.factor,
+		Jitter:   c.jitter,
+		Steps:    c.steps,
+		Cap:      c.cap,
+	}
+}
+
+var (
+	coreGuardBackoff = coreGuardBackoffConfig{
+		initialDelay: 1 * time.Second,
+		factor:       2.0,
+		jitter:       0.1,
+		steps:        5,
+		cap:          30 * time.Second,
+	}
+	dialKonnectivityServer     = dialKonnectivityServerTCP
+	bootstrapKonnectivityFn    = bootstrapKonnectivity
+	tryBootstrapKonnectivityFn = tryBootstrapKonnectivity
+	getConfigFn                = ctrl.GetConfig
+	newClientFn                = client.New
+)
+
+// runWithCoreGuard keeps the process alive while konnectivity infrastructure becomes
+// reachable, retrying transient failures with exponential backoff instead of exiting.
+func runWithCoreGuard(ctx context.Context, log logr.Logger, opts konnectivityproxy.Options, servingPort uint32, serve func(dialer konnectivityproxy.ProxyDialer) error) error {
+	delay := coreGuardBackoff.waitBackoff().DelayFunc()
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		dialer, err := bootstrapKonnectivityFn(ctx, log, opts)
+		if err != nil {
+			return err
+		}
+
+		log.Info("Konnectivity socks5 proxy bootstrap complete, starting server", "port", servingPort)
+		if err := serve(dialer); err != nil {
+			if !isTransientKonnectivityError(err) {
+				return fmt.Errorf("socks5 server exited: %w", err)
+			}
+			log.Error(err, "socks5 server stopped due to transient error, retrying")
+			sleepDuration := delay()
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(sleepDuration):
+				continue
+			}
+		}
+		return nil
+	}
+}
+
+// serveWithGracefulShutdown creates and runs a socks5 server with proper graceful shutdown handling.
+// It returns nil on clean shutdown (context cancellation), or an error if the server fails.
+func serveWithGracefulShutdown(ctx context.Context, dialer konnectivityproxy.ProxyDialer, servingPort uint32, log logr.Logger) error {
+	conf := &socks5.Config{
+		Dial:     dialer.DialContext,
+		Resolver: dialer,
+	}
+	server, err := socks5.New(conf)
+	if err != nil {
+		return fmt.Errorf("cannot create socks5 server: %w", err)
+	}
+
+	// Create listener explicitly for graceful shutdown
+	lc := &net.ListenConfig{}
+	listener, err := lc.Listen(ctx, "tcp", fmt.Sprintf(":%d", servingPort))
+	if err != nil {
+		return fmt.Errorf("cannot create listener: %w", err)
+	}
+
+	// Run server in goroutine
+	serveDone := make(chan error, 1)
+	go func() {
+		serveDone <- server.Serve(listener)
+	}()
+
+	// Wait for either context cancellation or serve error
+	select {
+	case <-ctx.Done():
+		// Graceful shutdown: close listener to stop accepting new connections
+		if err := listener.Close(); err != nil {
+			log.Error(err, "failed to close listener during shutdown")
+		}
+		// Wait for Serve to finish
+		<-serveDone
+		// Treat context cancellation as clean shutdown
+		return nil
+	case err := <-serveDone:
+		// Server stopped, return the error
+		return err
+	}
+}
+
+func bootstrapKonnectivity(ctx context.Context, log logr.Logger, opts konnectivityproxy.Options) (konnectivityproxy.ProxyDialer, error) {
+	// Create kube client once - client creation failures are permanent (missing files, bad config)
+	// and should not be retried. Only konnectivity server availability is retried.
+	cfg, err := getConfigFn()
+	if err != nil {
+		return nil, fmt.Errorf("cannot get client config: %w", err)
+	}
+
+	kubeClient, err := newClientFn(cfg, client.Options{})
+	if err != nil {
+		return nil, fmt.Errorf("cannot get client: %w", err)
+	}
+
+	opts.Client = kubeClient
+
+	delay := coreGuardBackoff.waitBackoff().DelayFunc()
+	attempt := 0
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		attempt++
+
+		d, err := tryBootstrapKonnectivityFn(ctx, opts)
+		if err == nil {
+			return d, nil
+		}
+		if !isTransientKonnectivityError(err) {
+			return nil, fmt.Errorf("konnectivity bootstrap failed: %w", err)
+		}
+
+		log.Error(err, "transient konnectivity bootstrap failure, retrying", "attempt", attempt)
+		sleepDuration := delay()
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(sleepDuration):
+			// Continue retry loop
+		}
+	}
+}
+
+func tryBootstrapKonnectivity(ctx context.Context, opts konnectivityproxy.Options) (konnectivityproxy.ProxyDialer, error) {
+	dialer, err := konnectivityproxy.NewKonnectivityDialer(opts)
+	if err != nil {
+		return nil, fmt.Errorf("cannot initialize konnectivity dialer: %w", err)
+	}
+
+	host := opts.KonnectivityHost
+	if host == "" {
+		host = defaultKonnectivityHost
+	}
+	port := opts.KonnectivityPort
+	if port == 0 {
+		port = defaultKonnectivityPort
+	}
+
+	if err := dialKonnectivityServer(ctx, host, port); err != nil {
+		return nil, fmt.Errorf("cannot dial konnectivity server at %s:%d: %w", host, port, err)
+	}
+
+	return dialer, nil
+}
+
+func dialKonnectivityServerTCP(ctx context.Context, host string, port uint32) error {
+	address := net.JoinHostPort(host, fmt.Sprintf("%d", port))
+	conn, err := (&net.Dialer{Timeout: konnectivityDialTimeout}).DialContext(ctx, "tcp", address)
+	if err != nil {
+		return err
+	}
+	_ = conn.Close()
+	return nil
+}
+
+func isTransientKonnectivityError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		if isTransientKonnectivityError(opErr.Err) {
+			return true
+		}
+	}
+
+	var syscallErr syscall.Errno
+	if errors.As(err, &syscallErr) {
+		switch syscallErr {
+		case syscall.ECONNREFUSED, syscall.ECONNRESET, syscall.ETIMEDOUT,
+			syscall.EHOSTUNREACH, syscall.ENETUNREACH, syscall.EPIPE:
+			return true
+		}
+	}
+
+	// Configuration errors such as missing certificate files should fail fast, not retry.
+	if errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+
+	msg := err.Error()
+	transientFragments := []string{
+		"connection refused",
+		"connection reset",
+		"i/o timeout",
+		"context deadline exceeded",
+		"no route to host",
+		"network is unreachable",
+		"operation timed out",
+		"TLS handshake timeout",
+	}
+	for _, fragment := range transientFragments {
+		if strings.Contains(msg, fragment) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/konnectivity-socks5-proxy/guard_test.go
+++ b/konnectivity-socks5-proxy/guard_test.go
@@ -1,0 +1,503 @@
+package konnectivitysocks5proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/support/konnectivityproxy"
+
+	"k8s.io/client-go/rest"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-logr/logr"
+)
+
+// mockProxyDialer implements konnectivityproxy.ProxyDialer interface
+type mockProxyDialer struct{}
+
+func (m *mockProxyDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return nil, nil
+}
+
+func (m *mockProxyDialer) Dial(network, address string) (net.Conn, error) {
+	return nil, nil
+}
+
+func (m *mockProxyDialer) Resolve(ctx context.Context, name string) (context.Context, net.IP, error) {
+	return ctx, net.ParseIP("127.0.0.1"), nil
+}
+
+func (m *mockProxyDialer) IsCloudAPI(host string) bool {
+	return false
+}
+
+func waitBackoffForTest() coreGuardBackoffConfig {
+	return coreGuardBackoffConfig{
+		initialDelay: 10 * time.Millisecond,
+		factor:       2.0,
+		cap:          50 * time.Millisecond,
+	}
+}
+
+// setupRunWithCoreGuardTest saves package-level variables and restores them via t.Cleanup.
+// Use this helper for tests that mock runWithCoreGuard behavior.
+func setupRunWithCoreGuardTest(t *testing.T) {
+	t.Helper()
+	originalBackoff := coreGuardBackoff
+	originalBootstrap := bootstrapKonnectivityFn
+
+	coreGuardBackoff = waitBackoffForTest()
+
+	t.Cleanup(func() {
+		coreGuardBackoff = originalBackoff
+		bootstrapKonnectivityFn = originalBootstrap
+	})
+}
+
+// setupBootstrapKonnectivityTest saves package-level variables and restores them via t.Cleanup.
+// Use this helper for tests that mock bootstrapKonnectivity behavior.
+func setupBootstrapKonnectivityTest(t *testing.T) {
+	t.Helper()
+	originalBackoff := coreGuardBackoff
+	originalTry := tryBootstrapKonnectivityFn
+	originalGetConfig := getConfigFn
+	originalNewClient := newClientFn
+
+	coreGuardBackoff = waitBackoffForTest()
+
+	// Stub getConfigFn and newClientFn to avoid environment dependency
+	getConfigFn = func() (*rest.Config, error) {
+		return &rest.Config{}, nil
+	}
+	newClientFn = func(config *rest.Config, options client.Options) (client.Client, error) {
+		return nil, nil // Return nil client - not used since tryBootstrapKonnectivityFn is mocked
+	}
+
+	t.Cleanup(func() {
+		coreGuardBackoff = originalBackoff
+		tryBootstrapKonnectivityFn = originalTry
+		getConfigFn = originalGetConfig
+		newClientFn = originalNewClient
+	})
+}
+
+func TestIsTransientKonnectivityError(t *testing.T) {
+	t.Run("When error is nil, it should not be transient", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		g.Expect(isTransientKonnectivityError(nil)).To(BeFalse())
+	})
+
+	t.Run("When error is context deadline exceeded, it should be transient", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		g.Expect(isTransientKonnectivityError(context.DeadlineExceeded)).To(BeTrue())
+	})
+
+	t.Run("When error is connection refused, it should be transient", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		g.Expect(isTransientKonnectivityError(fmt.Errorf("dial tcp: connection refused"))).To(BeTrue())
+	})
+
+	t.Run("When error is syscall ECONNREFUSED, it should be transient", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		g.Expect(isTransientKonnectivityError(syscall.ECONNREFUSED)).To(BeTrue())
+	})
+
+	t.Run("When error is syscall ECONNRESET, it should be transient", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		g.Expect(isTransientKonnectivityError(syscall.ECONNRESET)).To(BeTrue())
+	})
+
+	t.Run("When error is syscall ETIMEDOUT, it should be transient", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		g.Expect(isTransientKonnectivityError(syscall.ETIMEDOUT)).To(BeTrue())
+	})
+
+	t.Run("When error is syscall EHOSTUNREACH, it should be transient", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		g.Expect(isTransientKonnectivityError(syscall.EHOSTUNREACH)).To(BeTrue())
+	})
+
+	t.Run("When error is syscall ENETUNREACH, it should be transient", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		g.Expect(isTransientKonnectivityError(syscall.ENETUNREACH)).To(BeTrue())
+	})
+
+	t.Run("When error is syscall EPIPE, it should be transient", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		g.Expect(isTransientKonnectivityError(syscall.EPIPE)).To(BeTrue())
+	})
+
+	t.Run("When error is network timeout, it should be transient", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		timeoutErr := &net.OpError{Op: "dial", Err: errors.New("i/o timeout")}
+		g.Expect(isTransientKonnectivityError(timeoutErr)).To(BeTrue())
+	})
+
+	t.Run("When error contains TLS handshake timeout, it should be transient", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		g.Expect(isTransientKonnectivityError(errors.New("TLS handshake timeout"))).To(BeTrue())
+	})
+
+	t.Run("When error contains connection reset, it should be transient", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		g.Expect(isTransientKonnectivityError(errors.New("connection reset by peer"))).To(BeTrue())
+	})
+
+	t.Run("When error contains no route to host, it should be transient", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		g.Expect(isTransientKonnectivityError(errors.New("no route to host"))).To(BeTrue())
+	})
+
+	t.Run("When error contains network is unreachable, it should be transient", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		g.Expect(isTransientKonnectivityError(errors.New("network is unreachable"))).To(BeTrue())
+	})
+
+	t.Run("When error is validation failure, it should not be transient", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		g.Expect(isTransientKonnectivityError(errors.New("failed validation: KonnectivityHost is required"))).To(BeFalse())
+	})
+
+	t.Run("When error is file not found, it should not be transient", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		g.Expect(isTransientKonnectivityError(os.ErrNotExist)).To(BeFalse())
+	})
+
+	t.Run("When error is wrapped in OpError with syscall error, it should be transient", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		opErr := &net.OpError{Op: "dial", Err: syscall.ECONNREFUSED}
+		g.Expect(isTransientKonnectivityError(opErr)).To(BeTrue())
+	})
+}
+
+func TestDialKonnectivityServerTCP(t *testing.T) {
+	t.Run("When a local listener accepts connections, it should succeed", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		lc := &net.ListenConfig{}
+		ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+		g.Expect(err).ToNot(HaveOccurred())
+		defer ln.Close()
+
+		_, portStr, err := net.SplitHostPort(ln.Addr().String())
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var port uint32
+		_, err = fmt.Sscanf(portStr, "%d", &port)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(dialKonnectivityServerTCP(context.Background(), "127.0.0.1", port)).To(Succeed())
+	})
+}
+
+func TestDialKonnectivityServerTCP_ConnectionRefused(t *testing.T) {
+	t.Run("When port is not listening, it should return connection refused", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		// Try to connect to a port that's not listening (port 1 requires root)
+		err := dialKonnectivityServerTCP(context.Background(), "127.0.0.1", 54321)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(isTransientKonnectivityError(err)).To(BeTrue())
+	})
+
+	t.Run("When context is canceled during dial, it should abort immediately", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		// Use a non-routable address (RFC 5737 TEST-NET-1) to ensure dial blocks
+		// This guarantees the dial will timeout unless context cancellation works
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		start := time.Now()
+		err := dialKonnectivityServerTCP(ctx, "192.0.2.1", 9999)
+		elapsed := time.Since(start)
+
+		g.Expect(err).To(HaveOccurred())
+		// Should fail quickly (< 1 second) due to context cancellation, not wait for 5s timeout
+		g.Expect(elapsed).To(BeNumerically("<", 1*time.Second))
+		g.Expect(err.Error()).To(Or(ContainSubstring("context canceled"), ContainSubstring("operation was canceled")))
+	})
+}
+
+func TestCoreGuardBackoff(t *testing.T) {
+	t.Run("When using default backoff, it should have correct configuration", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		// Verify the default backoff configuration
+		g.Expect(coreGuardBackoff.initialDelay).To(Equal(1 * time.Second))
+		g.Expect(coreGuardBackoff.factor).To(Equal(2.0))
+		g.Expect(coreGuardBackoff.jitter).To(Equal(0.1))
+		g.Expect(coreGuardBackoff.steps).To(Equal(5))
+		g.Expect(coreGuardBackoff.cap).To(Equal(30 * time.Second))
+	})
+}
+
+func TestDefaultConstants(t *testing.T) {
+	t.Run("When using default host and port, they should have correct values", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		g.Expect(defaultKonnectivityHost).To(Equal("konnectivity-server-local"))
+		g.Expect(int(defaultKonnectivityPort)).To(Equal(8090))
+		g.Expect(konnectivityDialTimeout).To(Equal(5 * time.Second))
+	})
+}
+
+func TestRunWithCoreGuard(t *testing.T) {
+	t.Run("When serve succeeds immediately, it should return nil", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		setupRunWithCoreGuardTest(t)
+
+		mockDialer := &mockProxyDialer{}
+		bootstrapKonnectivityFn = func(ctx context.Context, log logr.Logger, opts konnectivityproxy.Options) (konnectivityproxy.ProxyDialer, error) {
+			return mockDialer, nil
+		}
+
+		serveCalled := false
+		mockServe := func(_ konnectivityproxy.ProxyDialer) error {
+			serveCalled = true
+			return nil
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		err := runWithCoreGuard(ctx, logr.Discard(), konnectivityproxy.Options{}, 8090, mockServe)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(serveCalled).To(BeTrue())
+	})
+
+	t.Run("When bootstrap fails permanently, it should return error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		setupRunWithCoreGuardTest(t)
+
+		permanentErr := errors.New("fatal bootstrap error")
+		bootstrapKonnectivityFn = func(ctx context.Context, log logr.Logger, opts konnectivityproxy.Options) (konnectivityproxy.ProxyDialer, error) {
+			return nil, permanentErr
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		err := runWithCoreGuard(ctx, logr.Discard(), konnectivityproxy.Options{}, 8090, func(_ konnectivityproxy.ProxyDialer) error {
+			return nil
+		})
+
+		g.Expect(err).To(Equal(permanentErr))
+	})
+
+	t.Run("When serve fails with transient error then succeeds, it should retry", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		setupRunWithCoreGuardTest(t)
+
+		mockDialer := &mockProxyDialer{}
+		bootstrapKonnectivityFn = func(ctx context.Context, log logr.Logger, opts konnectivityproxy.Options) (konnectivityproxy.ProxyDialer, error) {
+			return mockDialer, nil
+		}
+
+		attempts := 0
+		mockServe := func(_ konnectivityproxy.ProxyDialer) error {
+			attempts++
+			if attempts < 2 {
+				return syscall.ECONNREFUSED
+			}
+			return nil
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		err := runWithCoreGuard(ctx, logr.Discard(), konnectivityproxy.Options{}, 8090, mockServe)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(attempts).To(Equal(2))
+	})
+
+	t.Run("When serve fails with permanent error, it should fail fast", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		setupRunWithCoreGuardTest(t)
+
+		mockDialer := &mockProxyDialer{}
+		bootstrapKonnectivityFn = func(ctx context.Context, log logr.Logger, opts konnectivityproxy.Options) (konnectivityproxy.ProxyDialer, error) {
+			return mockDialer, nil
+		}
+
+		permanentErr := errors.New("invalid configuration")
+		mockServe := func(_ konnectivityproxy.ProxyDialer) error {
+			return permanentErr
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		err := runWithCoreGuard(ctx, logr.Discard(), konnectivityproxy.Options{}, 8090, mockServe)
+
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("invalid configuration"))
+	})
+
+	t.Run("When context is canceled during bootstrap, it should return context error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		setupRunWithCoreGuardTest(t)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		err := runWithCoreGuard(ctx, logr.Discard(), konnectivityproxy.Options{}, 8090, func(_ konnectivityproxy.ProxyDialer) error {
+			return nil
+		})
+
+		g.Expect(err).To(Equal(context.Canceled))
+	})
+}
+
+func TestBootstrapKonnectivity(t *testing.T) {
+	t.Run("When tryBootstrap succeeds immediately, it should return dialer", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		setupBootstrapKonnectivityTest(t)
+
+		mockDialer := &mockProxyDialer{}
+		tryBootstrapKonnectivityFn = func(ctx context.Context, opts konnectivityproxy.Options) (konnectivityproxy.ProxyDialer, error) {
+			return mockDialer, nil
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		dialer, err := bootstrapKonnectivity(ctx, logr.Discard(), konnectivityproxy.Options{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(dialer).To(Equal(mockDialer))
+	})
+
+	t.Run("When tryBootstrap fails with transient error then succeeds, it should retry", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		setupBootstrapKonnectivityTest(t)
+
+		attempts := 0
+		mockDialer := &mockProxyDialer{}
+		tryBootstrapKonnectivityFn = func(ctx context.Context, opts konnectivityproxy.Options) (konnectivityproxy.ProxyDialer, error) {
+			attempts++
+			if attempts < 3 {
+				return nil, syscall.ECONNREFUSED
+			}
+			return mockDialer, nil
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		dialer, err := bootstrapKonnectivity(ctx, logr.Discard(), konnectivityproxy.Options{})
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(dialer).To(Equal(mockDialer))
+		g.Expect(attempts).To(Equal(3))
+	})
+
+	t.Run("When tryBootstrap fails with permanent error, it should fail fast", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		setupBootstrapKonnectivityTest(t)
+
+		permanentErr := os.ErrNotExist
+		tryBootstrapKonnectivityFn = func(ctx context.Context, opts konnectivityproxy.Options) (konnectivityproxy.ProxyDialer, error) {
+			return nil, permanentErr
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		dialer, err := bootstrapKonnectivity(ctx, logr.Discard(), konnectivityproxy.Options{})
+
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(dialer).To(BeNil())
+		g.Expect(err.Error()).To(ContainSubstring("konnectivity bootstrap failed"))
+	})
+
+	t.Run("When context is canceled, it should return context error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		setupBootstrapKonnectivityTest(t)
+
+		tryBootstrapKonnectivityFn = func(ctx context.Context, opts konnectivityproxy.Options) (konnectivityproxy.ProxyDialer, error) {
+			time.Sleep(100 * time.Millisecond)
+			return nil, syscall.ECONNREFUSED
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		dialer, err := bootstrapKonnectivity(ctx, logr.Discard(), konnectivityproxy.Options{})
+
+		g.Expect(err).To(Equal(context.Canceled))
+		g.Expect(dialer).To(BeNil())
+	})
+
+	t.Run("When context is canceled during sleep, it should exit immediately", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		originalBackoff := coreGuardBackoff
+		originalTry := tryBootstrapKonnectivityFn
+		originalGetConfig := getConfigFn
+		originalNewClient := newClientFn
+		t.Cleanup(func() {
+			coreGuardBackoff = originalBackoff
+			tryBootstrapKonnectivityFn = originalTry
+			getConfigFn = originalGetConfig
+			newClientFn = originalNewClient
+		})
+
+		// Stub client creation to avoid environment dependency
+		getConfigFn = func() (*rest.Config, error) {
+			return &rest.Config{}, nil
+		}
+		newClientFn = func(config *rest.Config, options client.Options) (client.Client, error) {
+			return nil, nil
+		}
+
+		// Use a backoff with long delays to ensure we're testing cancellation during sleep
+		coreGuardBackoff = coreGuardBackoffConfig{
+			initialDelay: 5 * time.Second,
+			factor:       1.0,
+			jitter:       0.0,
+			steps:        1,
+			cap:          5 * time.Second,
+		}
+
+		attempts := 0
+		tryBootstrapKonnectivityFn = func(ctx context.Context, opts konnectivityproxy.Options) (konnectivityproxy.ProxyDialer, error) {
+			attempts++
+			return nil, syscall.ECONNREFUSED // Always fail with transient error
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		// Start bootstrap in a goroutine
+		errChan := make(chan error, 1)
+		go func() {
+			_, err := bootstrapKonnectivity(ctx, logr.Discard(), konnectivityproxy.Options{})
+			errChan <- err
+		}()
+
+		// Wait a bit for first attempt to happen
+		time.Sleep(50 * time.Millisecond)
+
+		// Cancel context during sleep
+		cancel()
+
+		// Should exit quickly (much faster than the 5 second sleep)
+		select {
+		case err := <-errChan:
+			g.Expect(err).To(Equal(context.Canceled))
+			g.Expect(attempts).To(Equal(1)) // Should have only attempted once
+		case <-time.After(1 * time.Second):
+			g.Fail("Context cancellation did not interrupt sleep")
+		}
+	})
+}

--- a/konnectivity-socks5-proxy/main.go
+++ b/konnectivity-socks5-proxy/main.go
@@ -1,18 +1,18 @@
 package konnectivitysocks5proxy
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/openshift/hypershift/support/konnectivityproxy"
 	"github.com/openshift/hypershift/support/supportedversion"
 
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
-	"github.com/armon/go-socks5"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap/zapcore"
 )
@@ -52,32 +52,21 @@ func NewStartCommand() *cobra.Command {
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		l.Info("Starting proxy", "version", supportedversion.String())
-		client, err := client.New(ctrl.GetConfigOrDie(), client.Options{})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: cannot get client: %v", err)
-			os.Exit(1)
-		}
-
-		opts.Client = client
 		opts.Log = l
 
-		dialer, err := konnectivityproxy.NewKonnectivityDialer(opts)
+		ctx := signals.SetupSignalHandler()
+
+		err := runWithCoreGuard(ctx, l, opts, servingPort, func(dialer konnectivityproxy.ProxyDialer) error {
+			return serveWithGracefulShutdown(ctx, dialer, servingPort, l)
+		})
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: cannot initialize konnectivity dialer: %v", err)
+			// Treat context cancellation/timeout as clean shutdown (triggered by signals)
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				l.Info("Shutting down gracefully")
+				return
+			}
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
-		}
-
-		conf := &socks5.Config{
-			Dial:     dialer.DialContext,
-			Resolver: dialer,
-		}
-		server, err := socks5.New(conf)
-		if err != nil {
-			panic(err)
-		}
-
-		if err := server.ListenAndServe("tcp", fmt.Sprintf(":%d", servingPort)); err != nil {
-			panic(err)
 		}
 	}
 

--- a/konnectivity-socks5-proxy/main_test.go
+++ b/konnectivity-socks5-proxy/main_test.go
@@ -1,0 +1,125 @@
+package konnectivitysocks5proxy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
+)
+
+func TestNewStartCommand(t *testing.T) {
+	t.Run("When creating start command, it should have correct structure", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		cmd := NewStartCommand()
+
+		g.Expect(cmd).ToNot(BeNil())
+		g.Expect(cmd.Use).To(Equal("konnectivity-socks5-proxy"))
+		g.Expect(cmd.Short).To(ContainSubstring("konnectivity socks5 proxy"))
+		g.Expect(cmd.Run).ToNot(BeNil())
+	})
+
+	t.Run("When command has flags, it should have all required flags", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		cmd := NewStartCommand()
+
+		// Check that all expected flags are present
+		flags := []string{
+			"konnectivity-hostname",
+			"konnectivity-port",
+			"serving-port",
+			"connect-directly-to-cloud-apis",
+			"resolve-from-guest-cluster-dns",
+			"resolve-from-management-cluster-dns",
+			"disable-resolver",
+			"ca-cert-path",
+			"tls-cert-path",
+			"tls-key-path",
+		}
+
+		for _, flagName := range flags {
+			flag := cmd.Flags().Lookup(flagName)
+			g.Expect(flag).ToNot(BeNil(), "Flag %s should exist", flagName)
+		}
+	})
+
+	t.Run("When checking flag defaults, they should be correct", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		cmd := NewStartCommand()
+
+		// Check default values
+		hostnameFlag := cmd.Flags().Lookup("konnectivity-hostname")
+		g.Expect(hostnameFlag.DefValue).To(Equal("konnectivity-server-local"))
+
+		konnectivityPortFlag := cmd.Flags().Lookup("konnectivity-port")
+		g.Expect(konnectivityPortFlag.DefValue).To(Equal("8090"))
+
+		servingPortFlag := cmd.Flags().Lookup("serving-port")
+		g.Expect(servingPortFlag.DefValue).To(Equal("8090"))
+
+		caPathFlag := cmd.Flags().Lookup("ca-cert-path")
+		g.Expect(caPathFlag.DefValue).To(Equal("/etc/konnectivity/proxy-ca/ca.crt"))
+
+		tlsCertFlag := cmd.Flags().Lookup("tls-cert-path")
+		g.Expect(tlsCertFlag.DefValue).To(Equal("/etc/konnectivity/proxy-client/tls.crt"))
+
+		tlsKeyFlag := cmd.Flags().Lookup("tls-key-path")
+		g.Expect(tlsKeyFlag.DefValue).To(Equal("/etc/konnectivity/proxy-client/tls.key"))
+	})
+
+	t.Run("When checking boolean flag defaults, they should be false", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		cmd := NewStartCommand()
+
+		boolFlags := []string{
+			"connect-directly-to-cloud-apis",
+			"resolve-from-guest-cluster-dns",
+			"resolve-from-management-cluster-dns",
+			"disable-resolver",
+		}
+
+		for _, flagName := range boolFlags {
+			flag := cmd.Flags().Lookup(flagName)
+			g.Expect(flag.DefValue).To(Equal("false"), "Flag %s should default to false", flagName)
+		}
+	})
+
+	t.Run("When validating graceful shutdown behavior in serve function", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		// This test verifies that serveWithGracefulShutdown respects context cancellation
+		// by checking that it returns nil (clean shutdown) when context is canceled
+
+		// Create a mock dialer (minimal implementation)
+		mockDialer := &mockProxyDialer{}
+
+		// Test context cancellation leads to clean shutdown
+		ctx, cancel := context.WithCancel(context.Background())
+
+		// Start the server in a goroutine
+		errChan := make(chan error, 1)
+		go func() {
+			errChan <- serveWithGracefulShutdown(ctx, mockDialer, 0, logr.Discard()) // Port 0 = random available port
+		}()
+
+		// Give server time to start
+		time.Sleep(50 * time.Millisecond)
+
+		// Cancel context (simulating SIGTERM)
+		cancel()
+
+		// Server should shut down cleanly (return nil)
+		select {
+		case err := <-errChan:
+			g.Expect(err).To(BeNil(), "Context cancellation should result in clean shutdown (nil error)")
+		case <-time.After(1 * time.Second):
+			g.Fail("Server did not shut down within timeout")
+		}
+	})
+}

--- a/support/controlplane-component/konnectivity-container.go
+++ b/support/controlplane-component/konnectivity-container.go
@@ -14,14 +14,16 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 )
 
 type ProxyMode string
 
 const (
-	Socks5 ProxyMode = "socks5"
-	HTTPS  ProxyMode = "https"
+	Socks5             ProxyMode = "socks5"
+	HTTPS              ProxyMode = "https"
+	DefaultServingPort int32     = 8090
 
 	// Dual mode will inject 2 konnectivity containers, one using HTTPS mode and the other using Socks5 mode.
 	Dual ProxyMode = "dual"
@@ -198,6 +200,18 @@ func (opts KonnectivityContainerOptions) buildContainer(hcp *hyperv1.HostedContr
 		kubeconfingVolumeName = "kubeconfig"
 	}
 
+	servingPort := DefaultServingPort
+	switch opts.Mode {
+	case HTTPS:
+		if opts.HTTPSOptions.ServingPort != 0 {
+			servingPort = int32(opts.HTTPSOptions.ServingPort)
+		}
+	case Socks5:
+		if opts.Socks5Options.ServingPort != 0 {
+			servingPort = int32(opts.Socks5Options.ServingPort)
+		}
+	}
+
 	container := corev1.Container{
 		Name:    fmt.Sprintf("konnectivity-proxy-%s", opts.Mode),
 		Image:   image,
@@ -214,6 +228,17 @@ func (opts KonnectivityContainerOptions) buildContainer(hcp *hyperv1.HostedContr
 			Name:  "KUBECONFIG",
 			Value: "/etc/kubernetes/secrets/kubeconfig/kubeconfig",
 		}},
+		StartupProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.FromInt32(servingPort),
+				},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       2,
+			FailureThreshold:    30,
+			TimeoutSeconds:      1,
+		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      kubeconfingVolumeName,

--- a/support/controlplane-component/konnectivity-container_test.go
+++ b/support/controlplane-component/konnectivity-container_test.go
@@ -8,10 +8,184 @@ import (
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/api/util/ipnet"
+	"github.com/openshift/hypershift/support/testutil"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 )
+
+func TestKonnectivityContainerBuildContainer_Socks5StartupProbe(t *testing.T) {
+	t.Run("When building socks5 container with default port, it should have TCP startup probe on DefaultServingPort", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		opts := KonnectivityContainerOptions{
+			Mode: Socks5,
+			Socks5Options: Socks5Options{
+				ResolveFromGuestClusterDNS: ptr.To(true),
+			},
+		}
+
+		hcp := &hyperv1.HostedControlPlane{}
+		container := opts.buildContainer(hcp, "test-image", nil)
+
+		g.Expect(container.Name).To(Equal("konnectivity-proxy-socks5"))
+		g.Expect(container.Image).To(Equal("test-image"))
+		g.Expect(container.StartupProbe).ToNot(BeNil())
+		g.Expect(container.StartupProbe.TCPSocket).ToNot(BeNil())
+		g.Expect(container.StartupProbe.TCPSocket.Port).To(Equal(intstr.FromInt32(DefaultServingPort)))
+		g.Expect(container.StartupProbe.InitialDelaySeconds).To(Equal(int32(5)))
+		g.Expect(container.StartupProbe.PeriodSeconds).To(Equal(int32(2)))
+		g.Expect(container.StartupProbe.FailureThreshold).To(Equal(int32(30)))
+		g.Expect(container.StartupProbe.TimeoutSeconds).To(Equal(int32(1)))
+	})
+
+	t.Run("When building socks5 container with custom port, it should have TCP startup probe on custom port", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		opts := KonnectivityContainerOptions{
+			Mode: Socks5,
+			Socks5Options: Socks5Options{
+				ServingPort: 9999,
+			},
+		}
+
+		hcp := &hyperv1.HostedControlPlane{}
+		container := opts.buildContainer(hcp, "test-image", nil)
+
+		g.Expect(container.StartupProbe).ToNot(BeNil())
+		g.Expect(container.StartupProbe.TCPSocket.Port).To(Equal(intstr.FromInt32(9999)))
+	})
+}
+
+func TestKonnectivityContainerBuildContainer_HTTPSStartupProbe(t *testing.T) {
+	t.Run("When building HTTPS container with default port, it should have TCP startup probe on DefaultServingPort", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		opts := KonnectivityContainerOptions{
+			Mode: HTTPS,
+		}
+
+		hcp := &hyperv1.HostedControlPlane{}
+		container := opts.buildContainer(hcp, "test-image", nil)
+
+		g.Expect(container.Name).To(Equal("konnectivity-proxy-https"))
+		g.Expect(container.StartupProbe).ToNot(BeNil())
+		g.Expect(container.StartupProbe.TCPSocket.Port).To(Equal(intstr.FromInt32(DefaultServingPort)))
+	})
+
+	t.Run("When building HTTPS container with custom port, it should have TCP startup probe on custom port", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		opts := KonnectivityContainerOptions{
+			Mode: HTTPS,
+			HTTPSOptions: HTTPSOptions{
+				ServingPort: 8092,
+			},
+		}
+
+		hcp := &hyperv1.HostedControlPlane{}
+		container := opts.buildContainer(hcp, "test-image", nil)
+
+		g.Expect(container.StartupProbe.TCPSocket.Port).To(Equal(intstr.FromInt32(8092)))
+	})
+}
+
+func TestKonnectivityContainerBuildContainer_Args(t *testing.T) {
+	t.Run("When building socks5 container with resolve flags, it should include correct args", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		opts := KonnectivityContainerOptions{
+			Mode: Socks5,
+			Socks5Options: Socks5Options{
+				KonnectivityHost:                "custom-host",
+				KonnectivityPort:                9000,
+				ServingPort:                     8888,
+				ResolveFromGuestClusterDNS:      ptr.To(true),
+				ResolveFromManagementClusterDNS: ptr.To(false),
+				DisableResolver:                 ptr.To(false),
+			},
+		}
+
+		hcp := &hyperv1.HostedControlPlane{}
+		container := opts.buildContainer(hcp, "test-image", nil)
+
+		g.Expect(container.Args).To(ContainElement("--konnectivity-hostname=custom-host"))
+		g.Expect(container.Args).To(ContainElement("--konnectivity-port=9000"))
+		g.Expect(container.Args).To(ContainElement("--serving-port=8888"))
+		g.Expect(container.Args).To(ContainElement("--resolve-from-guest-cluster-dns=true"))
+		g.Expect(container.Args).To(ContainElement("--resolve-from-management-cluster-dns=false"))
+		g.Expect(container.Args).To(ContainElement("--disable-resolver=false"))
+	})
+
+	t.Run("When building HTTPS container with cloud API bypass, it should include correct args", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		opts := KonnectivityContainerOptions{
+			Mode: HTTPS,
+			HTTPSOptions: HTTPSOptions{
+				ConnectDirectlyToCloudAPIs: ptr.To(true),
+			},
+		}
+
+		hcp := &hyperv1.HostedControlPlane{}
+		container := opts.buildContainer(hcp, "test-image", nil)
+
+		g.Expect(container.Args).To(ContainElement("--connect-directly-to-cloud-apis=true"))
+	})
+}
+
+func TestKonnectivityContainerInjectKonnectivityContainer(t *testing.T) {
+	t.Run("When injecting socks5 container into podspec, it should add container and volumes", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		opts := KonnectivityContainerOptions{
+			Mode: Socks5,
+		}
+
+		hcp := &hyperv1.HostedControlPlane{}
+		podSpec := &corev1.PodSpec{}
+
+		cpContext := ControlPlaneContext{
+			HCP:                  hcp,
+			ReleaseImageProvider: testutil.FakeImageProvider(),
+		}
+
+		opts.injectKonnectivityContainer(cpContext, podSpec)
+
+		g.Expect(podSpec.Containers).To(HaveLen(1))
+		g.Expect(podSpec.Containers[0].Name).To(Equal("konnectivity-proxy-socks5"))
+		g.Expect(podSpec.Containers[0].StartupProbe).ToNot(BeNil())
+
+		g.Expect(podSpec.Volumes).To(HaveLen(2))
+		g.Expect(podSpec.Volumes[0].Name).To(Equal("konnectivity-proxy-cert"))
+		g.Expect(podSpec.Volumes[1].Name).To(Equal("konnectivity-proxy-ca"))
+	})
+
+	t.Run("When injecting Dual mode into podspec, it should add both HTTPS and Socks5 containers", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		opts := KonnectivityContainerOptions{
+			Mode: Dual,
+		}
+
+		hcp := &hyperv1.HostedControlPlane{}
+		podSpec := &corev1.PodSpec{}
+
+		cpContext := ControlPlaneContext{
+			HCP:                  hcp,
+			ReleaseImageProvider: testutil.FakeImageProvider(),
+		}
+
+		opts.injectKonnectivityContainer(cpContext, podSpec)
+
+		g.Expect(podSpec.Containers).To(HaveLen(2))
+		g.Expect(podSpec.Containers[0].Name).To(Equal("konnectivity-proxy-https"))
+		g.Expect(podSpec.Containers[0].StartupProbe).ToNot(BeNil())
+		g.Expect(podSpec.Containers[1].Name).To(Equal("konnectivity-proxy-socks5"))
+		g.Expect(podSpec.Containers[1].StartupProbe).ToNot(BeNil())
+	})
+}
 
 func findEnvVar(envVars []corev1.EnvVar, name string) *corev1.EnvVar {
 	for i := range envVars {


### PR DESCRIPTION
This PR fixes the intermittent E2E test failures where the konnectivity-proxy-socks5 sidecar container crashes and restarts during cluster bootstrap. Fix includes retry loop, native Kubernetes startup probes, and explicit component dependency ordering.
Proxy Internal Retry Logic
- Added a new retry infrastructure with exponential backoff to handle transient connection errors safely. The container process now stays alive while waiting for the network tunnel to become available.

Native Startup Probes
konnectivity-container.go: Added a native TCP startup probe to all Konnectivity sidecar containers. This gives the sidecars a safe 60-second window to initialize during cluster bootstrap before any readiness or liveness checks trigger.

Component Dependency Ordering
Deployment graph is updated with dependency check. The openshift-oauth-apiserver pods will now explicitly wait for the konnectivity-agent to be completely Available and RolloutComplete before they begin scheduling.

Test Fixtures are updated accordingly 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic recovery for temporary Konnectivity connection and startup failures.
  - Added graceful shutdown handling for the SOCKS5 proxy.
  - Added startup health checks for Konnectivity containers, including support for custom serving ports.
  - Integrated Konnectivity as a dependency of the OAuth API server.

- **Bug Fixes**
  - Improved error handling to distinguish retryable failures from permanent errors.

- **Tests**
  - Expanded coverage for retries, shutdown, health checks, configuration, and component initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->