### PR TITLE
CNTRLPLANE-3529: Add operator IAM role creation command and install role ARN flags

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -24,6 +24,7 @@ func NewCommand() *cobra.Command {
 	cmd.AddCommand(cluster.NewCreateCommands())
 	cmd.AddCommand(infra.NewCreateCommand())
 	cmd.AddCommand(infra.NewCreateIAMCommand())
+	cmd.AddCommand(infra.NewCreateOperatorRolesCommand())
 	cmd.AddCommand(kubeconfig.NewCreateCommand())
 	cmd.AddCommand(nodepool.NewCreateCommand())
 	cmd.AddCommand(bastion.NewCreateCommand())

--- a/cmd/infra/aws/create_operator_roles.go
+++ b/cmd/infra/aws/create_operator_roles.go
@@ -1,0 +1,415 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
+	"github.com/openshift/hypershift/cmd/log"
+	"github.com/openshift/hypershift/cmd/util"
+	"github.com/openshift/hypershift/support/awsapi"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+)
+
+const (
+	CredentialSourceWebIdentity         = "web-identity"
+	CredentialSourceEC2InstanceMetadata = "ec2-instance-metadata"
+)
+
+type CreateOperatorRolesOptions struct {
+	AWSCredentialsOpts awsutil.AWSCredentialsOptions
+	Region             string
+	NamePrefix         string
+
+	OIDCIssuerURL   string
+	InstanceRoleARN string
+
+	OIDCStorageProviderS3BucketName string
+	Route53HostedZoneID             string
+	OperatorNamespace               string
+	OutputFile                      string
+	AdditionalTags                  []string
+
+	additionalIAMTags []iamtypes.Tag
+}
+
+type CreateOperatorRolesOutput struct {
+	OperatorEC2RoleARN    string `json:"operatorEC2RoleARN"`
+	OperatorOIDCS3RoleARN string `json:"operatorOIDCS3RoleARN"`
+	ExternalDNSRoleARN    string `json:"externalDNSRoleARN"`
+}
+
+func NewCreateOperatorRolesCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "aws",
+		Short:        "Creates AWS IAM roles for the HyperShift operator and external-dns",
+		SilenceUsage: true,
+	}
+
+	opts := CreateOperatorRolesOptions{
+		NamePrefix:        "hypershift",
+		OperatorNamespace: "hypershift",
+	}
+
+	cmd.Flags().StringVar(&opts.Region, "region", opts.Region, "AWS region (defaults to AWS_REGION, AWS_DEFAULT_REGION, or ~/.aws/config)")
+	cmd.Flags().StringVar(&opts.NamePrefix, "name-prefix", opts.NamePrefix, "Prefix for IAM role names")
+	cmd.Flags().StringVar(&opts.OIDCIssuerURL, "oidc-issuer-url", "", "Management cluster OIDC issuer URL for web identity trust (auto-discovered from cluster if not set). Mutually exclusive with --instance-role-arn.")
+	cmd.Flags().StringVar(&opts.InstanceRoleARN, "instance-role-arn", "", "ARN of the instance role to trust via sts:AssumeRole (for clusters without an OIDC provider). Mutually exclusive with --oidc-issuer-url.")
+	cmd.Flags().StringVar(&opts.OIDCStorageProviderS3BucketName, "oidc-storage-provider-s3-bucket-name", "", "S3 bucket name for OIDC documents (scopes the S3 policy)")
+	cmd.Flags().StringVar(&opts.Route53HostedZoneID, "route53-hosted-zone-id", "", "Route53 hosted zone ID to scope the external-dns policy (defaults to all zones)")
+	cmd.Flags().StringVar(&opts.OperatorNamespace, "operator-namespace", opts.OperatorNamespace, "Namespace where the HyperShift operator is installed")
+	cmd.Flags().StringVar(&opts.OutputFile, "output-file", "", "Path to file for JSON output (optional, defaults to stdout)")
+	cmd.Flags().StringSliceVar(&opts.AdditionalTags, "additional-tags", nil, "Additional tags to set on IAM resources (key=value)")
+
+	opts.AWSCredentialsOpts.BindFlags(cmd.Flags())
+
+	_ = cmd.MarkFlagRequired("oidc-storage-provider-s3-bucket-name")
+
+	logger := log.Log
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := opts.Validate(cmd.Context()); err != nil {
+			return err
+		}
+		return opts.Run(cmd.Context(), logger)
+	}
+
+	return cmd
+}
+
+func (o *CreateOperatorRolesOptions) Validate(ctx context.Context) error {
+	if o.OIDCIssuerURL != "" && o.InstanceRoleARN != "" {
+		return fmt.Errorf("--oidc-issuer-url and --instance-role-arn are mutually exclusive")
+	}
+	if o.OIDCIssuerURL == "" && o.InstanceRoleARN == "" {
+		// Auto-discover OIDC issuer from management cluster
+		client, err := util.GetClient()
+		if err != nil {
+			return fmt.Errorf("no --oidc-issuer-url or --instance-role-arn specified, and failed to connect to cluster for auto-discovery: %w", err)
+		}
+		issuer, err := discoverOIDCIssuerURL(ctx, client)
+		if err != nil {
+			return fmt.Errorf("no --oidc-issuer-url or --instance-role-arn specified, and auto-discovery failed: %w", err)
+		}
+		o.OIDCIssuerURL = issuer
+	}
+	return nil
+}
+
+func discoverOIDCIssuerURL(ctx context.Context, client crclient.Client) (string, error) {
+	auth := &configv1.Authentication{}
+	auth.Name = "cluster"
+	if err := client.Get(ctx, crclient.ObjectKeyFromObject(auth), auth); err != nil {
+		return "", fmt.Errorf("failed to get Authentication CR: %w", err)
+	}
+	issuer := auth.Spec.ServiceAccountIssuer
+	if issuer == "" {
+		return "", fmt.Errorf("authentication CR has no serviceAccountIssuer set; specify --oidc-issuer-url or --instance-role-arn explicitly")
+	}
+	return issuer, nil
+}
+
+func (o *CreateOperatorRolesOptions) Run(ctx context.Context, logger logr.Logger) error {
+	if err := o.parseAdditionalTags(); err != nil {
+		return err
+	}
+
+	var awsSession *aws.Config
+	if o.AWSCredentialsOpts.AWSCredentialsFile != "" || o.AWSCredentialsOpts.STSCredentialsFile != "" {
+		if err := o.AWSCredentialsOpts.Validate(); err != nil {
+			return err
+		}
+		var err error
+		awsSession, err = o.AWSCredentialsOpts.GetSession(ctx, "cli-create-operator-roles", nil, o.Region)
+		if err != nil {
+			return err
+		}
+	} else {
+		awsSession = awsutil.NewSession(ctx, "cli-create-operator-roles", "", "", "", o.Region)
+	}
+	awsConfig := awsutil.NewConfig()
+	iamClient := iam.NewFromConfig(*awsSession, func(o *iam.Options) {
+		o.Retryer = awsConfig()
+	})
+
+	results, err := o.CreateOperatorRoles(ctx, iamClient, logger)
+	if err != nil {
+		return err
+	}
+
+	return o.output(results, logger)
+}
+
+func (o *CreateOperatorRolesOptions) CreateOperatorRoles(ctx context.Context, iamClient awsapi.IAMAPI, logger logr.Logger) (*CreateOperatorRolesOutput, error) {
+	trustPolicies, err := o.buildTrustPolicies(ctx, iamClient, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	output := &CreateOperatorRolesOutput{}
+
+	// Role 1: Operator EC2/ELBv2 — VPC endpoint services and instance type queries
+	ec2RoleOpts := CreateIAMRoleOptions{
+		RoleName:          fmt.Sprintf("%s-operator-ec2", o.NamePrefix),
+		TrustPolicy:       trustPolicies.operatorTrust,
+		PermissionsPolicy: operatorEC2Policy,
+		additionalIAMTags: o.additionalIAMTags,
+	}
+	output.OperatorEC2RoleARN, err = createOrUpdateRole(ctx, iamClient, ec2RoleOpts, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create operator EC2 role: %w", err)
+	}
+
+	// Role 2: Operator OIDC S3 — upload/delete OIDC discovery docs
+	s3RoleOpts := CreateIAMRoleOptions{
+		RoleName:          fmt.Sprintf("%s-operator-oidc-s3", o.NamePrefix),
+		TrustPolicy:       trustPolicies.operatorTrust,
+		PermissionsPolicy: fmt.Sprintf(operatorOIDCS3PolicyTemplate, o.OIDCStorageProviderS3BucketName),
+		additionalIAMTags: o.additionalIAMTags,
+	}
+	output.OperatorOIDCS3RoleARN, err = createOrUpdateRole(ctx, iamClient, s3RoleOpts, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create operator OIDC S3 role: %w", err)
+	}
+
+	// Role 3: External DNS — Route53 record management
+	route53Resource := "arn:aws:route53:::hostedzone/*"
+	if o.Route53HostedZoneID != "" {
+		route53Resource = fmt.Sprintf("arn:aws:route53:::hostedzone/%s", o.Route53HostedZoneID)
+	}
+	externalDNSRoleOpts := CreateIAMRoleOptions{
+		RoleName:          fmt.Sprintf("%s-external-dns", o.NamePrefix),
+		TrustPolicy:       trustPolicies.externalDNSTrust,
+		PermissionsPolicy: fmt.Sprintf(externalDNSPolicyTemplate, route53Resource),
+		additionalIAMTags: o.additionalIAMTags,
+	}
+	output.ExternalDNSRoleARN, err = createOrUpdateRole(ctx, iamClient, externalDNSRoleOpts, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create external-dns role: %w", err)
+	}
+
+	return output, nil
+}
+
+func createOrUpdateRole(ctx context.Context, iamClient awsapi.IAMAPI, opts CreateIAMRoleOptions, logger logr.Logger) (string, error) {
+	arn, err := opts.CreateRoleWithInlinePolicy(ctx, iamClient, logger)
+	if err != nil {
+		return "", err
+	}
+
+	_, err = iamClient.UpdateAssumeRolePolicy(ctx, &iam.UpdateAssumeRolePolicyInput{
+		RoleName:       aws.String(opts.RoleName),
+		PolicyDocument: aws.String(opts.TrustPolicy),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to update trust policy for role %s: %w", opts.RoleName, err)
+	}
+	logger.Info("Ensured trust policy is up to date", "role", opts.RoleName)
+
+	return arn, nil
+}
+
+type operatorTrustPolicies struct {
+	operatorTrust    string
+	externalDNSTrust string
+}
+
+func (o *CreateOperatorRolesOptions) buildTrustPolicies(ctx context.Context, iamClient awsapi.IAMAPI, logger logr.Logger) (*operatorTrustPolicies, error) {
+	if o.InstanceRoleARN != "" {
+		trust := instanceRoleTrustPolicy(o.InstanceRoleARN)
+		return &operatorTrustPolicies{
+			operatorTrust:    trust,
+			externalDNSTrust: trust,
+		}, nil
+	}
+
+	providerARN, providerName, err := o.resolveOIDCProvider(ctx, iamClient, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	operatorSA := fmt.Sprintf("system:serviceaccount:%s:operator", o.OperatorNamespace)
+	externalDNSSA := fmt.Sprintf("system:serviceaccount:%s:external-dns", o.OperatorNamespace)
+
+	return &operatorTrustPolicies{
+		operatorTrust:    oidcTrustPolicy(providerARN, providerName, operatorSA),
+		externalDNSTrust: oidcTrustPolicy(providerARN, providerName, externalDNSSA),
+	}, nil
+}
+
+func (o *CreateOperatorRolesOptions) resolveOIDCProvider(ctx context.Context, iamClient awsapi.IAMAPI, logger logr.Logger) (providerARN, providerName string, err error) {
+	providerName = strings.TrimPrefix(o.OIDCIssuerURL, "https://")
+
+	providers, err := iamClient.ListOpenIDConnectProviders(ctx, &iam.ListOpenIDConnectProvidersInput{})
+	if err != nil {
+		return "", "", fmt.Errorf("failed to list OIDC providers: %w", err)
+	}
+
+	for _, p := range providers.OpenIDConnectProviderList {
+		if strings.HasSuffix(*p.Arn, "/"+providerName) {
+			logger.Info("Found OIDC provider", "arn", *p.Arn)
+			return *p.Arn, providerName, nil
+		}
+	}
+
+	return "", "", fmt.Errorf("no OIDC provider found matching issuer URL %q; register the management cluster's OIDC provider in AWS IAM first", o.OIDCIssuerURL)
+}
+
+func instanceRoleTrustPolicy(roleARN string) string {
+	return fmt.Sprintf(`{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Principal": {
+				"AWS": %q
+			},
+			"Action": "sts:AssumeRole"
+		}
+	]
+}`, roleARN)
+}
+
+func (o *CreateOperatorRolesOptions) output(results *CreateOperatorRolesOutput, logger logr.Logger) error {
+	out := os.Stdout
+	if o.OutputFile != "" {
+		var err error
+		out, err = os.Create(o.OutputFile)
+		if err != nil {
+			return fmt.Errorf("cannot create output file: %w", err)
+		}
+		defer func() {
+			if cerr := out.Close(); cerr != nil {
+				logger.Error(cerr, "failed to close output file")
+			}
+		}()
+	}
+
+	outputBytes, err := json.MarshalIndent(results, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to serialize result: %w", err)
+	}
+	if _, err = out.Write(outputBytes); err != nil {
+		return fmt.Errorf("failed to write result: %w", err)
+	}
+
+	credSource := CredentialSourceWebIdentity
+	if o.InstanceRoleARN != "" {
+		credSource = CredentialSourceEC2InstanceMetadata
+	}
+	logger.Info("Operator roles created. Install with:",
+		"command", fmt.Sprintf(
+			"hypershift install --aws-private-role-arn=%s --oidc-storage-provider-s3-role-arn=%s --external-dns-role-arn=%s --aws-role-credential-source=%s ...",
+			results.OperatorEC2RoleARN,
+			results.OperatorOIDCS3RoleARN,
+			results.ExternalDNSRoleARN,
+			credSource,
+		),
+	)
+
+	return nil
+}
+
+func (o *CreateOperatorRolesOptions) parseAdditionalTags() error {
+	parsed, err := util.ParseAWSTags(o.AdditionalTags)
+	if err != nil {
+		return err
+	}
+	for k, v := range parsed {
+		o.additionalIAMTags = append(o.additionalIAMTags, iamtypes.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(v),
+		})
+	}
+	return nil
+}
+
+const operatorEC2Policy = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "VPCEndpointServiceManagement",
+			"Effect": "Allow",
+			"Action": [
+				"ec2:CreateVpcEndpointServiceConfiguration",
+				"ec2:DeleteVpcEndpointServiceConfigurations",
+				"ec2:DescribeVpcEndpointServiceConfigurations",
+				"ec2:DescribeVpcEndpointServicePermissions",
+				"ec2:ModifyVpcEndpointServicePermissions",
+				"ec2:DescribeVpcEndpointConnections",
+				"ec2:RejectVpcEndpointConnections",
+				"ec2:CreateTags"
+			],
+			"Resource": "*"
+		},
+		{
+			"Sid": "LoadBalancerDiscovery",
+			"Effect": "Allow",
+			"Action": [
+				"elasticloadbalancing:DescribeLoadBalancers"
+			],
+			"Resource": "*"
+		},
+		{
+			"Sid": "InstanceTypeDiscovery",
+			"Effect": "Allow",
+			"Action": [
+				"ec2:DescribeInstanceTypes"
+			],
+			"Resource": "*"
+		}
+	]
+}`
+
+const operatorOIDCS3PolicyTemplate = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "OIDCDocumentManagement",
+			"Effect": "Allow",
+			"Action": [
+				"s3:PutObject",
+				"s3:DeleteObject",
+				"s3:DeleteObjects"
+			],
+			"Resource": "arn:aws:s3:::%s/*"
+		}
+	]
+}`
+
+const externalDNSPolicyTemplate = `{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "HostedZoneDiscovery",
+			"Effect": "Allow",
+			"Action": [
+				"route53:ListHostedZones",
+				"route53:GetHostedZone",
+				"route53:GetChange"
+			],
+			"Resource": "*"
+		},
+		{
+			"Sid": "DNSRecordManagement",
+			"Effect": "Allow",
+			"Action": [
+				"route53:ChangeResourceRecordSets",
+				"route53:ListResourceRecordSets"
+			],
+			"Resource": "%s"
+		}
+	]
+}`

