### PR TITLE
GCP-688: Port remaining v1 TestCreateCluster gaps to v2 e2e

### DIFF
--- a/test/e2e/v2/AGENTS.md
+++ b/test/e2e/v2/AGENTS.md
@@ -11,7 +11,7 @@ This is a Ginkgo v2 BDD test suite for validating hosted cluster control planes.
 
 ## Architecture
 
-The framework is organized into three packages under `test/e2e/v2/`:
+The framework is organized into the following packages under `test/e2e/v2/`:
 
 - `internal/` — Framework internals (test context, workload registry, fail handler, env var management). Do not add tests here.
 - `tests/` — All standard v2 test files. Each file is feature-scoped with a top-level `Describe` and `Label`. The suite entry point is `suite_test.go`.
@@ -77,6 +77,18 @@ Register all environment variables via `RegisterEnvVar()` or `RegisterEnvVarWith
 ### 9. State Mutation and Cleanup
 
 When a test mutates cluster state, capture the original state before mutation and defer restoration. In cleanup functions, check `apierrors.IsNotFound()` to handle cases where the resource was already deleted.
+
+When creating a resource, register `DeferCleanup` immediately after `Create` — not later in the test flow. If the test fails before reaching a manual deletion, the resource leaks. Manual deletion is fine as part of test verification, but `DeferCleanup` ensures cleanup on all exit paths.
+
+```go
+Expect(hcClient.Create(tc.Context, secret)).To(Succeed())
+DeferCleanup(func() {
+    err := hcClient.Delete(tc.Context, secret)
+    if err != nil && !apierrors.IsNotFound(err) {
+        Expect(err).NotTo(HaveOccurred(), "cleanup: failed to delete %s", secret.Name)
+    }
+})
+```
 
 ### 10. Labels
 
@@ -146,6 +158,49 @@ Expect(routeList.Items).NotTo(BeEmpty(),
 for i := range routeList.Items {
     // per-item assertions
 }
+```
+
+This also applies to condition-search loops: when iterating with `if match { ... break }`, add a `found` boolean and assert it's true after the loop. An unmatched loop silently passes.
+
+```go
+found := false
+for _, cond := range nodePool.Status.Conditions {
+    if cond.Type == expectedType {
+        found = true
+        // assertions on cond
+        break
+    }
+}
+Expect(found).To(BeTrue(), "expected condition %s on NodePool %s", expectedType, nodePool.Name)
+```
+
+### 17. Idempotent Resource Creation
+
+When a helper function creates a resource that might already exist, don't silently return on `AlreadyExists`. Either reconcile the existing resource to the desired state (Get + Update) or fail with a diagnostic message. Silent return masks stale state that can invalidate test baselines.
+
+```go
+err := hcClient.Create(tc.Context, secret)
+if apierrors.IsAlreadyExists(err) {
+    existing := &corev1.Secret{}
+    Expect(hcClient.Get(tc.Context, crclient.ObjectKeyFromObject(secret), existing)).To(Succeed())
+    existing.Data = secret.Data
+    existing.Type = secret.Type
+    Expect(hcClient.Update(tc.Context, existing)).To(Succeed())
+    return
+}
+Expect(err).NotTo(HaveOccurred(), "failed to create additional-pull-secret")
+```
+
+### 18. Dynamic Assertion Values
+
+When a test extracts a value from one resource to validate against another (e.g., `expectedStrategy` from HostedCluster checked against IngressController), use the extracted variable in assertions — not hardcoded enum constants. Hardcoded values make the test brittle and hide the logical contract being verified.
+
+```go
+// WRONG — hardcoded constants
+g.Expect(ic.Spec.EndpointPublishingStrategy.Type).To(Equal(operatorv1.LoadBalancerServiceStrategyType))
+
+// RIGHT — compare against the extracted expectation
+g.Expect(ic.Spec.EndpointPublishingStrategy.Type).To(Equal(expectedStrategy.Type))
 ```
 
 ## Expanding v2

--- a/test/e2e/v2/internal/env_vars.go
+++ b/test/e2e/v2/internal/env_vars.go
@@ -208,4 +208,9 @@ func init() {
 		"Azure DiskEncryptionSet resource ID for disk encryption NodePool tests.",
 		false,
 	)
+	RegisterEnvVar(
+		"E2E_ADDITIONAL_PULL_SECRET_FILE",
+		"Path to an additional pull secret file for the global pull secret lifecycle test.",
+		false,
+	)
 }

