### PR TITLE
NO-jira: api: use omitzero for structs and omitempty for scalars

### DIFF
--- a/api/hypershift/v1beta1/controlplaneversion_types.go
+++ b/api/hypershift/v1beta1/controlplaneversion_types.go
@@ -14,7 +14,7 @@ type ControlPlaneVersionStatus struct {
 	// desired is the release version that the control plane is reconciling towards.
 	// It is derived from the HostedControlPlane release image fields.
 	// +required
-	Desired configv1.Release `json:"desired,omitempty,omitzero"`
+	Desired configv1.Release `json:"desired,omitzero"`
 
 	// history contains a list of versions applied to management-side control plane components. The newest entry is
 	// first in the list. Entries have state Completed when all ControlPlaneComponent resources report the target
@@ -29,7 +29,7 @@ type ControlPlaneVersionStatus struct {
 	// +optional
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=9007199254740992
-	ObservedGeneration int64 `json:"observedGeneration,omitempty,omitzero"`
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // ControlPlaneUpdateHistory is a record of a single version transition for management-side
@@ -46,13 +46,13 @@ type ControlPlaneUpdateHistory struct {
 
 	// startedTime is the time at which the update was started.
 	// +required
-	StartedTime metav1.Time `json:"startedTime,omitempty,omitzero"`
+	StartedTime metav1.Time `json:"startedTime,omitzero"`
 
 	// completionTime is the time at which the update completed. It is set
 	// when all management-side components have reached the target version.
 	// It is not set while the update is in progress.
 	// +optional
-	CompletionTime metav1.Time `json:"completionTime,omitempty,omitzero"`
+	CompletionTime metav1.Time `json:"completionTime,omitzero"`
 
 	// version is a semantic version string identifying the update version
 	// (e.g. "4.20.1").

--- a/api/hypershift/v1beta1/operator.go
+++ b/api/hypershift/v1beta1/operator.go
@@ -97,7 +97,7 @@ type OVNKubernetesConfig struct {
 	// set ipv6.internalJoinSubnet to a value different from the management cluster's
 	// join subnet (default fd98::/64) to avoid IPv6 routing conflicts.
 	// +optional
-	IPv6 OVNIPv6Config `json:"ipv6,omitzero,omitempty"`
+	IPv6 OVNIPv6Config `json:"ipv6,omitzero"`
 
 	// mtu is the MTU to use for the tunnel interface on hosted cluster nodes.
 	// This must be 100 bytes smaller than the uplink MTU.

--- a/api/karpenter/v1/karpenter_types.go
+++ b/api/karpenter/v1/karpenter_types.go
@@ -394,7 +394,7 @@ type BlockDeviceMapping struct {
 	// ebs contains parameters used to automatically set up EBS volumes when an instance is launched.
 	// +kubebuilder:validation:XValidation:message="snapshotID or volumeSizeGiB must be defined",rule="has(self.snapshotID) || has(self.volumeSizeGiB)"
 	// +optional
-	EBS BlockDevice `json:"ebs,omitempty,omitzero"`
+	EBS BlockDevice `json:"ebs,omitzero"`
 
 	// rootVolume indicates whether this device is mounted as kubelet root dir. You can
 	// configure at most one root volume in BlockDeviceMappings.
@@ -561,7 +561,7 @@ type CapacityReservation struct {
 	// endTime is the time at which the capacity reservation expires. Once expired, the reserved capacity is released and Karpenter
 	// will no longer be able to launch instances into that reservation.
 	// +optional
-	EndTime metav1.Time `json:"endTime,omitempty,omitzero"`
+	EndTime metav1.Time `json:"endTime,omitzero"`
 	// id is the id for the capacity reservation.
 	// +required
 	// +kubebuilder:validation:MinLength=1
@@ -681,7 +681,7 @@ type OpenshiftEC2NodeClass struct {
 
 	// status defines the observed state of the OpenshiftEC2NodeClass.
 	// +optional
-	Status OpenshiftEC2NodeClassStatus `json:"status,omitempty,omitzero"`
+	Status OpenshiftEC2NodeClassStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -40453,7 +40453,7 @@ indicates the update was successfully rolled out.</p>
 </tr>
 <tr>
 <td>
-<code>startedTime,omitempty,omitzero</code></br>
+<code>startedTime,omitzero</code></br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#time-v1-meta">
 Kubernetes meta/v1.Time
@@ -40466,7 +40466,7 @@ Kubernetes meta/v1.Time
 </tr>
 <tr>
 <td>
-<code>completionTime,omitempty,omitzero</code></br>
+<code>completionTime,omitzero</code></br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#time-v1-meta">
 Kubernetes meta/v1.Time
@@ -40526,7 +40526,7 @@ the last observed generation of the HostedControlPlane spec.</p>
 <tbody>
 <tr>
 <td>
-<code>desired,omitempty,omitzero</code></br>
+<code>desired,omitzero</code></br>
 <em>
 <a href="https://docs.openshift.com/container-platform/4.10/rest_api/config_apis/config-apis-index.html">
 github.com/openshift/api/config/v1.Release
@@ -40556,7 +40556,7 @@ version with RolloutComplete=True. Entries have state Partial when the rollout i
 </tr>
 <tr>
 <td>
-<code>observedGeneration,omitempty,omitzero</code></br>
+<code>observedGeneration</code></br>
 <em>
 int64
 </em>

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -6409,7 +6409,7 @@ indicates the update was successfully rolled out.</p>
 </tr>
 <tr>
 <td>
-<code>startedTime,omitempty,omitzero</code></br>
+<code>startedTime,omitzero</code></br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#time-v1-meta">
 Kubernetes meta/v1.Time
@@ -6422,7 +6422,7 @@ Kubernetes meta/v1.Time
 </tr>
 <tr>
 <td>
-<code>completionTime,omitempty,omitzero</code></br>
+<code>completionTime,omitzero</code></br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#time-v1-meta">
 Kubernetes meta/v1.Time
@@ -6482,7 +6482,7 @@ the last observed generation of the HostedControlPlane spec.</p>
 <tbody>
 <tr>
 <td>
-<code>desired,omitempty,omitzero</code></br>
+<code>desired,omitzero</code></br>
 <em>
 <a href="https://docs.openshift.com/container-platform/4.10/rest_api/config_apis/config-apis-index.html">
 github.com/openshift/api/config/v1.Release
@@ -6512,7 +6512,7 @@ version with RolloutComplete=True. Entries have state Partial when the rollout i
 </tr>
 <tr>
 <td>
-<code>observedGeneration,omitempty,omitzero</code></br>
+<code>observedGeneration</code></br>
 <em>
 int64
 </em>

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/controlplaneversion_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/controlplaneversion_types.go
@@ -14,7 +14,7 @@ type ControlPlaneVersionStatus struct {
 	// desired is the release version that the control plane is reconciling towards.
 	// It is derived from the HostedControlPlane release image fields.
 	// +required
-	Desired configv1.Release `json:"desired,omitempty,omitzero"`
+	Desired configv1.Release `json:"desired,omitzero"`
 
 	// history contains a list of versions applied to management-side control plane components. The newest entry is
 	// first in the list. Entries have state Completed when all ControlPlaneComponent resources report the target
@@ -29,7 +29,7 @@ type ControlPlaneVersionStatus struct {
 	// +optional
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=9007199254740992
-	ObservedGeneration int64 `json:"observedGeneration,omitempty,omitzero"`
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // ControlPlaneUpdateHistory is a record of a single version transition for management-side
@@ -46,13 +46,13 @@ type ControlPlaneUpdateHistory struct {
 
 	// startedTime is the time at which the update was started.
 	// +required
-	StartedTime metav1.Time `json:"startedTime,omitempty,omitzero"`
+	StartedTime metav1.Time `json:"startedTime,omitzero"`
 
 	// completionTime is the time at which the update completed. It is set
 	// when all management-side components have reached the target version.
 	// It is not set while the update is in progress.
 	// +optional
-	CompletionTime metav1.Time `json:"completionTime,omitempty,omitzero"`
+	CompletionTime metav1.Time `json:"completionTime,omitzero"`
 
 	// version is a semantic version string identifying the update version
 	// (e.g. "4.20.1").

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/operator.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/operator.go
@@ -97,7 +97,7 @@ type OVNKubernetesConfig struct {
 	// set ipv6.internalJoinSubnet to a value different from the management cluster's
 	// join subnet (default fd98::/64) to avoid IPv6 routing conflicts.
 	// +optional
-	IPv6 OVNIPv6Config `json:"ipv6,omitzero,omitempty"`
+	IPv6 OVNIPv6Config `json:"ipv6,omitzero"`
 
 	// mtu is the MTU to use for the tunnel interface on hosted cluster nodes.
 	// This must be 100 bytes smaller than the uplink MTU.

--- a/vendor/github.com/openshift/hypershift/api/karpenter/v1/karpenter_types.go
+++ b/vendor/github.com/openshift/hypershift/api/karpenter/v1/karpenter_types.go
@@ -394,7 +394,7 @@ type BlockDeviceMapping struct {
 	// ebs contains parameters used to automatically set up EBS volumes when an instance is launched.
 	// +kubebuilder:validation:XValidation:message="snapshotID or volumeSizeGiB must be defined",rule="has(self.snapshotID) || has(self.volumeSizeGiB)"
 	// +optional
-	EBS BlockDevice `json:"ebs,omitempty,omitzero"`
+	EBS BlockDevice `json:"ebs,omitzero"`
 
 	// rootVolume indicates whether this device is mounted as kubelet root dir. You can
 	// configure at most one root volume in BlockDeviceMappings.
@@ -561,7 +561,7 @@ type CapacityReservation struct {
 	// endTime is the time at which the capacity reservation expires. Once expired, the reserved capacity is released and Karpenter
 	// will no longer be able to launch instances into that reservation.
 	// +optional
-	EndTime metav1.Time `json:"endTime,omitempty,omitzero"`
+	EndTime metav1.Time `json:"endTime,omitzero"`
 	// id is the id for the capacity reservation.
 	// +required
 	// +kubebuilder:validation:MinLength=1
@@ -681,7 +681,7 @@ type OpenshiftEC2NodeClass struct {
 
 	// status defines the observed state of the OpenshiftEC2NodeClass.
 	// +optional
-	Status OpenshiftEC2NodeClassStatus `json:"status,omitempty,omitzero"`
+	Status OpenshiftEC2NodeClassStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true


### PR DESCRIPTION
Replace redundant omitempty,omitzero double tags with the correct single tag: omitzero for struct fields (where omitempty is a no-op) and omitempty for scalar fields (int64).

<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated JSON serialization behavior for control plane version metadata and configuration API responses to ensure consistent handling of data fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->