### PR TITLE
OCPBUGS-86662: Optimize CPO deployment polling interval in tests of additional trust bundle propagation

### DIFF
--- a/test/e2e/nodepool_additionalTrustBundlePropagation_test.go
+++ b/test/e2e/nodepool_additionalTrustBundlePropagation_test.go
@@ -54,6 +54,14 @@ func (k *AdditionalTrustBundlePropagationTest) BuildNodePoolManifest(defaultNode
 }
 
 func (k *AdditionalTrustBundlePropagationTest) Run(t *testing.T, nodePool hyperv1.NodePool, nodes []corev1.Node) {
+	const (
+		nodePoolConfigUpdateStartTimeout    = 5 * time.Minute
+		nodePoolConfigUpdateFinishTimeout   = 20 * time.Minute
+		defaultPollInterval                 = 15 * time.Second
+		cpoDeploymentUpdateTimeout          = 10 * time.Minute
+		guestUserCABundlePropagationTimeout = 5 * time.Minute
+	)
+
 	t.Run("AdditionalTrustBundlePropagationTest", func(t *testing.T) {
 		e2eutil.AtLeast(t, e2eutil.Version418)
 
@@ -90,7 +98,7 @@ func (k *AdditionalTrustBundlePropagationTest) Run(t *testing.T, nodePool hyperv
 					Status: metav1.ConditionTrue,
 				}),
 			},
-			e2eutil.WithInterval(10*time.Second), e2eutil.WithTimeout(5*time.Minute),
+			e2eutil.WithInterval(defaultPollInterval), e2eutil.WithTimeout(nodePoolConfigUpdateStartTimeout),
 		)
 
 		e2eutil.EventuallyObject(t, k.ctx, fmt.Sprintf("Waiting for NodePool %s/%s to stop updating", nodePool.Namespace, nodePool.Name),
@@ -108,7 +116,7 @@ func (k *AdditionalTrustBundlePropagationTest) Run(t *testing.T, nodePool hyperv
 					Status: metav1.ConditionTrue,
 				}),
 			},
-			e2eutil.WithInterval(10*time.Second), e2eutil.WithTimeout(20*time.Minute),
+			e2eutil.WithInterval(defaultPollInterval), e2eutil.WithTimeout(nodePoolConfigUpdateFinishTimeout),
 		)
 
 		// Sanity check: ensure the user-ca-bundle exists in the guest cluster before removal to avoid false positives
@@ -127,7 +135,7 @@ func (k *AdditionalTrustBundlePropagationTest) Run(t *testing.T, nodePool hyperv
 				[]e2eutil.Predicate[*corev1.ConfigMap]{
 					func(obj *corev1.ConfigMap) (bool, string, error) { return true, "exists", nil },
 				},
-				e2eutil.WithInterval(10*time.Second), e2eutil.WithTimeout(5*time.Minute),
+				e2eutil.WithInterval(defaultPollInterval), e2eutil.WithTimeout(guestUserCABundlePropagationTimeout),
 			)
 		}
 
@@ -164,6 +172,7 @@ func (k *AdditionalTrustBundlePropagationTest) Run(t *testing.T, nodePool hyperv
 					return true, "Additional trust bundle configmap is not included in CPO", nil
 				},
 			},
+			e2eutil.WithInterval(defaultPollInterval), e2eutil.WithTimeout(cpoDeploymentUpdateTimeout),
 		)
 
 		e2eutil.EventuallyObject(t, k.ctx, fmt.Sprintf("Waiting for NodePool %s/%s to begin updating", nodePool.Namespace, nodePool.Name),
@@ -177,7 +186,7 @@ func (k *AdditionalTrustBundlePropagationTest) Run(t *testing.T, nodePool hyperv
 					Status: metav1.ConditionTrue,
 				}),
 			},
-			e2eutil.WithInterval(10*time.Second), e2eutil.WithTimeout(5*time.Minute),
+			e2eutil.WithInterval(defaultPollInterval), e2eutil.WithTimeout(nodePoolConfigUpdateStartTimeout),
 		)
 
 		e2eutil.EventuallyObject(t, k.ctx, fmt.Sprintf("Waiting for NodePool %s/%s to stop updating", nodePool.Namespace, nodePool.Name),
@@ -195,7 +204,7 @@ func (k *AdditionalTrustBundlePropagationTest) Run(t *testing.T, nodePool hyperv
 					Status: metav1.ConditionTrue,
 				}),
 			},
-			e2eutil.WithInterval(10*time.Second), e2eutil.WithTimeout(20*time.Minute),
+			e2eutil.WithInterval(defaultPollInterval), e2eutil.WithTimeout(nodePoolConfigUpdateFinishTimeout),
 		)
 
 		// Ensure the user-ca-bundle configmap is deleted from the guest cluster
