### PR TITLE
OCPBUGS-86690: fix Azure cluster deletion hanging when resource groups are already deleted

### DIFF
--- a/cmd/cluster/azure/destroy.go
+++ b/cmd/cluster/azure/destroy.go
@@ -2,7 +2,9 @@ package azure
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -140,7 +142,12 @@ func DestroyCluster(ctx context.Context, o *core.DestroyOptions) error {
 		}
 
 		if _, err = resourceGroupClient.Get(ctx, o.AzurePlatform.ResourceGroupName, nil); err != nil {
-			return fmt.Errorf("failed to get resource group name, '%s': %w", o.AzurePlatform.ResourceGroupName, err)
+			var respErr *azcore.ResponseError
+			if stderrors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
+				o.Log.Info("Resource group not found, continuing with cluster deletion", "resourceGroup", o.AzurePlatform.ResourceGroupName)
+			} else {
+				return fmt.Errorf("failed to get resource group name, '%s': %w", o.AzurePlatform.ResourceGroupName, err)
+			}
 		}
 	} else {
 		o.AzurePlatform.ResourceGroupName = o.Name + "-" + o.InfraID

--- a/cmd/cluster/azure/destroy.go
+++ b/cmd/cluster/azure/destroy.go
@@ -2,7 +2,9 @@ package azure
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -22,6 +24,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/errors"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 )
 
@@ -139,14 +142,37 @@ func DestroyCluster(ctx context.Context, o *core.DestroyOptions) error {
 			return fmt.Errorf("failed to create new resource groups client: %w", err)
 		}
 
-		if _, err = resourceGroupClient.Get(ctx, o.AzurePlatform.ResourceGroupName, nil); err != nil {
-			return fmt.Errorf("failed to get resource group name, '%s': %w", o.AzurePlatform.ResourceGroupName, err)
+		if err := checkResourceGroup(ctx, resourceGroupClient, o.AzurePlatform.ResourceGroupName, o.Log); err != nil {
+			return err
 		}
 	} else {
 		o.AzurePlatform.ResourceGroupName = o.Name + "-" + o.InfraID
 	}
 
 	return core.DestroyCluster(ctx, hostedCluster, o, destroyPlatformSpecifics)
+}
+
+type resourceGroupClient interface {
+	Get(context.Context, string, *armresources.ResourceGroupsClientGetOptions) (armresources.ResourceGroupsClientGetResponse, error)
+}
+
+func checkResourceGroup(ctx context.Context, client resourceGroupClient, resourceGroupName string, logger logr.Logger) error {
+	if _, err := client.Get(ctx, resourceGroupName, nil); err != nil {
+		if isResourceGroupNotFound(err) {
+			logger.Info("Resource group not found, continuing with cluster deletion", "resourceGroup", resourceGroupName)
+		} else {
+			return fmt.Errorf("failed to get resource group name, '%s': %w", resourceGroupName, err)
+		}
+	}
+	return nil
+}
+
+// isResourceGroupNotFound returns true if err is an Azure 404 response, indicating the
+// resource group was already deleted out-of-band (e.g. via the Azure portal or an expired
+// credential's cleanup process).
+func isResourceGroupNotFound(err error) bool {
+	var respErr *azcore.ResponseError
+	return stderrors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
 }
 
 func destroyPlatformSpecifics(ctx context.Context, o *core.DestroyOptions) error {

--- a/cmd/cluster/azure/destroy_test.go
+++ b/cmd/cluster/azure/destroy_test.go
@@ -1,6 +1,9 @@
 package azure
 
 import (
+	"context"
+	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
@@ -10,6 +13,9 @@ import (
 	"github.com/openshift/hypershift/cmd/cluster/core"
 	"github.com/openshift/hypershift/cmd/log"
 	"github.com/openshift/hypershift/support/config"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 )
 
 func TestDestroyClusterSetsCloudFromHostedCluster(t *testing.T) {
@@ -167,6 +173,77 @@ func TestDestroyClusterSetsGracePeriodFromTopology(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 
 			g.Expect(opts.ClusterGracePeriod).To(Equal(test.expectedGracePeriod))
+		})
+	}
+}
+
+func TestIsResourceGroupNotFound(t *testing.T) {
+	tests := map[string]struct {
+		err      error
+		expected bool
+	}{
+		"When err is an azcore.ResponseError with 404 status, it should return true": {
+			err:      &azcore.ResponseError{StatusCode: http.StatusNotFound},
+			expected: true,
+		},
+		"When err is an azcore.ResponseError with a non-404 status, it should return false": {
+			err:      &azcore.ResponseError{StatusCode: http.StatusForbidden},
+			expected: false,
+		},
+		"When err is a generic error, it should return false": {
+			err:      fmt.Errorf("some unrelated failure"),
+			expected: false,
+		},
+		"When err wraps an azcore.ResponseError with 404 status, it should return true": {
+			err:      fmt.Errorf("wrapped: %w", &azcore.ResponseError{StatusCode: http.StatusNotFound}),
+			expected: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			g.Expect(isResourceGroupNotFound(test.err)).To(Equal(test.expected))
+		})
+	}
+}
+
+type fakeResourceGroupClient struct {
+	err error
+}
+
+func (f fakeResourceGroupClient) Get(context.Context, string, *armresources.ResourceGroupsClientGetOptions) (armresources.ResourceGroupsClientGetResponse, error) {
+	return armresources.ResourceGroupsClientGetResponse{}, f.err
+}
+
+func TestCheckResourceGroup(t *testing.T) {
+	tests := map[string]struct {
+		err         error
+		expectError bool
+	}{
+		"When the resource group returns 404, it should continue": {
+			err: &azcore.ResponseError{StatusCode: http.StatusNotFound},
+		},
+		"When the resource group returns a wrapped 404, it should continue": {
+			err: fmt.Errorf("wrapped: %w", &azcore.ResponseError{StatusCode: http.StatusNotFound}),
+		},
+		"When the resource group returns a non-404 error, it should return an error": {
+			err:         &azcore.ResponseError{StatusCode: http.StatusForbidden},
+			expectError: true,
+		},
+		"When the resource group lookup succeeds, it should continue": {},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			err := checkResourceGroup(context.Background(), fakeResourceGroupClient{err: test.err}, "test-resource-group", log.Log)
+			if test.expectError {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("failed to get resource group name, 'test-resource-group'"))
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
 		})
 	}
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure.go
@@ -369,11 +369,6 @@ const deletionFailedThreshold = 10 * time.Minute
 // for a Ready=False condition with Reason=DeletionFailed. Orphaning the machine allows management
 // cluster cleanup to proceed without requiring valid cloud credentials.
 func (Azure) DeleteOrphanedMachines(ctx context.Context, c client.Client, hc *hyperv1.HostedCluster, controlPlaneNamespace string) error {
-	// This orphaning behavior is intended for managed-identity cleanup flow.
-	if hc.Spec.Platform.Azure.AzureAuthenticationConfig.ManagedIdentities == nil {
-		return nil
-	}
-
 	azureMachineList := capiazure.AzureMachineList{}
 	if err := c.List(ctx, &azureMachineList, client.InNamespace(controlPlaneNamespace)); err != nil {
 		return fmt.Errorf("failed to list AzureMachines in %s: %w", controlPlaneNamespace, err)
@@ -403,7 +398,7 @@ func (Azure) DeleteOrphanedMachines(ctx context.Context, c client.Client, hc *hy
 				azureMachine.Namespace, azureMachine.Name, err))
 			continue
 		}
