### PR TITLE
OCPBUGS-87018: Revert conditional deletion of openshift-ingress NetworkPolicy

### DIFF
--- a/hypershift-operator/controllers/hostedcluster/network_policies.go
+++ b/hypershift-operator/controllers/hostedcluster/network_policies.go
@@ -15,8 +15,6 @@ import (
 	"github.com/openshift/hypershift/support/awsutil"
 	"github.com/openshift/hypershift/support/capabilities"
 	"github.com/openshift/hypershift/support/config"
-	"github.com/openshift/hypershift/support/k8sutil"
-	"github.com/openshift/hypershift/support/netutil"
 	"github.com/openshift/hypershift/support/rhobsmonitoring"
 	"github.com/openshift/hypershift/support/upsert"
 
@@ -44,11 +42,15 @@ const (
 func (r *HostedClusterReconciler) reconcileNetworkPolicies(ctx context.Context, log logr.Logger, createOrUpdate upsert.CreateOrUpdateFN, hcluster *hyperv1.HostedCluster, hcp *hyperv1.HostedControlPlane, version semver.Version, controlPlaneOperatorAppliesManagementKASNetworkPolicyLabel bool) error {
 	controlPlaneNamespaceName := manifests.HostedControlPlaneNamespace(hcluster.Namespace, hcluster.Name)
 
-	if err := r.reconcileIngressNetworkPolicy(ctx, createOrUpdate, hcp, controlPlaneNamespaceName); err != nil {
-		return err
+	// Reconcile openshift-ingress Network Policy
+	policy := networkpolicy.OpenshiftIngressNetworkPolicy(controlPlaneNamespaceName)
+	if _, err := createOrUpdate(ctx, r.Client, policy, func() error {
+		return reconcileOpenshiftIngressNetworkPolicy(policy)
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile ingress network policy: %w", err)
 	}
 
-	policy := networkpolicy.SameNamespaceNetworkPolicy(controlPlaneNamespaceName)
+	policy = networkpolicy.SameNamespaceNetworkPolicy(controlPlaneNamespaceName)
 	if _, err := createOrUpdate(ctx, r.Client, policy, func() error {
 		return reconcileSameNamespaceNetworkPolicy(policy)
 	}); err != nil {
@@ -98,24 +100,6 @@ func (r *HostedClusterReconciler) reconcileNetworkPolicies(ctx context.Context, 
 	}
 
 	return r.reconcileServiceNetworkPolicies(ctx, createOrUpdate, hcluster, controlPlaneNamespaceName)
-}
-
-func (r *HostedClusterReconciler) reconcileIngressNetworkPolicy(ctx context.Context, createOrUpdate upsert.CreateOrUpdateFN, hcp *hyperv1.HostedControlPlane, controlPlaneNamespaceName string) error {
-	// Only needed when routes are served by the management cluster's default ingress controller,
-	// i.e., when routes are NOT labeled for the HCP router.
-	policy := networkpolicy.OpenshiftIngressNetworkPolicy(controlPlaneNamespaceName)
-	if !netutil.LabelHCPRoutes(hcp) {
-		if _, err := createOrUpdate(ctx, r.Client, policy, func() error {
-			return reconcileOpenshiftIngressNetworkPolicy(policy)
-		}); err != nil {
-			return fmt.Errorf("failed to reconcile ingress network policy: %w", err)
-		}
-	} else {
-		if _, err := k8sutil.DeleteIfNeeded(ctx, r.Client, policy); err != nil {
-			return fmt.Errorf("failed to delete ingress network policy: %w", err)
-		}
-	}
-	return nil
 }
 
 func (r *HostedClusterReconciler) getManagementClusterNetwork(ctx context.Context) (*configv1.Network, error) {

--- a/hypershift-operator/controllers/hostedcluster/network_policies_test.go
+++ b/hypershift-operator/controllers/hostedcluster/network_policies_test.go
@@ -266,12 +266,14 @@ func TestGCPPrivateRouterNetworkPolicy_IngressOnly(t *testing.T) {
 }
 
 func TestReconcileNetworkPolicies_OpenshiftIngressPolicy(t *testing.T) {
+	// The openshift-ingress NetworkPolicy must always be created regardless of
+	// platform, endpoint access mode, or KAS publishing strategy.
+	// Removing it triggers an OVN-Kubernetes bug where port group references
+	// become stale during MC KAS rollouts. See OCPBUGS-87018.
 	tests := []struct {
-		name          string
-		hcluster      *hyperv1.HostedCluster
-		hcp           *hyperv1.HostedControlPlane
-		expectCreated bool
-		expectDeleted bool
+		name     string
+		hcluster *hyperv1.HostedCluster
+		hcp      *hyperv1.HostedControlPlane
 	}{
 		{
 			name: "When AWS public cluster uses KAS LoadBalancer it should create policy",
@@ -292,10 +294,9 @@ func TestReconcileNetworkPolicies_OpenshiftIngressPolicy(t *testing.T) {
 					},
 				},
 			},
-			expectCreated: true,
 		},
 		{
-			name: "When AWS private cluster uses KAS LoadBalancer it should delete policy",
+			name: "When AWS private cluster uses KAS LoadBalancer it should create policy",
 			hcluster: &hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
 				Spec: hyperv1.HostedClusterSpec{
@@ -313,31 +314,9 @@ func TestReconcileNetworkPolicies_OpenshiftIngressPolicy(t *testing.T) {
 					},
 				},
 			},
-			expectDeleted: true,
 		},
 		{
-			name: "When AWS PublicAndPrivate cluster uses KAS LoadBalancer it should create policy",
-			hcluster: &hyperv1.HostedCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
-				Spec: hyperv1.HostedClusterSpec{
-					Platform: hyperv1.PlatformSpec{Type: hyperv1.AWSPlatform, AWS: &hyperv1.AWSPlatformSpec{EndpointAccess: hyperv1.PublicAndPrivate}},
-					Services: []hyperv1.ServicePublishingStrategyMapping{
-						{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.LoadBalancer}},
-					},
-				},
-			},
-			hcp: &hyperv1.HostedControlPlane{
-				Spec: hyperv1.HostedControlPlaneSpec{
-					Platform: hyperv1.PlatformSpec{Type: hyperv1.AWSPlatform, AWS: &hyperv1.AWSPlatformSpec{EndpointAccess: hyperv1.PublicAndPrivate}},
-					Services: []hyperv1.ServicePublishingStrategyMapping{
-						{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.LoadBalancer}},
-					},
-				},
-			},
-			expectCreated: true,
-		},
-		{
-			name: "When AWS public cluster uses KAS Route with hostname it should delete policy",
+			name: "When AWS public cluster uses KAS Route with hostname it should create policy",
 			hcluster: &hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
 				Spec: hyperv1.HostedClusterSpec{
@@ -361,31 +340,9 @@ func TestReconcileNetworkPolicies_OpenshiftIngressPolicy(t *testing.T) {
 					},
 				},
 			},
-			expectDeleted: true,
 		},
 		{
-			name: "When GCP PublicAndPrivate cluster uses KAS LoadBalancer it should create policy",
-			hcluster: &hyperv1.HostedCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
-				Spec: hyperv1.HostedClusterSpec{
-					Platform: hyperv1.PlatformSpec{Type: hyperv1.GCPPlatform, GCP: &hyperv1.GCPPlatformSpec{EndpointAccess: hyperv1.GCPEndpointAccessPublicAndPrivate}},
-					Services: []hyperv1.ServicePublishingStrategyMapping{
-						{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.LoadBalancer}},
-					},
-				},
-			},
-			hcp: &hyperv1.HostedControlPlane{
-				Spec: hyperv1.HostedControlPlaneSpec{
-					Platform: hyperv1.PlatformSpec{Type: hyperv1.GCPPlatform, GCP: &hyperv1.GCPPlatformSpec{EndpointAccess: hyperv1.GCPEndpointAccessPublicAndPrivate}},
-					Services: []hyperv1.ServicePublishingStrategyMapping{
-						{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.LoadBalancer}},
-					},
-				},
-			},
-			expectCreated: true,
-		},
-		{
-			name: "When GCP private cluster uses KAS LoadBalancer it should delete policy",
+			name: "When GCP private cluster uses KAS LoadBalancer it should create policy",
 			hcluster: &hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
 				Spec: hyperv1.HostedClusterSpec{
@@ -403,52 +360,9 @@ func TestReconcileNetworkPolicies_OpenshiftIngressPolicy(t *testing.T) {
 					},
 				},
 			},
