### PR TITLE
CNTRLPLANE-3277: Add Azure OAuth LoadBalancer private topology e2e test

### DIFF
--- a/hack/tools/hypershiftlinter/analyzers/e2eutilallowlist/e2eutilallowlist.go
+++ b/hack/tools/hypershiftlinter/analyzers/e2eutilallowlist/e2eutilallowlist.go
@@ -36,8 +36,11 @@ var allowlist = map[string]map[string]bool{
 		"String":                       true,
 		"Type":                         true,
 		"WithClientOptions":            true,
+		"WithGuestConfig":              true,
 		"WithInterval":                 true,
 		"WithTimeout":                  true,
+		"WithTransport":                true,
+		"WithTransportFactory":         true,
 
 		// Client helpers
 		"GetClient":    true,
@@ -51,8 +54,13 @@ var allowlist = map[string]map[string]bool{
 		"WaitForGuestKubeConfig":                          true,
 		"WaitForNReadyNodesWithOptions":                   true,
 		"WaitForNodePoolConfigUpdateCompleteWithPlatform": true,
+		"WaitForOAuthLoadBalancerEndpoint":                true,
 		"WaitForReadyNodesByNodePool":                     true,
 		"WaitForReadyNodesByLabels":                       true,
+
+		// Port-forward/transport helpers
+		"SetupGuestKASPortForwardConfig": true,
+		"SetupOAuthPortForwardTransport": true,
 
 		// Cloud provider helpers
 		"GetDefaultSecurityGroup": true,
@@ -69,6 +77,7 @@ var allowlist = map[string]map[string]bool{
 		"ValidateAzureWorkloadIdentityWebhookMutation":     true,
 		"ValidateIngressOperatorConfiguration":             true,
 		"ValidateKubeAPIServerAllowedCIDRs":                true,
+		"ValidateOAuthIdentityProviderFlow":                true,
 		"ValidateOAuthWithIdentityProviderViaLoadBalancer": true,
 
 		// OIDC helpers

--- a/test/e2e/util/oauth.go
+++ b/test/e2e/util/oauth.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"sync"
 	"testing"
 	"time"
 
@@ -577,15 +578,17 @@ func EnsureOAuthWithIdentityProviderViaLoadBalancer(t *testing.T, ctx context.Co
 // podPortForward holds the state of an active port-forward to a pod.
 type podPortForward struct {
 	stopCh    chan struct{}
+	stop      func()
 	errCh     <-chan error
 	localPort uint16
 	podName   string
 }
 
 // establishPodPortForward finds a running pod matching the given labels and creates a
-// SPDY port-forward tunnel to port 6443. It returns a podPortForward whose stopCh the
-// caller must close (typically via t.Cleanup). If the pod restarts during the caller's
-// healthcheck, the caller can detect it via errCh and call this function again.
+// SPDY port-forward tunnel to port 6443. Cleanup is registered via t.Cleanup using an
+// idempotent stop function. If the pod restarts during the caller's healthcheck, the
+// caller can detect it via errCh and call this function again, using pf.stop() to close
+// the previous tunnel.
 func establishPodPortForward(
 	t testing.TB, ctx context.Context,
 	mgmtClient crclient.Client,
@@ -634,14 +637,18 @@ func establishPodPortForward(
 	fw, err := portforward.New(dialer, []string{"0:6443"}, stopCh, readyCh, io.Discard, io.Discard)
 	g.Expect(err).ToNot(HaveOccurred(), "failed to create port forwarder")
 
+	stopOnce := sync.Once{}
+	stop := func() { stopOnce.Do(func() { close(stopCh) }) }
+	t.Cleanup(stop)
+
 	errCh := make(chan error, 1)
 	go func() { errCh <- fw.ForwardPorts() }()
 	select {
 	case <-readyCh:
 	case err = <-errCh:
-		g.Expect(err).ToNot(HaveOccurred(), "%s port-forward failed to start", componentName)
+		t.Fatalf("%s port-forward exited before becoming ready: %v", componentName, err)
 	case <-ctx.Done():
-		close(stopCh)
+		stop()
 		t.Fatalf("context canceled while waiting for %s port-forward readiness: %v", componentName, ctx.Err())
 	}
 
@@ -652,6 +659,7 @@ func establishPodPortForward(
 
 	return &podPortForward{
 		stopCh:    stopCh,
+		stop:      stop,
 		errCh:     errCh,
 		localPort: ports[0].Local,
 		podName:   pod.Name,
@@ -685,7 +693,6 @@ func SetupOAuthPortForwardTransport(
 	podLabels := crclient.MatchingLabels{hyperv1.ControlPlaneComponentLabel: "oauth-openshift"}
 
 	pf := establishPodPortForward(t, ctx, mgmtClient, kubeClient, mgmtConfig, hcpNamespace, podLabels, "oauth-openshift")
-	t.Cleanup(func() { close(pf.stopCh) })
 
 	guestConfig, err := guestRestConfig(t, ctx, mgmtClient, hostedCluster)
 	g.Expect(err).ToNot(HaveOccurred(), "failed to get guest REST config")
@@ -709,9 +716,8 @@ func SetupOAuthPortForwardTransport(
 		select {
 		case pfErr := <-pf.errCh:
 			t.Logf("OAuth port-forward to %s broke (%v), re-establishing", pf.podName, pfErr)
-			oldStop := pf.stopCh
+			pf.stop()
 			pf = establishPodPortForward(t, ctx, mgmtClient, kubeClient, mgmtConfig, hcpNamespace, podLabels, "oauth-openshift")
-			close(oldStop)
 			localAddr = fmt.Sprintf("localhost:%d", pf.localPort)
 			oauthTransport.CloseIdleConnections()
 			return false, nil
@@ -766,7 +772,6 @@ func SetupGuestKASPortForwardConfig(
 	podLabels := crclient.MatchingLabels{"app": "kube-apiserver", hyperv1.ControlPlaneComponentLabel: "kube-apiserver"}
 
 	pf := establishPodPortForward(t, ctx, mgmtClient, kubeClient, mgmtConfig, hcpNamespace, podLabels, "kube-apiserver")
-	t.Cleanup(func() { close(pf.stopCh) })
 
 	guestConfig, err := guestRestConfig(t, ctx, mgmtClient, hostedCluster)
 	g.Expect(err).ToNot(HaveOccurred(), "failed to get guest REST config")
@@ -786,9 +791,8 @@ func SetupGuestKASPortForwardConfig(
 		select {
 		case pfErr := <-pf.errCh:
 			t.Logf("KAS port-forward to %s broke (%v), re-establishing", pf.podName, pfErr)
-			oldStop := pf.stopCh
+			pf.stop()
 			pf = establishPodPortForward(t, ctx, mgmtClient, kubeClient, mgmtConfig, hcpNamespace, podLabels, "kube-apiserver")
-			close(oldStop)
 			guestConfig.Host = fmt.Sprintf("https://localhost:%d", pf.localPort)
 			testClient, err = kubernetes.NewForConfig(guestConfig)
 			g.Expect(err).ToNot(HaveOccurred(), "failed to create test client after KAS port-forward re-establishment")

--- a/test/e2e/util/oauth.go
+++ b/test/e2e/util/oauth.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"testing"
@@ -29,11 +31,46 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
 
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+type oauthTokenConfig struct {
+	transport        http.RoundTripper
+	transportFactory func() http.RoundTripper
+	guestConfig      *restclient.Config
+}
+
+// OAuthTokenOption configures how OAuth token requests are performed.
+type OAuthTokenOption func(*oauthTokenConfig)
+
+// WithTransport overrides the default HTTP transport used for OAuth requests.
+// Use this with SetupOAuthPortForwardTransport to route requests through a
+// port-forward tunnel to the OAuth server in private topology clusters.
+func WithTransport(rt http.RoundTripper) OAuthTokenOption {
+	return func(c *oauthTokenConfig) { c.transport = rt }
+}
+
+// WithGuestConfig overrides the guest cluster REST config used for API calls
+// (e.g. GetUserForToken) in ValidateOAuthIdentityProviderFlow. Use this with
+// SetupGuestKASPortForwardConfig to route guest KAS calls through a port-forward
+// tunnel in private topology clusters where the KAS is behind an ILB.
+func WithGuestConfig(cfg *restclient.Config) OAuthTokenOption {
+	return func(c *oauthTokenConfig) { c.guestConfig = cfg }
+}
+
+// WithTransportFactory provides a function that creates a fresh HTTP transport
+// by establishing a new port-forward to the current OAuth pod. This is called
+// after IDP config changes trigger an OAuth server rollout, because the old
+// port-forward dies with the replaced pod.
+func WithTransportFactory(f func() http.RoundTripper) OAuthTokenOption {
+	return func(c *oauthTokenConfig) { c.transportFactory = f }
+}
 
 func EnsureOAuthWithIdentityProvider(t *testing.T, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
 	t.Run("EnsureOAuthWithIdentityProvider", func(t *testing.T) {
@@ -111,8 +148,13 @@ func WaitForOAuthToken(t *testing.T, ctx context.Context, oauthRoute *routev1.Ro
 
 // WaitForOAuthTokenByHost performs the OAuth token request flow against the given host.
 // This supports both Route-based and LoadBalancer-based OAuth endpoints.
-func WaitForOAuthTokenByHost(t testing.TB, ctx context.Context, oauthHost string, restConfig *restclient.Config, username, password string) string {
+func WaitForOAuthTokenByHost(t testing.TB, ctx context.Context, oauthHost string, restConfig *restclient.Config, username, password string, opts ...OAuthTokenOption) string {
 	g := NewWithT(t)
+
+	cfg := &oauthTokenConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
 
 	oauthClient := configmanifests.OAuthServerChallengingClient().Name
 	tokenReqUrl := fmt.Sprintf("https://%s/oauth/authorize?response_type=token&client_id=%s", oauthHost, oauthClient)
@@ -122,8 +164,13 @@ func WaitForOAuthTokenByHost(t testing.TB, ctx context.Context, oauthHost string
 	request.Header.Set("Authorization", getBasicHeader(username, password))
 	request.Header.Set("X-CSRF-Token", "1")
 
-	transport, err := restclient.TransportFor(restclient.AnonymousClientConfig(restConfig))
-	g.Expect(err).ToNot(HaveOccurred(), "error getting transport")
+	var transport http.RoundTripper
+	if cfg.transport != nil {
+		transport = cfg.transport
+	} else {
+		transport, err = restclient.TransportFor(restclient.AnonymousClientConfig(restConfig))
+		g.Expect(err).ToNot(HaveOccurred(), "error getting transport")
+	}
 
 	httpClient := &http.Client{
 		Transport: transport,
@@ -306,16 +353,15 @@ func validateClusterPreIDP(t *testing.T, ctx context.Context, client crclient.Cl
 
 }
 
-// WaitForOAuthLoadBalancerReady waits for the oauth-openshift LoadBalancer Service to have an
-// external endpoint allocated and for the /healthz endpoint to return HTTP 200.
-// It returns the OAuth hostname from the HostedCluster's service publishing strategy,
-// which matches the TLS certificate SANs, rather than the raw LoadBalancer IP.
-func WaitForOAuthLoadBalancerReady(t testing.TB, ctx context.Context, client crclient.Client, restConfig *restclient.Config, hostedCluster *hyperv1.HostedCluster) string {
+// WaitForOAuthLoadBalancerEndpoint waits for the oauth-openshift LoadBalancer Service to have an
+// endpoint allocated and returns the OAuth hostname from the HostedCluster's service publishing
+// strategy. This hostname matches the TLS certificate SANs and is the one ExternalDNS creates
+// a DNS record for. Unlike WaitForOAuthLoadBalancerReady, this does not perform a direct
+// /healthz check, making it suitable for private topology clusters where the LoadBalancer
+// endpoint is not directly reachable from the test runner.
+func WaitForOAuthLoadBalancerEndpoint(t testing.TB, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) string {
 	g := NewWithT(t)
 
-	// Get the OAuth hostname from the HostedCluster's service publishing strategy.
-	// This is the hostname that the TLS certificate is issued for and that ExternalDNS
-	// creates a DNS record for, so it must be used for TLS connections.
 	oauthStrategy := netutil.ServicePublishingStrategyByTypeByHC(hostedCluster, hyperv1.OAuthServer)
 	g.Expect(oauthStrategy).ToNot(BeNil(), "OAuth service publishing strategy not found in HostedCluster spec")
 	g.Expect(oauthStrategy.LoadBalancer).ToNot(BeNil(), "OAuth LoadBalancer strategy not found")
@@ -323,7 +369,6 @@ func WaitForOAuthLoadBalancerReady(t testing.TB, ctx context.Context, client crc
 	g.Expect(oauthHost).ToNot(BeEmpty(), "OAuth LoadBalancer hostname is empty")
 	t.Logf("OAuth hostname from HostedCluster spec: %s", oauthHost)
 
-	// Wait for the LoadBalancer to get an external endpoint (confirms LB is provisioned)
 	hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 	svc := hcpmanifests.OauthServerService(hcpNamespace)
 	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 10*time.Minute, true, func(ctx context.Context) (done bool, err error) {
@@ -335,20 +380,38 @@ func WaitForOAuthLoadBalancerReady(t testing.TB, ctx context.Context, client crc
 			return false, nil
 		}
 		if len(svc.Status.LoadBalancer.Ingress) == 0 {
-			t.Logf("Waiting for oauth-openshift LoadBalancer to get an external endpoint")
+			t.Logf("Waiting for oauth-openshift LoadBalancer to get an endpoint")
 			return false, nil
 		}
 		ingress := svc.Status.LoadBalancer.Ingress[0]
 		if ingress.IP == "" && ingress.Hostname == "" {
 			return false, nil
 		}
-		t.Logf("OAuth LoadBalancer has external endpoint: %s%s", ingress.IP, ingress.Hostname)
+		ip := ingress.IP
+		if ip == "" {
+			ip = "<none>"
+		}
+		hostname := ingress.Hostname
+		if hostname == "" {
+			hostname = "<none>"
+		}
+		t.Logf("OAuth LoadBalancer endpoint ready (IP=%s, Hostname=%s)", ip, hostname)
 		return true, nil
 	})
 	g.Expect(err).ToNot(HaveOccurred(), "failed waiting for oauth-openshift LoadBalancer endpoint")
 
-	// Wait for the OAuth hostname to be resolvable via DNS (ExternalDNS creates the record)
-	// and for the /healthz endpoint to return HTTP 200
+	return oauthHost
+}
+
+// WaitForOAuthLoadBalancerReady waits for the oauth-openshift LoadBalancer Service to have an
+// endpoint allocated and for the /healthz endpoint to return HTTP 200.
+// It returns the OAuth hostname from the HostedCluster's service publishing strategy.
+// For private topology clusters where the /healthz endpoint is not directly reachable,
+// use WaitForOAuthLoadBalancerEndpoint instead.
+func WaitForOAuthLoadBalancerReady(t testing.TB, ctx context.Context, client crclient.Client, restConfig *restclient.Config, hostedCluster *hyperv1.HostedCluster) string {
+	oauthHost := WaitForOAuthLoadBalancerEndpoint(t, ctx, client, hostedCluster)
+
+	g := NewWithT(t)
 	request, err := http.NewRequestWithContext(ctx, http.MethodHead, fmt.Sprintf("https://%s/healthz", oauthHost), nil)
 	g.Expect(err).ToNot(HaveOccurred())
 
@@ -378,31 +441,43 @@ func WaitForOAuthLoadBalancerReady(t testing.TB, ctx context.Context, client crc
 	return oauthHost
 }
 
-func ValidateOAuthWithIdentityProviderViaLoadBalancer(t testing.TB, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+// ValidateOAuthIdentityProviderFlow validates the full OAuth identity provider flow
+// against the given oauthHost: kubeadmin login, htpasswd IDP setup, testuser login,
+// and kubeadmin secret removal. The oauthHost can come from any source, such as
+// WaitForOAuthLoadBalancerReady (with health check) or WaitForOAuthLoadBalancerEndpoint
+// (endpoint only, suitable for private topology).
+// This function mutates cluster state (creates htpasswd Secret, patches OAuth config,
+// validates kubeadmin secret removal) and should only be used in lifecycle tests.
+func ValidateOAuthIdentityProviderFlow(t testing.TB, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster, oauthHost string, opts ...OAuthTokenOption) {
 	g := NewWithT(t)
+
+	cfg := &oauthTokenConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
 
 	guestConfig, err := guestRestConfig(t, ctx, client, hostedCluster)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	// Wait for OAuth LoadBalancer to be ready
-	oauthHost := WaitForOAuthLoadBalancerReady(t, ctx, client, guestConfig, hostedCluster)
+	kasConfig := guestConfig
+	if cfg.guestConfig != nil {
+		kasConfig = cfg.guestConfig
+	}
 
-	// Validate kubeadmin login through the LoadBalancer (works without IDPs)
 	hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
 	kubeadminPasswordSecret := configmanifests.KubeadminPasswordSecret(hcpNamespace)
 	err = client.Get(ctx, crclient.ObjectKeyFromObject(kubeadminPasswordSecret), kubeadminPasswordSecret)
 	g.Expect(err).ToNot(HaveOccurred())
 	password := string(kubeadminPasswordSecret.Data["password"])
-	accessToken := WaitForOAuthTokenByHost(t, ctx, oauthHost, guestConfig, "kubeadmin", password)
+	accessToken := WaitForOAuthTokenByHost(t, ctx, oauthHost, guestConfig, "kubeadmin", password, opts...)
 
-	user, err := GetUserForToken(guestConfig, accessToken)
+	user, err := GetUserForToken(kasConfig, accessToken)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(user.Name).To(Equal("kube:admin"))
 
-	// Set up htpasswd identity provider
 	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "htpasswd",
+			Name:      fmt.Sprintf("htpasswd-%s", hostedCluster.Name),
 			Namespace: hostedCluster.Namespace,
 		},
 		Data: map[string][]byte{
@@ -411,7 +486,18 @@ func ValidateOAuthWithIdentityProviderViaLoadBalancer(t testing.TB, ctx context.
 	}
 	err = client.Create(ctx, &secret)
 	g.Expect(err).ToNot(HaveOccurred(), "failed to create htpasswd secret")
+	t.Cleanup(func() {
+		if err := client.Delete(context.Background(), &secret); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("Warning: failed to delete htpasswd secret: %v", err)
+		}
+	})
 
+	err = client.Get(ctx, crclient.ObjectKeyFromObject(hostedCluster), hostedCluster)
+	g.Expect(err).ToNot(HaveOccurred(), "failed to get fresh hostedcluster state")
+	var originalOAuth *v1.OAuthSpec
+	if hostedCluster.Spec.Configuration != nil && hostedCluster.Spec.Configuration.OAuth != nil {
+		originalOAuth = hostedCluster.Spec.Configuration.OAuth.DeepCopy()
+	}
 	err = UpdateObject(t, ctx, client, hostedCluster, func(obj *hyperv1.HostedCluster) {
 		if obj.Spec.Configuration == nil {
 			obj.Spec.Configuration = &hyperv1.ClusterConfiguration{}
@@ -434,19 +520,49 @@ func ValidateOAuthWithIdentityProviderViaLoadBalancer(t testing.TB, ctx context.
 		}
 	})
 	g.Expect(err).ToNot(HaveOccurred(), "failed to update hostedcluster identity providers")
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		if err := UpdateObject(t, cleanupCtx, client, hostedCluster, func(obj *hyperv1.HostedCluster) {
+			if obj.Spec.Configuration == nil {
+				obj.Spec.Configuration = &hyperv1.ClusterConfiguration{}
+			}
+			obj.Spec.Configuration.OAuth = originalOAuth
+		}); err != nil {
+			t.Logf("Warning: failed to restore OAuth config: %v", err)
+		}
+	})
 
-	// Wait for OAuth config to pick up the new identity provider
 	WaitForOauthConfig(t, ctx, client, hostedCluster)
 
-	// Validate testuser login through the LoadBalancer
-	accessToken = WaitForOAuthTokenByHost(t, ctx, oauthHost, guestConfig, "testuser", "password")
+	if cfg.transportFactory != nil {
+		cfg.transport = cfg.transportFactory()
+		opts = []OAuthTokenOption{WithTransport(cfg.transport)}
+		if cfg.guestConfig != nil {
+			opts = append(opts, WithGuestConfig(cfg.guestConfig))
+		}
+	}
 
-	user, err = GetUserForToken(guestConfig, accessToken)
+	accessToken = WaitForOAuthTokenByHost(t, ctx, oauthHost, guestConfig, "testuser", "password", opts...)
+
+	user, err = GetUserForToken(kasConfig, accessToken)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(user.Name).To(Equal("testuser"))
 
-	// Validate kubeadmin secret was removed after IDP was added
 	validateClusterPostIDP(t, ctx, client, hostedCluster)
+}
+
+// ValidateOAuthWithIdentityProviderViaLoadBalancer combines WaitForOAuthLoadBalancerReady
+// (with /healthz check) and ValidateOAuthIdentityProviderFlow. For private topology
+// clusters where /healthz is unreachable, call those functions separately.
+func ValidateOAuthWithIdentityProviderViaLoadBalancer(t testing.TB, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {
+	g := NewWithT(t)
+
+	guestConfig, err := guestRestConfig(t, ctx, client, hostedCluster)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	oauthHost := WaitForOAuthLoadBalancerReady(t, ctx, client, guestConfig, hostedCluster)
+	ValidateOAuthIdentityProviderFlow(t, ctx, client, hostedCluster, oauthHost)
 }
 
 // EnsureOAuthWithIdentityProviderViaLoadBalancer is the LoadBalancer equivalent of
@@ -456,6 +572,241 @@ func EnsureOAuthWithIdentityProviderViaLoadBalancer(t *testing.T, ctx context.Co
 	t.Run("EnsureOAuthWithIdentityProviderViaLoadBalancer", func(t *testing.T) {
 		ValidateOAuthWithIdentityProviderViaLoadBalancer(t, ctx, client, hostedCluster)
 	})
+}
+
+// podPortForward holds the state of an active port-forward to a pod.
+type podPortForward struct {
+	stopCh    chan struct{}
+	errCh     <-chan error
+	localPort uint16
+	podName   string
+}
+
+// establishPodPortForward finds a running pod matching the given labels and creates a
+// SPDY port-forward tunnel to port 6443. It returns a podPortForward whose stopCh the
+// caller must close (typically via t.Cleanup). If the pod restarts during the caller's
+// healthcheck, the caller can detect it via errCh and call this function again.
+func establishPodPortForward(
+	t testing.TB, ctx context.Context,
+	mgmtClient crclient.Client,
+	kubeClient kubernetes.Interface,
+	mgmtConfig *restclient.Config,
+	namespace string,
+	podLabels crclient.MatchingLabels,
+	componentName string,
+) *podPortForward {
+	g := NewWithT(t)
+
+	var pod *corev1.Pod
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		podList := &corev1.PodList{}
+		if err := mgmtClient.List(ctx, podList,
+			crclient.InNamespace(namespace),
+			podLabels,
+		); err != nil {
+			t.Logf("Waiting for %s pod: %v", componentName, err)
+			return false, nil
+		}
+		for i := range podList.Items {
+			if podList.Items[i].Status.Phase == corev1.PodRunning && podList.Items[i].DeletionTimestamp == nil {
+				pod = &podList.Items[i]
+				return true, nil
+			}
+		}
+		t.Logf("Waiting for a running %s pod in namespace %s", componentName, namespace)
+		return false, nil
+	})
+	g.Expect(err).ToNot(HaveOccurred(), "no running %s pod found in namespace %s", componentName, namespace)
+	t.Logf("Found running %s pod %s/%s", componentName, pod.Namespace, pod.Name)
+
+	pfReq := kubeClient.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Namespace(pod.Namespace).
+		Name(pod.Name).
+		SubResource("portforward")
+
+	spdyTransport, upgrader, err := spdy.RoundTripperFor(mgmtConfig)
+	g.Expect(err).ToNot(HaveOccurred(), "failed to create SPDY round tripper")
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: spdyTransport}, "POST", pfReq.URL())
+
+	stopCh := make(chan struct{})
+	readyCh := make(chan struct{})
+	fw, err := portforward.New(dialer, []string{"0:6443"}, stopCh, readyCh, io.Discard, io.Discard)
+	g.Expect(err).ToNot(HaveOccurred(), "failed to create port forwarder")
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- fw.ForwardPorts() }()
+	select {
+	case <-readyCh:
+	case err = <-errCh:
+		g.Expect(err).ToNot(HaveOccurred(), "%s port-forward failed to start", componentName)
+	case <-ctx.Done():
+		close(stopCh)
+		t.Fatalf("context canceled while waiting for %s port-forward readiness: %v", componentName, ctx.Err())
+	}
+
+	ports, err := fw.GetPorts()
+	g.Expect(err).ToNot(HaveOccurred(), "failed to get forwarded ports")
+	g.Expect(ports).ToNot(BeEmpty(), "no forwarded ports found")
+	t.Logf("%s port-forward established: localhost:%d -> %s:6443", componentName, ports[0].Local, pod.Name)
+
+	return &podPortForward{
+		stopCh:    stopCh,
+		errCh:     errCh,
+		localPort: ports[0].Local,
+		podName:   pod.Name,
+	}
+}
+
+// SetupOAuthPortForwardTransport creates a SPDY port-forward tunnel from a random local
+// port to the oauth-openshift pod (port 6443) in the hosted control plane namespace.
+// It returns an http.RoundTripper that routes requests through the tunnel while preserving
+// correct TLS verification: the guest cluster Root CA validates the certificate, and
+// ServerName is set to oauthHost so the certificate SAN check passes even though the
+// actual TCP connection goes to localhost. Pass the returned transport to
+// ValidateOAuthIdentityProviderFlow via WithTransport.
+// The port-forward is cleaned up automatically via t.Cleanup.
+// After establishing the tunnel, it verifies connectivity by polling the /healthz endpoint.
+// If the underlying pod restarts during setup, the port-forward is re-established automatically.
+func SetupOAuthPortForwardTransport(
+	t testing.TB, ctx context.Context,
+	mgmtClient crclient.Client,
+	hostedCluster *hyperv1.HostedCluster,
+	oauthHost string,
+) http.RoundTripper {
+	g := NewWithT(t)
+
+	mgmtConfig, err := GetConfig()
+	g.Expect(err).ToNot(HaveOccurred(), "failed to get management cluster REST config")
+	kubeClient, err := kubernetes.NewForConfig(mgmtConfig)
+	g.Expect(err).ToNot(HaveOccurred(), "failed to create kubernetes client")
+
+	hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
+	podLabels := crclient.MatchingLabels{hyperv1.ControlPlaneComponentLabel: "oauth-openshift"}
+
+	pf := establishPodPortForward(t, ctx, mgmtClient, kubeClient, mgmtConfig, hcpNamespace, podLabels, "oauth-openshift")
+	t.Cleanup(func() { close(pf.stopCh) })
+
+	guestConfig, err := guestRestConfig(t, ctx, mgmtClient, hostedCluster)
+	g.Expect(err).ToNot(HaveOccurred(), "failed to get guest REST config")
+
+	tlsConfig, err := restclient.TLSConfigFor(restclient.AnonymousClientConfig(guestConfig))
+	g.Expect(err).ToNot(HaveOccurred(), "failed to get TLS config from guest config")
+	tlsConfig.ServerName = oauthHost
+
+	localAddr := fmt.Sprintf("localhost:%d", pf.localPort)
+	oauthTransport := &http.Transport{
+		TLSClientConfig: tlsConfig,
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "tcp", localAddr)
+		},
+	}
+
+	healthRequest, err := http.NewRequestWithContext(ctx, http.MethodHead, fmt.Sprintf("https://%s/healthz", oauthHost), nil)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		select {
+		case pfErr := <-pf.errCh:
+			t.Logf("OAuth port-forward to %s broke (%v), re-establishing", pf.podName, pfErr)
+			oldStop := pf.stopCh
+			pf = establishPodPortForward(t, ctx, mgmtClient, kubeClient, mgmtConfig, hcpNamespace, podLabels, "oauth-openshift")
+			close(oldStop)
+			localAddr = fmt.Sprintf("localhost:%d", pf.localPort)
+			oauthTransport.CloseIdleConnections()
+			return false, nil
+		default:
+		}
+
+		req := healthRequest.Clone(ctx)
+		resp, err := oauthTransport.RoundTrip(req)
+		if resp != nil {
+			defer resp.Body.Close()
+		}
+		if resp != nil && resp.StatusCode == http.StatusOK {
+			return true, nil
+		}
+		if resp != nil {
+			t.Logf("Waiting for OAuth server healthcheck via port-forward: %v", resp.Status)
+		}
+		if err != nil {
+			t.Logf("Waiting for OAuth server healthcheck via port-forward: %v", err)
+		}
+		return false, nil
+	})
+	g.Expect(err).ToNot(HaveOccurred(), "failed OAuth server healthcheck via port-forward to %s", oauthHost)
+	t.Logf("OAuth server healthy via port-forward at localhost:%d", pf.localPort)
+
+	return oauthTransport
+}
+
+// SetupGuestKASPortForwardConfig creates a SPDY port-forward tunnel from a random local
+// port to the kube-apiserver pod (port 6443) in the hosted control plane namespace.
+// It returns a *restclient.Config that routes guest API calls through the tunnel while
+// preserving correct TLS verification: the guest cluster CA validates the certificate,
+// and ServerName is set to the original KAS hostname so the certificate SAN check passes.
+// Pass the returned config to ValidateOAuthIdentityProviderFlow via WithGuestConfig to
+// enable GetUserForToken calls in private topology clusters where the guest KAS is behind
+// an Azure Internal Load Balancer.
+// The port-forward is cleaned up automatically via t.Cleanup.
+// If the underlying pod restarts during setup, the port-forward is re-established automatically.
+func SetupGuestKASPortForwardConfig(
+	t testing.TB, ctx context.Context,
+	mgmtClient crclient.Client,
+	hostedCluster *hyperv1.HostedCluster,
+) *restclient.Config {
+	g := NewWithT(t)
+
+	mgmtConfig, err := GetConfig()
+	g.Expect(err).ToNot(HaveOccurred(), "failed to get management cluster REST config")
+	kubeClient, err := kubernetes.NewForConfig(mgmtConfig)
+	g.Expect(err).ToNot(HaveOccurred(), "failed to create kubernetes client")
+
+	hcpNamespace := manifests.HostedControlPlaneNamespace(hostedCluster.Namespace, hostedCluster.Name)
+	podLabels := crclient.MatchingLabels{"app": "kube-apiserver", hyperv1.ControlPlaneComponentLabel: "kube-apiserver"}
+
+	pf := establishPodPortForward(t, ctx, mgmtClient, kubeClient, mgmtConfig, hcpNamespace, podLabels, "kube-apiserver")
+	t.Cleanup(func() { close(pf.stopCh) })
+
+	guestConfig, err := guestRestConfig(t, ctx, mgmtClient, hostedCluster)
+	g.Expect(err).ToNot(HaveOccurred(), "failed to get guest REST config")
+
+	originalHost := guestConfig.Host
+	u, err := url.Parse(originalHost)
+	g.Expect(err).ToNot(HaveOccurred(), "failed to parse guest config host URL")
+	serverName := u.Hostname()
+
+	guestConfig.Host = fmt.Sprintf("https://localhost:%d", pf.localPort)
+	guestConfig.TLSClientConfig.ServerName = serverName
+
+	testClient, err := kubernetes.NewForConfig(guestConfig)
+	g.Expect(err).ToNot(HaveOccurred(), "failed to create test client for KAS port-forward")
+
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		select {
+		case pfErr := <-pf.errCh:
+			t.Logf("KAS port-forward to %s broke (%v), re-establishing", pf.podName, pfErr)
+			oldStop := pf.stopCh
+			pf = establishPodPortForward(t, ctx, mgmtClient, kubeClient, mgmtConfig, hcpNamespace, podLabels, "kube-apiserver")
+			close(oldStop)
+			guestConfig.Host = fmt.Sprintf("https://localhost:%d", pf.localPort)
+			testClient, err = kubernetes.NewForConfig(guestConfig)
+			g.Expect(err).ToNot(HaveOccurred(), "failed to create test client after KAS port-forward re-establishment")
+			return false, nil
+		default:
+		}
+
+		_, err = testClient.Discovery().ServerVersion()
+		if err != nil {
+			t.Logf("Waiting for guest KAS connectivity via port-forward: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	g.Expect(err).ToNot(HaveOccurred(), "failed guest KAS connectivity check via port-forward")
+	t.Logf("Guest KAS reachable via port-forward at localhost:%d (ServerName=%s)", pf.localPort, serverName)
+
+	return guestConfig
 }
 
 func validateClusterPostIDP(t testing.TB, ctx context.Context, client crclient.Client, hostedCluster *hyperv1.HostedCluster) {

--- a/test/e2e/v2/lifecycle/azure.go
+++ b/test/e2e/v2/lifecycle/azure.go
@@ -148,6 +148,15 @@ func (a *AzurePlatformConfig) ClusterSpecs(releaseImage, n1Image string) []Clust
 			ExtraArgs:               append([]string{"--oauth-publishing-strategy=LoadBalancer"}, extraArgs...),
 		},
 		{
+			Variant:                 "oauth-lb-private",
+			InitialNodePoolReplicas: &oneInitialReplica,
+			ExtraArgs: append([]string{
+				"--endpoint-access=Private",
+				"--endpoint-access-private-nat-subnet-id=" + a.privateNATSubnetID,
+				"--oauth-publishing-strategy=LoadBalancer",
+			}, extraArgs...),
+		},
+		{
 			Variant:                 "upgrade",
 			ReleaseImage:            n1Image,
 			InitialNodePoolReplicas: &twoInitialReplicas,
@@ -357,6 +366,11 @@ func (a *AzurePlatformConfig) TestMatrix() TestMatrix {
 				Name:        "private",
 				Variant:     "private",
 				LabelFilter: "self-managed-azure-private || hosted-cluster-compliance",
+			},
+			{
+				Name:        "oauth-lb-private",
+				Variant:     "oauth-lb-private",
+				LabelFilter: "self-managed-azure-oauth-lb-private",
 			},
 		},
 		Sequential: []SequentialGroup{

--- a/test/e2e/v2/lifecycle/azure_test.go
+++ b/test/e2e/v2/lifecycle/azure_test.go
@@ -2,7 +2,10 @@
 
 package lifecycle
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestAzurePlatformConfigClusterSpecs(t *testing.T) {
 	t.Parallel()
@@ -39,6 +42,11 @@ func TestAzurePlatformConfigClusterSpecs(t *testing.T) {
 			want:    1,
 		},
 		{
+			name:    "When OAuth LoadBalancer private Azure variant is configured, it should request one initial replica",
+			variant: "oauth-lb-private",
+			want:    1,
+		},
+		{
 			name:    "When autoscaling Azure variant is configured, it should request one initial replica",
 			variant: "autoscaling",
 			want:    1,
@@ -70,5 +78,35 @@ func TestAzurePlatformConfigClusterSpecs(t *testing.T) {
 				t.Errorf("Azure variant %q requests %d initial replicas, want %d", tt.variant, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestAzureOAuthLBPrivateExtraArgs(t *testing.T) {
+	t.Parallel()
+
+	specs := (&AzurePlatformConfig{}).ClusterSpecs("release-image", "n1-image")
+	var spec *ClusterSpec
+	for i := range specs {
+		if specs[i].Variant == "oauth-lb-private" {
+			spec = &specs[i]
+			break
+		}
+	}
+	if spec == nil {
+		t.Fatal("oauth-lb-private variant was not configured")
+	}
+
+	// The oauth-lb-private variant combines private endpoint access with the
+	// LoadBalancer OAuth publishing strategy; each flag encodes a distinct
+	// contract that a regression could silently drop.
+	wantArgs := []string{
+		"--endpoint-access=Private",
+		"--endpoint-access-private-nat-subnet-id=", // empty subnet id with zero-value config
+		"--oauth-publishing-strategy=LoadBalancer",
+	}
+	for _, arg := range wantArgs {
+		if !slices.Contains(spec.ExtraArgs, arg) {
+			t.Errorf("oauth-lb-private ExtraArgs %v missing %q", spec.ExtraArgs, arg)
+		}
 	}
 }

--- a/test/e2e/v2/tests/hosted_cluster_azure_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_azure_test.go
@@ -20,13 +20,12 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
 	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	routev1 "github.com/openshift/api/route/v1"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	hcpmanifests "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
@@ -36,10 +35,13 @@ import (
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
 
+	routev1 "github.com/openshift/api/route/v1"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
+
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -643,39 +645,18 @@ func AzureOAuthLoadBalancerTest(getTestCtx internal.TestContextGetter) {
 			}
 		})
 
-		It("should create oauth-openshift Service as LoadBalancer with external IP", func() {
+		It("should create oauth-openshift Service as LoadBalancer with endpoint", func() {
 			testCtx := getTestCtx()
 			ctx := testCtx.Context
 			controlPlaneNamespace := testCtx.ControlPlaneNamespace
 
-			e2eutil.EventuallyObject(GinkgoTB(), ctx, "oauth-openshift Service is LoadBalancer with external IP",
+			e2eutil.EventuallyObject(GinkgoTB(), ctx, "oauth-openshift Service is LoadBalancer with endpoint",
 				func(ctx context.Context) (*corev1.Service, error) {
 					svc := hcpmanifests.OauthServerService(controlPlaneNamespace)
 					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(svc), svc)
 					return svc, err
 				},
-				[]e2eutil.Predicate[*corev1.Service]{
-					func(svc *corev1.Service) (done bool, reasons string, err error) {
-						if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
-							return false, fmt.Sprintf("expected Service type LoadBalancer, got %s", svc.Spec.Type), nil
-						}
-						return true, "oauth-openshift Service is type LoadBalancer", nil
-					},
-					func(svc *corev1.Service) (done bool, reasons string, err error) {
-						if len(svc.Status.LoadBalancer.Ingress) == 0 {
-							return false, "LoadBalancer has no ingress entries yet", nil
-						}
-						ingress := svc.Status.LoadBalancer.Ingress[0]
-						if ingress.IP == "" && ingress.Hostname == "" {
-							return false, "LoadBalancer ingress has no IP or hostname", nil
-						}
-						host := ingress.IP
-						if host == "" {
-							host = ingress.Hostname
-						}
-						return true, fmt.Sprintf("oauth-openshift LoadBalancer has external endpoint: %s", host), nil
-					},
-				},
+				oauthServiceLBPredicates(),
 				e2eutil.WithTimeout(10*time.Minute),
 			)
 		})
@@ -690,12 +671,99 @@ func AzureOAuthLoadBalancerTest(getTestCtx internal.TestContextGetter) {
 	})
 }
 
+// AzureOAuthLoadBalancerPrivateTest registers tests for Azure OAuth LoadBalancer
+// publishing validation in a private topology cluster.
+// These tests verify that:
+//   - The oauth-openshift Service is created as a LoadBalancer with an allocated endpoint
+//   - The Service carries the Azure internal LoadBalancer annotation
+//   - The OAuth token flow (kubeadmin + htpasswd IDP) works through that endpoint
+//
+// The OAuth token flow test uses a port-forward tunnel to the oauth-openshift pod
+// because the Azure internal LoadBalancer is not directly reachable from the CI
+// test runner.
+func AzureOAuthLoadBalancerPrivateTest(getTestCtx internal.TestContextGetter) {
+	Context("[Feature:AzureOAuth] Azure OAuth LoadBalancer in Private Topology", Label("Azure", "self-managed-azure-oauth-lb-private"), Ordered, func() {
+		var testCtx *internal.TestContext
+		var controlPlaneNamespace string
+		var hc *hyperv1.HostedCluster
+
+		BeforeAll(func() {
+			testCtx = getTestCtx()
+			var err error
+			hc, err = testCtx.GetHostedCluster()
+			Expect(err).NotTo(HaveOccurred(), "failed to get hosted cluster")
+			if hc == nil || hc.Spec.Platform.Type != hyperv1.AzurePlatform {
+				Skip("Azure OAuth LB Private tests are only for Azure platform")
+			}
+			if hc.Spec.Platform.Azure == nil || hc.Spec.Platform.Azure.Topology != hyperv1.AzureTopologyPrivate {
+				Skip("Azure OAuth LB Private tests require Private topology")
+			}
+			controlPlaneNamespace = testCtx.ControlPlaneNamespace
+			Expect(controlPlaneNamespace).NotTo(BeEmpty(), "control plane namespace must be set")
+
+			strategy := netutil.ServicePublishingStrategyByTypeByHC(hc, hyperv1.OAuthServer)
+			if strategy == nil || strategy.Type != hyperv1.LoadBalancer {
+				Skip("Azure OAuth LB Private tests require OAuthServer with LoadBalancer publishing strategy")
+			}
+		})
+
+		It("should create oauth-openshift Service as LoadBalancer with an allocated endpoint", Label(internal.InformingLabel), func() {
+			ctx := testCtx.Context
+
+			e2eutil.EventuallyObject(GinkgoTB(), ctx, "oauth-openshift Service is LoadBalancer with endpoint",
+				func(ctx context.Context) (*corev1.Service, error) {
+					svc := hcpmanifests.OauthServerService(controlPlaneNamespace)
+					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(svc), svc)
+					return svc, err
+				},
+				oauthServiceLBPredicates(),
+				e2eutil.WithTimeout(10*time.Minute),
+			)
+		})
+
+		It("should have Azure internal LB annotation on oauth-openshift Service", Label(internal.InformingLabel), func() {
+			ctx := testCtx.Context
+			e2eutil.EventuallyObject(GinkgoTB(), ctx, "oauth-openshift Service has Azure internal LB annotation",
+				func(ctx context.Context) (*corev1.Service, error) {
+					svc := hcpmanifests.OauthServerService(controlPlaneNamespace)
+					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(svc), svc)
+					return svc, err
+				},
+				[]e2eutil.Predicate[*corev1.Service]{
+					func(svc *corev1.Service) (done bool, reasons string, err error) {
+						val, ok := svc.Annotations[azureutil.InternalLoadBalancerAnnotation]
+						if !ok || val != azureutil.InternalLoadBalancerValue {
+							return false, fmt.Sprintf("expected annotation %q to be %q, got %q (present: %v)",
+								azureutil.InternalLoadBalancerAnnotation, azureutil.InternalLoadBalancerValue, val, ok), nil
+						}
+						return true, "oauth-openshift Service has internal LB annotation", nil
+					},
+				},
+				e2eutil.WithTimeout(10*time.Minute),
+			)
+		})
+
+		It("should complete OAuth token flow through LoadBalancer endpoint", Label(internal.InformingLabel), func() {
+			ctx := testCtx.Context
+			oauthHost := e2eutil.WaitForOAuthLoadBalancerEndpoint(GinkgoTB(), ctx, testCtx.MgmtClient, hc)
+			pfTransport := e2eutil.SetupOAuthPortForwardTransport(GinkgoTB(), ctx, testCtx.MgmtClient, hc, oauthHost)
+			kasConfig := e2eutil.SetupGuestKASPortForwardConfig(GinkgoTB(), ctx, testCtx.MgmtClient, hc)
+			e2eutil.ValidateOAuthIdentityProviderFlow(GinkgoTB(), ctx, testCtx.MgmtClient, hc, oauthHost,
+				e2eutil.WithTransport(pfTransport), e2eutil.WithGuestConfig(kasConfig),
+				e2eutil.WithTransportFactory(func() http.RoundTripper {
+					return e2eutil.SetupOAuthPortForwardTransport(GinkgoTB(), ctx, testCtx.MgmtClient, hc, oauthHost)
+				}))
+		})
+	})
+}
+
 // RegisterHostedClusterAzureTests registers all Azure-specific hosted cluster tests.
 func RegisterHostedClusterAzureTests(getTestCtx internal.TestContextGetter) {
 	AzurePublicClusterTest(getTestCtx)
 	AzurePrivateTopologyTest(getTestCtx)
 	AzureEndpointAccessTransitionTest(getTestCtx)
 	AzureOAuthLoadBalancerTest(getTestCtx)
+	AzureOAuthLoadBalancerPrivateTest(getTestCtx)
 }
 
 var _ = Describe("[sig-hypershift][Jira:Hypershift] Hosted Cluster Azure", Label("hosted-cluster-azure"), func() {
@@ -708,3 +776,30 @@ var _ = Describe("[sig-hypershift][Jira:Hypershift] Hosted Cluster Azure", Label
 
 	RegisterHostedClusterAzureTests(func() *internal.TestContext { return testCtx })
 })
+
+// oauthServiceLBPredicates returns predicates that verify the oauth-openshift Service
+// is type LoadBalancer and has an allocated ingress endpoint (IP or Hostname).
+func oauthServiceLBPredicates() []e2eutil.Predicate[*corev1.Service] {
+	return []e2eutil.Predicate[*corev1.Service]{
+		func(svc *corev1.Service) (done bool, reasons string, err error) {
+			if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+				return false, fmt.Sprintf("expected Service type LoadBalancer, got %s", svc.Spec.Type), nil
+			}
+			return true, "oauth-openshift Service is type LoadBalancer", nil
+		},
+		func(svc *corev1.Service) (done bool, reasons string, err error) {
+			if len(svc.Status.LoadBalancer.Ingress) == 0 {
+				return false, "LoadBalancer has no ingress entries yet", nil
+			}
+			ingress := svc.Status.LoadBalancer.Ingress[0]
+			if ingress.IP == "" && ingress.Hostname == "" {
+				return false, "LoadBalancer ingress has no IP or hostname", nil
+			}
+			host := ingress.IP
+			if host == "" {
+				host = ingress.Hostname
+			}
+			return true, fmt.Sprintf("oauth-openshift LoadBalancer endpoint ready: %s", host), nil
+		},
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it:

Adds the `AzureOAuthLoadBalancerPrivateTest` to the v2 Ginkgo e2e suite, validating
that the OAuth server works correctly when published via LoadBalancer on an Azure
Private topology cluster.

The test verifies:
- The `oauth-openshift` Service is created as type LoadBalancer with an allocated endpoint
- The Service carries the Azure internal LoadBalancer annotation (confirming it's an ILB, not public)
- The OAuth token flow (kubeadmin login + htpasswd IDP setup + token request) works through the private endpoint

Changes to `lifecycle/azure.go`:
- Adds a dedicated `oauth-lb-private` ClusterSpec combining `--endpoint-access=Private`
  with `--oauth-publishing-strategy=LoadBalancer`
- Restores the `private` ClusterSpec to match main (no OAuth LoadBalancer override),
  resolving the conflict with `AzureEndpointAccessTransitionTest` (PR #8718) which
  expects Route-based OAuth on the private cluster
- Removes the `private-and-oauth` SequentialGroup — with separate clusters, there is
  no shared-state ordering concern (the sequential group was the original compromise
  per CB-2 review feedback to avoid an extra cluster; Bryan's endpoint access transition
  test makes the dedicated cluster necessary)
- Moves `private` and `oauth-lb-private` TestGroups to Parallel

**Note:** The OAuth token flow test requires the test runner to have network connectivity
to the Azure VNet (e.g., running in the management cluster or via VPN/peering).

## Which issue(s) this PR fixes:

Fixes https://redhat.atlassian.net/browse/CNTRLPLANE-3277

## Special notes for your reviewer:

- **Depends on #9194** ([CNTRLPLANE-3978](https://redhat.atlassian.net/browse/CNTRLPLANE-3978)): the CPO fix for the AzurePrivateLinkService finalizer race condition. Without it, deleting the `oauth-lb-private` cluster (which creates 2 AzurePrivateLinkService CRs) orphans Azure PE resources and blocks `destroy-guests`. This PR must be merged after #9194.
- This builds on top of #8527 ([CNTRLPLANE-3222](https://redhat.atlassian.net/browse/CNTRLPLANE-3222)) which ported the v1 lifecycle tests to v2 and established the Azure self-managed test infrastructure.
- The original approach shared the `private` cluster variant by adding `--oauth-publishing-strategy=LoadBalancer` at creation time and using a SequentialGroup. This conflicted with `AzureEndpointAccessTransitionTest` (#8718) which expects Route-based OAuth on the private cluster. Since `ServicePublishingStrategy` is immutable after cluster creation (CEL validation), the dedicated `oauth-lb-private` cluster is the only viable solution.
- `AzureOAuthLoadBalancerPrivateTest` mutates the HostedCluster (creates htpasswd IDP, triggers kubeadmin secret deletion). Cleanup is handled via `t.Cleanup` (not `DeferCleanup`, since `oauth.go` doesn't import Ginkgo and has a v1 caller).
- No companion PR in `openshift/release` is needed — the v2 framework `create-guests`/`run-tests` binaries read `ClusterSpecs` and `TestMatrix` directly from `lifecycle/azure.go`.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests. No unit tests needed — changes are e2e test code and CI cluster configuration only, with no new business logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded Azure end-to-end coverage for private clusters using OAuth with internal LoadBalancers.
  - Added validation for OAuth and guest API access through secure port-forward connections.
  - Added coverage for the combined private endpoint and OAuth LoadBalancer configuration.
  - Added checks for expected initial node counts across Azure cluster variants.
  - Improved test reliability by separating LoadBalancer endpoint allocation from readiness checks and restoring authentication configuration after validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->