### PR TITLE
CNTRLPLANE-3552: Multi-stream CoreOS metadata parsing and stream resolution

### DIFF
--- a/hypershift-operator/controllers/nodepool/stream.go
+++ b/hypershift-operator/controllers/nodepool/stream.go
@@ -1,0 +1,50 @@
+package nodepool
+
+import (
+	"fmt"
+
+	"github.com/openshift/hypershift/support/releaseinfo"
+
+	"github.com/blang/semver"
+)
+
+const (
+	StreamRHEL9  = releaseinfo.StreamRHEL9
+	StreamRHEL10 = releaseinfo.StreamRHEL10
+)
+
+// GetRHELStream resolves which RHEL CoreOS stream a NodePool should use.
+// Returns the resolved stream name, or an error for invalid combinations.
+// An empty return means "use legacy single-stream behavior" (OCP 4.x).
+// Exported for use by integration tests and future Phase 2 consumers
+// (token secret plumbing, validMachineConfigCondition).
+func GetRHELStream(explicitStream string, releaseVersion semver.Version, usesRunc bool) (string, error) {
+	isOCP5Plus := releaseVersion.Major >= 5
+
+	if explicitStream != "" {
+		switch explicitStream {
+		case StreamRHEL9:
+			return StreamRHEL9, nil
+		case StreamRHEL10:
+			if !isOCP5Plus {
+				return "", fmt.Errorf("stream %q requires OCP >= 5.0, but release version is %s", explicitStream, releaseVersion)
+			}
+			if usesRunc {
+				return "", fmt.Errorf("stream %q is incompatible with runc: RHEL 10 does not ship runc", explicitStream)
+			}
+			return StreamRHEL10, nil
+		default:
+			return "", fmt.Errorf("unknown RHEL stream %q; valid values are %q and %q", explicitStream, StreamRHEL9, StreamRHEL10)
+		}
+	}
+
+	if !isOCP5Plus {
+		return "", nil
+	}
+
+	if usesRunc {
+		return StreamRHEL9, nil
+	}
+
+	return StreamRHEL10, nil
+}

--- a/hypershift-operator/controllers/nodepool/stream_test.go
+++ b/hypershift-operator/controllers/nodepool/stream_test.go
@@ -1,0 +1,171 @@
+package nodepool
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/blang/semver"
+)
+
+func TestGetRHELStream(t *testing.T) {
+	tests := []struct {
+		name           string
+		explicitStream string
+		releaseVersion semver.Version
+		usesRunc       bool
+		expectResult   string
+		expectError    bool
+	}{
+		// --- Implicit stream (explicitStream = "") ---
+		{
+			name:           "When no explicit stream and release is 4.x it should return empty string",
+			explicitStream: "",
+			releaseVersion: semver.MustParse("4.18.0"),
+			expectResult:   "",
+		},
+		{
+			name:           "When no explicit stream and release is 4.x with runc it should return empty string",
+			explicitStream: "",
+			releaseVersion: semver.MustParse("4.19.0"),
+			usesRunc:       true,
+			expectResult:   "",
+		},
+		{
+			name:           "When no explicit stream and release is 5.0 it should return rhel-10",
+			explicitStream: "",
+			releaseVersion: semver.MustParse("5.0.0"),
+			expectResult:   "rhel-10",
+		},
+		{
+			name:           "When no explicit stream and release is 5.0 with runc it should return rhel-9",
+			explicitStream: "",
+			releaseVersion: semver.MustParse("5.0.0"),
+			usesRunc:       true,
+			expectResult:   "rhel-9",
+		},
+		{
+			name:           "When no explicit stream and release is 5.1 it should return rhel-10",
+			explicitStream: "",
+			releaseVersion: semver.MustParse("5.1.0"),
+			expectResult:   "rhel-10",
+		},
+		{
+			name:           "When no explicit stream and release is 5.1 with runc it should return rhel-9",
+			explicitStream: "",
+			releaseVersion: semver.MustParse("5.1.0"),
+			usesRunc:       true,
+			expectResult:   "rhel-9",
+		},
+
+		// --- Explicit rhel-9 ---
+		{
+			name:           "When explicit rhel-9 and release is 4.x it should return rhel-9",
+			explicitStream: "rhel-9",
+			releaseVersion: semver.MustParse("4.18.0"),
+			expectResult:   "rhel-9",
+		},
+		{
+			name:           "When explicit rhel-9 and release is 4.x with runc it should return rhel-9",
+			explicitStream: "rhel-9",
+			releaseVersion: semver.MustParse("4.18.0"),
+			usesRunc:       true,
+			expectResult:   "rhel-9",
+		},
+		{
+			name:           "When explicit rhel-9 and release is 5.0 it should return rhel-9",
+			explicitStream: "rhel-9",
+			releaseVersion: semver.MustParse("5.0.0"),
+			expectResult:   "rhel-9",
+		},
+		{
+			name:           "When explicit rhel-9 and release is 5.0 with runc it should return rhel-9",
+			explicitStream: "rhel-9",
+			releaseVersion: semver.MustParse("5.0.0"),
+			usesRunc:       true,
+			expectResult:   "rhel-9",
+		},
+		{
+			name:           "When explicit rhel-9 and release is 5.1 it should return rhel-9",
+			explicitStream: "rhel-9",
+			releaseVersion: semver.MustParse("5.1.0"),
+			expectResult:   "rhel-9",
+		},
+		{
+			name:           "When explicit rhel-9 and release is 5.1 with runc it should return rhel-9",
+			explicitStream: "rhel-9",
+			releaseVersion: semver.MustParse("5.1.0"),
+			usesRunc:       true,
+			expectResult:   "rhel-9",
+		},
+
+		// --- Explicit rhel-10 ---
+		{
+			name:           "When explicit rhel-10 and release is 4.x it should return error",
+			explicitStream: "rhel-10",
+			releaseVersion: semver.MustParse("4.19.0"),
+			expectError:    true,
+		},
+		{
+			name:           "When explicit rhel-10 and release is 4.x with runc it should return error",
+			explicitStream: "rhel-10",
+			releaseVersion: semver.MustParse("4.19.0"),
+			usesRunc:       true,
+			expectError:    true,
+		},
+		{
+			name:           "When explicit rhel-10 and release is 5.0 it should return rhel-10",
+			explicitStream: "rhel-10",
+			releaseVersion: semver.MustParse("5.0.0"),
+			expectResult:   "rhel-10",
+		},
+		{
+			name:           "When explicit rhel-10 and release is 5.0 with runc it should return error",
+			explicitStream: "rhel-10",
+			releaseVersion: semver.MustParse("5.0.0"),
+			usesRunc:       true,
+			expectError:    true,
+		},
+		{
+			name:           "When explicit rhel-10 and release is 5.1 it should return rhel-10",
+			explicitStream: "rhel-10",
+			releaseVersion: semver.MustParse("5.1.0"),
+			expectResult:   "rhel-10",
+		},
+		{
+			name:           "When explicit rhel-10 and release is 5.1 with runc it should return error",
+			explicitStream: "rhel-10",
+			releaseVersion: semver.MustParse("5.1.0"),
+			usesRunc:       true,
+			expectError:    true,
+		},
+
+		// --- Unknown stream ---
+		{
+			name:           "When explicit unknown stream and release is 4.x it should return error",
+			explicitStream: "rhel-8",
+			releaseVersion: semver.MustParse("4.18.0"),
+			expectError:    true,
+		},
+		{
+			name:           "When explicit unknown stream and release is 5.0 it should return error",
+			explicitStream: "rhel-8",
+			releaseVersion: semver.MustParse("5.0.0"),
+			expectError:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			result, err := GetRHELStream(tt.explicitStream, tt.releaseVersion, tt.usesRunc)
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(result).To(Equal(tt.expectResult))
+		})
+	}
+}

--- a/support/releaseinfo/deserialize.go
+++ b/support/releaseinfo/deserialize.go
@@ -21,18 +21,37 @@ func DeserializeImageStream(data []byte) (*imageapi.ImageStream, error) {
 	return &imageStream, nil
 }
 