--- a/test/e2e/v2/tests/hosted_cluster_aws_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_aws_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -91,6 +92,8 @@ func EnsureDefaultSecurityGroupTagsTest(getTestCtx internal.TestContextGetter) {
 			day2TagKey := "test-day2-tag"
 			day2TagValue := "test-day2-value"
 
+			originalTags := append([]hyperv1.AWSResourceTag(nil), hc.Spec.Platform.AWS.ResourceTags...)
+
 			err = e2eutil.UpdateObject(GinkgoTB(), tc.Context, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
 				obj.Spec.Platform.AWS.ResourceTags = append(obj.Spec.Platform.AWS.ResourceTags, hyperv1.AWSResourceTag{
 					Key:   day2TagKey,
@@ -98,6 +101,14 @@ func EnsureDefaultSecurityGroupTagsTest(getTestCtx internal.TestContextGetter) {
 				})
 			})
 			Expect(err).NotTo(HaveOccurred(), "failed to update HostedCluster with day-2 tag")
+			DeferCleanup(func() {
+				err := e2eutil.UpdateObject(GinkgoTB(), tc.Context, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+					obj.Spec.Platform.AWS.ResourceTags = append([]hyperv1.AWSResourceTag(nil), originalTags...)
+				})
+				if err != nil && !apierrors.IsNotFound(err) {
+					Expect(err).NotTo(HaveOccurred(), "cleanup: failed to restore HostedCluster AWS resource tags")
+				}
+			})
 
 			Eventually(func(g Gomega) {
 				sg, err := e2eutil.GetDefaultSecurityGroup(tc.Context, awsCredsFile, region, sgID)
@@ -159,9 +170,12 @@ func AWSCCMWithCustomizationsTest(getTestCtx internal.TestContextGetter) {
 					},
 				}
 				Expect(hcClient.Create(tc.Context, testNS)).To(Succeed(), "failed to create test namespace")
-				defer func() {
-					_ = hcClient.Delete(tc.Context, testNS)
-				}()
+				DeferCleanup(func() {
+					err := hcClient.Delete(tc.Context, testNS)
+					if err != nil && !apierrors.IsNotFound(err) {
+						Expect(err).NotTo(HaveOccurred(), "cleanup: failed to delete test namespace %s", testNS.Name)
+					}
+				})
 
 				testSvc := &corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/v2/tests/hosted_cluster_aws_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_aws_test.go
@@ -1,0 +1,265 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	elbv2 "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	"github.com/openshift/hypershift/test/e2e/v2/internal"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func RegisterHostedClusterAWSTests(getTestCtx internal.TestContextGetter) {
+	EnsureDefaultSecurityGroupTagsTest(getTestCtx)
+	AWSCCMWithCustomizationsTest(getTestCtx)
+}
+
+func EnsureDefaultSecurityGroupTagsTest(getTestCtx internal.TestContextGetter) {
+	When("a day-2 resource tag is added to the HostedCluster spec", func() {
+		It("should apply the tag to the default worker security group via AWS API", Label("AWS"), func() {
+			tc := getTestCtx()
+			if e2eutil.IsLessThan(e2eutil.Version420) {
+				Skip("default security group tags test requires version >= 4.20")
+			}
+			hc := tc.GetHostedCluster()
+			if hc.Spec.Platform.Type != hyperv1.AWSPlatform {
+				Skip("default security group tags test is only for AWS platform")
+			}
+
+			sgID := hc.Status.Platform.AWS.DefaultWorkerSecurityGroupID
+			Expect(sgID).NotTo(BeEmpty(), "HostedCluster status should have DefaultWorkerSecurityGroupID set")
+
+			awsCredsFile := internal.GetEnvVarValue("AWS_GUEST_INFRA_CREDENTIALS_FILE")
+			Expect(awsCredsFile).NotTo(BeEmpty(), "AWS_GUEST_INFRA_CREDENTIALS_FILE must be set for AWS security group tests")
+
+			region := hc.Spec.Platform.AWS.Region
+			Expect(region).NotTo(BeEmpty(), "HostedCluster AWS region should be set")
+
+			tagsPolicy := fmt.Sprintf(`{
+				"Version": "2012-10-17",
+				"Statement": [
+					{
+						"Effect": "Allow",
+						"Action": [
+							"ec2:CreateTags",
+							"ec2:DeleteTags"
+						],
+						"Resource": "arn:aws:ec2:*:*:security-group/%s"
+					}
+				]
+			}`, sgID)
+
+			Expect(hc.Spec.Platform.AWS.RolesRef.ControlPlaneOperatorARN).NotTo(BeEmpty(),
+				"HostedCluster should have ControlPlaneOperatorARN set")
+
+			cleanup, err := e2eutil.PutRolePolicy(tc.Context, awsCredsFile, region,
+				hc.Spec.Platform.AWS.RolesRef.ControlPlaneOperatorARN, tagsPolicy)
+			Expect(err).NotTo(HaveOccurred(), "failed to put role policy for tagging default security group")
+			defer func() {
+				Expect(cleanup()).To(Succeed(), "failed to cleanup role policy for tagging default security group")
+			}()
+
+			day2TagKey := "test-day2-tag"
+			day2TagValue := "test-day2-value"
+
+			err = e2eutil.UpdateObject(GinkgoTB(), tc.Context, tc.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+				obj.Spec.Platform.AWS.ResourceTags = append(obj.Spec.Platform.AWS.ResourceTags, hyperv1.AWSResourceTag{
+					Key:   day2TagKey,
+					Value: day2TagValue,
+				})
+			})
+			Expect(err).NotTo(HaveOccurred(), "failed to update HostedCluster with day-2 tag")
+
+			Eventually(func(g Gomega) {
+				sg, err := e2eutil.GetDefaultSecurityGroup(tc.Context, awsCredsFile, region, sgID)
+				g.Expect(err).NotTo(HaveOccurred(), "failed to get default security group")
+				g.Expect(sg.Tags).To(ContainElement(ec2types.Tag{
+					Key:   aws.String(day2TagKey),
+					Value: aws.String(day2TagValue),
+				}), "day-2 tag should be applied to the default worker security group")
+			}, 10*time.Minute, time.Second).Should(Succeed())
+		})
+	})
+}
+
+func AWSCCMWithCustomizationsTest(getTestCtx internal.TestContextGetter) {
+	Context("AWS CCM NLB Security Group", Label("AWS", "CCM"), func() {
+		BeforeEach(func() {
+			tc := getTestCtx()
+			if e2eutil.IsLessThan(e2eutil.Version423) {
+				Skip("AWS CCM NLB security group test requires version >= 4.23")
+			}
+			hc := tc.GetHostedCluster()
+			if hc.Spec.Platform.Type != hyperv1.AWSPlatform {
+				Skip("AWS CCM test is only for AWS platform")
+			}
+		})
+
+		When("AWSServiceLBNetworkSecurityGroup feature gate is enabled", func() {
+			It("should have NLBSecurityGroupMode=Managed in the aws-cloud-config ConfigMap", func() {
+				tc := getTestCtx()
+
+				Eventually(func(g Gomega) {
+					cm := &corev1.ConfigMap{}
+					g.Expect(tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
+						Namespace: tc.ControlPlaneNamespace,
+						Name:      "aws-cloud-config",
+					}, cm)).To(Succeed(), "failed to get aws-cloud-config ConfigMap")
+
+					awsConf, exists := cm.Data["aws.conf"]
+					g.Expect(exists).To(BeTrue(), "aws.conf key should exist in ConfigMap")
+					g.Expect(awsConf).To(ContainSubstring("NLBSecurityGroupMode = Managed"),
+						"aws.conf should contain NLBSecurityGroupMode = Managed")
+				}, 2*time.Minute, 5*time.Second).Should(Succeed())
+			})
+		})
+
+		When("a LoadBalancer NLB service is created in the hosted cluster", func() {
+			It("should attach managed security groups to the NLB", func() {
+				tc := getTestCtx()
+				tc.ValidateHostedClusterClient()
+				hcClient := tc.GetHostedClusterClient()
+				hc := tc.GetHostedCluster()
+
+				awsCredsFile := internal.GetEnvVarValue("AWS_GUEST_INFRA_CREDENTIALS_FILE")
+				Expect(awsCredsFile).NotTo(BeEmpty(), "AWS_GUEST_INFRA_CREDENTIALS_FILE must be set for AWS CCM NLB test")
+
+				testNS := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-ccm-nlb-sg",
+					},
+				}
+				Expect(hcClient.Create(tc.Context, testNS)).To(Succeed(), "failed to create test namespace")
+				defer func() {
+					_ = hcClient.Delete(tc.Context, testNS)
+				}()
+
+				testSvc := &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ccm-nlb-sg-svc",
+						Namespace: testNS.Name,
+						Annotations: map[string]string{
+							"service.beta.kubernetes.io/aws-load-balancer-type":                     "nlb",
+							"service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags": "red-hat-managed=true",
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Type: corev1.ServiceTypeLoadBalancer,
+						Selector: map[string]string{
+							"app": "test-ccm-nlb-sg",
+						},
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "http",
+								Port:       80,
+								TargetPort: intstr.FromInt32(8080),
+								Protocol:   corev1.ProtocolTCP,
+							},
+						},
+					},
+				}
+				Expect(hcClient.Create(tc.Context, testSvc)).To(Succeed(), "failed to create LoadBalancer service")
+
+				var lbHostname string
+				Eventually(func(g Gomega) {
+					svc := &corev1.Service{}
+					g.Expect(hcClient.Get(tc.Context, crclient.ObjectKey{
+						Namespace: testNS.Name,
+						Name:      testSvc.Name,
+					}, svc)).To(Succeed(), "failed to get test service")
+
+					g.Expect(svc.Status.LoadBalancer.Ingress).NotTo(BeEmpty(),
+						"LoadBalancer should have at least one ingress entry")
+					g.Expect(svc.Status.LoadBalancer.Ingress[0].Hostname).NotTo(BeEmpty(),
+						"LoadBalancer ingress hostname should be set")
+					lbHostname = svc.Status.LoadBalancer.Ingress[0].Hostname
+				}, 5*time.Minute, 10*time.Second).Should(Succeed())
+
+				lbName := extractLBNameFromHostname(lbHostname)
+				Expect(lbName).NotTo(BeEmpty(), "load balancer name should be extracted from hostname %s", lbHostname)
+
+				awsSession := awsutil.NewSession(tc.Context, "e2e-ccm-nlb-sg", awsCredsFile, "", "", hc.Spec.Platform.AWS.Region)
+				Expect(awsSession).NotTo(BeNil(), "failed to create AWS session")
+
+				awsConfig := awsutil.NewConfig()
+				Expect(awsConfig).NotTo(BeNil(), "failed to create AWS config")
+
+				elbv2Client := elbv2.NewFromConfig(*awsSession, func(o *elbv2.Options) {
+					o.Retryer = awsConfig()
+				})
+
+				describeLBInput := &elbv2.DescribeLoadBalancersInput{
+					Names: []string{lbName},
+				}
+
+				waiter := elbv2.NewLoadBalancerAvailableWaiter(elbv2Client, func(o *elbv2.LoadBalancerAvailableWaiterOptions) {
+					o.MinDelay = 5 * time.Second
+					o.MaxDelay = 30 * time.Second
+				})
+				Expect(waiter.Wait(tc.Context, describeLBInput, 3*time.Minute)).To(Succeed(),
+					"load balancer %s did not become available in time", lbName)
+
+				describeLBOutput, err := elbv2Client.DescribeLoadBalancers(tc.Context, describeLBInput)
+				Expect(err).NotTo(HaveOccurred(), "failed to describe load balancer %s", lbName)
+				Expect(describeLBOutput.LoadBalancers).NotTo(BeEmpty(),
+					"no load balancers found with name %s", lbName)
+
+				lb := describeLBOutput.LoadBalancers[0]
+				Expect(lb.SecurityGroups).NotTo(BeEmpty(),
+					"load balancer should have security groups attached when NLBSecurityGroupMode = Managed")
+			})
+		})
+	})
+}
+
+func extractLBNameFromHostname(hostname string) string {
+	firstLabel := strings.SplitN(hostname, ".", 2)[0]
+	firstLabel = strings.TrimPrefix(firstLabel, "internal-")
+	lastHyphen := strings.LastIndex(firstLabel, "-")
+	if lastHyphen == -1 {
+		return firstLabel
+	}
+	return firstLabel[:lastHyphen]
+}
+
+var _ = Describe("Hosted Cluster AWS", Label("lifecycle", "hosted-cluster-aws"), func() {
+	var testCtx *internal.TestContext
+
+	BeforeEach(func() {
+		testCtx = internal.GetTestContext()
+		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
+
+		testCtx.ValidateHostedCluster()
+	})
+
+	RegisterHostedClusterAWSTests(func() *internal.TestContext { return testCtx })
+})

