### PR TITLE
OCPBUGS-86774: Pin azure-cli to 2.72.0 in e2e Dockerfile

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -30,5 +30,5 @@ COPY --from=builder /hypershift/hack/run-reqserving-e2e.sh /hypershift/hack/run-
 RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc && \
     dnf install -y https://packages.microsoft.com/config/rhel/9/packages-microsoft-prod.rpm && \
     mv /etc/yum.repos.d/microsoft-prod.repo /etc/yum.repos.art/ci/ && \
-    dnf install -y azure-cli && \
+    dnf install -y azure-cli-2.72.0 && \
     dnf clean all


### PR DESCRIPTION
## Summary

- Pin `azure-cli` to version 2.72.0 in `Dockerfile.e2e` to fix 100% e2e CI failure

## Problem

After [openshift/release#79773](https://github.com/openshift/release/pull/79773) switched CI RHEL 9 repos from `mirror2.openshift.com` (GA content) to `cdn.redhat.com` E4S/EUS endpoints, the `hypershift-tests-amd64` Docker image build fails because:

1. `azure-cli >= 2.73.0` requires `python3.12`
2. `python3.12` is **not available** in E4S/EUS repos
3. `dnf install azure-cli` picks the latest version (2.86.0), which cannot be installed

Error:
```
nothing provides python3.12 needed by azure-cli-2.86.0-1.el9.x86_64 from packages-microsoft-com-prod
```

## Fix

Pin to `azure-cli-2.72.0`, the last version that depends on `python3.9` (available in E4S). Version boundary verified from Microsoft's RHEL 9 repo metadata:
- `azure-cli <= 2.72.0` → requires `python3.9`
- `azure-cli >= 2.73.0` → requires `python3.12`

## Timeline

| Time (UTC) | Event |
|---|---|
| May 28 03:17 | Last clean e2e-aws pass |
| May 28 07:49 | openshift/release#79773 merged |
| May 28 08:04 | First `DockerBuildFailed` |
| May 29 05:38+ | 100% failure rate |

## Test plan

- [x] Trigger `/test e2e-aws` to verify image builds successfully
- [ ] Confirm e2e tests pass end-to-end

Fixes: [OCPBUGS-86774](https://issues.redhat.com/browse/OCPBUGS-86774)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the test environment Docker setup by pinning a CLI tool version in the final test image to ensure more reproducible and stable test builds and executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->