### PR TITLE
OCPBUGS-85079: Fix global pull-secret label sync on HO upgrade

### DIFF
--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -192,13 +192,16 @@ type NodePoolSpec struct {
 	// +optional
 	NodeVolumeDetachTimeout *metav1.Duration `json:"nodeVolumeDetachTimeout,omitempty"`
 
-	// nodeLabels propagates a list of labels to Nodes, only once on creation.
+	// nodeLabels propagates a list of labels to Nodes.
+	// Labels are re-synced additively whenever the desired state changes;
+	// labels set by other controllers (kubelet, autoscaler) are preserved.
 	// Valid values are those in https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
 	// +optional
 	NodeLabels map[string]string `json:"nodeLabels,omitempty"`
 
-	// taints if specified, propagates a list of taints to Nodes, only once on creation.
-	// These taints are additive to the ones applied by other controllers
+	// taints if specified, propagates a list of taints to Nodes.
+	// Taints are re-synced whenever the desired state changes.
+	// These taints are additive to the ones applied by other controllers.
 	// +kubebuilder:validation:MaxItems=50
 	// +optional
 	Taints []Taint `json:"taints,omitempty"`

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
@@ -317,7 +317,9 @@ spec:
                 additionalProperties:
                   type: string
                 description: |-
-                  nodeLabels propagates a list of labels to Nodes, only once on creation.
+                  nodeLabels propagates a list of labels to Nodes.
+                  Labels are re-synced additively whenever the desired state changes;
+                  labels set by other controllers (kubelet, autoscaler) are preserved.
                   Valid values are those in https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
                 type: object
               nodeVolumeDetachTimeout:
@@ -1421,8 +1423,9 @@ spec:
                 type: integer
               taints:
                 description: |-
-                  taints if specified, propagates a list of taints to Nodes, only once on creation.
-                  These taints are additive to the ones applied by other controllers
+                  taints if specified, propagates a list of taints to Nodes.
+                  Taints are re-synced whenever the desired state changes.
+                  These taints are additive to the ones applied by other controllers.
                 items:
                   description: |-
                     taint is as v1 Core but without TimeAdded.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
@@ -317,7 +317,9 @@ spec:
                 additionalProperties:
                   type: string
                 description: |-
-                  nodeLabels propagates a list of labels to Nodes, only once on creation.
+                  nodeLabels propagates a list of labels to Nodes.
+                  Labels are re-synced additively whenever the desired state changes;
+                  labels set by other controllers (kubelet, autoscaler) are preserved.
                   Valid values are those in https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
                 type: object
               nodeVolumeDetachTimeout:
@@ -1690,8 +1692,9 @@ spec:
                 type: integer
               taints:
                 description: |-
-                  taints if specified, propagates a list of taints to Nodes, only once on creation.
-                  These taints are additive to the ones applied by other controllers
+                  taints if specified, propagates a list of taints to Nodes.
+                  Taints are re-synced whenever the desired state changes.
+                  These taints are additive to the ones applied by other controllers.
                 items:
                   description: |-
                     taint is as v1 Core but without TimeAdded.

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
@@ -317,7 +317,9 @@ spec:
                 additionalProperties:
                   type: string
                 description: |-
-                  nodeLabels propagates a list of labels to Nodes, only once on creation.
+                  nodeLabels propagates a list of labels to Nodes.
+                  Labels are re-synced additively whenever the desired state changes;
+                  labels set by other controllers (kubelet, autoscaler) are preserved.
                   Valid values are those in https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
                 type: object
               nodeVolumeDetachTimeout:
@@ -1608,8 +1610,9 @@ spec:
                 type: integer
               taints:
                 description: |-
-                  taints if specified, propagates a list of taints to Nodes, only once on creation.
-                  These taints are additive to the ones applied by other controllers
+                  taints if specified, propagates a list of taints to Nodes.
+                  Taints are re-synced whenever the desired state changes.
+                  These taints are additive to the ones applied by other controllers.
                 items:
                   description: |-
                     taint is as v1 Core but without TimeAdded.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -320,7 +320,9 @@ spec:
                 additionalProperties:
                   type: string
                 description: |-
-                  nodeLabels propagates a list of labels to Nodes, only once on creation.
+                  nodeLabels propagates a list of labels to Nodes.
+                  Labels are re-synced additively whenever the desired state changes;
+                  labels set by other controllers (kubelet, autoscaler) are preserved.
                   Valid values are those in https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
                 type: object
               nodeVolumeDetachTimeout:
@@ -1878,8 +1880,9 @@ spec:
                 type: integer
               taints:
                 description: |-
-                  taints if specified, propagates a list of taints to Nodes, only once on creation.
-                  These taints are additive to the ones applied by other controllers
+                  taints if specified, propagates a list of taints to Nodes.
+                  Taints are re-synced whenever the desired state changes.
+                  These taints are additive to the ones applied by other controllers.
                 items:
                   description: |-
                     taint is as v1 Core but without TimeAdded.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -320,7 +320,9 @@ spec:
                 additionalProperties:
                   type: string
                 description: |-
-                  nodeLabels propagates a list of labels to Nodes, only once on creation.
+                  nodeLabels propagates a list of labels to Nodes.
+                  Labels are re-synced additively whenever the desired state changes;
+                  labels set by other controllers (kubelet, autoscaler) are preserved.
                   Valid values are those in https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
                 type: object
               nodeVolumeDetachTimeout:
@@ -1424,8 +1426,9 @@ spec:
                 type: integer
               taints:
                 description: |-
-                  taints if specified, propagates a list of taints to Nodes, only once on creation.
-                  These taints are additive to the ones applied by other controllers
+                  taints if specified, propagates a list of taints to Nodes.
+                  Taints are re-synced whenever the desired state changes.
+                  These taints are additive to the ones applied by other controllers.
                 items:
                   description: |-
                     taint is as v1 Core but without TimeAdded.

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -320,7 +320,9 @@ spec:
                 additionalProperties:
                   type: string
                 description: |-
-                  nodeLabels propagates a list of labels to Nodes, only once on creation.
+                  nodeLabels propagates a list of labels to Nodes.
+                  Labels are re-synced additively whenever the desired state changes;
+                  labels set by other controllers (kubelet, autoscaler) are preserved.
                   Valid values are those in https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
                 type: object
               nodeVolumeDetachTimeout:
@@ -1878,8 +1880,9 @@ spec:
                 type: integer
               taints:
                 description: |-
-                  taints if specified, propagates a list of taints to Nodes, only once on creation.
-                  These taints are additive to the ones applied by other controllers
+                  taints if specified, propagates a list of taints to Nodes.
+                  Taints are re-synced whenever the desired state changes.
+                  These taints are additive to the ones applied by other controllers.
                 items:
                   description: |-
                     taint is as v1 Core but without TimeAdded.

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/node/node.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/node/node.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -47,46 +49,58 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	var apiErr *apierrors.StatusError
-	nodePoolName, err := r.nodeToNodePoolName(ctx, node)
+	machine, err := r.getMachineForNode(ctx, node)
 	if err != nil {
 		if errors.As(err, &apiErr) && !apierrors.IsNotFound(err) {
-			// Return error and retry only if the API interaction failed. Other errors are because the nodeToNodePoolName expected
-			// annotations are not in place yet, so we'll reconcile triggered by the event which sets them in the Node.
+			// Return error and retry only if the API interaction failed.
+			// Other errors mean CAPI annotations aren't set on the Node yet;
+			// we'll reconcile when the event that sets them fires.
 			return ctrl.Result{}, err
 		} else {
-			log.Error(err, "failed to get nodePool name from Node")
+			log.Error(err, "failed to get Machine for Node")
 			return ctrl.Result{}, nil
 		}
 	}
 
-	if labelsHaveSynced(node) {
-		return reconcile.Result{}, nil
+	nodePoolName, err := nodePoolNameFromMachine(machine)
+	if err != nil {
+		log.Error(err, "failed to get nodePool name from Machine")
+		return ctrl.Result{}, nil
 	}
 
-	machine, err := r.getMachineForNode(ctx, node)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
 	labelsToSync := getManagedLabels(machine.Labels)
 	labelsToSync[hyperv1.NodePoolLabel] = nodePoolName
 
 	var taints []corev1.Taint
-	taintsInJSON := machine.Annotations[nodePoolAnnotationTaints]
-	err = json.Unmarshal([]byte(taintsInJSON), &taints)
+	if taintsInJSON := machine.Annotations[nodePoolAnnotationTaints]; taintsInJSON != "" {
+		if err = json.Unmarshal([]byte(taintsInJSON), &taints); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
+	expectedHash, err := computeSyncHash(labelsToSync, taints)
 	if err != nil {
-		return reconcile.Result{}, err
+		return reconcile.Result{}, fmt.Errorf("failed to compute sync hash: %w", err)
+	}
+	if labelsHaveSynced(node, expectedHash) {
+		return reconcile.Result{}, nil
 	}
 
 	result, err := r.CreateOrUpdate(ctx, r.guestClusterClient, node, func() error {
-		node.Annotations[labelsSyncedAnnotation] = "true"
-
-		// Sync labels.
-		for k, v := range labelsToSync {
-			node.Labels[k] = v
+		if node.Annotations == nil {
+			node.Annotations = make(map[string]string)
 		}
+		node.Annotations[labelsSyncedAnnotation] = expectedHash
 
-		// Sync taints.
-		node.Spec.Taints = append(node.Spec.Taints, taints...)
+		if node.Labels == nil {
+			node.Labels = make(map[string]string)
+		}
+		// Additive-only: ensures managed labels are present on the Node.
+		// Does not remove labels absent from labelsToSync, since the Node
+		// may have labels set by kubelet, autoscaler, or other controllers.
+		maps.Copy(node.Labels, labelsToSync)
+
+		node.Spec.Taints = mergeTaints(node.Spec.Taints, taints)
 
 		return nil
 	})
@@ -134,19 +148,74 @@ func (r *reconciler) getMachineForNode(ctx context.Context, node *corev1.Node) (
 	return machine, nil
 }
 
-func labelsHaveSynced(node *corev1.Node) bool {
-	if _, ok := node.Annotations[labelsSyncedAnnotation]; ok {
-		return true
+func labelsHaveSynced(node *corev1.Node, expectedHash string) bool {
+	val, ok := node.Annotations[labelsSyncedAnnotation]
+	if !ok {
+		return false
 	}
-
-	return false
+	return val == expectedHash
 }
-func (r *reconciler) nodeToNodePoolName(ctx context.Context, node *corev1.Node) (string, error) {
-	machine, err := r.getMachineForNode(ctx, node)
-	if err != nil {
-		return "", err
+
+type syncState struct {
+	Labels []labelEntry `json:"labels"`
+	Taints []taintEntry `json:"taints"`
+}
+
+type labelEntry struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type taintEntry struct {
+	Key    string             `json:"key"`
+	Value  string             `json:"value"`
+	Effect corev1.TaintEffect `json:"effect"`
+}
+
+func computeSyncHash(labels map[string]string, taints []corev1.Taint) (string, error) {
+	state := syncState{
+		Labels: make([]labelEntry, 0, len(labels)),
+		Taints: make([]taintEntry, 0, len(taints)),
 	}
 
+	for _, k := range slices.Sorted(maps.Keys(labels)) {
+		state.Labels = append(state.Labels, labelEntry{Key: k, Value: labels[k]})
+	}
+
+	for _, t := range taints {
+		state.Taints = append(state.Taints, taintEntry{Key: t.Key, Value: t.Value, Effect: t.Effect})
+	}
+	slices.SortFunc(state.Taints, func(a, b taintEntry) int {
+		return strings.Compare(taintEntryKey(a), taintEntryKey(b))
+	})
+
+	return supportutil.HashStruct(state)
+}
+
+func taintEntryKey(t taintEntry) string {
+	return fmt.Sprintf("%s=%s:%s", t.Key, t.Value, t.Effect)
+}
+
+func mergeTaints(existing, desired []corev1.Taint) []corev1.Taint {
+	seen := make(map[string]struct{}, len(existing))
+	for _, t := range existing {
+		seen[taintKey(t)] = struct{}{}
+	}
+	merged := make([]corev1.Taint, len(existing), len(existing)+len(desired))
+	copy(merged, existing)
+	for _, t := range desired {
+		if _, ok := seen[taintKey(t)]; !ok {
+			merged = append(merged, t)
+		}
+	}
+	return merged
+}
+
+func taintKey(t corev1.Taint) string {
+	return fmt.Sprintf("%s=%s:%s", t.Key, t.Value, t.Effect)
+}
+
+func nodePoolNameFromMachine(machine *capiv1.Machine) (string, error) {
 	nodePoolName, ok := machine.Annotations[nodePoolAnnotation]
 	if !ok || nodePoolName == "" {
 		return "", fmt.Errorf("failed to find nodePoolAnnotation on Machine %q", machine.Name)

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/node/node_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/node/node_test.go
@@ -1,10 +1,14 @@
 package node
 
 import (
+	"context"
+	"encoding/json"
+	"maps"
 	"testing"
 
 	. "github.com/onsi/gomega"
 
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	supportutil "github.com/openshift/hypershift/support/util"
 
 	corev1 "k8s.io/api/core/v1"
@@ -12,124 +16,609 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 
 	capiv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func TestNodeToNodePoolName(t *testing.T) {
-	_ = capiv1.AddToScheme(scheme.Scheme)
+const (
+	testMachineNamespace = "test-ns"
+	testNodePoolName     = "test-ns/test-nodepool"
+	testMachineName      = "test-machine"
+	testNodeName         = "test-node"
+	testGlobalPSLabel    = "hypershift.openshift.io/nodepool-globalps-enabled"
+)
 
-	machineNamespace := "test"
-	nodePoolName := "ns/name"
-	machineWithNodePoolAnnotation := &capiv1.Machine{
+func newTestNode(extraAnnotations, labels map[string]string, taints ...corev1.Taint) *corev1.Node {
+	annotations := map[string]string{
+		capiv1.ClusterNamespaceAnnotation: testMachineNamespace,
+		capiv1.MachineAnnotation:          testMachineName,
+	}
+	maps.Copy(annotations, extraAnnotations)
+	return &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: machineNamespace,
-			Name:      "hasNodePoolAnnotation",
-			Annotations: map[string]string{
-				nodePoolAnnotation: nodePoolName,
-			},
+			Name:        testNodeName,
+			Annotations: annotations,
+			Labels:      labels,
+		},
+		Spec: corev1.NodeSpec{
+			Taints: taints,
 		},
 	}
-	machineWithOutNodePoolAnnotation := &capiv1.Machine{
+}
+
+func newTestMachine(annotations map[string]string, labels map[string]string) *capiv1.Machine {
+	baseAnnotations := map[string]string{
+		nodePoolAnnotation: testNodePoolName,
+	}
+	maps.Copy(baseAnnotations, annotations)
+	return &capiv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: machineNamespace,
-			Name:      "DoNotHaveNodePoolAnnotation",
+			Namespace:   testMachineNamespace,
+			Name:        testMachineName,
+			Annotations: baseAnnotations,
+			Labels:      labels,
 		},
 	}
+}
+
+func taintsJSON(taints []corev1.Taint) string {
+	data, _ := json.Marshal(taints)
+	return string(data)
+}
+
+func managedLabel(key string) string {
+	return labelManagedPrefix + "." + key
+}
+
+func TestNodePoolNameFromMachine(t *testing.T) {
+	t.Parallel()
 
 	testCases := []struct {
 		name                 string
-		node                 *corev1.Node
+		machine              *capiv1.Machine
 		expectedNodePoolName string
-		error                bool
+		expectError          bool
 	}{
 		{
-			name: "When MachineAnnotation does not exist in Node it should fail",
-			node: &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						capiv1.ClusterNamespaceAnnotation: machineNamespace,
-					},
-				},
-			},
-			expectedNodePoolName: "",
-			error:                true,
-		},
-		{
-			name: "When ClusterNamespaceAnnotation does not exist in Node it should fail",
-			node: &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						capiv1.MachineAnnotation: machineWithNodePoolAnnotation.Name,
-					},
-				},
-			},
-			expectedNodePoolName: "",
-			error:                true,
-		},
-		{
 			name: "When nodePoolAnnotation does not exist in Machine it should fail",
-			node: &corev1.Node{
+			machine: &capiv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
+					Name: "no-annotation",
+				},
+			},
+			expectedNodePoolName: "",
+			expectError:          true,
+		},
+		{
+			name: "When nodePoolAnnotation is empty it should fail",
+			machine: &capiv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "empty-annotation",
 					Annotations: map[string]string{
-						capiv1.ClusterNamespaceAnnotation: machineNamespace,
-						capiv1.MachineAnnotation:          machineWithOutNodePoolAnnotation.Name,
+						nodePoolAnnotation: "",
 					},
 				},
 			},
 			expectedNodePoolName: "",
-			error:                true,
+			expectError:          true,
 		},
 		{
-			name: "When Machine does not exist it should fail",
-			node: &corev1.Node{
+			name: "When nodePoolAnnotation exists it should return the NodePool Name",
+			machine: &capiv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
+					Name: "has-annotation",
 					Annotations: map[string]string{
-						capiv1.ClusterNamespaceAnnotation: machineNamespace,
-						capiv1.MachineAnnotation:          "doesNotExist",
+						nodePoolAnnotation: "ns/name",
 					},
 				},
 			},
-			expectedNodePoolName: "",
-			error:                true,
-		},
-		{
-			name: "When all annotations and Machine exist it should return the NodePool Name",
-			node: &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						capiv1.ClusterNamespaceAnnotation: machineNamespace,
-						capiv1.MachineAnnotation:          machineWithNodePoolAnnotation.Name,
-					},
-				},
-			},
-			expectedNodePoolName: supportutil.ParseNamespacedName(nodePoolName).Name,
-			error:                false,
+			expectedNodePoolName: supportutil.ParseNamespacedName("ns/name").Name,
+			expectError:          false,
 		},
 	}
 