--- a/test/e2e/v2/tests/hosted_cluster_aws_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_aws_test.go
@@ -85,9 +85,9 @@ func EnsureDefaultSecurityGroupTagsTest(getTestCtx internal.TestContextGetter) {
 			cleanup, err := e2eutil.PutRolePolicy(tc.Context, awsCredsFile, region,
 				hc.Spec.Platform.AWS.RolesRef.ControlPlaneOperatorARN, tagsPolicy)
 			Expect(err).NotTo(HaveOccurred(), "failed to put role policy for tagging default security group")
-			defer func() {
+			DeferCleanup(func() {
 				Expect(cleanup()).To(Succeed(), "failed to cleanup role policy for tagging default security group")
-			}()
+			})
 
 			day2TagKey := "test-day2-tag"
 			day2TagValue := "test-day2-value"

--- a/test/e2e/v2/tests/hosted_cluster_cpo_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_cpo_test.go
@@ -1,0 +1,98 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	controlplaneoperatoroverrides "github.com/openshift/hypershift/hypershift-operator/controlplaneoperator-overrides"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	"github.com/openshift/hypershift/test/e2e/v2/internal"
+
+	corev1 "k8s.io/api/core/v1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func RegisterHostedClusterCPOTests(getTestCtx internal.TestContextGetter) {
+	VerifyCPOOverrideImageTest(getTestCtx)
+}
+
+func VerifyCPOOverrideImageTest(getTestCtx internal.TestContextGetter) {
+	When("a CPO override image is configured for the platform and version", func() {
+		It("should run the control-plane-operator pod with the expected override image", func() {
+			tc := getTestCtx()
+			hc := tc.GetHostedCluster()
+
+			releaseImage := hc.Spec.Release.Image
+			Expect(releaseImage).NotTo(BeEmpty(), "HostedCluster release image should be set")
+
+			version := e2eutil.ExtractVersionFromReleaseImage(releaseImage)
+			if version == "" {
+				Skip(fmt.Sprintf("could not extract version from release image %s", releaseImage))
+			}
+
+			platform := string(hc.Spec.Platform.Type)
+			expectedImage := controlplaneoperatoroverrides.CPOImage(platform, version)
+			if expectedImage == "" {
+				Skip(fmt.Sprintf("no CPO override configured for platform %s and version %s", platform, version))
+			}
+
+			Eventually(func(g Gomega) {
+				podList := &corev1.PodList{}
+				g.Expect(tc.MgmtClient.List(tc.Context, podList,
+					crclient.InNamespace(tc.ControlPlaneNamespace),
+					crclient.MatchingLabels{"app": "control-plane-operator"},
+				)).To(Succeed(), "failed to list control-plane-operator pods")
+
+				g.Expect(podList.Items).NotTo(BeEmpty(),
+					"expected at least one control-plane-operator pod in namespace %s", tc.ControlPlaneNamespace)
+
+				var runningPod *corev1.Pod
+				for i := range podList.Items {
+					if podList.Items[i].Status.Phase == corev1.PodRunning {
+						runningPod = &podList.Items[i]
+						break
+					}
+				}
+				g.Expect(runningPod).NotTo(BeNil(),
+					"expected at least one running control-plane-operator pod in namespace %s", tc.ControlPlaneNamespace)
+				g.Expect(runningPod.Spec.Containers).NotTo(BeEmpty(),
+					"control-plane-operator pod %s should have at least one container", runningPod.Name)
+				g.Expect(runningPod.Spec.Containers[0].Image).To(Equal(expectedImage),
+					"control-plane-operator pod %s container image should match override (expected %s, got %s)",
+					runningPod.Name, expectedImage, runningPod.Spec.Containers[0].Image)
+			}, 5*time.Minute, 10*time.Second).Should(Succeed())
+		})
+	})
+}
+
+var _ = Describe("Hosted Cluster CPO", Label("hosted-cluster-cpo"), func() {
+	var testCtx *internal.TestContext
+
+	BeforeEach(func() {
+		testCtx = internal.GetTestContext()
+		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
+
+		testCtx.ValidateHostedCluster()
+	})
+
+	RegisterHostedClusterCPOTests(func() *internal.TestContext { return testCtx })
+})

