### PR TITLE
NO-JIRA: Fix HCCO deployment location in AGENTS.md

### DIFF
--- a/control-plane-operator/AGENTS.md
+++ b/control-plane-operator/AGENTS.md
@@ -21,7 +21,7 @@ See `support/controlplane-component/AGENTS.md` and `support/controlplane-compone
 
 ## HCCO (Hosted Cluster Config Operator)
 
-HCCO is a **separate binary in the same image**, invoked as `control-plane-operator hosted-cluster-config-operator`. It runs as a Deployment **in the guest cluster** (not the management cluster), reconciling guest-side resources: `openshift-config/pull-secret`, node configuration, in-place upgrades, global pull secret, draining, etc.
+HCCO is a **separate binary in the same image**, invoked as `control-plane-operator hosted-cluster-config-operator`. It runs as a Deployment in the control plane namespace, mainly reconciling guest-side resources: `openshift-config/pull-secret`, node configuration, in-place upgrades, global pull secret, draining, etc.
 
 HCCO controllers are in `hostedclusterconfigoperator/controllers/`. They do **not** use the v2 component framework today — this is a migration opportunity.
 


### PR DESCRIPTION
## Summary
- Corrects HCCO description in `control-plane-operator/AGENTS.md`: HCCO runs as a Deployment in the control plane namespace on the management cluster, not "in the guest cluster"
- It reconciles guest-side resources by talking to the guest API server, but the pod itself lives in the HCP namespace

## Test plan
- [ ] Documentation-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that HCCO runs as a Deployment in the control plane namespace rather than inside the guest cluster. Documentation also reiterates that HCCO continues to reconcile guest-side resources (pull secrets, node configuration, in-place upgrades, global pull secret handling, and node draining) so users can expect the same guest-facing behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->