### PR TITLE
CNTRLPLANE-3329: Rebuild runner image on gocacheprog and pipeline changes

### DIFF
--- a/.tekton/hypershift-gh-actions-runner-pull-request.yaml
+++ b/.tekton/hypershift-gh-actions-runner-pull-request.yaml
@@ -9,7 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && "Dockerfile.github-actions-runner".pathChanged()
+      == "main" && ("Dockerfile.github-actions-runner".pathChanged() || "contrib/ci/gocacheprog".pathChanged()
+      || ".tekton/hypershift-gh-actions-runner-pull-request.yaml".pathChanged())
     pipelinesascode.tekton.dev/pipeline: ".tekton/pipelines/common-operator-build.yaml"
   creationTimestamp: null
   labels:

--- a/.tekton/hypershift-gh-actions-runner-push.yaml
+++ b/.tekton/hypershift-gh-actions-runner-push.yaml
@@ -8,7 +8,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && "Dockerfile.github-actions-runner".pathChanged()
+      == "main" && ("Dockerfile.github-actions-runner".pathChanged() || "contrib/ci/gocacheprog".pathChanged()
+      || ".tekton/hypershift-gh-actions-runner-push.yaml".pathChanged())
     pipelinesascode.tekton.dev/pipeline: ".tekton/pipelines/common-operator-build.yaml"
   creationTimestamp: null
   labels:


### PR DESCRIPTION
## Summary

- The runner image `COPY`s `contrib/ci/gocacheprog/` but the Tekton pipelines only triggered on `Dockerfile.github-actions-runner` changes
- Adds `pathChanged()` for `contrib/ci/gocacheprog` and each pipeline's own YAML so the image rebuilds when either is updated
- This will trigger the image rebuild that includes the atomic writes fix from #8624

## Test plan

- [ ] Konflux PR pipeline triggers on this PR (validates `.tekton/*.yaml` self-trigger)
- [ ] After merge, push pipeline triggers and rebuilds the runner image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline trigger conditions for pull requests and push events to run when workflow and configuration files change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->