### PR TITLE
NO-JIRA: test(e2e/v2): sweep AGENTS.md conformance violations

### DIFF
--- a/test/e2e/v2/tests/control_plane_infrastructure_test.go
+++ b/test/e2e/v2/tests/control_plane_infrastructure_test.go
@@ -91,6 +91,7 @@ func InfrastructureRegistryValidationTest(getTestCtx internal.TestContextGetter)
 			testCtx := getTestCtx()
 
 			var podsNotBelongingToWorkloads []string
+			namespacesChecked := 0
 
 			for _, namespace := range internal.GetInfrastructureNamespaces() {
 				ns := &corev1.Namespace{}
@@ -99,6 +100,7 @@ func InfrastructureRegistryValidationTest(getTestCtx internal.TestContextGetter)
 					continue
 				}
 				Expect(err).NotTo(HaveOccurred(), "failed to get namespace %s", namespace)
+				namespacesChecked++
 
 				podList := &corev1.PodList{}
 				err = testCtx.MgmtClient.List(testCtx.Context, podList, &crclient.ListOptions{
@@ -122,6 +124,8 @@ func InfrastructureRegistryValidationTest(getTestCtx internal.TestContextGetter)
 				}
 			}
 
+			Expect(namespacesChecked).NotTo(BeZero(),
+				"expected at least one infrastructure namespace to exist")
 			Expect(podsNotBelongingToWorkloads).To(BeEmpty(),
 				"The following pods do not belong to any predefined infrastructure workload:\n%s",
 				strings.Join(podsNotBelongingToWorkloads, "\n"))
@@ -156,6 +160,10 @@ func InfrastructureResourceRequestsTest(getTestCtx internal.TestContextGetter) {
 						if workload.MatchesPod(pod) {
 							matchingPods = append(matchingPods, pod)
 						}
+					}
+
+					if len(matchingPods) == 0 {
+						Skip(fmt.Sprintf("no matching pods found for workload %s", workload.Name))
 					}
 
 					var failures []string

--- a/test/e2e/v2/tests/control_plane_workloads_test.go
+++ b/test/e2e/v2/tests/control_plane_workloads_test.go
@@ -82,7 +82,7 @@ func DeploymentGenerationTest(getTestCtx internal.TestContextGetter) {
 					}
 
 					deployment := &appsv1.Deployment{}