--- a/test/e2e/v2/tests/hosted_cluster_cpo_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_cpo_test.go
@@ -45,9 +45,7 @@ func VerifyCPOOverrideImageTest(getTestCtx internal.TestContextGetter) {
 			Expect(releaseImage).NotTo(BeEmpty(), "HostedCluster release image should be set")
 
 			version := e2eutil.ExtractVersionFromReleaseImage(releaseImage)
-			if version == "" {
-				Skip(fmt.Sprintf("could not extract version from release image %s", releaseImage))
-			}
+			Expect(version).NotTo(BeEmpty(), "could not extract version from release image %s", releaseImage)
 
 			platform := string(hc.Spec.Platform.Type)
 			expectedImage := controlplaneoperatoroverrides.CPOImage(platform, version)
@@ -65,20 +63,29 @@ func VerifyCPOOverrideImageTest(getTestCtx internal.TestContextGetter) {
 				g.Expect(podList.Items).NotTo(BeEmpty(),
 					"expected at least one control-plane-operator pod in namespace %s", tc.ControlPlaneNamespace)
 
-				var runningPod *corev1.Pod
+				foundRunning := false
+				foundExpectedImage := false
 				for i := range podList.Items {
-					if podList.Items[i].Status.Phase == corev1.PodRunning {
-						runningPod = &podList.Items[i]
+					pod := &podList.Items[i]
+					if pod.Status.Phase != corev1.PodRunning {
+						continue
+					}
+					foundRunning = true
+					for _, c := range pod.Spec.Containers {
+						if c.Name == "control-plane-operator" && c.Image == expectedImage {
+							foundExpectedImage = true
+							break
+						}
+					}
+					if foundExpectedImage {
 						break
 					}
 				}
-				g.Expect(runningPod).NotTo(BeNil(),
+				g.Expect(foundRunning).To(BeTrue(),
 					"expected at least one running control-plane-operator pod in namespace %s", tc.ControlPlaneNamespace)
-				g.Expect(runningPod.Spec.Containers).NotTo(BeEmpty(),
-					"control-plane-operator pod %s should have at least one container", runningPod.Name)
-				g.Expect(runningPod.Spec.Containers[0].Image).To(Equal(expectedImage),
-					"control-plane-operator pod %s container image should match override (expected %s, got %s)",
-					runningPod.Name, expectedImage, runningPod.Spec.Containers[0].Image)
+				g.Expect(foundExpectedImage).To(BeTrue(),
+					"expected a running control-plane-operator container with image %s in namespace %s",
+					expectedImage, tc.ControlPlaneNamespace)
 			}, 5*time.Minute, 10*time.Second).Should(Succeed())
 		})
 	})

--- a/test/e2e/v2/tests/hosted_cluster_ingress_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_ingress_test.go
@@ -50,12 +50,6 @@ func ValidateIngressOperatorConfigurationTest(getTestCtx internal.TestContextGet
 			}
 
 			expectedStrategy := hc.Spec.OperatorConfiguration.IngressOperator.EndpointPublishingStrategy
-			Expect(expectedStrategy.Type).To(Equal(operatorv1.LoadBalancerServiceStrategyType),
-				"EndpointPublishingStrategy type should be LoadBalancerService")
-			Expect(expectedStrategy.LoadBalancer).NotTo(BeNil(),
-				"LoadBalancer configuration should be set")
-			Expect(expectedStrategy.LoadBalancer.Scope).To(Equal(operatorv1.InternalLoadBalancer),
-				"LoadBalancer scope should be Internal")
 
 			tc.ValidateHostedClusterClient()
 			hcClient := tc.GetHostedClusterClient()

--- a/test/e2e/v2/tests/hosted_cluster_ingress_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_ingress_test.go
@@ -1,0 +1,94 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	"github.com/openshift/hypershift/test/e2e/v2/internal"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func RegisterHostedClusterIngressTests(getTestCtx internal.TestContextGetter) {
+	ValidateIngressOperatorConfigurationTest(getTestCtx)
+}
+
+func ValidateIngressOperatorConfigurationTest(getTestCtx internal.TestContextGetter) {
+	When("hosted cluster has IngressOperator EndpointPublishingStrategy configured", func() {
+		It("should reflect the custom strategy in the hosted cluster IngressController", func() {
+			tc := getTestCtx()
+			if e2eutil.IsLessThan(e2eutil.Version421) {
+				Skip("Ingress operator configuration requires version >= 4.21")
+			}
+			hc := tc.GetHostedCluster()
+
+			if hc.Spec.OperatorConfiguration == nil ||
+				hc.Spec.OperatorConfiguration.IngressOperator == nil ||
+				hc.Spec.OperatorConfiguration.IngressOperator.EndpointPublishingStrategy == nil {
+				Skip("HostedCluster does not have IngressOperator EndpointPublishingStrategy configured")
+			}
+
+			expectedStrategy := hc.Spec.OperatorConfiguration.IngressOperator.EndpointPublishingStrategy
+			Expect(expectedStrategy.Type).To(Equal(operatorv1.LoadBalancerServiceStrategyType),
+				"EndpointPublishingStrategy type should be LoadBalancerService")
+			Expect(expectedStrategy.LoadBalancer).NotTo(BeNil(),
+				"LoadBalancer configuration should be set")
+			Expect(expectedStrategy.LoadBalancer.Scope).To(Equal(operatorv1.InternalLoadBalancer),
+				"LoadBalancer scope should be Internal")
+
+			tc.ValidateHostedClusterClient()
+			hcClient := tc.GetHostedClusterClient()
+
+			Eventually(func(g Gomega) {
+				ic := &operatorv1.IngressController{}
+				g.Expect(hcClient.Get(tc.Context, types.NamespacedName{
+					Namespace: "openshift-ingress-operator",
+					Name:      "default",
+				}, ic)).To(Succeed(), "failed to get IngressController default in hosted cluster")
+
+				g.Expect(ic.Spec.EndpointPublishingStrategy).NotTo(BeNil(),
+					"IngressController EndpointPublishingStrategy should be set")
+				g.Expect(ic.Spec.EndpointPublishingStrategy.Type).To(Equal(operatorv1.LoadBalancerServiceStrategyType),
+					fmt.Sprintf("expected EndpointPublishingStrategy type LoadBalancerService, got %s", ic.Spec.EndpointPublishingStrategy.Type))
+				g.Expect(ic.Spec.EndpointPublishingStrategy.LoadBalancer).NotTo(BeNil(),
+					"IngressController LoadBalancer configuration should be set")
+				g.Expect(ic.Spec.EndpointPublishingStrategy.LoadBalancer.Scope).To(Equal(operatorv1.InternalLoadBalancer),
+					fmt.Sprintf("expected LoadBalancer scope Internal, got %s", ic.Spec.EndpointPublishingStrategy.LoadBalancer.Scope))
+			}, 5*time.Minute, 10*time.Second).Should(Succeed())
+		})
+	})
+}
+
+var _ = Describe("Hosted Cluster Ingress", Label("hosted-cluster-ingress"), func() {
+	var testCtx *internal.TestContext
+
+	BeforeEach(func() {
+		testCtx = internal.GetTestContext()
+		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
+
+		testCtx.ValidateHostedCluster()
+	})
+
+	RegisterHostedClusterIngressTests(func() *internal.TestContext { return testCtx })
+})

