### PR TITLE
fix: OCPBUGS-86693: add machineNetwork CIDRs to KAS NO_PROXY to prevent x509 errors

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/deployment.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/deployment.go
@@ -179,13 +179,17 @@ func updateMainContainer(podSpec *corev1.PodSpec, hcp *hyperv1.HostedControlPlan
 			fmt.Sprintf("--v=%d", kasVerbosityLevel),
 		)
 
-		// We have to exempt the pod and service CIDR, otherwise the proxy will get respected by the transport inside
-		// the the egress transport and that breaks the egress selection/konnektivity usage.
+		// We have to exempt the pod, service, and machine CIDRs, otherwise the proxy will get respected by the
+		// transport inside the egress transport and that breaks the egress selection/konnectivity usage.
+		// The machine network must be included because KAS connects to kubelets on node IPs
+		// (for oc logs/exec/attach) via konnectivity; without it the management cluster proxy
+		// intercepts these HTTPS connections causing TLS failures.
 		// Using a CIDR is not supported by Go's default ProxyFunc, but Kube uses a custom one by default that does support it:
 		// https://github.com/kubernetes/kubernetes/blob/ab13c85316015cf9f115e29923ba9740bd1564fd/staging/src/k8s.io/apimachinery/pkg/util/net/http.go#L112-L114
 		var additionalNoProxyCIDRS []string
 		additionalNoProxyCIDRS = append(additionalNoProxyCIDRS, netutil.ClusterCIDRs(hcp.Spec.Networking.ClusterNetwork)...)
 		additionalNoProxyCIDRS = append(additionalNoProxyCIDRS, netutil.ServiceCIDRs(hcp.Spec.Networking.ServiceNetwork)...)
+		additionalNoProxyCIDRS = append(additionalNoProxyCIDRS, netutil.MachineCIDRs(hcp.Spec.Networking.MachineNetwork)...)
 		proxy.SetEnvVars(&c.Env, additionalNoProxyCIDRS...)
 
 		if hcp.Annotations[hyperv1.KubeAPIServerGOGCAnnotation] != "" {

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/kas/deployment_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/kas/deployment_test.go
@@ -6,8 +6,89 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/api/util/ipnet"
+
 	corev1 "k8s.io/api/core/v1"
 )
