### PR TITLE
NO-JIRA: bump claude max-turns to 50 in WIF test

### DIFF
--- a/.github/workflows/claude-wif-test.yaml
+++ b/.github/workflows/claude-wif-test.yaml
@@ -65,7 +65,7 @@ jobs:
           ANTHROPIC_VERTEX_PROJECT_ID: hosted-control-planes
         run: |
           claude --version
-          claude -p "Generate an AI SBOM for this session." --model claude-opus-4-6 --max-turns 1 | tee /tmp/claude-output.txt
+          claude -p "Generate an AI SBOM for this session." --model claude-opus-4-6 --max-turns 50 | tee /tmp/claude-output.txt
           if grep -qi "ai-assisted\|ai.sbom\|sbom" /tmp/claude-output.txt; then
             echo "Plugin verified: ai-sbom plugin executed successfully"
           else


### PR DESCRIPTION
## Summary
- Bumps `--max-turns` from 1 to 50 in the WIF test workflow
- The previous run failed with `Error: Reached max turns (1)` because Claude used its single turn on plugin initialization

## Test plan
- [ ] Merge and trigger `/test-wif` on any open PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal infrastructure updates only. No user-facing changes to document.

* **Chores**
  * Updated testing infrastructure configuration for improved validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->