### PR TITLE
CNTRLPLANE-3534: ci: add --allowedTools to address-review-comments workflow

### DIFF
--- a/.github/workflows/address-review-comments.yaml
+++ b/.github/workflows/address-review-comments.yaml
@@ -25,6 +25,14 @@ jobs:
     env:
       HOME: /tmp
     steps:
+      - name: Link to run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --body "🤖 Addressing review comments: [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+
       - name: Get PR ref
         id: pr
         run: |
@@ -68,4 +76,4 @@ jobs:
           PR_NUMBER: ${{ github.event.issue.number }}
         run: |
           claude --version
-          claude -p "/utils:address-reviews $PR_NUMBER" --model claude-opus-4-6 --max-turns 100
+          claude -p "/utils:address-reviews $PR_NUMBER" --model claude-opus-4-6 --max-turns 100 --allowedTools "Bash Read Write Edit Grep Glob WebFetch"


### PR DESCRIPTION
## Summary
- Add `--allowedTools "Bash Read Write Edit Grep Glob WebFetch"` to the Claude Code invocation in the address-review-comments GHA workflow
- Without this flag, Claude prompts for tool permissions in non-interactive mode and exits without doing any work ([failed run](https://github.com/openshift/hypershift/actions/runs/26648851238/job/78541638670))
- Matches the same allowlist used by the Prow review-agent job in openshift/release
- Add a "Link to run" step that posts a comment on the PR with a direct link to the workflow run, since `issue_comment`-triggered runs don't appear in the PR checks tab

## Jira
https://redhat.atlassian.net/browse/CNTRLPLANE-3534

## Test plan
- [ ] Trigger `/address-review-comments` on a PR after merge and verify Claude processes reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)