--- a/test/e2e/v2/tests/hosted_cluster_ingress_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_ingress_test.go
@@ -69,12 +69,14 @@ func ValidateIngressOperatorConfigurationTest(getTestCtx internal.TestContextGet
 
 				g.Expect(ic.Spec.EndpointPublishingStrategy).NotTo(BeNil(),
 					"IngressController EndpointPublishingStrategy should be set")
-				g.Expect(ic.Spec.EndpointPublishingStrategy.Type).To(Equal(operatorv1.LoadBalancerServiceStrategyType),
-					fmt.Sprintf("expected EndpointPublishingStrategy type LoadBalancerService, got %s", ic.Spec.EndpointPublishingStrategy.Type))
-				g.Expect(ic.Spec.EndpointPublishingStrategy.LoadBalancer).NotTo(BeNil(),
-					"IngressController LoadBalancer configuration should be set")
-				g.Expect(ic.Spec.EndpointPublishingStrategy.LoadBalancer.Scope).To(Equal(operatorv1.InternalLoadBalancer),
-					fmt.Sprintf("expected LoadBalancer scope Internal, got %s", ic.Spec.EndpointPublishingStrategy.LoadBalancer.Scope))
+				g.Expect(ic.Spec.EndpointPublishingStrategy.Type).To(Equal(expectedStrategy.Type),
+					fmt.Sprintf("expected EndpointPublishingStrategy type %s, got %s", expectedStrategy.Type, ic.Spec.EndpointPublishingStrategy.Type))
+				if expectedStrategy.LoadBalancer != nil {
+					g.Expect(ic.Spec.EndpointPublishingStrategy.LoadBalancer).NotTo(BeNil(),
+						"IngressController LoadBalancer configuration should be set")
+					g.Expect(ic.Spec.EndpointPublishingStrategy.LoadBalancer.Scope).To(Equal(expectedStrategy.LoadBalancer.Scope),
+						fmt.Sprintf("expected LoadBalancer scope %s, got %s", expectedStrategy.LoadBalancer.Scope, ic.Spec.EndpointPublishingStrategy.LoadBalancer.Scope))
+				}
 			}, 5*time.Minute, 10*time.Second).Should(Succeed())
 		})
 	})

--- a/test/e2e/v2/tests/hosted_cluster_node_communication_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_node_communication_test.go
@@ -51,10 +51,17 @@ func EnsureNodeCommunicationTest(getTestCtx internal.TestContextGetter) {
 				g.Expect(err).NotTo(HaveOccurred(), "failed to list konnectivity-agent pods")
 				g.Expect(podList.Items).NotTo(BeEmpty(), "expected at least one konnectivity-agent pod in kube-system")
 
-				_, err = clientset.CoreV1().Pods("kube-system").GetLogs(podList.Items[0].Name, &corev1.PodLogOptions{
-					Container: "konnectivity-agent",
-				}).DoRaw(tc.Context)
-				g.Expect(err).NotTo(HaveOccurred(), "failed to retrieve logs from konnectivity-agent pod %s", podList.Items[0].Name)
+				retrieved := false
+				for _, pod := range podList.Items {
+					_, err = clientset.CoreV1().Pods("kube-system").GetLogs(pod.Name, &corev1.PodLogOptions{
+						Container: "konnectivity-agent",
+					}).DoRaw(tc.Context)
+					if err == nil {
+						retrieved = true
+						break
+					}
+				}
+				g.Expect(retrieved).To(BeTrue(), "failed to retrieve logs from any konnectivity-agent pod")
 			}, 5*time.Minute, 10*time.Second).Should(Succeed())
 		})
 	})

--- a/test/e2e/v2/tests/hosted_cluster_node_communication_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_node_communication_test.go
@@ -1,0 +1,74 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/test/e2e/v2/internal"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func RegisterNodeCommunicationTests(getTestCtx internal.TestContextGetter) {
+	EnsureNodeCommunicationTest(getTestCtx)
+}
+
+func EnsureNodeCommunicationTest(getTestCtx internal.TestContextGetter) {
+	When("hosted cluster has konnectivity tunnel configured", func() {
+		It("should have konnectivity-agent pods with retrievable logs", func() {
+			tc := getTestCtx()
+			tc.ValidateHostedClusterClient()
+			restConfig := tc.GetHostedClusterRESTConfig()
+			Expect(restConfig).NotTo(BeNil(), "hosted cluster REST config should be available")
+
+			clientset, err := kubernetes.NewForConfig(restConfig)
+			Expect(err).NotTo(HaveOccurred(), "failed to create hosted cluster kubernetes clientset")
+
+			Eventually(func(g Gomega) {
+				podList, err := clientset.CoreV1().Pods("kube-system").List(tc.Context, metav1.ListOptions{
+					LabelSelector: "app=konnectivity-agent",
+				})
+				g.Expect(err).NotTo(HaveOccurred(), "failed to list konnectivity-agent pods")
+				g.Expect(podList.Items).NotTo(BeEmpty(), "expected at least one konnectivity-agent pod in kube-system")
+
+				_, err = clientset.CoreV1().Pods("kube-system").GetLogs(podList.Items[0].Name, &corev1.PodLogOptions{
+					Container: "konnectivity-agent",
+				}).DoRaw(tc.Context)
+				g.Expect(err).NotTo(HaveOccurred(), "failed to retrieve logs from konnectivity-agent pod %s", podList.Items[0].Name)
+			}, 5*time.Minute, 10*time.Second).Should(Succeed())
+		})
+	})
+}
+
+var _ = Describe("Hosted Cluster Node Communication", Label("hosted-cluster-node-communication"), func() {
+	var testCtx *internal.TestContext
+
+	BeforeEach(func() {
+		testCtx = internal.GetTestContext()
+		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
+
+		testCtx.ValidateHostedCluster()
+	})
+
+	RegisterNodeCommunicationTests(func() *internal.TestContext { return testCtx })
+})

--- a/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
@@ -79,11 +79,19 @@ func EnsureGlobalPullSecretTest(getTestCtx internal.TestContextGetter) {
 				"failed to list NodePools")
 			Expect(npList.Items).NotTo(BeEmpty(), "expected at least one NodePool")
 
