### PR TITLE
fix: OCPBUGS-87162: Validate restore --hc-name matches backup namespaces

### DIFF
--- a/cmd/oadp/restore.go
+++ b/cmd/oadp/restore.go
@@ -3,6 +3,7 @@ package oadp
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/openshift/hypershift/cmd/log"
@@ -73,8 +74,8 @@ https://hypershift.pages.dev/how-to/disaster-recovery/dr-cli/`,
 	}
 
 	// Required flags
-	cmd.Flags().StringVar(&opts.HCName, "hc-name", "", "Name of the hosted cluster to restore (required)")
-	cmd.Flags().StringVar(&opts.HCNamespace, "hc-namespace", "", "Namespace of the hosted cluster to restore (required)")
+	cmd.Flags().StringVar(&opts.HCName, "hc-name", "", "Name of the hosted cluster as it was backed up (must match the original, required)")
+	cmd.Flags().StringVar(&opts.HCNamespace, "hc-namespace", "", "Namespace of the hosted cluster as it was backed up (must match the original, required)")
 	cmd.Flags().StringVar(&opts.BackupName, "from-backup", "", "Name of the backup to restore from (mutually exclusive with --from-schedule)")
 	cmd.Flags().StringVar(&opts.ScheduleName, "from-schedule", "", "Name of the schedule to restore from (uses latest backup, mutually exclusive with --from-backup)")
 
@@ -285,6 +286,32 @@ func (o *CreateOptions) validateBackupExists(ctx context.Context, renderMode boo
 			o.Log.Info("Warning: Backup is not completed, but proceeding with render", "backup", o.BackupName, "phase", phase)
 		} else {
 			return fmt.Errorf("backup '%s' is not completed, current phase: %s", o.BackupName, phase)
+		}
+	}
+
+	// Verify that the expected HCP namespace exists in the backup's includedNamespaces.
+	// A mismatch means the restore would target a namespace that the backup never captured,
+	// resulting in a silently partial restore.
+	backupNamespaces, nsFound, nsErr := unstructured.NestedStringSlice(backup.Object, "spec", "includedNamespaces")
+	if nsErr != nil {
+		if renderMode {
+			o.Log.Info("Warning: failed to parse backup includedNamespaces, skipping namespace validation",
+				"backup", o.BackupName, "error", nsErr.Error())
+		} else {
+			return fmt.Errorf("failed to parse includedNamespaces from backup '%s': %w", o.BackupName, nsErr)
+		}
+	} else if nsFound && len(backupNamespaces) > 0 {
+		expectedHCPNamespace := fmt.Sprintf("%s-%s", o.HCNamespace, o.HCName)
+		if !slices.Contains(backupNamespaces, expectedHCPNamespace) {
+			if renderMode {
+				o.Log.Info("Warning: backup does not contain the expected control plane namespace",
+					"backup", o.BackupName, "expected", expectedHCPNamespace, "actual", backupNamespaces)
+			} else {
+				return fmt.Errorf("backup '%s' does not contain the expected control plane namespace '%s'. "+
+					"The backup includes namespaces %v. "+
+					"Ensure --hc-name and --hc-namespace match the original backed-up cluster",
+					o.BackupName, expectedHCPNamespace, backupNamespaces)
+			}
 		}
 	}
 

