### PR TITLE
AROSLSRE-830: Add etcd EndpointSlice self-registration to fix DNS resolution delays

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/etcd.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/etcd.go
@@ -91,6 +91,33 @@ func EtcdDefragControllerServiceAccount(ns string) *corev1.ServiceAccount {
 	}
 }
 
+func EtcdServiceAccount(ns string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "etcd",
+			Namespace: ns,
+		},
+	}
+}
+
+func EtcdSelfRegisterRole(ns string) *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "etcd-self-register",
+			Namespace: ns,
+		},
+	}
+}
+
+func EtcdSelfRegisterRoleBinding(ns string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "etcd-self-register",
+			Namespace: ns,
+		},
+	}
+}
+
 func EtcdBackupServiceAccount(hcpNamespace string) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/AROSwift/zz_fixture_TestControlPlaneComponents_etcd_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/AROSwift/zz_fixture_TestControlPlaneComponents_etcd_controlplanecomponent.yaml
@@ -22,6 +22,15 @@ status:
   - group: ""
     kind: Service
     name: etcd-discovery
+  - group: rbac.authorization.k8s.io
+    kind: Role
+    name: etcd-self-register
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
+    name: etcd-self-register
+  - group: ""
+    kind: ServiceAccount
+    name: etcd
   - group: policy
     kind: PodDisruptionBudget
     name: etcd

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/AROSwift/zz_fixture_TestControlPlaneComponents_etcd_self_register_role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/AROSwift/zz_fixture_TestControlPlaneComponents_etcd_self_register_role.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: etcd-self-register
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+rules:
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/AROSwift/zz_fixture_TestControlPlaneComponents_etcd_self_register_rolebinding.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/AROSwift/zz_fixture_TestControlPlaneComponents_etcd_self_register_rolebinding.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: etcd-self-register
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: etcd-self-register
+subjects:
+- kind: ServiceAccount
+  name: etcd
+  namespace: hcp-namespace

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/AROSwift/zz_fixture_TestControlPlaneComponents_etcd_serviceaccount.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/AROSwift/zz_fixture_TestControlPlaneComponents_etcd_serviceaccount.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+imagePullSecrets:
+- name: pull-secret
+kind: ServiceAccount
+metadata:
+  name: etcd
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/AROSwift/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/AROSwift/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
@@ -270,7 +270,7 @@ spec:
       initContainers:
       - args:
         - -c
-        - exec control-plane-operator resolve-dns ${HOSTNAME}.etcd-discovery.${NAMESPACE}.svc
+        - exec control-plane-operator resolve-dns --self-register ${HOSTNAME}.etcd-discovery.${NAMESPACE}.svc
         command:
         - /bin/bash
         env:
@@ -279,6 +279,11 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
         image: controlplane-operator
         imagePullPolicy: IfNotPresent
         name: ensure-dns
@@ -351,6 +356,7 @@ spec:
       priorityClassName: hypershift-etcd
       restartPolicy: Always
       schedulerName: default-scheduler
+      serviceAccountName: etcd
       tolerations:
       - effect: NoSchedule
         key: hypershift.openshift.io/control-plane

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/GCP/zz_fixture_TestControlPlaneComponents_etcd_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/GCP/zz_fixture_TestControlPlaneComponents_etcd_controlplanecomponent.yaml
@@ -22,6 +22,15 @@ status:
   - group: ""
     kind: Service
     name: etcd-discovery
+  - group: rbac.authorization.k8s.io
+    kind: Role
+    name: etcd-self-register
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
+    name: etcd-self-register
+  - group: ""
+    kind: ServiceAccount
+    name: etcd
   - group: policy
     kind: PodDisruptionBudget
     name: etcd

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/GCP/zz_fixture_TestControlPlaneComponents_etcd_self_register_role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/GCP/zz_fixture_TestControlPlaneComponents_etcd_self_register_role.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: etcd-self-register
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+rules:
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/GCP/zz_fixture_TestControlPlaneComponents_etcd_self_register_rolebinding.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/GCP/zz_fixture_TestControlPlaneComponents_etcd_self_register_rolebinding.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: etcd-self-register
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: etcd-self-register
+subjects:
+- kind: ServiceAccount
+  name: etcd
+  namespace: hcp-namespace

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/GCP/zz_fixture_TestControlPlaneComponents_etcd_serviceaccount.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/GCP/zz_fixture_TestControlPlaneComponents_etcd_serviceaccount.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+imagePullSecrets:
+- name: pull-secret
+kind: ServiceAccount
+metadata:
+  name: etcd
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/GCP/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/GCP/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
@@ -285,7 +285,7 @@ spec:
       initContainers:
       - args:
         - -c
-        - exec control-plane-operator resolve-dns ${HOSTNAME}.etcd-discovery.${NAMESPACE}.svc
+        - exec control-plane-operator resolve-dns --self-register ${HOSTNAME}.etcd-discovery.${NAMESPACE}.svc
         command:
         - /bin/bash
         env:
@@ -294,6 +294,11 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
         image: controlplane-operator
         imagePullPolicy: IfNotPresent
         name: ensure-dns
@@ -378,6 +383,7 @@ spec:
       priorityClassName: hypershift-etcd
       restartPolicy: Always
       schedulerName: default-scheduler
+      serviceAccountName: etcd
       tolerations:
       - effect: NoSchedule
         key: hypershift.openshift.io/control-plane

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/IBMCloud/zz_fixture_TestControlPlaneComponents_etcd_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/IBMCloud/zz_fixture_TestControlPlaneComponents_etcd_controlplanecomponent.yaml
@@ -22,6 +22,15 @@ status:
   - group: ""
     kind: Service
     name: etcd-discovery
+  - group: rbac.authorization.k8s.io
+    kind: Role
+    name: etcd-self-register
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
+    name: etcd-self-register
+  - group: ""
+    kind: ServiceAccount
+    name: etcd
   - group: policy
     kind: PodDisruptionBudget
     name: etcd

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/IBMCloud/zz_fixture_TestControlPlaneComponents_etcd_self_register_role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/IBMCloud/zz_fixture_TestControlPlaneComponents_etcd_self_register_role.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: etcd-self-register
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+rules:
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/IBMCloud/zz_fixture_TestControlPlaneComponents_etcd_self_register_rolebinding.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/IBMCloud/zz_fixture_TestControlPlaneComponents_etcd_self_register_rolebinding.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: etcd-self-register
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: etcd-self-register
+subjects:
+- kind: ServiceAccount
+  name: etcd
+  namespace: hcp-namespace

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/IBMCloud/zz_fixture_TestControlPlaneComponents_etcd_serviceaccount.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/IBMCloud/zz_fixture_TestControlPlaneComponents_etcd_serviceaccount.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+imagePullSecrets:
+- name: pull-secret
+kind: ServiceAccount
+metadata:
+  name: etcd
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/IBMCloud/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/IBMCloud/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
@@ -270,7 +270,7 @@ spec:
       initContainers:
       - args:
         - -c