-			np := &npList.Items[0]
-			if np.Spec.Management.UpgradeType == hyperv1.UpgradeTypeInPlace {
-				Skip("InPlace upgrade type is not supported for global pull secret test")
+			var np *hyperv1.NodePool
+			for i := range npList.Items {
+				candidate := &npList.Items[i]
+				if candidate.Spec.Management.UpgradeType != hyperv1.UpgradeTypeInPlace &&
+					candidate.Spec.Replicas != nil &&
+					*candidate.Spec.Replicas > 0 {
+					np = candidate
+					break
+				}
 			}
-			Expect(np.Spec.Replicas).NotTo(BeNil(), "NodePool replicas should be set")
+			if np == nil {
+				Skip("no suitable NodePool found (need non-InPlace upgrade type with replicas > 0)")
+			}
 			nodeCount := *np.Spec.Replicas
 
 			var dummyPullSecretData = []byte(`{"auths": {"quay.io": {"auth": "YWRtaW46cGFzc3dvcmQ="}}}`)
@@ -98,6 +106,13 @@ func EnsureGlobalPullSecretTest(getTestCtx internal.TestContextGetter) {
 
 			By("creating additional-pull-secret with dummy data")
 			createAdditionalPullSecret(tc, hcClient, dummyPullSecretData)
+			DeferCleanup(func() {
+				additionalPS := hccomanifests.AdditionalPullSecret()
+				err := hcClient.Delete(tc.Context, additionalPS)
+				if err != nil && !apierrors.IsNotFound(err) {
+					Expect(err).NotTo(HaveOccurred(), "cleanup: failed to delete additional-pull-secret")
+				}
+			})
 
 			By("verifying GlobalPullSecret is created in the hosted cluster")
 			var oldGlobalPSData []byte
@@ -186,14 +201,21 @@ func verifyPullSecretPropagation(tc *internal.TestContext, hc *hyperv1.HostedClu
 
 	DeferCleanup(func() {
 		fresh := &corev1.Secret{}
-		if err := tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
+		err := tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
 			Namespace: hc.Namespace,
 			Name:      hc.Spec.PullSecret.Name,
-		}, fresh); err != nil {
+		}, fresh)
+		if apierrors.IsNotFound(err) {
 			return
 		}
+		Expect(err).NotTo(HaveOccurred(),
+			"cleanup: failed to get management-cluster pull secret %s/%s", hc.Namespace, hc.Spec.PullSecret.Name)
+		if fresh.Data == nil {
+			fresh.Data = map[string][]byte{}
+		}
 		fresh.Data[corev1.DockerConfigJsonKey] = originalData
-		_ = tc.MgmtClient.Update(tc.Context, fresh)
+		Expect(tc.MgmtClient.Update(tc.Context, fresh)).To(Succeed(),
+			"cleanup: failed to restore management-cluster pull secret %s/%s", hc.Namespace, hc.Spec.PullSecret.Name)
 	})
 
 	type dockerConfigJSON struct {
@@ -229,13 +251,17 @@ func verifyPullSecretPropagation(tc *internal.TestContext, hc *hyperv1.HostedClu
 
 	nodePool := &hyperv1.NodePool{}
 	Expect(tc.MgmtClient.Get(tc.Context, crclient.ObjectKeyFromObject(np), nodePool)).To(Succeed())
+	foundUpdatingConfig := false
 	for _, cond := range nodePool.Status.Conditions {
 		if cond.Type == hyperv1.NodePoolUpdatingConfigConditionType {
+			foundUpdatingConfig = true
 			Expect(string(cond.Status)).To(Equal(string(metav1.ConditionFalse)),
 				"UpdatingConfig should be False — in-place pull secret update must not trigger a rollout")
 			break
 		}
 	}
+	Expect(foundUpdatingConfig).To(BeTrue(),
+		"NodePool %s should have UpdatingConfig condition", nodePool.Name)
 
 	nodeList := &corev1.NodeList{}
 	Expect(hcClient.List(tc.Context, nodeList, crclient.MatchingLabels{
@@ -274,6 +300,13 @@ func createAdditionalPullSecret(tc *internal.TestContext, hcClient crclient.Clie
 	}
 	err := hcClient.Create(tc.Context, secret)
 	if apierrors.IsAlreadyExists(err) {
+		existing := &corev1.Secret{}
+		Expect(hcClient.Get(tc.Context, crclient.ObjectKeyFromObject(secret), existing)).To(Succeed(),
+			"failed to get existing additional-pull-secret for reconciliation")
+		existing.Data = secret.Data
+		existing.Type = secret.Type
+		Expect(hcClient.Update(tc.Context, existing)).To(Succeed(),
+			"failed to reconcile existing additional-pull-secret")
 		return
 	}
 	Expect(err).NotTo(HaveOccurred(), "failed to create additional-pull-secret")

--- a/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
@@ -1,0 +1,332 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hccomanifests "github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/controllers/resources/manifests"
+	"github.com/openshift/hypershift/support/netutil"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	"github.com/openshift/hypershift/test/e2e/v2/internal"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func RegisterGlobalPullSecretTests(getTestCtx internal.TestContextGetter) {
+	EnsureGlobalPullSecretTest(getTestCtx)
+}
+
+func EnsureGlobalPullSecretTest(getTestCtx internal.TestContextGetter) {
+	When("an additional pull secret is created in the hosted cluster", func() {
+		It("should propagate it through the global pull secret pipeline and clean up on deletion", func() {
+			tc := getTestCtx()
+			if e2eutil.IsLessThan(e2eutil.Version419) {
+				Skip("global pull secret test requires version >= 4.19")
+			}
+
+			hc := tc.GetHostedCluster()
+
+			if hc.Spec.Platform.Type != hyperv1.AzurePlatform && hc.Spec.Platform.Type != hyperv1.AWSPlatform {
+				Skip("global pull secret test is only supported on AWS and Azure platforms")
+			}
+			if hc.Spec.Platform.Type == hyperv1.AWSPlatform && e2eutil.IsLessThan(e2eutil.Version421) {
+				Skip("AWS platform requires version >= 4.21 for global pull secret")
+			}
+			if !netutil.IsPublicHC(hc) {
+				Skip("global pull secret test is only supported on public clusters")
+			}
+
+			additionalPullSecretFile := internal.GetEnvVarValue("E2E_ADDITIONAL_PULL_SECRET_FILE")
+			if additionalPullSecretFile == "" {
+				Skip("E2E_ADDITIONAL_PULL_SECRET_FILE not set, skipping global pull secret test")
+			}
+
+			additionalPullSecretData, err := os.ReadFile(additionalPullSecretFile)
+			Expect(err).NotTo(HaveOccurred(), "failed to read additional pull secret file %s", additionalPullSecretFile)
+
+			tc.ValidateHostedClusterClient()
+			hcClient := tc.GetHostedClusterClient()
+
+			npList := &hyperv1.NodePoolList{}
+			Expect(tc.MgmtClient.List(tc.Context, npList, crclient.InNamespace(hc.Namespace))).To(Succeed(),
+				"failed to list NodePools")
+			Expect(npList.Items).NotTo(BeEmpty(), "expected at least one NodePool")
+
+			np := &npList.Items[0]
+			if np.Spec.Management.UpgradeType == hyperv1.UpgradeTypeInPlace {
+				Skip("InPlace upgrade type is not supported for global pull secret test")
+			}
+			Expect(np.Spec.Replicas).NotTo(BeNil(), "NodePool replicas should be set")
+			nodeCount := *np.Spec.Replicas
+
+			var dummyPullSecretData = []byte(`{"auths": {"quay.io": {"auth": "YWRtaW46cGFzc3dvcmQ="}}}`)
+
+			By("verifying in-place management-cluster pull secret propagation without rollout")
+			if !e2eutil.IsLessThan(e2eutil.Version422) {
+				verifyPullSecretPropagation(tc, hc, np, hcClient, nodeCount)
+			}
+
+			By("verifying Replace nodes have globalPS label")
+			verifyGlobalPSLabel(tc, hcClient, np, nodeCount)
+
+			By("creating additional-pull-secret with dummy data")
+			createAdditionalPullSecret(tc, hcClient, dummyPullSecretData)
+
+			By("verifying GlobalPullSecret is created in the hosted cluster")
+			var oldGlobalPSData []byte
+			Eventually(func(g Gomega) {
+				globalPS := hccomanifests.GlobalPullSecret()
+				g.Expect(hcClient.Get(tc.Context, crclient.ObjectKeyFromObject(globalPS), globalPS)).To(Succeed(),
+					"global-pull-secret should exist")
+				g.Expect(globalPS.Data[corev1.DockerConfigJsonKey]).NotTo(BeEmpty(),
+					"global-pull-secret data should not be empty")
+				oldGlobalPSData = globalPS.Data[corev1.DockerConfigJsonKey]
+			}, 30*time.Second, 5*time.Second).Should(Succeed())
+
+			By("verifying critical DaemonSets are ready (first check)")
+			verifyDaemonSetsReady(tc, hcClient, nodeCount)
+
+			By("updating additional-pull-secret with valid pull secret data")
+			additionalPS := hccomanifests.AdditionalPullSecret()
+			Expect(hcClient.Get(tc.Context, crclient.ObjectKeyFromObject(additionalPS), additionalPS)).To(Succeed(),
+				"failed to get additional-pull-secret")
+			additionalPS.Data[corev1.DockerConfigJsonKey] = additionalPullSecretData
+			Expect(hcClient.Update(tc.Context, additionalPS)).To(Succeed(),
+				"failed to update additional-pull-secret with valid data")
+
+			By("waiting for nodes to stabilize after pull secret update")
+			e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), tc.Context, hcClient, np, hc.Spec.Platform.Type)
+
+			By("verifying GlobalPullSecret is updated in the hosted cluster")
+			Eventually(func(g Gomega) {
+				globalPS := hccomanifests.GlobalPullSecret()
+				g.Expect(hcClient.Get(tc.Context, crclient.ObjectKeyFromObject(globalPS), globalPS)).To(Succeed())
+				g.Expect(globalPS.Data[corev1.DockerConfigJsonKey]).NotTo(BeEmpty())
+				g.Expect(bytes.Equal(globalPS.Data[corev1.DockerConfigJsonKey], oldGlobalPSData)).To(BeFalse(),
+					"global-pull-secret should be updated after adding valid pull secret")
+			}, 30*time.Second, 5*time.Second).Should(Succeed())
+
+			By("verifying critical DaemonSets are ready (second check)")
+			verifyDaemonSetsReady(tc, hcClient, nodeCount)
+
+			By("deleting additional-pull-secret")
+			Expect(hcClient.Delete(tc.Context, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "additional-pull-secret",
+					Namespace: "kube-system",
+				},
+			})).To(Succeed(), "failed to delete additional-pull-secret")
+
+			By("verifying GlobalPullSecret is deleted from the hosted cluster")
+			Eventually(func() error {
+				globalPS := hccomanifests.GlobalPullSecret()
+				err := hcClient.Get(tc.Context, crclient.ObjectKeyFromObject(globalPS), globalPS)
+				if apierrors.IsNotFound(err) {
+					return nil
+				}
+				if err != nil {
+					return err
+				}
+				return fmt.Errorf("global-pull-secret still exists")
+			}, 30*time.Second, 5*time.Second).Should(Succeed())
+
+			By("waiting for nodes to stabilize after pull secret deletion")
+			e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), tc.Context, hcClient, np, hc.Spec.Platform.Type)
+
+			By("verifying global-pull-secret-syncer DaemonSet is ready after cleanup")
+			Eventually(func(g Gomega) {
+				ds := &appsv1.DaemonSet{}
+				g.Expect(hcClient.Get(tc.Context, crclient.ObjectKey{
+					Name:      hccomanifests.GlobalPullSecretDSName,
+					Namespace: hccomanifests.GlobalPullSecretNamespace,
+				}, ds)).To(Succeed())
+				g.Expect(ds.Status.DesiredNumberScheduled).To(BeNumerically(">=", nodeCount))
+				g.Expect(ds.Status.NumberReady).To(Equal(ds.Status.DesiredNumberScheduled))
+			}, 20*time.Minute, 10*time.Second).Should(Succeed())
+		})
+	})
+}
+
+func verifyPullSecretPropagation(tc *internal.TestContext, hc *hyperv1.HostedCluster, np *hyperv1.NodePool, hcClient crclient.Client, nodeCount int32) {
+	mgmtSecret := &corev1.Secret{}
+	Expect(tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
+		Namespace: hc.Namespace,
+		Name:      hc.Spec.PullSecret.Name,
+	}, mgmtSecret)).To(Succeed(), "failed to get management-cluster pull secret")
+
+	originalData := make([]byte, len(mgmtSecret.Data[corev1.DockerConfigJsonKey]))
+	copy(originalData, mgmtSecret.Data[corev1.DockerConfigJsonKey])
+
+	DeferCleanup(func() {
+		fresh := &corev1.Secret{}
+		if err := tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{
+			Namespace: hc.Namespace,
+			Name:      hc.Spec.PullSecret.Name,
+		}, fresh); err != nil {
+			return
+		}
+		fresh.Data[corev1.DockerConfigJsonKey] = originalData
+		_ = tc.MgmtClient.Update(tc.Context, fresh)
+	})
+
+	type dockerConfigJSON struct {
+		Auths map[string]json.RawMessage `json:"auths"`
+	}
+	var cfg dockerConfigJSON
+	Expect(json.Unmarshal(originalData, &cfg)).To(Succeed(), "failed to parse pull secret")
+	cfg.Auths["e2e-dummy.example.com"] = json.RawMessage(`{"auth":"e2e-dummy-token"}`)
+	modifiedData, err := json.Marshal(cfg)
+	Expect(err).NotTo(HaveOccurred(), "failed to marshal modified pull secret")
+
+	mgmtSecret.Data[corev1.DockerConfigJsonKey] = modifiedData
+	Expect(tc.MgmtClient.Update(tc.Context, mgmtSecret)).To(Succeed(),
+		"failed to update management-cluster pull secret")
+
+	Eventually(func() bool {
+		secret := &corev1.Secret{}
+		if err := hcClient.Get(tc.Context, crclient.ObjectKey{Name: "pull-secret", Namespace: "openshift-config"}, secret); err != nil {
+			return false
+		}
+		return bytes.Contains(secret.Data[corev1.DockerConfigJsonKey], []byte("e2e-dummy.example.com"))
+	}, 150*time.Second, 5*time.Second).Should(BeTrue(),
+		"openshift-config/pull-secret did not propagate dummy entry")
+
+	Eventually(func() bool {
+		secret := hccomanifests.OriginalPullSecret()
+		if err := hcClient.Get(tc.Context, crclient.ObjectKeyFromObject(secret), secret); err != nil {
+			return false
+		}
+		return bytes.Contains(secret.Data[corev1.DockerConfigJsonKey], []byte("e2e-dummy.example.com"))
+	}, 150*time.Second, 5*time.Second).Should(BeTrue(),
+		"kube-system/original-pull-secret did not propagate dummy entry")
+
+	nodePool := &hyperv1.NodePool{}
+	Expect(tc.MgmtClient.Get(tc.Context, crclient.ObjectKeyFromObject(np), nodePool)).To(Succeed())
+	for _, cond := range nodePool.Status.Conditions {
+		if cond.Type == hyperv1.NodePoolUpdatingConfigConditionType {
+			Expect(string(cond.Status)).To(Equal(string(metav1.ConditionFalse)),
+				"UpdatingConfig should be False — in-place pull secret update must not trigger a rollout")
+			break
+		}
+	}
+
+	nodeList := &corev1.NodeList{}
+	Expect(hcClient.List(tc.Context, nodeList, crclient.MatchingLabels{
+		hyperv1.NodePoolLabel: np.Name,
+	})).To(Succeed())
+	Expect(len(nodeList.Items)).To(Equal(int(nodeCount)),
+		"node count changed — unexpected rollout")
+}
+
+func verifyGlobalPSLabel(tc *internal.TestContext, hcClient crclient.Client, np *hyperv1.NodePool, nodeCount int32) {
+	globalPSLabelKey := "hypershift.openshift.io/nodepool-globalps-enabled"
+	Eventually(func(g Gomega) {
+		nodeList := &corev1.NodeList{}
+		g.Expect(hcClient.List(tc.Context, nodeList, crclient.MatchingLabels{
+			hyperv1.NodePoolLabel: np.Name,
+		})).To(Succeed())
+		g.Expect(nodeList.Items).To(HaveLen(int(nodeCount)),
+			"expected %d nodes for NodePool %s", nodeCount, np.Name)
+		for _, node := range nodeList.Items {
+			g.Expect(node.Labels).To(HaveKeyWithValue(globalPSLabelKey, "true"),
+				"node %s should have the globalPS label", node.Name)
+		}
+	}, 30*time.Second, 5*time.Second).Should(Succeed())
+}
+
+func createAdditionalPullSecret(tc *internal.TestContext, hcClient crclient.Client, pullSecretData []byte) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "additional-pull-secret",
+			Namespace: "kube-system",
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{
+			corev1.DockerConfigJsonKey: pullSecretData,
+		},
+	}
+	err := hcClient.Create(tc.Context, secret)
+	if apierrors.IsAlreadyExists(err) {
+		return
+	}
+	Expect(err).NotTo(HaveOccurred(), "failed to create additional-pull-secret")
+}
+
+func verifyDaemonSetsReady(tc *internal.TestContext, hcClient crclient.Client, nodeCount int32) {
+	daemonSets := []struct {
+		name      string
+		namespace string
+	}{
+		{"ovnkube-node", "openshift-ovn-kubernetes"},
+		{hccomanifests.GlobalPullSecretDSName, hccomanifests.GlobalPullSecretNamespace},
+	}
+
+	konnDS := hccomanifests.KonnectivityAgentDaemonSet()
+	daemonSets = append(daemonSets, struct {
+		name      string
+		namespace string
+	}{konnDS.Name, konnDS.Namespace})
+
+	for _, ds := range daemonSets {
+		Eventually(func(g Gomega) {
+			daemonSet := &appsv1.DaemonSet{}
+			g.Expect(hcClient.Get(tc.Context, crclient.ObjectKey{
+				Name:      ds.name,
+				Namespace: ds.namespace,
+			}, daemonSet)).To(Succeed(), "failed to get DaemonSet %s/%s", ds.namespace, ds.name)
+
+			g.Expect(daemonSet.Status.DesiredNumberScheduled).To(BeNumerically(">=", nodeCount),
+				"DaemonSet %s desired=%d < minExpected=%d", ds.name, daemonSet.Status.DesiredNumberScheduled, nodeCount)
+			g.Expect(daemonSet.Status.NumberReady).To(Equal(daemonSet.Status.DesiredNumberScheduled),
+				"DaemonSet %s not fully ready: %d/%d", ds.name, daemonSet.Status.NumberReady, daemonSet.Status.DesiredNumberScheduled)
+		}, 20*time.Minute, 10*time.Second).Should(Succeed(), "DaemonSet %s/%s did not become ready", ds.namespace, ds.name)
+	}
+}
+
+func init() {
+	internal.RegisterEnvVar(
+		"E2E_ADDITIONAL_PULL_SECRET_FILE",
+		"Path to an additional pull secret file for the global pull secret lifecycle test.",
+		false,
+	)
+}
+
+var _ = Describe("Global Pull Secret", Label("lifecycle", "global-pull-secret"), func() {
+	var testCtx *internal.TestContext
+
+	BeforeEach(func() {
+		testCtx = internal.GetTestContext()
+		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
+
+		testCtx.ValidateHostedCluster()
+	})
+
+	RegisterGlobalPullSecretTests(func() *internal.TestContext { return testCtx })
+})

