### PR TITLE
CNTRLPLANE-1357: add KMSv2 secret encryption e2e v2 test for Self Managed Azure

### DIFF
--- a/test/e2e/v2/lifecycle/azure.go
+++ b/test/e2e/v2/lifecycle/azure.go
@@ -23,6 +23,7 @@ const (
 	defaultOIDCIssuerURL      = "https://smazure.blob.core.windows.net/smazure"
 	defaultSATokenKeyPath     = "/etc/hypershift-ci-jobs-self-managed-azure-e2e/serviceaccount-signer.private"
 	defaultWorkloadIdentities = "/etc/hypershift-ci-jobs-self-managed-azure-e2e/workload-identities.json"
+	defaultEncryptionKeyID    = "/etc/hypershift-ci-jobs-self-managed-azure-e2e/AZURE_ENCRYPTION_KEY_ID"
 )
 
 // AzurePlatformConfig holds Azure-specific configuration for the
@@ -36,6 +37,7 @@ type AzurePlatformConfig struct {
 	dnsZoneRG          string
 	privateNATSubnetID string
 	sharedDir          string
+	encryptionKeyID    string
 
 	marketplacePublisher string
 	marketplaceOffer     string
@@ -71,6 +73,16 @@ func NewAzurePlatformConfig(sharedDir string) *AzurePlatformConfig {
 		log.Printf("WARNING: AZURE_PRIVATE_NAT_SUBNET_ID is not set; private cluster creation will fail")
 	}
 
+	cfg.encryptionKeyID = os.Getenv("AZURE_ENCRYPTION_KEY_ID")
+	if cfg.encryptionKeyID == "" {
+		if data, err := os.ReadFile(defaultEncryptionKeyID); err == nil {
+			cfg.encryptionKeyID = strings.TrimSpace(string(data))
+		}
+	}
+	if cfg.encryptionKeyID == "" {
+		log.Printf("WARNING: AZURE_ENCRYPTION_KEY_ID is not set; secret encryption tests will be skipped")
+	}
+
 	if cfg.marketplaceSKU == "" && cfg.marketplacePublisher != "" && sharedDir != "" {
 		if data, err := os.ReadFile(filepath.Join(sharedDir, "azure-marketplace-image-sku")); err == nil {
 			cfg.marketplaceSKU = strings.TrimSpace(string(data))
@@ -92,10 +104,16 @@ func (a *AzurePlatformConfig) DefaultBaseDomain() string {
 }
 
 func (a *AzurePlatformConfig) ClusterSpecs(releaseImage, n1Image string) []ClusterSpec {
+	var publicExtraArgs []string
+	if a.encryptionKeyID != "" {
+		publicExtraArgs = append(publicExtraArgs, "--encryption-key-id="+a.encryptionKeyID)
+	}
+
 	return []ClusterSpec{
 		{
 			Variant:    "public",
 			OutputFile: "cluster-name-public",
+			ExtraArgs:  publicExtraArgs,
 		},
 		{
 			Variant:    "private",
@@ -187,7 +205,7 @@ func (a *AzurePlatformConfig) TestMatrix(releaseImage string) TestMatrix {
 			{
 				Name:        "public",
 				ClusterFile: "cluster-name-public",
-				LabelFilter: "self-managed-azure-public || nodepool-lifecycle",
+				LabelFilter: "self-managed-azure-public || nodepool-lifecycle || secret-encryption",
 				Skip:        "KAS allowed CIDRs",
 				JUnitFile:   "junit_self_managed_azure_public.xml",
 			},

--- a/test/e2e/v2/tests/hosted_cluster_secret_encryption_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_secret_encryption_test.go
@@ -1,0 +1,166 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	"github.com/openshift/hypershift/test/e2e/v2/internal"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// KMSSpecValidationTest validates that the HostedCluster's SecretEncryption KMS spec
+// fields are correctly populated. Stateless — reads HC spec only.
+func KMSSpecValidationTest(getTestCtx internal.TestContextGetter) {
+	Context("KMS Spec Validation", func() {
+		Context("Azure KMS", func() {
+			BeforeEach(func() {
+				testCtx := getTestCtx()
+				hc := testCtx.GetHostedCluster()
+				if hc == nil || hc.Spec.Platform.Type != hyperv1.AzurePlatform ||
+					hc.Spec.SecretEncryption == nil || hc.Spec.SecretEncryption.KMS == nil ||
+					hc.Spec.SecretEncryption.KMS.Azure == nil {
+					Skip("Azure KMS spec validation requires Azure platform with KMS configured")
+				}
+			})
+
+			It("should have ActiveKey fields populated", func() {
+				testCtx := getTestCtx()
+				hc := testCtx.GetHostedCluster()
+				azureKMS := hc.Spec.SecretEncryption.KMS.Azure
+
+				Expect(azureKMS.ActiveKey.KeyVaultName).NotTo(BeEmpty(),
+					"ActiveKey.KeyVaultName must be set")
+				Expect(azureKMS.ActiveKey.KeyName).NotTo(BeEmpty(),
+					"ActiveKey.KeyName must be set")
+				Expect(azureKMS.ActiveKey.KeyVersion).NotTo(BeEmpty(),
+					"ActiveKey.KeyVersion must be set")
+			})
+
+			It("should have KMS authentication configured", func() {
+				testCtx := getTestCtx()
+				hc := testCtx.GetHostedCluster()
+				azureKMS := hc.Spec.SecretEncryption.KMS.Azure
+
+				hasWorkloadIdentity := azureKMS.WorkloadIdentity.ClientID != ""
+				hasManagedIdentity := azureKMS.KMS.CredentialsSecretName != ""
+				Expect(hasWorkloadIdentity || hasManagedIdentity).To(BeTrue(),
+					"either WorkloadIdentity.ClientID or KMS.CredentialsSecretName must be set")
+
+				if hasWorkloadIdentity {
+					Expect(string(azureKMS.WorkloadIdentity.ClientID)).NotTo(BeEmpty(),
+						"WorkloadIdentity.ClientID must be non-empty for self-managed Azure")
+				}
+				if hasManagedIdentity {
+					Expect(azureKMS.KMS.CredentialsSecretName).NotTo(BeEmpty(),
+						"KMS.CredentialsSecretName must be non-empty for managed Azure")
+					Expect(string(azureKMS.KMS.ObjectEncoding)).NotTo(BeEmpty(),
+						"KMS.ObjectEncoding must be non-empty for managed Azure")
+				}
+			})
+		})
+	})
+}
+
+// KMSFunctionalValidationTest validates that secrets stored in etcd are encrypted
+// using KMSv2. Creates a test secret in the hosted cluster, reads it from etcd
+// via etcdctl, and asserts the k8s:enc:kms:v2 prefix. Cleans up via DeferCleanup.
+func KMSFunctionalValidationTest(getTestCtx internal.TestContextGetter) {
+	Context("KMS Functional Validation", func() {
+		It("should encrypt secrets in etcd using KMSv2", func() {
+			e2eutil.GinkgoAtLeast(e2eutil.Version417)
+			testCtx := getTestCtx()
+			ctx := testCtx.Context
+
+			hostedClusterClient := testCtx.GetHostedClusterClient()
+			Expect(hostedClusterClient).NotTo(BeNil(),
+				"hosted cluster client is required; KubeConfig may not be set")
+
+			testSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "e2e-kms-test-secret",
+					Namespace: "default",
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					"testKey": []byte("testData"),
+				},
+			}
+			Expect(hostedClusterClient.Create(ctx, testSecret)).To(Succeed(),
+				"failed to create test secret in hosted cluster")
+
+			DeferCleanup(func() {
+				if err := hostedClusterClient.Delete(context.Background(), testSecret); err != nil && !apierrors.IsNotFound(err) {
+					GinkgoWriter.Printf("WARNING: failed to cleanup test secret: %v\n", err)
+				}
+			})
+
+			secretEtcdKey := fmt.Sprintf("/kubernetes.io/secrets/%s/%s",
+				testSecret.Namespace, testSecret.Name)
+			command := []string{
+				"/usr/bin/etcdctl",
+				"--endpoints=localhost:2379",
+				"--cacert=/etc/etcd/tls/etcd-ca/ca.crt",
+				"--cert=/etc/etcd/tls/client/etcd-client.crt",
+				"--key=/etc/etcd/tls/client/etcd-client.key",
+				"get",
+				secretEtcdKey,
+			}
+
+			output, err := e2eutil.RunCommandInPod(ctx, testCtx.MgmtClient, "etcd",
+				testCtx.ControlPlaneNamespace, command, "etcd", 5*time.Minute)
+			Expect(err).NotTo(HaveOccurred(), "failed to execute etcdctl command")
+			Expect(output).NotTo(BeEmpty(), "etcdctl returned empty output for key %s", secretEtcdKey)
+			Expect(output).To(ContainSubstring("k8s:enc:kms:v2"),
+				"secret should be encrypted using KMSv2")
+			Expect(output).NotTo(ContainSubstring("testData"),
+				"secret data should not be readable in plaintext from etcd")
+		})
+	})
+}
+
+// RegisterHostedClusterSecretEncryptionTests registers all secret encryption tests.
+func RegisterHostedClusterSecretEncryptionTests(getTestCtx internal.TestContextGetter) {
+	KMSSpecValidationTest(getTestCtx)
+	KMSFunctionalValidationTest(getTestCtx)
+}
+
+var _ = Describe("Hosted Cluster Secret Encryption", Label("secret-encryption"), func() {
+	var testCtx *internal.TestContext
+
+	BeforeEach(func() {
+		testCtx = internal.GetTestContext()
+		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
+
+		hc := testCtx.GetHostedCluster()
+		if hc == nil || hc.Spec.SecretEncryption == nil || hc.Spec.SecretEncryption.KMS == nil {
+			Skip("SecretEncryption with KMS is not configured on this hosted cluster")
+		}
+	})
+
+	RegisterHostedClusterSecretEncryptionTests(func() *internal.TestContext { return testCtx })
+})


### PR DESCRIPTION
## What this PR does / why we need it:

Adds an e2e v2 test that validates KMSv2 secret encryption on Azure self-managed hosted clusters. This ports the KMS validation from the v1 `TestCreateClusterCustomConfig` test into the v2 framework.

- KMS spec validation: asserts ActiveKey fields (KeyVaultName, KeyName, KeyVersion) and auth config (WorkloadIdentity for self-managed, ManagedIdentity for ARO HCP)
- KMS functional validation: creates test secret in hosted cluster, execs etcdctl in etcd pod, asserts `k8s:enc:kms:v2` prefix in raw etcd value
- Adds `--encryption-key-id` to the public cluster variant when `AZURE_ENCRYPTION_KEY_ID` is set (env var or vault-mounted file)
- Adds `secret-encryption` label to the public test group's label filter
- Skips gracefully when KMS is not configured, so existing CI jobs are unaffected

### CI Prerequisites

Azure resources created in `self-managed-azure-ci` resource group:
- Key Vault: `sm-azure-ci-kms`
- Encryption key: `e2e-encryption-key`
- KMS managed identity with Key Vault Crypto User role and federated credential

Vault secrets updated in `hypershift-ci-jobs-self-managed-azure-e2e`:
- `workload-identities.json`: added `kmsClientID`
- `AZURE_ENCRYPTION_KEY_ID`: new field with key URL

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/CNTRLPLANE-1357

## Special notes for your reviewer:

The test file is designed to be platform-extensible — future AWS and GCP KMS contexts can be added without touching the Azure block.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Azure E2E test suite expanded to include secret encryption validation scenarios
  * New tests verify that secrets are properly encrypted at rest in etcd using KMS v2
  * Encryption key ID configuration now supported for Azure E2E tests via environment variable
  * Added validation tests for secret encryption configuration on hosted clusters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->