-        - exec control-plane-operator resolve-dns ${HOSTNAME}.etcd-discovery.${NAMESPACE}.svc
+        - exec control-plane-operator resolve-dns --self-register ${HOSTNAME}.etcd-discovery.${NAMESPACE}.svc
         command:
         - /bin/bash
         env:
@@ -279,6 +279,11 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
         image: controlplane-operator
         imagePullPolicy: IfNotPresent
         name: ensure-dns
@@ -351,6 +356,7 @@ spec:
       priorityClassName: hypershift-etcd
       restartPolicy: Always
       schedulerName: default-scheduler
+      serviceAccountName: etcd
       tolerations:
       - effect: NoSchedule
         key: hypershift.openshift.io/control-plane

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_etcd_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_etcd_controlplanecomponent.yaml
@@ -22,6 +22,15 @@ status:
   - group: ""
     kind: Service
     name: etcd-discovery
+  - group: rbac.authorization.k8s.io
+    kind: Role
+    name: etcd-self-register
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
+    name: etcd-self-register
+  - group: ""
+    kind: ServiceAccount
+    name: etcd
   - group: policy
     kind: PodDisruptionBudget
     name: etcd

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_etcd_self_register_role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_etcd_self_register_role.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: etcd-self-register
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+rules:
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_etcd_self_register_rolebinding.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_etcd_self_register_rolebinding.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: etcd-self-register
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: etcd-self-register
+subjects:
+- kind: ServiceAccount
+  name: etcd
+  namespace: hcp-namespace

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_etcd_serviceaccount.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_etcd_serviceaccount.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+imagePullSecrets:
+- name: pull-secret
+kind: ServiceAccount
+metadata:
+  name: etcd
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/TechPreviewNoUpgrade/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
@@ -270,7 +270,7 @@ spec:
       initContainers:
       - args:
         - -c
-        - exec control-plane-operator resolve-dns ${HOSTNAME}.etcd-discovery.${NAMESPACE}.svc
+        - exec control-plane-operator resolve-dns --self-register ${HOSTNAME}.etcd-discovery.${NAMESPACE}.svc
         command:
         - /bin/bash
         env:
@@ -279,6 +279,11 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
         image: controlplane-operator
         imagePullPolicy: IfNotPresent
         name: ensure-dns
@@ -351,6 +356,7 @@ spec:
       priorityClassName: hypershift-etcd
       restartPolicy: Always
       schedulerName: default-scheduler
+      serviceAccountName: etcd
       tolerations:
       - effect: NoSchedule
         key: hypershift.openshift.io/control-plane

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_etcd_controlplanecomponent.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_etcd_controlplanecomponent.yaml
@@ -22,6 +22,15 @@ status:
   - group: ""
     kind: Service
     name: etcd-discovery
+  - group: rbac.authorization.k8s.io
+    kind: Role
+    name: etcd-self-register
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
+    name: etcd-self-register
+  - group: ""
+    kind: ServiceAccount
+    name: etcd
   - group: policy
     kind: PodDisruptionBudget
     name: etcd

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_etcd_self_register_role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_etcd_self_register_role.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: etcd-self-register
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+rules:
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_etcd_self_register_rolebinding.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_etcd_self_register_rolebinding.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: etcd-self-register
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: etcd-self-register
+subjects:
+- kind: ServiceAccount
+  name: etcd
+  namespace: hcp-namespace

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_etcd_serviceaccount.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_etcd_serviceaccount.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+imagePullSecrets:
+- name: pull-secret
+kind: ServiceAccount
+metadata:
+  name: etcd
+  namespace: hcp-namespace
+  ownerReferences:
+  - apiVersion: hypershift.openshift.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: HostedControlPlane
+    name: hcp
+    uid: ""
+  resourceVersion: "1"

--- a/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/testdata/etcd/zz_fixture_TestControlPlaneComponents_etcd_statefulset.yaml
@@ -270,7 +270,7 @@ spec:
       initContainers:
       - args:
         - -c
-        - exec control-plane-operator resolve-dns ${HOSTNAME}.etcd-discovery.${NAMESPACE}.svc
+        - exec control-plane-operator resolve-dns --self-register ${HOSTNAME}.etcd-discovery.${NAMESPACE}.svc
         command:
         - /bin/bash
         env:
@@ -279,6 +279,11 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
         image: controlplane-operator
         imagePullPolicy: IfNotPresent
         name: ensure-dns
@@ -351,6 +356,7 @@ spec:
       priorityClassName: hypershift-etcd
       restartPolicy: Always
       schedulerName: default-scheduler
+      serviceAccountName: etcd
       tolerations:
       - effect: NoSchedule
         key: hypershift.openshift.io/control-plane

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/etcd/defrag-serviceaccount.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/etcd/defrag-serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcd-defrag-controller

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/etcd/etcd-self-register-role.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/etcd/etcd-self-register-role.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: etcd-self-register
+rules:
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/etcd/etcd-self-register-rolebinding-defrag.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/etcd/etcd-self-register-rolebinding-defrag.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: etcd-defrag-controller
+  name: etcd-self-register-defrag
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: etcd-defrag-controller
+  name: etcd-self-register
 subjects:
 - kind: ServiceAccount
   name: etcd-defrag-controller

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/etcd/etcd-self-register-rolebinding.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/etcd/etcd-self-register-rolebinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: etcd-defrag-controller
+  name: etcd-self-register
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: etcd-defrag-controller
+  name: etcd-self-register
 subjects:
 - kind: ServiceAccount
   name: etcd

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/etcd/etcd-serviceaccount.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/etcd/etcd-serviceaccount.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: etcd-defrag-controller
+  name: etcd

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/etcd/statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/etcd/statefulset.yaml
@@ -187,6 +187,9 @@ spec:
         - mountPath: /etc/etcd/tls/etcd-ca
           name: etcd-ca
       initContainers:
+      # Self-register this pod's IP into an EndpointSlice before waiting for DNS resolution.
+      # This bypasses stale kube-controller-manager EndpointSlice cache issues under high HCP density
+      # (2,500+ namespaces), where the standard controller can delay DNS updates by minutes to hours.
       - args:
         - -c
         - exec control-plane-operator resolve-dns --self-register ${HOSTNAME}.etcd-discovery.${NAMESPACE}.svc

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/assets/etcd/statefulset.yaml
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/assets/etcd/statefulset.yaml
@@ -189,7 +189,7 @@ spec:
       initContainers:
       - args:
         - -c
-        - exec control-plane-operator resolve-dns ${HOSTNAME}.etcd-discovery.${NAMESPACE}.svc
+        - exec control-plane-operator resolve-dns --self-register ${HOSTNAME}.etcd-discovery.${NAMESPACE}.svc
         command:
         - /bin/bash
         env:
