### PR TITLE
fix: OCPBUGS-86799: Add SpotTerminationHandlerConfigured condition for spot NodePools

### DIFF
--- a/api/hypershift/v1beta1/nodepool_conditions.go
+++ b/api/hypershift/v1beta1/nodepool_conditions.go
@@ -84,6 +84,12 @@ const (
 	// KubeVirtNodesLiveMigratable indicates if all (VirtualMachines) nodes of the kubevirt
 	// hosted cluster can be live migrated without experiencing a node restart
 	NodePoolKubeVirtLiveMigratableType = "KubeVirtNodesLiveMigratable"
+
+	// NodePoolSpotTerminationHandlerConfiguredConditionType signals whether the required
+	// infrastructure for graceful spot instance termination handling is configured on the HostedCluster.
+	// When False, spot interruptions will result in abrupt instance termination with no graceful pod drain.
+	// This condition is only set on NodePools with spot instances enabled.
+	NodePoolSpotTerminationHandlerConfiguredConditionType = "SpotTerminationHandlerConfigured"
 )
 
 // PerformanceProfile Conditions
@@ -114,19 +120,20 @@ const (
 
 // Reasons
 const (
-	NodePoolValidationFailedReason        = "ValidationFailed"
-	NodePoolInplaceUpgradeFailedReason    = "InplaceUpgradeFailed"
-	NodePoolNotFoundReason                = "NotFound"
-	NodePoolFailedToGetReason             = "FailedToGet"
-	IgnitionEndpointMissingReason         = "IgnitionEndpointMissing"
-	IgnitionCACertMissingReason           = "IgnitionCACertMissing"
-	IgnitionNotReached                    = "ignitionNotReached"
-	DefaultAWSSecurityGroupNotReadyReason = "DefaultSGNotReady"
-	NodePoolValidArchPlatform             = "ValidArchPlatform"
-	NodePoolInvalidArchPlatform           = "InvalidArchPlatform"
-	InvalidKubevirtMachineTemplate        = "InvalidKubevirtMachineTemplate"
-	InvalidOpenStackMachineTemplate       = "InvalidOpenStackMachineTemplate"
-	CIDRConflictReason                    = "CIDRConflict"
-	NodePoolKubeVirtLiveMigratableReason  = "KubeVirtNodesNotLiveMigratable"
-	NodePoolUnsupportedSkewReason         = "UnsupportedSkew"
+	NodePoolValidationFailedReason         = "ValidationFailed"
+	NodePoolInplaceUpgradeFailedReason     = "InplaceUpgradeFailed"
+	NodePoolNotFoundReason                 = "NotFound"
+	NodePoolFailedToGetReason              = "FailedToGet"
+	IgnitionEndpointMissingReason          = "IgnitionEndpointMissing"
+	IgnitionCACertMissingReason            = "IgnitionCACertMissing"
+	IgnitionNotReached                     = "ignitionNotReached"
+	DefaultAWSSecurityGroupNotReadyReason  = "DefaultSGNotReady"
+	NodePoolValidArchPlatform              = "ValidArchPlatform"
+	NodePoolInvalidArchPlatform            = "InvalidArchPlatform"
+	InvalidKubevirtMachineTemplate         = "InvalidKubevirtMachineTemplate"
+	InvalidOpenStackMachineTemplate        = "InvalidOpenStackMachineTemplate"
+	CIDRConflictReason                     = "CIDRConflict"
+	NodePoolKubeVirtLiveMigratableReason   = "KubeVirtNodesNotLiveMigratable"
+	NodePoolUnsupportedSkewReason          = "UnsupportedSkew"
+	TerminationHandlerQueueURLNotSetReason = "TerminationHandlerQueueURLNotSet"
 )

--- a/hypershift-operator/controllers/nodepool/conditions.go
+++ b/hypershift-operator/controllers/nodepool/conditions.go
@@ -925,6 +925,34 @@ func (r NodePoolReconciler) validPlatformConfigCondition(ctx context.Context, no
 	return nil, nil
 }
 
+// spotTerminationHandlerConfiguredCondition sets the SpotTerminationHandlerConfigured condition
+// on spot-enabled NodePools. It warns when the HostedCluster does not have terminationHandlerQueueURL
+// configured, which means NTH cannot be deployed and spot interruptions will not be gracefully handled.
+func (r *NodePoolReconciler) spotTerminationHandlerConfiguredCondition(_ context.Context, nodePool *hyperv1.NodePool, hc *hyperv1.HostedCluster) (*ctrl.Result, error) {
+	if !isSpotEnabled(nodePool) {
+		removeStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolSpotTerminationHandlerConfiguredConditionType)
+		return nil, nil
+	}
+
+	condition := hyperv1.NodePoolCondition{
+		Type:               hyperv1.NodePoolSpotTerminationHandlerConfiguredConditionType,
+		ObservedGeneration: nodePool.Generation,
+	}
+
+	if hc.Spec.Platform.AWS != nil && hc.Spec.Platform.AWS.TerminationHandlerQueueURL != "" {
+		condition.Status = corev1.ConditionTrue
+		condition.Reason = hyperv1.AsExpectedReason
+		condition.Message = hyperv1.AllIsWellMessage
+	} else {
+		condition.Status = corev1.ConditionFalse
+		condition.Reason = hyperv1.TerminationHandlerQueueURLNotSetReason
+		condition.Message = "Spot instances require spec.platform.aws.terminationHandlerQueueURL on the HostedCluster to enable graceful handling of spot instance terminations."
+	}
+
+	SetStatusCondition(&nodePool.Status.Conditions, condition)
+	return nil, nil
+}
+
 func (r *NodePoolReconciler) supportedVersionSkewCondition(ctx context.Context, nodePool *hyperv1.NodePool, hcluster *hyperv1.HostedCluster) (*ctrl.Result, error) {
 	if hcluster.Status.Version == nil {
 		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{

--- a/hypershift-operator/controllers/nodepool/conditions_test.go
+++ b/hypershift-operator/controllers/nodepool/conditions_test.go
@@ -505,3 +505,121 @@ func setUpDummyMachineSet(nodePool *hyperv1.NodePool, hostedCluster *hyperv1.Hos
 	}
 	return machineSet
 }
+
+func TestSpotTerminationHandlerConfiguredCondition(t *testing.T) {
+	tests := []struct {
+		name                       string
+		spotEnabled                bool
+		terminationHandlerQueueURL string
+		existingCondition          bool
+		expectedConditionPresent   bool
+		expectedStatus             corev1.ConditionStatus
+		expectedReason             string
+		expectedMessage            string
+	}{
+		{
+			name:                       "When spot is enabled and terminationHandlerQueueURL is set it should set condition to True",
+			spotEnabled:                true,
+			terminationHandlerQueueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/my-queue",
+			expectedConditionPresent:   true,
+			expectedStatus:             corev1.ConditionTrue,
+			expectedReason:             hyperv1.AsExpectedReason,
+			expectedMessage:            hyperv1.AllIsWellMessage,
+		},
+		{
+			name:                       "When spot is enabled and terminationHandlerQueueURL is empty it should set condition to False",
+			spotEnabled:                true,
+			terminationHandlerQueueURL: "",
+			expectedConditionPresent:   true,
+			expectedStatus:             corev1.ConditionFalse,
+			expectedReason:             hyperv1.TerminationHandlerQueueURLNotSetReason,
+			expectedMessage:            "Spot instances require spec.platform.aws.terminationHandlerQueueURL on the HostedCluster to enable graceful handling of spot instance terminations.",
+		},
+		{
+			name:                       "When spot is enabled and AWS platform is nil it should set condition to False",
+			spotEnabled:                true,
+			terminationHandlerQueueURL: "",
+			expectedConditionPresent:   true,
+			expectedStatus:             corev1.ConditionFalse,
+			expectedReason:             hyperv1.TerminationHandlerQueueURLNotSetReason,
+			expectedMessage:            "Spot instances require spec.platform.aws.terminationHandlerQueueURL on the HostedCluster to enable graceful handling of spot instance terminations.",
+		},
+		{
+			name:                     "When spot is not enabled it should remove the condition",
+			spotEnabled:              false,
+			existingCondition:        true,
+			expectedConditionPresent: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			nodePool := &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-nodepool",
+					Namespace:  "test-ns",
+					Generation: 1,
+				},
+				Spec: hyperv1.NodePoolSpec{
+					Platform: hyperv1.NodePoolPlatform{
+						Type: hyperv1.AWSPlatform,
+					},
+				},
+			}
+
+			if tc.spotEnabled {
+				nodePool.Spec.Platform.AWS = &hyperv1.AWSNodePoolPlatform{
+					Placement: &hyperv1.PlacementOptions{
+						MarketType: hyperv1.MarketTypeSpot,
+					},
+				}
+			}
+
+			if tc.existingCondition {
+				nodePool.Status.Conditions = []hyperv1.NodePoolCondition{
+					{
+						Type:   hyperv1.NodePoolSpotTerminationHandlerConfiguredConditionType,
+						Status: corev1.ConditionFalse,
+						Reason: hyperv1.TerminationHandlerQueueURLNotSetReason,
+					},
+				}
+			}
+
+			hc := &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+				},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+					},
+				},
+			}
+
+			if tc.terminationHandlerQueueURL != "" {
+				hc.Spec.Platform.AWS = &hyperv1.AWSPlatformSpec{
+					TerminationHandlerQueueURL: tc.terminationHandlerQueueURL,
+				}
+			}
+
+			r := &NodePoolReconciler{}
+
+			_, err := r.spotTerminationHandlerConfiguredCondition(t.Context(), nodePool, hc)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			condition := FindStatusCondition(nodePool.Status.Conditions, hyperv1.NodePoolSpotTerminationHandlerConfiguredConditionType)
+			if tc.expectedConditionPresent {
+				g.Expect(condition).ToNot(BeNil())
+				g.Expect(condition.Status).To(Equal(tc.expectedStatus))
+				g.Expect(condition.Reason).To(Equal(tc.expectedReason))
+				g.Expect(condition.Message).To(Equal(tc.expectedMessage))
+				g.Expect(condition.ObservedGeneration).To(Equal(nodePool.Generation))
+			} else {
+				g.Expect(condition).To(BeNil())
+			}
+		})
+	}
+}

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -300,6 +300,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		r.reachedIgnitionEndpointCondition,
 		r.machineAndNodeConditions,
 		r.validPlatformConfigCondition,
