### PR TITLE
OCPBUGS-57453: fix(cpo): use Status.DNSZoneID before querying AWS Route53

### DIFF
--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
@@ -789,15 +789,19 @@ func (r *AWSEndpointServiceReconciler) reconcileEndpointDNSRecords(ctx context.C
 
 	zn := zoneName(hcp.Name)
 	var zoneID string
-	if r.awsClientBuilder.getLocalHostedZoneID() == "" {
+	if localZoneID := r.awsClientBuilder.getLocalHostedZoneID(); localZoneID != "" {
+		zoneID = localZoneID
+	} else if awsEndpointService.Status.DNSZoneID != "" {
+		zoneID = awsEndpointService.Status.DNSZoneID
+		r.awsClientBuilder.setLocalHostedZoneID(zoneID)
+		log.Info("using DNSZoneID from status", "zoneID", zoneID)
+	} else {
 		var err error
 		zoneID, err = lookupZoneID(ctx, route53Client, zn)
 		if err != nil {
 			return nil, "", err
 		}
 		r.awsClientBuilder.setLocalHostedZoneID(zoneID)
-	} else {
-		zoneID = r.awsClientBuilder.getLocalHostedZoneID()
 	}
 
 	var fqdns []string

--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller.go
@@ -57,6 +57,7 @@ import (
 const (
 	defaultResync               = 10 * time.Hour
 	externalPrivateServiceLabel = "hypershift.openshift.io/external-private-service"
+	throttleRequeueDelay        = 2 * time.Minute
 )
 
 // PrivateServiceObserver watches a given Service type LB and reconciles
@@ -527,6 +528,10 @@ func (r *AWSEndpointServiceReconciler) Reconcile(ctx context.Context, req ctrl.R
 				return ctrl.Result{}, err
 			}
 		}
+		if isAWSThrottleError(err) {
+			log.Info("AWS rate limit hit, backing off", "requeueAfter", throttleRequeueDelay)
+			return ctrl.Result{RequeueAfter: throttleRequeueDelay}, nil
+		}
 		return ctrl.Result{}, err
 	}
 
@@ -546,6 +551,14 @@ func (r *AWSEndpointServiceReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// always requeue to catch and report out of band changes in AWS
 	// NOTICE: if the RequeueAfter interval is short enough, it could result in hitting some AWS request limits.
 	return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+}
+
+func isAWSThrottleError(err error) bool {
+	switch supportawsutil.AWSErrorCode(err) {
+	case "Throttling", "ThrottlingException", "RequestLimitExceeded", "TooManyRequestsException":
+		return true
+	}
+	return false
 }
 
 func hasAWSConfig(platform *hyperv1.PlatformSpec) bool {
@@ -810,6 +823,12 @@ func (r *AWSEndpointServiceReconciler) reconcileEndpointDNSRecords(ctx context.C
 		fqdns = append(fqdns, fqdn)
 		err := CreateRecord(ctx, route53Client, zoneID, fqdn, aws.ToString(endpointDNSEntries[0].DnsName), route53types.RRTypeCname)
 		if err != nil {
+			var noSuchZone *route53types.NoSuchHostedZone
+			if errors.As(err, &noSuchZone) {
+				r.awsClientBuilder.setLocalHostedZoneID("")
+				awsEndpointService.Status.DNSZoneID = ""
+				log.Info("hosted zone not found, clearing cached DNSZoneID", "zoneID", zoneID)
+			}
 			return nil, "", err
 		}
 		log.Info("DNS record created", "fqdn", fqdn)

--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller_test.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller_test.go
@@ -1920,3 +1920,56 @@ func TestReconcileEndpointDNSRecords(t *testing.T) {
 		})
 	}
 }
