### PR TITLE
CNTRLPLANE-3535: Add codecov carryforward flags to stabilize project coverage checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,18 @@ codecov:
   notify:
     wait_for_ci: false
 
+flags:
+  cpo-hostedcontrolplane:
+    carryforward: true
+  cpo-other:
+    carryforward: true
+  hypershift-operator:
+    carryforward: true
+  cmd-support:
+    carryforward: true
+  other:
+    carryforward: true
+
 ignore:
   - "test/**"
   - "hack/**"


### PR DESCRIPTION
## Summary

- Adds `carryforward: true` flag definitions for all 5 unit test shards in `codecov.yml`
- Fixes nondeterministic `codecov/project` check failures across PRs

## Problem

Unit tests run in 5 parallel shards (`cpo-hostedcontrolplane`, `cpo-other`, `hypershift-operator`, `cmd-support`, `other`), each uploading a separate coverage file. Without `carryforward`, Codecov recomputes the project total after each shard arrives and posts intermediate `codecov/project` statuses. The last shard to arrive determines pass/fail.

Evidence from main branch: coverage on the same commit swings between ~40% and ~47% depending on shard upload timing. For example, commit `adfbcddc2e` went 41.80% → 47.18% → 45.84% within 10 minutes as shards arrived.

## Fix

With `carryforward: true`, when a shard hasn't uploaded yet for a given commit, Codecov uses its last-known coverage data instead of treating it as empty. This stabilizes the project total from the first status update through the last.

## Test plan

- [ ] Verify `codecov/project` status stabilizes on this PR (should not show ~5% swings between shard uploads)
- [ ] Confirm the check remains blocking (no `informational: true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code coverage configuration to enable persistent tracking of coverage data across multiple components and continuous integration runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->