### PR TITLE
OCPBUGS-74599: Bump go-toolset to 1.25.9 to fix GO-2025-4155

### DIFF
--- a/Containerfile.control-plane
+++ b/Containerfile.control-plane
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/rhel9/go-toolset:1.23.6-1745588370 AS builder
+FROM registry.redhat.io/rhel9/go-toolset:1.25.9-1778675823 AS builder
 
 WORKDIR /hypershift
 

--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/rhel9/go-toolset:1.23.6-1745588370 AS builder
+FROM registry.redhat.io/rhel9/go-toolset:1.25.9-1778675823 AS builder
 
 WORKDIR /hypershift
 


### PR DESCRIPTION
Update builder image from rhel9/go-toolset:1.23.6 to 1.25.9 to address CVE GO-2025-4155 in crypto/x509 package. This is a builder-only change; go.mod remains at go 1.23.6 for compatibility. 

Fixes: [GO-2025-4155](https://pkg.go.dev/vuln/GO-2025-4155) 

