### PR TITLE
NO-JIRA: ci(runner): update base image to actions-runner v2.334.0

### DIFF
--- a/Dockerfile.github-actions-runner
+++ b/Dockerfile.github-actions-runner
@@ -1,4 +1,4 @@
-FROM ghcr.io/actions/actions-runner@sha256:1ad983536759ceec39ed75a2c8f007ca8c37b66eee35ed86f13623b29a4db97d
+FROM ghcr.io/actions/actions-runner@sha256:b6614fce332517f74d0a76e7c762fb08e4f2ff13dcf333183397c8a5725b6e8e
 
 USER root
 


### PR DESCRIPTION
## Summary

- Update the pinned `ghcr.io/actions/actions-runner` base image digest from v2.333.0 to v2.334.0
- GitHub deprecated runner v2.333.0 server-side on 2026-05-29, causing all self-hosted runner pods to crash-loop with `HTTP 403 Forbidden` from the broker API

## What happened

At approximately 1:00 PM ET on May 29, GitHub began rejecting runner v2.333.0 at the message broker endpoint (`broker.actions.githubusercontent.com`). Runners connect and authenticate successfully, but the first poll for jobs returns:

```
GET request to https://broker.actions.githubusercontent.com/message?...&runnerVersion=2.333.0&... failed. HTTP Status: Forbidden

An error occurred: Runner version v2.333.0 is deprecated and cannot receive messages.
```

This causes every ephemeral runner pod to exit within ~2 seconds of starting, with ARC continuously spinning up 70 replacement pods that all fail the same way.

Full runner pod log attached: [arc-runner-deprecation-log.txt](https://github.com/openshift/hypershift/files/arc-runner-deprecation-log.txt)

## Fix

Update the base image digest to v2.334.0 (the current `:latest`). Once merged, Konflux will rebuild and push the runner image, and new pods will self-heal.

## Test plan

- [ ] Konflux builds the new image successfully
- [ ] Runner pods connect to GitHub and pick up jobs
- [ ] GHA checks on PRs complete (lint, test, verify, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions runner infrastructure to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->