### PR TITLE
NO-JIRA: feat(ci): add skopeo and gh CLI to ARC runner image

### DIFF
--- a/Dockerfile.github-actions-runner
+++ b/Dockerfile.github-actions-runner
@@ -11,6 +11,11 @@ RUN apt-get update && \
         curl \
         ca-certificates \
         python3-pip \
+        skopeo \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH


### PR DESCRIPTION
## Summary
- Add `skopeo` and `gh` CLI to the ARC runner Docker image
- These tools are needed by the CPO override validation workflow to inspect container images and query PR metadata

wanted by https://github.com/openshift/hypershift/pull/8616

## Test plan
- [ ] Runner image builds successfully
- [ ] `skopeo inspect` works inside the runner
- [ ] `gh pr view` works inside the runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the GitHub Actions runner container image to include additional system tools (container image tooling and the GitHub CLI). This enhances workflow automation, improves developer experience, and enables more robust repository and image management within CI environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->