### PR TITLE
Revert "OCPBUGS-86774: Pin azure-cli to 2.72.0 in e2e Dockerfile"

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -30,5 +30,5 @@ COPY --from=builder /hypershift/hack/run-reqserving-e2e.sh /hypershift/hack/run-
 RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc && \
     dnf install -y https://packages.microsoft.com/config/rhel/9/packages-microsoft-prod.rpm && \
     mv /etc/yum.repos.d/microsoft-prod.repo /etc/yum.repos.art/ci/ && \
-    dnf install -y azure-cli-2.72.0 && \
+    dnf install -y azure-cli && \
     dnf clean all


### PR DESCRIPTION
Reverts openshift/hypershift#8638

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Azure CLI configuration in test environment setup to use the latest available version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->