### PR TITLE
CNTRLPLANE-3533: Add Dockerfiles to codecov ignore list

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -15,6 +15,7 @@ ignore:
   - "**/*.md"
   - "**/*.yaml"
   - "**/*.yml"
+  - "**/Dockerfile*"
   - "*.mod"
   - "*.sum"
   # Generated mock files


### PR DESCRIPTION
## Summary

- Adds `**/Dockerfile*` to the codecov ignore list so Dockerfile-only PRs (e.g. #8627) don't fail patch coverage checks

## Test plan

- [ ] Verify codecov no longer flags Dockerfile changes as uncovered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage reporting configuration to exclude Docker-related files from coverage metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->