@@ -198,6 +198,11 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
         image: controlplane-operator
         imagePullPolicy: IfNotPresent
         name: ensure-dns

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/component.go
@@ -51,8 +51,13 @@ func NewComponent() component.ControlPlaneComponent {
 			component.WithPredicate(defragControllerPredicate),
 		).
 		WithManifestAdapter(
-			"defrag-serviceaccount.yaml",
-			component.WithPredicate(defragControllerPredicate),
+			"etcd-serviceaccount.yaml",
+		).
+		WithManifestAdapter(
+			"etcd-self-register-role.yaml",
+		).
+		WithManifestAdapter(
+			"etcd-self-register-rolebinding.yaml",
 		).
 		Build()
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/component.go
@@ -51,6 +51,10 @@ func NewComponent() component.ControlPlaneComponent {
 			component.WithPredicate(defragControllerPredicate),
 		).
 		WithManifestAdapter(
+			"defrag-serviceaccount.yaml",
+			component.WithPredicate(defragControllerPredicate),
+		).
+		WithManifestAdapter(
 			"etcd-serviceaccount.yaml",
 		).
 		WithManifestAdapter(
@@ -58,6 +62,10 @@ func NewComponent() component.ControlPlaneComponent {
 		).
 		WithManifestAdapter(
 			"etcd-self-register-rolebinding.yaml",
+		).
+		WithManifestAdapter(
+			"etcd-self-register-rolebinding-defrag.yaml",
+			component.WithPredicate(defragControllerPredicate),
 		).
 		Build()
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/statefulset.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/statefulset.go
@@ -72,9 +72,10 @@ func adaptStatefulSet(cpContext component.WorkloadContext, sts *appsv1.StatefulS
 		)
 	})
 
+	sts.Spec.Template.Spec.ServiceAccountName = manifests.EtcdServiceAccount("").Name
+
 	if defragControllerPredicate(cpContext) {
 		sts.Spec.Template.Spec.Containers = append(sts.Spec.Template.Spec.Containers, buildEtcdDefragControllerContainer(hcp.Namespace))
-		sts.Spec.Template.Spec.ServiceAccountName = manifests.EtcdDefragControllerServiceAccount("").Name
 	}
 
 	snapshotRestored := meta.IsStatusConditionTrue(hcp.Status.Conditions, string(hyperv1.EtcdSnapshotRestored))

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/statefulset.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/etcd/statefulset.go
@@ -72,10 +72,14 @@ func adaptStatefulSet(cpContext component.WorkloadContext, sts *appsv1.StatefulS
 		)
 	})
 
-	sts.Spec.Template.Spec.ServiceAccountName = manifests.EtcdServiceAccount("").Name
-
+	// Use etcd SA for self-registration (all topologies) or etcd-defrag-controller SA for defrag (HA-only).
+	// The etcd SA is always created and has RBAC for EndpointSlice self-registration.
+	// The etcd-defrag-controller SA is only created in HA mode and has RBAC for defragmentation.
 	if defragControllerPredicate(cpContext) {
+		sts.Spec.Template.Spec.ServiceAccountName = manifests.EtcdDefragControllerServiceAccount("").Name
 		sts.Spec.Template.Spec.Containers = append(sts.Spec.Template.Spec.Containers, buildEtcdDefragControllerContainer(hcp.Namespace))
+	} else {
+		sts.Spec.Template.Spec.ServiceAccountName = manifests.EtcdServiceAccount("").Name
 	}
 
 	snapshotRestored := meta.IsStatusConditionTrue(hcp.Status.Conditions, string(hyperv1.EtcdSnapshotRestored))

--- a/dnsresolver/cmd.go
+++ b/dnsresolver/cmd.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift/hypershift/support/netutil"
+
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -43,6 +45,9 @@ func NewCommand() *cobra.Command {
 		},
 	}
 
+	// --self-register creates an EndpointSlice for this pod before waiting for DNS resolution.
+	// This bypasses stale kube-controller-manager EndpointSlice cache issues under high HCP density,
+	// where the standard controller can delay DNS updates by minutes to hours.
 	cmd.Flags().BoolVar(&selfRegister, "self-register", false, "Register this pod's IP into an EndpointSlice before resolving DNS")
 	return cmd
 }
@@ -108,9 +113,14 @@ func ensureEndpointSlice(ctx context.Context, client kubernetes.Interface, dnsNa
 		return fmt.Errorf("failed to get pod %s/%s: %w", namespace, hostname, err)
 	}
 