--- a/cmd/infra/aws/create_operator_roles_test.go
+++ b/cmd/infra/aws/create_operator_roles_test.go
@@ -1,0 +1,516 @@
+package aws
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/hypershift/support/awsapi"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+
+	"github.com/go-logr/logr"
+	"go.uber.org/mock/gomock"
+)
+
+func TestCreateOperatorRolesValidate(t *testing.T) {
+	tests := map[string]struct {
+		opts        CreateOperatorRolesOptions
+		expectError bool
+	}{
+		"When both oidc-issuer-url and instance-role-arn are provided it should error": {
+			opts: CreateOperatorRolesOptions{
+				OIDCIssuerURL:   "https://oidc.example.com",
+				InstanceRoleARN: "arn:aws:iam::123456789012:role/instance-role",
+			},
+			expectError: true,
+		},
+		"When oidc-issuer-url is provided it should succeed": {
+			opts: CreateOperatorRolesOptions{
+				OIDCIssuerURL: "https://oidc.example.com",
+			},
+			expectError: false,
+		},
+		"When instance-role-arn is provided it should succeed": {
+			opts: CreateOperatorRolesOptions{
+				InstanceRoleARN: "arn:aws:iam::123456789012:role/instance-role",
+			},
+			expectError: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			err := test.opts.Validate(context.Background())
+			if test.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	}
+}
+
+func TestResolveOIDCProvider(t *testing.T) {
+	tests := map[string]struct {
+		issuerURL     string
+		providers     []iamtypes.OpenIDConnectProviderListEntry
+		listErr       error
+		expectARN     string
+		expectName    string
+		expectError   bool
+		errorContains string
+	}{
+		"When matching provider exists it should return its ARN": {
+			issuerURL: "https://oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE123",
+			providers: []iamtypes.OpenIDConnectProviderListEntry{
+				{Arn: aws.String("arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE123")},
+			},
+			expectARN:  "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE123",
+			expectName: "oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE123",
+		},
+		"When no matching provider exists it should error": {
+			issuerURL: "https://oidc.example.com",
+			providers: []iamtypes.OpenIDConnectProviderListEntry{
+				{Arn: aws.String("arn:aws:iam::123456789012:oidc-provider/other.example.com")},
+			},
+			expectError:   true,
+			errorContains: "no OIDC provider found",
+		},
+		"When listing providers fails it should error": {
+			issuerURL:     "https://oidc.example.com",
+			listErr:       fmt.Errorf("access denied"),
+			expectError:   true,
+			errorContains: "failed to list OIDC providers",
+		},
+		"When provider list is empty it should error": {
+			issuerURL:     "https://oidc.example.com",
+			providers:     []iamtypes.OpenIDConnectProviderListEntry{},
+			expectError:   true,
+			errorContains: "no OIDC provider found",
+		},
+		"When issuer URL has https prefix it should strip it for matching": {
+			issuerURL: "https://s3.us-east-1.amazonaws.com/mybucket",
+			providers: []iamtypes.OpenIDConnectProviderListEntry{
+				{Arn: aws.String("arn:aws:iam::123456789012:oidc-provider/s3.us-east-1.amazonaws.com/mybucket")},
+			},
+			expectARN:  "arn:aws:iam::123456789012:oidc-provider/s3.us-east-1.amazonaws.com/mybucket",
+			expectName: "s3.us-east-1.amazonaws.com/mybucket",
+		},
+		"When substring match exists but not suffix match it should not match": {
+			issuerURL: "https://example.com",
+			providers: []iamtypes.OpenIDConnectProviderListEntry{
+				{Arn: aws.String("arn:aws:iam::123456789012:oidc-provider/my-example.com")},
+			},
+			expectError:   true,
+			errorContains: "no OIDC provider found",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			ctrl := gomock.NewController(t)
+			mockIAM := awsapi.NewMockIAMAPI(ctrl)
+
+			mockIAM.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&iam.ListOpenIDConnectProvidersOutput{
+					OpenIDConnectProviderList: test.providers,
+				}, test.listErr)
+
+			opts := &CreateOperatorRolesOptions{OIDCIssuerURL: test.issuerURL}
+			arn, name, err := opts.resolveOIDCProvider(context.Background(), mockIAM, logr.Discard())
+
+			if test.expectError {
+				g.Expect(err).To(HaveOccurred())
+				if test.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(test.errorContains))
+				}
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(arn).To(Equal(test.expectARN))
+				g.Expect(name).To(Equal(test.expectName))
+			}
+		})
+	}
+}
+
+func TestBuildTrustPolicies(t *testing.T) {
+	tests := map[string]struct {
+		opts          CreateOperatorRolesOptions
+		setupMock     func(*awsapi.MockIAMAPI)
+		expectError   bool
+		errorContains string
+		validate      func(*GomegaWithT, *operatorTrustPolicies)
+	}{
+		"When instance role ARN is provided it should use instance role trust policy": {
+			opts: CreateOperatorRolesOptions{
+				InstanceRoleARN:   "arn:aws:iam::123456789012:role/instance-role",
+				OperatorNamespace: "hypershift",
+			},
+			setupMock: func(m *awsapi.MockIAMAPI) {},
+			validate: func(g *GomegaWithT, tp *operatorTrustPolicies) {
+				g.Expect(tp.operatorTrust).To(ContainSubstring("arn:aws:iam::123456789012:role/instance-role"))
+				g.Expect(tp.operatorTrust).To(ContainSubstring("sts:AssumeRole"))
+				g.Expect(tp.operatorTrust).To(Equal(tp.externalDNSTrust))
+			},
+		},
+		"When OIDC issuer URL is provided it should resolve provider and build trust policies": {
+			opts: CreateOperatorRolesOptions{
+				OIDCIssuerURL:     "https://oidc.example.com",
+				OperatorNamespace: "hypershift",
+			},
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.ListOpenIDConnectProvidersOutput{
+						OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{
+							{Arn: aws.String("arn:aws:iam::123456789012:oidc-provider/oidc.example.com")},
+						},
+					}, nil)
+			},
+			validate: func(g *GomegaWithT, tp *operatorTrustPolicies) {
+				g.Expect(tp.operatorTrust).To(ContainSubstring("system:serviceaccount:hypershift:operator"))
+				g.Expect(tp.externalDNSTrust).To(ContainSubstring("system:serviceaccount:hypershift:external-dns"))
+				g.Expect(tp.operatorTrust).ToNot(Equal(tp.externalDNSTrust))
+			},
+		},
+		"When OIDC provider resolution fails it should return error": {
+			opts: CreateOperatorRolesOptions{
+				OIDCIssuerURL:     "https://unknown.example.com",
+				OperatorNamespace: "hypershift",
+			},
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.ListOpenIDConnectProvidersOutput{
+						OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{},
+					}, nil)
+			},
+			expectError:   true,
+			errorContains: "no OIDC provider found",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			ctrl := gomock.NewController(t)
+			mockIAM := awsapi.NewMockIAMAPI(ctrl)
+			test.setupMock(mockIAM)
+
+			tp, err := test.opts.buildTrustPolicies(context.Background(), mockIAM, logr.Discard())
+			if test.expectError {
+				g.Expect(err).To(HaveOccurred())
+				if test.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(test.errorContains))
+				}
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+				test.validate(g, tp)
+			}
+		})
+	}
+}
+
+func TestCreateOrUpdateRole(t *testing.T) {
+	const (
+		roleName = "test-role"
+		roleARN  = "arn:aws:iam::123456789012:role/" + roleName
+	)
+
+	tests := map[string]struct {
+		setupMock     func(*awsapi.MockIAMAPI)
+		expectARN     string
+		expectError   bool
+		errorContains string
+	}{
+		"When role creation and trust update succeed it should return the ARN": {
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.GetRoleOutput{Role: &iamtypes.Role{
+						RoleName: aws.String(roleName),
+						Arn:      aws.String(roleARN),
+					}}, nil)
+				m.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.PutRolePolicyOutput{}, nil)
+				m.EXPECT().UpdateAssumeRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.UpdateAssumeRolePolicyOutput{}, nil)
+			},
+			expectARN: roleARN,
+		},
+		"When trust policy update fails it should return error": {
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.GetRoleOutput{Role: &iamtypes.Role{
+						RoleName: aws.String(roleName),
+						Arn:      aws.String(roleARN),
+					}}, nil)
+				m.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&iam.PutRolePolicyOutput{}, nil)
+				m.EXPECT().UpdateAssumeRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, fmt.Errorf("access denied"))
+			},
+			expectError:   true,
+			errorContains: "failed to update trust policy",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			ctrl := gomock.NewController(t)
+			mockIAM := awsapi.NewMockIAMAPI(ctrl)
+			test.setupMock(mockIAM)
+
+			opts := CreateIAMRoleOptions{
+				RoleName:          roleName,
+				TrustPolicy:       `{"Version":"2012-10-17"}`,
+				PermissionsPolicy: `{"Version":"2012-10-17"}`,
+			}
+
+			arn, err := createOrUpdateRole(context.Background(), mockIAM, opts, logr.Discard())
+			if test.expectError {
+				g.Expect(err).To(HaveOccurred())
+				if test.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(test.errorContains))
+				}
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(arn).To(Equal(test.expectARN))
+			}
+		})
+	}
+}
+
+func TestCreateOperatorRoles(t *testing.T) {
+	const (
+		ec2RoleARN  = "arn:aws:iam::123456789012:role/hypershift-operator-ec2"
+		s3RoleARN   = "arn:aws:iam::123456789012:role/hypershift-operator-oidc-s3"
+		dnsRoleARN  = "arn:aws:iam::123456789012:role/hypershift-external-dns"
+		providerARN = "arn:aws:iam::123456789012:oidc-provider/oidc.example.com"
+	)
+
+	setupSuccessfulMock := func(m *awsapi.MockIAMAPI) {
+		// OIDC provider resolution
+		m.EXPECT().ListOpenIDConnectProviders(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&iam.ListOpenIDConnectProvidersOutput{
+				OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{
+					{Arn: aws.String(providerARN)},
+				},
+			}, nil)
+
+		// Three role creations (GetRole + PutRolePolicy + UpdateAssumeRolePolicy each)
+		for _, roleInfo := range []struct{ name, arn string }{
+			{"hypershift-operator-ec2", ec2RoleARN},
+			{"hypershift-operator-oidc-s3", s3RoleARN},
+			{"hypershift-external-dns", dnsRoleARN},
+		} {
+			m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&iam.GetRoleOutput{Role: &iamtypes.Role{
+					RoleName: aws.String(roleInfo.name),
+					Arn:      aws.String(roleInfo.arn),
+				}}, nil)
+			m.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&iam.PutRolePolicyOutput{}, nil)
+			m.EXPECT().UpdateAssumeRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&iam.UpdateAssumeRolePolicyOutput{}, nil)
+		}
+	}
+
+	tests := map[string]struct {
+		opts          CreateOperatorRolesOptions
+		setupMock     func(*awsapi.MockIAMAPI)
+		expectError   bool
+		errorContains string
+		validate      func(*GomegaWithT, *CreateOperatorRolesOutput)
+	}{
+		"When all roles are created successfully with OIDC it should return all ARNs": {
+			opts: CreateOperatorRolesOptions{
+				OIDCIssuerURL:                   "https://oidc.example.com",
+				NamePrefix:                      "hypershift",
+				OIDCStorageProviderS3BucketName: "test-bucket",
+				OperatorNamespace:               "hypershift",
+			},
+			setupMock: setupSuccessfulMock,
+			validate: func(g *GomegaWithT, output *CreateOperatorRolesOutput) {
+				g.Expect(output.OperatorEC2RoleARN).To(Equal(ec2RoleARN))
+				g.Expect(output.OperatorOIDCS3RoleARN).To(Equal(s3RoleARN))
+				g.Expect(output.ExternalDNSRoleARN).To(Equal(dnsRoleARN))
+			},
+		},
+		"When Route53 hosted zone ID is specified it should scope the policy": {
+			opts: CreateOperatorRolesOptions{
+				InstanceRoleARN:                 "arn:aws:iam::123456789012:role/instance-role",
+				NamePrefix:                      "hypershift",
+				OIDCStorageProviderS3BucketName: "test-bucket",
+				Route53HostedZoneID:             "Z0123456789ABCDEF",
+				OperatorNamespace:               "hypershift",
+			},
+			setupMock: func(m *awsapi.MockIAMAPI) {
+				for _, roleInfo := range []struct{ name, arn string }{
+					{"hypershift-operator-ec2", ec2RoleARN},
+					{"hypershift-operator-oidc-s3", s3RoleARN},
+					{"hypershift-external-dns", dnsRoleARN},
+				} {
+					m.EXPECT().GetRole(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.GetRoleOutput{Role: &iamtypes.Role{
+							RoleName: aws.String(roleInfo.name),
+							Arn:      aws.String(roleInfo.arn),
+						}}, nil)
+					m.EXPECT().PutRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.PutRolePolicyOutput{}, nil)
+					m.EXPECT().UpdateAssumeRolePolicy(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(&iam.UpdateAssumeRolePolicyOutput{}, nil)
+				}
+			},
+			validate: func(g *GomegaWithT, output *CreateOperatorRolesOutput) {
+				g.Expect(output.OperatorEC2RoleARN).To(Equal(ec2RoleARN))
+				g.Expect(output.ExternalDNSRoleARN).To(Equal(dnsRoleARN))
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			ctrl := gomock.NewController(t)
+			mockIAM := awsapi.NewMockIAMAPI(ctrl)
+			test.setupMock(mockIAM)
+
+			output, err := test.opts.CreateOperatorRoles(context.Background(), mockIAM, logr.Discard())
+			if test.expectError {
+				g.Expect(err).To(HaveOccurred())
+				if test.errorContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(test.errorContains))
+				}
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+				test.validate(g, output)
+			}
+		})
+	}
+}
+
+func TestInstanceRoleTrustPolicy(t *testing.T) {
+	g := NewGomegaWithT(t)
+	roleARN := "arn:aws:iam::123456789012:role/my-instance-role"
+	policy := instanceRoleTrustPolicy(roleARN)
+
+	g.Expect(policy).To(ContainSubstring(roleARN))
+	g.Expect(policy).To(ContainSubstring("sts:AssumeRole"))
+	g.Expect(policy).To(ContainSubstring(`"Effect": "Allow"`))
+
+	var parsed map[string]interface{}
+	g.Expect(json.Unmarshal([]byte(policy), &parsed)).To(Succeed())
+}
+
+func TestParseAdditionalTags(t *testing.T) {
+	tests := map[string]struct {
+		tags        []string
+		expectError bool
+		expectCount int
+	}{
+		"When no tags provided it should succeed with empty list": {
+			tags:        nil,
+			expectCount: 0,
+		},
+		"When valid tags provided it should parse them": {
+			tags:        []string{"env=prod", "team=platform"},
+			expectCount: 2,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			opts := &CreateOperatorRolesOptions{AdditionalTags: test.tags}
+			err := opts.parseAdditionalTags()
+			if test.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(opts.additionalIAMTags).To(HaveLen(test.expectCount))
+			}
+		})
+	}
+}
+
+func TestOutput(t *testing.T) {
+	results := &CreateOperatorRolesOutput{
+		OperatorEC2RoleARN:    "arn:aws:iam::123456789012:role/op-ec2",
+		OperatorOIDCS3RoleARN: "arn:aws:iam::123456789012:role/op-s3",
+		ExternalDNSRoleARN:    "arn:aws:iam::123456789012:role/ext-dns",
+	}
+
+	t.Run("When output file is specified it should write JSON to file", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		dir := t.TempDir()
+		outFile := filepath.Join(dir, "roles.json")
+
+		opts := &CreateOperatorRolesOptions{OutputFile: outFile}
+		err := opts.output(results, logr.Discard())
+		g.Expect(err).ToNot(HaveOccurred())
+
+		data, err := os.ReadFile(outFile)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var parsed CreateOperatorRolesOutput
+		g.Expect(json.Unmarshal(data, &parsed)).To(Succeed())
+		g.Expect(parsed.OperatorEC2RoleARN).To(Equal(results.OperatorEC2RoleARN))
+		g.Expect(parsed.OperatorOIDCS3RoleARN).To(Equal(results.OperatorOIDCS3RoleARN))
+		g.Expect(parsed.ExternalDNSRoleARN).To(Equal(results.ExternalDNSRoleARN))
+	})
+
+	t.Run("When output file cannot be created it should return error", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		opts := &CreateOperatorRolesOptions{OutputFile: "/nonexistent/path/roles.json"}
+		err := opts.output(results, logr.Discard())
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("cannot create output file"))
+	})
+
+	t.Run("When no output file is specified it should write to stdout", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		// Redirect stdout
+		oldStdout := os.Stdout
+		r, w, err := os.Pipe()
+		g.Expect(err).ToNot(HaveOccurred())
+		os.Stdout = w
+
+		opts := &CreateOperatorRolesOptions{}
+		err = opts.output(results, logr.Discard())
+		g.Expect(err).ToNot(HaveOccurred())
+
+		w.Close()
+		os.Stdout = oldStdout
+
+		var buf bytes.Buffer
+		_, err = buf.ReadFrom(r)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(buf.String()).To(ContainSubstring("op-ec2"))
+	})
+
+	t.Run("When instance role ARN is set it should log ec2-instance-metadata credential source", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		dir := t.TempDir()
+		outFile := filepath.Join(dir, "roles.json")
+
+		opts := &CreateOperatorRolesOptions{
+			OutputFile:      outFile,
+			InstanceRoleARN: "arn:aws:iam::123456789012:role/instance",
+		}
+		err := opts.output(results, logr.Discard())
+		g.Expect(err).ToNot(HaveOccurred())
+		_ = strings.Contains(CredentialSourceEC2InstanceMetadata, "ec2")
+		g.Expect(CredentialSourceEC2InstanceMetadata).To(Equal("ec2-instance-metadata"))
+	})
+}

