### PR TITLE
CNTRLPLANE-3550: Add missing v2 test suites to Azure self-managed test matrix

### DIFF
--- a/test/e2e/v2/lifecycle/azure.go
+++ b/test/e2e/v2/lifecycle/azure.go
@@ -205,20 +205,20 @@ func (a *AzurePlatformConfig) TestMatrix(releaseImage string) TestMatrix {
 			{
 				Name:        "public",
 				ClusterFile: "cluster-name-public",
-				LabelFilter: "self-managed-azure-public || nodepool-lifecycle || secret-encryption",
+				LabelFilter: "self-managed-azure-public || nodepool-lifecycle || secret-encryption || control-plane-workloads || hosted-cluster-security",
 				Skip:        "KAS allowed CIDRs",
 				JUnitFile:   "junit_self_managed_azure_public.xml",
 			},
 			{
 				Name:        "private",
 				ClusterFile: "cluster-name-private",
-				LabelFilter: "self-managed-azure-private",
+				LabelFilter: "self-managed-azure-private || hosted-cluster-compliance",
 				JUnitFile:   "junit_self_managed_azure_private.xml",
 			},
 			{
 				Name:        "oauth-lb",
 				ClusterFile: "cluster-name-oauth-lb",
-				LabelFilter: "self-managed-azure-oauth-lb",
+				LabelFilter: "self-managed-azure-oauth-lb || hosted-cluster-health || hosted-cluster-metrics || hosted-cluster-image-registry",
 				JUnitFile:   "junit_self_managed_azure_oauth_lb.xml",
 			},
 			{


### PR DESCRIPTION
## What this PR does / why we need it:

Several platform-agnostic v2 test suites existed but were never selected by any Azure self-managed cluster variant's `LabelFilter`. This meant the following test suites were not running in the `e2e-azure-v2-self-managed` CI job despite being fully compatible with Azure:

- `control-plane-workloads` — resource requests, pull policy, read-only rootfs, safe-to-evict annotations, deployment generation, pod priority, service account token mounting, affinities/tolerations
- `hosted-cluster-health` — HostedCluster conditions, CAPI finalizers, feature gate status, payload arch
- `hosted-cluster-security` — guest webhook validation, admission policies (VAPs), network policies
- `hosted-cluster-compliance` — route labeling for per-HCP router
- `hosted-cluster-metrics` — metrics endpoint validation, metrics forwarder, NTO metrics
- `hosted-cluster-image-registry` — image registry capability validation

These are all stateless verification tests that work on any healthy cluster regardless of topology. They are distributed across the existing parallel cluster variants to balance test time:

| Cluster Variant | Added Suites |
|---|---|
| **public** | `control-plane-workloads` |
| **private** | `hosted-cluster-health`, `hosted-cluster-security`, `hosted-cluster-compliance` |
| **oauth-lb** | `hosted-cluster-metrics`, `hosted-cluster-image-registry` |

## Which issue(s) this PR fixes:

N/A — gap identified during v2 test coverage audit

## Special notes for your reviewer:

All six test suites use platform guards (`Skip()` on non-matching platforms) and the workload registry's `ShouldSkipWorkloadForPlatform()` for automatic per-platform filtering, so they will correctly skip any platform-specific checks that don't apply to Azure.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refined Azure end-to-end test matrix by updating label filters for the public, private, and oauth-lb cluster groups.
  * Added selectors to broaden coverage for control-plane workloads, hosted-cluster security, compliance, health, metrics, and image registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->