-	addressType := discoveryv1.AddressTypeIPv4
-	if net.ParseIP(podIP) != nil && net.ParseIP(podIP).To4() == nil {
-		addressType = discoveryv1.AddressTypeIPv6
+	// Determine address type based on pod IP
+	isIPv4, err := netutil.IsIPv4Address(podIP)
+	if err != nil {
+		return fmt.Errorf("failed to parse pod IP %s: %w", podIP, err)
+	}
+	addressType := discoveryv1.AddressTypeIPv6
+	if isIPv4 {
+		addressType = discoveryv1.AddressTypeIPv4
 	}
 
 	sliceName := fmt.Sprintf("%s-self-%s", serviceName, hostname)

--- a/dnsresolver/cmd.go
+++ b/dnsresolver/cmd.go
@@ -64,10 +64,6 @@ func resolveDNS(ctx context.Context, hostName string) error {
 	return nil
 }
 
-// selfRegisterEndpointSlice creates an EndpointSlice for this pod's IP
-// so that CoreDNS can resolve the pod's DNS name without waiting for the
-// standard EndpointSlice controller, which may have a stale informer cache
-// under high cluster density.
 func selfRegisterEndpointSlice(dnsName string) error {
 	podIP := os.Getenv("POD_IP")
 	if podIP == "" {
@@ -82,11 +78,6 @@ func selfRegisterEndpointSlice(dnsName string) error {
 		return fmt.Errorf("failed to get hostname: %w", err)
 	}
 
-	serviceName, err := parseServiceName(dnsName)
-	if err != nil {
-		return fmt.Errorf("failed to parse service name from DNS name %q: %w", dnsName, err)
-	}
-
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		return fmt.Errorf("failed to get in-cluster config: %w", err)
@@ -96,7 +87,20 @@ func selfRegisterEndpointSlice(dnsName string) error {
 		return fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	return ensureEndpointSlice(context.Background(), client, dnsName, hostname, namespace, podIP)
+}
+
+// ensureEndpointSlice creates or updates a self-registration EndpointSlice for
+// this pod's IP so that CoreDNS can resolve the pod's DNS name without waiting
+// for the standard EndpointSlice controller, which may have a stale informer
+// cache under high cluster density.
+func ensureEndpointSlice(ctx context.Context, client kubernetes.Interface, dnsName, hostname, namespace, podIP string) error {
+	serviceName, err := parseServiceName(dnsName)
+	if err != nil {
+		return fmt.Errorf("failed to parse service name from DNS name %q: %w", dnsName, err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	pod, err := client.CoreV1().Pods(namespace).Get(ctx, hostname, metav1.GetOptions{})

--- a/dnsresolver/cmd.go
+++ b/dnsresolver/cmd.go
@@ -120,14 +120,16 @@ func ensureEndpointSlice(ctx context.Context, client kubernetes.Interface, dnsNa
 			Namespace: namespace,
 			Labels: map[string]string{
 				discoveryv1.LabelServiceName: serviceName,
-				discoveryv1.LabelManagedBy:   "control-plane-operator",
+				discoveryv1.LabelManagedBy:   "etcd-self-register.hypershift.openshift.io",
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: "v1",
-					Kind:       "Pod",
-					Name:       pod.Name,
-					UID:        pod.UID,
+					APIVersion:         "v1",
+					Kind:               "Pod",
+					Name:               pod.Name,
+					UID:                pod.UID,
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
 				},
 			},
 		},

--- a/dnsresolver/cmd.go
+++ b/dnsresolver/cmd.go
@@ -10,6 +10,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -155,12 +156,14 @@ func selfRegisterEndpointSlice(dnsName string) error {
 			return fmt.Errorf("failed to update EndpointSlice %s: %w", sliceName, err)
 		}
 		fmt.Printf("Updated self-registration EndpointSlice %s with address %s\n", sliceName, podIP)
-	} else {
+	} else if apierrors.IsNotFound(err) {
 		_, err = client.DiscoveryV1().EndpointSlices(namespace).Create(ctx, endpointSlice, metav1.CreateOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to create EndpointSlice %s: %w", sliceName, err)
 		}
 		fmt.Printf("Created self-registration EndpointSlice %s with address %s\n", sliceName, podIP)
+	} else {
+		return fmt.Errorf("failed to get EndpointSlice %s: %w", sliceName, err)
 	}
 	return nil
 }

--- a/dnsresolver/cmd.go
+++ b/dnsresolver/cmd.go
@@ -5,20 +5,35 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
 
 	"github.com/spf13/cobra"
 )
 
 func NewCommand() *cobra.Command {
+	var selfRegister bool
+
 	cmd := &cobra.Command{
 		Use:   "resolve-dns NAME",
 		Short: "Utility that ensures a DNS name can be resolved.",
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 0 {
 				fmt.Printf("Specify a DNS name to lookup\n")
+				os.Exit(1)
+			}
+			if selfRegister {
+				if err := selfRegisterEndpointSlice(args[0]); err != nil {
+					fmt.Printf("Warning: self-registration failed, falling back to DNS-only: %v\n", err)
+				}
 			}
 			if err := resolveDNS(context.Background(), args[0]); err != nil {
 				fmt.Printf("Error: %v", err)
@@ -26,6 +41,8 @@ func NewCommand() *cobra.Command {
 			}
 		},
 	}
+
+	cmd.Flags().BoolVar(&selfRegister, "self-register", false, "Register this pod's IP into an EndpointSlice before resolving DNS")
 	return cmd
 }
 
@@ -44,4 +61,116 @@ func resolveDNS(ctx context.Context, hostName string) error {
 		return err
 	}
 	return nil
+}
+
+// selfRegisterEndpointSlice creates an EndpointSlice for this pod's IP
+// so that CoreDNS can resolve the pod's DNS name without waiting for the
+// standard EndpointSlice controller, which may have a stale informer cache
+// under high cluster density.
+func selfRegisterEndpointSlice(dnsName string) error {
+	podIP := os.Getenv("POD_IP")
+	if podIP == "" {
+		return fmt.Errorf("POD_IP environment variable not set")
+	}
+	namespace := os.Getenv("NAMESPACE")
+	if namespace == "" {
+		return fmt.Errorf("NAMESPACE environment variable not set")
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		return fmt.Errorf("failed to get hostname: %w", err)
+	}
+
+	serviceName, err := parseServiceName(dnsName)
+	if err != nil {
+		return fmt.Errorf("failed to parse service name from DNS name %q: %w", dnsName, err)
+	}
+
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get in-cluster config: %w", err)
+	}
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pod, err := client.CoreV1().Pods(namespace).Get(ctx, hostname, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get pod %s/%s: %w", namespace, hostname, err)
+	}
+
+	addressType := discoveryv1.AddressTypeIPv4
+	if net.ParseIP(podIP) != nil && net.ParseIP(podIP).To4() == nil {
+		addressType = discoveryv1.AddressTypeIPv6
+	}
+
+	sliceName := fmt.Sprintf("%s-self-%s", serviceName, hostname)
+	endpointSlice := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sliceName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				discoveryv1.LabelServiceName: serviceName,
+				discoveryv1.LabelManagedBy:   "control-plane-operator",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Name:       pod.Name,
+					UID:        pod.UID,
+				},
+			},
+		},
+		AddressType: addressType,
+		Endpoints: []discoveryv1.Endpoint{
+			{
+				Addresses:  []string{podIP},
+				Hostname:   ptr.To(hostname),
+				NodeName:   ptr.To(pod.Spec.NodeName),
+				Conditions: discoveryv1.EndpointConditions{Ready: ptr.To(true)},
+				TargetRef: &corev1.ObjectReference{
+					Kind:      "Pod",
+					Name:      pod.Name,
+					Namespace: namespace,
+					UID:       pod.UID,
+				},
+			},
+		},
+		Ports: []discoveryv1.EndpointPort{
+			{Name: ptr.To("peer"), Port: ptr.To(int32(2380)), Protocol: ptr.To(corev1.ProtocolTCP)},
+			{Name: ptr.To("etcd-client"), Port: ptr.To(int32(2379)), Protocol: ptr.To(corev1.ProtocolTCP)},
+		},
+	}
+
+	existing, err := client.DiscoveryV1().EndpointSlices(namespace).Get(ctx, sliceName, metav1.GetOptions{})
+	if err == nil {
+		endpointSlice.ResourceVersion = existing.ResourceVersion
+		_, err = client.DiscoveryV1().EndpointSlices(namespace).Update(ctx, endpointSlice, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to update EndpointSlice %s: %w", sliceName, err)
+		}
+		fmt.Printf("Updated self-registration EndpointSlice %s with address %s\n", sliceName, podIP)
+	} else {
+		_, err = client.DiscoveryV1().EndpointSlices(namespace).Create(ctx, endpointSlice, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to create EndpointSlice %s: %w", sliceName, err)
+		}
+		fmt.Printf("Created self-registration EndpointSlice %s with address %s\n", sliceName, podIP)
+	}
+	return nil
+}
+
+// parseServiceName extracts the service name from a headless service DNS name.
+// Format: <hostname>.<service-name>.<namespace>.svc[.cluster.local]
+func parseServiceName(dnsName string) (string, error) {
+	parts := strings.Split(dnsName, ".")
+	if len(parts) < 3 {
+		return "", fmt.Errorf("expected at least 3 dot-separated components, got %d", len(parts))
+	}
+	return parts[1], nil
 }

--- a/dnsresolver/cmd_test.go
+++ b/dnsresolver/cmd_test.go
@@ -173,6 +173,15 @@ func TestEnsureEndpointSlice(t *testing.T) {
 		g.Expect(err).To(MatchError(ContainSubstring("failed to parse service name")))
 	})
 