-	c := fake.NewClientBuilder().WithObjects(machineWithNodePoolAnnotation, machineWithOutNodePoolAnnotation).Build()
-	r := &reconciler{
-		client: c,
-	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			g := NewWithT(t)
-			got, err := r.nodeToNodePoolName(t.Context(), tc.node)
+			got, err := nodePoolNameFromMachine(tc.machine)
 			g.Expect(got).To(Equal(tc.expectedNodePoolName))
-			g.Expect(err != nil).To(Equal(tc.error))
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
 		})
 	}
 }
 
 func TestGetManagedLabels(t *testing.T) {
+	t.Parallel()
 	g := NewWithT(t)
 	labels := map[string]string{
-		labelManagedPrefix + "." + "foo": "bar",
-		"not-managed":                    "true",
+		managedLabel("foo"): "bar",
+		"not-managed":       "true",
 	}
 
 	managedLabels := getManagedLabels(labels)
 	g.Expect(managedLabels).To(BeEquivalentTo(map[string]string{
 		"foo": "bar",
 	}))
+}
+
+func TestComputeSyncHash(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		labels map[string]string
+		taints []corev1.Taint
+		verify func(g Gomega, hash string, err error)
+	}{
+		{
+			name:   "When labels and taints are empty it should return a stable hash",
+			labels: map[string]string{},
+			taints: []corev1.Taint{},
+			verify: func(g Gomega, hash string, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(hash).NotTo(BeEmpty())
+				second, err2 := computeSyncHash(map[string]string{}, []corev1.Taint{})
+				g.Expect(err2).NotTo(HaveOccurred())
+				g.Expect(hash).To(Equal(second))
+			},
+		},
+		{
+			name:   "When labels are nil it should return a stable hash",
+			labels: nil,
+			taints: nil,
+			verify: func(g Gomega, hash string, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(hash).NotTo(BeEmpty())
+			},
+		},
+		{
+			name: "When labels are provided it should produce a deterministic hash",
+			labels: map[string]string{
+				"foo": "bar",
+				"baz": "qux",
+			},
+			taints: []corev1.Taint{},
+			verify: func(g Gomega, hash string, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+				second, err2 := computeSyncHash(map[string]string{"baz": "qux", "foo": "bar"}, []corev1.Taint{})
+				g.Expect(err2).NotTo(HaveOccurred())
+				g.Expect(hash).To(Equal(second))
+			},
+		},
+		{
+			name:   "When taints are provided it should produce a deterministic hash",
+			labels: map[string]string{},
+			taints: []corev1.Taint{
+				{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "key2", Value: "val2", Effect: corev1.TaintEffectNoExecute},
+			},
+			verify: func(g Gomega, hash string, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+				reversed, err2 := computeSyncHash(map[string]string{}, []corev1.Taint{
+					{Key: "key2", Value: "val2", Effect: corev1.TaintEffectNoExecute},
+					{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+				})
+				g.Expect(err2).NotTo(HaveOccurred())
+				g.Expect(hash).To(Equal(reversed))
+			},
+		},
+		{
+			name: "When labels differ it should produce different hashes",
+			labels: map[string]string{
+				"foo": "bar",
+			},
+			taints: []corev1.Taint{},
+			verify: func(g Gomega, hash string, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+				different, err2 := computeSyncHash(map[string]string{"foo": "changed"}, []corev1.Taint{})
+				g.Expect(err2).NotTo(HaveOccurred())
+				g.Expect(hash).NotTo(Equal(different))
+			},
+		},
+		{
+			name:   "When taints differ it should produce different hashes",
+			labels: map[string]string{},
+			taints: []corev1.Taint{
+				{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+			},
+			verify: func(g Gomega, hash string, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+				different, err2 := computeSyncHash(map[string]string{}, []corev1.Taint{
+					{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoExecute},
+				})
+				g.Expect(err2).NotTo(HaveOccurred())
+				g.Expect(hash).NotTo(Equal(different))
+			},
+		},
+		{
+			name: "When a new label is added it should produce a different hash",
+			labels: map[string]string{
+				"existing": "label",
+			},
+			taints: []corev1.Taint{},
+			verify: func(g Gomega, hash string, err error) {
+				g.Expect(err).NotTo(HaveOccurred())
+				withNewLabel, err2 := computeSyncHash(map[string]string{
+					"existing":        "label",
+					testGlobalPSLabel: "true",
+				}, []corev1.Taint{})
+				g.Expect(err2).NotTo(HaveOccurred())
+				g.Expect(hash).NotTo(Equal(withNewLabel))
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			hash, err := computeSyncHash(tc.labels, tc.taints)
+			tc.verify(g, hash, err)
+		})
+	}
+}
+
+func TestLabelsHaveSynced(t *testing.T) {
+	t.Parallel()
+
+	expectedHash, _ := computeSyncHash(map[string]string{"foo": "bar"}, []corev1.Taint{})
+
+	testCases := []struct {
+		name     string
+		node     *corev1.Node
+		expected bool
+	}{
+		{
+			name: "When annotation matches expected hash it should return true",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						labelsSyncedAnnotation: expectedHash,
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "When annotation has different hash it should return false",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						labelsSyncedAnnotation: "differenthashvalue",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "When annotation has legacy value true it should return false",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						labelsSyncedAnnotation: "true",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "When annotation is empty string it should return false",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						labelsSyncedAnnotation: "",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "When annotation does not exist it should return false",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "When annotations map is nil it should return false",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			g.Expect(labelsHaveSynced(tc.node, expectedHash)).To(Equal(tc.expected))
+		})
+	}
+}
+
+func TestMergeTaints(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		existing []corev1.Taint
+		desired  []corev1.Taint
+		expected []corev1.Taint
+	}{
+		{
+			name:     "When both slices are empty it should return empty",
+			existing: []corev1.Taint{},
+			desired:  []corev1.Taint{},
+			expected: []corev1.Taint{},
+		},
+		{
+			name:     "When existing is nil it should return desired",
+			existing: nil,
+			desired: []corev1.Taint{
+				{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+			},
+			expected: []corev1.Taint{
+				{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+			},
+		},
+		{
+			name: "When desired is empty it should return existing unchanged",
+			existing: []corev1.Taint{
+				{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+			},
+			desired: []corev1.Taint{},
+			expected: []corev1.Taint{
+				{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+			},
+		},
+		{
+			name: "When desired has new taints it should append them",
+			existing: []corev1.Taint{
+				{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+			},
+			desired: []corev1.Taint{
+				{Key: "key2", Value: "val2", Effect: corev1.TaintEffectNoExecute},
+			},
+			expected: []corev1.Taint{
+				{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "key2", Value: "val2", Effect: corev1.TaintEffectNoExecute},
+			},
+		},
+		{
+			name: "When desired has duplicate taints it should not duplicate them",
+			existing: []corev1.Taint{
+				{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+			},
+			desired: []corev1.Taint{
+				{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+			},
+			expected: []corev1.Taint{
+				{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+			},
+		},
+		{
+			name: "When desired has same key but different effect it should add it",
+			existing: []corev1.Taint{
+				{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+			},
+			desired: []corev1.Taint{
+				{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoExecute},
+			},
+			expected: []corev1.Taint{
+				{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoExecute},
+			},
+		},
+		{
+			name: "When desired has mix of new and existing taints it should only add new ones",
+			existing: []corev1.Taint{
+				{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "key2", Value: "val2", Effect: corev1.TaintEffectNoExecute},
+			},
+			desired: []corev1.Taint{
+				{Key: "key2", Value: "val2", Effect: corev1.TaintEffectNoExecute},
+				{Key: "key3", Value: "val3", Effect: corev1.TaintEffectPreferNoSchedule},
+			},
+			expected: []corev1.Taint{
+				{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "key2", Value: "val2", Effect: corev1.TaintEffectNoExecute},
+				{Key: "key3", Value: "val3", Effect: corev1.TaintEffectPreferNoSchedule},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			result := mergeTaints(tc.existing, tc.desired)
+			g.Expect(result).To(Equal(tc.expected))
+		})
+	}
+}
+
+func TestReconcile(t *testing.T) {
+	_ = capiv1.AddToScheme(scheme.Scheme)
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		node           *corev1.Node
+		machine        *capiv1.Machine
+		expectedResult reconcile.Result
+		expectError    bool
+		verify         func(g Gomega, node *corev1.Node)
+	}{
+		{
+			name: "When labels have not been synced it should sync labels and taints and set hash annotation",
+			node: newTestNode(nil, map[string]string{}),
+			machine: newTestMachine(
+				map[string]string{nodePoolAnnotationTaints: taintsJSON([]corev1.Taint{{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoSchedule}})},
+				map[string]string{managedLabel(testGlobalPSLabel): "true"},
+			),
+			verify: func(g Gomega, node *corev1.Node) {
+				g.Expect(node.Labels).To(HaveKeyWithValue(testGlobalPSLabel, "true"))
+				g.Expect(node.Labels).To(HaveKeyWithValue(hyperv1.NodePoolLabel, "test-nodepool"))
+				g.Expect(node.Spec.Taints).To(ContainElement(corev1.Taint{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoSchedule}))
+				g.Expect(node.Annotations[labelsSyncedAnnotation]).NotTo(Equal("true"))
+				g.Expect(node.Annotations[labelsSyncedAnnotation]).NotTo(BeEmpty())
+			},
+		},
+		{
+			name: "When labels have legacy value true it should re-sync and update to hash",
+			node: newTestNode(
+				map[string]string{labelsSyncedAnnotation: "true"},
+				map[string]string{hyperv1.NodePoolLabel: "test-nodepool"},
+			),
+			machine: newTestMachine(
+				map[string]string{nodePoolAnnotationTaints: taintsJSON([]corev1.Taint{})},
+				map[string]string{managedLabel(testGlobalPSLabel): "true"},
+			),
+			verify: func(g Gomega, node *corev1.Node) {
+				g.Expect(node.Labels).To(HaveKeyWithValue(testGlobalPSLabel, "true"))
+				g.Expect(node.Annotations[labelsSyncedAnnotation]).NotTo(Equal("true"))
+				g.Expect(node.Annotations[labelsSyncedAnnotation]).NotTo(BeEmpty())
+			},
+		},
+		{
+			name: "When hash matches it should not modify the node",
+			node: func() *corev1.Node {
+				labels := map[string]string{hyperv1.NodePoolLabel: "test-nodepool"}
+				hash, _ := computeSyncHash(labels, []corev1.Taint{})
+				return newTestNode(map[string]string{labelsSyncedAnnotation: hash}, labels)
+			}(),
+			machine: newTestMachine(
+				map[string]string{nodePoolAnnotationTaints: taintsJSON([]corev1.Taint{})},
+				map[string]string{},
+			),
+			verify: func(g Gomega, node *corev1.Node) {
+				g.Expect(node.Labels).NotTo(HaveKey(testGlobalPSLabel))
+			},
+		},
+		{
+			name: "When hash mismatches due to new Machine label it should re-sync",
+			node: func() *corev1.Node {
+				oldLabels := map[string]string{hyperv1.NodePoolLabel: "test-nodepool"}
+				oldHash, _ := computeSyncHash(oldLabels, []corev1.Taint{})
+				return newTestNode(map[string]string{labelsSyncedAnnotation: oldHash}, oldLabels)
+			}(),
+			machine: newTestMachine(
+				map[string]string{nodePoolAnnotationTaints: taintsJSON([]corev1.Taint{})},
+				map[string]string{managedLabel(testGlobalPSLabel): "true"},
+			),
+			verify: func(g Gomega, node *corev1.Node) {
+				g.Expect(node.Labels).To(HaveKeyWithValue(testGlobalPSLabel, "true"))
+				newExpectedLabels := map[string]string{
+					hyperv1.NodePoolLabel: "test-nodepool",
+					testGlobalPSLabel:     "true",
+				}
+				newHash, err := computeSyncHash(newExpectedLabels, []corev1.Taint{})
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(node.Annotations[labelsSyncedAnnotation]).To(Equal(newHash))
+			},
+		},
+		{
+			name: "When re-syncing with existing taints it should not duplicate them",
+			node: newTestNode(
+				map[string]string{labelsSyncedAnnotation: "true"},
+				map[string]string{},
+				corev1.Taint{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoSchedule},
+			),
+			machine: newTestMachine(
+				map[string]string{nodePoolAnnotationTaints: taintsJSON([]corev1.Taint{{Key: "key1", Value: "val1", Effect: corev1.TaintEffectNoSchedule}})},
+				map[string]string{},
+			),
+			verify: func(g Gomega, node *corev1.Node) {
+				count := 0
+				for _, t := range node.Spec.Taints {
+					if t.Key == "key1" && t.Value == "val1" && t.Effect == corev1.TaintEffectNoSchedule {
+						count++
+					}
+				}
+				g.Expect(count).To(Equal(1))
+			},
+		},
+		{
+			name:    "When Machine has no taints annotation it should sync labels without error",
+			node:    newTestNode(nil, map[string]string{}),
+			machine: newTestMachine(nil, map[string]string{managedLabel(testGlobalPSLabel): "true"}),
+			verify: func(g Gomega, node *corev1.Node) {
+				g.Expect(node.Labels).To(HaveKeyWithValue(testGlobalPSLabel, "true"))
+				g.Expect(node.Labels).To(HaveKeyWithValue(hyperv1.NodePoolLabel, "test-nodepool"))
+				g.Expect(node.Annotations[labelsSyncedAnnotation]).NotTo(BeEmpty())
+			},
+		},
+		{
+			name: "When Machine has invalid taints JSON it should return an error",
+			node: newTestNode(nil, map[string]string{}),
+			machine: newTestMachine(
+				map[string]string{nodePoolAnnotationTaints: "not-valid-json"},
+				map[string]string{},
+			),
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			mgmtClient := fake.NewClientBuilder().WithObjects(tc.machine).Build()
+			guestClient := fake.NewClientBuilder().WithObjects(tc.node).Build()
+
+			r := &reconciler{
+				client:                 mgmtClient,
+				guestClusterClient:     guestClient,
+				CreateOrUpdateProvider: &simpleCreateOrUpdate{},
+			}
+
+			result, err := r.Reconcile(t.Context(), reconcile.Request{
+				NamespacedName: client.ObjectKeyFromObject(tc.node),
+			})
+
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			if tc.expectedResult != (reconcile.Result{}) {
+				g.Expect(result).To(Equal(tc.expectedResult))
+			}
+
+			if tc.verify != nil {
+				updatedNode := &corev1.Node{}
+				err := guestClient.Get(t.Context(), client.ObjectKeyFromObject(tc.node), updatedNode)
+				g.Expect(err).NotTo(HaveOccurred())
+				tc.verify(g, updatedNode)
+			}
+		})
+	}
+}
+
+// simpleCreateOrUpdate implements CreateOrUpdateProvider with a
+// get-mutate-update cycle for unit tests without server-side apply.
+type simpleCreateOrUpdate struct{}
+
+func (s *simpleCreateOrUpdate) CreateOrUpdate(ctx context.Context, c client.Client, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
+	if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+		return controllerutil.OperationResultNone, err
+	}
+	if err := f(); err != nil {
+		return controllerutil.OperationResultNone, err
+	}
+	if err := c.Update(ctx, obj); err != nil {
+		return controllerutil.OperationResultNone, err
+	}
+	return controllerutil.OperationResultUpdated, nil
 }

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -35822,7 +35822,9 @@ map[string]string
 </td>
 <td>
 <em>(Optional)</em>
-<p>nodeLabels propagates a list of labels to Nodes, only once on creation.
+<p>nodeLabels propagates a list of labels to Nodes.
+Labels are re-synced additively whenever the desired state changes;
+labels set by other controllers (kubelet, autoscaler) are preserved.
 Valid values are those in <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set">https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set</a></p>
 </td>
 </tr>
@@ -35837,8 +35839,9 @@ Valid values are those in <a href="https://kubernetes.io/docs/concepts/overview/
 </td>
 <td>
 <em>(Optional)</em>
-<p>taints if specified, propagates a list of taints to Nodes, only once on creation.
-These taints are additive to the ones applied by other controllers</p>
+<p>taints if specified, propagates a list of taints to Nodes.
+Taints are re-synced whenever the desired state changes.
+These taints are additive to the ones applied by other controllers.</p>
 </td>
 </tr>
 <tr>
@@ -47853,7 +47856,9 @@ map[string]string
 </td>
 <td>
 <em>(Optional)</em>
-<p>nodeLabels propagates a list of labels to Nodes, only once on creation.
+<p>nodeLabels propagates a list of labels to Nodes.
+Labels are re-synced additively whenever the desired state changes;
+labels set by other controllers (kubelet, autoscaler) are preserved.
 Valid values are those in <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set">https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set</a></p>
 </td>
 </tr>
@@ -47868,8 +47873,9 @@ Valid values are those in <a href="https://kubernetes.io/docs/concepts/overview/
 </td>
 <td>
 <em>(Optional)</em>
-<p>taints if specified, propagates a list of taints to Nodes, only once on creation.
-These taints are additive to the ones applied by other controllers</p>
+<p>taints if specified, propagates a list of taints to Nodes.
+Taints are re-synced whenever the desired state changes.
+These taints are additive to the ones applied by other controllers.</p>
 </td>
 </tr>
 <tr>

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -1247,7 +1247,9 @@ map[string]string
 </td>
 <td>
 <em>(Optional)</em>
-<p>nodeLabels propagates a list of labels to Nodes, only once on creation.
+<p>nodeLabels propagates a list of labels to Nodes.
+Labels are re-synced additively whenever the desired state changes;
+labels set by other controllers (kubelet, autoscaler) are preserved.
 Valid values are those in <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set">https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set</a></p>
 </td>
 </tr>
@@ -1262,8 +1264,9 @@ Valid values are those in <a href="https://kubernetes.io/docs/concepts/overview/
 </td>
 <td>
 <em>(Optional)</em>
-<p>taints if specified, propagates a list of taints to Nodes, only once on creation.
-These taints are additive to the ones applied by other controllers</p>
+<p>taints if specified, propagates a list of taints to Nodes.
+Taints are re-synced whenever the desired state changes.
+These taints are additive to the ones applied by other controllers.</p>
 </td>
 </tr>
 <tr>
@@ -13278,7 +13281,9 @@ map[string]string
 </td>
 <td>
 <em>(Optional)</em>
-<p>nodeLabels propagates a list of labels to Nodes, only once on creation.
+<p>nodeLabels propagates a list of labels to Nodes.
+Labels are re-synced additively whenever the desired state changes;
+labels set by other controllers (kubelet, autoscaler) are preserved.
 Valid values are those in <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set">https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set</a></p>
 </td>
 </tr>
@@ -13293,8 +13298,9 @@ Valid values are those in <a href="https://kubernetes.io/docs/concepts/overview/
 </td>
 <td>
 <em>(Optional)</em>
-<p>taints if specified, propagates a list of taints to Nodes, only once on creation.
-These taints are additive to the ones applied by other controllers</p>
+<p>taints if specified, propagates a list of taints to Nodes.
+Taints are re-synced whenever the desired state changes.
+These taints are additive to the ones applied by other controllers.</p>
 </td>
 </tr>
 <tr>

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -192,13 +192,16 @@ type NodePoolSpec struct {
 	// +optional
 	NodeVolumeDetachTimeout *metav1.Duration `json:"nodeVolumeDetachTimeout,omitempty"`
 
-	// nodeLabels propagates a list of labels to Nodes, only once on creation.
+	// nodeLabels propagates a list of labels to Nodes.
+	// Labels are re-synced additively whenever the desired state changes;
+	// labels set by other controllers (kubelet, autoscaler) are preserved.
 	// Valid values are those in https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
 	// +optional
 	NodeLabels map[string]string `json:"nodeLabels,omitempty"`
 
-	// taints if specified, propagates a list of taints to Nodes, only once on creation.
-	// These taints are additive to the ones applied by other controllers
+	// taints if specified, propagates a list of taints to Nodes.
+	// Taints are re-synced whenever the desired state changes.
+	// These taints are additive to the ones applied by other controllers.
 	// +kubebuilder:validation:MaxItems=50
 	// +optional
 	Taints []Taint `json:"taints,omitempty"`


### PR DESCRIPTION
## What this PR does / why we need it:

The HCCO Node controller uses a boolean annotation (`hypershift.openshift.io/labelsSynced: "true"`) as a one-shot gate. Once set, managed labels are never re-synced from Machine to Node. When the HO upgrades from v0.1.74 to v0.1.75, the new `globalps-enabled` label added to Machines by the NodePool controller never reaches pre-existing Nodes because the gate is already set. This causes the `global-pull-secret-syncer` DaemonSet to not schedule on those nodes (its nodeSelector requires the label).

This PR replaces the boolean value with a SHA-256 hash of the Machine's managed labels and taints. When the set of managed labels or taints changes, the hash won't match the stored annotation, triggering a re-sync. Nodes with the legacy `"true"` value are automatically re-synced once on the first reconciliation after the CPO upgrade.

Additionally fixes a latent taint duplication bug: the original code used `append()` without deduplication, which would duplicate taints on re-sync. The new `mergeTaints()` function prevents this.

## Which issue(s) this PR fixes:

- Fixes https://issues.redhat.com/browse/OCPBUGS-85079

## Special notes for your reviewer:

- **No API changes** — only the annotation value format changes (from `"true"` to a 16-char hex hash)
- **One-time benign re-sync** on upgrade: all existing nodes will re-sync once after CPO upgrade because the old `"true"` value won't match the computed hash. This is the desired behavior — it ensures all nodes get any labels added since their initial sync.
- **Future-proof**: any new managed label added in future HO versions will automatically trigger re-sync on affected nodes, preventing the same class of bug.
- The fix is in the HCCO (part of OCP release payload), so the OCP version in the ControlPlane must be updated to pick up the fix.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deterministic sync hashing and stricter sync-state checks so nodes skip reconciliation only when the stored hash exactly matches the computed value.
  * Deterministic, deduplicating merge of node taints and safer, additive label application to avoid duplicate or unnecessary updates.
  * More reliable node-pool resolution by deriving the pool from the associated machine.

* **Tests**
  * Expanded unit and reconciliation tests covering hash computation, label/taint sync and merge behavior, name resolution, and end-to-end reconcile scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->