### PR TITLE
OCPBUGS-86668: fix CA rotation race in ReconcileTotalClientCA

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/ca.go
@@ -2,12 +2,18 @@ package pki
 
 import (
 	"bytes"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
+	"sort"
 
 	"github.com/openshift/hypershift/support/certs"
 	"github.com/openshift/hypershift/support/config"
 
+	"github.com/openshift/library-go/pkg/crypto"
+
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 )
 
 func reconcileSelfSignedCA(secret *corev1.Secret, ownerRef config.OwnerRef, cn, ou string) error {
@@ -66,6 +72,9 @@ func ReconcileAggregatorClientCA(cm *corev1.ConfigMap, ownerRef config.OwnerRef,
 }
 
 func ReconcileTotalClientCA(cm *corev1.ConfigMap, ownerRef config.OwnerRef, additional []*corev1.ConfigMap, signers ...*corev1.Secret) error {
+	// nil map read is safe; reconcileAggregateCA initializes cm.Data below
+	previousBundle := cm.Data[certs.CASignerCertMapKey]
+
 	if err := reconcileAggregateCA(cm, ownerRef, signers...); err != nil {
 		return err
 	}
@@ -74,11 +83,40 @@ func ReconcileTotalClientCA(cm *corev1.ConfigMap, ownerRef config.OwnerRef, addi
 		return err
 	}
 	for _, add := range additional {
-		if _, err := combined.WriteString(add.Data[certs.OCPCASignerCertMapKey]); err != nil {
+		caData := add.Data[certs.OCPCASignerCertMapKey]
+		if len(caData) == 0 {
+			klog.Warningf("additional ConfigMap %s/%s has empty %s key", add.Namespace, add.Name, certs.OCPCASignerCertMapKey)
+		}
+		if _, err := combined.WriteString(caData); err != nil {
 			return err
 		}
 	}
-	cm.Data[certs.CASignerCertMapKey] = combined.String()
+
+	// Preserve non-expired CAs from the previous bundle that are absent
+	// from the new bundle. This prevents client certificate breakage when
+	// a CA (e.g. kube-csr-signer) rotates: clients still holding certs
+	// signed by the old CA remain trusted until that CA expires.
+	allCerts := parsePEMCertificates(combined.Bytes())
+	allCerts = append(allCerts, parsePEMCertificates([]byte(previousBundle))...)
+
+	allCerts = crypto.FilterExpiredCerts(allCerts...)
+	allCerts = deduplicateCerts(allCerts)
+
+	if len(allCerts) == 0 {
+		return fmt.Errorf("refusing to write empty CA bundle: all certificates expired or invalid")
+	}
+
+	// Sort by raw bytes for stable output, avoiding spurious ConfigMap
+	// updates when cert ordering shifts between reconciliation loops.
+	sort.SliceStable(allCerts, func(i, j int) bool {
+		return bytes.Compare(allCerts[i].Raw, allCerts[j].Raw) < 0
+	})
+
+	caBytes, err := crypto.EncodeCertificates(allCerts...)
+	if err != nil {
+		return fmt.Errorf("failed to encode CA bundle: %w", err)
+	}
+	cm.Data[certs.CASignerCertMapKey] = string(caBytes)
 	return nil
 }
 
@@ -120,4 +158,44 @@ func ReconcileRootCAConfigMap(cm *corev1.ConfigMap, ownerRef config.OwnerRef, ro
 
 func ReconcileKonnectivityConfigMap(cm *corev1.ConfigMap, ownerRef config.OwnerRef, konnectivityCA *corev1.Secret) error {
 	return reconcileAggregateCA(cm, ownerRef, konnectivityCA)
+}
+
+func parsePEMCertificates(data []byte) []*x509.Certificate {
+	var result []*x509.Certificate
+	for len(data) > 0 {
+		var block *pem.Block
+		block, data = pem.Decode(data)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			klog.Warningf("skipping corrupted CERTIFICATE PEM block: %v", err)
+			continue
+		}
+		result = append(result, cert)
+	}
+	return result
+}
+
+// deduplicateCerts removes duplicate certificates by comparing raw DER bytes,
+// matching the approach used in library-go's cabundle.go.
+func deduplicateCerts(in []*x509.Certificate) []*x509.Certificate {
+	var out []*x509.Certificate
+	for i := range in {
+		found := false
+		for j := range out {
+			if bytes.Equal(in[i].Raw, out[j].Raw) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			out = append(out, in[i])
+		}
+	}
+	return out
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/pki/ca_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/pki/ca_test.go
@@ -1,0 +1,373 @@
+package pki
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openshift/hypershift/support/certs"
+	"github.com/openshift/hypershift/support/config"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func generateSelfSignedCA(cn string, notBefore, notAfter time.Time) ([]byte, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, err
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: cn, OrganizationalUnit: []string{"openshift"}},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, err
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), nil
+}
+
+func mustGenerateCA(t *testing.T, cn string, notBefore, notAfter time.Time) []byte {
+	t.Helper()
+	data, err := generateSelfSignedCA(cn, notBefore, notAfter)
+	if err != nil {
+		t.Fatalf("failed to generate CA %q: %v", cn, err)
+	}
+	return data
+}
+
+func countCertsInPEM(data string) int {
+	return len(parsePEMCertificates([]byte(data)))
+}
+
+func certCNsInPEM(data string) []string {
+	certs := parsePEMCertificates([]byte(data))
+	names := make([]string, len(certs))
+	for i, c := range certs {
+		names[i] = c.Subject.CommonName
+	}
+	return names
+}
+
+func newOwnerRef() config.OwnerRef {
+	return config.OwnerRef{
+		Reference: &metav1.OwnerReference{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Name:       "test",
+			UID:        "test-uid",
+		},
+	}
+}
+
+func TestReconcileTotalClientCA_PreservesPreviousCAsOnRotation(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+
+	oldCA := mustGenerateCA(t, "kube-csr-signer-old", now.Add(-24*time.Hour), now.Add(8760*time.Hour))
+	newCA := mustGenerateCA(t, "kube-csr-signer-new", now.Add(-1*time.Hour), now.Add(8760*time.Hour))
+	controlPlaneSigner := mustGenerateCA(t, "kube-control-plane-signer", now.Add(-24*time.Hour), now.Add(8760*time.Hour))
+
+	cm := &corev1.ConfigMap{
+		Data: map[string]string{
+			certs.CASignerCertMapKey: string(controlPlaneSigner) + string(oldCA),
+		},
+	}
+
+	signerWithNewCA := &corev1.Secret{
+		Data: map[string][]byte{
+			certs.CASignerCertMapKey: append(controlPlaneSigner, newCA...),
+		},
+	}
+
+	err := ReconcileTotalClientCA(cm, newOwnerRef(), nil, signerWithNewCA)
+	if err != nil {
+		t.Fatalf("ReconcileTotalClientCA failed: %v", err)
+	}
+
+	bundle := cm.Data[certs.CASignerCertMapKey]
+	cns := certCNsInPEM(bundle)
+
+	wantCNs := map[string]bool{
+		"kube-control-plane-signer": false,
+		"kube-csr-signer-new":       false,
+		"kube-csr-signer-old":       false,
+	}
+	for _, cn := range cns {
+		if _, ok := wantCNs[cn]; ok {
+			wantCNs[cn] = true
+		}
+	}
+	for cn, found := range wantCNs {
+		if !found {
+			t.Errorf("expected CA %q in bundle but it was missing; got CNs: %v", cn, cns)
+		}
+	}
+}
+
+func TestReconcileTotalClientCA_EvictsExpiredCAs(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+
+	expiredCA := mustGenerateCA(t, "kube-csr-signer-expired", now.Add(-48*time.Hour), now.Add(-1*time.Hour))
+	currentCA := mustGenerateCA(t, "kube-csr-signer-current", now.Add(-1*time.Hour), now.Add(8760*time.Hour))
+
+	cm := &corev1.ConfigMap{
+		Data: map[string]string{
+			certs.CASignerCertMapKey: string(expiredCA) + string(currentCA),
+		},
+	}
+
+	signerWithCurrentCA := &corev1.Secret{
+		Data: map[string][]byte{
+			certs.CASignerCertMapKey: currentCA,
+		},
+	}
+
+	err := ReconcileTotalClientCA(cm, newOwnerRef(), nil, signerWithCurrentCA)
+	if err != nil {
+		t.Fatalf("ReconcileTotalClientCA failed: %v", err)
+	}
+
+	bundle := cm.Data[certs.CASignerCertMapKey]
+	cns := certCNsInPEM(bundle)
+
+	if countCertsInPEM(bundle) != 1 {
+		t.Errorf("expected 1 cert in bundle (expired should be evicted), got %d: %v", countCertsInPEM(bundle), cns)
+	}
+	for _, cn := range cns {
+		if strings.Contains(cn, "expired") {
+			t.Errorf("expired CA %q should have been evicted from bundle", cn)
+		}
+	}
+}
+
+func TestReconcileTotalClientCA_NoDuplicatesOnSteadyState(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+
+	ca1 := mustGenerateCA(t, "kube-csr-signer", now.Add(-24*time.Hour), now.Add(8760*time.Hour))
+	ca2 := mustGenerateCA(t, "kube-control-plane-signer", now.Add(-24*time.Hour), now.Add(8760*time.Hour))
+
+	initialBundle := string(ca1) + string(ca2)
+	cm := &corev1.ConfigMap{
+		Data: map[string]string{
+			certs.CASignerCertMapKey: initialBundle,
+		},
+	}
+
+	signer := &corev1.Secret{
+		Data: map[string][]byte{
+			certs.CASignerCertMapKey: append(ca1, ca2...),
+		},
+	}
+
+	// Run reconcile multiple times
+	for i := 0; i < 5; i++ {
+		err := ReconcileTotalClientCA(cm, newOwnerRef(), nil, signer)
+		if err != nil {
+			t.Fatalf("iteration %d: ReconcileTotalClientCA failed: %v", i, err)
+		}
+	}
+
+	bundle := cm.Data[certs.CASignerCertMapKey]
+	if countCertsInPEM(bundle) != 2 {
+		t.Errorf("expected 2 certs in bundle after repeated reconcile, got %d: %v",
+			countCertsInPEM(bundle), certCNsInPEM(bundle))
+	}
+}
+
+func TestReconcileTotalClientCA_EmptyPreviousBundle(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+
+	ca := mustGenerateCA(t, "kube-csr-signer", now.Add(-1*time.Hour), now.Add(8760*time.Hour))
+
+	cm := &corev1.ConfigMap{
+		Data: map[string]string{},
+	}
+
+	signer := &corev1.Secret{
+		Data: map[string][]byte{
+			certs.CASignerCertMapKey: ca,
+		},
+	}
+
+	err := ReconcileTotalClientCA(cm, newOwnerRef(), nil, signer)
+	if err != nil {
+		t.Fatalf("ReconcileTotalClientCA failed: %v", err)
+	}
+
+	bundle := cm.Data[certs.CASignerCertMapKey]
+	if countCertsInPEM(bundle) != 1 {
+		t.Errorf("expected 1 cert in bundle for fresh ConfigMap, got %d", countCertsInPEM(bundle))
+	}
+}
+
+func TestReconcileTotalClientCA_WithAdditionalConfigMaps(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+
+	signerCA := mustGenerateCA(t, "kube-csr-signer", now.Add(-1*time.Hour), now.Add(8760*time.Hour))
+	additionalCA := mustGenerateCA(t, "ocp-additional-ca", now.Add(-1*time.Hour), now.Add(8760*time.Hour))
+	oldSignerCA := mustGenerateCA(t, "kube-csr-signer-old", now.Add(-48*time.Hour), now.Add(8760*time.Hour))
+
+	cm := &corev1.ConfigMap{
+		Data: map[string]string{
+			certs.CASignerCertMapKey: string(oldSignerCA) + string(additionalCA),
+		},
+	}
+
+	signer := &corev1.Secret{
+		Data: map[string][]byte{
+			certs.CASignerCertMapKey: signerCA,
+		},
+	}
+
+	additional := []*corev1.ConfigMap{
+		{Data: map[string]string{certs.OCPCASignerCertMapKey: string(additionalCA)}},
+	}
+
+	err := ReconcileTotalClientCA(cm, newOwnerRef(), additional, signer)
+	if err != nil {
+		t.Fatalf("ReconcileTotalClientCA failed: %v", err)
+	}
+
+	bundle := cm.Data[certs.CASignerCertMapKey]
+	cns := certCNsInPEM(bundle)
+
+	wantCNs := map[string]bool{
+		"kube-csr-signer":     false,
+		"ocp-additional-ca":   false,
+		"kube-csr-signer-old": false,
+	}
+	for _, cn := range cns {
+		if _, ok := wantCNs[cn]; ok {
+			wantCNs[cn] = true
+		}
+	}
+	for cn, found := range wantCNs {
+		if !found {
+			t.Errorf("expected CA %q in bundle but it was missing; got CNs: %v", cn, cns)
+		}
+	}
+
+	if countCertsInPEM(bundle) != 3 {
+		t.Errorf("expected 3 certs in bundle, got %d: %v", countCertsInPEM(bundle), cns)
+	}
+}
+
+func TestReconcileTotalClientCA_RefusesEmptyBundle(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+
+	expiredCA := mustGenerateCA(t, "kube-csr-signer-expired", now.Add(-48*time.Hour), now.Add(-1*time.Hour))
+
+	cm := &corev1.ConfigMap{
+		Data: map[string]string{
+			certs.CASignerCertMapKey: string(expiredCA),
+		},
+	}
+
+	signer := &corev1.Secret{
+		Data: map[string][]byte{
+			certs.CASignerCertMapKey: expiredCA,
+		},
+	}
+
+	err := ReconcileTotalClientCA(cm, newOwnerRef(), nil, signer)
+	if err == nil {
+		t.Fatal("expected error when all certificates are expired, got nil")
+	}
+	if !strings.Contains(err.Error(), "refusing to write empty CA bundle") {
+		t.Errorf("expected empty bundle error, got: %v", err)
+	}
+}
+
+func TestReconcileTotalClientCA_SequentialRotation(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+
+	caA := mustGenerateCA(t, "kube-csr-signer-A", now.Add(-72*time.Hour), now.Add(8760*time.Hour))
+	caB := mustGenerateCA(t, "kube-csr-signer-B", now.Add(-48*time.Hour), now.Add(8760*time.Hour))
+	caC := mustGenerateCA(t, "kube-csr-signer-C", now.Add(-1*time.Hour), now.Add(8760*time.Hour))
+	controlPlane := mustGenerateCA(t, "kube-control-plane-signer", now.Add(-72*time.Hour), now.Add(8760*time.Hour))
+
+	// Start with CA_A as the active signer
+	cm := &corev1.ConfigMap{
+		Data: map[string]string{
+			certs.CASignerCertMapKey: string(controlPlane) + string(caA),
+		},
+	}
+
+	// Rotation 1: CA_A → CA_B
+	signerB := &corev1.Secret{
+		Data: map[string][]byte{
+			certs.CASignerCertMapKey: append(controlPlane, caB...),
+		},
+	}
+	if err := ReconcileTotalClientCA(cm, newOwnerRef(), nil, signerB); err != nil {
+		t.Fatalf("rotation A→B failed: %v", err)
+	}
+
+	bundleAfterB := cm.Data[certs.CASignerCertMapKey]
+	cnsAfterB := certCNsInPEM(bundleAfterB)
+	for _, want := range []string{"kube-csr-signer-A", "kube-csr-signer-B", "kube-control-plane-signer"} {
+		found := false
+		for _, cn := range cnsAfterB {
+			if cn == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("after A→B rotation: expected %q in bundle, got: %v", want, cnsAfterB)
+		}
+	}
+
+	// Rotation 2: CA_B → CA_C (CA_A should still be preserved from prior bundle)
+	signerC := &corev1.Secret{
+		Data: map[string][]byte{
+			certs.CASignerCertMapKey: append(controlPlane, caC...),
+		},
+	}
+	if err := ReconcileTotalClientCA(cm, newOwnerRef(), nil, signerC); err != nil {
+		t.Fatalf("rotation B→C failed: %v", err)
+	}
+
+	bundleAfterC := cm.Data[certs.CASignerCertMapKey]
+	cnsAfterC := certCNsInPEM(bundleAfterC)
+	for _, want := range []string{"kube-csr-signer-A", "kube-csr-signer-B", "kube-csr-signer-C", "kube-control-plane-signer"} {
+		found := false
+		for _, cn := range cnsAfterC {
+			if cn == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("after B→C rotation: expected %q in bundle, got: %v", want, cnsAfterC)
+		}
+	}
+
+	if countCertsInPEM(bundleAfterC) != 4 {
+		t.Errorf("expected 4 certs after sequential rotation, got %d: %v", countCertsInPEM(bundleAfterC), cnsAfterC)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a cross-platform bug where `kube-apiserver` rejects client certificates after a CA rotation (e.g. `kube-csr-signer`) because `ReconcileTotalClientCA` replaces the entire `client-ca` ConfigMap bundle with only the *new* CA, dropping the previous CA that already-issued client certs were signed against.

**Bug**: [OCPBUGS-86668](https://issues.redhat.com/browse/OCPBUGS-86668)
**Discovered during**: [OCPSTRAT-2252](https://redhat.atlassian.net/browse/OCPSTRAT-2252) (Self-managed HCP on Azure) testing
**Cross-platform impact**: The `reconcilePKI` → `setupKASClientSigners` → `ReconcileTotalClientCA` code path is entirely platform-agnostic — it runs unconditionally for every `HostedControlPlane` regardless of `spec.platform.type`. Any hosted cluster on **any provider** (AWS, Azure, GCP, KubeVirt, bare metal, IBM Cloud) that experiences a CA rotation will hit this bug.

## Changes

**`control-plane-operator/controllers/hostedcontrolplane/pki/ca.go`**:
- Modified `ReconcileTotalClientCA` to snapshot the previous `client-ca` bundle before reconciliation
- After building the new bundle from current signers + additional CMs, merge in non-expired CAs from the previous bundle
- Uses `library-go`'s `crypto.FilterExpiredCerts` to evict expired CAs (preventing unbounded bundle growth)
- Uses `crypto.EncodeCertificates` for consistent PEM encoding
- Deduplicates certificates using DER-level `reflect.DeepEqual` (matching `library-go`'s `cabundle.go` pattern)
- Sorts the final bundle by raw DER bytes for stable output across reconciliation loops
- Added `parsePEMCertificates` and `deduplicateCerts` helper functions

**`control-plane-operator/controllers/hostedcontrolplane/pki/ca_test.go`** (new):
- `TestReconcileTotalClientCA_PreservesPreviousCAsOnRotation` — verifies old CA is retained when a signer rotates
- `TestReconcileTotalClientCA_EvictsExpiredCAs` — verifies expired CAs are removed from the bundle
- `TestReconcileTotalClientCA_NoDuplicatesOnSteadyState` — verifies no duplicate growth after repeated reconciliations
- `TestReconcileTotalClientCA_EmptyPreviousBundle` — verifies correct behavior on fresh ConfigMap
- `TestReconcileTotalClientCA_WithAdditionalConfigMaps` — verifies additional CMs are included in the bundle

## Live Cluster Test Evidence

Tested on a real HostedCluster (`hcprc4clean-hc`) running OCP 4.22.0-rc.4 on Azure:

### 1. Custom CPO Image Deployed
```
Image: quay.io/rhn_support_chdeshpa/control-plane-operator:ocpbugs-86668
Pod: control-plane-operator-769dcd544b-6gktg  2/2 Running  0 restarts
```

### 2. Pre-Rotation State
```
client-ca ConfigMap: 8 certificates (6 signers + 2 additional CMs)
cluster-signer-ca serial: 6C0DE684295545BC (CN=kube-csr-signer)
```

### 3. CA Rotation Triggered
Deleted `cluster-signer-ca` secret → CPO regenerated it with new serial `0772662815699FD7`.

### 4. Post-Rotation Verification — FIX CONFIRMED
```
client-ca ConfigMap: 9 certificates
  Cert 2: CN=kube-csr-signer  serial=0772662815699FD7  (NEW — regenerated)
  Cert 3: CN=kube-csr-signer  serial=6C0DE684295545BC  (OLD — PRESERVED by fix)
```
Both old and new `kube-csr-signer` CAs coexist in the bundle. Clients holding certificates signed by the old CA remain trusted.

### 5. Steady State — No Duplicate Growth
After triggering re-reconciliation: still 9 certificates (deduplication working correctly).

### 6. Health Verification — No Breakage
```
KubeAPIServerAvailable: True
EtcdAvailable:          True
Available:              True
InfrastructureReady:    True
401 errors in KAS logs: 0
CPO pod restarts:       0
```

## Test plan

- [x] Unit tests pass (`go test ./control-plane-operator/controllers/hostedcontrolplane/pki/...`)
- [x] Live cluster test: CA rotation preserves old CA in bundle
- [x] Live cluster test: no duplicate growth on re-reconciliation
- [x] Live cluster test: no 401 errors post-rotation
- [x] Live cluster test: all HCP conditions healthy after rotation
- [ ] CI e2e tests


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved CA certificate bundle reconciliation to preserve existing non-expired certificates during rotation, remove expired entries, deduplicate duplicates, keep output stable, and avoid writing empty or invalid bundles.

* **Tests**
  * Added coverage for certificate rotation, expiration cleanup, deduplication, additional certificate sources, sequential rotations, empty bundles, and refusal behavior when no valid certificates remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->