+	t.Run("When given a malformed IP address it should return an error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		client := fake.NewClientset(newPod())
+		invalidIP := "not-an-ip-address"
+
+		err := ensureEndpointSlice(t.Context(), client, dnsName, hostname, namespace, invalidIP)
+		g.Expect(err).To(MatchError(ContainSubstring("failed to parse pod IP")))
+	})
+
 	t.Run("When called for etcd-1 it should use the correct slice name and hostname", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		pod1 := &corev1.Pod{

--- a/dnsresolver/cmd_test.go
+++ b/dnsresolver/cmd_test.go
@@ -1,7 +1,7 @@
 package dnsresolver
 
 import (
-	"context"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -89,14 +89,14 @@ func TestEnsureEndpointSlice(t *testing.T) {
 		g := NewGomegaWithT(t)
 		client := fake.NewClientset(newPod())
 
-		err := ensureEndpointSlice(context.Background(), client, dnsName, hostname, namespace, podIP)
+		err := ensureEndpointSlice(t.Context(), client, dnsName, hostname, namespace, podIP)
 		g.Expect(err).NotTo(HaveOccurred())
 
-		slice, err := client.DiscoveryV1().EndpointSlices(namespace).Get(context.Background(), "etcd-discovery-self-etcd-0", metav1.GetOptions{})
+		slice, err := client.DiscoveryV1().EndpointSlices(namespace).Get(t.Context(), "etcd-discovery-self-etcd-0", metav1.GetOptions{})
 		g.Expect(err).NotTo(HaveOccurred())
 
 		g.Expect(slice.Labels[discoveryv1.LabelServiceName]).To(Equal("etcd-discovery"))
-		g.Expect(slice.Labels[discoveryv1.LabelManagedBy]).To(Equal("control-plane-operator"))
+		g.Expect(slice.Labels[discoveryv1.LabelManagedBy]).To(Equal("etcd-self-register.hypershift.openshift.io"))
 		g.Expect(slice.AddressType).To(Equal(discoveryv1.AddressTypeIPv4))
 		g.Expect(slice.Endpoints).To(HaveLen(1))
 		g.Expect(slice.Endpoints[0].Addresses).To(Equal([]string{podIP}))
@@ -125,7 +125,7 @@ func TestEnsureEndpointSlice(t *testing.T) {
 				Namespace: namespace,
 				Labels: map[string]string{
 					discoveryv1.LabelServiceName: "etcd-discovery",
-					discoveryv1.LabelManagedBy:   "control-plane-operator",
+					discoveryv1.LabelManagedBy:   "etcd-self-register.hypershift.openshift.io",
 				},
 			},
 			AddressType: discoveryv1.AddressTypeIPv4,
@@ -135,10 +135,10 @@ func TestEnsureEndpointSlice(t *testing.T) {
 		}
 		client := fake.NewClientset(newPod(), existingSlice)
 
-		err := ensureEndpointSlice(context.Background(), client, dnsName, hostname, namespace, podIP)
+		err := ensureEndpointSlice(t.Context(), client, dnsName, hostname, namespace, podIP)
 		g.Expect(err).NotTo(HaveOccurred())
 
-		slice, err := client.DiscoveryV1().EndpointSlices(namespace).Get(context.Background(), "etcd-discovery-self-etcd-0", metav1.GetOptions{})
+		slice, err := client.DiscoveryV1().EndpointSlices(namespace).Get(t.Context(), "etcd-discovery-self-etcd-0", metav1.GetOptions{})
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(slice.Endpoints[0].Addresses).To(Equal([]string{podIP}))
 	})
@@ -148,10 +148,10 @@ func TestEnsureEndpointSlice(t *testing.T) {
 		client := fake.NewClientset(newPod())
 		ipv6 := "fd00::1"
 
-		err := ensureEndpointSlice(context.Background(), client, dnsName, hostname, namespace, ipv6)
+		err := ensureEndpointSlice(t.Context(), client, dnsName, hostname, namespace, ipv6)
 		g.Expect(err).NotTo(HaveOccurred())
 
-		slice, err := client.DiscoveryV1().EndpointSlices(namespace).Get(context.Background(), "etcd-discovery-self-etcd-0", metav1.GetOptions{})
+		slice, err := client.DiscoveryV1().EndpointSlices(namespace).Get(t.Context(), "etcd-discovery-self-etcd-0", metav1.GetOptions{})
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(slice.AddressType).To(Equal(discoveryv1.AddressTypeIPv6))
 		g.Expect(slice.Endpoints[0].Addresses).To(Equal([]string{ipv6}))
@@ -161,18 +161,16 @@ func TestEnsureEndpointSlice(t *testing.T) {
 		g := NewGomegaWithT(t)
 		client := fake.NewClientset()
 
-		err := ensureEndpointSlice(context.Background(), client, dnsName, hostname, namespace, podIP)
-		g.Expect(err).To(HaveOccurred())
-		g.Expect(err.Error()).To(ContainSubstring("failed to get pod"))
+		err := ensureEndpointSlice(t.Context(), client, dnsName, hostname, namespace, podIP)
+		g.Expect(err).To(MatchError(ContainSubstring("failed to get pod")))
 	})
 
 	t.Run("When given an invalid DNS name it should return an error", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		client := fake.NewClientset(newPod())
 
-		err := ensureEndpointSlice(context.Background(), client, "invalid", hostname, namespace, podIP)
-		g.Expect(err).To(HaveOccurred())
-		g.Expect(err.Error()).To(ContainSubstring("failed to parse service name"))
+		err := ensureEndpointSlice(t.Context(), client, "invalid", hostname, namespace, podIP)
+		g.Expect(err).To(MatchError(ContainSubstring("failed to parse service name")))
 	})
 
 	t.Run("When called for etcd-1 it should use the correct slice name and hostname", func(t *testing.T) {
@@ -187,10 +185,10 @@ func TestEnsureEndpointSlice(t *testing.T) {
 		}
 		client := fake.NewClientset(pod1)
 
-		err := ensureEndpointSlice(context.Background(), client, "etcd-1.etcd-discovery.ocm-test-namespace.svc", "etcd-1", namespace, "10.128.64.187")
+		err := ensureEndpointSlice(t.Context(), client, "etcd-1.etcd-discovery.ocm-test-namespace.svc", "etcd-1", namespace, "10.128.64.187")
 		g.Expect(err).NotTo(HaveOccurred())
 
-		slice, err := client.DiscoveryV1().EndpointSlices(namespace).Get(context.Background(), "etcd-discovery-self-etcd-1", metav1.GetOptions{})
+		slice, err := client.DiscoveryV1().EndpointSlices(namespace).Get(t.Context(), "etcd-discovery-self-etcd-1", metav1.GetOptions{})
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(*slice.Endpoints[0].Hostname).To(Equal("etcd-1"))
 		g.Expect(slice.Endpoints[0].Addresses).To(Equal([]string{"10.128.64.187"}))
@@ -208,12 +206,12 @@ func TestEnsureEndpointSlice(t *testing.T) {
 		for i := range 3 {
 			h := metav1.ObjectMeta{Name: pods[i].(*corev1.Pod).Name}.Name
 			dns := h + ".etcd-discovery." + namespace + ".svc"
-			ip := "10.128.64." + string(rune('1'+i))
-			err := ensureEndpointSlice(context.Background(), client, dns, h, namespace, ip)
+			ip := fmt.Sprintf("10.128.64.%d", 186+i)
+			err := ensureEndpointSlice(t.Context(), client, dns, h, namespace, ip)
 			g.Expect(err).NotTo(HaveOccurred())
 		}
 
-		slices, err := client.DiscoveryV1().EndpointSlices(namespace).List(context.Background(), metav1.ListOptions{})
+		slices, err := client.DiscoveryV1().EndpointSlices(namespace).List(t.Context(), metav1.ListOptions{})
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(slices.Items).To(HaveLen(3))
 	})

--- a/dnsresolver/cmd_test.go
+++ b/dnsresolver/cmd_test.go
@@ -1,9 +1,17 @@
 package dnsresolver
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestParseServiceName(t *testing.T) {
@@ -52,4 +60,161 @@ func TestParseServiceName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEnsureEndpointSlice(t *testing.T) {
+	const (
+		namespace = "ocm-test-namespace"
+		hostname  = "etcd-0"
+		podIP     = "10.128.64.186"
+		dnsName   = "etcd-0.etcd-discovery.ocm-test-namespace.svc"
+		podUID    = "test-pod-uid-1234"
+		nodeName  = "aks-userswft1-12345-vmss000000"
+	)
+
+	newPod := func() *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hostname,
+				Namespace: namespace,
+				UID:       types.UID(podUID),
+			},
+			Spec: corev1.PodSpec{
+				NodeName: nodeName,
+			},
+		}
+	}
+
+	t.Run("When no EndpointSlice exists it should create one with correct fields", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		client := fake.NewSimpleClientset(newPod())
+
+		err := ensureEndpointSlice(context.Background(), client, dnsName, hostname, namespace, podIP)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		slice, err := client.DiscoveryV1().EndpointSlices(namespace).Get(context.Background(), "etcd-discovery-self-etcd-0", metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(slice.Labels[discoveryv1.LabelServiceName]).To(Equal("etcd-discovery"))
+		g.Expect(slice.Labels[discoveryv1.LabelManagedBy]).To(Equal("control-plane-operator"))
+		g.Expect(slice.AddressType).To(Equal(discoveryv1.AddressTypeIPv4))
+		g.Expect(slice.Endpoints).To(HaveLen(1))
+		g.Expect(slice.Endpoints[0].Addresses).To(Equal([]string{podIP}))
+		g.Expect(*slice.Endpoints[0].Hostname).To(Equal(hostname))
+		g.Expect(*slice.Endpoints[0].NodeName).To(Equal(nodeName))
+		g.Expect(*slice.Endpoints[0].Conditions.Ready).To(BeTrue())
+		g.Expect(slice.Endpoints[0].TargetRef.Kind).To(Equal("Pod"))
+		g.Expect(slice.Endpoints[0].TargetRef.Name).To(Equal(hostname))
+		g.Expect(slice.Endpoints[0].TargetRef.UID).To(Equal(types.UID(podUID)))
+		g.Expect(slice.Ports).To(HaveLen(2))
+		g.Expect(*slice.Ports[0].Name).To(Equal("peer"))
+		g.Expect(*slice.Ports[0].Port).To(Equal(int32(2380)))
+		g.Expect(*slice.Ports[1].Name).To(Equal("etcd-client"))
+		g.Expect(*slice.Ports[1].Port).To(Equal(int32(2379)))
+		g.Expect(slice.OwnerReferences).To(HaveLen(1))
+		g.Expect(slice.OwnerReferences[0].Kind).To(Equal("Pod"))
+		g.Expect(slice.OwnerReferences[0].Name).To(Equal(hostname))
+		g.Expect(slice.OwnerReferences[0].UID).To(Equal(types.UID(podUID)))
+	})
+
+	t.Run("When an EndpointSlice already exists it should update it", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		existingSlice := &discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "etcd-discovery-self-etcd-0",
+				Namespace: namespace,
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: "etcd-discovery",
+					discoveryv1.LabelManagedBy:   "control-plane-operator",
+				},
+			},
+			AddressType: discoveryv1.AddressTypeIPv4,
+			Endpoints: []discoveryv1.Endpoint{
+				{Addresses: []string{"10.0.0.99"}},
+			},
+		}
+		client := fake.NewSimpleClientset(newPod(), existingSlice)
+
+		err := ensureEndpointSlice(context.Background(), client, dnsName, hostname, namespace, podIP)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		slice, err := client.DiscoveryV1().EndpointSlices(namespace).Get(context.Background(), "etcd-discovery-self-etcd-0", metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(slice.Endpoints[0].Addresses).To(Equal([]string{podIP}))
+	})
+
+	t.Run("When given an IPv6 address it should set AddressTypeIPv6", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		client := fake.NewSimpleClientset(newPod())
+		ipv6 := "fd00::1"
+
+		err := ensureEndpointSlice(context.Background(), client, dnsName, hostname, namespace, ipv6)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		slice, err := client.DiscoveryV1().EndpointSlices(namespace).Get(context.Background(), "etcd-discovery-self-etcd-0", metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(slice.AddressType).To(Equal(discoveryv1.AddressTypeIPv6))
+		g.Expect(slice.Endpoints[0].Addresses).To(Equal([]string{ipv6}))
+	})
+
+	t.Run("When the pod does not exist it should return an error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		client := fake.NewSimpleClientset()
+
+		err := ensureEndpointSlice(context.Background(), client, dnsName, hostname, namespace, podIP)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("failed to get pod"))
+	})
+
+	t.Run("When given an invalid DNS name it should return an error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		client := fake.NewSimpleClientset(newPod())
+
+		err := ensureEndpointSlice(context.Background(), client, "invalid", hostname, namespace, podIP)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("failed to parse service name"))
+	})
+
+	t.Run("When called for etcd-1 it should use the correct slice name and hostname", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		pod1 := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "etcd-1",
+				Namespace: namespace,
+				UID:       "uid-etcd-1",
+			},
+			Spec: corev1.PodSpec{NodeName: nodeName},
+		}
+		client := fake.NewSimpleClientset(pod1)
+
+		err := ensureEndpointSlice(context.Background(), client, "etcd-1.etcd-discovery.ocm-test-namespace.svc", "etcd-1", namespace, "10.128.64.187")
+		g.Expect(err).NotTo(HaveOccurred())
+
+		slice, err := client.DiscoveryV1().EndpointSlices(namespace).Get(context.Background(), "etcd-discovery-self-etcd-1", metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(*slice.Endpoints[0].Hostname).To(Equal("etcd-1"))
+		g.Expect(slice.Endpoints[0].Addresses).To(Equal([]string{"10.128.64.187"}))
+	})
+
+	t.Run("When multiple etcd pods self-register it should create separate EndpointSlices", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		pods := []runtime.Object{
+			&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "etcd-0", Namespace: namespace, UID: "uid-0"}, Spec: corev1.PodSpec{NodeName: nodeName}},
+			&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "etcd-1", Namespace: namespace, UID: "uid-1"}, Spec: corev1.PodSpec{NodeName: nodeName}},
+			&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "etcd-2", Namespace: namespace, UID: "uid-2"}, Spec: corev1.PodSpec{NodeName: nodeName}},
+		}
+		client := fake.NewSimpleClientset(pods...)
+
+		for i := range 3 {
+			h := metav1.ObjectMeta{Name: pods[i].(*corev1.Pod).Name}.Name
+			dns := h + ".etcd-discovery." + namespace + ".svc"
+			ip := "10.128.64." + string(rune('1'+i))
+			err := ensureEndpointSlice(context.Background(), client, dns, h, namespace, ip)
+			g.Expect(err).NotTo(HaveOccurred())
+		}
+
+		slices, err := client.DiscoveryV1().EndpointSlices(namespace).List(context.Background(), metav1.ListOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(slices.Items).To(HaveLen(3))
+	})
 }