-func DeserializeImageMetadata(data []byte) (*stream.Stream, error) {
+func DeserializeImageMetadata(data []byte) (*stream.Stream, map[string]*stream.Stream, error) {
 	var coreOSMetaCM corev1.ConfigMap
 	if err := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 100).Decode(&coreOSMetaCM); err != nil {
-		return nil, fmt.Errorf("couldn't read image lookup data as serialized ConfigMap: %w\nraw data:\n%s", err, string(data))
+		return nil, nil, fmt.Errorf("couldn't read image lookup data as serialized ConfigMap: %w\nraw data:\n%s", err, string(data))
 	}
+
+	var osStreams map[string]*stream.Stream
+	if streamsData, ok := coreOSMetaCM.Data["streams"]; ok {
+		if err := json.Unmarshal([]byte(streamsData), &osStreams); err != nil {
+			return nil, nil, fmt.Errorf("couldn't decode multi-stream metadata: %w\n%s", err, streamsData)
+		}
+	}
+	hasOSStreams := len(osStreams) > 0
+
 	streamData, hasStreamData := coreOSMetaCM.Data["stream"]
-	if !hasStreamData {
-		return nil, fmt.Errorf("coreos stream metadata configmap is missing the 'stream' key")
+	if !hasStreamData && !hasOSStreams {
+		return nil, nil, fmt.Errorf("coreos stream metadata configmap is missing both 'stream' and 'streams' keys")
 	}
-	var coreOSMeta stream.Stream
-	if err := json.Unmarshal([]byte(streamData), &coreOSMeta); err != nil {
-		return nil, fmt.Errorf("couldn't decode stream metadata data: %w\n%s", err, streamData)
+
+	var coreOSMeta *stream.Stream
+	if hasStreamData {
+		coreOSMeta = &stream.Stream{}
+		if err := json.Unmarshal([]byte(streamData), coreOSMeta); err != nil {
+			return nil, nil, fmt.Errorf("couldn't decode stream metadata: %w\n%s", err, streamData)
+		}
 	}
-	return &coreOSMeta, nil
+
+	// No fallback when "stream" is absent: the MCO team confirmed the legacy
+	// "stream" key is frozen to rhel-9 and present until rhel-9 EoL (OCP 5.3).
+	// Consumers must use StreamForName() to pick the stream they need.
+	// Ref: https://redhat-internal.slack.com/archives/C02CZNQHGN8/p1781604462650819
+
+	return coreOSMeta, osStreams, nil
 }

--- a/support/releaseinfo/deserialize_test.go
+++ b/support/releaseinfo/deserialize_test.go
@@ -1,11 +1,12 @@
 package releaseinfo
 
 import (
+	"fmt"
 	"testing"
 
-	"github.com/openshift/hypershift/support/releaseinfo/fixtures"
+	. "github.com/onsi/gomega"
 
-	"github.com/coreos/stream-metadata-go/stream"
+	"github.com/openshift/hypershift/support/releaseinfo/fixtures"
 )
 
 func TestDeserializeImageStream(t *testing.T) {
@@ -16,22 +17,245 @@ func TestDeserializeImageStream(t *testing.T) {
 	}
 }
 
+func testConfigMap(dataFields map[string]string) []byte {
+	cm := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: test\ndata:\n"
+	for k, v := range dataFields {
+		cm += fmt.Sprintf("  %s: %s\n", k, v)
+	}
+	return []byte(cm)
+}
+
 func TestDeserializeImageMetadata(t *testing.T) {
-	for _, imageMetadata := range [][]byte{fixtures.CoreOSBootImagesYAML_4_8, fixtures.CoreOSBootImagesYAML_4_10} {
-		var coreOSMetadata *stream.Stream
-		coreOSMetadata, err := DeserializeImageMetadata(imageMetadata)
-		if err != nil {
-			t.Fatal(err)
-		}
+	tests := []struct {
+		name           string
+		data           []byte
+		expectHasArch  bool
+		expectOSStream bool
+		expectError    bool
+	}{
+		{
+			name:          "When parsing a single-stream 4.8 ConfigMap it should populate Architectures and leave OSStreams nil",
+			data:          fixtures.CoreOSBootImagesYAML_4_8,
+			expectHasArch: true,
+		},
+		{
+			name:          "When parsing a single-stream 4.10 ConfigMap it should populate Architectures and leave OSStreams nil",
+			data:          fixtures.CoreOSBootImagesYAML_4_10,
+			expectHasArch: true,
+		},
+		{
+			name:           "When parsing a multi-stream 5.0 ConfigMap it should populate both Architectures and OSStreams",
+			data:           fixtures.CoreOSBootImagesYAML_5_0,
+			expectHasArch:  true,
+			expectOSStream: true,
+		},
+		{
+			name: "When ConfigMap has only streams key it should return nil default and populate OSStreams",
+			data: testConfigMap(map[string]string{
+				"streams": `'{"rhel-9":{"stream":"rhcos-4.21","architectures":{"x86_64":{"artifacts":{},"images":{}}}}}'`,
+			}),
+			expectHasArch:  false,
+			expectOSStream: true,
+		},
+		{
+			name:        "When ConfigMap is missing both stream and streams keys it should return an error",
+			data:        testConfigMap(map[string]string{"releaseVersion": `"5.0.0"`}),
+			expectError: true,
+		},
+		{
+			name:        "When stream JSON is invalid it should return an error",
+			data:        testConfigMap(map[string]string{"stream": `"not valid json {"`}),
+			expectError: true,
+		},
+		{
+			name:        "When streams JSON is invalid it should return an error",
+			data:        testConfigMap(map[string]string{"streams": `"not valid json {"`}),
+			expectError: true,
+		},
+		{
+			name:        "When input is empty it should return an error",
+			data:        []byte{},
+			expectError: true,
+		},
+		{
+			name:        "When input is not valid YAML it should return an error",
+			data:        []byte(`{not yaml at all`),
+			expectError: true,
+		},
+		{
+			name:        "When streams map is empty it should return an error",
+			data:        testConfigMap(map[string]string{"streams": `"{}"`}),
+			expectError: true,
+		},
+		{
+			name: "When streams is valid but stream JSON is invalid it should return an error",
+			data: testConfigMap(map[string]string{
+				"streams": `'{"rhel-9":{"stream":"rhcos-4.21","architectures":{"x86_64":{"artifacts":{},"images":{}}}}}'`,
+				"stream":  `"not valid json {"`,
+			}),
+			expectError: true,
+		},
+	}
 
-		arch, ok := coreOSMetadata.Architectures["x86_64"]
-		if !ok {
-			t.Fatal("missing x86_64 architecture")
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 
-		if arch.RHELCoreOSExtensions == nil || arch.RHELCoreOSExtensions.AzureDisk == nil || arch.RHELCoreOSExtensions.AzureDisk.URL == "" {
-			t.Fatal("missing azure disk URL")
-		}
+			result, osStreams, err := DeserializeImageMetadata(tt.data)
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
 
+			if tt.expectHasArch {
+				_, hasX86 := result.Architectures["x86_64"]
+				g.Expect(hasX86).To(BeTrue())
+			}
+
+			if tt.expectOSStream {
+				g.Expect(osStreams).ToNot(BeNil())
+				g.Expect(len(osStreams)).To(BeNumerically(">", 0))
+			} else {
+				g.Expect(osStreams).To(BeNil())
+			}
+		})
+	}
+}
+
+func TestDeserializeImageMetadataStreamsOnly(t *testing.T) {
+	g := NewWithT(t)
+
+	data := testConfigMap(map[string]string{
+		"streams": `'{"rhel-9":{"stream":"rhcos-4.21","architectures":{"x86_64":{"artifacts":{},"images":{"aws":{"regions":{"us-east-1":{"release":"9.8","image":"ami-fallback"}}}}}}}}'`,
+	})
+
+	defaultStream, osStreams, err := DeserializeImageMetadata(data)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(osStreams).ToNot(BeNil())
+
+	t.Run("When ConfigMap has only streams key it should return nil default stream", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(defaultStream).To(BeNil())
+	})
+
+	t.Run("When ConfigMap has only streams key consumers should use StreamForName to pick a stream", func(t *testing.T) {
+		g := NewWithT(t)
+		rhel9, ok := osStreams[StreamRHEL9]
+		g.Expect(ok).To(BeTrue())
+		ami := rhel9.Architectures["x86_64"].Images.Aws.Regions["us-east-1"].Image
+		g.Expect(ami).To(Equal("ami-fallback"))
+	})
+}
+
+func TestDeserializeImageMetadataMultiStreamContent(t *testing.T) {
+	defaultStream, osStreams, err := DeserializeImageMetadata(fixtures.CoreOSBootImagesYAML_5_0)
+	if err != nil {
+		t.Fatalf("failed to parse 5.0 fixture: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		assert func(g Gomega)
+	}{
+		{
+			name: "When parsing a 5.0 ConfigMap it should have rhel-9 and rhel-10 in OSStreams",
+			assert: func(g Gomega) {
+				g.Expect(osStreams).To(HaveKey("rhel-9"))
+				g.Expect(osStreams).To(HaveKey("rhel-10"))
+			},
+		},
+		{
+			name: "When looking up rhel-9 stream it should have distinct AWS AMIs from rhel-10",
+			assert: func(g Gomega) {
+				rhel9AMI := osStreams["rhel-9"].Architectures["x86_64"].Images.Aws.Regions["us-east-1"].Image
+				rhel10AMI := osStreams["rhel-10"].Architectures["x86_64"].Images.Aws.Regions["us-east-1"].Image
+				g.Expect(rhel9AMI).To(Equal("ami-06a6b025350ff1e23"))
+				g.Expect(rhel10AMI).To(Equal("ami-04b3d999e39d62c5b"))
+				g.Expect(rhel9AMI).ToNot(Equal(rhel10AMI))
+			},
+		},
+		{
+			name: "When looking up rhel-9 stream it should have distinct GCP images from rhel-10",
+			assert: func(g Gomega) {
+				rhel9GCP := osStreams["rhel-9"].Architectures["x86_64"].Images.Gcp.Name
+				rhel10GCP := osStreams["rhel-10"].Architectures["x86_64"].Images.Gcp.Name
+				g.Expect(rhel9GCP).To(Equal("rhcos-9-8-20260403-0-gcp-x86-64"))
+				g.Expect(rhel10GCP).To(Equal("rhcos-10-2-20260405-0-gcp-x86-64"))
+			},
+		},
+		{
+			name: "When looking up rhel-9 stream it should have distinct KubeVirt images from rhel-10",
+			assert: func(g Gomega) {
+				rhel9KV := osStreams["rhel-9"].Architectures["x86_64"].Images.KubeVirt.DigestRef
+				rhel10KV := osStreams["rhel-10"].Architectures["x86_64"].Images.KubeVirt.DigestRef
+				g.Expect(rhel9KV).ToNot(BeEmpty())
+				g.Expect(rhel10KV).ToNot(BeEmpty())
+				g.Expect(rhel9KV).ToNot(Equal(rhel10KV))
+			},
+		},
+		{
+			name: "When looking up streams both rhel-9 and rhel-10 should have ppc64le architecture",
+			assert: func(g Gomega) {
+				_, rhel9HasPPC := osStreams["rhel-9"].Architectures["ppc64le"]
+				_, rhel10HasPPC := osStreams["rhel-10"].Architectures["ppc64le"]
+				g.Expect(rhel9HasPPC).To(BeTrue())
+				g.Expect(rhel10HasPPC).To(BeTrue())
+			},
+		},
+		{
+			name: "When looking up a non-existent stream it should not exist in OSStreams",
+			assert: func(g Gomega) {
+				_, exists := osStreams["rhel-8"]
+				g.Expect(exists).To(BeFalse())
+			},
+		},
+		{
+			name: "When the default stream is parsed it should match the rhel-9 stream content",
+			assert: func(g Gomega) {
+				defaultAMI := defaultStream.Architectures["x86_64"].Images.Aws.Regions["us-east-1"].Image
+				rhel9AMI := osStreams["rhel-9"].Architectures["x86_64"].Images.Aws.Regions["us-east-1"].Image
+				g.Expect(defaultAMI).To(Equal(rhel9AMI))
+			},
+		},
+		{
+			name: "When looking up stream names it should report correct coreos stream identifiers",
+			assert: func(g Gomega) {
+				g.Expect(osStreams["rhel-9"].Stream).To(Equal("rhcos-4.21"))
+				g.Expect(osStreams["rhel-10"].Stream).To(Equal("rhcos-4.22"))
+			},
+		},
+		{
+			name: "When looking up aarch64 architecture it should have distinct AMIs between streams",
+			assert: func(g Gomega) {
+				rhel9ARM := osStreams["rhel-9"].Architectures["aarch64"].Images.Aws.Regions["us-east-1"].Image
+				rhel10ARM := osStreams["rhel-10"].Architectures["aarch64"].Images.Aws.Regions["us-east-1"].Image
+				g.Expect(rhel9ARM).To(Equal("ami-0e73a95fb409d8abd"))
+				g.Expect(rhel10ARM).To(Equal("ami-0d7237e6b04d9a9e1"))
+				g.Expect(rhel9ARM).ToNot(Equal(rhel10ARM))
+			},
+		},
+		{
+			name: "When looking up Azure marketplace data rhel-10 should have no no-purchase-plan entries",
+			assert: func(g Gomega) {
+				rhel9Ext := osStreams["rhel-9"].Architectures["x86_64"].RHELCoreOSExtensions
+				rhel10Ext := osStreams["rhel-10"].Architectures["x86_64"].RHELCoreOSExtensions
+				g.Expect(rhel9Ext).ToNot(BeNil())
+				g.Expect(rhel9Ext.Marketplace).ToNot(BeNil())
+				g.Expect(rhel9Ext.Marketplace.Azure).ToNot(BeNil())
+				g.Expect(rhel9Ext.Marketplace.Azure.NoPurchasePlan).ToNot(BeNil())
+				g.Expect(rhel9Ext.Marketplace.Azure.NoPurchasePlan.Gen2).ToNot(BeNil())
+				if rhel10Ext != nil && rhel10Ext.Marketplace != nil && rhel10Ext.Marketplace.Azure != nil && rhel10Ext.Marketplace.Azure.NoPurchasePlan != nil {
+					g.Expect(rhel10Ext.Marketplace.Azure.NoPurchasePlan.Gen1).To(BeNil())
+					g.Expect(rhel10Ext.Marketplace.Azure.NoPurchasePlan.Gen2).To(BeNil())
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assert(NewWithT(t))
+		})
 	}
 }

--- a/support/releaseinfo/fixtures/5.0-installer-coreos-bootimages.yaml
+++ b/support/releaseinfo/fixtures/5.0-installer-coreos-bootimages.yaml
@@ -1,0 +1,1047 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coreos-bootimages
+  namespace: openshift-machine-config-operator
+data:
+  releaseVersion: 5.0.0-ec.2
+  stream: |-
+    {
+      "stream": "rhcos-4.21",
+      "architectures": {
+        "x86_64": {
+          "artifacts": {
+            "openstack": {
+              "release": "9.8.20260403-0",
+              "formats": {
+                "qcow2.gz": {
+                  "disk": {
+                    "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-openstack.x86_64.qcow2.gz",
+                    "sha256": "d774960b396372c0ed2ea00a4d98151b1cfea9c5bcfc106d3e51566b4e9cce33",
+                    "uncompressed-sha256": "4664af3a371164888f096806e4b6e887f49e74d36e01c3a3a187600143a7d6e3"
+                  }
+                }
+              }
+            }
+          },
+          "images": {
+            "aws": {
+              "regions": {
+                "us-east-1": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-06a6b025350ff1e23"
+                },
+                "us-west-2": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-087857c3acb318eac"
+                }
+              }
+            },
+            "gcp": {
+              "release": "9.8.20260403-0",
+              "project": "rhcos-cloud",
+              "name": "rhcos-9-8-20260403-0-gcp-x86-64"
+            },
+            "kubevirt": {
+              "release": "9.8.20260403-0",
+              "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-9.8-coreos-kubevirt",
+              "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:833cbd9ad76a1dfae732741380fbca39220e9b123123995cc93ba0702a497d65"
+            }
+          },
+          "rhel-coreos-extensions": {
+            "azure-disk": {
+              "release": "9.8.20260403-0",
+              "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.8.20260403-0-azure.x86_64.vhd"
+            },
+            "marketplace": {
+              "azure": {
+                "no-purchase-plan": {
+                  "hyperVGen1": {
+                    "publisher": "azureopenshift",
+                    "offer": "aro4",
+                    "sku": "aro_420",
+                    "version": "9.6.20251015"
+                  },
+                  "hyperVGen2": {
+                    "publisher": "azureopenshift",
+                    "offer": "aro4",
+                    "sku": "420-v2",
+                    "version": "9.6.20251015"
+                  }
+                },
+                "ocp": {
+                  "hyperVGen1": {
+                    "publisher": "redhat",
+                    "offer": "rh-ocp-worker",
+                    "sku": "rh-ocp-worker-gen1",
+                    "version": "4.18.2025031114"
+                  },
+                  "hyperVGen2": {
+                    "publisher": "redhat",
+                    "offer": "rh-ocp-worker",
+                    "sku": "rh-ocp-worker",
+                    "version": "4.18.2025031114"
+                  }
+                },
+                "opp": {
+                  "hyperVGen1": {
+                    "publisher": "redhat",
+                    "offer": "rh-opp-worker",
+                    "sku": "rh-opp-worker-gen1",
+                    "version": "4.18.2025031114"
+                  },
+                  "hyperVGen2": {
+                    "publisher": "redhat",
+                    "offer": "rh-opp-worker",
+                    "sku": "rh-opp-worker",
+                    "version": "4.18.2025031114"
+                  }
+                },
+                "oke": {
+                  "hyperVGen1": {
+                    "publisher": "redhat",
+                    "offer": "rh-oke-worker",
+                    "sku": "rh-oke-worker-gen1",
+                    "version": "4.18.2025031114"
+                  },
+                  "hyperVGen2": {
+                    "publisher": "redhat",
+                    "offer": "rh-oke-worker",
+                    "sku": "rh-oke-worker",
+                    "version": "4.18.2025031114"
+                  }
+                },
+                "ocp-emea": {
+                  "hyperVGen1": {
+                    "publisher": "redhat-limited",
+                    "offer": "rh-ocp-worker",
+                    "sku": "rh-ocp-worker-gen1",
+                    "version": "4.18.2025031114"
+                  },
+                  "hyperVGen2": {
+                    "publisher": "redhat-limited",
+                    "offer": "rh-ocp-worker",
+                    "sku": "rh-ocp-worker",
+                    "version": "4.18.2025031114"
+                  }
+                },
+                "opp-emea": {
+                  "hyperVGen1": {
+                    "publisher": "redhat-limited",
+                    "offer": "rh-opp-worker",
+                    "sku": "rh-opp-worker-gen1",
+                    "version": "4.18.2025031114"
+                  },
+                  "hyperVGen2": {
+                    "publisher": "redhat-limited",
+                    "offer": "rh-opp-worker",
+                    "sku": "rh-opp-worker",
+                    "version": "4.18.2025031114"
+                  }
+                },
+                "oke-emea": {
+                  "hyperVGen1": {
+                    "publisher": "redhat-limited",
+                    "offer": "rh-oke-worker",
+                    "sku": "rh-oke-worker-gen1",
+                    "version": "4.18.2025031114"
+                  },
+                  "hyperVGen2": {
+                    "publisher": "redhat-limited",
+                    "offer": "rh-oke-worker",
+                    "sku": "rh-oke-worker",
+                    "version": "4.18.2025031114"
+                  }
+                }
+              }
+            },
+            "aws-winli": {
+              "regions": {
+                "af-south-1": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-0c10eabe1eaf19070"
+                },
+                "ap-east-1": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-0000a100764a57637"
+                },
+                "ap-east-2": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-0d0a9b4f768e40721"
+                },
+                "ap-northeast-1": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-06bccded362a4e123"
+                },
+                "ap-northeast-2": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-074a3c1013b645e2b"
+                },
+                "ap-northeast-3": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-0a973131ad159455f"
+                },
+                "ap-south-1": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-01a91ed16e6fe8c42"
+                },
+                "ap-south-2": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-088c4f18c1ba6d16f"
+                },
+                "ap-southeast-1": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-0aa3b2c76834dfc35"
+                },
+                "ap-southeast-2": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-0e3287c7017d769e6"
+                },
+                "ap-southeast-3": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-01a6db14a61da69d2"
+                },
+                "ap-southeast-4": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-06bfcd79e173b66fc"
+                },
+                "ap-southeast-5": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-05d555e5f6ca0351b"
+                },
+                "ap-southeast-6": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-003fa9bac974b122f"
+                },
+                "ap-southeast-7": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-0a4ae56adf95a7571"
+                },
+                "ca-central-1": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-0753bb5559cfe8de7"
+                },
+                "ca-west-1": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-0cdc9f4fd19c77c20"
+                },
+                "eu-central-1": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-070d80434ccbb1fa8"
+                },
+                "eu-central-2": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-0c9b3aaa71a563f6d"
+                },
+                "eu-north-1": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-061e33ce3cf0d8f30"
+                },
+                "eu-south-1": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-060a1299d1a87244e"
+                },
+                "eu-south-2": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-09d986ef8bc88b3ce"
+                },
+                "eu-west-1": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-0abacf8acd414929a"
+                },
+                "eu-west-2": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-0d52292d89797f1dc"
+                },
+                "eu-west-3": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-08cf1b6d46bea0b36"
+                },
+                "il-central-1": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-08f660deb548ef5d3"
+                },
+                "mx-central-1": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-028dd27c939e3d1e9"
+                },
+                "sa-east-1": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-0cbff95e01bb72566"
+                },
+                "us-east-1": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-07fb473b3b815c46a"
+                },
+                "us-east-2": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-0b57bb61d7bd17440"
+                },
+                "us-west-1": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-0ab712daedccb957a"
+                },
+                "us-west-2": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-076797a55a7d516dc"
+                }
+              }
+            }
+          }
+        },
+        "aarch64": {
+          "artifacts": {
+            "openstack": {
+              "release": "9.8.20260403-0",
+              "formats": {
+                "qcow2.gz": {
+                  "disk": {
+                    "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-openstack.aarch64.qcow2.gz",
+                    "sha256": "9132bed288761f6df76605bcccd2ac0c58a371ca64097e5fb876e01f3c20dfe2",
+                    "uncompressed-sha256": "d6ae130c04e2347994a73a05080e857622cf9ea0ed424b01cd9181ef885cb451"
+                  }
+                }
+              }
+            }
+          },
+          "images": {
+            "aws": {
+              "regions": {
+                "us-east-1": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-0e73a95fb409d8abd"
+                },
+                "us-west-2": {
+                  "release": "9.8.20260403-0",
+                  "image": "ami-0f4439b005ce8bb83"
+                }
+              }
+            },
+            "gcp": {
+              "release": "9.8.20260403-0",
+              "project": "rhcos-cloud",
+              "name": "rhcos-9-8-20260403-0-gcp-aarch64"
+            }
+          },
+          "rhel-coreos-extensions": {
+            "azure-disk": {
+              "release": "9.8.20260403-0",
+              "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.8.20260403-0-azure.aarch64.vhd"
+            },
+            "marketplace": {
+              "azure": {
+                "no-purchase-plan": {
+                  "hyperVGen2": {
+                    "publisher": "azureopenshift",
+                    "offer": "aro4",
+                    "sku": "420-arm",
+                    "version": "9.6.20251015"
+                  }
+                }
+              }
+            },
+            "aws-winli": {
+              "regions": {}
+            }
+          }
+        },
+        "ppc64le": {
+          "artifacts": {
+            "openstack": {
+              "release": "9.8.20260403-0",
+              "formats": {
+                "qcow2.gz": {
+                  "disk": {
+                    "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/ppc64le/rhcos-9.8.20260403-0-openstack.ppc64le.qcow2.gz",
+                    "sha256": "098d862bbe8ea4bade551bbb7d0b1b39c009c51bc6e07a360fd5f21ef15a5781",
+                    "uncompressed-sha256": "7088202adf16433b1fdf82f75d276b39e12559f0e80564ef26bda1558557d92f"
+                  }
+                }
+              }
+            }
+          },
+          "images": {
+            "powervs": {
+              "regions": {
+                "au-syd": {
+                  "release": "9.8.20260403-0",
+                  "object": "rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz",
+                  "bucket": "rhcos-powervs-images-au-syd",
+                  "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz"
+                }
+              }
+            }
+          },
+          "rhel-coreos-extensions": {
+            "azure-disk": {},
+            "marketplace": {
+              "azure": {
+                "no-purchase-plan": {}
+              }
+            },
+            "aws-winli": {
+              "regions": {}
+            }
+          }
+        }
+      }
+    }
+  streams: |-
+    {
+      "rhel-10": {
+        "stream": "rhcos-4.22",
+        "architectures": {
+          "x86_64": {
+            "artifacts": {
+              "openstack": {
+                "release": "10.2.20260405-0",
+                "formats": {
+                  "qcow2.gz": {
+                    "disk": {
+                      "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/x86_64/rhcos-10.2.20260405-0-openstack.x86_64.qcow2.gz",
+                      "sha256": "baa7d50598d76c76e65342d38fd5e90e34e9874ae1f6e82c3f2ad8303747a3ca",
+                      "uncompressed-sha256": "a502fba4cc14d2c057f0f37635b9269d78bce51e2f0ec4d51d2ba18f33abcd8a"
+                    }
+                  }
+                }
+              }
+            },
+            "images": {
+              "aws": {
+                "regions": {
+                  "us-east-1": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-04b3d999e39d62c5b"
+                  },
+                  "us-west-2": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-07e365adf44ca432a"
+                  }
+                }
+              },
+              "gcp": {
+                "release": "10.2.20260405-0",
+                "project": "rhcos-cloud",
+                "name": "rhcos-10-2-20260405-0-gcp-x86-64"
+              },
+              "kubevirt": {
+                "release": "10.2.20260405-0",
+                "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-10.2-coreos-kubevirt",
+                "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:843e75c16c01218cae95c74a879934a1f3ad80a2149963510a51b1f45c712c56"
+              }
+            },
+            "rhel-coreos-extensions": {
+              "azure-disk": {
+                "release": "10.2.20260405-0",
+                "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-10.2.20260405-0-azure.x86_64.vhd"
+              },
+              "marketplace": {
+                "azure": {
+                  "no-purchase-plan": {}
+                }
+              },
+              "aws-winli": {
+                "regions": {
+                  "af-south-1": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-0f00691d8919286c4"
+                  },
+                  "ap-east-1": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-02085d30468be6719"
+                  },
+                  "ap-east-2": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-0b96642864753f697"
+                  },
+                  "ap-northeast-1": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-0b5b4c2fe3e88be4c"
+                  },
+                  "ap-northeast-2": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-0be7d6848e2b14148"
+                  },
+                  "ap-northeast-3": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-03fb1d841af122247"
+                  },
+                  "ap-south-1": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-0609e9fa550a150e4"
+                  },
+                  "ap-south-2": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-0036e48df55f3a921"
+                  },
+                  "ap-southeast-1": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-03f094834eda476c7"
+                  },
+                  "ap-southeast-2": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-00cfb331b864e5fbe"
+                  },
+                  "ap-southeast-3": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-0042f8ac85b52471b"
+                  },
+                  "ap-southeast-4": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-0824247384380ad67"
+                  },
+                  "ap-southeast-5": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-048aacf6d224a325c"
+                  },
+                  "ap-southeast-6": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-03253e81cb2e25e2e"
+                  },
+                  "ap-southeast-7": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-01cb1c80408928303"
+                  },
+                  "ca-central-1": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-0589bafba30fe4c4b"
+                  },
+                  "ca-west-1": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-0f4dc7e47df2182a4"
+                  },
+                  "eu-central-1": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-0d2f1dd6ae6c1fdbe"
+                  },
+                  "eu-central-2": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-032877114a3719bda"
+                  },
+                  "eu-north-1": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-031b0c6271a807e8e"
+                  },
+                  "eu-south-1": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-0690f5cbf014a02d0"
+                  },
+                  "eu-south-2": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-09ae00621ff968d46"
+                  },
+                  "eu-west-1": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-09b17993cb4bf253c"
+                  },
+                  "eu-west-2": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-02dff4f6a9f6c5ff2"
+                  },
+                  "eu-west-3": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-0d1d7fc52c042403b"
+                  },
+                  "il-central-1": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-03bb42b35d1200c2a"
+                  },
+                  "mx-central-1": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-06bb2a8ffc898e0ad"
+                  },
+                  "sa-east-1": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-0fe32d1a681daeb35"
+                  },
+                  "us-east-1": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-0d7d1fceead28e9d8"
+                  },
+                  "us-east-2": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-01125c8cf99da2698"
+                  },
+                  "us-west-1": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-07c4334822b5d5674"
+                  },
+                  "us-west-2": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-086ae350505bf8d38"
+                  }
+                }
+              }
+            }
+          },
+          "aarch64": {
+            "artifacts": {
+              "openstack": {
+                "release": "10.2.20260405-0",
+                "formats": {
+                  "qcow2.gz": {
+                    "disk": {
+                      "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/aarch64/rhcos-10.2.20260405-0-openstack.aarch64.qcow2.gz",
+                      "sha256": "6d534cd2f188970920ff2b506321ce947c4520992c9608d0a7ad812a9d059c1f",
+                      "uncompressed-sha256": "e241eef78bd60d6a24b2fb8d2abaad91ef94f48ee0b7ecee570f169c174bb923"
+                    }
+                  }
+                }
+              }
+            },
+            "images": {
+              "aws": {
+                "regions": {
+                  "us-east-1": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-0d7237e6b04d9a9e1"
+                  },
+                  "us-west-2": {
+                    "release": "10.2.20260405-0",
+                    "image": "ami-067c61e7fb4d54a67"
+                  }
+                }
+              },
+              "gcp": {
+                "release": "10.2.20260405-0",
+                "project": "rhcos-cloud",
+                "name": "rhcos-10-2-20260405-0-gcp-aarch64"
+              }
+            },
+            "rhel-coreos-extensions": {
+              "azure-disk": {
+                "release": "10.2.20260405-0",
+                "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-10.2.20260405-0-azure.aarch64.vhd"
+              },
+              "marketplace": {
+                "azure": {
+                  "no-purchase-plan": {}
+                }
+              },
+              "aws-winli": {
+                "regions": {}
+              }
+            }
+          },
+          "ppc64le": {
+            "artifacts": {
+              "openstack": {
+                "release": "10.2.20260405-0",
+                "formats": {
+                  "qcow2.gz": {
+                    "disk": {
+                      "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260405-0/ppc64le/rhcos-10.2.20260405-0-openstack.ppc64le.qcow2.gz",
+                      "sha256": "8c1edfc4372ad8c544103c512a8fe1b856c2dfc87cbefd4100c3d46c9e849a90",
+                      "uncompressed-sha256": "918dac1deee062bd20eb3af6ab8134a73f9bfdd7bd071fe9f774967126373b8e"
+                    }
+                  }
+                }
+              }
+            },
+            "images": {
+              "powervs": {
+                "regions": {
+                  "au-syd": {
+                    "release": "10.2.20260405-0",
+                    "object": "rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz",
+                    "bucket": "rhcos-powervs-images-au-syd",
+                    "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-10-2-20260405-0-ppc64le-powervs.ova.gz"
+                  }
+                }
+              }
+            },
+            "rhel-coreos-extensions": {
+              "azure-disk": {},
+              "marketplace": {
+                "azure": {
+                  "no-purchase-plan": {}
+                }
+              },
+              "aws-winli": {
+                "regions": {}
+              }
+            }
+          }
+        }
+      },
+      "rhel-9": {
+        "stream": "rhcos-4.21",
+        "architectures": {
+          "x86_64": {
+            "artifacts": {
+              "openstack": {
+                "release": "9.8.20260403-0",
+                "formats": {
+                  "qcow2.gz": {
+                    "disk": {
+                      "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/x86_64/rhcos-9.8.20260403-0-openstack.x86_64.qcow2.gz",
+                      "sha256": "d774960b396372c0ed2ea00a4d98151b1cfea9c5bcfc106d3e51566b4e9cce33",
+                      "uncompressed-sha256": "4664af3a371164888f096806e4b6e887f49e74d36e01c3a3a187600143a7d6e3"
+                    }
+                  }
+                }
+              }
+            },
+            "images": {
+              "aws": {
+                "regions": {
+                  "us-east-1": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-06a6b025350ff1e23"
+                  },
+                  "us-west-2": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-087857c3acb318eac"
+                  }
+                }
+              },
+              "gcp": {
+                "release": "9.8.20260403-0",
+                "project": "rhcos-cloud",
+                "name": "rhcos-9-8-20260403-0-gcp-x86-64"
+              },
+              "kubevirt": {
+                "release": "9.8.20260403-0",
+                "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-9.8-coreos-kubevirt",
+                "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:833cbd9ad76a1dfae732741380fbca39220e9b123123995cc93ba0702a497d65"
+              }
+            },
+            "rhel-coreos-extensions": {
+              "azure-disk": {
+                "release": "9.8.20260403-0",
+                "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.8.20260403-0-azure.x86_64.vhd"
+              },
+              "marketplace": {
+                "azure": {
+                  "no-purchase-plan": {
+                    "hyperVGen1": {
+                      "publisher": "azureopenshift",
+                      "offer": "aro4",
+                      "sku": "aro_420",
+                      "version": "9.6.20251015"
+                    },
+                    "hyperVGen2": {
+                      "publisher": "azureopenshift",
+                      "offer": "aro4",
+                      "sku": "420-v2",
+                      "version": "9.6.20251015"
+                    }
+                  },
+                  "ocp": {
+                    "hyperVGen1": {
+                      "publisher": "redhat",
+                      "offer": "rh-ocp-worker",
+                      "sku": "rh-ocp-worker-gen1",
+                      "version": "4.18.2025031114"
+                    },
+                    "hyperVGen2": {
+                      "publisher": "redhat",
+                      "offer": "rh-ocp-worker",
+                      "sku": "rh-ocp-worker",
+                      "version": "4.18.2025031114"
+                    }
+                  },
+                  "opp": {
+                    "hyperVGen1": {
+                      "publisher": "redhat",
+                      "offer": "rh-opp-worker",
+                      "sku": "rh-opp-worker-gen1",
+                      "version": "4.18.2025031114"
+                    },
+                    "hyperVGen2": {
+                      "publisher": "redhat",
+                      "offer": "rh-opp-worker",
+                      "sku": "rh-opp-worker",
+                      "version": "4.18.2025031114"
+                    }
+                  },
+                  "oke": {
+                    "hyperVGen1": {
+                      "publisher": "redhat",
+                      "offer": "rh-oke-worker",
+                      "sku": "rh-oke-worker-gen1",
+                      "version": "4.18.2025031114"
+                    },
+                    "hyperVGen2": {
+                      "publisher": "redhat",
+                      "offer": "rh-oke-worker",
+                      "sku": "rh-oke-worker",
+                      "version": "4.18.2025031114"
+                    }
+                  },
+                  "ocp-emea": {
+                    "hyperVGen1": {
+                      "publisher": "redhat-limited",
+                      "offer": "rh-ocp-worker",
+                      "sku": "rh-ocp-worker-gen1",
+                      "version": "4.18.2025031114"
+                    },
+                    "hyperVGen2": {
+                      "publisher": "redhat-limited",
+                      "offer": "rh-ocp-worker",
+                      "sku": "rh-ocp-worker",
+                      "version": "4.18.2025031114"
+                    }
+                  },
+                  "opp-emea": {
+                    "hyperVGen1": {
+                      "publisher": "redhat-limited",
+                      "offer": "rh-opp-worker",
+                      "sku": "rh-opp-worker-gen1",
+                      "version": "4.18.2025031114"
+                    },
+                    "hyperVGen2": {
+                      "publisher": "redhat-limited",
+                      "offer": "rh-opp-worker",
+                      "sku": "rh-opp-worker",
+                      "version": "4.18.2025031114"
+                    }
+                  },
+                  "oke-emea": {
+                    "hyperVGen1": {
+                      "publisher": "redhat-limited",
+                      "offer": "rh-oke-worker",
+                      "sku": "rh-oke-worker-gen1",
+                      "version": "4.18.2025031114"
+                    },
+                    "hyperVGen2": {
+                      "publisher": "redhat-limited",
+                      "offer": "rh-oke-worker",
+                      "sku": "rh-oke-worker",
+                      "version": "4.18.2025031114"
+                    }
+                  }
+                }
+              },
+              "aws-winli": {
+                "regions": {
+                  "af-south-1": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-0c10eabe1eaf19070"
+                  },
+                  "ap-east-1": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-0000a100764a57637"
+                  },
+                  "ap-east-2": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-0d0a9b4f768e40721"
+                  },
+                  "ap-northeast-1": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-06bccded362a4e123"
+                  },
+                  "ap-northeast-2": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-074a3c1013b645e2b"
+                  },
+                  "ap-northeast-3": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-0a973131ad159455f"
+                  },
+                  "ap-south-1": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-01a91ed16e6fe8c42"
+                  },
+                  "ap-south-2": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-088c4f18c1ba6d16f"
+                  },
+                  "ap-southeast-1": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-0aa3b2c76834dfc35"
+                  },
+                  "ap-southeast-2": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-0e3287c7017d769e6"
+                  },
+                  "ap-southeast-3": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-01a6db14a61da69d2"
+                  },
+                  "ap-southeast-4": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-06bfcd79e173b66fc"
+                  },
+                  "ap-southeast-5": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-05d555e5f6ca0351b"
+                  },
+                  "ap-southeast-6": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-003fa9bac974b122f"
+                  },
+                  "ap-southeast-7": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-0a4ae56adf95a7571"
+                  },
+                  "ca-central-1": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-0753bb5559cfe8de7"
+                  },
+                  "ca-west-1": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-0cdc9f4fd19c77c20"
+                  },
+                  "eu-central-1": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-070d80434ccbb1fa8"
+                  },
+                  "eu-central-2": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-0c9b3aaa71a563f6d"
+                  },
+                  "eu-north-1": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-061e33ce3cf0d8f30"
+                  },
+                  "eu-south-1": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-060a1299d1a87244e"
+                  },
+                  "eu-south-2": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-09d986ef8bc88b3ce"
+                  },
+                  "eu-west-1": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-0abacf8acd414929a"
+                  },
+                  "eu-west-2": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-0d52292d89797f1dc"
+                  },
+                  "eu-west-3": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-08cf1b6d46bea0b36"
+                  },
+                  "il-central-1": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-08f660deb548ef5d3"
+                  },
+                  "mx-central-1": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-028dd27c939e3d1e9"
+                  },
+                  "sa-east-1": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-0cbff95e01bb72566"
+                  },
+                  "us-east-1": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-07fb473b3b815c46a"
+                  },
+                  "us-east-2": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-0b57bb61d7bd17440"
+                  },
+                  "us-west-1": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-0ab712daedccb957a"
+                  },
+                  "us-west-2": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-076797a55a7d516dc"
+                  }
+                }
+              }
+            }
+          },
+          "aarch64": {
+            "artifacts": {
+              "openstack": {
+                "release": "9.8.20260403-0",
+                "formats": {
+                  "qcow2.gz": {
+                    "disk": {
+                      "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/aarch64/rhcos-9.8.20260403-0-openstack.aarch64.qcow2.gz",
+                      "sha256": "9132bed288761f6df76605bcccd2ac0c58a371ca64097e5fb876e01f3c20dfe2",
+                      "uncompressed-sha256": "d6ae130c04e2347994a73a05080e857622cf9ea0ed424b01cd9181ef885cb451"
+                    }
+                  }
+                }
+              }
+            },
+            "images": {
+              "aws": {
+                "regions": {
+                  "us-east-1": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-0e73a95fb409d8abd"
+                  },
+                  "us-west-2": {
+                    "release": "9.8.20260403-0",
+                    "image": "ami-0f4439b005ce8bb83"
+                  }
+                }
+              },
+              "gcp": {
+                "release": "9.8.20260403-0",
+                "project": "rhcos-cloud",
+                "name": "rhcos-9-8-20260403-0-gcp-aarch64"
+              }
+            },
+            "rhel-coreos-extensions": {
+              "azure-disk": {
+                "release": "9.8.20260403-0",
+                "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.8.20260403-0-azure.aarch64.vhd"
+              },
+              "marketplace": {
+                "azure": {
+                  "no-purchase-plan": {
+                    "hyperVGen2": {
+                      "publisher": "azureopenshift",
+                      "offer": "aro4",
+                      "sku": "420-arm",
+                      "version": "9.6.20251015"
+                    }
+                  }
+                }
+              },
+              "aws-winli": {
+                "regions": {}
+              }
+            }
+          },
+          "ppc64le": {
+            "artifacts": {
+              "openstack": {
+                "release": "9.8.20260403-0",
+                "formats": {
+                  "qcow2.gz": {
+                    "disk": {
+                      "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260403-0/ppc64le/rhcos-9.8.20260403-0-openstack.ppc64le.qcow2.gz",
+                      "sha256": "098d862bbe8ea4bade551bbb7d0b1b39c009c51bc6e07a360fd5f21ef15a5781",
+                      "uncompressed-sha256": "7088202adf16433b1fdf82f75d276b39e12559f0e80564ef26bda1558557d92f"
+                    }
+                  }
+                }
+              }
+            },
+            "images": {
+              "powervs": {
+                "regions": {
+                  "au-syd": {
+                    "release": "9.8.20260403-0",
+                    "object": "rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz",
+                    "bucket": "rhcos-powervs-images-au-syd",
+                    "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-9-8-20260403-0-ppc64le-powervs.ova.gz"
+                  }
+                }
+              }
+            },
+            "rhel-coreos-extensions": {
+              "azure-disk": {},
+              "marketplace": {
+                "azure": {
+                  "no-purchase-plan": {}
+                }
+              },
+              "aws-winli": {
+                "regions": {}
+              }
+            }
+          }
+        }
+      }
+    }

