### PR TITLE
NO-JIRA: fix(tekton): remove path filter from control-plane-operator pipelines

### DIFF
--- a/.tekton/control-plane-operator-4-19-pull-request.yaml
+++ b/.tekton/control-plane-operator-4-19-pull-request.yaml
@@ -8,13 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request"
-      && target_branch == "release-4.19"
-      && ( "control-plane-operator/***".pathChanged() ||
-           "support/***".pathChanged() ||
-           ".tekton/control-plane-operator*".pathChanged() ||
-           "/Containerfile.control-plane-operator".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-4.19"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: control-plane-operator-4-19

--- a/.tekton/control-plane-operator-4-19-push.yaml
+++ b/.tekton/control-plane-operator-4-19-push.yaml
@@ -7,13 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push"
-      && target_branch == "release-4.19"
-      && ( "control-plane-operator/***".pathChanged() ||
-           "support/***".pathChanged() ||
-           ".tekton/control-plane-operator*".pathChanged() ||
-           "/Containerfile.control-plane-operator".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-4.19"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: control-plane-operator-4-19


### PR DESCRIPTION
## Summary

- The control-plane-operator Tekton pipelines had a CEL path filter that prevented them from triggering on most PRs to `release-4.19`, including CVE fixes and dependency bumps
- The filter referenced a non-existent file (`/Containerfile.control-plane-operator` instead of `Containerfile.control-plane`) and excluded `go.mod`/`vendor/` changes entirely
- Removed the path filter to match the other release-4.19 pipelines (`hypershift-cli-mce-29`, `hypershift-release-mce-29`), which already trigger on all PRs/pushes

## Why

PR https://github.com/openshift/hypershift/pull/8647 (go-toolset bump for CVE fix) did not trigger the control-plane-operator Konflux build. On a release branch, all changes are intentional backports and should be verified with a build.

## Test plan

- [ ] Verify this PR itself triggers the `control-plane-operator-4-19-on-pull-request` Konflux pipeline
- [ ] Verify the other two pipelines (`hypershift-cli-mce-29`, `hypershift-release-mce-29`) continue to trigger as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)