### PR TITLE
NO-JIRA: remove path filter from control-plane-operator pipelines

### DIFF
--- a/.tekton/control-plane-operator-4-20-pull-request.yaml
+++ b/.tekton/control-plane-operator-4-20-pull-request.yaml
@@ -8,13 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request"
-      && target_branch == "release-4.20"
-      && ( "control-plane-operator/***".pathChanged() ||
-           "support/***".pathChanged() ||
-           ".tekton/control-plane-operator*".pathChanged() ||
-           "/Containerfile.control-plane-operator".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-4.20"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: control-plane-operator-4-20

--- a/.tekton/control-plane-operator-4-20-push.yaml
+++ b/.tekton/control-plane-operator-4-20-push.yaml
@@ -6,13 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "push"
-      && target_branch == "release-4.20"
-      && ( "control-plane-operator/***".pathChanged() ||
-           "support/***".pathChanged() ||
-           ".tekton/control-plane-operator*".pathChanged() ||
-           "/Containerfile.control-plane-operator".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-4.20"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: control-plane-operator-4-20


### PR DESCRIPTION
## Summary

- The control-plane-operator Tekton pipelines had a CEL path filter that prevented them from triggering on most PRs to `release-4.20`, including CVE fixes and dependency bumps
- The filter excluded `go.mod`/`vendor/` changes entirely, meaning dependency-level CVE fixes could merge without a build verification
- Removed the path filter to match the other release-4.20 pipelines, which already trigger on all PRs/pushes

## Why

PR https://github.com/openshift/hypershift/pull/8647 (go-toolset bump for CVE fix) did not trigger the control-plane-operator Konflux build on release-4.19. The same issue exists on all supported release branches.

See also: https://github.com/openshift/hypershift/pull/8664 (release-4.19 fix)

## Test plan

- [ ] Verify this PR itself triggers the `control-plane-operator` Konflux pipeline
- [ ] Verify the other pipelines continue to trigger as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)