### PR TITLE
OCPBUGS-43444: Allow kubevirt-csi storageclass default to be changed by user

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/kubevirt.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/kubevirt.go
@@ -135,9 +135,17 @@ func reconcileCustomTenantStorageClass(sc *storagev1.StorageClass, infraSCName s
 }
 
 func reconcileDefaultTenantStorageClass(sc *storagev1.StorageClass) error {
-	sc.Annotations = map[string]string{
-		"storageclass.kubernetes.io/is-default-class": "true",
+	if sc.Annotations == nil {
+		sc.Annotations = map[string]string{}
 	}
+
+	// Only set the default storage class when the annotation doesn't exist.
+	// This allows users to set is-default-class=false if they wish to
+	// install their own CSI drivers and choose a different default.
+	if _, exists := sc.Annotations["storageclass.kubernetes.io/is-default-class"]; !exists {
+		sc.Annotations["storageclass.kubernetes.io/is-default-class"] = "true"
+	}
+
 	sc.Provisioner = "csi.kubevirt.io"
 	sc.Parameters = map[string]string{
 		"bus": "scsi",

--- a/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/kubevirt_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/csi/kubevirt/kubevirt_test.go
@@ -111,12 +111,49 @@ func TestReconcileDefaultTenantStorageClass(t *testing.T) {
 		test func(t *testing.T, g Gomega)
 	}{
 		{
-			name: "When called, it should set the is-default-class annotation to true",
+			name: "When annotation does not exist, it should set the is-default-class annotation to true",
 			test: func(t *testing.T, g Gomega) {
 				sc := &storagev1.StorageClass{}
 				err := reconcileDefaultTenantStorageClass(sc)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(sc.Annotations).To(HaveKeyWithValue("storageclass.kubernetes.io/is-default-class", "true"))
+			},
+		},
+		{
+			name: "When is-default-class annotation is already set to false, it should preserve the user's choice",
+			test: func(t *testing.T, g Gomega) {
+				sc := &storagev1.StorageClass{}
+				sc.Annotations = map[string]string{
+					"storageclass.kubernetes.io/is-default-class": "false",
+				}
+				err := reconcileDefaultTenantStorageClass(sc)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(sc.Annotations).To(HaveKeyWithValue("storageclass.kubernetes.io/is-default-class", "false"))
+			},
+		},
+		{
+			name: "When is-default-class annotation is already set to true, it should preserve the value",
+			test: func(t *testing.T, g Gomega) {
+				sc := &storagev1.StorageClass{}
+				sc.Annotations = map[string]string{
+					"storageclass.kubernetes.io/is-default-class": "true",
+				}
+				err := reconcileDefaultTenantStorageClass(sc)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(sc.Annotations).To(HaveKeyWithValue("storageclass.kubernetes.io/is-default-class", "true"))
+			},
+		},
+		{
+			name: "When other annotations exist, it should preserve them and add is-default-class",
+			test: func(t *testing.T, g Gomega) {
+				sc := &storagev1.StorageClass{}
+				sc.Annotations = map[string]string{
+					"some-other-annotation": "some-value",
+				}
+				err := reconcileDefaultTenantStorageClass(sc)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(sc.Annotations).To(HaveKeyWithValue("storageclass.kubernetes.io/is-default-class", "true"))
+				g.Expect(sc.Annotations).To(HaveKeyWithValue("some-other-annotation", "some-value"))
 			},
 		},
 		{


### PR DESCRIPTION
When creating an HCP cluster on OpenShift Virtualization (KubeVirt), the `kubevirt-csi-infra-default` StorageClass is automatically set as the default via the `storageclass.kubernetes.io/is-default-class` annotation. The `reconcileDefaultTenantStorageClass` function unconditionally overwrites the entire annotations map with `is-default-class: "true"` on every reconciliation cycle. This prevents users from setting the annotation to "false" to designate a different CSI driver's StorageClass as the default — any manual change is immediately reverted by the operator.

This behavior is inconsistent with non-HCP OCP clusters where users can freely toggle the default StorageClass, and has caused issues where applications pick the `kubevirt-csi` StorageClass via the "default" designation when a different one is intended.

This commit changes `reconcileDefaultTenantStorageClass` to:
- Initialize the annotations map only when nil, preserving any pre-existing annotations instead of clobbering them.
- Only set `is-default-class` to "true" when the annotation does not already exist. If the annotation is present (regardless of value), the user's choice is preserved across reconciliation cycles.

Unit tests are added covering:
- Fresh StorageClass (no annotation) gets is-default-class: "true"
- User-set annotation of "false" is preserved
- User-set annotation of "true" is preserved
- Pre-existing unrelated annotations are not clobbered



<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes: https://redhat.atlassian.net/browse/OCPBUGS-43444

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed StorageClass annotation handling to preserve existing annotations instead of overwriting them during reconciliation.

* **Tests**
  * Added comprehensive test coverage for StorageClass configuration management, including annotation preservation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->