### PR TITLE
NO-JIRA: Make codecov project check informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,15 @@ codecov:
   notify:
     wait_for_ci: false
 
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        target: 80%
+
 flags:
   cpo-hostedcontrolplane:
     carryforward: true


### PR DESCRIPTION
## Summary

- Make the `codecov/project` status check informational (reports but does not block merge)
- Keep the `codecov/patch` check as the merge gate with an 80% target

## Description

The `codecov/project` check produces false negatives when carryforward coverage data is stale. When a CI run on the base commit is partially cancelled, some test shards never upload fresh coverage. Codecov carries forward older, smaller snapshots for those flags. When a PR runs all 5 shards successfully against the current codebase (which may have grown significantly since the stale base data), the freshly-measured project coverage appears lower — not because the PR reduced coverage, but because previously invisible files now show their actual (lower) coverage.

This was observed in [#8368](https://github.com/openshift/hypershift/pull/8368) where patch coverage was 95.47% but `codecov/project` reported -4.46% due to 2 stale shards (`cmd-support` and `other`) on the base commit.

The `patch` check is a more reliable gate: it validates that new/changed lines are properly tested, regardless of base commit data quality.

## Test plan

- [x] Verify `codecov/project` reports as informational (does not block tide)
- [x] Verify `codecov/patch` still blocks with 80% target

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage reporting configuration to establish clearer coverage metrics. Now sets a target of 80% coverage for patches and designates project-level coverage reporting as informational.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->