### PR TITLE
OCPBUGS-86912: [release-4.22] Stop controllers fighting over HCP status

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -1926,10 +1926,11 @@ func (r *HostedControlPlaneReconciler) reconcileValidIDPConfigurationCondition(c
 			Message: fmt.Sprintf("failed to initialize identity providers: %v", err),
 		}
 	}
-	// Update the condition on the HCP if it has changed
+	// Patch the condition on the HCP if it has changed
+	originalHCP := hcp.DeepCopy()
 	if meta.SetStatusCondition(&hcp.Status.Conditions, new) {
-		if err := r.Status().Update(ctx, hcp); err != nil {
-			return fmt.Errorf("failed to update valid IDP configuration condition: %w", err)
+		if err := r.Status().Patch(ctx, hcp, client.MergeFromWithOptions(originalHCP, client.MergeFromWithOptimisticLock{})); err != nil {
+			return fmt.Errorf("failed to patch valid IDP configuration condition: %w", err)
 		}
 	}
 	return nil
@@ -2462,6 +2463,7 @@ func (r *HostedControlPlaneReconciler) removeCloudResources(ctx context.Context,
 		return false, nil
 	}
 	if cvoScaledDownCond == nil || cvoScaledDownCond.Status != metav1.ConditionTrue {
+		originalHCP := hcp.DeepCopy()
 		cvoScaledDownCond = &metav1.Condition{
 			Type:               string(hyperv1.CVOScaledDown),
 			Status:             metav1.ConditionTrue,
@@ -2469,8 +2471,8 @@ func (r *HostedControlPlaneReconciler) removeCloudResources(ctx context.Context,
 			LastTransitionTime: metav1.Now(),
 		}
 		meta.SetStatusCondition(&hcp.Status.Conditions, *cvoScaledDownCond)
-		if err := r.Status().Update(ctx, hcp); err != nil {
-			return false, fmt.Errorf("failed to set CVO scaled down condition: %w", err)
+		if err := r.Status().Patch(ctx, hcp, client.MergeFromWithOptions(originalHCP, client.MergeFromWithOptimisticLock{})); err != nil {
+			return false, fmt.Errorf("failed to patch CVO scaled down condition: %w", err)
 		}
 	}
 	return false, nil

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/hcpstatus/hcpstatus.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/hcpstatus/hcpstatus.go
@@ -1,9 +1,10 @@
 package hcpstatus
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
-	"reflect"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"github.com/openshift/hypershift/control-plane-operator/hostedclusterconfigoperator/operator"
@@ -11,6 +12,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -74,15 +76,74 @@ func (h *hcpStatusReconciler) Reconcile(ctx context.Context, req reconcile.Reque
 		return reconcile.Result{}, err
 	}
 
-	if !reflect.DeepEqual(hcp.Status, originalHCP.Status) {
-		log.Info("Updating HCP status with new configuration and version status")
-		if err := h.mgtClusterClient.Status().Update(ctx, hcp); err != nil {
-			return reconcile.Result{}, fmt.Errorf("failed to update hcp: %w", err)
-		}
-		log.Info("Successfully updated HCP status")
+	if equality.Semantic.DeepEqual(hcp.Status, originalHCP.Status) {
+		return reconcile.Result{}, nil
 	}
 
+	// Use JSON Patch (RFC 6902) instead of JSON Merge Patch (RFC 7386).
+	// Merge patch interprets null as "delete field" (RFC 7386 §7), which corrupts
+	// +required +nullable fields in configv1.ClusterVersionStatus that have no
+	// omitempty and serialize nil as JSON null:
+	//   - AvailableUpdates []configv1.Release `json:"availableUpdates"` — nil slice → null
+	//   - CompletionTime *metav1.Time `json:"completionTime"` (in UpdateHistory) — nil pointer → null
+	// JSON Patch "replace"/"add" ops carry null as a literal value, preserving it correctly.
+	patch, err := buildStatusPatch(originalHCP, hcp)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to build status patch: %w", err)
+	}
+
+	log.Info("Patching HCP status with new configuration and version status")
+	if err := h.mgtClusterClient.Status().Patch(ctx, hcp,
+		crclient.RawPatch(types.JSONPatchType, patch)); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to patch hcp status: %w", err)
+	}
+	log.Info("Successfully patched HCP status")
+
 	return reconcile.Result{}, nil
+}
+
+type jsonPatchOp struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value,omitempty"`
+}
+
+func buildStatusPatch(original, modified *hyperv1.HostedControlPlane) ([]byte, error) {
+	origJSON, err := json.Marshal(original.Status)
+	if err != nil {
+		return nil, err
+	}
+	modJSON, err := json.Marshal(modified.Status)
+	if err != nil {
+		return nil, err
+	}
+
+	var origMap, modMap map[string]json.RawMessage
+	if err := json.Unmarshal(origJSON, &origMap); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(modJSON, &modMap); err != nil {
+		return nil, err
+	}
+
+	// Optimistic lock: fail if the object was modified since our read.
+	ops := []jsonPatchOp{{Op: "test", Path: "/metadata/resourceVersion", Value: original.ResourceVersion}}
+
+	for key, modVal := range modMap {
+		origVal, exists := origMap[key]
+		if !exists {
+			ops = append(ops, jsonPatchOp{Op: "add", Path: "/status/" + key, Value: modVal})
+		} else if !bytes.Equal(origVal, modVal) {
+			ops = append(ops, jsonPatchOp{Op: "replace", Path: "/status/" + key, Value: modVal})
+		}
+	}
+	for key := range origMap {
+		if _, exists := modMap[key]; !exists {
+			ops = append(ops, jsonPatchOp{Op: "remove", Path: "/status/" + key})
+		}
+	}
+
+	return json.Marshal(ops)
 }
 
 // findClusterOperatorStatusCondition is identical to meta.FindStatusCondition except that it works on config1.ClusterOperatorStatusCondition instead of

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/hcpstatus/hcpstatus_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/hcpstatus/hcpstatus_test.go
@@ -1,0 +1,541 @@
+package hcpstatus
+
+import (
+	"encoding/json"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/support/api"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestHCPStatusReconciler(t *testing.T) {
+	t.Parallel()
+
+	hcp := &hyperv1.HostedControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-hcp",
+			Namespace: "test-ns",
+		},
+	}
+
+	expectedOAuthConfigMapName := "oauth-metadata-configmap"
+
+	tests := []struct {
+		name                 string
+		hostedClusterObjects []crclient.Object
+		expectError          bool
+		expectedOAuthName    string
+		validateConditions   func(g Gomega, hcp *hyperv1.HostedControlPlane)
+	}{
+		{
+			name: "When Authentication resource exists it should propagate status to HCP",
+			hostedClusterObjects: []crclient.Object{
+				&configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version"}},
+				&configv1.Authentication{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: configv1.AuthenticationStatus{
+						IntegratedOAuthMetadata: configv1.ConfigMapNameReference{
+							Name: expectedOAuthConfigMapName,
+						},
+					},
+				},
+			},
+			expectedOAuthName: expectedOAuthConfigMapName,
+		},
+		{
+			name: "When Authentication resource is missing it should return an error",
+			hostedClusterObjects: []crclient.Object{
+				&configv1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version"}},
+			},
+			expectError: true,
+		},
+		{
+			name: "When ClusterVersion has conditions it should propagate them to HCP",
+			hostedClusterObjects: []crclient.Object{
+				&configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{Name: "version"},
+					Status: configv1.ClusterVersionStatus{
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{
+								Type:    configv1.OperatorAvailable,
+								Status:  configv1.ConditionTrue,
+								Reason:  "AsExpected",
+								Message: "cluster is available",
+							},
+							{
+								Type:    configv1.OperatorProgressing,
+								Status:  configv1.ConditionFalse,
+								Reason:  "AsExpected",
+								Message: "cluster is not progressing",
+							},
+						},
+					},
+				},
+				&configv1.Authentication{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: configv1.AuthenticationStatus{
+						IntegratedOAuthMetadata: configv1.ConfigMapNameReference{Name: expectedOAuthConfigMapName},
+					},
+				},
+			},
+			expectedOAuthName: expectedOAuthConfigMapName,
+			validateConditions: func(g Gomega, hcp *hyperv1.HostedControlPlane) {
+				availableCond := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ClusterVersionAvailable))
+				g.Expect(availableCond).NotTo(BeNil())
+				g.Expect(availableCond.Status).To(Equal(metav1.ConditionTrue))
+				g.Expect(availableCond.Reason).To(Equal("AsExpected"))
+
+				progressingCond := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ClusterVersionProgressing))
+				g.Expect(progressingCond).NotTo(BeNil())
+				g.Expect(progressingCond.Status).To(Equal(metav1.ConditionFalse))
+			},
+		},
+		{
+			name: "When ClusterVersion has no Upgradeable condition it should default to True",
+			hostedClusterObjects: []crclient.Object{
+				&configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{Name: "version"},
+					Status: configv1.ClusterVersionStatus{
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{
+								Type:   configv1.OperatorAvailable,
+								Status: configv1.ConditionTrue,
+								Reason: "AsExpected",
+							},
+						},
+					},
+				},
+				&configv1.Authentication{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: configv1.AuthenticationStatus{
+						IntegratedOAuthMetadata: configv1.ConfigMapNameReference{Name: expectedOAuthConfigMapName},
+					},
+				},
+			},
+			expectedOAuthName: expectedOAuthConfigMapName,
+			validateConditions: func(g Gomega, hcp *hyperv1.HostedControlPlane) {
+				upgradeableCond := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ClusterVersionUpgradeable))
+				g.Expect(upgradeableCond).NotTo(BeNil())
+				g.Expect(upgradeableCond.Status).To(Equal(metav1.ConditionTrue))
+				g.Expect(upgradeableCond.Reason).To(Equal(hyperv1.FromClusterVersionReason))
+			},
+		},
+		{
+			name: "When CVO condition has empty Reason it should use FromClusterVersionReason",
+			hostedClusterObjects: []crclient.Object{
+				&configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{Name: "version"},
+					Status: configv1.ClusterVersionStatus{
+						Conditions: []configv1.ClusterOperatorStatusCondition{
+							{
+								Type:    configv1.OperatorAvailable,
+								Status:  configv1.ConditionTrue,
+								Reason:  "",
+								Message: "all good",
+							},
+						},
+					},
+				},
+				&configv1.Authentication{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Status: configv1.AuthenticationStatus{
+						IntegratedOAuthMetadata: configv1.ConfigMapNameReference{Name: expectedOAuthConfigMapName},
+					},
+				},
+			},
+			expectedOAuthName: expectedOAuthConfigMapName,
+			validateConditions: func(g Gomega, hcp *hyperv1.HostedControlPlane) {
+				availableCond := meta.FindStatusCondition(hcp.Status.Conditions, string(hyperv1.ClusterVersionAvailable))
+				g.Expect(availableCond).NotTo(BeNil())
+				g.Expect(availableCond.Reason).To(Equal(hyperv1.FromClusterVersionReason))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			mgmtClient := fake.NewClientBuilder().
+				WithScheme(api.Scheme).
+				WithObjects(hcp.DeepCopy()).
+				WithStatusSubresource(&hyperv1.HostedControlPlane{}).
+				Build()
+
+			hostedClusterClient := fake.NewClientBuilder().
+				WithScheme(api.Scheme).
+				WithObjects(tt.hostedClusterObjects...).
+				Build()
+
+			reconciler := &hcpStatusReconciler{
+				mgtClusterClient:    mgmtClient,
+				hostedClusterClient: hostedClusterClient,
+			}
+
+			_, err := reconciler.Reconcile(t.Context(), reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      hcp.Name,
+					Namespace: hcp.Namespace,
+				},
+			})
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("Authentication"),
+					"error should be about missing Authentication resource, got: %v", err)
+				return
+			}
+
+			g.Expect(err).NotTo(HaveOccurred())
+			updatedHCP := &hyperv1.HostedControlPlane{}
+			g.Expect(mgmtClient.Get(t.Context(), crclient.ObjectKeyFromObject(hcp), updatedHCP)).To(Succeed())
+			g.Expect(updatedHCP.Status.Configuration).NotTo(BeNil())
+			g.Expect(updatedHCP.Status.Configuration.Authentication.IntegratedOAuthMetadata.Name).To(Equal(tt.expectedOAuthName))
+
+			if tt.validateConditions != nil {
+				tt.validateConditions(g, updatedHCP)
+			}
+		})
+	}
+}
+
+func TestBuildStatusPatch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("When versionStatus changes, it should produce a replace op with optimistic lock", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		hcp := &hyperv1.HostedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "test",
+				Namespace:       "test-ns",
+				ResourceVersion: "100",
+			},
+			Status: hyperv1.HostedControlPlaneStatus{
+				VersionStatus: &hyperv1.ClusterVersionStatus{
+					Desired: configv1.Release{Version: "4.16.0", Image: "quay.io/old:latest"},
+				},
+			},
+		}
+		original := hcp.DeepCopy()
+
+		hcp.Status.VersionStatus = &hyperv1.ClusterVersionStatus{
+			Desired: configv1.Release{Version: "4.17.0", Image: "quay.io/new:latest"},
+		}
+
+		patchBytes, err := buildStatusPatch(original, hcp)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var ops []jsonPatchOp
+		g.Expect(json.Unmarshal(patchBytes, &ops)).To(Succeed())
+
+		g.Expect(ops).To(HaveLen(2))
+
+		g.Expect(ops[0].Op).To(Equal("test"))
+		g.Expect(ops[0].Path).To(Equal("/metadata/resourceVersion"))
+		g.Expect(ops[0].Value).To(Equal("100"))
+
+		g.Expect(ops[1].Op).To(Equal("replace"))
+		g.Expect(ops[1].Path).To(Equal("/status/versionStatus"))
+	})
+
+	t.Run("When versionStatus is added for the first time, it should produce an add op", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		hcp := &hyperv1.HostedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "test",
+				Namespace:       "test-ns",
+				ResourceVersion: "100",
+			},
+		}
+		original := hcp.DeepCopy()
+
+		hcp.Status.VersionStatus = &hyperv1.ClusterVersionStatus{
+			Desired: configv1.Release{Version: "4.17.0", Image: "quay.io/test:latest"},
+		}
+
+		patchBytes, err := buildStatusPatch(original, hcp)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var ops []jsonPatchOp
+		g.Expect(json.Unmarshal(patchBytes, &ops)).To(Succeed())
+
+		g.Expect(ops).To(HaveLen(2))
+		g.Expect(ops[1].Op).To(Equal("add"))
+		g.Expect(ops[1].Path).To(Equal("/status/versionStatus"))
+	})
+
+	t.Run("When nothing changes, it should produce only the test op", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		hcp := &hyperv1.HostedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "test",
+				Namespace:       "test-ns",
+				ResourceVersion: "100",
+			},
+			Status: hyperv1.HostedControlPlaneStatus{
+				Conditions: []metav1.Condition{
+					{Type: "ConditionA", Status: metav1.ConditionTrue, Reason: "OK"},
+				},
+			},
+		}
+		original := hcp.DeepCopy()
+
+		patchBytes, err := buildStatusPatch(original, hcp)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var ops []jsonPatchOp
+		g.Expect(json.Unmarshal(patchBytes, &ops)).To(Succeed())
+
+		g.Expect(ops).To(HaveLen(1))
+		g.Expect(ops[0].Op).To(Equal("test"))
+		g.Expect(ops[0].Path).To(Equal("/metadata/resourceVersion"))
+	})
+
+	t.Run("When conditions change, it should replace the entire conditions array", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		hcp := &hyperv1.HostedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "test",
+				Namespace:       "test-ns",
+				ResourceVersion: "100",
+			},
+			Status: hyperv1.HostedControlPlaneStatus{
+				Conditions: []metav1.Condition{
+					{Type: "ConditionA", Status: metav1.ConditionTrue, Reason: "OK"},
+					{Type: "ConditionB", Status: metav1.ConditionTrue, Reason: "OK"},
+				},
+			},
+		}
+		original := hcp.DeepCopy()
+
+		meta.SetStatusCondition(&hcp.Status.Conditions, metav1.Condition{
+			Type:   "ConditionA",
+			Status: metav1.ConditionFalse,
+			Reason: "NowBad",
+		})
+
+		patchBytes, err := buildStatusPatch(original, hcp)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var ops []jsonPatchOp
+		g.Expect(json.Unmarshal(patchBytes, &ops)).To(Succeed())
+
+		g.Expect(ops).To(HaveLen(2))
+		g.Expect(ops[1].Op).To(Equal("replace"))
+		g.Expect(ops[1].Path).To(Equal("/status/conditions"))
+
+		conditionsJSON, err := json.Marshal(ops[1].Value)
+		g.Expect(err).ToNot(HaveOccurred())
+		var conditions []metav1.Condition
+		g.Expect(json.Unmarshal(conditionsJSON, &conditions)).To(Succeed())
+		g.Expect(conditions).To(HaveLen(2), "all conditions from the read should be in the patch")
+	})
+
+	t.Run("When versionStatus has nil availableUpdates and nil completionTime, the patch should preserve null values", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		hcp := &hyperv1.HostedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "test",
+				Namespace:       "test-ns",
+				ResourceVersion: "100",
+			},
+		}
+		original := hcp.DeepCopy()
+
+		startedTime := metav1.Now()
+		hcp.Status.VersionStatus = &hyperv1.ClusterVersionStatus{
+			Desired: configv1.Release{Version: "4.17.0", Image: "quay.io/test:latest"},
+			History: []configv1.UpdateHistory{
+				{
+					State:       configv1.PartialUpdate,
+					StartedTime: startedTime,
+					// CompletionTime is nil — update in progress
+					Version: "4.17.0",
+					Image:   "quay.io/test:latest",
+				},
+			},
+			// AvailableUpdates is nil — CVO hasn't checked yet
+		}
+
+		patchBytes, err := buildStatusPatch(original, hcp)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Parse the raw JSON to verify null handling.
+		// JSON Patch (RFC 6902) uses "value": null to mean "set to null",
+		// unlike JSON Merge Patch (RFC 7386) where null means "delete".
+		var rawOps []json.RawMessage
+		g.Expect(json.Unmarshal(patchBytes, &rawOps)).To(Succeed())
+		g.Expect(rawOps).To(HaveLen(2))
+
+		// Parse the versionStatus op's value to check null fields
+		var op struct {
+			Op    string          `json:"op"`
+			Path  string          `json:"path"`
+			Value json.RawMessage `json:"value"`
+		}
+		g.Expect(json.Unmarshal(rawOps[1], &op)).To(Succeed())
+		g.Expect(op.Op).To(Equal("add"))
+		g.Expect(op.Path).To(Equal("/status/versionStatus"))
+
+		var vs map[string]interface{}
+		g.Expect(json.Unmarshal(op.Value, &vs)).To(Succeed())
+
+		// availableUpdates should be null (nil slice serializes as null with no omitempty)
+		au, ok := vs["availableUpdates"]
+		g.Expect(ok).To(BeTrue(), "availableUpdates key must be present in the patch")
+		g.Expect(au).To(BeNil(), "availableUpdates should be null — JSON Patch preserves this correctly")
+
+		// completionTime in history should be null (nil *metav1.Time)
+		history := vs["history"].([]interface{})
+		entry := history[0].(map[string]interface{})
+		ct, ok := entry["completionTime"]
+		g.Expect(ok).To(BeTrue(), "completionTime key must be present in the patch")
+		g.Expect(ct).To(BeNil(), "completionTime should be null — JSON Patch preserves this correctly")
+	})
+
+	t.Run("When configuration changes, it should produce a replace op", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		hcp := &hyperv1.HostedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "test",
+				Namespace:       "test-ns",
+				ResourceVersion: "100",
+			},
+			Status: hyperv1.HostedControlPlaneStatus{
+				Configuration: &hyperv1.ConfigurationStatus{},
+			},
+		}
+		original := hcp.DeepCopy()
+
+		hcp.Status.Configuration = &hyperv1.ConfigurationStatus{
+			Authentication: configv1.AuthenticationStatus{
+				IntegratedOAuthMetadata: configv1.ConfigMapNameReference{Name: "oauth-metadata"},
+			},
+		}
+
+		patchBytes, err := buildStatusPatch(original, hcp)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var ops []jsonPatchOp
+		g.Expect(json.Unmarshal(patchBytes, &ops)).To(Succeed())
+
+		g.Expect(ops).To(HaveLen(2))
+		g.Expect(ops[1].Op).To(Equal("replace"))
+		g.Expect(ops[1].Path).To(Equal("/status/configuration"))
+	})
+
+	t.Run("When versionStatus is removed, it should produce a remove op", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		hcp := &hyperv1.HostedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "test",
+				Namespace:       "test-ns",
+				ResourceVersion: "100",
+			},
+			Status: hyperv1.HostedControlPlaneStatus{
+				VersionStatus: &hyperv1.ClusterVersionStatus{
+					Desired: configv1.Release{Version: "4.17.0", Image: "quay.io/test:latest"},
+				},
+			},
+		}
+		original := hcp.DeepCopy()
+
+		hcp.Status.VersionStatus = nil
+
+		patchBytes, err := buildStatusPatch(original, hcp)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var ops []jsonPatchOp
+		g.Expect(json.Unmarshal(patchBytes, &ops)).To(Succeed())
+
+		g.Expect(ops).To(HaveLen(2))
+		g.Expect(ops[0].Op).To(Equal("test"))
+		g.Expect(ops[1].Op).To(Equal("remove"))
+		g.Expect(ops[1].Path).To(Equal("/status/versionStatus"))
+	})
+
+	t.Run("When multiple fields change, it should produce ops for each changed field", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		hcp := &hyperv1.HostedControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "test",
+				Namespace:       "test-ns",
+				ResourceVersion: "100",
+			},
+			Status: hyperv1.HostedControlPlaneStatus{
+				VersionStatus: &hyperv1.ClusterVersionStatus{
+					Desired: configv1.Release{Version: "4.16.0"},
+				},
+				Conditions: []metav1.Condition{
+					{Type: "ConditionA", Status: metav1.ConditionTrue, Reason: "OK"},
+				},
+				Configuration: &hyperv1.ConfigurationStatus{},
+				Version:       "4.16.0",
+				ReleaseImage:  "quay.io/old:latest",
+			},
+		}
+		original := hcp.DeepCopy()
+
+		hcp.Status.VersionStatus.Desired.Version = "4.17.0"
+		meta.SetStatusCondition(&hcp.Status.Conditions, metav1.Condition{
+			Type: "ConditionA", Status: metav1.ConditionFalse, Reason: "Bad",
+		})
+		hcp.Status.Configuration = &hyperv1.ConfigurationStatus{
+			Authentication: configv1.AuthenticationStatus{
+				IntegratedOAuthMetadata: configv1.ConfigMapNameReference{Name: "new"},
+			},
+		}
+		hcp.Status.Version = "4.17.0"
+		hcp.Status.ReleaseImage = "quay.io/new:latest"
+
+		patchBytes, err := buildStatusPatch(original, hcp)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var ops []jsonPatchOp
+		g.Expect(json.Unmarshal(patchBytes, &ops)).To(Succeed())
+
+		// test + versionStatus + conditions + configuration + version + releaseImage
+		g.Expect(ops).To(HaveLen(6))
+
+		paths := make([]string, len(ops))
+		for i, op := range ops {
+			paths[i] = op.Path
+		}
+		g.Expect(paths).To(ContainElements(
+			"/metadata/resourceVersion",
+			"/status/versionStatus",
+			"/status/conditions",
+			"/status/configuration",
+			"/status/version",
+			"/status/releaseImage",
+		))
+	})
+}

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/resources.go
@@ -1651,7 +1651,7 @@ func (r *reconciler) patchHCPStatusCondition(ctx context.Context, hcp *hyperv1.H
 	if !meta.SetStatusCondition(&hcp.Status.Conditions, *condition) {
 		return nil // No status change; avoid unnecessary API call.
 	}
-	if err := r.cpClient.Status().Patch(ctx, hcp, client.MergeFrom(originalHCP)); err != nil {
+	if err := r.cpClient.Status().Patch(ctx, hcp, client.MergeFromWithOptions(originalHCP, client.MergeFromWithOptimisticLock{})); err != nil {
 		return fmt.Errorf("failed to update HostedControlPlane status with %s condition: %w", condition.Type, err)
 	}
 	log.Info(string(condition.Type) + " condition updated")
@@ -2686,8 +2686,8 @@ func (r *reconciler) destroyCloudResources(ctx context.Context, hcp *hyperv1.Hos
 	meta.SetStatusCondition(&hcp.Status.Conditions, *resourcesDestroyedCond)
 
 	if !equality.Semantic.DeepEqual(hcp, originalHCP) {
-		if err := r.cpClient.Status().Update(ctx, hcp); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to set resources destroyed condition: %w", err)
+		if err := r.cpClient.Status().Patch(ctx, hcp, client.MergeFromWithOptions(originalHCP, client.MergeFromWithOptimisticLock{})); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to patch resources destroyed condition: %w", err)
 		}
 	}
 

--- a/hypershift-operator/controllers/etcdbackup/reconciler.go
+++ b/hypershift-operator/controllers/etcdbackup/reconciler.go
@@ -313,9 +313,10 @@ func (r *HCPEtcdBackupReconciler) setCondition(backup *hyperv1.HCPEtcdBackup, co
 // updateHCPBackupCondition sets a condition on the HostedControlPlane to bubble
 // up the etcd backup status. The HC controller propagates this to the HostedCluster.
 func (r *HCPEtcdBackupReconciler) updateHCPBackupCondition(ctx context.Context, hcp *hyperv1.HostedControlPlane, condition metav1.Condition) error {
+	originalHCP := hcp.DeepCopy()
 	condition.ObservedGeneration = hcp.Generation
 	meta.SetStatusCondition(&hcp.Status.Conditions, condition)
-	return r.Status().Update(ctx, hcp)
+	return r.Status().Patch(ctx, hcp, client.MergeFromWithOptions(originalHCP, client.MergeFromWithOptimisticLock{}))
 }
 
 // updateHostedClusterBackupURL persists the snapshot URL in the HostedCluster

--- a/hypershift-operator/controllers/etcdbackup/reconciler_test.go
+++ b/hypershift-operator/controllers/etcdbackup/reconciler_test.go
@@ -1498,3 +1498,78 @@ func TestUpdateHostedClusterBackupURL(t *testing.T) {
 		g.Expect(updatedHC.Status.LastSuccessfulEtcdBackupURL).To(Equal("s3://bucket/snapshot.db"))
 	})
 }
+
+func TestUpdateHCPBackupCondition(t *testing.T) {
+	t.Parallel()
+
+	t.Run("When patching a backup condition, it should not stomp unrelated status fields", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		hcp := newHostedControlPlane()
+		hcp.Generation = 3
+		hcp.Status.AutoNode = hyperv1.AutoNodeStatus{
+			NodeCount: ptr.To[int32](3),
+		}
+
+		r := newReconciler(hcp)
+
+		err := r.updateHCPBackupCondition(t.Context(), hcp, metav1.Condition{
+			Type:    string(hyperv1.EtcdBackupSucceeded),
+			Status:  metav1.ConditionTrue,
+			Reason:  "BackupComplete",
+			Message: "backup finished",
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var updated hyperv1.HostedControlPlane
+		g.Expect(r.Get(t.Context(), types.NamespacedName{
+			Name:      testHCPName,
+			Namespace: testHCPNamespace,
+		}, &updated)).To(Succeed())
+
+		cond := meta.FindStatusCondition(updated.Status.Conditions, string(hyperv1.EtcdBackupSucceeded))
+		g.Expect(cond).ToNot(BeNil())
+		g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+		g.Expect(cond.Reason).To(Equal("BackupComplete"))
+		g.Expect(cond.ObservedGeneration).To(Equal(int64(3)))
+
+		g.Expect(updated.Status.AutoNode.NodeCount).To(Equal(ptr.To[int32](3)),
+			"autoNode should be preserved — patch must not stomp unrelated fields")
+	})
+
+	t.Run("When patching a backup condition onto an HCP with existing conditions, it should preserve them", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		hcp := newHostedControlPlane()
+		hcp.Status.Conditions = []metav1.Condition{
+			{
+				Type:   string(hyperv1.ClusterVersionAvailable),
+				Status: metav1.ConditionTrue,
+				Reason: "OK",
+			},
+		}
+
+		r := newReconciler(hcp)
+
+		err := r.updateHCPBackupCondition(t.Context(), hcp, metav1.Condition{
+			Type:    string(hyperv1.EtcdBackupSucceeded),
+			Status:  metav1.ConditionTrue,
+			Reason:  "BackupComplete",
+			Message: "backup finished",
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var updated hyperv1.HostedControlPlane
+		g.Expect(r.Get(t.Context(), types.NamespacedName{
+			Name:      testHCPName,
+			Namespace: testHCPNamespace,
+		}, &updated)).To(Succeed())
+
+		g.Expect(updated.Status.Conditions).To(HaveLen(2),
+			"both the existing condition and the new backup condition should be present")
+		g.Expect(meta.FindStatusCondition(updated.Status.Conditions, string(hyperv1.ClusterVersionAvailable))).ToNot(BeNil())
+		g.Expect(meta.FindStatusCondition(updated.Status.Conditions, string(hyperv1.EtcdBackupSucceeded))).ToNot(BeNil())
+	})
+}

--- a/ignition-server/controllers/local_ignitionprovider.go
+++ b/ignition-server/controllers/local_ignitionprovider.go
@@ -714,6 +714,7 @@ func (r *LocalIgnitionProvider) reconcileValidReleaseInfoCondition(ctx context.C
 	}
 
 	hostedControlPlane := hcpList.Items[0]
+	originalHCP := hostedControlPlane.DeepCopy()
 
 	if len(releaseImageProvider.GetMissingImages()) == 0 {
 		meta.SetStatusCondition(&hostedControlPlane.Status.Conditions, metav1.Condition{
@@ -733,7 +734,7 @@ func (r *LocalIgnitionProvider) reconcileValidReleaseInfoCondition(ctx context.C
 		})
 	}
 
-	return r.Client.Status().Update(ctx, &hostedControlPlane)
+	return r.Client.Status().Patch(ctx, &hostedControlPlane, client.MergeFromWithOptions(originalHCP, client.MergeFromWithOptimisticLock{}))
 }
 
 // copyFile copies a file named src to dst, preserving attributes.


### PR DESCRIPTION
## What this PR does / why we need it:

Draft 4.22 backport of of https://github.com/openshift/hypershift/pull/8562 since it's not a clean cherry-pick (`reconcileClusterRecovery` doesn't exist in 4.22) 

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.