-			expectDeleted: true,
 		},
 		{
-			name: "When IBM Cloud cluster uses KAS Route it should create policy",
-			hcluster: &hyperv1.HostedCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
-				Spec: hyperv1.HostedClusterSpec{
-					Platform: hyperv1.PlatformSpec{Type: hyperv1.IBMCloudPlatform},
-					Services: []hyperv1.ServicePublishingStrategyMapping{
-						{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.Route}},
-					},
-				},
-			},
-			hcp: &hyperv1.HostedControlPlane{
-				Spec: hyperv1.HostedControlPlaneSpec{
-					Platform: hyperv1.PlatformSpec{Type: hyperv1.IBMCloudPlatform},
-					Services: []hyperv1.ServicePublishingStrategyMapping{
-						{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.Route}},
-					},
-				},
-			},
-			expectCreated: true,
-		},
-		{
-			name: "When Agent cluster uses KAS LoadBalancer it should create policy",
-			hcluster: &hyperv1.HostedCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
-				Spec: hyperv1.HostedClusterSpec{
-					Platform: hyperv1.PlatformSpec{Type: hyperv1.AgentPlatform},
-					Services: []hyperv1.ServicePublishingStrategyMapping{
-						{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.LoadBalancer}},
-					},
-				},
-			},
-			hcp: &hyperv1.HostedControlPlane{
-				Spec: hyperv1.HostedControlPlaneSpec{
-					Platform: hyperv1.PlatformSpec{Type: hyperv1.AgentPlatform},
-					Services: []hyperv1.ServicePublishingStrategyMapping{
-						{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.LoadBalancer}},
-					},
-				},
-			},
-			expectCreated: true,
-		},
-		{
-			name: "When Agent cluster uses KAS Route with hostname it should delete policy",
+			name: "When Agent cluster uses KAS Route with hostname it should create policy",
 			hcluster: &hyperv1.HostedCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
 				Spec: hyperv1.HostedClusterSpec{
@@ -472,28 +386,6 @@ func TestReconcileNetworkPolicies_OpenshiftIngressPolicy(t *testing.T) {
 					},
 				},
 			},
