### PR TITLE
NO-JIRA: fix(cpo): switch etcd-client to ClusterIP service

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/AROSwift/zz_fixture_TestControlPlaneComponents_etcd_client_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/AROSwift/zz_fixture_TestControlPlaneComponents_etcd_client_service.yaml
@@ -14,7 +14,6 @@ metadata:
     uid: ""
   resourceVersion: "1"
 spec:
-  clusterIP: None
   ports:
   - name: etcd-client
     port: 2379

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/GCP/zz_fixture_TestControlPlaneComponents_etcd_client_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/GCP/zz_fixture_TestControlPlaneComponents_etcd_client_service.yaml
@@ -14,7 +14,6 @@ metadata:
     uid: ""
   resourceVersion: "1"
 spec:
-  clusterIP: None
   ports:
   - name: etcd-client
     port: 2379

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/IBMCloud/zz_fixture_TestControlPlaneComponents_etcd_client_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/IBMCloud/zz_fixture_TestControlPlaneComponents_etcd_client_service.yaml
@@ -14,7 +14,6 @@ metadata:
     uid: ""
   resourceVersion: "1"
 spec:
-  clusterIP: None
   ports:
   - name: etcd-client
     port: 2379

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_etcd_client_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_etcd_client_service.yaml
@@ -14,7 +14,6 @@ metadata:
     uid: ""
   resourceVersion: "1"
 spec:
-  clusterIP: None
   ports:
   - name: etcd-client
     port: 2379

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_etcd_client_service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_etcd_client_service.yaml
@@ -14,7 +14,6 @@ metadata:
     uid: ""
   resourceVersion: "1"
 spec:
-  clusterIP: None
   ports:
   - name: etcd-client
     port: 2379

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/etcd/service.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/etcd/service.yaml
@@ -5,7 +5,6 @@ metadata:
     app: etcd
   name: etcd-client
 spec:
-  clusterIP: None
   ports:
   - name: etcd-client
     port: 2379


### PR DESCRIPTION
Two headless services (etcd-client and etcd-discovery) both select app=etcd pods, causing indeterministic reverse DNS lookups. Convert etcd-client to a regular ClusterIP service so only etcd-discovery remains headless for StatefulSet peer DNS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified etcd-client Service configuration to assign a stable cluster IP address instead of operating as a headless service, improving service discovery and internal access patterns within the cluster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->