+
+func TestIsAWSThrottleError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "Throttling error should be detected",
+			err:      &testAPIError{code: "Throttling"},
+			expected: true,
+		},
+		{
+			name:     "ThrottlingException should be detected",
+			err:      &testAPIError{code: "ThrottlingException"},
+			expected: true,
+		},
+		{
+			name:     "RequestLimitExceeded should be detected",
+			err:      &testAPIError{code: "RequestLimitExceeded"},
+			expected: true,
+		},
+		{
+			name:     "TooManyRequestsException should be detected",
+			err:      &testAPIError{code: "TooManyRequestsException"},
+			expected: true,
+		},
+		{
+			name:     "Non-throttle AWS error should not be detected",
+			err:      &testAPIError{code: "NoSuchHostedZone"},
+			expected: false,
+		},
+		{
+			name:     "Non-AWS error should not be detected",
+			err:      errors.New("network error"),
+			expected: false,
+		},
+		{
+			name:     "Nil error should not be detected",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isAWSThrottleError(tt.err)
+			if result != tt.expected {
+				t.Errorf("isAWSThrottleError() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller_test.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller_test.go
@@ -1654,13 +1654,14 @@ func TestExtractNLBName(t *testing.T) {
 
 func TestReconcileEndpointDNSRecords(t *testing.T) {
 	testCases := []struct {
-		name            string
-		awsEndpointSvc  *hyperv1.AWSEndpointService
-		hcp             *hyperv1.HostedControlPlane
-		setupMocks      func(*gomock.Controller) (*MockawsClientProvider, *awsapi.MockROUTE53API)
-		expectedZoneID  string
-		expectError     bool
-		expectFQDNCount int
+		name                   string
+		awsEndpointSvc         *hyperv1.AWSEndpointService
+		hcp                    *hyperv1.HostedControlPlane
+		setupMocks             func(*gomock.Controller) (*MockawsClientProvider, *awsapi.MockROUTE53API)
+		expectedZoneID         string
+		expectError            bool
+		expectFQDNCount        int
+		expectDNSZoneIDCleared bool
 	}{
 		{
 			name: "When Status.DNSZoneID is set and in-memory cache is empty, it should use the status value",
@@ -1853,6 +1854,39 @@ func TestReconcileEndpointDNSRecords(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			name: "When CreateRecord fails with NoSuchHostedZone, it should clear both caches",
+			awsEndpointSvc: &hyperv1.AWSEndpointService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver-private",
+					Namespace: "clusters-test",
+				},
+				Status: hyperv1.AWSEndpointServiceStatus{
+					DNSZoneID: "ZSTALE",
+				},
+			},
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: "clusters-test",
+				},
+			},
+			setupMocks: func(mockCtrl *gomock.Controller) (*MockawsClientProvider, *awsapi.MockROUTE53API) {
+				mockBuilder := NewMockawsClientProvider(mockCtrl)
+				mockRoute53 := awsapi.NewMockROUTE53API(mockCtrl)
+
+				mockBuilder.EXPECT().getLocalHostedZoneID().Return("")
+				mockBuilder.EXPECT().setLocalHostedZoneID("ZSTALE")
+				mockBuilder.EXPECT().setLocalHostedZoneID("")
+
+				mockRoute53.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, &route53types.NoSuchHostedZone{Message: aws.String("Hosted zone ZSTALE not found")})
+
+				return mockBuilder, mockRoute53
+			},
+			expectError:            true,
+			expectDNSZoneIDCleared: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1879,6 +1913,9 @@ func TestReconcileEndpointDNSRecords(t *testing.T) {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(zoneID).To(Equal(tc.expectedZoneID))
 				g.Expect(fqdns).To(HaveLen(tc.expectFQDNCount))
+			}
+			if tc.expectDNSZoneIDCleared {
+				g.Expect(tc.awsEndpointSvc.Status.DNSZoneID).To(BeEmpty())
 			}
 		})
 	}

--- a/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller_test.go
+++ b/control-plane-operator/controllers/awsprivatelink/awsprivatelink_controller_test.go
@@ -1651,3 +1651,235 @@ func TestExtractNLBName(t *testing.T) {
 		})
 	}
 }