-			expectDeleted: true,
-		},
-		{
-			name: "When KubeVirt cluster uses KAS LoadBalancer it should create policy",
-			hcluster: &hyperv1.HostedCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
-				Spec: hyperv1.HostedClusterSpec{
-					Platform: hyperv1.PlatformSpec{Type: hyperv1.KubevirtPlatform, Kubevirt: &hyperv1.KubevirtPlatformSpec{}},
-					Services: []hyperv1.ServicePublishingStrategyMapping{
-						{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.LoadBalancer}},
-					},
-				},
-			},
-			hcp: &hyperv1.HostedControlPlane{
-				Spec: hyperv1.HostedControlPlaneSpec{
-					Platform: hyperv1.PlatformSpec{Type: hyperv1.KubevirtPlatform, Kubevirt: &hyperv1.KubevirtPlatformSpec{}},
-					Services: []hyperv1.ServicePublishingStrategyMapping{
-						{Service: hyperv1.APIServer, ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{Type: hyperv1.LoadBalancer}},
-					},
-				},
-			},
-			expectCreated: true,
 		},
 	}
 
@@ -535,15 +427,6 @@ func TestReconcileNetworkPolicies_OpenshiftIngressPolicy(t *testing.T) {
 			}
 
 			objs := []client.Object{kubernetesEndpoint, managementClusterNetwork}
