### PR TITLE
NO-JIRA: test Claude Code WIF auth in GitHub Actions

### DIFF
--- a/.github/workflows/claude-wif-test.yaml
+++ b/.github/workflows/claude-wif-test.yaml
@@ -1,0 +1,59 @@
+name: Test Claude Code WIF Auth
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch: {}
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  test-wif:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/test-wif') &&
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'OWNER')
+    runs-on: arc-runner-set
+    timeout-minutes: 10
+    steps:
+      - name: Get PR ref
+        if: github.event_name == 'issue_comment'
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_DATA=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }})
+          echo "ref=$(echo "$PR_DATA" | jq -r '.head.sha')" >> "$GITHUB_OUTPUT"
+          echo "repo=$(echo "$PR_DATA" | jq -r '.head.repo.full_name')" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ steps.pr.outputs.ref || github.sha }}
+          repository: ${{ steps.pr.outputs.repo || github.repository }}
+          persist-credentials: false
+
+      - name: Install Claude Code
+        run: |
+          curl -fsSL https://claude.ai/install.sh | sh
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Authenticate to GCP via WIF
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          project_id: hosted-control-planes
+          service_account: claude-gha@hosted-control-planes.iam.gserviceaccount.com
+          workload_identity_provider: projects/21066242673/locations/global/workloadIdentityPools/itpc-identity-pool/providers/github-com
+
+      - name: Test Claude Code
+        env:
+          CLAUDE_CODE_USE_VERTEX: "1"
+          CLOUD_ML_REGION: global
+          ANTHROPIC_VERTEX_PROJECT_ID: hosted-control-planes
+        run: |
+          claude --version
+          claude -p "Say hello in one sentence" --max-turns 1


### PR DESCRIPTION
## Summary
- Adds a test workflow to validate Claude Code authentication via GCP Workload Identity Federation (WIF)
- Uses the shared IT WIF provider (`itpc-identity-pool`) instead of service account keys
- Reference PR for teams wanting to run Claude Code in GitHub Actions without managing secrets

## How it works
1. GitHub Actions mints an OIDC token
2. `google-github-actions/auth@v2` exchanges it with GCP's WIF pool for temporary credentials
3. Claude Code picks up the credentials via Application Default Credentials (ADC)

## Prerequisites
- `openshift` org must be in the WIF provider's `repository_owner` allowlist
- `roles/aiplatform.user` granted to the principalSet on the target GCP project

## Test plan
- [ ] Trigger workflow manually via Actions tab
- [ ] Verify WIF authentication succeeds
- [ ] Verify Claude Code responds via Vertex AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated CI workflow that validates tooling and integration on pull requests or via manual trigger.
  * CI now installs the assistant CLI, performs a version check, and runs a one-turn runtime validation using cloud-enabled execution to ensure assistant interactions and cloud execution paths function correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->