### PR TITLE
NO-JIRA: fix(ci): harden Claude WIF test workflow

### DIFF
--- a/.github/workflows/claude-wif-test.yaml
+++ b/.github/workflows/claude-wif-test.yaml
@@ -16,28 +16,14 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.issue.pull_request &&
        contains(github.event.comment.body, '/test-wif') &&
-       github.event.comment.author_association == 'MEMBER' ||
-       github.event.comment.author_association == 'OWNER')
+       (github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'COLLABORATOR'))
     runs-on: arc-runner-set
     timeout-minutes: 10
     env:
       HOME: /tmp
     steps:
-      - name: Get PR ref
-        if: github.event_name == 'issue_comment'
-        id: pr
-        run: |
-          curl -fsSL -H "Authorization: token ${{ github.token }}" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}" > /tmp/pr.json
-          echo "ref=$(jq -r '.head.sha' /tmp/pr.json)" >> "$GITHUB_OUTPUT"
-          echo "repo=$(jq -r '.head.repo.full_name' /tmp/pr.json)" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          ref: ${{ steps.pr.outputs.ref || github.sha }}
-          repository: ${{ steps.pr.outputs.repo || github.repository }}
-          persist-credentials: false
-
       - name: Authenticate to GCP via WIF
         uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
@@ -45,16 +31,12 @@ jobs:
           service_account: claude-gha@hosted-control-planes.iam.gserviceaccount.com
           workload_identity_provider: projects/21066242673/locations/global/workloadIdentityPools/itpc-identity-pool/providers/github-com
 
-      - name: Install Claude Code
-        run: |
-          curl -fsSL https://claude.ai/install.sh | bash
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Test Claude Code
+      - name: Test Claude Code via Vertex AI
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        with:
+          use_vertex: "true"
+          prompt: "Say hello in one sentence"
+          claude_args: "--max-turns 1"
         env:
-          CLAUDE_CODE_USE_VERTEX: "1"
           CLOUD_ML_REGION: global
           ANTHROPIC_VERTEX_PROJECT_ID: hosted-control-planes
-        run: |
-          claude --version
-          claude -p "Say hello in one sentence" --max-turns 1


### PR DESCRIPTION
## Summary

- **Fix operator precedence bug** in the job's `if` condition — `&&` binds tighter than `||` in GitHub Actions expressions, so the original condition allowed any OWNER comment on any issue (not just PRs with `/test-wif`) to trigger the workflow with GCP credentials. Added parentheses to properly scope the author association check.
- **Replace `curl | bash` installation** with the official `anthropics/claude-code-action` GitHub Action (pinned by SHA), which handles Claude Code installation internally and is tracked by dependabot via the existing `github-actions` ecosystem config. This eliminates unverified code execution on a runner holding a GCP WIF token.
- **Add `COLLABORATOR`** to the allowed author associations for the `/test-wif` trigger.

## Test plan

- [ ] Trigger the workflow via `workflow_dispatch` to verify the basic auth flow works
- [ ] Test `/test-wif` on a PR comment to verify `issue_comment` handling with `claude-code-action`
- [ ] Verify the `if` condition correctly rejects: non-PR issue comments, comments without `/test-wif`, and comments from external contributors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration for internal testing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->