+		r.spotTerminationHandlerConfiguredCondition,
 		// TODO(alberto): consider moving here:
 		// NodePoolUpdatingPlatformMachineTemplateConditionType,
 		// NodePoolAutorepairEnabledConditionType.

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_conditions.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_conditions.go
@@ -84,6 +84,12 @@ const (
 	// KubeVirtNodesLiveMigratable indicates if all (VirtualMachines) nodes of the kubevirt
 	// hosted cluster can be live migrated without experiencing a node restart
 	NodePoolKubeVirtLiveMigratableType = "KubeVirtNodesLiveMigratable"
+
+	// NodePoolSpotTerminationHandlerConfiguredConditionType signals whether the required
+	// infrastructure for graceful spot instance termination handling is configured on the HostedCluster.
+	// When False, spot interruptions will result in abrupt instance termination with no graceful pod drain.
+	// This condition is only set on NodePools with spot instances enabled.
+	NodePoolSpotTerminationHandlerConfiguredConditionType = "SpotTerminationHandlerConfigured"
 )
 
 // PerformanceProfile Conditions
@@ -114,19 +120,20 @@ const (
 
 // Reasons
 const (
-	NodePoolValidationFailedReason        = "ValidationFailed"
-	NodePoolInplaceUpgradeFailedReason    = "InplaceUpgradeFailed"
-	NodePoolNotFoundReason                = "NotFound"
-	NodePoolFailedToGetReason             = "FailedToGet"
-	IgnitionEndpointMissingReason         = "IgnitionEndpointMissing"
-	IgnitionCACertMissingReason           = "IgnitionCACertMissing"
-	IgnitionNotReached                    = "ignitionNotReached"
-	DefaultAWSSecurityGroupNotReadyReason = "DefaultSGNotReady"
-	NodePoolValidArchPlatform             = "ValidArchPlatform"
-	NodePoolInvalidArchPlatform           = "InvalidArchPlatform"
-	InvalidKubevirtMachineTemplate        = "InvalidKubevirtMachineTemplate"
-	InvalidOpenStackMachineTemplate       = "InvalidOpenStackMachineTemplate"
-	CIDRConflictReason                    = "CIDRConflict"
-	NodePoolKubeVirtLiveMigratableReason  = "KubeVirtNodesNotLiveMigratable"
-	NodePoolUnsupportedSkewReason         = "UnsupportedSkew"
+	NodePoolValidationFailedReason         = "ValidationFailed"
+	NodePoolInplaceUpgradeFailedReason     = "InplaceUpgradeFailed"
+	NodePoolNotFoundReason                 = "NotFound"
+	NodePoolFailedToGetReason              = "FailedToGet"
+	IgnitionEndpointMissingReason          = "IgnitionEndpointMissing"
+	IgnitionCACertMissingReason            = "IgnitionCACertMissing"
+	IgnitionNotReached                     = "ignitionNotReached"
+	DefaultAWSSecurityGroupNotReadyReason  = "DefaultSGNotReady"
+	NodePoolValidArchPlatform              = "ValidArchPlatform"
+	NodePoolInvalidArchPlatform            = "InvalidArchPlatform"
+	InvalidKubevirtMachineTemplate         = "InvalidKubevirtMachineTemplate"
+	InvalidOpenStackMachineTemplate        = "InvalidOpenStackMachineTemplate"
+	CIDRConflictReason                     = "CIDRConflict"
+	NodePoolKubeVirtLiveMigratableReason   = "KubeVirtNodesNotLiveMigratable"
+	NodePoolUnsupportedSkewReason          = "UnsupportedSkew"
+	TerminationHandlerQueueURLNotSetReason = "TerminationHandlerQueueURLNotSet"
 )


### PR DESCRIPTION
## Summary

- Add a new NodePool condition `SpotTerminationHandlerConfigured` that warns users when a spot-enabled NodePool exists but the HostedCluster lacks `spec.platform.aws.terminationHandlerQueueURL`
- The condition is set to `False` with reason `TerminationHandlerQueueURLNotSet` and an actionable message when the queue URL is missing
- The condition is only present on spot-enabled NodePools (removed for on-demand NodePools)
- This is a warning only — NodePool reconciliation continues normally

**Jira:** https://redhat.atlassian.net/browse/OCPBUGS-86799

## Problem

When a NodePool with `marketType: Spot` is created on a HostedCluster without `terminationHandlerQueueURL`, the Node Termination Handler (NTH) silently fails to deploy. Users unknowingly run spot instances without graceful interruption handling — spot interruptions result in abrupt instance termination with no cordon, drain, or PDB compliance.

## Solution

Surface a NodePool status condition that:
1. Only appears on spot-enabled NodePools
2. Clearly tells the user what is missing and how to fix it
3. Does not block reconciliation (warning only)

## Test plan

- [x] Unit tests added in `conditions_test.go` covering:
  - When spot enabled + queue URL set → condition True
  - When spot enabled + queue URL empty → condition False with message
  - When spot enabled + AWS platform nil → condition False with message
  - When spot not enabled → condition removed
- [x] Full `./hypershift-operator/controllers/nodepool/...` test suite passes
- [x] `make hypershift-api` regenerates CRDs successfully
- [x] `gofmt` clean


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added nodepool condition monitoring for spot instance termination handler configuration. The system now tracks and reports whether the infrastructure for graceful spot instance termination is properly configured when spot instances are enabled on a nodepool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->