-
-			// For deletion tests, pre-create the openshift-ingress NetworkPolicy
-			if tc.expectDeleted {
-				existingPolicy := networkpolicy.OpenshiftIngressNetworkPolicy(controlPlaneNamespaceName)
-				existingPolicy.Spec.PodSelector = metav1.LabelSelector{}
-				existingPolicy.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}
-				objs = append(objs, existingPolicy)
-			}
-
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
 
 			reconciler := &HostedClusterReconciler{
@@ -571,20 +454,8 @@ func TestReconcileNetworkPolicies_OpenshiftIngressPolicy(t *testing.T) {
 				t.Fatalf("reconcileNetworkPolicies failed: %v", err)
 			}
 
-			_, policyCreated := createdNetworkPolicies["openshift-ingress"]
-			if tc.expectCreated && !policyCreated {
+			if _, policyCreated := createdNetworkPolicies["openshift-ingress"]; !policyCreated {
 				t.Error("Expected openshift-ingress NetworkPolicy to be created, but it was not")
-			}
-			if !tc.expectCreated && policyCreated {
-				t.Error("Expected openshift-ingress NetworkPolicy to NOT be created, but it was")
-			}
-
-			if tc.expectDeleted {
-				policyObj := networkpolicy.OpenshiftIngressNetworkPolicy(controlPlaneNamespaceName)
-				err := fakeClient.Get(ctx, client.ObjectKeyFromObject(policyObj), policyObj)
-				if !apierrors.IsNotFound(err) {
-					t.Error("Expected openshift-ingress NetworkPolicy to be deleted from the cluster, but it still exists")
-				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Reverts PR #7872 which conditionally deleted the `openshift-ingress` NetworkPolicy when `LabelHCPRoutes` was true
- The absence of this policy triggers an OVN-Kubernetes port group race during MC kube-apiserver revision rollouts, causing 20-30+ minute API blackouts for all hosted clusters

## Problem

When the management cluster kube-apiserver undergoes a revision rollout (cert rotation, config change, or forced redeployment), all hosted cluster private-router NLBs experience sustained traffic blackouts. The issue was introduced in HO v0.1.75 and does not self-heal — manual deletion of HCP `router` pods is required to restore traffic.

### Root Cause

During a MC KAS rollout, `ovnkube-controller` briefly loses its API connection and re-syncs. During this re-sync, it writes OVN NorthDB logical flows that reference port groups before those port groups are fully restored. `ovn-controller` fails to parse the flow match rules:

```
lflow|WARN|error parsing match "... inport == @a15503844857551241179":
  Syntax error at `@a15503844857551241179' expecting port group name.
```

These broken flows are the **allow rules** for NodePort/LoadBalancer ingress traffic. Without them, the namespace default-deny ingress ACL drops all NLB traffic to HCP router pods on port 8443.

### Evidence from must-gather

ACL logging confirmed the mechanism:
- **11,110 ACL drops** across all 6 router pods on 3 hosted clusters
- **100% of drops** target router IPs on port 8443
- Drops correlate exactly with `ovn-controller` lflow parse errors during the KAS rollout window
- Each HC namespace has a different missing port group, but the pattern is identical

| Node | HC | Router IP | ACL Drops | Window |
|---|---|---|---|---|
| ovnkube-node-25pbh | hc-c (4.18) | 10.128.34.26 | 4,773 | 17:45–17:49 |
| ovnkube-node-htzlx | hc-c (4.18) | 10.128.35.25 | 4,928 | 17:45–17:52 |
| ovnkube-node-49p92 | hc-c2 (4.21) | 10.128.195.22 | 188 | 17:46–17:50 |
| ovnkube-node-dwlb6 | hc-c2 (4.21) | 10.128.197.21 | 329 | 17:46–17:52 |
| ovnkube-node-btfb9 | hc-default | 10.128.200.22 | 536 | 17:43–17:51 |
| ovnkube-node-575vk | hc-default | 10.128.201.22 | 356 | 17:43–17:50 |

### Why re-adding the policy helps

The exact mechanism by which the `openshift-ingress` NetworkPolicy prevents the race is not yet fully understood — other policies in the namespace also use `podSelector: {}`, so it is not simply the presence of a broad port group. It may be related to the cross-namespace `namespaceSelector` reference (matching `network.openshift.io/policy-group: ingress`) or to reducing the amount of OVN NorthDB churn during re-sync. Regardless, manual testing confirmed that re-applying the policy prevents the outage, and removing it reliably reproduces it.

The underlying OVN-Kubernetes bug (non-atomic port group + logical flow updates during re-sync) should be tracked and fixed separately.

## Test plan

- [x] Unit tests updated — all deletion test cases changed to expect creation
- [x] All network policy tests pass
- [ ] Manual verification: trigger MC KAS rollout with this fix applied, confirm no HC API blackout
- [ ] Verify the `openshift-ingress` NetworkPolicy is present in HCP namespaces for private/PublicAndPrivate clusters

🤖 Generated with [Claude Code](https://claude.com/claude-code)