### PR TITLE
CNTRLPLANE-3329: Disable GOCACHEPROG for golangci-lint

### DIFF
--- a/.github/workflows/lint-reusable.yaml
+++ b/.github/workflows/lint-reusable.yaml
@@ -30,3 +30,5 @@ jobs:
             touch hack/tools/bin/golangci-lint hack/tools/bin/kube-api-linter.so
           fi
       - run: make lint
+        env:
+          GOCACHEPROG: ""


### PR DESCRIPTION
## Summary

- Disables `GOCACHEPROG` for the `make lint` step in CI
- The shared EFS build cache causes `typecheck` failures in golangci-lint due to cache entry checksum mismatches
- Temporary fix until we work out cache compatibility with golangci-lint's type-checking pass

## Test plan

- [ ] Lint job passes on this PR
- [ ] Unit test jobs still use GOCACHEPROG (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build workflow configuration to optimize lint job execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->