### PR TITLE
NO-JIRA: replace container image with workflow-step plugin setup

### DIFF
--- a/.github/workflows/claude-wif-test.yaml
+++ b/.github/workflows/claude-wif-test.yaml
@@ -20,8 +20,6 @@ jobs:
         github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'COLLABORATOR'))
     runs-on: arc-runner-set
-    container:
-      image: quay.io/rh_ee_brcox/hypershift:ai-helpers-arm64
     timeout-minutes: 10
     env:
       HOME: /tmp
@@ -52,6 +50,13 @@ jobs:
         run: |
           curl -fsSL https://claude.ai/install.sh | bash
           echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Set up ai-helpers plugins
+        run: |
+          git clone --depth 1 https://github.com/openshift-eng/ai-helpers.git /tmp/ai-helpers
+          mkdir -p "$HOME/.claude/plugins"
+          printf '%s\n' '{"enabledPlugins":{"hello-world@ai-helpers":true,"jira@ai-helpers":true,"ci@ai-helpers":true}}' > "$HOME/.claude/settings.json"
+          printf '%s\n' '{"ai-helpers":{"source":{"source":"directory","path":"/tmp/ai-helpers"},"installLocation":"/tmp/ai-helpers","lastUpdated":"2025-10-27T12:00:00.000Z"}}' > "$HOME/.claude/plugins/known_marketplaces.json"
 
       - name: Test Claude Code
         env:


### PR DESCRIPTION
## Summary
- Remove `container:` block from Claude WIF test workflow — ARC runners don't support container mode without `anyuid` SCC and a long-running entrypoint
- Install Claude Code and clone ai-helpers repo directly in workflow steps
- Set up plugin config (`settings.json`, `known_marketplaces.json`) pointing at the cloned ai-helpers path

## Test plan
- [ ] Merge to main (issue_comment runs from default branch)
- [ ] Post `/test-wif` on any PR to trigger the workflow
- [ ] Verify Claude invokes the hello-world plugin successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to run directly on the runner instead of a job-level container.
  * Added a test setup step that installs AI-helper plugins and configures the test environment to enable the hello-world, jira, and ci plugins and point marketplace sources for testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->