### PR TITLE
OCPBUGS-85065: Fix repeated CPO Deployment churn due to OPENSHIFT_IMG_OVERRIDES reordering

### DIFF
--- a/support/util/util.go
+++ b/support/util/util.go
@@ -251,6 +251,7 @@ func ConvertOpenShiftImageRegistryOverridesToCommandLineFlag(registryOverrides m
 
 	for _, registrySource := range sortedRegistrySources {
 		registryReplacements := registryOverrides[registrySource]
+		sort.Strings(registryReplacements)
 		for _, registryReplacement := range registryReplacements {
 			commandLineFlagArray = append(commandLineFlagArray, fmt.Sprintf("%s=%s", registrySource, registryReplacement))
 		}

--- a/support/util/util.go
+++ b/support/util/util.go
@@ -277,6 +277,7 @@ func ConvertOpenShiftImageRegistryOverridesToCommandLineFlag(registryOverrides m
 
 	for _, registrySource := range sortedRegistrySources {
 		registryReplacements := registryOverrides[registrySource]
+		sort.Strings(registryReplacements)
 		for _, registryReplacement := range registryReplacements {
 			commandLineFlagArray = append(commandLineFlagArray, fmt.Sprintf("%s=%s", registrySource, registryReplacement))
 		}

--- a/support/util/util_test.go
+++ b/support/util/util_test.go
@@ -142,6 +142,21 @@ func TestConvertOpenShiftImageRegistryOverridesToCommandLineFlag(t *testing.T) {
 			},
 			expectedFlag: "registry1=mirror1.1,registry1=mirror1.2,registry1=mirror1.3,registry2=mirror2.1,registry2=mirror2.2,registry3=mirror3.1",
 		},
+		{
+			name: "When mirrors are in non-alphabetical order, it should sort them deterministically",
+			registryOverrides: map[string][]string{
+				"cp.icr.io/cp": {
+					"mirror-c.example.com",
+					"mirror-a.example.com",
+					"mirror-b.example.com",
+				},
+				"icr.io/cpopen": {
+					"mirror-z.example.com",
+					"mirror-x.example.com",
+				},
+			},
+			expectedFlag: "cp.icr.io/cp=mirror-a.example.com,cp.icr.io/cp=mirror-b.example.com,cp.icr.io/cp=mirror-c.example.com,icr.io/cpopen=mirror-x.example.com,icr.io/cpopen=mirror-z.example.com",
+		},
 	}
 
 	t.Parallel()


### PR DESCRIPTION
## What this PR does / why we need it:

Sorts mirrors within each registry source alphabetically when building
the `OPENSHIFT_IMG_OVERRIDES` environment variable string. Without this,
overlapping mirror definitions across multiple IDMS/ICSP objects for the
same source produce non-deterministic mirror ordering, causing the CPO
Deployment to roll out repeatedly even though the content is identical.

The prior fix (OCPBUGS-57626) sorted ICSP items by name but did not sort
the mirrors within each source. This is a variant where the same source
appears in multiple IDMS/ICSP objects, and the mirror values for that
source get appended in non-deterministic order.

## Which issue(s) this PR fixes:

Fixes OCPBUGS-85065

## Special notes for your reviewer:

The fix is a single `sort.Strings()` call in
`ConvertOpenShiftImageRegistryOverridesToCommandLineFlag()`. This makes
the output deterministic regardless of how mirrors are collected upstream
from IDMS/ICSP objects.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image registry mirror replacements are now sorted deterministically when converting to command-line flags, ensuring consistent output.

* **Tests**
  * Added test coverage validating consistent sorting of registry mirrors provided in non-alphabetical order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->