### PR TITLE
OCPBUGS-89360: NO-JIRA: build(operator): drop hypershift-no-cgo from operator container images

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -6,15 +6,11 @@ WORKDIR /hypershift
 COPY --chown=default . .
 
 RUN make hypershift \
-  && make hypershift-no-cgo \
   && make hypershift-operator \
-  && make product-cli \
   && make karpenter-operator
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1777857961
 COPY --from=builder /hypershift/bin/hypershift \
-  /hypershift/bin/hypershift-no-cgo \
-  /hypershift/bin/hcp \
   /hypershift/bin/hypershift-operator \
   /hypershift/bin/karpenter-operator \
   /usr/bin/


### PR DESCRIPTION
## What this PR does / why we need it:
Remove the QE-only non-CGO hypershift CLI from production operator images built via Containerfile.operator and Dockerfile. The non-FIPS hypershift-no-cgo binary causes Enterprise Contract FIPS violations in Konflux builds for MCE.
The FIPS-compliant hypershift binary (CGO_ENABLED=1) remains as the shipped CLI. Also remove the hypershift-no-cgo Makefile target and update the build-ho-image skill docs to match.

```
multicluster-engine-hypershift-operator,/usr/bin/hcp,go binary is not CGO_ENABLED
  multicluster-engine-hypershift-operator,/usr/bin/hypershift-no-cgo,go binary does not contain required symbol(s)
  multicluster-engine-managedcluster-import-controller-container,/etc/redhat-release,operating system is not FIPS certified
```
Conversation
Ref: https://redhat-internal.slack.com/archives/C058TF9K37Z/p1779803011756959

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized operator container image by streamlining build artifacts and removing unnecessary binaries from the final runtime image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->