-					err := testCtx.MgmtClient.Get(context.Background(), crclient.ObjectKey{
+					err := testCtx.MgmtClient.Get(testCtx.Context, crclient.ObjectKey{
 						Namespace: testCtx.ControlPlaneNamespace,
 						Name:      workload.Name,
 					}, deployment)
@@ -722,6 +722,8 @@ func WorkloadRegistryValidationTest(getTestCtx internal.TestContextGetter) {
 				Namespace: testCtx.ControlPlaneNamespace,
 			})
 			Expect(err).NotTo(HaveOccurred(), "failed to list pods in control plane namespace")
+			Expect(podList.Items).NotTo(BeEmpty(),
+				"expected pods in control plane namespace %s", testCtx.ControlPlaneNamespace)
 
 			workloadSelectors := make(map[string]labels.Selector)
 			for _, workload := range workloads {
@@ -767,7 +769,7 @@ func SecurityContextUIDTest(getTestCtx internal.TestContextGetter) {
 
 			// Get the control plane namespace to check for UID annotation
 			controlPlaneNamespace := &corev1.Namespace{}
-			err := testCtx.MgmtClient.Get(context.Background(), crclient.ObjectKey{Name: testCtx.ControlPlaneNamespace}, controlPlaneNamespace)
+			err := testCtx.MgmtClient.Get(testCtx.Context, crclient.ObjectKey{Name: testCtx.ControlPlaneNamespace}, controlPlaneNamespace)
 			Expect(err).NotTo(HaveOccurred(), "failed to get namespace %s", testCtx.ControlPlaneNamespace)
 
 			uid, ok := controlPlaneNamespace.Annotations["hypershift.openshift.io/default-security-context-uid"]

--- a/test/e2e/v2/tests/etcd_chaos_test.go
+++ b/test/e2e/v2/tests/etcd_chaos_test.go
@@ -126,13 +126,14 @@ func EtcdKillRandomMembersTest(getTestCtx internal.TestContextGetter) {
 		ctx := testCtx.Context
 		cpNamespace := testCtx.ControlPlaneNamespace
 
-		guestClient := testCtx.GetHostedClusterClient()
+		hcClient := testCtx.GetHostedClusterClient()
 
 		// Create marker data that should survive the chaos
-		markerCM := createMarkerConfigMap(ctx, guestClient)
+		markerCM := createMarkerConfigMap(ctx, hcClient)
 		DeferCleanup(func() {
-			if err := guestClient.Delete(ctx, markerCM); err != nil && !apierrors.IsNotFound(err) {
-				GinkgoWriter.Printf("Warning: failed to cleanup marker ConfigMap: %v\n", err)
+			err := hcClient.Delete(ctx, markerCM)
+			if err != nil && !apierrors.IsNotFound(err) {
+				Expect(err).NotTo(HaveOccurred(), "cleanup: failed to delete marker ConfigMap %s", markerCM.Name)
 			}
 		})
 
@@ -160,7 +161,7 @@ func EtcdKillRandomMembersTest(getTestCtx internal.TestContextGetter) {
 
 		waitForEtcdConvergence(ctx, testCtx.MgmtClient, cpNamespace, ptr.Deref(etcdSts.Spec.Replicas, 0))
 
-		verifyMarkerSurvived(ctx, guestClient, markerCM)
+		verifyMarkerSurvived(ctx, hcClient, markerCM)
 	})
 }
 
@@ -173,13 +174,14 @@ func EtcdKillAllMembersTest(getTestCtx internal.TestContextGetter) {
 		ctx := testCtx.Context
 		cpNamespace := testCtx.ControlPlaneNamespace
 
-		guestClient := testCtx.GetHostedClusterClient()
+		hcClient := testCtx.GetHostedClusterClient()
 
 		// Create marker data that should survive the chaos
-		markerCM := createMarkerConfigMap(ctx, guestClient)
+		markerCM := createMarkerConfigMap(ctx, hcClient)
 		DeferCleanup(func() {
-			if err := guestClient.Delete(ctx, markerCM); err != nil && !apierrors.IsNotFound(err) {
-				GinkgoWriter.Printf("Warning: failed to cleanup marker ConfigMap: %v\n", err)
+			err := hcClient.Delete(ctx, markerCM)
+			if err != nil && !apierrors.IsNotFound(err) {
+				Expect(err).NotTo(HaveOccurred(), "cleanup: failed to delete marker ConfigMap %s", markerCM.Name)
 			}
 		})
 
@@ -236,7 +238,7 @@ func EtcdKillAllMembersTest(getTestCtx internal.TestContextGetter) {
 
 		waitForEtcdConvergence(ctx, testCtx.MgmtClient, cpNamespace, ptr.Deref(etcdSts.Spec.Replicas, 0))
 
-		verifyMarkerSurvived(ctx, guestClient, markerCM)
+		verifyMarkerSurvived(ctx, hcClient, markerCM)
 	})
 }
 

--- a/test/e2e/v2/tests/hosted_cluster_aws_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_aws_test.go
@@ -56,6 +56,10 @@ func EnsureDefaultSecurityGroupTagsTest(getTestCtx internal.TestContextGetter) {
 				Skip("default security group tags test is only for AWS platform")
 			}
 
+			Expect(hc.Status.Platform).NotTo(BeNil(),
+				"HostedCluster %s/%s should have platform status", hc.Namespace, hc.Name)
+			Expect(hc.Status.Platform.AWS).NotTo(BeNil(),
+				"HostedCluster %s/%s should have AWS platform status", hc.Namespace, hc.Name)
 			sgID := hc.Status.Platform.AWS.DefaultWorkerSecurityGroupID
 			Expect(sgID).NotTo(BeEmpty(), "HostedCluster status should have DefaultWorkerSecurityGroupID set")
 
@@ -202,6 +206,12 @@ func AWSCCMWithCustomizationsTest(getTestCtx internal.TestContextGetter) {
 					},
 				}
 				Expect(hcClient.Create(tc.Context, testSvc)).To(Succeed(), "failed to create LoadBalancer service")
+				DeferCleanup(func() {
+					err := hcClient.Delete(tc.Context, testSvc)
+					if err != nil && !apierrors.IsNotFound(err) {
+						Expect(err).NotTo(HaveOccurred(), "cleanup: failed to delete test service %s", testSvc.Name)
+					}
+				})
 
 				var lbHostname string
 				Eventually(func(g Gomega) {

--- a/test/e2e/v2/tests/hosted_cluster_ccm_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_ccm_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package tests
 
 import (
-	"context"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -51,7 +50,7 @@ func GCPCloudControllerManagerTest(getTestCtx internal.TestContextGetter) {
 				Expect(hostedClusterClient).NotTo(BeNil(), "hosted cluster client is nil; HostedCluster may not have KubeConfig status set")
 
 				nodes = &corev1.NodeList{}
-				Expect(hostedClusterClient.List(context.Background(), nodes)).To(Succeed())
+				Expect(hostedClusterClient.List(testCtx.Context, nodes)).To(Succeed())
 				Expect(nodes.Items).NotTo(BeEmpty(), "cluster should have nodes")
 			})
 
@@ -112,6 +111,7 @@ var _ = Describe("Hosted Cluster CCM", Label("hosted-cluster-ccm"), func() {
 	BeforeEach(func() {
 		testCtx = internal.GetTestContext()
 		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
+		testCtx.ValidateHostedCluster()
 	})
 
 	RegisterHostedClusterCCMTests(func() *internal.TestContext { return testCtx })

--- a/test/e2e/v2/tests/hosted_cluster_health_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_health_test.go
@@ -80,6 +80,8 @@ func EnsureCAPIFinalizersTest(getTestCtx internal.TestContextGetter) {
 	When("CAPI components are deployed", func() {
 		It("should have component finalizers on all CAPI deployments", func() {
 			tc := getTestCtx()
+			Expect(hcc.CAPIComponents).NotTo(BeEmpty(),
+				"expected CAPI components to be defined in HostedControlPlaneConfiguration")
 			for _, name := range hcc.CAPIComponents {
 				deployment := &appsv1.Deployment{}
 				Expect(tc.MgmtClient.Get(tc.Context, crclient.ObjectKey{

--- a/test/e2e/v2/tests/hosted_cluster_image_registry_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_image_registry_test.go
@@ -144,6 +144,8 @@ func ImageRegistryCapabilityEnabledTest(getTestCtx internal.TestContextGetter) {
 				}
 				Expect(hc.Spec.Platform.GCP).NotTo(BeNil(),
 					"GCP platform spec must be set for GCP HostedCluster %s/%s", hc.Namespace, hc.Name)
+				Expect(hc.Spec.Platform.GCP.WorkloadIdentity).NotTo(BeNil(),
+					"GCP platform spec should have WorkloadIdentity configured for HostedCluster %s/%s", hc.Namespace, hc.Name)
 				imageRegistryEmail = string(hc.Spec.Platform.GCP.WorkloadIdentity.ServiceAccountsEmails.ImageRegistry)
 				Expect(imageRegistryEmail).NotTo(BeEmpty(),
 					"imageRegistry service account email must be set in GCP WorkloadIdentity config for %s/%s",

--- a/test/e2e/v2/tests/hosted_cluster_metrics_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_metrics_test.go
@@ -189,7 +189,7 @@ func EnsureMetricsForwarderWorkingTest(getTestCtx internal.TestContextGetter) {
 				g.Expect(pod.Status.Phase).To(Equal(corev1.PodRunning), "prometheus pod should be running")
 			}, 5*time.Minute, 10*time.Second).Should(Succeed())
 
-			By("Verifying guest Prometheus is scraping kube-apiserver via the metrics-forwarder")
+			By("Verifying hosted cluster Prometheus is scraping kube-apiserver via the metrics-forwarder")
 			Eventually(func(g Gomega) {
 				output, err := v2util.RunCommandInPod(tc.Context, hcClientset, hcRestConfig,
 					monitoringNamespace, promPodName, "prometheus",

--- a/test/e2e/v2/tests/hosted_cluster_security_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_security_test.go
@@ -45,12 +45,12 @@ import (
 )
 
 func RegisterHostedClusterSecurityTests(getTestCtx internal.TestContextGetter) {
-	EnsureGuestWebhooksValidatedTest(getTestCtx)
+	EnsureHostedClusterWebhooksValidatedTest(getTestCtx)
 	EnsureAdmissionPoliciesTest(getTestCtx)
 	EnsureNetworkPoliciesTest(getTestCtx)
 }
 
-func EnsureGuestWebhooksValidatedTest(getTestCtx internal.TestContextGetter) {
+func EnsureHostedClusterWebhooksValidatedTest(getTestCtx internal.TestContextGetter) {
 	When("a webhook targeting a control plane service is created in the hosted cluster", func() {
 		It("should be automatically deleted", func() {
 			tc := getTestCtx()

--- a/test/e2e/v2/tests/nodepool_autoscaling_test.go
+++ b/test/e2e/v2/tests/nodepool_autoscaling_test.go
@@ -47,7 +47,7 @@ func AutoscalingScaleUpDownTest(getTestCtx internal.TestContextGetter) {
 		testCtx.ValidateHostedClusterClient()
 
 		hc := testCtx.GetHostedCluster()
-		guestClient := testCtx.GetHostedClusterClient()
+		hcClient := testCtx.GetHostedClusterClient()
 		ctx := testCtx.Context
 
 		// Find the default NodePool to copy platform config
@@ -63,14 +63,16 @@ func AutoscalingScaleUpDownTest(getTestCtx internal.TestContextGetter) {
 		GinkgoWriter.Printf("Created autoscaling NodePool %s with min=1, max=3\n", autoscalingNP.Name)
 
 		// Ensure cleanup
-		defer cleanupNodePool(ctx, testCtx.MgmtClient, autoscalingNP)
+		DeferCleanup(func() {
+			cleanupNodePool(ctx, testCtx.MgmtClient, autoscalingNP)
+		})
 
 		npLabelSelector := e2eutil.WithClientOptions(crclient.MatchingLabelsSelector{
 			Selector: labels.SelectorFromSet(labels.Set{hyperv1.NodePoolLabel: autoscalingNP.Name}),
 		})
 
 		// Wait for NodePool to be ready with 1 node (min replicas)
-		nodes := e2eutil.WaitForNReadyNodesWithOptions(GinkgoTB(), ctx, guestClient, 1, hc.Spec.Platform.Type, fmt.Sprintf("for NodePool %s", autoscalingNP.Name), npLabelSelector)
+		nodes := e2eutil.WaitForNReadyNodesWithOptions(GinkgoTB(), ctx, hcClient, 1, hc.Spec.Platform.Type, fmt.Sprintf("for NodePool %s", autoscalingNP.Name), npLabelSelector)
 		Expect(nodes).To(HaveLen(1), "should have exactly 1 node initially")
 
 		// Get node capacity for workload sizing
@@ -83,19 +85,21 @@ func AutoscalingScaleUpDownTest(getTestCtx internal.TestContextGetter) {
 		// cluster autoscaler must scale it up.
 		workloadMemRequest := *resource.NewQuantity(bytes/2, resource.BinarySI)
 		workload := newAutoscalingWorkload(3, workloadMemRequest, autoscalingLabel)
-		err = guestClient.Create(ctx, workload)
+		err = hcClient.Create(ctx, workload)
 		Expect(err).NotTo(HaveOccurred(), "failed to create workload")
 
-		defer cleanupWorkload(ctx, guestClient, workload)
+		DeferCleanup(func() {
+			cleanupWorkload(ctx, hcClient, workload)
+		})
 
 		// Wait for scale-up to 3 nodes
-		e2eutil.WaitForNReadyNodesWithOptions(GinkgoTB(), ctx, guestClient, 3, hc.Spec.Platform.Type, fmt.Sprintf("for NodePool %s", autoscalingNP.Name), npLabelSelector)
+		e2eutil.WaitForNReadyNodesWithOptions(GinkgoTB(), ctx, hcClient, 3, hc.Spec.Platform.Type, fmt.Sprintf("for NodePool %s", autoscalingNP.Name), npLabelSelector)
 
 		// Delete workload to trigger scale-down
-		cleanupWorkload(ctx, guestClient, workload)
+		cleanupWorkload(ctx, hcClient, workload)
 
 		// Wait for scale-down to 1 node (min replicas)
-		e2eutil.WaitForNReadyNodesWithOptions(GinkgoTB(), ctx, guestClient, 1, hc.Spec.Platform.Type, fmt.Sprintf("for NodePool %s", autoscalingNP.Name), npLabelSelector)
+		e2eutil.WaitForNReadyNodesWithOptions(GinkgoTB(), ctx, hcClient, 1, hc.Spec.Platform.Type, fmt.Sprintf("for NodePool %s", autoscalingNP.Name), npLabelSelector)
 	})
 }
 
@@ -110,7 +114,7 @@ func AutoscalingBalancingTest(getTestCtx internal.TestContextGetter) {
 		e2eutil.GinkgoAtLeast(e2eutil.Version420)
 
 		hc := testCtx.GetHostedCluster()
-		guestClient := testCtx.GetHostedClusterClient()
+		hcClient := testCtx.GetHostedClusterClient()
 		ctx := testCtx.Context
 		cpNamespace := testCtx.ControlPlaneNamespace
 
@@ -133,15 +137,12 @@ func AutoscalingBalancingTest(getTestCtx internal.TestContextGetter) {
 
 		DeferCleanup(func() {
 			latest := &hyperv1.HostedCluster{}
-			if err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(hc), latest); err != nil {
-				GinkgoWriter.Printf("Warning: failed to get HostedCluster for cleanup: %v\n", err)
-				return
-			}
+			Expect(testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(hc), latest)).To(Succeed(),
+				"cleanup: failed to get HostedCluster for autoscaling config reset")
 			patch := crclient.MergeFrom(latest.DeepCopy())
 			latest.Spec.Autoscaling = hyperv1.ClusterAutoscaling{}
-			if err := testCtx.MgmtClient.Patch(ctx, latest, patch); err != nil {
-				GinkgoWriter.Printf("Warning: failed to reset autoscaler config: %v\n", err)
-			}
+			Expect(testCtx.MgmtClient.Patch(ctx, latest, patch)).To(Succeed(),
+				"cleanup: failed to reset autoscaler config on HostedCluster")
 		})
 
 		// Wait for autoscaler deployment to pick up the new config
@@ -184,12 +185,16 @@ func AutoscalingBalancingTest(getTestCtx internal.TestContextGetter) {
 		autoscalingNP1 := buildAutoscalingNodePool(defaultNP, 1, 3, np1Labels)
 		err = testCtx.MgmtClient.Create(ctx, autoscalingNP1)
 		Expect(err).NotTo(HaveOccurred(), "failed to create first autoscaling NodePool")
-		defer cleanupNodePool(ctx, testCtx.MgmtClient, autoscalingNP1)
+		DeferCleanup(func() {
+			cleanupNodePool(ctx, testCtx.MgmtClient, autoscalingNP1)
+		})
 
 		autoscalingNP2 := buildAutoscalingNodePool(defaultNP, 1, 3, np2Labels)
 		err = testCtx.MgmtClient.Create(ctx, autoscalingNP2)
 		Expect(err).NotTo(HaveOccurred(), "failed to create second autoscaling NodePool")
-		defer cleanupNodePool(ctx, testCtx.MgmtClient, autoscalingNP2)
+		DeferCleanup(func() {
+			cleanupNodePool(ctx, testCtx.MgmtClient, autoscalingNP2)
+		})
 
 		np1LabelSelector := e2eutil.WithClientOptions(crclient.MatchingLabelsSelector{
 			Selector: labels.SelectorFromSet(labels.Set{hyperv1.NodePoolLabel: autoscalingNP1.Name}),
@@ -199,8 +204,8 @@ func AutoscalingBalancingTest(getTestCtx internal.TestContextGetter) {
 		})
 
 		// Wait for initial nodes (1 per NodePool at min replicas)
-		nodes := e2eutil.WaitForNReadyNodesWithOptions(GinkgoTB(), ctx, guestClient, 1, hc.Spec.Platform.Type, "for NP1", np1LabelSelector)
-		e2eutil.WaitForNReadyNodesWithOptions(GinkgoTB(), ctx, guestClient, 1, hc.Spec.Platform.Type, "for NP2", np2LabelSelector)
+		nodes := e2eutil.WaitForNReadyNodesWithOptions(GinkgoTB(), ctx, hcClient, 1, hc.Spec.Platform.Type, "for NP1", np1LabelSelector)
+		e2eutil.WaitForNReadyNodesWithOptions(GinkgoTB(), ctx, hcClient, 1, hc.Spec.Platform.Type, "for NP2", np2LabelSelector)
 
 		// Get node capacity for workload sizing
 		memCapacity := nodes[0].Status.Allocatable[corev1.ResourceMemory]
@@ -210,9 +215,11 @@ func AutoscalingBalancingTest(getTestCtx internal.TestContextGetter) {
 		// Create workload targeting the autoscaling NodePools via the shared label.
 		workloadMemRequest := *resource.NewQuantity(bytes/2, resource.BinarySI)
 		workload := newAutoscalingWorkload(4, workloadMemRequest, sharedLabel)
-		err = guestClient.Create(ctx, workload)
+		err = hcClient.Create(ctx, workload)
 		Expect(err).NotTo(HaveOccurred(), "failed to create workload")
-		defer cleanupWorkload(ctx, guestClient, workload)
+		DeferCleanup(func() {
+			cleanupWorkload(ctx, hcClient, workload)
+		})
 
 		// Wait for total 4 nodes across both NPs, then verify balanced distribution
 		Eventually(func() (bool, error) {

--- a/test/e2e/v2/tests/nodepool_lifecycle_test.go
+++ b/test/e2e/v2/tests/nodepool_lifecycle_test.go
@@ -92,7 +92,7 @@ func NodePoolMachineconfigRolloutTest(getTestCtx internal.TestContextGetter) {
 			Skip("test is skipped for KubeVirt platform until https://issues.redhat.com/browse/CNV-38196 is addressed")
 		}
 
-		guestClient := testCtx.GetHostedClusterClient()
+		hcClient := testCtx.GetHostedClusterClient()
 
 		ctx := testCtx.Context
 
@@ -114,9 +114,11 @@ func NodePoolMachineconfigRolloutTest(getTestCtx internal.TestContextGetter) {
 		err := testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s\n", np.Name)
-		defer cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		DeferCleanup(func() {
+			cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, guestClient, np, hc.Spec.Platform.Type)
+		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		// Build MachineConfig with a custom file at /etc/custom-config
 		ignitionConfig := ignitionapi.Config{
@@ -153,6 +155,11 @@ func NodePoolMachineconfigRolloutTest(getTestCtx internal.TestContextGetter) {
 			Data: map[string]string{"config": string(serializedMC)},
 		}
 		Expect(testCtx.MgmtClient.Create(ctx, mcConfigMap)).To(Succeed(), "failed to create MachineConfig ConfigMap")
+		DeferCleanup(func() {
+			if err := testCtx.MgmtClient.Delete(ctx, mcConfigMap); err != nil && !apierrors.IsNotFound(err) {
+				Expect(err).NotTo(HaveOccurred(), "cleanup: failed to delete ConfigMap %s", mcConfigMap.Name)
+			}
+		})
 		GinkgoWriter.Printf("Created MachineConfig ConfigMap %s\n", mcConfigMap.Name)
 
 		original := np.DeepCopy()
@@ -162,11 +169,11 @@ func NodePoolMachineconfigRolloutTest(getTestCtx internal.TestContextGetter) {
 
 		// Build verification DaemonSet that checks /etc/custom-config exists
 		ds := buildMachineConfigVerificationDaemonSet(np)
-		Expect(guestClient.Create(ctx, ds)).To(Succeed(), "failed to create verification DaemonSet")
+		Expect(hcClient.Create(ctx, ds)).To(Succeed(), "failed to create verification DaemonSet")
 
 		e2eutil.WaitForNodePoolConfigUpdateCompleteWithPlatform(GinkgoTB(), ctx, testCtx.MgmtClient, np, hc.Spec.Platform.Type)
-		waitForDaemonSetRollout(ctx, guestClient, ds, 1, np.Spec.Platform.Type)
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, guestClient, np, hc.Spec.Platform.Type)
+		waitForDaemonSetRollout(ctx, hcClient, ds, 1, np.Spec.Platform.Type)
+		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		// TODO: EnsureNoCrashingPods, EnsureAllContainersHavePullPolicyIfNotPresent,
 		// EnsureHCPContainersHaveResourceRequests, EnsureNoPodsWithTooHighPriority
@@ -190,7 +197,7 @@ func NodePoolNTORolloutTest(getTestCtx internal.TestContextGetter) {
 			Skip("test is skipped for OpenStack platform until https://issues.redhat.com/browse/OSASINFRA-3566 is addressed")
 		}
 
-		guestClient := testCtx.GetHostedClusterClient()
+		hcClient := testCtx.GetHostedClusterClient()
 
 		ctx := testCtx.Context
 
@@ -212,9 +219,11 @@ func NodePoolNTORolloutTest(getTestCtx internal.TestContextGetter) {
 		err := testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s\n", np.Name)
-		defer cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		DeferCleanup(func() {
+			cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, guestClient, np, hc.Spec.Platform.Type)
+		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		tuningCM := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -224,6 +233,11 @@ func NodePoolNTORolloutTest(getTestCtx internal.TestContextGetter) {
 			Data: map[string]string{tuningConfigKey: hugepagesTunedYAML},
 		}
 		Expect(testCtx.MgmtClient.Create(ctx, tuningCM)).To(Succeed(), "failed to create Tuned ConfigMap")
+		DeferCleanup(func() {
+			if err := testCtx.MgmtClient.Delete(ctx, tuningCM); err != nil && !apierrors.IsNotFound(err) {
+				Expect(err).NotTo(HaveOccurred(), "cleanup: failed to delete ConfigMap %s", tuningCM.Name)
+			}
+		})
 
 		original := np.DeepCopy()
 		np.Spec.TuningConfig = append(np.Spec.TuningConfig, corev1.LocalObjectReference{Name: tuningCM.Name})
@@ -231,11 +245,11 @@ func NodePoolNTORolloutTest(getTestCtx internal.TestContextGetter) {
 			"failed to patch NodePool %s with TuningConfig", np.Name)
 
 		ds := buildNTOVerificationDaemonSet(np)
-		Expect(guestClient.Create(ctx, ds)).To(Succeed(), "failed to create NTO verification DaemonSet")
+		Expect(hcClient.Create(ctx, ds)).To(Succeed(), "failed to create NTO verification DaemonSet")
 
 		e2eutil.WaitForNodePoolConfigUpdateCompleteWithPlatform(GinkgoTB(), ctx, testCtx.MgmtClient, np, hc.Spec.Platform.Type)
-		waitForDaemonSetRollout(ctx, guestClient, ds, 2, np.Spec.Platform.Type)
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, guestClient, np, hc.Spec.Platform.Type)
+		waitForDaemonSetRollout(ctx, hcClient, ds, 2, np.Spec.Platform.Type)
+		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		// TODO: EnsureNoCrashingPods, EnsureAllContainersHavePullPolicyIfNotPresent,
 		// EnsureHCPContainersHaveResourceRequests, EnsureNoPodsWithTooHighPriority
@@ -257,7 +271,7 @@ func NodePoolNTOInPlaceTest(getTestCtx internal.TestContextGetter) {
 			Skip("test is skipped for OpenStack platform until https://issues.redhat.com/browse/OSASINFRA-3566 is addressed")
 		}
 
-		guestClient := testCtx.GetHostedClusterClient()
+		hcClient := testCtx.GetHostedClusterClient()
 
 		ctx := testCtx.Context
 
@@ -273,9 +287,11 @@ func NodePoolNTOInPlaceTest(getTestCtx internal.TestContextGetter) {
 		err := testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s\n", np.Name)
-		defer cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		DeferCleanup(func() {
+			cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, guestClient, np, hc.Spec.Platform.Type)
+		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		tuningCM := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -285,6 +301,11 @@ func NodePoolNTOInPlaceTest(getTestCtx internal.TestContextGetter) {
 			Data: map[string]string{tuningConfigKey: hugepagesTunedYAML},
 		}
 		Expect(testCtx.MgmtClient.Create(ctx, tuningCM)).To(Succeed(), "failed to create Tuned ConfigMap")
+		DeferCleanup(func() {
+			if err := testCtx.MgmtClient.Delete(ctx, tuningCM); err != nil && !apierrors.IsNotFound(err) {
+				Expect(err).NotTo(HaveOccurred(), "cleanup: failed to delete ConfigMap %s", tuningCM.Name)
+			}
+		})
 
 		original := np.DeepCopy()
 		np.Spec.TuningConfig = append(np.Spec.TuningConfig, corev1.LocalObjectReference{Name: tuningCM.Name})
@@ -292,11 +313,11 @@ func NodePoolNTOInPlaceTest(getTestCtx internal.TestContextGetter) {
 			"failed to patch NodePool %s with TuningConfig", np.Name)
 
 		ds := buildNTOVerificationDaemonSet(np)
-		Expect(guestClient.Create(ctx, ds)).To(Succeed(), "failed to create NTO verification DaemonSet")
+		Expect(hcClient.Create(ctx, ds)).To(Succeed(), "failed to create NTO verification DaemonSet")
 
 		e2eutil.WaitForNodePoolConfigUpdateCompleteWithPlatform(GinkgoTB(), ctx, testCtx.MgmtClient, np, hc.Spec.Platform.Type)
-		waitForDaemonSetRollout(ctx, guestClient, ds, 2, np.Spec.Platform.Type)
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, guestClient, np, hc.Spec.Platform.Type)
+		waitForDaemonSetRollout(ctx, hcClient, ds, 2, np.Spec.Platform.Type)
+		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		// TODO: EnsureNoCrashingPods, EnsureAllContainersHavePullPolicyIfNotPresent,
 		// EnsureHCPContainersHaveResourceRequests, EnsureNoPodsWithTooHighPriority
@@ -312,7 +333,7 @@ func NodePoolReplaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 		testCtx.ValidateHostedClusterClient()
 
 		hc := testCtx.GetHostedCluster()
-		guestClient := testCtx.GetHostedClusterClient()
+		hcClient := testCtx.GetHostedClusterClient()
 
 		previousImage := internal.GetEnvVarValue("E2E_PREVIOUS_RELEASE_IMAGE")
 		latestImage := internal.GetEnvVarValue("E2E_LATEST_RELEASE_IMAGE")
@@ -341,9 +362,11 @@ func NodePoolReplaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 		err := testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s at previous release %s\n", np.Name, previousImage)
-		defer cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		DeferCleanup(func() {
+			cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, guestClient, np, hc.Spec.Platform.Type)
+		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		// Update NodePool to latest release image
 		GinkgoWriter.Printf("Upgrading NodePool %s to latest release %s\n", np.Name, latestImage)
@@ -383,7 +406,7 @@ func NodePoolReplaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 			e2eutil.WithTimeout(upgradeTimeout),
 		)
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, guestClient, np, hc.Spec.Platform.Type)
+		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		// TODO: EnsureNodesLabelsAndTaints, EnsureNodesRuntime require *testing.T
 	})
@@ -397,7 +420,7 @@ func NodePoolInPlaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 		testCtx.ValidateHostedClusterClient()
 
 		hc := testCtx.GetHostedCluster()
-		guestClient := testCtx.GetHostedClusterClient()
+		hcClient := testCtx.GetHostedClusterClient()
 
 		previousImage := internal.GetEnvVarValue("E2E_PREVIOUS_RELEASE_IMAGE")
 		latestImage := internal.GetEnvVarValue("E2E_LATEST_RELEASE_IMAGE")
@@ -420,9 +443,11 @@ func NodePoolInPlaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 		err := testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s at previous release %s\n", np.Name, previousImage)
-		defer cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		DeferCleanup(func() {
+			cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, guestClient, np, hc.Spec.Platform.Type)
+		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		GinkgoWriter.Printf("Upgrading NodePool %s to latest release %s\n", np.Name, latestImage)
 		Expect(e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, np, func(obj *hyperv1.NodePool) {
@@ -461,7 +486,7 @@ func NodePoolInPlaceUpgradeTest(getTestCtx internal.TestContextGetter) {
 			e2eutil.WithTimeout(upgradeTimeout),
 		)
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, guestClient, np, hc.Spec.Platform.Type)
+		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		// TODO: EnsureNodesLabelsAndTaints, EnsureNodesRuntime require *testing.T
 	})
@@ -481,7 +506,7 @@ func NodePoolRollingUpgradeTest(getTestCtx internal.TestContextGetter) {
 			Skip("rolling upgrade test only supported on AWS and Azure platforms")
 		}
 
-		guestClient := testCtx.GetHostedClusterClient()
+		hcClient := testCtx.GetHostedClusterClient()
 
 		ctx := testCtx.Context
 
@@ -503,9 +528,11 @@ func NodePoolRollingUpgradeTest(getTestCtx internal.TestContextGetter) {
 		err := testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s with 2 replicas\n", np.Name)
-		defer cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		DeferCleanup(func() {
+			cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, guestClient, np, platform)
+		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, platform)
 
 		// Change instance type / VM size to trigger rolling upgrade
 		var newInstanceType, newVMSize string
@@ -578,7 +605,7 @@ func NodePoolPrevReleaseN1Test(getTestCtx internal.TestContextGetter) {
 			Skip("E2E_N1_RELEASE_IMAGE not set, skipping N-1 release test")
 		}
 
-		guestClient := testCtx.GetHostedClusterClient()
+		hcClient := testCtx.GetHostedClusterClient()
 
 		ctx := testCtx.Context
 
@@ -594,9 +621,11 @@ func NodePoolPrevReleaseN1Test(getTestCtx internal.TestContextGetter) {
 		err := testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s at N-1 release %s\n", np.Name, n1Image)
-		defer cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		DeferCleanup(func() {
+			cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, guestClient, np, hc.Spec.Platform.Type)
+		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		// TODO: EnsureNodesLabelsAndTaints requires *testing.T
 	})
@@ -615,7 +644,7 @@ func NodePoolPrevReleaseN2Test(getTestCtx internal.TestContextGetter) {
 			Skip("E2E_N2_RELEASE_IMAGE not set, skipping N-2 release test")
 		}
 
-		guestClient := testCtx.GetHostedClusterClient()
+		hcClient := testCtx.GetHostedClusterClient()
 
 		ctx := testCtx.Context
 
@@ -631,9 +660,11 @@ func NodePoolPrevReleaseN2Test(getTestCtx internal.TestContextGetter) {
 		err := testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s at N-2 release %s\n", np.Name, n2Image)
-		defer cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		DeferCleanup(func() {
+			cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, guestClient, np, hc.Spec.Platform.Type)
+		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		// TODO: EnsureNodesLabelsAndTaints requires *testing.T
 	})
@@ -652,7 +683,7 @@ func NodePoolMirrorConfigsTest(getTestCtx internal.TestContextGetter) {
 			Skip("mirror configs test only applicable for 4.18+")
 		}
 
-		guestClient := testCtx.GetHostedClusterClient()
+		hcClient := testCtx.GetHostedClusterClient()
 
 		ctx := testCtx.Context
 
@@ -667,9 +698,11 @@ func NodePoolMirrorConfigsTest(getTestCtx internal.TestContextGetter) {
 		err := testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s\n", np.Name)
-		defer cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		DeferCleanup(func() {
+			cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, guestClient, np, hc.Spec.Platform.Type)
+		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		kcConfigMap := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -681,7 +714,7 @@ func NodePoolMirrorConfigsTest(getTestCtx internal.TestContextGetter) {
 		Expect(testCtx.MgmtClient.Create(ctx, kcConfigMap)).To(Succeed(), "failed to create KubeletConfig ConfigMap")
 		DeferCleanup(func() {
 			if err := testCtx.MgmtClient.Delete(ctx, kcConfigMap); err != nil && !apierrors.IsNotFound(err) {
-				GinkgoWriter.Printf("Warning: failed to cleanup KubeletConfig ConfigMap %s: %v\n", kcConfigMap.Name, err)
+				Expect(err).NotTo(HaveOccurred(), "cleanup: failed to delete ConfigMap %s", kcConfigMap.Name)
 			}
 		})
 
@@ -694,7 +727,7 @@ func NodePoolMirrorConfigsTest(getTestCtx internal.TestContextGetter) {
 		e2eutil.EventuallyObjects(GinkgoTB(), ctx, "KubeletConfig should be mirrored to the hosted cluster",
 			func(ctx context.Context) ([]*corev1.ConfigMap, error) {
 				list := &corev1.ConfigMapList{}
-				err := guestClient.List(ctx, list, crclient.InNamespace(configManagedNamespace),
+				err := hcClient.List(ctx, list, crclient.InNamespace(configManagedNamespace),
 					crclient.MatchingLabels(map[string]string{
 						nodepool.KubeletConfigConfigMapLabel: "true",
 						hyperv1.NodePoolLabel:                np.Name,
@@ -746,7 +779,7 @@ func NodePoolMirrorConfigsTest(getTestCtx internal.TestContextGetter) {
 		e2eutil.EventuallyObjects(GinkgoTB(), ctx, "KubeletConfig ConfigMap to be deleted from hosted cluster",
 			func(ctx context.Context) ([]*corev1.ConfigMap, error) {
 				list := &corev1.ConfigMapList{}
-				err := guestClient.List(ctx, list, crclient.InNamespace(configManagedNamespace),
+				err := hcClient.List(ctx, list, crclient.InNamespace(configManagedNamespace),
 					crclient.MatchingLabels(map[string]string{
 						nodepool.KubeletConfigConfigMapLabel: "true",
 						hyperv1.NodePoolLabel:                np.Name,
@@ -779,7 +812,7 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 		e2eutil.GinkgoAtLeast(e2eutil.Version418)
 
 		hc := testCtx.GetHostedCluster()
-		guestClient := testCtx.GetHostedClusterClient()
+		hcClient := testCtx.GetHostedClusterClient()
 
 		ctx := testCtx.Context
 
@@ -792,9 +825,11 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 		})
 		Expect(testCtx.MgmtClient.Create(ctx, np)).To(Succeed(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s for trust bundle test\n", np.Name)
-		defer cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		DeferCleanup(func() {
+			cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, guestClient, np, hc.Spec.Platform.Type)
+		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		// Create additional trust bundle ConfigMap
 		trustBundle := &corev1.ConfigMap{
@@ -805,6 +840,11 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 			Data: map[string]string{"ca-bundle.crt": "dummy"},
 		}
 		Expect(testCtx.MgmtClient.Create(ctx, trustBundle)).To(Succeed(), "failed to create trust bundle ConfigMap")
+		DeferCleanup(func() {
+			if err := testCtx.MgmtClient.Delete(ctx, trustBundle); err != nil && !apierrors.IsNotFound(err) {
+				Expect(err).NotTo(HaveOccurred(), "cleanup: failed to delete ConfigMap %s", trustBundle.Name)
+			}
+		})
 
 		// Update HostedCluster to reference the trust bundle
 		GinkgoWriter.Printf("Updating HostedCluster with additional trust bundle %s\n", trustBundle.Name)
@@ -813,14 +853,14 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 		})).To(Succeed(), "failed to update HostedCluster with trust bundle")
 
 		// Defer cleanup: remove trust bundle reference from HostedCluster
-		defer func() {
-			err := e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+		DeferCleanup(func() {
+			err := e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, testCtx.GetHostedCluster(), func(obj *hyperv1.HostedCluster) {
 				obj.Spec.AdditionalTrustBundle = nil
 			})
-			if err != nil {
-				GinkgoWriter.Printf("WARNING: failed to clean up trust bundle reference: %v\n", err)
+			if err != nil && !apierrors.IsNotFound(err) {
+				Expect(err).NotTo(HaveOccurred(), "cleanup: failed to remove additional trust bundle")
 			}
-		}()
+		})
 
 		e2eutil.EventuallyObject(GinkgoTB(), ctx, fmt.Sprintf("NodePool %s/%s to begin updating", np.Namespace, np.Name),
 			func(ctx context.Context) (*hyperv1.NodePool, error) {
@@ -866,7 +906,7 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 		e2eutil.EventuallyObject(GinkgoTB(), ctx, "user-ca-bundle to exist in hosted cluster",
 			func(ctx context.Context) (*corev1.ConfigMap, error) {
 				cm := &corev1.ConfigMap{}
-				err := guestClient.Get(ctx, crclient.ObjectKeyFromObject(userCAConfigMap), cm)
+				err := hcClient.Get(ctx, crclient.ObjectKeyFromObject(userCAConfigMap), cm)
 				return cm, err
 			},
 			[]e2eutil.Predicate[*corev1.ConfigMap]{
@@ -947,7 +987,7 @@ func NodePoolTrustBundleTest(getTestCtx internal.TestContextGetter) {
 
 		// Verify user-ca-bundle is deleted from the hosted cluster (4.22+)
 		if e2eutil.IsGreaterThanOrEqualTo(e2eutil.Version422) {
-			e2eutil.EventuallyNotFound(GinkgoTB(), ctx, guestClient, userCAConfigMap,
+			e2eutil.EventuallyNotFound(GinkgoTB(), ctx, hcClient, userCAConfigMap,
 				e2eutil.WithInterval(10*time.Second), e2eutil.WithTimeout(5*time.Minute),
 			)
 		}
@@ -967,7 +1007,7 @@ func NodePoolNTOPerformanceProfileTest(getTestCtx internal.TestContextGetter) {
 			Skip("test is skipped for OpenStack platform until https://issues.redhat.com/browse/OSASINFRA-3566 is addressed")
 		}
 
-		guestClient := testCtx.GetHostedClusterClient()
+		hcClient := testCtx.GetHostedClusterClient()
 
 		ctx := testCtx.Context
 
@@ -982,9 +1022,11 @@ func NodePoolNTOPerformanceProfileTest(getTestCtx internal.TestContextGetter) {
 		err := testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created NodePool %s\n", np.Name)
-		defer cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		DeferCleanup(func() {
+			cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, guestClient, np, hc.Spec.Platform.Type)
+		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		ppConfigMap := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -996,7 +1038,7 @@ func NodePoolNTOPerformanceProfileTest(getTestCtx internal.TestContextGetter) {
 		Expect(testCtx.MgmtClient.Create(ctx, ppConfigMap)).To(Succeed(), "failed to create PerformanceProfile ConfigMap")
 		DeferCleanup(func() {
 			if err := testCtx.MgmtClient.Delete(ctx, ppConfigMap); err != nil && !apierrors.IsNotFound(err) {
-				GinkgoWriter.Printf("Warning: failed to cleanup PerformanceProfile ConfigMap %s: %v\n", ppConfigMap.Name, err)
+				Expect(err).NotTo(HaveOccurred(), "cleanup: failed to delete ConfigMap %s", ppConfigMap.Name)
 			}
 		})
 
@@ -1128,7 +1170,7 @@ func NodePoolAutoRepairTest(getTestCtx internal.TestContextGetter) {
 			Skip("auto-repair test only supported on AWS and Azure platforms")
 		}
 
-		guestClient := testCtx.GetHostedClusterClient()
+		hcClient := testCtx.GetHostedClusterClient()
 
 		ctx := testCtx.Context
 
@@ -1144,9 +1186,11 @@ func NodePoolAutoRepairTest(getTestCtx internal.TestContextGetter) {
 		err := testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created auto-repair NodePool %s\n", np.Name)
-		defer cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		DeferCleanup(func() {
+			cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, guestClient, np, platform)
+		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, platform)
 
 		// TODO: Implement cloud-specific instance termination logic.
 		// For AWS: use EC2 TerminateInstances API to terminate the node's backing instance.
@@ -1173,7 +1217,7 @@ func NodePoolDiskEncryptionTest(getTestCtx internal.TestContextGetter) {
 			Skip("E2E_AZURE_DISK_ENCRYPTION_SET_ID not set, skipping disk encryption test")
 		}
 
-		guestClient := testCtx.GetHostedClusterClient()
+		hcClient := testCtx.GetHostedClusterClient()
 
 		ctx := testCtx.Context
 
@@ -1191,9 +1235,11 @@ func NodePoolDiskEncryptionTest(getTestCtx internal.TestContextGetter) {
 		err := testCtx.MgmtClient.Create(ctx, np)
 		Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
 		GinkgoWriter.Printf("Created disk encryption NodePool %s\n", np.Name)
-		defer cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		DeferCleanup(func() {
+			cleanupNodePool(ctx, testCtx.MgmtClient, np)
+		})
 
-		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, guestClient, np, hc.Spec.Platform.Type)
+		e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
 
 		// TODO: Verify disk encryption is applied by checking AzureMachine specs
 		// in the control plane namespace. This requires importing CAPI Azure types


### PR DESCRIPTION
## Summary

- **Rule 1 (Terminology)**: rename `guestClient` → `hcClient` in etcd, nodepool lifecycle, and autoscaling tests; rename `EnsureGuestWebhooksValidatedTest`; fix `"guest Prometheus"` string in metrics test
- **Rule 2 (File Org)**: add `ValidateHostedCluster()` to CCM test top-level `BeforeEach`
- **Rule 6 (Context)**: replace `context.Background()` with `tc.Context` in workloads and CCM tests; drop now-unused `"context"` import in CCM test
- **Rule 9 (DeferCleanup)**: convert 13 `defer cleanupNodePool` and 5 `defer cleanupWorkload` calls to `DeferCleanup` in lifecycle/autoscaling tests; add missing `DeferCleanup` for 4 ConfigMap creates and 1 Service create; convert trust bundle `defer func()` closure; fix all `GinkgoWriter.Printf("Warning: ...")` cleanup patterns to use `Expect`
- **Rule 11 (Pointer Safety)**: nil-check `Status.Platform.AWS` and `Spec.Platform.GCP.WorkloadIdentity` before dereference in AWS and image registry tests
- **Rule 16 (Vacuous Pass)**: add non-empty assertions before pod/component loops in workloads, infrastructure, and health tests; add `namespacesChecked` counter in infrastructure test; add `Skip` when `matchingPods` is empty

## Test plan

- [x] `make e2ev2` builds cleanly
- [x] `make backuprestore-e2e` builds cleanly
- [x] `make test` passes (unit tests)
- [x] `grep -rn 'guestClient' test/e2e/v2/tests/` → 0 matches
- [x] `grep -rn 'EnsureGuest' test/e2e/v2/tests/` → 0 matches
- [x] `grep -rn 'context\.Background()' test/e2e/v2/tests/` → only `suite_test.go:53`
- [x] `grep -rn 'defer cleanup\|defer func' test/e2e/v2/tests/` → 0 matches
- [x] `grep -rn 'GinkgoWriter.Printf.*Warning.*cleanup' test/e2e/v2/tests/` → 0 matches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved e2e test robustness with stronger assertions to avoid vacuous passes and clearer validation failures.
  * More reliable context and client usage across hosted-cluster and autoscaling scenarios to reduce flakiness.
  * Tighter cleanup and resource management (deferred/registered cleanup and tolerant deletion) to prevent leaks and ensure consistent test teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->