### PR TITLE
NO-JIRA: chore(ci): enforce v2 e2e AGENTS.md standards via CodeRabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -62,6 +62,11 @@ reviews:
 
     # Test fixtures and data
     - "!**/testdata/**"
+  path_instructions:
+    - path: "test/e2e/v2/**/*.go"
+      instructions: |
+        Strictly enforce all standards documented in test/e2e/v2/AGENTS.md
+        when reviewing changes to this file. Flag any violations.
   tools:
     golangci-lint:
       enabled: true
@@ -71,7 +76,7 @@ knowledge_base:
   code_guidelines:
     enabled: true
     filePatterns:
-      - AGENTS.md
+      - "**/AGENTS.md"
       - .claude/agents/*.md
       - .cursor/rules/*.mdc
   learnings:


### PR DESCRIPTION
## Summary

- Fix `knowledge_base.code_guidelines.filePatterns` glob from `AGENTS.md` (root-only match) to `**/AGENTS.md` so CodeRabbit actually ingests `test/e2e/v2/AGENTS.md` as a knowledge source
- Add a `path_instructions` entry scoped to `test/e2e/v2/**/*.go` that instructs CodeRabbit to actively enforce the standards from `test/e2e/v2/AGENTS.md` on every PR touching those files

`test/e2e/v2/AGENTS.md` remains the single source of truth — no rules are duplicated into the CodeRabbit config.

## Test plan

- [ ] Merge and open a follow-up PR touching a file under `test/e2e/v2/tests/` — confirm CodeRabbit flags violations of the AGENTS.md standards (e.g. use of `context.Background()`, "guest cluster" terminology, missing vacuous-pass guards)
- [ ] Alternatively, trigger `@coderabbitai review` on an existing PR touching v2 e2e files to validate the new instructions take effect


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration to enforce testing standards more strictly across automated test files and expanded guideline file matching to improve code quality consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->