--- a/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_pull_secret_test.go
@@ -343,14 +343,6 @@ func verifyDaemonSetsReady(tc *internal.TestContext, hcClient crclient.Client, n
 	}
 }
 
-func init() {
-	internal.RegisterEnvVar(
-		"E2E_ADDITIONAL_PULL_SECRET_FILE",
-		"Path to an additional pull secret file for the global pull secret lifecycle test.",
-		false,
-	)
-}
-
 var _ = Describe("Global Pull Secret", Label("lifecycle", "global-pull-secret"), func() {
 	var testCtx *internal.TestContext
 


### PR DESCRIPTION
## Summary

Ports the remaining 6 v1 `TestCreateCluster` validation gaps to v2 e2e tests, following up on PR #8511 which ported 14 validations.

**Non-lifecycle tests** (read-only verification, no cluster mutation):
- **EnsureNodeCommunication** (`hosted_cluster_node_communication_test.go`): Verifies konnectivity-agent pods exist in the hosted cluster and that pod logs are retrievable, confirming the konnectivity tunnel works
- **ValidateIngressOperatorConfiguration** (`hosted_cluster_ingress_test.go`): Platform-agnostic test that validates `EndpointPublishingStrategy` configured on the HostedCluster is reflected in the hosted cluster's IngressController (replaces Azure-only version with platform-agnostic coverage, requires 4.21+)
- **VerifyCPOOverrideImage** (`hosted_cluster_cpo_test.go`): Checks that when a CPO override image is configured for the platform/version, the running control-plane-operator pod uses that image (self-skips when no override is configured)

**Lifecycle tests** (mutate cluster state with cleanup):
- **EnsureDefaultSecurityGroupTags** (`hosted_cluster_aws_test.go`): AWS-only, adds a day-2 tag to the HostedCluster spec and verifies it's applied to the default worker security group via AWS API (requires 4.20+)
- **EnsureAWSCCMWithCustomizations** (`hosted_cluster_aws_test.go`): AWS-only, validates NLBSecurityGroupMode=Managed in aws-cloud-config ConfigMap and creates a LoadBalancer service to verify managed security groups are attached to the NLB (requires 4.23+)
- **EnsureGlobalPullSecret** (`hosted_cluster_pull_secret_test.go`): Full pull secret lifecycle — creates additional pull secret, verifies propagation through GlobalPullSecret pipeline, validates DaemonSet readiness, verifies in-place management-cluster pull secret propagation without rollout, and confirms cleanup on deletion (AWS/Azure, requires 4.19+)

## Test plan

- [x] `make e2ev2` compiles successfully
- [x] `make lint` passes with 0 issues
- [x] Pre-existing unit test failures are unrelated to these changes
- [x] Run v2 suite on GCP — non-lifecycle tests pass, AWS-only tests skip
- [x] Run v2 suite on AWS — lifecycle and non-lifecycle AWS tests pass
- [ ] Run v2 suite on Azure — global pull secret lifecycle test passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for hosted clusters: AWS security‑group tagging and load‑balancer validation, control‑plane operator image override checks, ingress operator endpoint behavior, node communication/log access verification, and global pull‑secret lifecycle scenarios.
* **Documentation**
  * Updated e2e framework guidelines: package organization, mandatory cleanup patterns, idempotent resource handling, and improved assertion and testing best practices.
* **Chores**
  * Added optional environment variable to configure an additional pull-secret file for e2e runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->