### PR TITLE
OCPBUGS-86354: add Konflux pipeline definitions for CPO 4.22

### DIFF
--- a/.tekton/control-plane-operator-4-22-pull-request.yaml
+++ b/.tekton/control-plane-operator-4-22-pull-request.yaml
@@ -4,22 +4,23 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/hypershift?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push"
-      && target_branch == "main"
+      event == "pull_request"
+      && target_branch == "release-4.22"
       && ( "control-plane-operator/***".pathChanged() ||
            "support/***".pathChanged() ||
            ".tekton/control-plane-operator*".pathChanged() ||
-           "/Containerfile.control-plane-operator".pathChanged() )
-    pipelinesascode.tekton.dev/pipeline: ".tekton/pipelines/common-operator-build.yaml"
+           "/Containerfile.control-plane".pathChanged() )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: control-plane-operator
-    appstudio.openshift.io/component: control-plane-operator-main
+    appstudio.openshift.io/application: control-plane-operator-4-22
+    appstudio.openshift.io/component: control-plane-operator-4-22
     pipelines.appstudio.openshift.io/type: build
-  name: control-plane-operator-main-on-push
+  name: control-plane-operator-4-22-on-pull-request
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -28,19 +29,31 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-main:{{revision}}
+    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
   - name: dockerfile
     value: /Containerfile.control-plane
   - name: path-context
     value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
   pipelineRef:
-    name: hypershift-common-operator-build
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/openshift/hypershift.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: .tekton/pipelines/common-operator-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-control-plane-operator-main
+    serviceAccountName: build-pipeline-control-plane-operator-4-22
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/control-plane-operator-4-22-push.yaml
+++ b/.tekton/control-plane-operator-4-22-push.yaml
@@ -4,24 +4,21 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/hypershift?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request"
-      && target_branch == "main"
+      event == "push"
+      && target_branch == "release-4.22"
       && ( "control-plane-operator/***".pathChanged() ||
            "support/***".pathChanged() ||
            ".tekton/control-plane-operator*".pathChanged() ||
-           "/Containerfile.control-plane-operator".pathChanged() )
-    pipelinesascode.tekton.dev/pipeline: ".tekton/pipelines/common-operator-build.yaml"
+           "/Containerfile.control-plane".pathChanged() )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: control-plane-operator
-    appstudio.openshift.io/component: control-plane-operator-main
+    appstudio.openshift.io/application: control-plane-operator-4-22
+    appstudio.openshift.io/component: control-plane-operator-4-22
     pipelines.appstudio.openshift.io/type: build
-  name: control-plane-operator-main-on-pull-request
+  name: control-plane-operator-4-22-on-push
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -30,20 +27,30 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-main:on-pr-{{revision}}
-  - name: image-expires-after
-    value: 5d
+    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/control-plane-operator-4-22:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
   - name: dockerfile
     value: /Containerfile.control-plane
   - name: path-context
     value: .
+  - name: build-source-image
+    value: "true"
+  - name: hermetic
+    value: "true"
   pipelineRef:
-    name: hypershift-common-operator-build
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/openshift/hypershift.git"
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: .tekton/pipelines/common-operator-build.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-control-plane-operator-main
+    serviceAccountName: build-pipeline-control-plane-operator-4-22
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
## Summary
- Add push and pull-request PipelineRun definitions for the `control-plane-operator-4-22` Konflux component
- Uses the common pipeline via git resolver, consistent with existing release branches
- Remove stale `control-plane-operator-main` pipeline files that were incorrectly present on the release branch

## Test plan
- [ ] Verify the Konflux `control-plane-operator-4-22` application triggers a push build after merge
- [ ] Confirm push builds produce valid multi-arch images

🤖 Generated with [Claude Code](https://claude.com/claude-code)