--- a/support/releaseinfo/fixtures/fixtures.go
+++ b/support/releaseinfo/fixtures/fixtures.go
@@ -15,3 +15,6 @@ var ImageReferencesJSON_4_10 []byte
 
 //go:embed 4.10-installer-coreos-bootimages.yaml
 var CoreOSBootImagesYAML_4_10 []byte
+
+//go:embed 5.0-installer-coreos-bootimages.yaml
+var CoreOSBootImagesYAML_5_0 []byte

--- a/support/releaseinfo/registry_mirror_provider.go
+++ b/support/releaseinfo/registry_mirror_provider.go
@@ -42,6 +42,7 @@ func (p *RegistryMirrorProviderDecorator) Lookup(ctx context.Context, image stri
 	return &ReleaseImage{
 		ImageStream:    imageStream,
 		StreamMetadata: releaseImage.StreamMetadata,
+		OSStreams:      releaseImage.OSStreams,
 	}, nil
 }
 

--- a/support/releaseinfo/registryclient_provider.go
+++ b/support/releaseinfo/registryclient_provider.go
@@ -36,7 +36,7 @@ func (p *RegistryClientProvider) Lookup(ctx context.Context, image string, pullS
 	if _, ok := fileContents[ReleaseImageMetadataFile]; !ok {
 		return nil, fmt.Errorf("release image metadata file not found in release image %s", image)
 	}
-	coreOSMeta, err := DeserializeImageMetadata(fileContents[ReleaseImageMetadataFile])
+	coreOSMeta, osStreams, err := DeserializeImageMetadata(fileContents[ReleaseImageMetadataFile])
 	if err != nil {
 		return nil, err
 	}
@@ -44,5 +44,6 @@ func (p *RegistryClientProvider) Lookup(ctx context.Context, image string, pullS
 	return &ReleaseImage{
 		ImageStream:    imageStream,
 		StreamMetadata: coreOSMeta,
+		OSStreams:      osStreams,
 	}, nil
 }

--- a/support/releaseinfo/releaseinfo.go
+++ b/support/releaseinfo/releaseinfo.go
@@ -35,11 +35,51 @@ type ProviderWithOpenShiftImageRegistryOverrides interface {
 	GetMirroredReleaseImage() string
 }
 
+const (
+	StreamRHEL9  = "rhel-9"
+	StreamRHEL10 = "rhel-10"
+)
+
 // ReleaseImage wraps an ImageStream with some utilities that help the user
 // discover constituent component image information.
 type ReleaseImage struct {
 	*imageapi.ImageStream `json:",inline"`
 	StreamMetadata        *stream.Stream `json:"streamMetadata"`
+	// OSStreams holds per-stream metadata parsed from the ConfigMap "streams" key.
+	// Nil for single-stream payloads (OCP < 5.0).
+	OSStreams map[string]*stream.Stream `json:"-"`
+}
+
+// StreamForName returns stream metadata by name. If name is empty, returns
+// the default stream (StreamMetadata). If name is non-empty, looks up
+// OSStreams and returns an error if the named stream is not found.
+func (i *ReleaseImage) StreamForName(name string) (*stream.Stream, error) {
+	if name == "" {
+		if i.StreamMetadata == nil {
+			return nil, fmt.Errorf("no default stream metadata available")
+		}
+		return i.StreamMetadata, nil
+	}
+	if i.OSStreams != nil {
+		meta, ok := i.OSStreams[name]
+		if !ok || meta == nil {
+			available := make([]string, 0, len(i.OSStreams))
+			for k, v := range i.OSStreams {
+				if v != nil {
+					available = append(available, k)
+				}
+			}
+			sort.Strings(available)
+			return nil, fmt.Errorf("stream %q not found; available streams: %v", name, available)
+		}
+		return meta, nil
+	}
+	// Fallback to legacy StreamMetadata for single-stream payloads (OCP < 5.0)
+	// where OSStreams is nil but StreamMetadata carries the data.
+	if i.StreamMetadata != nil {
+		return i.StreamMetadata, nil
+	}
+	return nil, fmt.Errorf("stream %q not found and no default stream metadata available", name)
 }
 
 func (i *ReleaseImage) Version() string {

--- a/support/releaseinfo/releaseinfo_test.go
+++ b/support/releaseinfo/releaseinfo_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/openshift/hypershift/support/releaseinfo/fixtures"
 
 	imageapi "github.com/openshift/api/image/v1"
+
+	"github.com/coreos/stream-metadata-go/stream"
 )
 
 func TestParseComponentVersionsLabel(t *testing.T) {
@@ -164,7 +166,7 @@ func TestReadComponentVersions(t *testing.T) {
 
 // TestReleaseInfoPowerVS test validates the presence of the powervs images in the 4.10 release
 func TestReleaseInfoPowerVS(t *testing.T) {
-	metadata, err := DeserializeImageMetadata(fixtures.CoreOSBootImagesYAML_4_10)
+	metadata, _, err := DeserializeImageMetadata(fixtures.CoreOSBootImagesYAML_4_10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,7 +186,7 @@ func TestReleaseInfoPowerVS(t *testing.T) {
 
 // TestReleaseInfoKubeVirt tests validates the presence of the kubevirt images
 func TestReleaseInfoKubeVirt(t *testing.T) {
-	metadata, err := DeserializeImageMetadata(fixtures.CoreOSBootImagesYAML_4_10)
+	metadata, _, err := DeserializeImageMetadata(fixtures.CoreOSBootImagesYAML_4_10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -194,5 +196,182 @@ func TestReleaseInfoKubeVirt(t *testing.T) {
 	}
 	if arch.Images.KubeVirt == nil || arch.Images.KubeVirt.DigestRef == "" {
 		t.Fatal("metadata does not contain a digest ref for kubevirt")
+	}
+}
+
+func TestStreamForName(t *testing.T) {
+	rhel9Stream := &stream.Stream{
+		Stream: "rhcos-4.21",
+		Architectures: map[string]stream.Arch{
+			"x86_64": {},
+		},
+	}
+	rhel10Stream := &stream.Stream{
+		Stream: "rhcos-5.0",
+		Architectures: map[string]stream.Arch{
+			"x86_64": {},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		releaseImage   *ReleaseImage
+		streamName     string
+		expectStream   string
+		expectError    bool
+		expectContains string
+	}{
+		{
+			name: "When name is empty it should return the default stream",
+			releaseImage: &ReleaseImage{
+				ImageStream: &imageapi.ImageStream{},
+				StreamMetadata: &stream.Stream{
+					Stream:        "rhcos-4.10",
+					Architectures: map[string]stream.Arch{"x86_64": {}},
+				},
+			},
+			streamName:   "",
+			expectStream: "rhcos-4.10",
+		},
+		{
+			name: "When name matches a stream it should return that stream",
+			releaseImage: &ReleaseImage{
+				ImageStream: &imageapi.ImageStream{},
+				StreamMetadata: &stream.Stream{
+					Stream:        "rhcos-4.10",
+					Architectures: map[string]stream.Arch{"x86_64": {}},
+				},
+				OSStreams: map[string]*stream.Stream{
+					"rhel-9":  rhel9Stream,
+					"rhel-10": rhel10Stream,
+				},
+			},
+			streamName:   "rhel-10",
+			expectStream: "rhcos-5.0",
+		},
+		{
+			name: "When name does not match any stream it should return an error listing available streams",
+			releaseImage: &ReleaseImage{
+				ImageStream: &imageapi.ImageStream{},
+				StreamMetadata: &stream.Stream{
+					Stream:        "rhcos-4.10",
+					Architectures: map[string]stream.Arch{"x86_64": {}},
+				},
+				OSStreams: map[string]*stream.Stream{
+					"rhel-9":  rhel9Stream,
+					"rhel-10": rhel10Stream,
+				},
+			},
+			streamName:     "rhel-8",
+			expectError:    true,
+			expectContains: "rhel-9",
+		},
+		{
+			name: "When OSStreams is nil and name is non-empty it should fall back to StreamMetadata",
+			releaseImage: &ReleaseImage{
+				ImageStream: &imageapi.ImageStream{},
+				StreamMetadata: &stream.Stream{
+					Stream:        "rhcos-4.10",
+					Architectures: map[string]stream.Arch{"x86_64": {}},
+				},
+			},
+			streamName:   "rhel-10",
+			expectStream: "rhcos-4.10",
+		},
+		{
+			name: "When StreamMetadata is nil and name is empty it should return an error",
+			releaseImage: &ReleaseImage{
+				ImageStream: &imageapi.ImageStream{},
+			},
+			streamName:  "",
+			expectError: true,
+		},
+		{
+			name: "When StreamMetadata is nil and OSStreams has entries it should return an error for empty name",
+			releaseImage: &ReleaseImage{
+				ImageStream: &imageapi.ImageStream{},
+				OSStreams: map[string]*stream.Stream{
+					"rhel-9": rhel9Stream,
+				},
+			},
+			streamName:  "",
+			expectError: true,
+		},
+		{
+			name: "When StreamMetadata is nil and OSStreams has matching entry it should return that stream",
+			releaseImage: &ReleaseImage{
+				ImageStream: &imageapi.ImageStream{},
+				OSStreams: map[string]*stream.Stream{
+					"rhel-9": rhel9Stream,
+				},
+			},
+			streamName:   "rhel-9",
+			expectStream: "rhcos-4.21",
+		},
+		{
+			name: "When StreamMetadata is nil and OSStreams has no matching entry it should return an error",
+			releaseImage: &ReleaseImage{
+				ImageStream: &imageapi.ImageStream{},
+				OSStreams: map[string]*stream.Stream{
+					"rhel-9": rhel9Stream,
+				},
+			},
+			streamName:     "rhel-10",
+			expectError:    true,
+			expectContains: "rhel-10",
+		},
+		{
+			name: "When both StreamMetadata and OSStreams are nil it should return an error for non-empty name",
+			releaseImage: &ReleaseImage{
+				ImageStream: &imageapi.ImageStream{},
+			},
+			streamName:  "rhel-10",
+			expectError: true,
+		},
+		{
+			name: "When OSStreams is an empty map it should return an error",
+			releaseImage: &ReleaseImage{
+				ImageStream: &imageapi.ImageStream{},
+				StreamMetadata: &stream.Stream{
+					Stream: "rhcos-4.10",
+				},
+				OSStreams: map[string]*stream.Stream{},
+			},
+			streamName:  "rhel-10",
+			expectError: true,
+		},
+		{
+			name: "When OSStreams entry has nil value it should return an error listing available streams",
+			releaseImage: &ReleaseImage{
+				ImageStream: &imageapi.ImageStream{},
+				StreamMetadata: &stream.Stream{
+					Stream: "rhcos-4.10",
+				},
+				OSStreams: map[string]*stream.Stream{
+					"rhel-10": nil,
+					"rhel-9":  rhel9Stream,
+				},
+			},
+			streamName:     "rhel-10",
+			expectError:    true,
+			expectContains: "rhel-9",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			result, err := tt.releaseImage.StreamForName(tt.streamName)
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				if tt.expectContains != "" {
+					g.Expect(err.Error()).To(ContainSubstring(tt.expectContains))
+				}
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(result.Stream).To(Equal(tt.expectStream))
+		})
 	}
 }


### PR DESCRIPTION
## What this PR does / why we need it:

Add multi-stream CoreOS boot image parsing and RHEL stream resolution logic for the dual-stream RHEL 9/10 NodePool feature (Phase 1 of [CNTRLPLANE-3018](https://redhat.atlassian.net/browse/CNTRLPLANE-3018)).

- Update `DeserializeImageMetadata` to parse both the legacy `stream` key (OCP < 5.0) and the new `streams` key (OCP >= 5.0) from the boot image ConfigMap
- Add `OSStreams` field to `ReleaseImage` and `StreamForName()` method for stream-specific boot image lookup
- Add `GetRHELStream()` pure function implementing the stream resolution table from the [dual-stream RHEL enhancement](https://github.com/openshift/enhancements/blob/master/enhancements/hypershift/dual-stream-rhel-nodepool.md)
- Add 5.0 boot image fixture extracted from `5.0.0-ec.2` release payload
- Fallback: when ConfigMap has only `streams` without `stream`, populate StreamMetadata from the first available stream to prevent nil panics in platform consumers

This is preparatory code — not reachable in production until Phase 2 connects `GetRHELStream` into the NodePool controller (`NewToken()`, `validMachineConfigCondition`). The multi-stream parsing only activates when a >= 5.0 payload carries the `streams` ConfigMap key.

### Stream Resolution Table

| explicit stream | release | runc  | result |
|-----------------|---------|-------|--------|
| unset           | 4.x     | -     | `""` (legacy) |
| unset           | 5.x     | false | `rhel-10` |
| unset           | 5.x     | true  | `rhel-9` (fallback) |
| `rhel-9`        | any     | -     | `rhel-9` |
| `rhel-10`       | <5.0    | -     | error |
| `rhel-10`       | >=5.0   | false | `rhel-10` |
| `rhel-10`       | >=5.0   | true  | error |

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-3552](https://issues.redhat.com/browse/CNTRLPLANE-3552)

## Special notes for your reviewer:

- Fixture data comes from a real `5.0.0-ec.2` payload (not synthetic)
- `GetRHELStream` is exported for future Phase 2 consumers
- The `OSStreams` field lives on `ReleaseImage` (not on `stream.Stream`) to keep the upstream struct clean
- Uses `stream.Stream` from `coreos/stream-metadata-go` (introduced by #8673)
- Stream constants `StreamRHEL9`/`StreamRHEL10` exported for reuse

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

## Test plan

Unit tests — parsing and stream resolution:
```bash
go test ./support/releaseinfo/... -v -count=1
go test -run TestGetRHELStream ./hypershift-operator/controllers/nodepool/ -v -count=1
```

Verification:
```bash
make lint-fix  # 0 issues
make test      # 0 failures
make verify    # passes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)