--- a/cmd/infra/aws/delegatingclientgenerator/main.go
+++ b/cmd/infra/aws/delegatingclientgenerator/main.go
@@ -446,6 +446,7 @@ var standaloneAPIs = map[string][]string{
 		"ListRolePolicies",
 		"PutRolePolicy",
 		"RemoveRoleFromInstanceProfile",
+		"UpdateAssumeRolePolicy",
 	},
 }
 

--- a/cmd/infra/create_operator_roles.go
+++ b/cmd/infra/create_operator_roles.go
@@ -1,0 +1,19 @@
+package infra
+
+import (
+	"github.com/openshift/hypershift/cmd/infra/aws"
+
+	"github.com/spf13/cobra"
+)
+
+func NewCreateOperatorRolesCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "operator-roles",
+		Short:        "Commands for creating IAM roles for the HyperShift operator",
+		SilenceUsage: true,
+	}
+
+	cmd.AddCommand(aws.NewCreateOperatorRolesCommand())
+
+	return cmd
+}

--- a/cmd/install/assets/hypershift_operator.go
+++ b/cmd/install/assets/hypershift_operator.go
@@ -258,6 +258,7 @@ type ExternalDNSDeployment struct {
 	GoogleProject         string
 	Interval              string
 	AWSZonesCacheDuration string
+	UseWebIdentity        bool
 }
 
 func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
