### PR TITLE
NO-JIRA: fix(karpenter): start node cleanup when CAPI Cluster is deleted

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/karpenter-operator/role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/karpenter-operator/role.yaml
@@ -84,6 +84,14 @@ rules:
       - "patch"
       - "delete"
   - apiGroups:
+      - "cluster.x-k8s.io"
+    resources:
+      - "clusters"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+  - apiGroups:
       - ""
     resources:
       - "pods"

--- a/karpenter-operator/controllers/karpenter/karpenter_controller.go
+++ b/karpenter-operator/controllers/karpenter/karpenter_controller.go
@@ -33,6 +33,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/utils/ptr"
 
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
@@ -137,6 +138,21 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, man
 		return fmt.Errorf("failed to watch HostedControlPlane: %w", err)
 	}
 
+	// Watch the CAPI Cluster management side. The CAPI Cluster is deleted earlier
+	// than the HCP in the HostedCluster deletion sequence, so reacting to it lets
+	// us start Karpenter node cleanup in parallel with regular CAPI node teardown
+	// rather than waiting for the HCP DeletionTimestamp (which is set much later).
+	if err := c.Watch(source.Kind[client.Object](managementCluster.GetCache(), &capiv1.Cluster{}, handler.EnqueueRequestsFromMapFunc(
+		func(ctx context.Context, o client.Object) []ctrl.Request {
+			if o.GetNamespace() != r.Namespace {
+				return nil
+			}
+			return []ctrl.Request{{NamespacedName: client.ObjectKey{Namespace: r.Namespace}}}
+		},
+	), namespacedPredicates)); err != nil {
+		return fmt.Errorf("failed to watch CAPI Cluster: %w", err)
+	}
+
 	// Only enqueue on Add/Delete — not status-only updates — since reconcileAutoNodeStatus cares only
 	// about count changes (nodes joining or leaving the cluster).
 	countChangePredicate := predicate.Funcs{
@@ -213,77 +229,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	if hcp.DeletionTimestamp != nil {
-		// TODO(maxcao13): if supporting disablement, we don't want to force delete immediately.
-		// When force=true, we skip the graceful timeout and immediately trigger forceful deletion.
-		// When force=false, we wait for NodeClaimDeletionTimeout before triggering forceful deletion.
-		force := true
-		if controllerutil.ContainsFinalizer(hcp, karpenterutil.KarpenterFinalizer) {
-			// The deletion flow is:
-			// 1. Delete all NodePools (NodeClaims will be marked for deletion from deleting the NodePools due to ownerReferences)
-			// 2. Make sure all NodeClaims are actually gone (gracefully first, unless force=true)
-			// 3. If graceful timeout or force=true, set the termination timestamp annotation to trigger Karpenter's forceful deletion
-			// 4. Remove the finalizer from the HostedControlPlane to allow the rest of the HCP deletion to complete
-
-			// Karpenter itself will make sure Nodes objects are deleted (and underlying instances are terminated) before finalizing the NodeClaims
-			nodePoolList := &karpenterv1.NodePoolList{}
-			if err := r.GuestClient.List(ctx, nodePoolList); err != nil {
-				return ctrl.Result{RequeueAfter: KarpenterDeletionRequeueInterval}, fmt.Errorf("failed to list NodePools: %w", err)
-			}
-
-			// Delete all NodePools first
-			if len(nodePoolList.Items) > 0 {
-				for _, nodePool := range nodePoolList.Items {
-					// If we still get the NodePool, but it's already marked as terminating, we don't need to call Delete again
-					if !nodePool.GetDeletionTimestamp().IsZero() {
-						continue
-					}
-					if err := r.GuestClient.Delete(ctx, &nodePool, &client.DeleteOptions{
-						GracePeriodSeconds: ptr.To(int64(0)),
-					}); err != nil {
-						return ctrl.Result{}, fmt.Errorf("failed to delete NodePool: %w", err)
-					}
-				}
-				return ctrl.Result{RequeueAfter: KarpenterDeletionRequeueInterval}, nil
-			}
-
-			// Make sure all NodeClaims are actually gone (gracefully first)
-			nodeClaimList := &karpenterv1.NodeClaimList{}
-			if err := r.GuestClient.List(ctx, nodeClaimList); err != nil {
-				return ctrl.Result{RequeueAfter: KarpenterDeletionRequeueInterval}, fmt.Errorf("failed to list NodeClaims: %w", err)
-			}
-			if len(nodeClaimList.Items) > 0 {
-				var elapsed time.Duration
-				for _, nodeClaim := range nodeClaimList.Items {
-					if nodeClaim.DeletionTimestamp == nil {
-						// This could happen if a NodeClaim has been orphaned without a NodePool owner ref
-						log.Info("NodeClaim has no deletion timestamp during deletion, deleting explicitly", "nodeClaim", nodeClaim.Name)
-						if err := r.GuestClient.Delete(ctx, &nodeClaim, &client.DeleteOptions{GracePeriodSeconds: ptr.To(int64(0))}); err != nil {
-							return ctrl.Result{RequeueAfter: KarpenterDeletionRequeueInterval}, fmt.Errorf("failed to delete NodeClaim: %w", err)
-						}
-						continue
-					}
-					elapsed = time.Since(nodeClaim.DeletionTimestamp.Time)
-					if !force && elapsed < NodeClaimDeletionTimeout {
-						continue
-					}
-
-					if err := r.handleForcefulNodeClaimDeletion(ctx, &nodeClaim); err != nil {
-						return ctrl.Result{RequeueAfter: KarpenterDeletionRequeueInterval}, fmt.Errorf("failed to handle forceful NodeClaim deletion: %w", err)
-					}
-				}
-				log.Info("Waiting for NodeClaims to be deleted, requeueing...", "nodeClaimCount", len(nodeClaimList.Items), "elapsed", elapsed)
-				return ctrl.Result{RequeueAfter: KarpenterDeletionRequeueInterval}, nil
-			}
-		}
-
-		originalHCP := hcp.DeepCopy()
-		controllerutil.RemoveFinalizer(hcp, karpenterutil.KarpenterFinalizer)
-		if err := r.ManagementClient.Patch(ctx, hcp, client.MergeFromWithOptions(originalHCP, client.MergeFromWithOptimisticLock{})); err != nil {
-			return ctrl.Result{RequeueAfter: KarpenterDeletionRequeueInterval}, fmt.Errorf("failed to remove finalizer from cluster: %w", err)
-		}
-		log.Info("Successfully removed all Karpenter NodePools and NodeClaims")
-		return ctrl.Result{}, nil
+	clusterDeleting, err := r.isClusterDeleting(ctx, hcp)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to check cluster deletion state: %w", err)
+	}
+	if clusterDeleting {
+		return r.reconcileDeletion(ctx, hcp)
 	}
 	if !controllerutil.ContainsFinalizer(hcp, karpenterutil.KarpenterFinalizer) {
 		originalHCP := hcp.DeepCopy()
@@ -511,6 +462,113 @@ func (r *Reconciler) reconcileOpenshiftEC2NodeClassDefault(ctx context.Context, 
 
 	log.Info("Reconciled default OpenshiftEC2NodeClass", "op", op)
 	return nil
+}
+
+func (r *Reconciler) reconcileDeletion(ctx context.Context, hcp *hyperv1.HostedControlPlane) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	// TODO(maxcao13): if supporting disablement, we don't want to force delete immediately.
+	// When force=true, we skip the graceful timeout and immediately trigger forceful deletion.
+	// When force=false, we wait for NodeClaimDeletionTimeout before triggering forceful deletion.
+	force := true
+	if controllerutil.ContainsFinalizer(hcp, karpenterutil.KarpenterFinalizer) {
+		// The deletion flow is:
+		// 1. Delete all NodePools (NodeClaims will be marked for deletion from deleting the NodePools due to ownerReferences)
+		// 2. Make sure all NodeClaims are actually gone (gracefully first, unless force=true)
+		// 3. If graceful timeout or force=true, set the termination timestamp annotation to trigger Karpenter's forceful deletion
+		// 4. Remove the finalizer from the HostedControlPlane to allow the rest of the HCP deletion to complete
+
+		// Karpenter itself will make sure Nodes objects are deleted (and underlying instances are terminated) before finalizing the NodeClaims
+		nodePoolList := &karpenterv1.NodePoolList{}
+		if err := r.GuestClient.List(ctx, nodePoolList); err != nil {
+			return ctrl.Result{RequeueAfter: KarpenterDeletionRequeueInterval}, fmt.Errorf("failed to list NodePools: %w", err)
+		}
+
+		// Delete all NodePools first
+		if len(nodePoolList.Items) > 0 {
+			for _, nodePool := range nodePoolList.Items {
+				if !nodePool.GetDeletionTimestamp().IsZero() {
+					continue
+				}
+				if err := r.GuestClient.Delete(ctx, &nodePool, &client.DeleteOptions{
+					GracePeriodSeconds: ptr.To(int64(0)),
+				}); err != nil {
+					return ctrl.Result{}, fmt.Errorf("failed to delete NodePool: %w", err)
+				}
+			}
+			return ctrl.Result{RequeueAfter: KarpenterDeletionRequeueInterval}, nil
+		}
+
+		// Make sure all NodeClaims are actually gone (gracefully first)
+		nodeClaimList := &karpenterv1.NodeClaimList{}
+		if err := r.GuestClient.List(ctx, nodeClaimList); err != nil {
+			return ctrl.Result{RequeueAfter: KarpenterDeletionRequeueInterval}, fmt.Errorf("failed to list NodeClaims: %w", err)
+		}
+		if len(nodeClaimList.Items) > 0 {
+			var elapsed time.Duration
+			for _, nodeClaim := range nodeClaimList.Items {
+				if nodeClaim.DeletionTimestamp == nil {
+					log.Info("NodeClaim has no deletion timestamp during deletion, deleting explicitly", "nodeClaim", nodeClaim.Name)
+					if err := r.GuestClient.Delete(ctx, &nodeClaim, &client.DeleteOptions{GracePeriodSeconds: ptr.To(int64(0))}); err != nil {
+						return ctrl.Result{RequeueAfter: KarpenterDeletionRequeueInterval}, fmt.Errorf("failed to delete NodeClaim: %w", err)
+					}
+					continue
+				}
+				elapsed = time.Since(nodeClaim.DeletionTimestamp.Time)
+				if !force && elapsed < NodeClaimDeletionTimeout {
+					continue
+				}
+
+				if err := r.handleForcefulNodeClaimDeletion(ctx, &nodeClaim); err != nil {
+					return ctrl.Result{RequeueAfter: KarpenterDeletionRequeueInterval}, fmt.Errorf("failed to handle forceful NodeClaim deletion: %w", err)
+				}
+			}
+			log.Info("Waiting for NodeClaims to be deleted, requeueing...", "nodeClaimCount", len(nodeClaimList.Items), "elapsed", elapsed)
+			return ctrl.Result{RequeueAfter: KarpenterDeletionRequeueInterval}, nil
+		}
+	}
+
+	// Only remove the finalizer once the HCP itself is being deleted.
+	// When triggered by the CAPI Cluster deletion alone, we clean up nodes
+	// but leave the finalizer in place — it will be removed on a subsequent
+	// reconcile when the HCP gets its own DeletionTimestamp.
+	if hcp.DeletionTimestamp != nil {
+		originalHCP := hcp.DeepCopy()
+		controllerutil.RemoveFinalizer(hcp, karpenterutil.KarpenterFinalizer)
+		if err := r.ManagementClient.Patch(ctx, hcp, client.MergeFromWithOptions(originalHCP, client.MergeFromWithOptimisticLock{})); err != nil {
+			return ctrl.Result{RequeueAfter: KarpenterDeletionRequeueInterval}, fmt.Errorf("failed to remove finalizer from hostedControlPlane: %w", err)
+		}
+		log.Info("Successfully removed all Karpenter NodePools and NodeClaims")
+	}
+	return ctrl.Result{}, nil
+}
+
+// isClusterDeleting returns true when the cluster is being torn down.
+// It checks both the HCP DeletionTimestamp and the CAPI Cluster DeletionTimestamp.
+// The CAPI Cluster is deleted earlier in the HostedCluster deletion sequence than
+// the HCP, so checking it allows node cleanup to begin sooner — in parallel with
+// regular CAPI node teardown instead of after it completes.
+func (r *Reconciler) isClusterDeleting(ctx context.Context, hcp *hyperv1.HostedControlPlane) (bool, error) {
+	if hcp.DeletionTimestamp != nil {
+		return true, nil
+	}
+
+	if hcp.Spec.InfraID == "" {
+		return false, nil
+	}
+
+	capiCluster := &capiv1.Cluster{}
+	if err := r.ManagementClient.Get(ctx, client.ObjectKey{
+		Namespace: r.Namespace,
+		Name:      hcp.Spec.InfraID,
+	}, capiCluster); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get CAPI Cluster: %w", err)
+	}
+
+	return !capiCluster.DeletionTimestamp.IsZero(), nil
 }
 
 // handleForcefulNodeClaimDeletion handles the timeout of a NodeClaim during cluster deletion.