+
+func TestReconcileEndpointDNSRecords(t *testing.T) {
+	testCases := []struct {
+		name            string
+		awsEndpointSvc  *hyperv1.AWSEndpointService
+		hcp             *hyperv1.HostedControlPlane
+		setupMocks      func(*gomock.Controller) (*MockawsClientProvider, *awsapi.MockROUTE53API)
+		expectedZoneID  string
+		expectError     bool
+		expectFQDNCount int
+	}{
+		{
+			name: "When Status.DNSZoneID is set and in-memory cache is empty, it should use the status value",
+			awsEndpointSvc: &hyperv1.AWSEndpointService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver-private",
+					Namespace: "clusters-test",
+				},
+				Status: hyperv1.AWSEndpointServiceStatus{
+					DNSZoneID: "Z1234567890",
+				},
+			},
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: "clusters-test",
+				},
+			},
+			setupMocks: func(mockCtrl *gomock.Controller) (*MockawsClientProvider, *awsapi.MockROUTE53API) {
+				mockBuilder := NewMockawsClientProvider(mockCtrl)
+				mockRoute53 := awsapi.NewMockROUTE53API(mockCtrl)
+
+				// In-memory cache is empty (simulates pod restart)
+				mockBuilder.EXPECT().getLocalHostedZoneID().Return("")
+				// Should populate the cache from status
+				mockBuilder.EXPECT().setLocalHostedZoneID("Z1234567890")
+
+				// Route53 ListHostedZones should NOT be called
+				// CreateRecord (ChangeResourceRecordSets) should be called with the status zone ID
+				mockRoute53.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, input *route53sdk.ChangeResourceRecordSetsInput, _ ...func(*route53sdk.Options)) (*route53sdk.ChangeResourceRecordSetsOutput, error) {
+						if aws.ToString(input.HostedZoneId) != "Z1234567890" {
+							return nil, fmt.Errorf("unexpected zone ID: %s", aws.ToString(input.HostedZoneId))
+						}
+						return &route53sdk.ChangeResourceRecordSetsOutput{}, nil
+					})
+
+				return mockBuilder, mockRoute53
+			},
+			expectedZoneID:  "Z1234567890",
+			expectError:     false,
+			expectFQDNCount: 1,
+		},
+		{
+			name: "When both Status.DNSZoneID and in-memory cache are empty, it should call AWS",
+			awsEndpointSvc: &hyperv1.AWSEndpointService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver-private",
+					Namespace: "clusters-test",
+				},
+				Status: hyperv1.AWSEndpointServiceStatus{},
+			},
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: "clusters-test",
+				},
+			},
+			setupMocks: func(mockCtrl *gomock.Controller) (*MockawsClientProvider, *awsapi.MockROUTE53API) {
+				mockBuilder := NewMockawsClientProvider(mockCtrl)
+				mockRoute53 := awsapi.NewMockROUTE53API(mockCtrl)
+
+				// In-memory cache is empty
+				mockBuilder.EXPECT().getLocalHostedZoneID().Return("")
+				// Should call lookupZoneID -> ListHostedZones (paginator passes ctx, input, optFns...)
+				mockRoute53.EXPECT().ListHostedZones(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					&route53sdk.ListHostedZonesOutput{
+						HostedZones: []route53types.HostedZone{
+							{
+								Id:     aws.String("/hostedzone/ZFROMAWS"),
+								Name:   aws.String("test-hcp.hypershift.local."),
+								Config: &route53types.HostedZoneConfig{PrivateZone: true},
+							},
+						},
+						IsTruncated: false,
+					}, nil)
+				// Should cache the result from AWS
+				mockBuilder.EXPECT().setLocalHostedZoneID("ZFROMAWS")
+
+				// CreateRecord should be called with the zone from AWS
+				mockRoute53.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, input *route53sdk.ChangeResourceRecordSetsInput, _ ...func(*route53sdk.Options)) (*route53sdk.ChangeResourceRecordSetsOutput, error) {
+						if aws.ToString(input.HostedZoneId) != "ZFROMAWS" {
+							return nil, fmt.Errorf("unexpected zone ID: %s", aws.ToString(input.HostedZoneId))
+						}
+						return &route53sdk.ChangeResourceRecordSetsOutput{}, nil
+					})
+
+				return mockBuilder, mockRoute53
+			},
+			expectedZoneID:  "ZFROMAWS",
+			expectError:     false,
+			expectFQDNCount: 1,
+		},
+		{
+			name: "When in-memory cache is populated, it should use the cache",
+			awsEndpointSvc: &hyperv1.AWSEndpointService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver-private",
+					Namespace: "clusters-test",
+				},
+				Status: hyperv1.AWSEndpointServiceStatus{
+					DNSZoneID: "ZOLDVALUE",
+				},
+			},
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: "clusters-test",
+				},
+			},
+			setupMocks: func(mockCtrl *gomock.Controller) (*MockawsClientProvider, *awsapi.MockROUTE53API) {
+				mockBuilder := NewMockawsClientProvider(mockCtrl)
+				mockRoute53 := awsapi.NewMockROUTE53API(mockCtrl)
+
+				// In-memory cache is populated
+				mockBuilder.EXPECT().getLocalHostedZoneID().Return("ZCACHED")
+
+				// Neither ListHostedZones nor setLocalHostedZoneID should be called
+				// CreateRecord should use the cached zone ID
+				mockRoute53.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, input *route53sdk.ChangeResourceRecordSetsInput, _ ...func(*route53sdk.Options)) (*route53sdk.ChangeResourceRecordSetsOutput, error) {
+						if aws.ToString(input.HostedZoneId) != "ZCACHED" {
+							return nil, fmt.Errorf("unexpected zone ID: %s", aws.ToString(input.HostedZoneId))
+						}
+						return &route53sdk.ChangeResourceRecordSetsOutput{}, nil
+					})
+
+				return mockBuilder, mockRoute53
+			},
+			expectedZoneID:  "ZCACHED",
+			expectError:     false,
+			expectFQDNCount: 1,
+		},
+		{
+			name: "When lookupZoneID fails, it should return error",
+			awsEndpointSvc: &hyperv1.AWSEndpointService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver-private",
+					Namespace: "clusters-test",
+				},
+				Status: hyperv1.AWSEndpointServiceStatus{},
+			},
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: "clusters-test",
+				},
+			},
+			setupMocks: func(mockCtrl *gomock.Controller) (*MockawsClientProvider, *awsapi.MockROUTE53API) {
+				mockBuilder := NewMockawsClientProvider(mockCtrl)
+				mockRoute53 := awsapi.NewMockROUTE53API(mockCtrl)
+
+				mockBuilder.EXPECT().getLocalHostedZoneID().Return("")
+				mockRoute53.EXPECT().ListHostedZones(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					nil, fmt.Errorf("Route53 throttling: Rate exceeded"))
+
+				return mockBuilder, mockRoute53
+			},
+			expectError: true,
+		},
+		{
+			name: "When CreateRecord fails, it should return error",
+			awsEndpointSvc: &hyperv1.AWSEndpointService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver-private",
+					Namespace: "clusters-test",
+				},
+				Status: hyperv1.AWSEndpointServiceStatus{
+					DNSZoneID: "Z1234567890",
+				},
+			},
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hcp",
+					Namespace: "clusters-test",
+				},
+			},
+			setupMocks: func(mockCtrl *gomock.Controller) (*MockawsClientProvider, *awsapi.MockROUTE53API) {
+				mockBuilder := NewMockawsClientProvider(mockCtrl)
+				mockRoute53 := awsapi.NewMockROUTE53API(mockCtrl)
+
+				mockBuilder.EXPECT().getLocalHostedZoneID().Return("")
+				mockBuilder.EXPECT().setLocalHostedZoneID("Z1234567890")
+
+				mockRoute53.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, &smithy.GenericAPIError{Code: "Throttling", Message: "Rate exceeded"})
+
+				return mockBuilder, mockRoute53
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			mockCtrl := gomock.NewController(t)
+			mockBuilder, mockRoute53 := tc.setupMocks(mockCtrl)
+
+			reconciler := &AWSEndpointServiceReconciler{
+				awsClientBuilder: mockBuilder,
+			}
+
+			ctx := ctrl.LoggerInto(context.Background(), ctrl.Log.WithName("test"))
+			endpointDNSEntries := []ec2types.DnsEntry{
+				{DnsName: aws.String("vpce-abc.vpce-svc.us-east-1.vpce.amazonaws.com")},
+			}
+
+			fqdns, zoneID, err := reconciler.reconcileEndpointDNSRecords(ctx, mockRoute53, tc.awsEndpointSvc, tc.hcp, endpointDNSEntries, ctrl.Log.WithName("test"))
+
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(zoneID).To(Equal(tc.expectedZoneID))
+				g.Expect(fqdns).To(HaveLen(tc.expectFQDNCount))
+			}
+		})
+	}
+}