@@ -394,6 +395,36 @@ func (o ExternalDNSDeployment) Build() *appsv1.Deployment {
 				// thus we can assume us-east-1 without having to request it on the command line
 				Value: "us-east-1",
 			})
+		if o.UseWebIdentity {
+			deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env,
+				corev1.EnvVar{Name: "AWS_SDK_LOAD_CONFIG", Value: "1"},
+			)
+			deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(
+				deployment.Spec.Template.Spec.Containers[0].VolumeMounts,
+				corev1.VolumeMount{
+					Name:      "token",
+					MountPath: "/var/run/secrets/openshift/serviceaccount",
+				},
+			)
+			deployment.Spec.Template.Spec.Volumes = append(
+				deployment.Spec.Template.Spec.Volumes,
+				corev1.Volume{
+					Name: "token",
+					VolumeSource: corev1.VolumeSource{
+						Projected: &corev1.ProjectedVolumeSource{
+							Sources: []corev1.VolumeProjection{
+								{
+									ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+										Audience: "openshift",
+										Path:     "token",
+									},
+								},
+							},
+						},
+					},
+				},
+			)
+		}
 		deployment.Spec.Template.Spec.Containers[0].Args = append(deployment.Spec.Template.Spec.Containers[0].Args,
 			"--aws-zone-type=public",
 			"--aws-batch-change-interval=10s",

--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	aws "github.com/openshift/hypershift/cmd/infra/aws"
 	"github.com/openshift/hypershift/cmd/install/assets"
 	crdassets "github.com/openshift/hypershift/cmd/install/assets/crds"
 	"github.com/openshift/hypershift/cmd/util"
@@ -105,6 +106,7 @@ type Options struct {
 	AWSPrivateCredentialsSecret               string
 	AWSPrivateCredentialsSecretKey            string
 	AWSPrivateRegion                          string
+	AWSPrivateRoleARN                         string
 	AzurePrivateCreds                         string
 	AzurePrivateCredentialsSecret             string
 	AzurePrivateCredentialsSecretKey          string
@@ -118,9 +120,11 @@ type Options struct {
 	OIDCStorageProviderS3Credentials          string
 	OIDCStorageProviderS3CredentialsSecret    string
 	OIDCStorageProviderS3CredentialsSecretKey string
+	OIDCStorageProviderS3RoleARN              string
 	ExternalDNSProvider                       string
 	ExternalDNSCredentials                    string
 	ExternalDNSCredentialsSecret              string
+	ExternalDNSRoleARN                        string
 	ExternalDNSDomainFilter                   string
 	ExternalDNSTxtOwnerId                     string
 	ExternalDNSImage                          string
@@ -156,17 +160,27 @@ type Options struct {
 	ScaleFromZeroCreds                        string
 	ScaleFromZeroCredentialsSecret            string
 	ScaleFromZeroCredentialsSecretKey         string
+	AWSRoleCredentialSource                   string
+	AWSOperatorRolesFile                      string
 	RenderSensitive                           bool
 	HCPEgressBlockCIDRs                       []string
 }
 
-func (o *Options) Validate() error {
-	var errs []error
+func (o *Options) Complete() error {
+	if err := o.loadOperatorRolesFile(); err != nil {
+		return err
+	}
 
 	o.ScaleFromZeroProvider = strings.TrimSpace(o.ScaleFromZeroProvider)
 	if len(o.ScaleFromZeroProvider) != 0 {
 		o.ScaleFromZeroProvider = strings.ToLower(o.ScaleFromZeroProvider)
 	}
+
+	return nil
+}
+
+func (o *Options) Validate() error {
+	var errs []error
 
 	errs = append(errs, o.validatePlatformConfig()...)
 	errs = append(errs, o.validateOIDCConfig()...)
@@ -194,8 +208,19 @@ func (o *Options) validatePlatformConfig() []error {
 	var errs []error
 	switch hyperv1.PlatformType(o.PrivatePlatform) {
 	case hyperv1.AWSPlatform:
-		if (len(o.AWSPrivateCreds) == 0 && len(o.AWSPrivateCredentialsSecret) == 0) || len(o.AWSPrivateRegion) == 0 {
-			errs = append(errs, fmt.Errorf("--aws-private-region and --aws-private-creds or --aws-private-secret are required with --private-platform=%s", hyperv1.AWSPlatform))
+		if len(o.AWSPrivateCreds) != 0 && len(o.AWSPrivateCredentialsSecret) != 0 {
+			errs = append(errs, fmt.Errorf("only one of --aws-private-creds or --aws-private-secret is supported"))
+		}
+		hasCredsFile := len(o.AWSPrivateCreds) != 0 || len(o.AWSPrivateCredentialsSecret) != 0
+		hasRoleARN := len(o.AWSPrivateRoleARN) != 0
+		if hasCredsFile && hasRoleARN {
+			errs = append(errs, fmt.Errorf("--aws-private-role-arn cannot be used with --aws-private-creds or --aws-private-secret"))
+		}
+		if !hasCredsFile && !hasRoleARN {
+			errs = append(errs, fmt.Errorf("--aws-private-creds, --aws-private-secret, or --aws-private-role-arn is required with --private-platform=%s", hyperv1.AWSPlatform))
+		}
+		if len(o.AWSPrivateRegion) == 0 {
+			errs = append(errs, fmt.Errorf("--aws-private-region is required with --private-platform=%s", hyperv1.AWSPlatform))
 		}
 	case hyperv1.GCPPlatform:
 		// GCP uses Workload Identity Federation, no credentials required.
@@ -239,11 +264,19 @@ func (o *Options) validateAzurePlatformConfig() []error {
 
 func (o *Options) validateOIDCConfig() []error {
 	var errs []error
+	hasCredsFile := len(o.OIDCStorageProviderS3CredentialsSecret) > 0 || len(o.OIDCStorageProviderS3Credentials) > 0
+	hasRoleARN := len(o.OIDCStorageProviderS3RoleARN) > 0
+	if hasCredsFile && hasRoleARN {
+		errs = append(errs, fmt.Errorf("--oidc-storage-provider-s3-role-arn cannot be used with --oidc-storage-provider-s3-credentials or --oidc-storage-provider-s3-secret"))
+	}
 	if len(o.OIDCStorageProviderS3CredentialsSecret) > 0 && len(o.OIDCStorageProviderS3Credentials) > 0 {
 		errs = append(errs, fmt.Errorf("only one of --oidc-storage-provider-s3-secret or --oidc-storage-provider-s3-credentials is supported"))
 	}
-	if (len(o.OIDCStorageProviderS3CredentialsSecret) > 0 || len(o.OIDCStorageProviderS3Credentials) > 0) &&
-		(len(o.OIDCStorageProviderS3BucketName) == 0 || len(o.OIDCStorageProviderS3Region) == 0 || len(o.OIDCStorageProviderS3CredentialsSecretKey) == 0) {
+	if (hasCredsFile || hasRoleARN) &&
+		(len(o.OIDCStorageProviderS3BucketName) == 0 || len(o.OIDCStorageProviderS3Region) == 0) {
+		errs = append(errs, fmt.Errorf("--oidc-storage-provider-s3-bucket-name and --oidc-storage-provider-s3-region are required when OIDC S3 credentials or role ARN are specified"))
+	}
+	if hasCredsFile && !hasRoleARN && len(o.OIDCStorageProviderS3CredentialsSecretKey) == 0 {
 		errs = append(errs, fmt.Errorf("all required oidc information is not set"))
 	}
 	if strings.Contains(o.OIDCStorageProviderS3BucketName, ".") {
@@ -259,8 +292,16 @@ func (o *Options) validateExternalDNSConfig() []error {
 	var errs []error
 	// Credentials are optional for GCP when using Workload Identity
 	credentialsRequired := o.ExternalDNSProvider != "google"
-	if credentialsRequired && len(o.ExternalDNSCredentials) == 0 && len(o.ExternalDNSCredentialsSecret) == 0 {
-		errs = append(errs, fmt.Errorf("--external-dns-credentials or --external-dns-credentials-secret are required with --external-dns-provider"))
+	hasCredsFile := len(o.ExternalDNSCredentials) != 0 || len(o.ExternalDNSCredentialsSecret) != 0
+	hasRoleARN := len(o.ExternalDNSRoleARN) != 0
+	if hasRoleARN && o.ExternalDNSProvider != "aws" {
+		errs = append(errs, fmt.Errorf("--external-dns-role-arn is only supported with --external-dns-provider=aws"))
+	}
+	if hasCredsFile && hasRoleARN {
+		errs = append(errs, fmt.Errorf("--external-dns-role-arn cannot be used with --external-dns-credentials or --external-dns-secret"))
+	}
+	if credentialsRequired && !hasCredsFile && !hasRoleARN {
+		errs = append(errs, fmt.Errorf("--external-dns-credentials, --external-dns-secret, or --external-dns-role-arn are required with --external-dns-provider"))
 	}
 	if len(o.ExternalDNSCredentials) != 0 && len(o.ExternalDNSCredentialsSecret) != 0 {
 		errs = append(errs, fmt.Errorf("only one of --external-dns-credentials or --external-dns-credentials-secret is supported"))
@@ -341,6 +382,14 @@ func (o *Options) validateMonitoringConfig() []error {
 
 func (o *Options) validateMiscConfig() []error {
 	var errs []error
+	hasAnyRoleARN := o.AWSPrivateRoleARN != "" || o.OIDCStorageProviderS3RoleARN != "" || o.ExternalDNSRoleARN != ""
+	if hasAnyRoleARN {
+		switch o.AWSRoleCredentialSource {
+		case aws.CredentialSourceWebIdentity, aws.CredentialSourceEC2InstanceMetadata:
+		default:
+			errs = append(errs, fmt.Errorf("--aws-role-credential-source must be %q or %q, got %q", aws.CredentialSourceWebIdentity, aws.CredentialSourceEC2InstanceMetadata, o.AWSRoleCredentialSource))
+		}
+	}
 	if len(o.ManagedService) > 0 && o.ManagedService != hyperv1.AroHCP {
 		errs = append(errs, fmt.Errorf("not a valid managed service type: %s", o.ManagedService))
 	}
@@ -399,6 +448,7 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.AWSPrivateCredentialsSecret, "aws-private-secret", "", "Name of an existing secret containing the AWS private link credentials.")
 	cmd.PersistentFlags().StringVar(&opts.AWSPrivateCredentialsSecretKey, "aws-private-secret-key", opts.AWSPrivateCredentialsSecretKey, "Name of the secret key containing the AWS private link credentials.")
 	cmd.PersistentFlags().StringVar(&opts.AWSPrivateRegion, "aws-private-region", opts.AWSPrivateRegion, "AWS region where private clusters are supported by this operator")
+	cmd.PersistentFlags().StringVar(&opts.AWSPrivateRoleARN, "aws-private-role-arn", "", "IAM role ARN for the operator's EC2/ELBv2 credentials (alternative to --aws-private-creds; uses web identity or instance role based on --aws-role-credential-source)")
 	cmd.PersistentFlags().StringVar(&opts.AzurePrivateCreds, "azure-private-creds", opts.AzurePrivateCreds, "Path to an Azure credentials file with privileges sufficient to manage private cluster resources")
 	cmd.PersistentFlags().StringVar(&opts.AzurePrivateCredentialsSecret, "azure-private-secret", "", "Name of an existing secret containing the Azure private link credentials")
 	cmd.PersistentFlags().StringVar(&opts.AzurePrivateCredentialsSecretKey, "azure-private-secret-key", "credentials", "Name of the secret key containing the Azure private link credentials")
@@ -412,9 +462,11 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.OIDCStorageProviderS3Credentials, "oidc-storage-provider-s3-credentials", opts.OIDCStorageProviderS3Credentials, "Credentials to use for writing the OIDC documents into the S3 bucket. Required for AWS guest clusters")
 	cmd.PersistentFlags().StringVar(&opts.OIDCStorageProviderS3CredentialsSecret, "oidc-storage-provider-s3-secret", "", "Name of an existing secret containing the OIDC S3 credentials.")
 	cmd.PersistentFlags().StringVar(&opts.OIDCStorageProviderS3CredentialsSecretKey, "oidc-storage-provider-s3-secret-key", opts.OIDCStorageProviderS3CredentialsSecretKey, "Name of the secret key containing the OIDC S3 credentials.")
+	cmd.PersistentFlags().StringVar(&opts.OIDCStorageProviderS3RoleARN, "oidc-storage-provider-s3-role-arn", "", "IAM role ARN for OIDC S3 access (alternative to --oidc-storage-provider-s3-credentials; uses web identity or instance role based on --aws-role-credential-source)")
 	cmd.PersistentFlags().StringVar(&opts.ExternalDNSProvider, "external-dns-provider", opts.ExternalDNSProvider, "Provider to use for managing DNS records using external-dns")
 	cmd.PersistentFlags().StringVar(&opts.ExternalDNSCredentials, "external-dns-credentials", opts.OIDCStorageProviderS3Credentials, "Credentials to use for managing DNS records using external-dns")
 	cmd.PersistentFlags().StringVar(&opts.ExternalDNSCredentialsSecret, "external-dns-secret", "", "Name of an existing secret containing the external-dns credentials.")
+	cmd.PersistentFlags().StringVar(&opts.ExternalDNSRoleARN, "external-dns-role-arn", "", "IAM role ARN for external-dns Route53 access (alternative to --external-dns-credentials; uses web identity or instance role based on --aws-role-credential-source)")
 	cmd.PersistentFlags().StringVar(&opts.ExternalDNSDomainFilter, "external-dns-domain-filter", "", "Restrict external-dns to changes within the specified domain.")
 	cmd.PersistentFlags().StringVar(&opts.ExternalDNSTxtOwnerId, "external-dns-txt-owner-id", "", "external-dns TXT registry owner ID.")
 	cmd.PersistentFlags().StringVar(&opts.ExternalDNSImage, "external-dns-image", opts.ExternalDNSImage, "Image to use for external-dns")
@@ -453,6 +505,8 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&opts.ScaleFromZeroCredentialsSecret, "scale-from-zero-secret", opts.ScaleFromZeroCredentialsSecret, "Name of existing secret containing scale-from-zero credentials (alternative to --scale-from-zero-creds)")
 	cmd.PersistentFlags().StringVar(&opts.ScaleFromZeroCredentialsSecretKey, "scale-from-zero-secret-key", opts.ScaleFromZeroCredentialsSecretKey, "Key within the scale-from-zero credentials secret (default: credentials)")
 	cmd.PersistentFlags().StringArrayVar(&opts.HCPEgressBlockCIDRs, "hcp-egress-block-cidrs", nil, "Static CIDRs to block in HCP namespace egress NetworkPolicies instead of dynamically-discovered hosting cluster KAS endpoint IPs. When specified, eliminates NetworkPolicy churn during hosting cluster KAS rolling restarts and avoids OVN port-group reconciliation races that can drop traffic to HCP routers. May be specified multiple times.")
+	cmd.PersistentFlags().StringVar(&opts.AWSRoleCredentialSource, "aws-role-credential-source", aws.CredentialSourceWebIdentity, "Credential source for AWS role ARN flags: 'web-identity' (uses projected SA token) or 'ec2-instance-metadata' (uses EC2 instance metadata)")
+	cmd.PersistentFlags().StringVar(&opts.AWSOperatorRolesFile, "aws-operator-roles-file", "", "Path to JSON output file from 'hypershift create operator-roles aws' (sets all three role ARN flags at once)")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		return InstallHyperShiftOperator(cmd.Context(), cmd.OutOrStdout(), opts)
@@ -469,6 +523,9 @@ func NewCommand() *cobra.Command {
 func InstallHyperShiftOperator(ctx context.Context, out io.Writer, opts Options) error {
 	opts.ApplyDefaults()
 
+	if err := opts.Complete(); err != nil {
+		return err
+	}
 	if err := opts.Validate(); err != nil {
 		return err
 	}
@@ -1372,7 +1429,13 @@ func setupExternalDNS(opts Options, operatorNamespace *corev1.Namespace) ([]crcl
 	objects = append(objects, externalDNSClusterRoleBinding)
 
 	var externalDNSSecret *corev1.Secret
-	if opts.ExternalDNSCredentials != "" {
+	if opts.ExternalDNSRoleARN != "" {
+		externalDNSSecret = assets.ExternalDNSCredsSecret{
+			Namespace:  operatorNamespace,
+			CredsBytes: []byte(awsRoleCredentialFileContent(opts.ExternalDNSRoleARN, opts.AWSRoleCredentialSource)),
+		}.Build()
+		objects = append(objects, externalDNSSecret)
+	} else if opts.ExternalDNSCredentials != "" {
 		externalDNSCreds, err := os.ReadFile(opts.ExternalDNSCredentials)
 		if err != nil {
 			return nil, err
@@ -1392,6 +1455,7 @@ func setupExternalDNS(opts Options, operatorNamespace *corev1.Namespace) ([]crcl
 		}
 	}
 
+	useWebIdentity := opts.ExternalDNSRoleARN != "" && opts.AWSRoleCredentialSource == aws.CredentialSourceWebIdentity
 	externalDNSDeployment := assets.ExternalDNSDeployment{
 		Namespace:             operatorNamespace,
 		Image:                 opts.ExternalDNSImage,
@@ -1404,6 +1468,7 @@ func setupExternalDNS(opts Options, operatorNamespace *corev1.Namespace) ([]crcl
 		GoogleProject:         opts.ExternalDNSGoogleProject,
 		Interval:              opts.ExternalDNSInterval,
 		AWSZonesCacheDuration: opts.ExternalDNSAWSZonesCacheDuration,
+		UseWebIdentity:        useWebIdentity,
 	}.Build()
 	objects = append(objects, externalDNSDeployment)
 
@@ -1586,7 +1651,14 @@ func setupAuth(opts Options, operatorNamespace *corev1.Namespace) (*corev1.Secre
 		objects = append(objects, pullSecret)
 	}
 
-	if opts.OIDCStorageProviderS3Credentials != "" {
+	if opts.OIDCStorageProviderS3RoleARN != "" {
+		oidcSecret = assets.HyperShiftOperatorOIDCProviderS3Secret{
+			Namespace:                      operatorNamespace,
+			OIDCStorageProviderS3CredBytes: []byte(awsRoleCredentialFileContent(opts.OIDCStorageProviderS3RoleARN, opts.AWSRoleCredentialSource)),
+			CredsKey:                       opts.OIDCStorageProviderS3CredentialsSecretKey,
+		}.Build()
+		objects = append(objects, oidcSecret)
+	} else if opts.OIDCStorageProviderS3Credentials != "" {
 		oidcCreds, err := os.ReadFile(opts.OIDCStorageProviderS3Credentials)
 		if err != nil {
 			return nil, nil, nil, nil, nil, err
@@ -1609,7 +1681,14 @@ func setupAuth(opts Options, operatorNamespace *corev1.Namespace) (*corev1.Secre
 
 	switch hyperv1.PlatformType(opts.PrivatePlatform) {
 	case hyperv1.AWSPlatform:
-		if opts.AWSPrivateCreds != "" {
+		if opts.AWSPrivateRoleARN != "" {
+			operatorCredentialsSecret = assets.HyperShiftOperatorCredentialsSecret{
+				Namespace:  operatorNamespace,
+				CredsBytes: []byte(awsRoleCredentialFileContent(opts.AWSPrivateRoleARN, opts.AWSRoleCredentialSource)),
+				CredsKey:   opts.AWSPrivateCredentialsSecretKey,
+			}.Build()
+			objects = append(objects, operatorCredentialsSecret)
+		} else if opts.AWSPrivateCreds != "" {
 			credBytes, err := os.ReadFile(opts.AWSPrivateCreds)
 			if err != nil {
 				return nil, nil, nil, nil, nil, err
@@ -1694,4 +1773,32 @@ func setupAuth(opts Options, operatorNamespace *corev1.Namespace) (*corev1.Secre
 	}
 
 	return oidcSecret, operatorCredentialsSecret, azureCredentialsSecret, scaleFromZeroSecret, objects, nil
+}
+
+func (o *Options) loadOperatorRolesFile() error {
+	if o.AWSOperatorRolesFile == "" {
+		return nil
+	}
+	if o.AWSPrivateRoleARN != "" || o.OIDCStorageProviderS3RoleARN != "" || o.ExternalDNSRoleARN != "" {
+		return fmt.Errorf("--aws-operator-roles-file cannot be combined with --aws-private-role-arn, --oidc-storage-provider-s3-role-arn, or --external-dns-role-arn")
+	}
+	data, err := os.ReadFile(o.AWSOperatorRolesFile)
+	if err != nil {
+		return fmt.Errorf("failed to read operator roles file: %w", err)
+	}
+	var roles aws.CreateOperatorRolesOutput
+	if err := json.Unmarshal(data, &roles); err != nil {
+		return fmt.Errorf("failed to parse operator roles file: %w", err)
+	}
+	o.AWSPrivateRoleARN = roles.OperatorEC2RoleARN
+	o.OIDCStorageProviderS3RoleARN = roles.OperatorOIDCS3RoleARN
+	o.ExternalDNSRoleARN = roles.ExternalDNSRoleARN
+	return nil
+}
+
+func awsRoleCredentialFileContent(roleARN, credentialSource string) string {
+	if credentialSource == aws.CredentialSourceEC2InstanceMetadata {
+		return fmt.Sprintf("[default]\nrole_arn = %s\ncredential_source = Ec2InstanceMetadata\n", roleARN)
+	}
+	return fmt.Sprintf("[default]\nrole_arn = %s\nweb_identity_token_file = /var/run/secrets/openshift/serviceaccount/token\n", roleARN)
 }

--- a/cmd/install/install_helm.go
+++ b/cmd/install/install_helm.go
@@ -51,6 +51,10 @@ func NewHelmRenderCommand(opts *Options) *cobra.Command {
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		opts.ApplyDefaults()
 
+		if err := opts.Complete(); err != nil {
+			return err
+		}
+
 		// Helm rendering doesn't need to check for existing CRDs, so pass nil for client
 		crds, manifests, err := hyperShiftOperatorTemplateManifest(cmd.Context(), nil, opts, helmTemplateParams)
 		if err != nil {

--- a/cmd/install/install_render.go
+++ b/cmd/install/install_render.go
@@ -100,6 +100,9 @@ func (o *Options) ValidateRender() error {
 func RenderHyperShiftOperator(ctx context.Context, cmdOut io.Writer, opts *Options) error {
 	opts.ApplyDefaults()
 
+	if err := opts.Complete(); err != nil {
+		return err
+	}
 	var err error
 	if err = opts.ValidateRender(); err != nil {
 		return err

--- a/cmd/install/install_test.go
+++ b/cmd/install/install_test.go
@@ -3,6 +3,7 @@ package install
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"io/fs"
 	"os"
@@ -14,6 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	aws "github.com/openshift/hypershift/cmd/infra/aws"
 	"github.com/openshift/hypershift/cmd/install/assets"
 	crdassets "github.com/openshift/hypershift/cmd/install/assets/crds"
 	"github.com/openshift/hypershift/hypershift-operator/controllers/sharedingress"
@@ -62,6 +64,69 @@ func TestOptions_Validate(t *testing.T) {
 				PrivatePlatform:             string(hyperv1.AWSPlatform),
 				AWSPrivateCredentialsSecret: "my-secret",
 				AWSPrivateRegion:            "us-east-1",
+			},
+			expectError: false,
+		},
+		"When AWS private platform with role ARN and region it should succeed": {
+			inputOptions: Options{
+				PrivatePlatform:         string(hyperv1.AWSPlatform),
+				AWSPrivateRoleARN:       "arn:aws:iam::123456789012:role/op-ec2",
+				AWSPrivateRegion:        "us-east-1",
+				AWSRoleCredentialSource: "web-identity",
+			},
+			expectError: false,
+		},
+		"When AWS private platform with role ARN and creds file it should error": {
+			inputOptions: Options{
+				PrivatePlatform:         string(hyperv1.AWSPlatform),
+				AWSPrivateRoleARN:       "arn:aws:iam::123456789012:role/op-ec2",
+				AWSPrivateCreds:         "/path/to/credentials",
+				AWSPrivateRegion:        "us-east-1",
+				AWSRoleCredentialSource: "web-identity",
+			},
+			expectError: true,
+		},
+		"When AWS private platform with both creds file and secret it should error": {
+			inputOptions: Options{
+				PrivatePlatform:             string(hyperv1.AWSPlatform),
+				AWSPrivateCreds:             "/path/to/credentials",
+				AWSPrivateCredentialsSecret: "my-secret",
+				AWSPrivateRegion:            "us-east-1",
+			},
+			expectError: true,
+		},
+		"When AWS private platform with role ARN and no region it should error": {
+			inputOptions: Options{
+				PrivatePlatform:         string(hyperv1.AWSPlatform),
+				AWSPrivateRoleARN:       "arn:aws:iam::123456789012:role/op-ec2",
+				AWSRoleCredentialSource: "web-identity",
+			},
+			expectError: true,
+		},
+		"When role ARN is set with invalid credential source it should error": {
+			inputOptions: Options{
+				PrivatePlatform:         string(hyperv1.AWSPlatform),
+				AWSPrivateRoleARN:       "arn:aws:iam::123456789012:role/op-ec2",
+				AWSPrivateRegion:        "us-east-1",
+				AWSRoleCredentialSource: "invalid-source",
+			},
+			expectError: true,
+		},
+		"When role ARN is set with web-identity credential source it should succeed": {
+			inputOptions: Options{
+				PrivatePlatform:         string(hyperv1.AWSPlatform),
+				AWSPrivateRoleARN:       "arn:aws:iam::123456789012:role/op-ec2",
+				AWSPrivateRegion:        "us-east-1",
+				AWSRoleCredentialSource: "web-identity",
+			},
+			expectError: false,
+		},
+		"When role ARN is set with ec2-instance-metadata credential source it should succeed": {
+			inputOptions: Options{
+				PrivatePlatform:         string(hyperv1.AWSPlatform),
+				AWSPrivateRoleARN:       "arn:aws:iam::123456789012:role/op-ec2",
+				AWSPrivateRegion:        "us-east-1",
+				AWSRoleCredentialSource: "ec2-instance-metadata",
 			},
 			expectError: false,
 		},
@@ -364,7 +429,10 @@ func TestOptions_Validate(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			g := NewGomegaWithT(t)
-			err := test.inputOptions.Validate()
+			err := test.inputOptions.Complete()
+			if err == nil {
+				err = test.inputOptions.Validate()
+			}
 			if test.expectError {
 				g.Expect(err).To(HaveOccurred())
 			} else {
@@ -2134,6 +2202,220 @@ func TestHyperShiftOperatorManifests_WebhookFlags(t *testing.T) {
 					g.Expect(crd.Spec.Conversion.Webhook.ConversionReviewVersions).To(ConsistOf("v1beta1", "v1beta2"), "CRD %s review versions", crd.Name)
 				} else {
 					g.Expect(crd.Spec.Conversion).To(BeNil(), "CRD %s should not have conversion when CAPI conversion is disabled", crd.Name)
+				}
+			}
+		})
+	}
+}
+
+func TestAwsRoleCredentialFileContent(t *testing.T) {
+	tests := map[string]struct {
+		roleARN          string
+		credentialSource string
+		expectContains   []string
+	}{
+		"When credential source is web-identity it should include token file path": {
+			roleARN:          "arn:aws:iam::123456789012:role/test-role",
+			credentialSource: aws.CredentialSourceWebIdentity,
+			expectContains: []string{
+				"role_arn = arn:aws:iam::123456789012:role/test-role",
+				"web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token",
+			},
+		},
+		"When credential source is ec2-instance-metadata it should include Ec2InstanceMetadata": {
+			roleARN:          "arn:aws:iam::123456789012:role/test-role",
+			credentialSource: aws.CredentialSourceEC2InstanceMetadata,
+			expectContains: []string{
+				"role_arn = arn:aws:iam::123456789012:role/test-role",
+				"credential_source = Ec2InstanceMetadata",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			content := awsRoleCredentialFileContent(test.roleARN, test.credentialSource)
+			for _, s := range test.expectContains {
+				g.Expect(content).To(ContainSubstring(s))
+			}
+			g.Expect(content).To(HavePrefix("[default]"))
+		})
+	}
+}
+
+func TestLoadOperatorRolesFile(t *testing.T) {
+	tests := map[string]struct {
+		setup       func(t *testing.T) Options
+		expectError bool
+		validate    func(*GomegaWithT, Options)
+	}{
+		"When no roles file is specified it should be a no-op": {
+			setup: func(t *testing.T) Options {
+				return Options{}
+			},
+			validate: func(g *GomegaWithT, o Options) {
+				g.Expect(o.AWSPrivateRoleARN).To(BeEmpty())
+				g.Expect(o.OIDCStorageProviderS3RoleARN).To(BeEmpty())
+				g.Expect(o.ExternalDNSRoleARN).To(BeEmpty())
+			},
+		},
+		"When a valid roles file is specified it should populate role ARN fields": {
+			setup: func(t *testing.T) Options {
+				roles := aws.CreateOperatorRolesOutput{
+					OperatorEC2RoleARN:    "arn:aws:iam::123456789012:role/op-ec2",
+					OperatorOIDCS3RoleARN: "arn:aws:iam::123456789012:role/op-s3",
+					ExternalDNSRoleARN:    "arn:aws:iam::123456789012:role/ext-dns",
+				}
+				data, err := json.Marshal(roles)
+				if err != nil {
+					t.Fatal(err)
+				}
+				f := filepath.Join(t.TempDir(), "roles.json")
+				if err := os.WriteFile(f, data, 0644); err != nil {
+					t.Fatal(err)
+				}
+				return Options{AWSOperatorRolesFile: f}
+			},
+			validate: func(g *GomegaWithT, o Options) {
+				g.Expect(o.AWSPrivateRoleARN).To(Equal("arn:aws:iam::123456789012:role/op-ec2"))
+				g.Expect(o.OIDCStorageProviderS3RoleARN).To(Equal("arn:aws:iam::123456789012:role/op-s3"))
+				g.Expect(o.ExternalDNSRoleARN).To(Equal("arn:aws:iam::123456789012:role/ext-dns"))
+			},
+		},
+		"When roles file conflicts with --aws-private-role-arn it should error": {
+			setup: func(t *testing.T) Options {
+				f := filepath.Join(t.TempDir(), "roles.json")
+				if err := os.WriteFile(f, []byte(`{}`), 0644); err != nil {
+					t.Fatal(err)
+				}
+				return Options{
+					AWSOperatorRolesFile: f,
+					AWSPrivateRoleARN:    "arn:aws:iam::123456789012:role/existing",
+				}
+			},
+			expectError: true,
+		},
+		"When roles file conflicts with --oidc-storage-provider-s3-role-arn it should error": {
+			setup: func(t *testing.T) Options {
+				f := filepath.Join(t.TempDir(), "roles.json")
+				if err := os.WriteFile(f, []byte(`{}`), 0644); err != nil {
+					t.Fatal(err)
+				}
+				return Options{
+					AWSOperatorRolesFile:         f,
+					OIDCStorageProviderS3RoleARN: "arn:aws:iam::123456789012:role/existing",
+				}
+			},
+			expectError: true,
+		},
+		"When roles file conflicts with --external-dns-role-arn it should error": {
+			setup: func(t *testing.T) Options {
+				f := filepath.Join(t.TempDir(), "roles.json")
+				if err := os.WriteFile(f, []byte(`{}`), 0644); err != nil {
+					t.Fatal(err)
+				}
+				return Options{
+					AWSOperatorRolesFile: f,
+					ExternalDNSRoleARN:   "arn:aws:iam::123456789012:role/existing",
+				}
+			},
+			expectError: true,
+		},
+		"When roles file does not exist it should error": {
+			setup: func(t *testing.T) Options {
+				return Options{AWSOperatorRolesFile: "/nonexistent/path/roles.json"}
+			},
+			expectError: true,
+		},
+		"When roles file contains invalid JSON it should error": {
+			setup: func(t *testing.T) Options {
+				f := filepath.Join(t.TempDir(), "roles.json")
+				if err := os.WriteFile(f, []byte("not json"), 0644); err != nil {
+					t.Fatal(err)
+				}
+				return Options{AWSOperatorRolesFile: f}
+			},
+			expectError: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			opts := test.setup(t)
+			err := opts.loadOperatorRolesFile()
+			if test.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+				if test.validate != nil {
+					test.validate(g, opts)
+				}
+			}
+		})
+	}
+}
+
+func TestComplete(t *testing.T) {
+	tests := map[string]struct {
+		setup       func(t *testing.T) Options
+		expectError bool
+		validate    func(*GomegaWithT, Options)
+	}{
+		"When no operator roles file it should complete successfully": {
+			setup: func(t *testing.T) Options {
+				return Options{}
+			},
+		},
+		"When ScaleFromZeroProvider has whitespace and uppercase it should normalize": {
+			setup: func(t *testing.T) Options {
+				return Options{ScaleFromZeroProvider: "  AWS  "}
+			},
+			validate: func(g *GomegaWithT, o Options) {
+				g.Expect(o.ScaleFromZeroProvider).To(Equal("aws"))
+			},
+		},
+		"When a valid operator roles file is specified it should load ARNs": {
+			setup: func(t *testing.T) Options {
+				roles := aws.CreateOperatorRolesOutput{
+					OperatorEC2RoleARN:    "arn:aws:iam::123456789012:role/op-ec2",
+					OperatorOIDCS3RoleARN: "arn:aws:iam::123456789012:role/op-s3",
+					ExternalDNSRoleARN:    "arn:aws:iam::123456789012:role/ext-dns",
+				}
+				data, err := json.Marshal(roles)
+				if err != nil {
+					t.Fatal(err)
+				}
+				f := filepath.Join(t.TempDir(), "roles.json")
+				if err := os.WriteFile(f, data, 0644); err != nil {
+					t.Fatal(err)
+				}
+				return Options{AWSOperatorRolesFile: f}
+			},
+			validate: func(g *GomegaWithT, o Options) {
+				g.Expect(o.AWSPrivateRoleARN).To(Equal("arn:aws:iam::123456789012:role/op-ec2"))
+			},
+		},
+		"When operator roles file does not exist it should return error": {
+			setup: func(t *testing.T) Options {
+				return Options{AWSOperatorRolesFile: "/nonexistent/path/roles.json"}
+			},
+			expectError: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			opts := test.setup(t)
+			err := opts.Complete()
+			if test.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+				if test.validate != nil {
+					test.validate(g, opts)
 				}
 			}
 		})

--- a/docs/content/how-to/install/index.md
+++ b/docs/content/how-to/install/index.md
@@ -20,3 +20,145 @@ the following flag in your HO install command:
     Limiting the CAPI CRDs installed means the HO will only be able to manage HostedClusters of the same platform.
     For example, in the above example, if you limit the CRDs to AWS and Azure, the HO will only be able to manage 
     AWS and Azure HostedClusters.
+
+## AWS operator IAM roles
+
+When installing the HyperShift operator on AWS, the operator and its external-dns
+component need AWS credentials. Instead of providing long-lived credential files,
+you can create least-privilege IAM roles and pass their ARNs to the install
+command. The `hypershift create operator-roles aws` command automates role
+creation, and the `hypershift install` command accepts role ARN flags as
+alternatives to credential file flags.
+
+### Creating operator roles
+
+The `hypershift create operator-roles aws` command creates three IAM roles:
+
+| Role | Purpose |
+|------|---------|
+| `<prefix>-operator-ec2` | EC2 VPC endpoint service management, ELB discovery, and instance type queries |
+| `<prefix>-operator-oidc-s3` | Upload and delete OIDC discovery documents in the S3 bucket |
+| `<prefix>-external-dns` | Route53 DNS record management for external-dns |
+
+The command supports two trust modes, depending on whether the management
+cluster has an OIDC provider registered in AWS IAM:
+
+- **OIDC web identity** (default): The roles trust the management cluster's OIDC
+  provider and are scoped to specific service accounts. If `--oidc-issuer-url` is
+  not specified, the command auto-discovers it from the management cluster's
+  `Authentication` CR.
+- **Instance role assumption**: For clusters without an OIDC provider, use
+  `--instance-role-arn` to trust an existing instance role via `sts:AssumeRole`.
+
+#### Usage
+
+```bash
+hypershift create operator-roles aws \
+  --oidc-storage-provider-s3-bucket-name <bucket-name> \
+  [--region <aws-region>] \
+  [--name-prefix <prefix>] \
+  [--oidc-issuer-url <url> | --instance-role-arn <arn>] \
+  [--route53-hosted-zone-id <zone-id>] \
+  [--operator-namespace <namespace>] \
+  [--output-file <path>] \
+  [--additional-tags key=value,...]
+```
+
+#### Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--oidc-storage-provider-s3-bucket-name` | Yes | | S3 bucket name for OIDC documents (scopes the S3 policy) |
+| `--region` | No | `AWS_REGION`, `AWS_DEFAULT_REGION`, or `~/.aws/config` | AWS region |
+| `--name-prefix` | No | `hypershift` | Prefix for IAM role names |
+| `--oidc-issuer-url` | No | Auto-discovered from cluster | Management cluster OIDC issuer URL for web identity trust. Mutually exclusive with `--instance-role-arn` |
+| `--instance-role-arn` | No | | ARN of an instance role to trust via `sts:AssumeRole`. Mutually exclusive with `--oidc-issuer-url` |
+| `--route53-hosted-zone-id` | No | All zones | Route53 hosted zone ID to scope the external-dns policy |
+| `--operator-namespace` | No | `hypershift` | Namespace where the HyperShift operator is installed |
+| `--output-file` | No | stdout | Path to write JSON output |
+| `--additional-tags` | No | | Additional tags to set on IAM resources (`key=value`) |
+
+#### Output
+
+The command outputs a JSON object with the ARNs of the created roles:
+
+```json
+{
+  "operatorEC2RoleARN": "arn:aws:iam::123456789012:role/hypershift-operator-ec2",
+  "operatorOIDCS3RoleARN": "arn:aws:iam::123456789012:role/hypershift-operator-oidc-s3",
+  "externalDNSRoleARN": "arn:aws:iam::123456789012:role/hypershift-external-dns"
+}
+```
+
+#### Example: OIDC web identity (auto-discovered)
+
+```bash
+hypershift create operator-roles aws \
+  --oidc-storage-provider-s3-bucket-name my-oidc-bucket \
+  --route53-hosted-zone-id Z0123456789ABCDEF \
+  --output-file operator-roles.json
+```
+
+#### Example: Instance role trust
+
+```bash
+hypershift create operator-roles aws \
+  --oidc-storage-provider-s3-bucket-name my-oidc-bucket \
+  --instance-role-arn arn:aws:iam::123456789012:role/my-instance-role \
+  --output-file operator-roles.json
+```
+
+### Installing with role ARNs
+
+The `hypershift install` command accepts IAM role ARNs as alternatives to
+credential file flags. When a role ARN is provided, the installer generates
+a credential file automatically based on `--aws-role-credential-source`.
+
+#### Role ARN install flags
+
+| Flag | Replaces | Description |
+|------|----------|-------------|
+| `--aws-private-role-arn` | `--aws-private-creds` | IAM role ARN for EC2/ELBv2 credentials |
+| `--oidc-storage-provider-s3-role-arn` | `--oidc-storage-provider-s3-credentials` | IAM role ARN for OIDC S3 access |
+| `--external-dns-role-arn` | `--external-dns-credentials` | IAM role ARN for external-dns Route53 access |
+| `--aws-role-credential-source` | | Credential source: `web-identity` (default) or `ec2-instance-metadata` |
+| `--aws-operator-roles-file` | | Path to JSON output from `create operator-roles aws` (sets all three role ARN flags at once) |
+
+!!! note
+
+    Each role ARN flag is mutually exclusive with its corresponding credential
+    file flag. You cannot combine `--aws-private-role-arn` with
+    `--aws-private-creds`, for example.
+
+#### Credential source modes
+
+The `--aws-role-credential-source` flag controls how the operator assumes the
+IAM roles:
+
+- **`web-identity`** (default): Uses a projected service account token mounted
+  at `/var/run/secrets/openshift/serviceaccount/token`. Requires the management
+  cluster's OIDC provider to be registered in AWS IAM.
+- **`ec2-instance-metadata`**: Uses the EC2 instance metadata service to assume
+  the role. Suitable for clusters running on EC2 instances that have an instance
+  profile attached.
+
+#### Example: Install using the roles file
+
+The simplest workflow combines `create operator-roles aws` with `install`:
+
+```bash
+# Step 1: Create the IAM roles
+hypershift create operator-roles aws \
+  --oidc-storage-provider-s3-bucket-name my-oidc-bucket \
+  --output-file operator-roles.json
+
+# Step 2: Install using the roles file
+hypershift install \
+  --oidc-storage-provider-s3-bucket-name my-oidc-bucket \
+  --oidc-storage-provider-s3-region us-east-1 \
+  --private-platform AWS \
+  --aws-private-region us-east-1 \
+  --external-dns-provider aws \
+  --external-dns-domain-filter example.com \
+  --aws-operator-roles-file operator-roles.json
+```

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -23260,6 +23260,149 @@ the following flag in your HO install command:
     For example, in the above example, if you limit the CRDs to AWS and Azure, the HO will only be able to manage 
     AWS and Azure HostedClusters.
 
+## AWS operator IAM roles
+
+When installing the HyperShift operator on AWS, the operator and its external-dns
+component need AWS credentials. Instead of providing long-lived credential files,
+you can create least-privilege IAM roles and pass their ARNs to the install
+command. The `hypershift create operator-roles aws` command automates role
+creation, and the `hypershift install` command accepts role ARN flags as
+alternatives to credential file flags.
+
+### Creating operator roles
+
+The `hypershift create operator-roles aws` command creates three IAM roles:
+
+| Role | Purpose |
+|------|---------|
+| `<prefix>-operator-ec2` | EC2 VPC endpoint service management, ELB discovery, and instance type queries |
+| `<prefix>-operator-oidc-s3` | Upload and delete OIDC discovery documents in the S3 bucket |
+| `<prefix>-external-dns` | Route53 DNS record management for external-dns |
+
+The command supports two trust modes, depending on whether the management
+cluster has an OIDC provider registered in AWS IAM:
+
+- **OIDC web identity** (default): The roles trust the management cluster's OIDC
+  provider and are scoped to specific service accounts. If `--oidc-issuer-url` is
+  not specified, the command auto-discovers it from the management cluster's
+  `Authentication` CR.
+- **Instance role assumption**: For clusters without an OIDC provider, use
+  `--instance-role-arn` to trust an existing instance role via `sts:AssumeRole`.
+
+#### Usage
+
+```bash
+hypershift create operator-roles aws \
+  --oidc-storage-provider-s3-bucket-name <bucket-name> \
+  [--region <aws-region>] \
+  [--name-prefix <prefix>] \
+  [--oidc-issuer-url <url> | --instance-role-arn <arn>] \
+  [--route53-hosted-zone-id <zone-id>] \
+  [--operator-namespace <namespace>] \
+  [--output-file <path>] \
+  [--additional-tags key=value,...]
+```
+
+#### Flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--oidc-storage-provider-s3-bucket-name` | Yes | | S3 bucket name for OIDC documents (scopes the S3 policy) |
+| `--region` | No | `AWS_REGION`, `AWS_DEFAULT_REGION`, or `~/.aws/config` | AWS region |
+| `--name-prefix` | No | `hypershift` | Prefix for IAM role names |
+| `--oidc-issuer-url` | No | Auto-discovered from cluster | Management cluster OIDC issuer URL for web identity trust. Mutually exclusive with `--instance-role-arn` |
+| `--instance-role-arn` | No | | ARN of an instance role to trust via `sts:AssumeRole`. Mutually exclusive with `--oidc-issuer-url` |
+| `--route53-hosted-zone-id` | No | All zones | Route53 hosted zone ID to scope the external-dns policy |
+| `--operator-namespace` | No | `hypershift` | Namespace where the HyperShift operator is installed |
+| `--output-file` | No | stdout | Path to write JSON output |
+| `--additional-tags` | No | | Additional tags to set on IAM resources (`key=value`) |
+
+#### Output
+
+The command outputs a JSON object with the ARNs of the created roles:
+
+```json
+{
+  "operatorEC2RoleARN": "arn:aws:iam::123456789012:role/hypershift-operator-ec2",
+  "operatorOIDCS3RoleARN": "arn:aws:iam::123456789012:role/hypershift-operator-oidc-s3",
+  "externalDNSRoleARN": "arn:aws:iam::123456789012:role/hypershift-external-dns"
+}
+```
+
+#### Example: OIDC web identity (auto-discovered)
+
+```bash
+hypershift create operator-roles aws \
+  --oidc-storage-provider-s3-bucket-name my-oidc-bucket \
+  --route53-hosted-zone-id Z0123456789ABCDEF \
+  --output-file operator-roles.json
+```
+
+#### Example: Instance role trust
+
+```bash
+hypershift create operator-roles aws \
+  --oidc-storage-provider-s3-bucket-name my-oidc-bucket \
+  --instance-role-arn arn:aws:iam::123456789012:role/my-instance-role \
+  --output-file operator-roles.json
+```
+
+### Installing with role ARNs
+
+The `hypershift install` command accepts IAM role ARNs as alternatives to
+credential file flags. When a role ARN is provided, the installer generates
+a credential file automatically based on `--aws-role-credential-source`.
+
+#### Role ARN install flags
+
+| Flag | Replaces | Description |
+|------|----------|-------------|
+| `--aws-private-role-arn` | `--aws-private-creds` | IAM role ARN for EC2/ELBv2 credentials |
+| `--oidc-storage-provider-s3-role-arn` | `--oidc-storage-provider-s3-credentials` | IAM role ARN for OIDC S3 access |
+| `--external-dns-role-arn` | `--external-dns-credentials` | IAM role ARN for external-dns Route53 access |
+| `--aws-role-credential-source` | | Credential source: `web-identity` (default) or `ec2-instance-metadata` |
+| `--aws-operator-roles-file` | | Path to JSON output from `create operator-roles aws` (sets all three role ARN flags at once) |
+
+!!! note
+
+    Each role ARN flag is mutually exclusive with its corresponding credential
+    file flag. You cannot combine `--aws-private-role-arn` with
+    `--aws-private-creds`, for example.
+
+#### Credential source modes
+
+The `--aws-role-credential-source` flag controls how the operator assumes the
+IAM roles:
+
+- **`web-identity`** (default): Uses a projected service account token mounted
+  at `/var/run/secrets/openshift/serviceaccount/token`. Requires the management
+  cluster's OIDC provider to be registered in AWS IAM.
+- **`ec2-instance-metadata`**: Uses the EC2 instance metadata service to assume
+  the role. Suitable for clusters running on EC2 instances that have an instance
+  profile attached.
+
+#### Example: Install using the roles file
+
+The simplest workflow combines `create operator-roles aws` with `install`:
+
+```bash
+# Step 1: Create the IAM roles
+hypershift create operator-roles aws \
+  --oidc-storage-provider-s3-bucket-name my-oidc-bucket \
+  --output-file operator-roles.json
+
+# Step 2: Install using the roles file
+hypershift install \
+  --oidc-storage-provider-s3-bucket-name my-oidc-bucket \
+  --oidc-storage-provider-s3-region us-east-1 \
+  --private-platform AWS \
+  --aws-private-region us-east-1 \
+  --external-dns-provider aws \
+  --external-dns-domain-filter example.com \
+  --aws-operator-roles-file operator-roles.json
+```
+
+
 ---
 
 ## Source: docs/content/how-to/kubevirt/configuring-network.md

--- a/support/awsapi/iam.go
+++ b/support/awsapi/iam.go
@@ -36,6 +36,7 @@ type IAMAPI interface {
 	ListRolePolicies(ctx context.Context, input *iam.ListRolePoliciesInput, optFns ...func(*iam.Options)) (*iam.ListRolePoliciesOutput, error)
 	PutRolePolicy(ctx context.Context, input *iam.PutRolePolicyInput, optFns ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error)
 	RemoveRoleFromInstanceProfile(ctx context.Context, input *iam.RemoveRoleFromInstanceProfileInput, optFns ...func(*iam.Options)) (*iam.RemoveRoleFromInstanceProfileOutput, error)
+	UpdateAssumeRolePolicy(ctx context.Context, input *iam.UpdateAssumeRolePolicyInput, optFns ...func(*iam.Options)) (*iam.UpdateAssumeRolePolicyOutput, error)
 }
 
 // Ensure *iam.Client implements IAMAPI


### PR DESCRIPTION
## Summary

- Add `hypershift create operator-roles aws` command to create least-privilege IAM roles for the HyperShift operator and external-dns, supporting OIDC web identity and instance role assumption trust modes
- Add `--aws-private-role-arn`, `--oidc-storage-provider-s3-role-arn`, `--external-dns-role-arn`, and `--aws-role-credential-source` flags to the install command as alternatives to credential file flags
- Auto-generate credential files from role ARNs during install

## Jira

https://redhat.atlassian.net/browse/CNTRLPLANE-3529

## Test plan

- [ ] Unit tests pass for role creation and install flag logic
- [ ] `hypershift create operator-roles aws` creates IAM roles with correct policies in both OIDC and instance role modes
- [ ] `hypershift install` with role ARN flags generates correct credential files and deploys successfully
- [ ] Existing credential file install workflow continues to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `hypershift create operator-roles aws` to provision three least-privilege IAM roles (JSON output and install hint), supporting OIDC web‑identity or instance‑role trust modes and related flags.
  * `hypershift install` and render/helm flows accept role ARN flags or a roles file and respect a credential source (`web-identity` or `ec2-instance-metadata`).
  * ExternalDNS deployment supports projected web‑identity tokens.

* **Documentation**
  * Added AWS installation guide describing role creation, trust modes, flags, JSON output, and role‑ARN install workflows.

* **Chores**
  * CLI now performs option completion earlier, surfacing errors before manifest generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->