--- a/karpenter-operator/controllers/karpenter/karpenter_controller_test.go
+++ b/karpenter-operator/controllers/karpenter/karpenter_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -35,21 +36,25 @@ func TestKarpenterDeletion(t *testing.T) {
 	scheme := api.Scheme
 	now := time.Now()
 
+	const testNamespace = "test-namespace"
+
 	testCases := []struct {
 		name                                string
 		hcp                                 *hyperv1.HostedControlPlane
+		managementObjects                   []client.Object
 		objects                             []client.Object
 		expectedNodePools                   int
 		expectedNodeClaims                  int
 		eventuallyKarpenterFinalizerRemoved bool
-		// expectedAnnotations maps NodeClaim name to whether it should have the termination timestamp annotation
-		expectedAnnotations map[string]bool
+		// expectedTerminationAnnotations maps NodeClaim name to whether it should have the termination timestamp annotation
+		expectedTerminationAnnotations map[string]bool
 	}{
 		{
 			name: "when hcp is deleted with no resources, it should remove karpenter finalizer",
 			hcp: &hyperv1.HostedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-hcp",
+					Name:      "test-hcp",
+					Namespace: testNamespace,
 					DeletionTimestamp: &metav1.Time{
 						Time: now,
 					},
@@ -68,7 +73,8 @@ func TestKarpenterDeletion(t *testing.T) {
 			name: "when hcp is deleted, it should delete karpenter NodePools and remove karpenter finalizer",
 			hcp: &hyperv1.HostedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-hcp",
+					Name:      "test-hcp",
+					Namespace: testNamespace,
 					DeletionTimestamp: &metav1.Time{
 						Time: now,
 					},
@@ -98,7 +104,8 @@ func TestKarpenterDeletion(t *testing.T) {
 			name: "when hcp is deleted, it should not remove karpenter finalizer if karpenter NodePools still exist",
 			hcp: &hyperv1.HostedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-hcp",
+					Name:      "test-hcp",
+					Namespace: testNamespace,
 					DeletionTimestamp: &metav1.Time{
 						Time: now,
 					},
@@ -125,7 +132,8 @@ func TestKarpenterDeletion(t *testing.T) {
 			name: "when hcp is deleted, it should set termination annotation on NodeClaims and not remove finalizer until they are gone",
 			hcp: &hyperv1.HostedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-hcp",
+					Name:      "test-hcp",
+					Namespace: testNamespace,
 					DeletionTimestamp: &metav1.Time{
 						Time: now,
 					},
@@ -163,7 +171,7 @@ func TestKarpenterDeletion(t *testing.T) {
 			expectedNodePools:                   0,
 			expectedNodeClaims:                  2,
 			eventuallyKarpenterFinalizerRemoved: false,
-			expectedAnnotations: map[string]bool{
+			expectedTerminationAnnotations: map[string]bool{
 				"test-nodeclaim-1": true,
 				"test-nodeclaim-2": true,
 			},
@@ -172,7 +180,8 @@ func TestKarpenterDeletion(t *testing.T) {
 			name: "when NodeClaim already has termination annotation, it should not set it again (idempotency)",
 			hcp: &hyperv1.HostedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-hcp",
+					Name:      "test-hcp",
+					Namespace: testNamespace,
 					DeletionTimestamp: &metav1.Time{
 						Time: now,
 					},
@@ -198,7 +207,7 @@ func TestKarpenterDeletion(t *testing.T) {
 			expectedNodePools:                   0,
 			expectedNodeClaims:                  1,
 			eventuallyKarpenterFinalizerRemoved: false,
-			expectedAnnotations: map[string]bool{
+			expectedTerminationAnnotations: map[string]bool{
 				"test-nodeclaim-1": true, // Already has annotation, should still have it
 			},
 		},
@@ -206,7 +215,8 @@ func TestKarpenterDeletion(t *testing.T) {
 			name: "when NodeClaim has no deletion timestamp (orphaned), it should be explicitly deleted then get termination annotation",
 			hcp: &hyperv1.HostedControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-hcp",
+					Name:      "test-hcp",
+					Namespace: testNamespace,
 					DeletionTimestamp: &metav1.Time{
 						Time: now,
 					},
@@ -227,10 +237,86 @@ func TestKarpenterDeletion(t *testing.T) {
 			expectedNodePools:                   0,
 			expectedNodeClaims:                  1, // Still exists due to finalizer
 			eventuallyKarpenterFinalizerRemoved: false,
-			expectedAnnotations: map[string]bool{
+			expectedTerminationAnnotations: map[string]bool{
 				// First reconcile explicitly deletes it (sets DeletionTimestamp),
 				// second reconcile sees DeletionTimestamp and sets termination annotation
 				"test-nodeclaim-orphaned": true,
+			},
+		},
+		{
+			name: "when CAPI Cluster is deleting but HCP is not, it should start node cleanup without removing karpenter finalizer",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: testNamespace,
+					Finalizers: []string{
+						karpenterutil.KarpenterFinalizer,
+						"some-other-finalizer",
+					},
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					InfraID: "test-infra-id",
+				},
+			},
+			managementObjects: []client.Object{
+				&capiv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "test-infra-id",
+						Namespace:         testNamespace,
+						DeletionTimestamp: &metav1.Time{Time: now},
+						Finalizers:        []string{"capi-finalizer"},
+					},
+				},
+			},
+			objects: []client.Object{
+				&karpenterv1.NodePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-nodepool-1",
+					},
+				},
+			},
+			expectedNodePools:                   0,
+			expectedNodeClaims:                  0,
+			eventuallyKarpenterFinalizerRemoved: false,
+		},
+		{
+			name: "when CAPI Cluster is deleting with NodeClaims, it should clean up nodes without removing karpenter finalizer",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: testNamespace,
+					Finalizers: []string{
+						karpenterutil.KarpenterFinalizer,
+					},
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					InfraID: "test-infra-id",
+				},
+			},
+			managementObjects: []client.Object{
+				&capiv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "test-infra-id",
+						Namespace:         testNamespace,
+						DeletionTimestamp: &metav1.Time{Time: now},
+						Finalizers:        []string{"capi-finalizer"},
+					},
+				},
+			},
+			objects: []client.Object{
+				&karpenterv1.NodeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "test-nodeclaim-1",
+						DeletionTimestamp: &metav1.Time{Time: now},
+						Finalizers:        []string{"karpenter-finalizer"},
+					},
+				},
+			},
+			expectedNodePools:                   0,
+			expectedNodeClaims:                  1,
+			eventuallyKarpenterFinalizerRemoved: false,
+			expectedTerminationAnnotations: map[string]bool{
+				"test-nodeclaim-1": true,
 			},
 		},
 	}