--- a/control-plane-operator/controllers/awsprivatelink/route53.go
+++ b/control-plane-operator/controllers/awsprivatelink/route53.go
@@ -2,7 +2,6 @@ package awsprivatelink
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -12,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	route53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
-	"github.com/aws/smithy-go"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -75,11 +73,7 @@ func CreateRecord(ctx context.Context, client awsapi.ROUTE53API, zoneID, name, v
 
 	_, err := client.ChangeResourceRecordSets(ctx, input)
 	if err != nil {
-		var apiErr smithy.APIError
-		if errors.As(err, &apiErr) {
-			log.Error(err, "failed to create records in hosted zone", "zone", zoneID)
-			return fmt.Errorf("%s", apiErr.ErrorCode())
-		}
+		log.Error(err, "failed to create records in hosted zone", "zone", zoneID)
 	}
 	return err
 }

--- a/control-plane-operator/controllers/awsprivatelink/route53_test.go
+++ b/control-plane-operator/controllers/awsprivatelink/route53_test.go
@@ -142,10 +142,11 @@ func TestFindRecord(t *testing.T) {
 
 func TestCreateRecord(t *testing.T) {
 	tests := []struct {
-		name          string
-		setupMock     func(*awsapi.MockROUTE53API)
-		expectError   bool
-		errorContains string
+		name           string
+		setupMock      func(*awsapi.MockROUTE53API)
+		expectError    bool
+		errorContains  string
+		checkErrorType func(*testing.T, error)
 	}{
 		{
 			name: "When ChangeResourceRecordSets succeeds it should return nil",
@@ -157,7 +158,7 @@ func TestCreateRecord(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "When API returns a smithy error it should return the error code as the error message",
+			name: "When API returns a smithy error it should preserve the original error type",
 			setupMock: func(m *awsapi.MockROUTE53API) {
 				m.EXPECT().ChangeResourceRecordSets(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 					nil, &testAPIError{code: "NoSuchHostedZone"},
@@ -165,6 +166,12 @@ func TestCreateRecord(t *testing.T) {
 			},
 			expectError:   true,
 			errorContains: "NoSuchHostedZone",
+			checkErrorType: func(t *testing.T, err error) {
+				var apiErr smithy.APIError
+				if !errors.As(err, &apiErr) {
+					t.Error("expected error to implement smithy.APIError for typed error detection")
+				}
+			},
 		},
 		{
 			name: "When API returns a non-smithy error it should propagate the original error",
@@ -192,6 +199,9 @@ func TestCreateRecord(t *testing.T) {
 				}
 				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
 					t.Errorf("expected error containing %q, got: %v", tt.errorContains, err)
+				}
+				if tt.checkErrorType != nil {
+					tt.checkErrorType(t, err)
 				}
 			} else {
 				if err != nil {


### PR DESCRIPTION
After a CPO pod restart, the **AWSEndpointService** reconciler called **Route53 ListHostedZones** to look up the DNS zone ID on every reconciliation, even though **Status.DNSZoneID** already had the correct value persisted in the CR. At scale with many HostedClusters failing, this could hit AWS rate limits.


<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

Added a three-tier lookup for the zone ID: 

- in-memory cache first, 
- then the persisted CR status, 
- and only fall back to the AWS API when both are empty (first-ever reconciliation). 

When reading from status, the in-memory cache is also populated so subsequent reconciles within the same pod lifetime use the fastest path.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes  : https://redhat.atlassian.net/browse/OCPBUGS-57453

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Resilience / Bug Fixes**
  * Improved reconciliation during AWS throttling: throttling errors are logged and retried after a fixed 2-minute backoff instead of failing immediately.
  * Enhanced DNS hosted-zone selection by preferring cached values, then using the status-provided value, and only looking up when both are missing.
  * If Route53 reports a missing hosted zone, cached and status-based hosted-zone identifiers are cleared to allow recovery.

* **Tests**
  * Added unit tests covering hosted-zone resolution, DNS record creation, throttling detection, and recovery behavior.
  * Extended Route53 record tests to verify the original AWS error type is preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->