@@ -208,7 +217,7 @@ func (k *AdditionalTrustBundlePropagationTest) Run(t *testing.T, nodePool hyperv
 				},
 			}
 			e2eutil.EventuallyNotFound(t, k.ctx, k.guestClient, userCAConfigMap,
-				e2eutil.WithInterval(10*time.Second), e2eutil.WithTimeout(5*time.Minute),
+				e2eutil.WithInterval(defaultPollInterval), e2eutil.WithTimeout(guestUserCABundlePropagationTimeout),
 			)
 		}
 	})

--- a/test/e2e/util/eventually.go
+++ b/test/e2e/util/eventually.go
@@ -26,7 +26,7 @@ import (
 
 func defaultOptions() *EventuallyOptions {
 	return &EventuallyOptions{
-		interval:       3 * time.Second, // Increased from 1s to 2s globally to reduce API load
+		interval:       3 * time.Second, // Polling interval set globally to reduce API load
 		timeout:        10 * time.Minute,
 		immediate:      true,
 		dumpConditions: true,

--- a/test/e2e/v2/tests/nodepool_lifecycle_test.go
+++ b/test/e2e/v2/tests/nodepool_lifecycle_test.go
@@ -816,6 +816,14 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 
 		ctx := testCtx.Context
 
+		const (
+			defaultPollInterval                 = 15 * time.Second
+			nodePoolConfigUpdateStartTimeout    = 5 * time.Minute
+			nodePoolConfigUpdateFinishTimeout   = 20 * time.Minute
+			cpoDeploymentUpdateTimeout          = 10 * time.Minute
+			guestUserCABundlePropagationTimeout = 5 * time.Minute
+		)
+
 		defaultNP := getDefaultNodePool(ctx, testCtx.MgmtClient, hc)
 		Expect(defaultNP).NotTo(BeNil(), "default NodePool should exist")
 
@@ -874,7 +882,7 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 					Status: metav1.ConditionTrue,
 				}),
 			},
-			e2eutil.WithInterval(10*time.Second), e2eutil.WithTimeout(5*time.Minute),
+			e2eutil.WithInterval(defaultPollInterval), e2eutil.WithTimeout(nodePoolConfigUpdateStartTimeout),
 		)
 
 		e2eutil.EventuallyObject(GinkgoTB(), ctx, fmt.Sprintf("NodePool %s/%s to stop updating", np.Namespace, np.Name),
@@ -893,7 +901,7 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 					Status: metav1.ConditionTrue,
 				}),
 			},
-			e2eutil.WithInterval(10*time.Second), e2eutil.WithTimeout(20*time.Minute),
+			e2eutil.WithInterval(defaultPollInterval), e2eutil.WithTimeout(nodePoolConfigUpdateFinishTimeout),
 		)
 
 		// Verify user-ca-bundle exists in the hosted cluster
@@ -912,7 +920,7 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 			[]e2eutil.Predicate[*corev1.ConfigMap]{
 				func(obj *corev1.ConfigMap) (bool, string, error) { return true, "exists", nil },
 			},
-			e2eutil.WithInterval(10*time.Second), e2eutil.WithTimeout(5*time.Minute),
+			e2eutil.WithInterval(defaultPollInterval), e2eutil.WithTimeout(guestUserCABundlePropagationTimeout),
 		)
 
 		// Remove trust bundle from HostedCluster
@@ -948,6 +956,7 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 					return true, "trust bundle volume removed from CPO", nil
 				},
 			},
+			e2eutil.WithInterval(defaultPollInterval), e2eutil.WithTimeout(cpoDeploymentUpdateTimeout),
 		)
 
 		// Wait for NodePool to cycle again
@@ -963,7 +972,7 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 					Status: metav1.ConditionTrue,
 				}),
 			},
-			e2eutil.WithInterval(10*time.Second), e2eutil.WithTimeout(5*time.Minute),
+			e2eutil.WithInterval(defaultPollInterval), e2eutil.WithTimeout(nodePoolConfigUpdateStartTimeout),
 		)
 
 		e2eutil.EventuallyObject(GinkgoTB(), ctx, fmt.Sprintf("NodePool %s/%s to stop updating after trust bundle removal", np.Namespace, np.Name),
@@ -982,7 +991,7 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 					Status: metav1.ConditionTrue,
 				}),
 			},
-			e2eutil.WithInterval(10*time.Second), e2eutil.WithTimeout(20*time.Minute),
+			e2eutil.WithInterval(defaultPollInterval), e2eutil.WithTimeout(nodePoolConfigUpdateFinishTimeout),
 		)
 
 		// Verify user-ca-bundle is deleted from the hosted cluster (4.22+)


### PR DESCRIPTION
This PR addresses inconsistent test timeouts in the trust bundle propagation tests. The root cause was aggressive API polling during the CPO deployment check, which lacked an explicit interval configuration and defaulted to the global 3s threshold.

By explicitly setting this check to 15s, we reduce API polling frequency by 5x, preventing API throttling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Centralized and reused timing parameters in node pool end-to-end tests for improved maintainability and consistency
  * Increased timeout for node pool status validation to reduce flakiness and improve reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->