@@ -250,6 +336,7 @@ func TestKarpenterDeletion(t *testing.T) {
 						Name: "pull-secret",
 					},
 				}).
+				WithObjects(tc.managementObjects...).
 				Build()
 
 			fakeGuestClient := fake.NewClientBuilder().
@@ -261,6 +348,7 @@ func TestKarpenterDeletion(t *testing.T) {
 				ManagementClient: fakeManagementClient,
 				GuestClient:      fakeGuestClient,
 				ReleaseProvider:  mockedProvider,
+				Namespace:        testNamespace,
 			}
 
 			ctx := log.IntoContext(t.Context(), testr.New(t))
@@ -295,7 +383,7 @@ func TestKarpenterDeletion(t *testing.T) {
 			g.Expect(nodeClaimList.Items).To(HaveLen(tc.expectedNodeClaims))
 
 			// verify annotations if specified
-			for nodeClaimName, shouldHaveAnnotation := range tc.expectedAnnotations {
+			for nodeClaimName, shouldHaveAnnotation := range tc.expectedTerminationAnnotations {
 				nodeClaim := &karpenterv1.NodeClaim{}
 				err := fakeGuestClient.Get(ctx, client.ObjectKey{Name: nodeClaimName}, nodeClaim)
 				g.Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## What this PR does / why we need it:

The karpenter-operator previously only began deleting Karpenter NodePools and NodeClaims when the HCP received its DeletionTimestamp. In the HostedCluster deletion sequence, the HCP is deleted much later than regular HyperShift NodePools — after CAPI Cluster deletion, AWS endpoint service cleanup, and other steps complete. This meant Karpenter nodes were torn down sequentially after regular CAPI nodes instead of in parallel.

Watch the CAPI Cluster object on the management side and treat its DeletionTimestamp as an early deletion signal. The CAPI Cluster is deleted at the same point regular NodePools are deleted, so Karpenter cleanup now runs concurrently with CAPI machine teardown.

The karpenter finalizer on the HCP is only removed once the HCP itself has a DeletionTimestamp, preserving the existing gate for HCP deletion.

Assisted by cursor agent with claude 4.6 opus.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
no-jira

## Special notes for your reviewer:

Alternatively, we could have the hcp deletion flow set a special hcp annotation for the karpenter-operator to consume, but I chose to go this route to reduce internal APIs. We also don't have a standalone lifecycle object for AutoNode (whereas there is one that exists for CAPI machines -- CAPI cluster object) -- we only have the autonode field in the HCP/HC. This will speed up deletion by a good amount on autonode enabled clusters (since we no longer wait until capi object is deleted to cleanup karpenter anymore), so I'm hoping this will also solve some teardown timeout flakes.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deletion cleanup coordination so hosted control planes and related clusters clean up resources reliably during complex deletion sequences.

* **Chores**
  * Broadened role permissions to allow access to cluster resources required for cleanup operations.

* **Tests**
  * Added and updated tests covering additional cluster deletion and cleanup scenarios, including cases where related cluster objects are deleted independently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->