--- a/dnsresolver/cmd_test.go
+++ b/dnsresolver/cmd_test.go
@@ -87,7 +87,7 @@ func TestEnsureEndpointSlice(t *testing.T) {
 
 	t.Run("When no EndpointSlice exists it should create one with correct fields", func(t *testing.T) {
 		g := NewGomegaWithT(t)
-		client := fake.NewSimpleClientset(newPod())
+		client := fake.NewClientset(newPod())
 
 		err := ensureEndpointSlice(context.Background(), client, dnsName, hostname, namespace, podIP)
 		g.Expect(err).NotTo(HaveOccurred())
@@ -133,7 +133,7 @@ func TestEnsureEndpointSlice(t *testing.T) {
 				{Addresses: []string{"10.0.0.99"}},
 			},
 		}
-		client := fake.NewSimpleClientset(newPod(), existingSlice)
+		client := fake.NewClientset(newPod(), existingSlice)
 
 		err := ensureEndpointSlice(context.Background(), client, dnsName, hostname, namespace, podIP)
 		g.Expect(err).NotTo(HaveOccurred())
@@ -145,7 +145,7 @@ func TestEnsureEndpointSlice(t *testing.T) {
 
 	t.Run("When given an IPv6 address it should set AddressTypeIPv6", func(t *testing.T) {
 		g := NewGomegaWithT(t)
-		client := fake.NewSimpleClientset(newPod())
+		client := fake.NewClientset(newPod())
 		ipv6 := "fd00::1"
 
 		err := ensureEndpointSlice(context.Background(), client, dnsName, hostname, namespace, ipv6)
@@ -159,7 +159,7 @@ func TestEnsureEndpointSlice(t *testing.T) {
 
 	t.Run("When the pod does not exist it should return an error", func(t *testing.T) {
 		g := NewGomegaWithT(t)
-		client := fake.NewSimpleClientset()
+		client := fake.NewClientset()
 
 		err := ensureEndpointSlice(context.Background(), client, dnsName, hostname, namespace, podIP)
 		g.Expect(err).To(HaveOccurred())
@@ -168,7 +168,7 @@ func TestEnsureEndpointSlice(t *testing.T) {
 
 	t.Run("When given an invalid DNS name it should return an error", func(t *testing.T) {
 		g := NewGomegaWithT(t)
-		client := fake.NewSimpleClientset(newPod())
+		client := fake.NewClientset(newPod())
 
 		err := ensureEndpointSlice(context.Background(), client, "invalid", hostname, namespace, podIP)
 		g.Expect(err).To(HaveOccurred())
@@ -185,7 +185,7 @@ func TestEnsureEndpointSlice(t *testing.T) {
 			},
 			Spec: corev1.PodSpec{NodeName: nodeName},
 		}
-		client := fake.NewSimpleClientset(pod1)
+		client := fake.NewClientset(pod1)
 
 		err := ensureEndpointSlice(context.Background(), client, "etcd-1.etcd-discovery.ocm-test-namespace.svc", "etcd-1", namespace, "10.128.64.187")
 		g.Expect(err).NotTo(HaveOccurred())
@@ -203,7 +203,7 @@ func TestEnsureEndpointSlice(t *testing.T) {
 			&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "etcd-1", Namespace: namespace, UID: "uid-1"}, Spec: corev1.PodSpec{NodeName: nodeName}},
 			&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "etcd-2", Namespace: namespace, UID: "uid-2"}, Spec: corev1.PodSpec{NodeName: nodeName}},
 		}
-		client := fake.NewSimpleClientset(pods...)
+		client := fake.NewClientset(pods...)
 
 		for i := range 3 {
 			h := metav1.ObjectMeta{Name: pods[i].(*corev1.Pod).Name}.Name

--- a/dnsresolver/cmd_test.go
+++ b/dnsresolver/cmd_test.go
@@ -1,0 +1,55 @@
+package dnsresolver
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestParseServiceName(t *testing.T) {
+	tests := []struct {
+		name        string
+		dnsName     string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:     "When given a standard headless service DNS name it should extract the service name",
+			dnsName:  "etcd-0.etcd-discovery.my-namespace.svc",
+			expected: "etcd-discovery",
+		},
+		{
+			name:     "When given a fully qualified DNS name it should extract the service name",
+			dnsName:  "etcd-0.etcd-discovery.my-namespace.svc.cluster.local",
+			expected: "etcd-discovery",
+		},
+		{
+			name:     "When given a DNS name with a long namespace it should extract the service name",
+			dnsName:  "etcd-2.etcd-discovery.ocm-arohcpci01-2q7h5rjtm2oud3pn6i3890qa6p37sts3-i2y6k1a2u2a0z1h.svc",
+			expected: "etcd-discovery",
+		},
+		{
+			name:        "When given a DNS name with too few components it should return an error",
+			dnsName:     "etcd-0.etcd-discovery",
+			expectError: true,
+		},
+		{
+			name:        "When given a single component it should return an error",
+			dnsName:     "etcd-0",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			result, err := parseServiceName(tt.dnsName)
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(result).To(Equal(tt.expected))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds EndpointSlice self-registration to the etcd `ensure-dns` init container, bypassing stale kube-controller-manager informer caches that delay DNS resolution under high HCP density
- Creates a dedicated `etcd` service account with minimal RBAC for EndpointSlice and pod get permissions
- Replaces the conditional `etcd-defrag-controller` SA with the always-present `etcd` SA, binding both self-register and defrag (HA-only) roles to it

## Problem

Under high cluster density (~2,500 HCP namespaces), the management cluster's kube-controller-manager EndpointSlice informer cache goes stale, causing `etcd-discovery` headless Service DNS records to be delayed by minutes to hours. The `ensure-dns` init container blocks waiting for DNS, preventing etcd from starting, which cascades into cluster creation timeouts.

### Evidence from Kusto (HostedControlPlaneLogs, hcp-dev-us-2.eastus2)

**Scale:** Hundreds to thousands of clusters affected daily across CI:

```
Date         Clusters   Failures   Prolonged(>5m)   Brief(<=5m)
2026-05-13        675     15,947           37            638
2026-05-14      1,210     24,869          142          1,063
2026-05-19      1,542     29,622          248          1,297
2026-05-20      1,228     22,563          180          1,039
2026-05-21      1,311     23,130          174          1,135
2026-05-26        980     17,884          138            842
```

**Breakdown (last 3 days):** Of 2,299 etcd pods that experienced DNS failures, 89.5% resolved within 30 seconds, but 8.1% (187 pods) took >5 minutes — these are the ones that cause E2E test timeouts.

### Root Cause: EndpointSlice informer cache staleness

Confirmed via `aksEvents` table (category `kube-controller-manager`) on May 14:

```
"Error syncing endpoint slices for service, retrying"
  key="ocm-arohcpprow-<cluster-id>/etcd-discovery"
  err="EndpointSlice informer cache is out of date"
```

This appeared for dozens of HCP namespaces — individual namespaces saw 136–227 sync errors. A secondary pattern (`"skipping Pod for Service, Node not found"`) shows the same informer staleness affecting node visibility, with top nodes seeing 330–557 skip events.

**What's ruled out:**
| Hypothesis | Evidence | Verdict |
|------------|----------|---------|
| CoreDNS unhealthy | No CoreDNS errors in logs | Ruled out |
| Node-specific issue | Failures evenly distributed across all nodes | Ruled out |
| CNI/IP assignment delay | CNS assigned IPs within seconds | Ruled out |
| Service creation race | Framework guarantees Service before StatefulSet | Ruled out |

**Specific case timeline (etcd-0 in a CI namespace, May 26):**

| Time | Event |
|------|-------|
| 17:57:52 | CPO reconciles `etcd-discovery` Service |
| 17:57:53 | CPO reconciles etcd StatefulSet |
| 17:58:22 | `ensure-dns` starts failing — `"no such host"` |
| 17:58:26 | CNS assigns pod IP `10.128.64.186` |
| 18:18:54 | DNS finally resolves — **20 minutes after IP assignment** |

The pod had its IP within 4 seconds, the Service existed 30 seconds before the pod, CoreDNS was healthy — the EndpointSlice controller simply hadn't updated the headless Service's endpoints.

### Impact on E2E stability

All three stage E2E jobs show poor stability:

| Job | Success Rate (last 20 runs) |
|-----|-----------------------------|
| `periodic-stage-e2e-parallel` | 40% |
| `periodic-stage-e2e-parallel-ocp-nightly` | 20% |
| `branch-...-stage-e2e-parallel` | 60% |

The Jira's specific failure was in `branch-ci-Azure-ARO-HCP-main-e2e-stage-e2e-parallel` build `2053695569343287296` (May 11 04:36 UTC), where the `patch-name-cluster` hit the 45-minute E2E timeout due to this etcd DNS issue.

## Solution: Etcd Pod Self-Registration

Each etcd pod creates its own EndpointSlice during the `ensure-dns` init container phase:

```
etcd-discovery Service (headless, selector: app=etcd)
    |
    +-- etcd-discovery-xxxxx  (managed-by: endpointslice-controller.k8s.io)
    |   [Standard controller — may be slow/stale under high density]
    |
    +-- etcd-discovery-self-etcd-0  (managed-by: control-plane-operator)
    |   [Created by etcd-0 init container — immediate]
    |
    +-- etcd-discovery-self-etcd-1  (managed-by: control-plane-operator)
    +-- etcd-discovery-self-etcd-2  (managed-by: control-plane-operator)
```

**Why this works:**
- The standard EndpointSlice controller only manages slices labeled `managed-by: endpointslice-controller.k8s.io` — it completely ignores slices with a different `managed-by` label
- CoreDNS merges endpoints from ALL EndpointSlices for a given Service regardless of who created them
- Once the self-registered slice exists, CoreDNS picks it up via its watch within ~100ms
- When the standard controller catches up, duplicate IPs are harmless for DNS
- OwnerReference to the Pod ensures cleanup on pod deletion

**Precedent:** The HCCO already uses this pattern for the `kubernetes` EndpointSlice in the guest cluster (`ReconcileKASEndpointSlice` in `hostedclusterconfigoperator/controllers/resources/kas/reconcile.go`).

### Changed files

| File | Change |
|------|--------|
| `dnsresolver/cmd.go` | Added `--self-register` flag and `selfRegisterEndpointSlice()` — creates EndpointSlice via K8s API before polling DNS, falls back to DNS-only on failure |
| `dnsresolver/cmd_test.go` | Unit tests for DNS name parsing |
| `v2/assets/etcd/statefulset.yaml` | Added `POD_IP` env var and `--self-register` flag to `ensure-dns` init container |
| `v2/assets/etcd/etcd-serviceaccount.yaml` | New `etcd` service account (always created) |
| `v2/assets/etcd/etcd-self-register-role.yaml` | Role granting EndpointSlice get/create/update and pod get |
| `v2/assets/etcd/etcd-self-register-rolebinding.yaml` | Binds role to `etcd` SA |
| `v2/assets/etcd/defrag-rolebinding.yaml` | Updated subject from `etcd-defrag-controller` to `etcd` SA |
| `v2/etcd/component.go` | Registered new RBAC assets, removed old defrag SA |
| `v2/etcd/statefulset.go` | Always set `ServiceAccountName = "etcd"` (not conditionally for HA) |
| `manifests/etcd.go` | Added `EtcdServiceAccount`, `EtcdSelfRegisterRole`, `EtcdSelfRegisterRoleBinding` helpers |

### Risks and mitigations

| Risk | Mitigation |
|------|-----------|
| Duplicate endpoints when controller catches up | CoreDNS deduplicates; harmless for DNS resolution |
| Self-registered EndpointSlice outlives pod | OwnerReference to Pod triggers GC on pod deletion |
| RBAC escalation | Scoped to get/create/update EndpointSlices + get pods in own namespace only |
| Init container fails to create EndpointSlice | Falls back to DNS-only behavior with a warning log |

## Test plan

- [x] Unit tests for DNS name parsing (`dnsresolver/cmd_test.go`)
- [x] Existing etcd component tests pass (14/14)
- [x] `make build` compiles cleanly
- [x] `make lint` passes with 0 issues
- [ ] E2E validation in staging environment
- [ ] Verify EndpointSlice creation in a live HCP namespace
- [ ] Verify DNS resolution timing improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Etcd pods can self-register EndpointSlices via an optional DNS-resolver self-register mode (warns and falls back to DNS-only on failure).
  * RBAC and ServiceAccount updates to support etcd self-registration and unify controller bindings; defrag controller now uses the standardized etcd ServiceAccount.
  * Init behavior updated to expose pod IP for self-registration.

* **Tests**
  * Added unit tests for DNS service-name parsing and EndpointSlice reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->