### PR TITLE
OCPBUGS-86567: fix Konflux application label for CPO 4.20 pipelines

### DIFF
--- a/.tekton/control-plane-operator-4-20-pull-request.yaml
+++ b/.tekton/control-plane-operator-4-20-pull-request.yaml
@@ -17,7 +17,7 @@ metadata:
            "/Containerfile.control-plane-operator".pathChanged() )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: control-plane-operator
+    appstudio.openshift.io/application: control-plane-operator-4-20
     appstudio.openshift.io/component: control-plane-operator-4-20
     pipelines.appstudio.openshift.io/type: build
   name: control-plane-operator-4-20-on-pull-request

--- a/.tekton/control-plane-operator-4-20-push.yaml
+++ b/.tekton/control-plane-operator-4-20-push.yaml
@@ -15,7 +15,7 @@ metadata:
            "/Containerfile.control-plane-operator".pathChanged() )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: control-plane-operator
+    appstudio.openshift.io/application: control-plane-operator-4-20
     appstudio.openshift.io/component: control-plane-operator-4-20
     pipelines.appstudio.openshift.io/type: build
   name: control-plane-operator-4-20-on-push


### PR DESCRIPTION
## Summary
- The PipelineRun definitions for `control-plane-operator-4-20` had the application label set to `control-plane-operator` (the main application) instead of `control-plane-operator-4-20`
- This caused build results to be attributed to the wrong Konflux application, making the 4.20 application page show "Build not started" despite builds completing successfully
- Fixes both the push and pull-request pipeline definitions

## Test plan
- [ ] Verify the Konflux UI for `control-plane-operator-4-20` shows build status after the next push build triggers
- [ ] Confirm push builds still produce valid multi-arch images

🤖 Generated with [Claude Code](https://claude.com/claude-code)