-		logger.Info("orphaning azuremachine stuck in deletion due to credential failure",
+		logger.Info("orphaning AzureMachine stuck in deletion due to deletion failure",
 			"machine", client.ObjectKeyFromObject(azureMachine))
 	}
 

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure_test.go
@@ -533,18 +533,6 @@ func TestReconcileKMSConfigSecret(t *testing.T) {
 func TestDeleteOrphanedMachines(t *testing.T) {
 	controlPlaneNamespace := "test-cp-namespace"
 
-	managedIdentitiesHC := &hyperv1.HostedCluster{
-		Spec: hyperv1.HostedClusterSpec{
-			Platform: hyperv1.PlatformSpec{
-				Azure: &hyperv1.AzurePlatformSpec{
-					AzureAuthenticationConfig: hyperv1.AzureAuthenticationConfiguration{
-						ManagedIdentities: &hyperv1.AzureResourceManagedIdentities{},
-					},
-				},
-			},
-		},
-	}
-
 	// staleDeletionTimestamp simulates a machine that has been pending deletion beyond the threshold.
 	staleDeletionTimestamp := metav1.NewTime(time.Now().Add(-(deletionFailedThreshold + time.Minute)))
 	recentDeletionTimestamp := metav1.NewTime(time.Now())
@@ -559,48 +547,18 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 
 	testCases := []struct {
 		name                      string
-		hostedCluster             *hyperv1.HostedCluster
 		azureMachines             []capiazure.AzureMachine
 		expectedFinalizersRemoved bool
 		expectedError             bool
 	}{
 		{
-			name: "when ManagedIdentities is nil it should return early without modifying machines",
-			hostedCluster: &hyperv1.HostedCluster{
-				Spec: hyperv1.HostedClusterSpec{
-					Platform: hyperv1.PlatformSpec{
-						Azure: &hyperv1.AzurePlatformSpec{
-							AzureAuthenticationConfig: hyperv1.AzureAuthenticationConfiguration{},
-						},
-					},
-				},
-			},
-			azureMachines: []capiazure.AzureMachine{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:              "machine-1",
-						Namespace:         controlPlaneNamespace,
-						Finalizers:        []string{capiazure.MachineFinalizer},
-						DeletionTimestamp: &staleDeletionTimestamp,
-					},
-					Status: capiazure.AzureMachineStatus{
-						Conditions: deletionFailedConditions,
-					},
-				},
-			},
-			expectedFinalizersRemoved: false,
-			expectedError:             false,
-		},
-		{
 			name:                      "when there are no machines it should succeed",
-			hostedCluster:             managedIdentitiesHC,
 			azureMachines:             []capiazure.AzureMachine{},
 			expectedFinalizersRemoved: false,
 			expectedError:             false,
 		},
 		{
-			name:          "when a machine has a stale DeletionTimestamp with DeletionFailed condition it should remove finalizers",
-			hostedCluster: managedIdentitiesHC,
+			name: "when a machine has a stale DeletionTimestamp with DeletionFailed condition it should remove finalizers",
 			azureMachines: []capiazure.AzureMachine{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -618,8 +576,7 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 			expectedError:             false,
 		},
 		{
-			name:          "when a machine has a recent DeletionTimestamp with DeletionFailed condition it should not remove finalizers",
-			hostedCluster: managedIdentitiesHC,
+			name: "when a machine has a recent DeletionTimestamp with DeletionFailed condition it should not remove finalizers",
 			azureMachines: []capiazure.AzureMachine{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -637,8 +594,7 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 			expectedError:             false,
 		},
 		{
-			name:          "when a machine has a stale DeletionTimestamp without DeletionFailed condition it should not remove finalizers",
-			hostedCluster: managedIdentitiesHC,
+			name: "when a machine has a stale DeletionTimestamp without DeletionFailed condition it should not remove finalizers",
 			azureMachines: []capiazure.AzureMachine{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -661,8 +617,7 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 			expectedError:             false,
 		},
 		{
-			name:          "when a machine is not pending deletion it should not remove finalizers regardless of conditions",
-			hostedCluster: managedIdentitiesHC,
+			name: "when a machine is not pending deletion it should not remove finalizers regardless of conditions",
 			azureMachines: []capiazure.AzureMachine{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -698,8 +653,9 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 				Build()
 
 			azure := Azure{}
+			hc := &hyperv1.HostedCluster{}
 
-			err := azure.DeleteOrphanedMachines(ctx, fakeClient, tc.hostedCluster, controlPlaneNamespace)
+			err := azure.DeleteOrphanedMachines(ctx, fakeClient, hc, controlPlaneNamespace)
 
 			if tc.expectedError {
 				g.Expect(err).To(HaveOccurred())
@@ -721,6 +677,71 @@ func TestDeleteOrphanedMachines(t *testing.T) {
 					g.Expect(machine.Finalizers).To(Equal(tc.azureMachines[0].Finalizers), "finalizers should not be modified")
 				}
 			}
+		})
+	}
+}
+
+func TestHasDeletionFailedCondition(t *testing.T) {
+	testCases := []struct {
+		name     string
+		machine  capiazure.AzureMachine
+		expected bool
+	}{
+		{
+			name: "Ready=False with DeletionFailed reason — true",
+			machine: capiazure.AzureMachine{
+				Status: capiazure.AzureMachineStatus{
+					Conditions: capiv1.Conditions{
+						{
+							Type:   capiv1.ReadyCondition,
+							Status: corev1.ConditionFalse,
+							Reason: capiazure.DeletionFailedReason,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Ready=True — false",
+			machine: capiazure.AzureMachine{
+				Status: capiazure.AzureMachineStatus{
+					Conditions: capiv1.Conditions{
+						{
+							Type:   capiv1.ReadyCondition,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Ready=False with different reason — false",
+			machine: capiazure.AzureMachine{
+				Status: capiazure.AzureMachineStatus{
+					Conditions: capiv1.Conditions{
+						{
+							Type:   capiv1.ReadyCondition,
+							Status: corev1.ConditionFalse,
+							Reason: "SomeOtherReason",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:     "No conditions — false",
+			machine:  capiazure.AzureMachine{},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(hasDeletionFailedCondition(&tc.machine)).To(Equal(tc.expected))
 		})
 	}
 }

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure_test.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/azure/azure_test.go
@@ -1054,3 +1054,68 @@ func TestCAPIProviderDeploymentSpec(t *testing.T) {
 		})
 	}
 }
+
+func TestHasDeletionFailedCondition(t *testing.T) {
+	testCases := []struct {
+		name     string
+		machine  capiazure.AzureMachine
+		expected bool
+	}{
+		{
+			name: "When Ready is False with DeletionFailed reason, it should return true",
+			machine: capiazure.AzureMachine{
+				Status: capiazure.AzureMachineStatus{
+					Conditions: capiv1.Conditions{
+						{
+							Type:   capiv1.ReadyCondition,
+							Status: corev1.ConditionFalse,
+							Reason: capiazure.DeletionFailedReason,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "When Ready is True, it should return false",
+			machine: capiazure.AzureMachine{
+				Status: capiazure.AzureMachineStatus{
+					Conditions: capiv1.Conditions{
+						{
+							Type:   capiv1.ReadyCondition,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "When Ready is False with a different reason, it should return false",
+			machine: capiazure.AzureMachine{
+				Status: capiazure.AzureMachineStatus{
+					Conditions: capiv1.Conditions{
+						{
+							Type:   capiv1.ReadyCondition,
+							Status: corev1.ConditionFalse,
+							Reason: "SomeOtherReason",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:     "When there are no conditions, it should return false",
+			machine:  capiazure.AzureMachine{},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(hasDeletionFailedCondition(&tc.machine)).To(Equal(tc.expected))
+		})
+	}
+}

--- a/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
+++ b/hypershift-operator/controllers/hostedcluster/internal/platform/platform.go
@@ -36,13 +36,14 @@ const (
 )
 
 var (
-	_ Platform = aws.AWS{}
-	_ Platform = azure.Azure{}
-	_ Platform = ibmcloud.IBMCloud{}
-	_ Platform = none.None{}
-	_ Platform = agent.Agent{}
-	_ Platform = kubevirt.Kubevirt{}
-	_ Platform = gcp.GCP{}
+	_ Platform      = aws.AWS{}
+	_ Platform      = azure.Azure{}
+	_ Platform      = ibmcloud.IBMCloud{}
+	_ Platform      = none.None{}
+	_ Platform      = agent.Agent{}
+	_ Platform      = kubevirt.Kubevirt{}
+	_ Platform      = gcp.GCP{}
+	_ OrphanDeleter = &azure.Azure{}
 )
 
 type Platform interface {


### PR DESCRIPTION
## What this PR does / why we need it:

When an Azure self-managed HCP cluster's resource groups are deleted out-of-band (e.g. via Azure portal or expired credentials), `hypershift destroy cluster azure` hangs indefinitely. AzureMachines get stuck in deletion because CAPZ cannot communicate with the deleted Azure infrastructure, and their finalizers are never cleared.

This PR uses the same DeletionFailed condition approach as #8296 (ARO HCP) but **extends coverage to self-managed Azure clusters**. PR #8296 guards with `ManagedIdentities == nil` early return, so self-managed clusters (which don't use managed identities) are not covered.

### How it works:

1. **Machine-level signal**: When CAPZ cannot delete an Azure VM (expired credentials, deleted resource group, etc.), it sets `Ready=False` with `Reason=DeletionFailed` on the AzureMachine.

2. **Orphaned machine cleanup** (`DeleteOrphanedMachines`): For each AzureMachine that has been deleting for >10 minutes (`deletionFailedThreshold`) AND has the `DeletionFailed` condition, the `MachineFinalizer` is removed — unblocking cluster teardown.

3. **CLI fix** (`cmd/cluster/azure/destroy.go`): Handles 404 on resource group during `hypershift destroy cluster azure` so it continues instead of failing hard when infrastructure is already gone.

### Difference from #8296:

| | PR #8296 (merged) | This PR |
|---|---|---|
| **Scope** | ARO HCP only (`ManagedIdentities != nil`) | Self-managed Azure clusters |
| **Signal** | Same: machine-level `DeletionFailed` condition | Same |
| **Threshold** | Same: 10 minutes | Same |
| **Guard** | `ManagedIdentities == nil` early return | No guard — applies to all Azure clusters |

The `DeletionFailed` condition is set by CAPZ regardless of credential type, so this approach works for both managed identity and service principal clusters.

## Which issue(s) this PR fixes:

Fixes [OCPBUGS-86690](https://issues.redhat.com/browse/OCPBUGS-86690)

## Special notes for your reviewer:

- Previous approach (credential-level `ValidAzureIdentityProvider` condition) has been fully removed per feedback from @enxebre. All CPO health check code, condition bubbling, and credential status types are gone.
- This now uses the exact same pattern as #8296 (`deletionFailedThreshold` + `hasDeletionFailedCondition`) without the `ManagedIdentities` guard.
- The `cmd/cluster/azure/destroy.go` 404 handling fix is independent and still needed.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes unit tests.