### PR TITLE
ACM-34234: build(cli): rename hcp archives to include OS and arch in filename

### DIFF
--- a/Containerfile.cli
+++ b/Containerfile.cli
@@ -8,16 +8,16 @@ COPY . .
 RUN make product-cli-release && \
     # Create tar.gz files for Linux architectures \
     for ARCH in amd64 arm64 ppc64le s390x; do \
-      tar -czvf ./bin/linux/${ARCH}/hcp.tar.gz -C ./bin/linux/${ARCH} ./hcp || exit 1; \
+      tar -czvf ./bin/hcp-linux-${ARCH}.tar.gz -C ./bin/linux/${ARCH} ./hcp || exit 1; \
     done && \
     # Create tar.gz files for Darwin and Windows architectures \
     for OS in darwin windows; do \
       for ARCH in amd64 arm64; do \
-        tar -czvf ./bin/${OS}/${ARCH}/hcp.tar.gz -C ./bin/${OS}/${ARCH} ./hcp || exit 1; \
+        tar -czvf ./bin/hcp-${OS}-${ARCH}.tar.gz -C ./bin/${OS}/${ARCH} ./hcp || exit 1; \
       done; \
     done && \
-    # Remove raw binaries, keep only tar.gz files \
-    find ./bin -type f ! -name "*.tar.gz" -delete
+    # Remove OS/arch subdirectories, keep only flat tar.gz files \
+    find ./bin -mindepth 1 -maxdepth 1 -type d -exec rm -rf {} +
 
 FROM registry.redhat.io/ubi9/nginx-124:latest
 


### PR DESCRIPTION
## What this PR does / why we need it

Each platform archive was previously named `hcp.tar.gz` regardless of OS/arch, causing filename collisions when Konflux derives the release artifact name from the component and archive name (the `filename` field is no longer used).

Archives are now named `hcp-<os>-<arch>.tar.gz` and written flat into `./bin/`, producing:
- `hcp-linux-amd64.tar.gz`
- `hcp-linux-arm64.tar.gz`
- `hcp-linux-ppc64le.tar.gz`
- `hcp-linux-s390x.tar.gz`
- `hcp-darwin-amd64.tar.gz`
- `hcp-darwin-arm64.tar.gz`
- `hcp-windows-amd64.tar.gz`
- `hcp-windows-arm64.tar.gz`

References:
- Konflux release data MR: https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/18358#note_21658264
- Jira: https://redhat.atlassian.net/browse/ACM-34234

## Which issue(s) this PR fixes

Fixes [ACM-34234](https://redhat.atlassian.net/browse/ACM-34234)

## Special notes for your reviewer

N/A

## Checklist

- [x] The code I'm writing is tested
- [x] Testing instructions provided below OR it's sufficiently covered by existing tests
- [x] Documentation added/updated if necessary

## How to test

Build the `Containerfile.cli` image and verify the resulting `/opt/app-root/src/` directory contains flat `hcp-<os>-<arch>.tar.gz` files with no OS/arch subdirectories.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved artifact packaging and cleanup in the build process for more efficient distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->