### PR TITLE
NO-JIRA: clone ai-helpers into workspace for plugin file access

### DIFF
--- a/.github/workflows/claude-wif-test.yaml
+++ b/.github/workflows/claude-wif-test.yaml
@@ -53,10 +53,10 @@ jobs:
 
       - name: Set up ai-helpers plugins
         run: |
-          git clone --depth 1 https://github.com/openshift-eng/ai-helpers.git /tmp/ai-helpers
+          git clone --depth 1 https://github.com/openshift-eng/ai-helpers.git "$GITHUB_WORKSPACE/ai-helpers"
           mkdir -p "$HOME/.claude/plugins"
           printf '%s\n' '{"enabledPlugins":{"hello-world@ai-helpers":true,"ai-sbom@ai-helpers":true,"jira@ai-helpers":true,"ci@ai-helpers":true}}' > "$HOME/.claude/settings.json"
-          printf '%s\n' '{"ai-helpers":{"source":{"source":"directory","path":"/tmp/ai-helpers"},"installLocation":"/tmp/ai-helpers","lastUpdated":"2025-10-27T12:00:00.000Z"}}' > "$HOME/.claude/plugins/known_marketplaces.json"
+          printf '%s\n' "{\"ai-helpers\":{\"source\":{\"source\":\"directory\",\"path\":\"$GITHUB_WORKSPACE/ai-helpers\"},\"installLocation\":\"$GITHUB_WORKSPACE/ai-helpers\",\"lastUpdated\":\"2025-10-27T12:00:00.000Z\"}}" > "$HOME/.claude/plugins/known_marketplaces.json"
 
       - name: Test Claude Code
         env:


### PR DESCRIPTION
## Summary
- Clones ai-helpers into `$GITHUB_WORKSPACE/ai-helpers` instead of `/tmp/ai-helpers`
- This puts plugin files within the project directory so Claude Code can read them without permission restrictions

## Test plan
- [ ] Merge and trigger `/test-wif` on any open PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal infrastructure and tooling updates with no end-user visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->