+
+func TestUpdateMainContainerNoProxy(t *testing.T) {
+	testCases := []struct {
+		name           string
+		clusterNetwork []hyperv1.ClusterNetworkEntry
+		serviceNetwork []hyperv1.ServiceNetworkEntry
+		machineNetwork []hyperv1.MachineNetworkEntry
+		expectedCIDRs  []string
+	}{
+		{
+			name:           "When proxy is configured with machineNetwork it should include cluster service machine and kube-apiserver in NO_PROXY",
+			clusterNetwork: []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("10.128.0.0/14")}},
+			serviceNetwork: []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.30.0.0/16")}},
+			machineNetwork: []hyperv1.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")}},
+			expectedCIDRs:  []string{"10.128.0.0/14", "172.30.0.0/16", "192.168.1.0/24", "kube-apiserver"},
+		},
+		{
+			name:           "When proxy is configured without machineNetwork it should include cluster and service in NO_PROXY",
+			clusterNetwork: []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("10.128.0.0/14")}},
+			serviceNetwork: []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.30.0.0/16")}},
+			expectedCIDRs:  []string{"10.128.0.0/14", "172.30.0.0/16", "kube-apiserver"},
+		},
+		{
+			name:           "When proxy is configured with dual-stack machineNetwork it should include both IPv4 and IPv6 CIDRs in NO_PROXY",
+			clusterNetwork: []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("10.128.0.0/14")}},
+			serviceNetwork: []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("172.30.0.0/16")}},
+			machineNetwork: []hyperv1.MachineNetworkEntry{
+				{CIDR: *ipnet.MustParseCIDR("192.168.1.0/24")},
+				{CIDR: *ipnet.MustParseCIDR("fd00::/48")},
+			},
+			expectedCIDRs: []string{"10.128.0.0/14", "172.30.0.0/16", "192.168.1.0/24", "fd00::/48", "kube-apiserver"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HTTP_PROXY", "http://proxy.example.com:3128")
+			t.Setenv("HTTPS_PROXY", "http://proxy.example.com:3128")
+			t.Setenv("NO_PROXY", "")
+
+			hcp := &hyperv1.HostedControlPlane{
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Networking: hyperv1.ClusterNetworking{
+						ClusterNetwork: tc.clusterNetwork,
+						ServiceNetwork: tc.serviceNetwork,
+						MachineNetwork: tc.machineNetwork,
+					},
+				},
+			}
+
+			podSpec := &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: ComponentName,
+						Ports: []corev1.ContainerPort{
+							{ContainerPort: 6443},
+						},
+					},
+				},
+			}
+
+			updateMainContainer(podSpec, hcp)
+
+			g := NewWithT(t)
+			var noProxyValue string
+			for _, env := range podSpec.Containers[0].Env {
+				if env.Name == "NO_PROXY" {
+					noProxyValue = env.Value
+					break
+				}
+			}
+			g.Expect(noProxyValue).ToNot(BeEmpty(), "NO_PROXY env var should be set when proxy is configured")
+			for _, cidr := range tc.expectedCIDRs {
+				g.Expect(noProxyValue).To(ContainSubstring(cidr), "NO_PROXY should contain %s", cidr)
+			}
+		})
+	}
+}
 
 func TestAddImagePrePullInitContainers(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
## Summary

When the management cluster uses an HTTP proxy, the KAS container in the hosted control plane inherits the management cluster's proxy environment via `proxy.SetEnvVars()` in the control-plane-operator. The `NO_PROXY` list for KAS already includes the guest cluster's `clusterNetwork` (pod) and `serviceNetwork` CIDRs, but **omits** the `machineNetwork` CIDRs.

KAS connects to kubelets on node IPs (which fall in the `machineNetwork` range) via the konnectivity tunnel for subresource operations (`oc logs`, `oc exec`, `oc attach`). Without the `machineNetwork` CIDRs in `NO_PROXY`, these HTTPS connections are routed through the management cluster's HTTP proxy. The proxy performs TLS interception, presenting its own certificate which KAS does not trust, resulting in:

```
x509: certificate signed by unknown authority
```

### Root Cause

In `control-plane-operator/controllers/hostedcontrolplane/v2/kas/deployment.go`, the `additionalNoProxyCIDRS` slice only includes `clusterNetwork` and `serviceNetwork`, but not `machineNetwork`:

```go
var additionalNoProxyCIDRS []string
additionalNoProxyCIDRS = append(additionalNoProxyCIDRS, netutil.ClusterCIDRs(hcp.Spec.Networking.ClusterNetwork)...)
additionalNoProxyCIDRS = append(additionalNoProxyCIDRS, netutil.ServiceCIDRs(hcp.Spec.Networking.ServiceNetwork)...)
// machineNetwork was missing here
proxy.SetEnvVars(&c.Env, additionalNoProxyCIDRS...)
```

### Fix

Add `machineNetwork` CIDRs to the KAS `NO_PROXY` list:

```go
additionalNoProxyCIDRS = append(additionalNoProxyCIDRS, netutil.MachineCIDRs(hcp.Spec.Networking.MachineNetwork)...)
```

### How to Reproduce

1. Deploy a management cluster **behind an HTTP proxy**
2. Create a HostedCluster where `machineNetwork` is NOT included in the management cluster's `NO_PROXY`
3. Run `oc logs <any-pod>` from the hosted cluster
4. Observe: `x509: certificate signed by unknown authority` error

### Customer Validation

A customer confirmed this fix resolves the issue — after manually adding the guest cluster's `machineNetwork` (along with `clusterNetwork` and `serviceNetwork`) to the management cluster's `NO_PROXY`, the `oc logs` x509 error was immediately resolved. This PR automates that by ensuring the control-plane-operator always includes `machineNetwork` in KAS's `NO_PROXY`.

## Test Plan

- [x] Existing unit tests pass (`go test ./control-plane-operator/controllers/hostedcontrolplane/v2/kas/...`)
- [ ] Verify on a proxied management cluster that `oc logs`, `oc exec`, `oc attach` work without manually adding `machineNetwork` to management cluster `NO_PROXY`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Proxy exemption handling updated so machine network CIDRs are excluded from proxy interception alongside pod and service networks, preventing TLS handshake failures caused by proxy interception and improving control-plane connectivity reliability.
* **Tests**
  * Added tests validating NO_PROXY is populated correctly, including cases with and without machine network CIDRs and dual-stack networks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->