### PR TITLE
feat(azure): add spec-level validation for workload identity config

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -164,6 +164,13 @@ const (
 	// A failure here indicates that the input is invalid, or permissions are missing to use the encryption key.
 	ValidAzureKMSConfig ConditionType = "ValidAzureKMSConfig"
 
+	// ValidAzureWorkloadIdentity indicates whether the required Azure Workload Identity
+	// configuration is present and valid in the HostedCluster spec. This validates that
+	// all mandatory managed identity client IDs are specified for self-managed Azure clusters
+	// using WorkloadIdentities authentication. A failure here indicates the cluster was
+	// created without running "hypershift create iam azure" or the spec is incomplete.
+	ValidAzureWorkloadIdentity ConditionType = "ValidAzureWorkloadIdentity"
+
 	// ValidGCPCredentials indicates if GCP credentials are valid and operational
 	// for the HostedCluster. This includes service account authentication and
 	// proper IAM permissions for CAPG controllers.
@@ -320,8 +327,11 @@ const (
 
 	InvalidIAMRoleReason = "InvalidIAMRole"
 
-	InvalidAzureCredentialsReason = "InvalidAzureCredentials"
-	AzureErrorReason              = "AzureError"
+	InvalidAzureCredentialsReason            = "InvalidAzureCredentials"
+	AzureWorkloadIdentityNotConfiguredReason = "WorkloadIdentityNotConfigured"
+	AzureWorkloadIdentityIncompleteReason    = "WorkloadIdentityIncomplete"
+	AzureWorkloadIdentityValidReason         = "ValidWorkloadIdentityConfiguration"
+	AzureErrorReason                         = "AzureError"
 
 	ExternalDNSHostNotReachableReason = "ExternalDNSHostNotReachable"
 

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -43450,6 +43450,13 @@ A failure here indicates that the role or the key are invalid, or the role doesn
 <td><p>ValidAzureKMSConfig indicates whether the given KMS input for the Azure platform is valid and operational
 A failure here indicates that the input is invalid, or permissions are missing to use the encryption key.</p>
 </td>
+</tr><tr><td><p>&#34;ValidAzureWorkloadIdentity&#34;</p></td>
+<td><p>ValidAzureWorkloadIdentity indicates whether the required Azure Workload Identity
+configuration is present and valid in the HostedCluster spec. This validates that
+all mandatory managed identity client IDs are specified for self-managed Azure clusters
+using WorkloadIdentities authentication. A failure here indicates the cluster was
+created without running &ldquo;hypershift create iam azure&rdquo; or the spec is incomplete.</p>
+</td>
 </tr><tr><td><p>&#34;ValidGCPCredentials&#34;</p></td>
 <td><p>ValidGCPCredentials indicates if GCP credentials are valid and operational
 for the HostedCluster. This includes service account authentication and

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -45412,6 +45412,13 @@ A failure here indicates that the role or the key are invalid, or the role doesn
 <td><p>ValidAzureKMSConfig indicates whether the given KMS input for the Azure platform is valid and operational
 A failure here indicates that the input is invalid, or permissions are missing to use the encryption key.</p>
 </td>
+</tr><tr><td><p>&#34;ValidAzureWorkloadIdentity&#34;</p></td>
+<td><p>ValidAzureWorkloadIdentity indicates whether the required Azure Workload Identity
+configuration is present and valid in the HostedCluster spec. This validates that
+all mandatory managed identity client IDs are specified for self-managed Azure clusters
+using WorkloadIdentities authentication. A failure here indicates the cluster was
+created without running &ldquo;hypershift create iam azure&rdquo; or the spec is incomplete.</p>
+</td>
 </tr><tr><td><p>&#34;ValidGCPCredentials&#34;</p></td>
 <td><p>ValidGCPCredentials indicates if GCP credentials are valid and operational
 for the HostedCluster. This includes service account authentication and

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -6308,6 +6308,13 @@ A failure here indicates that the role or the key are invalid, or the role doesn
 <td><p>ValidAzureKMSConfig indicates whether the given KMS input for the Azure platform is valid and operational
 A failure here indicates that the input is invalid, or permissions are missing to use the encryption key.</p>
 </td>
+</tr><tr><td><p>&#34;ValidAzureWorkloadIdentity&#34;</p></td>
+<td><p>ValidAzureWorkloadIdentity indicates whether the required Azure Workload Identity
+configuration is present and valid in the HostedCluster spec. This validates that
+all mandatory managed identity client IDs are specified for self-managed Azure clusters
+using WorkloadIdentities authentication. A failure here indicates the cluster was
+created without running &ldquo;hypershift create iam azure&rdquo; or the spec is incomplete.</p>
+</td>
 </tr><tr><td><p>&#34;ValidGCPCredentials&#34;</p></td>
 <td><p>ValidGCPCredentials indicates if GCP credentials are valid and operational
 for the HostedCluster. This includes service account authentication and

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller_test.go
@@ -2038,6 +2038,7 @@ func TestHostedClusterWatchesEverythingItCreates(t *testing.T) {
 									Disk:               hyperv1.WorkloadIdentity{ClientID: "12345678-1234-1234-1234-123456789abc"},
 									NodePoolManagement: hyperv1.WorkloadIdentity{ClientID: "12345678-1234-1234-1234-123456789abc"},
 									CloudProvider:      hyperv1.WorkloadIdentity{ClientID: "12345678-1234-1234-1234-123456789abc"},
+									Network:            hyperv1.WorkloadIdentity{ClientID: "12345678-1234-1234-1234-123456789abc"},
 								},
 							},
 							TenantID: "12345678-1234-1234-1234-123456789abc",

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
@@ -209,6 +209,7 @@ func (a Azure) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, _ *hy
 
 	// For self-managed Azure with workload identity, instruct Azure SDK to use the minted SA token
 	if azureutil.IsSelfManagedAzureWithWorkloadIdentity(hcluster.Spec.Platform.Type, hcluster.Spec.Platform.Azure) {
+
 		deploymentSpec.Template.Spec.Containers[0].Env = append(
 			deploymentSpec.Template.Spec.Containers[0].Env,
 			corev1.EnvVar{
@@ -285,6 +286,15 @@ func (a Azure) ReconcileCredentials(ctx context.Context, c client.Client, create
 
 	// For self-managed Azure, use workload identity credentials; for managed Azure, use the existing approach
 	if azureutil.IsSelfManagedAzureWithWorkloadIdentity(hcluster.Spec.Platform.Type, hcluster.Spec.Platform.Azure) {
+		// Validate workload identity configuration before proceeding.
+		// TODO(RFE-9351 Phase 2): Set ValidAzureWorkloadIdentity condition directly on
+		// hcluster.Status.Conditions instead of relying on error propagation through
+		// PlatformCredentialsFound. This requires either changing ReconcileCredentials to
+		// return []metav1.Condition or moving validation to the controller level.
+		if condition := validateWorkloadIdentityConfig(hcluster); condition != nil && condition.Status == metav1.ConditionFalse {
+			return fmt.Errorf("azure workload identity validation failed: %s", condition.Message)
+		}
+
 		// Add federated token file for workload identity authentication
 		baseSecretData["azure_federated_token_file"] = []byte(path.Join(config.CloudTokenMountPath, "token"))
 
@@ -329,6 +339,7 @@ func (a Azure) ReconcileCredentials(ctx context.Context, c client.Client, create
 		secretData := maps.Clone(baseSecretData)
 		// For self-managed Azure with workload identities, add the network client ID
 		if azureutil.IsSelfManagedAzureWithWorkloadIdentity(hcluster.Spec.Platform.Type, hcluster.Spec.Platform.Azure) {
+
 			secretData["azure_client_id"] = []byte(hcluster.Spec.Platform.Azure.AzureAuthenticationConfig.WorkloadIdentities.Network.ClientID)
 		}
 		cloudNetworkConfigCreds.Data = secretData
@@ -554,4 +565,76 @@ func reconcileKMSConfigSecret(secret *corev1.Secret, hc *hyperv1.HostedCluster) 
 	secret.Data[azure.CloudConfigKey] = serializedConfig
 
 	return nil
+}
+
+// validateWorkloadIdentityConfig validates that all required Azure Workload Identity
+// client IDs are present in the HostedCluster spec. Returns a metav1.Condition
+// reflecting the validation result. Currently the caller uses only the error path
+// (condition.Status == ConditionFalse); the condition struct is retained so Phase 2
+// can wire it directly onto HostedCluster.Status.Conditions.
+func validateWorkloadIdentityConfig(hcluster *hyperv1.HostedCluster) *metav1.Condition {
+	azureSpec := hcluster.Spec.Platform.Azure
+	if azureSpec == nil {
+		return nil
+	}
+
+	authConfig := azureSpec.AzureAuthenticationConfig
+	if authConfig.AzureAuthenticationConfigType != hyperv1.AzureAuthenticationTypeWorkloadIdentities {
+		return nil
+	}
+
+	wi := authConfig.WorkloadIdentities
+	if wi == nil {
+		return &metav1.Condition{
+			Type:               string(hyperv1.ValidAzureWorkloadIdentity),
+			Status:             metav1.ConditionFalse,
+			Reason:             hyperv1.AzureWorkloadIdentityNotConfiguredReason,
+			ObservedGeneration: hcluster.Generation,
+			Message:            "workloadIdentities is not configured; run 'hypershift create iam azure' to create the required managed identities and federated credentials",
+		}
+	}
+
+	var missing []string
+	if wi.CloudProvider.ClientID == "" {
+		missing = append(missing, "cloudProvider")
+	}
+	if wi.NodePoolManagement.ClientID == "" {
+		missing = append(missing, "nodePoolManagement")
+	}
+	if wi.Ingress.ClientID == "" {
+		missing = append(missing, "ingress")
+	}
+	if wi.ImageRegistry.ClientID == "" {
+		missing = append(missing, "imageRegistry")
+	}
+	if wi.Disk.ClientID == "" {
+		missing = append(missing, "disk")
+	}
+	if wi.File.ClientID == "" {
+		missing = append(missing, "file")
+	}
+	if wi.Network.ClientID == "" {
+		missing = append(missing, "network")
+	}
+	if azureSpec.Private.Type == hyperv1.AzurePrivateTypePrivateLink && wi.ControlPlaneOperator.ClientID == "" {
+		missing = append(missing, "controlPlaneOperator (required for Private Link)")
+	}
+
+	if len(missing) > 0 {
+		return &metav1.Condition{
+			Type:               string(hyperv1.ValidAzureWorkloadIdentity),
+			Status:             metav1.ConditionFalse,
+			Reason:             hyperv1.AzureWorkloadIdentityIncompleteReason,
+			ObservedGeneration: hcluster.Generation,
+			Message:            fmt.Sprintf("workloadIdentities is missing required clientID for: %s", strings.Join(missing, ", ")),
+		}
+	}
+
+	return &metav1.Condition{
+		Type:               string(hyperv1.ValidAzureWorkloadIdentity),
+		Status:             metav1.ConditionTrue,
+		Reason:             hyperv1.AzureWorkloadIdentityValidReason,
+		ObservedGeneration: hcluster.Generation,
+		Message:            "All required workload identity client IDs are configured",
+	}
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
@@ -215,6 +215,7 @@ func (a Azure) CAPIProviderDeploymentSpec(hcluster *hyperv1.HostedCluster, hcp *
 
 	// For self-managed Azure with workload identity, instruct Azure SDK to use the minted SA token
 	if azureutil.IsSelfManagedAzureWithWorkloadIdentity(hcluster.Spec.Platform.Type, hcluster.Spec.Platform.Azure) {
+
 		deploymentSpec.Template.Spec.Containers[0].Env = append(
 			deploymentSpec.Template.Spec.Containers[0].Env,
 			corev1.EnvVar{
@@ -291,6 +292,15 @@ func (a Azure) ReconcileCredentials(ctx context.Context, c client.Client, create
 
 	// For self-managed Azure, use workload identity credentials; for managed Azure, use the existing approach
 	if azureutil.IsSelfManagedAzureWithWorkloadIdentity(hcluster.Spec.Platform.Type, hcluster.Spec.Platform.Azure) {
+		// Validate workload identity configuration before proceeding.
+		// TODO(RFE-9351 Phase 2): Set ValidAzureWorkloadIdentity condition directly on
+		// hcluster.Status.Conditions instead of relying on error propagation through
+		// PlatformCredentialsFound. This requires either changing ReconcileCredentials to
+		// return []metav1.Condition or moving validation to the controller level.
+		if condition := validateWorkloadIdentityConfig(hcluster); condition != nil && condition.Status == metav1.ConditionFalse {
+			return fmt.Errorf("azure workload identity validation failed: %s", condition.Message)
+		}
+
 		// Add federated token file for workload identity authentication
 		baseSecretData["azure_federated_token_file"] = []byte(path.Join(config.CloudTokenMountPath, "token"))
 
@@ -335,6 +345,7 @@ func (a Azure) ReconcileCredentials(ctx context.Context, c client.Client, create
 		secretData := maps.Clone(baseSecretData)
 		// For self-managed Azure with workload identities, add the network client ID
 		if azureutil.IsSelfManagedAzureWithWorkloadIdentity(hcluster.Spec.Platform.Type, hcluster.Spec.Platform.Azure) {
+
 			secretData["azure_client_id"] = []byte(hcluster.Spec.Platform.Azure.AzureAuthenticationConfig.WorkloadIdentities.Network.ClientID)
 		}
 		cloudNetworkConfigCreds.Data = secretData
@@ -560,4 +571,76 @@ func reconcileKMSConfigSecret(secret *corev1.Secret, hc *hyperv1.HostedCluster) 
 	secret.Data[azure.CloudConfigKey] = serializedConfig
 
 	return nil
+}
+
+// validateWorkloadIdentityConfig validates that all required Azure Workload Identity
+// client IDs are present in the HostedCluster spec. Returns a metav1.Condition
+// reflecting the validation result. Currently the caller uses only the error path
+// (condition.Status == ConditionFalse); the condition struct is retained so Phase 2
+// can wire it directly onto HostedCluster.Status.Conditions.
+func validateWorkloadIdentityConfig(hcluster *hyperv1.HostedCluster) *metav1.Condition {
+	azureSpec := hcluster.Spec.Platform.Azure
+	if azureSpec == nil {
+		return nil
+	}
+
+	authConfig := azureSpec.AzureAuthenticationConfig
+	if authConfig.AzureAuthenticationConfigType != hyperv1.AzureAuthenticationTypeWorkloadIdentities {
+		return nil
+	}
+
+	wi := authConfig.WorkloadIdentities
+	if wi == nil {
+		return &metav1.Condition{
+			Type:               string(hyperv1.ValidAzureWorkloadIdentity),
+			Status:             metav1.ConditionFalse,
+			Reason:             hyperv1.AzureWorkloadIdentityNotConfiguredReason,
+			ObservedGeneration: hcluster.Generation,
+			Message:            "workloadIdentities is not configured; run 'hypershift create iam azure' to create the required managed identities and federated credentials",
+		}
+	}
+
+	var missing []string
+	if wi.CloudProvider.ClientID == "" {
+		missing = append(missing, "cloudProvider")
+	}
+	if wi.NodePoolManagement.ClientID == "" {
+		missing = append(missing, "nodePoolManagement")
+	}
+	if wi.Ingress.ClientID == "" {
+		missing = append(missing, "ingress")
+	}
+	if wi.ImageRegistry.ClientID == "" {
+		missing = append(missing, "imageRegistry")
+	}
+	if wi.Disk.ClientID == "" {
+		missing = append(missing, "disk")
+	}
+	if wi.File.ClientID == "" {
+		missing = append(missing, "file")
+	}
+	if wi.Network.ClientID == "" {
+		missing = append(missing, "network")
+	}
+	if azureSpec.Private.Type == hyperv1.AzurePrivateTypePrivateLink && wi.ControlPlaneOperator.ClientID == "" {
+		missing = append(missing, "controlPlaneOperator (required for Private Link)")
+	}
+
+	if len(missing) > 0 {
+		return &metav1.Condition{
+			Type:               string(hyperv1.ValidAzureWorkloadIdentity),
+			Status:             metav1.ConditionFalse,
+			Reason:             hyperv1.AzureWorkloadIdentityIncompleteReason,
+			ObservedGeneration: hcluster.Generation,
+			Message:            fmt.Sprintf("workloadIdentities is missing required clientID for: %s", strings.Join(missing, ", ")),
+		}
+	}
+
+	return &metav1.Condition{
+		Type:               string(hyperv1.ValidAzureWorkloadIdentity),
+		Status:             metav1.ConditionTrue,
+		Reason:             hyperv1.AzureWorkloadIdentityValidReason,
+		ObservedGeneration: hcluster.Generation,
+		Message:            "All required workload identity client IDs are configured",
+	}
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure_test.go
@@ -262,6 +262,12 @@ func TestReconcileCredentials(t *testing.T) {
 			name:           "self-managed Azure with workload identities creates all credential secrets",
 			managedService: "",
 			hcluster: createTestHostedCluster(true, &hyperv1.AzureWorkloadIdentities{
+				CloudProvider: hyperv1.WorkloadIdentity{
+					ClientID: "cloud-provider-client-id",
+				},
+				NodePoolManagement: hyperv1.WorkloadIdentity{
+					ClientID: "nodepool-mgmt-client-id",
+				},
 				Ingress: hyperv1.WorkloadIdentity{
 					ClientID: "ingress-client-id",
 				},
@@ -317,6 +323,12 @@ func TestReconcileCredentials(t *testing.T) {
 			managedService: "",
 			hcluster: func() *hyperv1.HostedCluster {
 				hc := createTestHostedCluster(true, &hyperv1.AzureWorkloadIdentities{
+					CloudProvider: hyperv1.WorkloadIdentity{
+						ClientID: "cloud-provider-client-id",
+					},
+					NodePoolManagement: hyperv1.WorkloadIdentity{
+						ClientID: "nodepool-mgmt-client-id",
+					},
 					Ingress: hyperv1.WorkloadIdentity{
 						ClientID: "ingress-client-id",
 					},
@@ -721,6 +733,206 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 					g.Expect(machine.Finalizers).To(Equal(tc.azureMachines[0].Finalizers), "finalizers should not be modified")
 				}
 			}
+		})
+	}
+}
+func TestValidateWorkloadIdentityConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		hcluster       *hyperv1.HostedCluster
+		expectNil      bool
+		expectStatus   metav1.ConditionStatus
+		expectReason   string
+		expectContains string
+	}{
+		{
+			name: "non-Azure platform returns nil",
+			hcluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+					},
+				},
+			},
+			expectNil: true,
+		},
+		{
+			name: "Azure with ManagedIdentities auth returns nil",
+			hcluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+						Azure: &hyperv1.AzurePlatformSpec{
+							AzureAuthenticationConfig: hyperv1.AzureAuthenticationConfiguration{
+								AzureAuthenticationConfigType: hyperv1.AzureAuthenticationTypeManagedIdentities,
+							},
+						},
+					},
+				},
+			},
+			expectNil: true,
+		},
+		{
+			name: "WorkloadIdentities auth with nil WorkloadIdentities returns not configured",
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{Generation: 3},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+						Azure: &hyperv1.AzurePlatformSpec{
+							AzureAuthenticationConfig: hyperv1.AzureAuthenticationConfiguration{
+								AzureAuthenticationConfigType: hyperv1.AzureAuthenticationTypeWorkloadIdentities,
+							},
+						},
+					},
+				},
+			},
+			expectNil:      false,
+			expectStatus:   metav1.ConditionFalse,
+			expectReason:   hyperv1.AzureWorkloadIdentityNotConfiguredReason,
+			expectContains: "not configured",
+		},
+		{
+			name: "WorkloadIdentities with missing clientIDs returns incomplete",
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{Generation: 5},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+						Azure: &hyperv1.AzurePlatformSpec{
+							AzureAuthenticationConfig: hyperv1.AzureAuthenticationConfiguration{
+								AzureAuthenticationConfigType: hyperv1.AzureAuthenticationTypeWorkloadIdentities,
+								WorkloadIdentities: &hyperv1.AzureWorkloadIdentities{
+									CloudProvider:      hyperv1.WorkloadIdentity{ClientID: "client-1"},
+									NodePoolManagement: hyperv1.WorkloadIdentity{ClientID: "client-2"},
+									Ingress:            hyperv1.WorkloadIdentity{ClientID: ""},
+									ImageRegistry:      hyperv1.WorkloadIdentity{ClientID: "client-4"},
+									Disk:               hyperv1.WorkloadIdentity{ClientID: "client-5"},
+									File:               hyperv1.WorkloadIdentity{ClientID: ""},
+									Network:            hyperv1.WorkloadIdentity{ClientID: "client-7"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectNil:      false,
+			expectStatus:   metav1.ConditionFalse,
+			expectReason:   hyperv1.AzureWorkloadIdentityIncompleteReason,
+			expectContains: "ingress, file",
+		},
+		{
+			name: "When Private Link is configured without controlPlaneOperator clientID, it should report incomplete",
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{Generation: 6},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+						Azure: &hyperv1.AzurePlatformSpec{
+							Private: hyperv1.AzurePrivateSpec{
+								Type: hyperv1.AzurePrivateTypePrivateLink,
+							},
+							AzureAuthenticationConfig: hyperv1.AzureAuthenticationConfiguration{
+								AzureAuthenticationConfigType: hyperv1.AzureAuthenticationTypeWorkloadIdentities,
+								WorkloadIdentities: &hyperv1.AzureWorkloadIdentities{
+									CloudProvider:      hyperv1.WorkloadIdentity{ClientID: "client-1"},
+									NodePoolManagement: hyperv1.WorkloadIdentity{ClientID: "client-2"},
+									Ingress:            hyperv1.WorkloadIdentity{ClientID: "client-3"},
+									ImageRegistry:      hyperv1.WorkloadIdentity{ClientID: "client-4"},
+									Disk:               hyperv1.WorkloadIdentity{ClientID: "client-5"},
+									File:               hyperv1.WorkloadIdentity{ClientID: "client-6"},
+									Network:            hyperv1.WorkloadIdentity{ClientID: "client-7"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectNil:      false,
+			expectStatus:   metav1.ConditionFalse,
+			expectReason:   hyperv1.AzureWorkloadIdentityIncompleteReason,
+			expectContains: "controlPlaneOperator",
+		},
+		{
+			name: "When Private Link is configured with controlPlaneOperator clientID, it should return valid",
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{Generation: 6},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+						Azure: &hyperv1.AzurePlatformSpec{
+							Private: hyperv1.AzurePrivateSpec{
+								Type: hyperv1.AzurePrivateTypePrivateLink,
+							},
+							AzureAuthenticationConfig: hyperv1.AzureAuthenticationConfiguration{
+								AzureAuthenticationConfigType: hyperv1.AzureAuthenticationTypeWorkloadIdentities,
+								WorkloadIdentities: &hyperv1.AzureWorkloadIdentities{
+									CloudProvider:        hyperv1.WorkloadIdentity{ClientID: "client-1"},
+									NodePoolManagement:   hyperv1.WorkloadIdentity{ClientID: "client-2"},
+									Ingress:              hyperv1.WorkloadIdentity{ClientID: "client-3"},
+									ImageRegistry:        hyperv1.WorkloadIdentity{ClientID: "client-4"},
+									Disk:                 hyperv1.WorkloadIdentity{ClientID: "client-5"},
+									File:                 hyperv1.WorkloadIdentity{ClientID: "client-6"},
+									Network:              hyperv1.WorkloadIdentity{ClientID: "client-7"},
+									ControlPlaneOperator: hyperv1.WorkloadIdentity{ClientID: "client-8"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectNil:      false,
+			expectStatus:   metav1.ConditionTrue,
+			expectReason:   hyperv1.AzureWorkloadIdentityValidReason,
+			expectContains: "All required",
+		},
+		{
+			name: "WorkloadIdentities with all clientIDs returns valid",
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{Generation: 7},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+						Azure: &hyperv1.AzurePlatformSpec{
+							AzureAuthenticationConfig: hyperv1.AzureAuthenticationConfiguration{
+								AzureAuthenticationConfigType: hyperv1.AzureAuthenticationTypeWorkloadIdentities,
+								WorkloadIdentities: &hyperv1.AzureWorkloadIdentities{
+									CloudProvider:      hyperv1.WorkloadIdentity{ClientID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"},
+									NodePoolManagement: hyperv1.WorkloadIdentity{ClientID: "aaaaaaaa-bbbb-cccc-dddd-ffffffffffff"},
+									Ingress:            hyperv1.WorkloadIdentity{ClientID: "aaaaaaaa-bbbb-cccc-dddd-111111111111"},
+									ImageRegistry:      hyperv1.WorkloadIdentity{ClientID: "aaaaaaaa-bbbb-cccc-dddd-222222222222"},
+									Disk:               hyperv1.WorkloadIdentity{ClientID: "aaaaaaaa-bbbb-cccc-dddd-333333333333"},
+									File:               hyperv1.WorkloadIdentity{ClientID: "aaaaaaaa-bbbb-cccc-dddd-444444444444"},
+									Network:            hyperv1.WorkloadIdentity{ClientID: "aaaaaaaa-bbbb-cccc-dddd-555555555555"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectNil:      false,
+			expectStatus:   metav1.ConditionTrue,
+			expectReason:   hyperv1.AzureWorkloadIdentityValidReason,
+			expectContains: "All required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			condition := validateWorkloadIdentityConfig(tc.hcluster)
+
+			if tc.expectNil {
+				g.Expect(condition).To(BeNil())
+				return
+			}
+
+			g.Expect(condition).NotTo(BeNil())
+			g.Expect(condition.Type).To(Equal(string(hyperv1.ValidAzureWorkloadIdentity)))
+			g.Expect(condition.Status).To(Equal(tc.expectStatus))
+			g.Expect(condition.Reason).To(Equal(tc.expectReason))
+			g.Expect(condition.Message).To(ContainSubstring(tc.expectContains))
+			g.Expect(condition.ObservedGeneration).To(Equal(tc.hcluster.Generation))
 		})
 	}
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure_test.go
@@ -881,7 +881,7 @@ func TestValidateWorkloadIdentityConfig(t *testing.T) {
 		expectContains string
 	}{
 		{
-			name: "non-Azure platform returns nil",
+			name: "When platform is not Azure, it should return nil",
 			hcluster: &hyperv1.HostedCluster{
 				Spec: hyperv1.HostedClusterSpec{
 					Platform: hyperv1.PlatformSpec{
@@ -892,7 +892,7 @@ func TestValidateWorkloadIdentityConfig(t *testing.T) {
 			expectNil: true,
 		},
 		{
-			name: "Azure with ManagedIdentities auth returns nil",
+			name: "When Azure uses ManagedIdentities auth, it should return nil",
 			hcluster: &hyperv1.HostedCluster{
 				Spec: hyperv1.HostedClusterSpec{
 					Platform: hyperv1.PlatformSpec{
@@ -908,7 +908,7 @@ func TestValidateWorkloadIdentityConfig(t *testing.T) {
 			expectNil: true,
 		},
 		{
-			name: "WorkloadIdentities auth with nil WorkloadIdentities returns not configured",
+			name: "When WorkloadIdentities auth has nil WorkloadIdentities, it should return not configured",
 			hcluster: &hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{Generation: 3},
 				Spec: hyperv1.HostedClusterSpec{
@@ -928,7 +928,7 @@ func TestValidateWorkloadIdentityConfig(t *testing.T) {
 			expectContains: "not configured",
 		},
 		{
-			name: "WorkloadIdentities with missing clientIDs returns incomplete",
+			name: "When WorkloadIdentities has missing clientIDs, it should return incomplete",
 			hcluster: &hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{Generation: 5},
 				Spec: hyperv1.HostedClusterSpec{
@@ -1022,7 +1022,7 @@ func TestValidateWorkloadIdentityConfig(t *testing.T) {
 			expectContains: "All required",
 		},
 		{
-			name: "WorkloadIdentities with all clientIDs returns valid",
+			name: "When WorkloadIdentities has all clientIDs, it should return valid",
 			hcluster: &hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{Generation: 7},
 				Spec: hyperv1.HostedClusterSpec{
@@ -1068,3 +1068,6 @@ func TestValidateWorkloadIdentityConfig(t *testing.T) {
 			g.Expect(condition.Reason).To(Equal(tc.expectReason))
 			g.Expect(condition.Message).To(ContainSubstring(tc.expectContains))
 			g.Expect(condition.ObservedGeneration).To(Equal(tc.hcluster.Generation))
+		})
+	}
+}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure_test.go
@@ -266,6 +266,12 @@ func TestReconcileCredentials(t *testing.T) {
 			name:           "self-managed Azure with workload identities creates all credential secrets",
 			managedService: "",
 			hcluster: createTestHostedCluster(true, &hyperv1.AzureWorkloadIdentities{
+				CloudProvider: hyperv1.WorkloadIdentity{
+					ClientID: "cloud-provider-client-id",
+				},
+				NodePoolManagement: hyperv1.WorkloadIdentity{
+					ClientID: "nodepool-mgmt-client-id",
+				},
 				Ingress: hyperv1.WorkloadIdentity{
 					ClientID: "ingress-client-id",
 				},
@@ -321,6 +327,12 @@ func TestReconcileCredentials(t *testing.T) {
 			managedService: "",
 			hcluster: func() *hyperv1.HostedCluster {
 				hc := createTestHostedCluster(true, &hyperv1.AzureWorkloadIdentities{
+					CloudProvider: hyperv1.WorkloadIdentity{
+						ClientID: "cloud-provider-client-id",
+					},
+					NodePoolManagement: hyperv1.WorkloadIdentity{
+						ClientID: "nodepool-mgmt-client-id",
+					},
 					Ingress: hyperv1.WorkloadIdentity{
 						ClientID: "ingress-client-id",
 					},
@@ -858,3 +870,201 @@ func TestCAPIProviderDeploymentSpec(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateWorkloadIdentityConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		hcluster       *hyperv1.HostedCluster
+		expectNil      bool
+		expectStatus   metav1.ConditionStatus
+		expectReason   string
+		expectContains string
+	}{
+		{
+			name: "non-Azure platform returns nil",
+			hcluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+					},
+				},
+			},
+			expectNil: true,
+		},
+		{
+			name: "Azure with ManagedIdentities auth returns nil",
+			hcluster: &hyperv1.HostedCluster{
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+						Azure: &hyperv1.AzurePlatformSpec{
+							AzureAuthenticationConfig: hyperv1.AzureAuthenticationConfiguration{
+								AzureAuthenticationConfigType: hyperv1.AzureAuthenticationTypeManagedIdentities,
+							},
+						},
+					},
+				},
+			},
+			expectNil: true,
+		},
+		{
+			name: "WorkloadIdentities auth with nil WorkloadIdentities returns not configured",
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{Generation: 3},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+						Azure: &hyperv1.AzurePlatformSpec{
+							AzureAuthenticationConfig: hyperv1.AzureAuthenticationConfiguration{
+								AzureAuthenticationConfigType: hyperv1.AzureAuthenticationTypeWorkloadIdentities,
+							},
+						},
+					},
+				},
+			},
+			expectNil:      false,
+			expectStatus:   metav1.ConditionFalse,
+			expectReason:   hyperv1.AzureWorkloadIdentityNotConfiguredReason,
+			expectContains: "not configured",
+		},
+		{
+			name: "WorkloadIdentities with missing clientIDs returns incomplete",
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{Generation: 5},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+						Azure: &hyperv1.AzurePlatformSpec{
+							AzureAuthenticationConfig: hyperv1.AzureAuthenticationConfiguration{
+								AzureAuthenticationConfigType: hyperv1.AzureAuthenticationTypeWorkloadIdentities,
+								WorkloadIdentities: &hyperv1.AzureWorkloadIdentities{
+									CloudProvider:      hyperv1.WorkloadIdentity{ClientID: "client-1"},
+									NodePoolManagement: hyperv1.WorkloadIdentity{ClientID: "client-2"},
+									Ingress:            hyperv1.WorkloadIdentity{ClientID: ""},
+									ImageRegistry:      hyperv1.WorkloadIdentity{ClientID: "client-4"},
+									Disk:               hyperv1.WorkloadIdentity{ClientID: "client-5"},
+									File:               hyperv1.WorkloadIdentity{ClientID: ""},
+									Network:            hyperv1.WorkloadIdentity{ClientID: "client-7"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectNil:      false,
+			expectStatus:   metav1.ConditionFalse,
+			expectReason:   hyperv1.AzureWorkloadIdentityIncompleteReason,
+			expectContains: "ingress, file",
+		},
+		{
+			name: "When Private Link is configured without controlPlaneOperator clientID, it should report incomplete",
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{Generation: 6},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+						Azure: &hyperv1.AzurePlatformSpec{
+							Private: hyperv1.AzurePrivateSpec{
+								Type: hyperv1.AzurePrivateTypePrivateLink,
+							},
+							AzureAuthenticationConfig: hyperv1.AzureAuthenticationConfiguration{
+								AzureAuthenticationConfigType: hyperv1.AzureAuthenticationTypeWorkloadIdentities,
+								WorkloadIdentities: &hyperv1.AzureWorkloadIdentities{
+									CloudProvider:      hyperv1.WorkloadIdentity{ClientID: "client-1"},
+									NodePoolManagement: hyperv1.WorkloadIdentity{ClientID: "client-2"},
+									Ingress:            hyperv1.WorkloadIdentity{ClientID: "client-3"},
+									ImageRegistry:      hyperv1.WorkloadIdentity{ClientID: "client-4"},
+									Disk:               hyperv1.WorkloadIdentity{ClientID: "client-5"},
+									File:               hyperv1.WorkloadIdentity{ClientID: "client-6"},
+									Network:            hyperv1.WorkloadIdentity{ClientID: "client-7"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectNil:      false,
+			expectStatus:   metav1.ConditionFalse,
+			expectReason:   hyperv1.AzureWorkloadIdentityIncompleteReason,
+			expectContains: "controlPlaneOperator",
+		},
+		{
+			name: "When Private Link is configured with controlPlaneOperator clientID, it should return valid",
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{Generation: 6},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+						Azure: &hyperv1.AzurePlatformSpec{
+							Private: hyperv1.AzurePrivateSpec{
+								Type: hyperv1.AzurePrivateTypePrivateLink,
+							},
+							AzureAuthenticationConfig: hyperv1.AzureAuthenticationConfiguration{
+								AzureAuthenticationConfigType: hyperv1.AzureAuthenticationTypeWorkloadIdentities,
+								WorkloadIdentities: &hyperv1.AzureWorkloadIdentities{
+									CloudProvider:        hyperv1.WorkloadIdentity{ClientID: "client-1"},
+									NodePoolManagement:   hyperv1.WorkloadIdentity{ClientID: "client-2"},
+									Ingress:              hyperv1.WorkloadIdentity{ClientID: "client-3"},
+									ImageRegistry:        hyperv1.WorkloadIdentity{ClientID: "client-4"},
+									Disk:                 hyperv1.WorkloadIdentity{ClientID: "client-5"},
+									File:                 hyperv1.WorkloadIdentity{ClientID: "client-6"},
+									Network:              hyperv1.WorkloadIdentity{ClientID: "client-7"},
+									ControlPlaneOperator: hyperv1.WorkloadIdentity{ClientID: "client-8"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectNil:      false,
+			expectStatus:   metav1.ConditionTrue,
+			expectReason:   hyperv1.AzureWorkloadIdentityValidReason,
+			expectContains: "All required",
+		},
+		{
+			name: "WorkloadIdentities with all clientIDs returns valid",
+			hcluster: &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{Generation: 7},
+				Spec: hyperv1.HostedClusterSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AzurePlatform,
+						Azure: &hyperv1.AzurePlatformSpec{
+							AzureAuthenticationConfig: hyperv1.AzureAuthenticationConfiguration{
+								AzureAuthenticationConfigType: hyperv1.AzureAuthenticationTypeWorkloadIdentities,
+								WorkloadIdentities: &hyperv1.AzureWorkloadIdentities{
+									CloudProvider:      hyperv1.WorkloadIdentity{ClientID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"},
+									NodePoolManagement: hyperv1.WorkloadIdentity{ClientID: "aaaaaaaa-bbbb-cccc-dddd-ffffffffffff"},
+									Ingress:            hyperv1.WorkloadIdentity{ClientID: "aaaaaaaa-bbbb-cccc-dddd-111111111111"},
+									ImageRegistry:      hyperv1.WorkloadIdentity{ClientID: "aaaaaaaa-bbbb-cccc-dddd-222222222222"},
+									Disk:               hyperv1.WorkloadIdentity{ClientID: "aaaaaaaa-bbbb-cccc-dddd-333333333333"},
+									File:               hyperv1.WorkloadIdentity{ClientID: "aaaaaaaa-bbbb-cccc-dddd-444444444444"},
+									Network:            hyperv1.WorkloadIdentity{ClientID: "aaaaaaaa-bbbb-cccc-dddd-555555555555"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectNil:      false,
+			expectStatus:   metav1.ConditionTrue,
+			expectReason:   hyperv1.AzureWorkloadIdentityValidReason,
+			expectContains: "All required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			condition := validateWorkloadIdentityConfig(tc.hcluster)
+
+			if tc.expectNil {
+				g.Expect(condition).To(BeNil())
+				return
+			}
+
+			g.Expect(condition).NotTo(BeNil())
+			g.Expect(condition.Type).To(Equal(string(hyperv1.ValidAzureWorkloadIdentity)))
+			g.Expect(condition.Status).To(Equal(tc.expectStatus))
+			g.Expect(condition.Reason).To(Equal(tc.expectReason))
+			g.Expect(condition.Message).To(ContainSubstring(tc.expectContains))
+			g.Expect(condition.ObservedGeneration).To(Equal(tc.hcluster.Generation))

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -164,6 +164,13 @@ const (
 	// A failure here indicates that the input is invalid, or permissions are missing to use the encryption key.
 	ValidAzureKMSConfig ConditionType = "ValidAzureKMSConfig"
 
+	// ValidAzureWorkloadIdentity indicates whether the required Azure Workload Identity
+	// configuration is present and valid in the HostedCluster spec. This validates that
+	// all mandatory managed identity client IDs are specified for self-managed Azure clusters
+	// using WorkloadIdentities authentication. A failure here indicates the cluster was
+	// created without running "hypershift create iam azure" or the spec is incomplete.
+	ValidAzureWorkloadIdentity ConditionType = "ValidAzureWorkloadIdentity"
+
 	// ValidGCPCredentials indicates if GCP credentials are valid and operational
 	// for the HostedCluster. This includes service account authentication and
 	// proper IAM permissions for CAPG controllers.
@@ -320,8 +327,11 @@ const (
 
 	InvalidIAMRoleReason = "InvalidIAMRole"
 
-	InvalidAzureCredentialsReason = "InvalidAzureCredentials"
-	AzureErrorReason              = "AzureError"
+	InvalidAzureCredentialsReason            = "InvalidAzureCredentials"
+	AzureWorkloadIdentityNotConfiguredReason = "WorkloadIdentityNotConfigured"
+	AzureWorkloadIdentityIncompleteReason    = "WorkloadIdentityIncomplete"
+	AzureWorkloadIdentityValidReason         = "ValidWorkloadIdentityConfiguration"
+	AzureErrorReason                         = "AzureError"
 
 	ExternalDNSHostNotReachableReason = "ExternalDNSHostNotReachable"
 


### PR DESCRIPTION
## Summary

- Azure HCP clusters using WorkloadIdentities auth enter an opaque degraded state when `hypershift create iam azure` is skipped or fails silently — the operator reconciles with empty client IDs producing confusing errors
- Adds `validateWorkloadIdentityConfig` to `ReconcileCredentials` that checks all 7 required clientID fields before proceeding, surfacing a descriptive error via `PlatformCredentialsFound` condition
- Phase 2 will promote `ValidAzureWorkloadIdentity` to a first-class condition on HostedCluster status

## Test plan

- [x] Unit tests: 5 new cases covering non-Azure (no-op), ManagedIdentities (no-op), nil WorkloadIdentities, partial clientIDs, complete clientIDs
- [x] Regression: existing `TestReconcileCredentials` suite passes (fixtures updated to include all required fields)
- [x] `go vet` / `gofmt` clean
- [ ] CI: e2e on Azure HCP with valid WI config (no behavioral change expected)
- [ ] CI: e2e on Azure HCP with intentionally missing clientID (verify early clear error)

Ref: [RFE-9351](https://redhat.atlassian.net/browse/RFE-9351)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Azure Workload Identity validation to verify required managed identity client IDs before credential reconciliation.
  * Added hosted-cluster status reporting and specific reason codes for Workload Identity configuration.

* **Bug Fixes**
  * Prevented federated credential and related secret reconciliation when Workload Identity configuration is incomplete, including Private Link requirements.

* **Tests**
  * Expanded Azure self-managed coverage for missing, incomplete, bypassed, and valid Workload Identity configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->