### PR TITLE
OCPBUGS-86416: add Konflux pipeline definitions for CPO 4.21

### DIFF
--- a/.tekton/control-plane-operator-4-21-pull-request.yaml
+++ b/.tekton/control-plane-operator-4-21-pull-request.yaml
@@ -10,18 +10,17 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request"
-      && target_branch == "main"
+      && target_branch == "release-4.21"
       && ( "control-plane-operator/***".pathChanged() ||
            "support/***".pathChanged() ||
            ".tekton/control-plane-operator*".pathChanged() ||
-           "/Containerfile.control-plane-operator".pathChanged() )
-    pipelinesascode.tekton.dev/pipeline: ".tekton/pipelines/common-operator-build.yaml"
+           "/Containerfile.control-plane".pathChanged() )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: control-plane-operator
-    appstudio.openshift.io/component: control-plane-operator-main
+    appstudio.openshift.io/application: control-plane-operator-4-21
+    appstudio.openshift.io/component: control-plane-operator-4-21
     pipelines.appstudio.openshift.io/type: build
-  name: control-plane-operator-main-on-pull-request
+  name: control-plane-operator-4-21-on-pull-request
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -30,7 +29,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-main:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms
@@ -40,10 +39,21 @@ spec:
     value: /Containerfile.control-plane
   - name: path-context
     value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
   pipelineRef:
-    name: hypershift-common-operator-build
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/openshift/hypershift.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: .tekton/pipelines/common-operator-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-control-plane-operator-main
+    serviceAccountName: build-pipeline-control-plane-operator-4-21
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/control-plane-operator-4-21-push.yaml
+++ b/.tekton/control-plane-operator-4-21-push.yaml
@@ -8,18 +8,17 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push"
-      && target_branch == "main"
+      && target_branch == "release-4.21"
       && ( "control-plane-operator/***".pathChanged() ||
            "support/***".pathChanged() ||
            ".tekton/control-plane-operator*".pathChanged() ||
-           "/Containerfile.control-plane-operator".pathChanged() )
-    pipelinesascode.tekton.dev/pipeline: ".tekton/pipelines/common-operator-build.yaml"
+           "/Containerfile.control-plane".pathChanged() )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: control-plane-operator
-    appstudio.openshift.io/component: control-plane-operator-main
+    appstudio.openshift.io/application: control-plane-operator-4-21
+    appstudio.openshift.io/component: control-plane-operator-4-21
     pipelines.appstudio.openshift.io/type: build
-  name: control-plane-operator-main-on-push
+  name: control-plane-operator-4-21-on-push
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -28,7 +27,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-main:{{revision}}
+    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-21:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
@@ -37,10 +36,21 @@ spec:
     value: /Containerfile.control-plane
   - name: path-context
     value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
   pipelineRef:
-    name: hypershift-common-operator-build
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/openshift/hypershift.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: .tekton/pipelines/common-operator-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-control-plane-operator-main
+    serviceAccountName: build-pipeline-control-plane-operator-4-21
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
## Summary
- Add push and pull-request PipelineRun definitions for the `control-plane-operator-4-21` Konflux component
- Uses the common pipeline via git resolver, consistent with existing release branches
- Remove stale `control-plane-operator-main` pipeline files that were incorrectly present on the release branch

## Test plan
- [ ] Verify the Konflux `control-plane-operator-4-21` application triggers a push build after merge
- [ ] Confirm push builds produce valid multi-arch images

🤖 Generated with [Claude Code](https://claude.com/claude-code)