### PR TITLE
OCPBUGS-87217: fix: add CPU partitioning workload annotation to control-plane-metrics-forwarder

### DIFF
--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/monitoring/metricsforwarder.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/monitoring/metricsforwarder.go
@@ -32,7 +32,8 @@ func ReconcileMetricsForwarderDeployment(deployment *appsv1.Deployment, haproxyI
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: labels,
 				Annotations: map[string]string{
-					"metrics-forwarder-config-checksum": configHash,
+					"metrics-forwarder-config-checksum":       configHash,
+					"target.workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
 				},
 			},
 			Spec: corev1.PodSpec{

--- a/control-plane-operator/hostedclusterconfigoperator/controllers/resources/monitoring/metricsforwarder_test.go
+++ b/control-plane-operator/hostedclusterconfigoperator/controllers/resources/monitoring/metricsforwarder_test.go
@@ -40,6 +40,7 @@ func TestReconcileMetricsForwarderDeployment(t *testing.T) {
 			err := ReconcileMetricsForwarderDeployment(deployment, tt.image, tt.configHash)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(deployment.Spec.Template.Annotations).To(HaveKeyWithValue("metrics-forwarder-config-checksum", tt.configHash))
+			g.Expect(deployment.Spec.Template.Annotations).To(HaveKeyWithValue("target.workload.openshift.io/management", `{"effect": "PreferredDuringScheduling"}`))
 			g.Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 			g.Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal(tt.image))
 		})


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/OCPBUGS-87217

## Summary

The `control-plane-metrics-forwarder` Deployment introduced in #8146 is missing the `target.workload.openshift.io/management` annotation. This annotation is required by the CPU partitioning conformance test:

```
[sig-node] CPU Partitioning cluster platform workloads should be annotated correctly for Deployments
```

This has caused 7+ consecutive HCP 5.0 conformance failures since May 30.

## Changes

- Add `target.workload.openshift.io/management: {"effect": "PreferredDuringScheduling"}` to the metrics forwarder pod template annotations, matching the pattern used by other HyperShift-managed workloads (e.g., kubevirt CSI, OLM catalogs).

## Test plan

- [ ] HCP conformance test `[sig-node] CPU Partitioning cluster platform workloads should be annotated correctly for Deployments` should pass
- [ ] Existing metrics forwarder functionality unaffected (annotation is metadata-only)