### PR TITLE
OCPBUGS-86494: fix(nodepool): preserve KubeVirt userdata Secrets during NodePool rollout

### DIFF
--- a/hypershift-operator/controllers/nodepool/secret_janitor.go
+++ b/hypershift-operator/controllers/nodepool/secret_janitor.go
@@ -169,19 +169,26 @@ func (r *secretJanitor) Reconcile(ctx context.Context, req reconcile.Request) (r
 }
 
 // shouldKeepOldUserData determines if the old user data should be kept.
-// For KubeVirt, we always keep the old userdata Secret: it is shared by all VMs in the
-// NodePool generation and must not be removed while any of them are still running.
-// For AWS < 4.16, we keep the old userdata Secret so old Machines during rolled out can be deleted.
-// Otherwise, deletion fails because of https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3805.
-// TODO (alberto): Drop this check when support for old versions without the fix is not needed anymore.
+// KubeVirt: the Secret is shared by all VMs in the NodePool generation and must
+// survive until the rollout completes and all old VMs are gone. This is an
+// architectural requirement, not a temporary workaround.
+// AWS: deletion fails on CAPA < v2.2.0 (OCP < 4.16) because of
+// https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3805.
+// TODO (Alberto): remove the AWS guard when OCP < 4.16 support is dropped.
 func (r *NodePoolReconciler) shouldKeepOldUserData(ctx context.Context, hc *hyperv1.HostedCluster) (bool, error) {
-	if hc.Spec.Platform.Type == hyperv1.KubevirtPlatform {
+	switch hc.Spec.Platform.Type {
+	case hyperv1.KubevirtPlatform:
 		return true, nil
-	}
-	if hc.Spec.Platform.Type != hyperv1.AWSPlatform {
+	case hyperv1.AWSPlatform:
+		return r.shouldKeepOldUserDataAWS(ctx, hc)
+	default:
 		return false, nil
 	}
+}
 
+// shouldKeepOldUserDataAWS checks whether the AWS hosted cluster version is old
+// enough to require preserving the previous userdata Secret during rollout.
+func (r *NodePoolReconciler) shouldKeepOldUserDataAWS(ctx context.Context, hc *hyperv1.HostedCluster) (bool, error) {
 	// If there's a current version in status, be conservative and assume that one is the one running CAPA.
 	releaseImage := hc.Spec.Release.Image
 	if hc.Status.Version != nil {

--- a/hypershift-operator/controllers/nodepool/secret_janitor.go
+++ b/hypershift-operator/controllers/nodepool/secret_janitor.go
@@ -169,10 +169,15 @@ func (r *secretJanitor) Reconcile(ctx context.Context, req reconcile.Request) (r
 }
 
 // shouldKeepOldUserData determines if the old user data should be kept.
+// For KubeVirt, we always keep the old userdata Secret: it is shared by all VMs in the
+// NodePool generation and must not be removed while any of them are still running.
 // For AWS < 4.16, we keep the old userdata Secret so old Machines during rolled out can be deleted.
 // Otherwise, deletion fails because of https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3805.
 // TODO (alberto): Drop this check when support for old versions without the fix is not needed anymore.
 func (r *NodePoolReconciler) shouldKeepOldUserData(ctx context.Context, hc *hyperv1.HostedCluster) (bool, error) {
+	if hc.Spec.Platform.Type == hyperv1.KubevirtPlatform {
+		return true, nil
+	}
 	if hc.Spec.Platform.Type != hyperv1.AWSPlatform {
 		return false, nil
 	}

--- a/hypershift-operator/controllers/nodepool/secret_janitor_test.go
+++ b/hypershift-operator/controllers/nodepool/secret_janitor_test.go
@@ -484,7 +484,7 @@ func TestShouldKeepOldUserData(t *testing.T) {
 		expected             bool
 	}{
 		{
-			name: "when hosted cluster is not aws it should NOT keep old user data",
+			name: "when hosted cluster is not aws or kubevirt it should NOT keep old user data",
 			hc: &hyperv1.HostedCluster{
 				TypeMeta: metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{
@@ -505,6 +505,29 @@ func TestShouldKeepOldUserData(t *testing.T) {
 			},
 			releaseProvider: releaseinfo.NewMockProviderWithRegistryOverrides(mockCtrl),
 			expected:        false,
+		},
+		{
+			name: "when hosted cluster is kubevirt it should keep old user data",
+			hc: &hyperv1.HostedCluster{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: pullSecret.Namespace,
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					PullSecret: corev1.LocalObjectReference{
+						Name: pullSecret.Name,
+					},
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.KubevirtPlatform,
+					},
+					Release: hyperv1.Release{
+						Image: "fake-release-image",
+					},
+				},
+				Status: hyperv1.HostedClusterStatus{},
+			},
+			releaseProvider: releaseinfo.NewMockProviderWithRegistryOverrides(mockCtrl),
+			expected:        true,
 		},
 		{
 			name: "when hosted cluster is less than 4.16 it should keep user data",

--- a/hypershift-operator/controllers/nodepool/token.go
+++ b/hypershift-operator/controllers/nodepool/token.go
@@ -187,10 +187,12 @@ func (t *Token) cleanupOutdated(ctx context.Context) error {
 		}
 	}
 
-	// For AWS, we keep the old userdata Secret so old Machines during rolled out can be deleted.
-	// Otherwise, deletion fails because of https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3805.
+	// For AWS and KubeVirt, we keep the old userdata Secret so old Machines during rollout can be deleted.
+	// AWS: deletion fails because of https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3805.
+	// KubeVirt: the Secret is shared by all VMs in the NodePool generation and must survive until
+	// the rollout completes and all old VMs are gone.
 	// TODO (Alberto): enable back deletion when the PR above gets merged.
-	if t.nodePool.Spec.Platform.Type != hyperv1.AWSPlatform {
+	if t.nodePool.Spec.Platform.Type != hyperv1.AWSPlatform && t.nodePool.Spec.Platform.Type != hyperv1.KubevirtPlatform {
 		userDataSecret := t.outdatedUserDataSecret()
 		err = t.Get(ctx, client.ObjectKeyFromObject(userDataSecret), userDataSecret)
 		if err != nil && !apierrors.IsNotFound(err) {

--- a/hypershift-operator/controllers/nodepool/token.go
+++ b/hypershift-operator/controllers/nodepool/token.go
@@ -188,10 +188,12 @@ func (t *Token) cleanupOutdated(ctx context.Context) error {
 	}
 
 	// For AWS and KubeVirt, we keep the old userdata Secret so old Machines during rollout can be deleted.
-	// AWS: deletion fails because of https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3805.
-	// KubeVirt: the Secret is shared by all VMs in the NodePool generation and must survive until
-	// the rollout completes and all old VMs are gone.
-	// TODO (Alberto): enable back deletion when the PR above gets merged.
+	// AWS: deletion fails on CAPA < v2.2.0 (OCP < 4.16) because of
+	// https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3805.
+	// TODO (Alberto): remove the AWS guard when OCP < 4.16 support is dropped.
+	// KubeVirt: the Secret is shared by all VMs in the NodePool generation and must
+	// survive until the rollout completes and all old VMs are gone. This is an
+	// architectural requirement, not a temporary workaround.
 	if t.nodePool.Spec.Platform.Type != hyperv1.AWSPlatform && t.nodePool.Spec.Platform.Type != hyperv1.KubevirtPlatform {
 		userDataSecret := t.outdatedUserDataSecret()
 		err = t.Get(ctx, client.ObjectKeyFromObject(userDataSecret), userDataSecret)

--- a/hypershift-operator/controllers/nodepool/token_test.go
+++ b/hypershift-operator/controllers/nodepool/token_test.go
@@ -434,6 +434,58 @@ func TestTokenCleanupOutdated(t *testing.T) {
 			},
 			expectedError: "",
 		},
+		{
+			name: "When platform is KubeVirt, outdated userdata secret should be preserved and token secret should get an expiration timestamp",
+			token: &Token{
+				ConfigGenerator: &ConfigGenerator{
+					nodePool: &hyperv1.NodePool{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: nodePoolName,
+							Annotations: map[string]string{
+								nodePoolAnnotationCurrentConfigVersion: outdatedHash,
+							},
+						},
+						Spec: hyperv1.NodePoolSpec{
+							Platform: hyperv1.NodePoolPlatform{
+								Type: hyperv1.KubevirtPlatform,
+							},
+						},
+					},
+					controlplaneNamespace: controlplaneNamespace,
+				},
+			},
+			fakeObjects: []crclient.Object{
+				userdataSecret.DeepCopy(),
+				tokenSecret.DeepCopy(),
+			},
+			expectedError: "",
+		},
+		{
+			name: "When platform is AWS, outdated userdata secret should be preserved and token secret should get an expiration timestamp",
+			token: &Token{
+				ConfigGenerator: &ConfigGenerator{
+					nodePool: &hyperv1.NodePool{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: nodePoolName,
+							Annotations: map[string]string{
+								nodePoolAnnotationCurrentConfigVersion: outdatedHash,
+							},
+						},
+						Spec: hyperv1.NodePoolSpec{
+							Platform: hyperv1.NodePoolPlatform{
+								Type: hyperv1.AWSPlatform,
+							},
+						},
+					},
+					controlplaneNamespace: controlplaneNamespace,
+				},
+			},
+			fakeObjects: []crclient.Object{
+				userdataSecret.DeepCopy(),
+				tokenSecret.DeepCopy(),
+			},
+			expectedError: "",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -451,12 +503,15 @@ func TestTokenCleanupOutdated(t *testing.T) {
 			}
 			g.Expect(err).NotTo(HaveOccurred())
 
-			// user data secret should be deleted.
 			got := &corev1.Secret{}
 			err = fakeClient.Get(t.Context(), crclient.ObjectKeyFromObject(userdataSecret), got)
-			g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			platformType := tc.token.nodePool.Spec.Platform.Type
+			if platformType == hyperv1.AWSPlatform || platformType == hyperv1.KubevirtPlatform {
+				g.Expect(err).ToNot(HaveOccurred(), "userdata secret should be preserved for %s platform", platformType)
+			} else {
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "userdata secret should be deleted for %s platform", platformType)
+			}
 
-			// token secret if exists it should be have an expiration time.
 			got = &corev1.Secret{}
 			err = fakeClient.Get(t.Context(), crclient.ObjectKeyFromObject(tokenSecret), got)
 			if err != nil {


### PR DESCRIPTION
## What this PR does / why we need it:

On KubeVirt, the bootstrap userdata Secret in the HCP namespace (`user-data-<nodepool>-<hash>`) is shared by all VMs in a given NodePool generation. During a rolling update, HyperShift's `secretJanitor` and `Token.cleanupOutdated()` eagerly delete the old userdata Secret as soon as a new config version is computed. Any VMs from the previous generation that are still running will then fail CAPK reconciliation because their referenced Secret no longer exists.

This PR extends the existing AWS platform guard (which already preserves old userdata Secrets for a different reason) to also cover KubeVirt. With this change, old userdata Secrets are retained until the rollout finishes and old VMs are cleaned up.

## Which issue(s) this PR fixes:

Fixes premature garbage collection of shared userdata Secrets on the KubeVirt provider during NodePool rolling updates.

## Special notes for your reviewer:

- The fix mirrors the existing AWS guard pattern. AWS preserves old userdata because of a CAPA bug (kubernetes-sigs/cluster-api-provider-aws#3805). KubeVirt needs it because the Secret is architecturally shared across VMs in a generation.
- Long term, a more targeted cleanup (e.g. checking whether any old-generation VMs still reference the Secret) would be preferable, but this minimal change is safe and consistent with the existing pattern.

## Manual testing

Verified on a real KubeVirt HostedCluster (OCP 4.20 management cluster with CNV 4.20.15, guest release 4.22.3, 2-replica NodePool). Triggered a rolling update by changing VM compute cores. The old userdata Secret was preserved throughout the rollout, both old machines were deleted cleanly, and the rollout completed with no errors. Full test evidence: https://github.com/openshift/hypershift/pull/8581#issuecomment-4809162171

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret retention handling for KubeVirt platforms, ensuring user-data secrets are properly preserved during node pool operations and cluster updates.

* **Tests**
  * Extended test coverage to validate secret lifecycle management behavior for KubeVirt platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->