--- a/cmd/oadp/restore_test.go
+++ b/cmd/oadp/restore_test.go
@@ -7,6 +7,8 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"github.com/openshift/hypershift/cmd/log"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
@@ -334,6 +336,125 @@ func TestValidateBackupExistsNotFound(t *testing.T) {
 		if !strings.Contains(err.Error(), "not found") {
 			t.Errorf("error should mention 'not found', got: %v", err)
 		}
+	}
+}
+
+// TestValidateBackupNamespaceMatch verifies that validateBackupExists detects when
+// the restore's --hc-name/--hc-namespace do not match the backup's includedNamespaces,
+// preventing silently partial restores. See OCPBUGS-87162.
+func TestValidateBackupNamespaceMatch(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name             string
+		hcName           string
+		hcNamespace      string
+		backupNamespaces []interface{}
+		renderMode       bool
+		shouldError      bool
+		errorSubstring   string
+	}{
+		{
+			name:             "When backup includes expected control plane namespace it should pass",
+			hcName:           "example",
+			hcNamespace:      "clusters",
+			backupNamespaces: []interface{}{"clusters", "clusters-example"},
+			renderMode:       false,
+			shouldError:      false,
+		},
+		{
+			name:             "When hc-name does not match backup namespaces it should fail",
+			hcName:           "restore-example",
+			hcNamespace:      "clusters",
+			backupNamespaces: []interface{}{"clusters", "clusters-example"},
+			renderMode:       false,
+			shouldError:      true,
+			errorSubstring:   "does not contain the expected control plane namespace 'clusters-restore-example'",
+		},
+		{
+			name:             "When hc-namespace does not match backup namespaces it should fail",
+			hcName:           "example",
+			hcNamespace:      "other-ns",
+			backupNamespaces: []interface{}{"clusters", "clusters-example"},
+			renderMode:       false,
+			shouldError:      true,
+			errorSubstring:   "does not contain the expected control plane namespace 'other-ns-example'",
+		},
+		{
+			name:             "When namespaces mismatch in render mode it should warn without failing",
+			hcName:           "restore-example",
+			hcNamespace:      "clusters",
+			backupNamespaces: []interface{}{"clusters", "clusters-example"},
+			renderMode:       true,
+			shouldError:      false,
+		},
+		{
+			name:             "When backup has no includedNamespaces it should skip namespace validation",
+			hcName:           "any-name",
+			hcNamespace:      "any-ns",
+			backupNamespaces: nil,
+			renderMode:       false,
+			shouldError:      false,
+		},
+		{
+			name:             "When expected namespace exists among additional namespaces it should pass",
+			hcName:           "prod",
+			hcNamespace:      "hcp",
+			backupNamespaces: []interface{}{"hcp", "hcp-prod", "agent-ns"},
+			renderMode:       false,
+			shouldError:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backupObj := map[string]interface{}{
+				"apiVersion": "velero.io/v1",
+				"kind":       "Backup",
+				"metadata": map[string]interface{}{
+					"name":      "test-backup",
+					"namespace": "openshift-adp",
+				},
+				"spec": map[string]interface{}{},
+				"status": map[string]interface{}{
+					"phase": "Completed",
+				},
+			}
+			if tt.backupNamespaces != nil {
+				backupObj["spec"].(map[string]interface{})["includedNamespaces"] = tt.backupNamespaces
+			}
+
+			backup := &unstructured.Unstructured{Object: backupObj}
+
+			scheme := runtime.NewScheme()
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(backup).
+				Build()
+
+			opts := &CreateOptions{
+				HCName:        tt.hcName,
+				HCNamespace:   tt.hcNamespace,
+				BackupName:    "test-backup",
+				OADPNamespace: "openshift-adp",
+				Client:        fakeClient,
+				Log:           log.Log,
+			}
+
+			err := opts.validateBackupExists(ctx, tt.renderMode)
+
+			if tt.shouldError {
+				if err == nil {
+					t.Errorf("expected error for hcName=%q hcNamespace=%q, but got none", tt.hcName, tt.hcNamespace)
+				} else if tt.errorSubstring != "" && !strings.Contains(err.Error(), tt.errorSubstring) {
+					t.Errorf("expected error to contain %q, got: %v", tt.errorSubstring, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, but got: %v", err)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Validate that the `--hc-name` / `--hc-namespace` provided to `hypershift create oadp-restore` match the cluster name stored in the backup's `spec.includedNamespaces`, preventing silently partial restores when mismatched
- Clarify `--hc-name` and `--hc-namespace` flag descriptions to indicate they must match the original backed-up cluster

## Problem

When a user runs `hypershift create oadp-restore --hc-name restore-example` against a backup of cluster `example`, the CLI computes `includedNamespaces: [clusters, clusters-restore-example]`. Since `clusters-restore-example` doesn't exist in the backup (it has `clusters-example`), the Velero Restore completes successfully but only restores resources from the shared HC namespace — the entire control plane namespace is silently skipped.

The restore reports `phase: Completed` with `itemsRestored: 19` even though no HostedControlPlane, deployments, statefulsets, or other control plane resources were restored.

## Fix

After confirming the backup exists and is Completed, read its `spec.includedNamespaces` and verify the expected HCP namespace (`{hcNamespace}-{hcName}`) is present. In non-render mode, return a hard error with a clear message showing the expected vs actual namespaces. In render mode, log a warning but proceed (consistent with existing render mode behavior).

## Test plan

- [x] New unit test `TestValidateBackupNamespaceMatch` covering:
  - Matching namespaces pass validation
  - Mismatched `--hc-name` fails with clear error
  - Mismatched `--hc-namespace` fails with clear error  
  - Render mode with mismatch warns but does not fail
  - Backup without `includedNamespaces` skips validation gracefully
  - Matching namespaces with additional namespaces pass
- [x] All existing `cmd/oadp/` unit tests continue to pass

Jira: https://redhat.atlassian.net/browse/OCPBUGS-87162


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validation now checks that a backup includes the expected control-plane namespace during restore operations.

* **Improvements**
  * Clarified `--hc-name` and `--hc-namespace` flag help text to state they must match the original backed-up cluster.
  * Restore validation behavior adjusted: mismatches produce errors in normal runs and warnings in render/preview mode.

* **Tests**
  * Added tests covering namespace-matching and render-mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->