### PR TITLE
NO-JIRA: Improve AI skill quality and restructure AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,234 +1,30 @@
-This file provides guidance when working with code in this repository.
-
-## Repository Overview
-
-HyperShift is a middleware for hosting OpenShift control planes at scale. It provides cost-effective and time-efficient cluster provisioning with portability across clouds while maintaining strong separation between management and workloads.
+This file provides non-obvious development guidance for the HyperShift repository. For architecture, components, and platform support, see [ARCHITECTURE.md](ARCHITECTURE.md).
 
 Project documentation is published via MkDocs. The site structure and navigation are defined in [docs/mkdocs.yml](docs/mkdocs.yml), with content under `docs/content/`. When adding or reorganizing documentation pages, update the `nav` section in `mkdocs.yml` to keep the site navigation in sync.
 
-## Architecture
+## Key References
 
-### Core Components
+| Topic | Where to look |
+|-------|---------------|
+| **Development commands and patterns** | [DEVELOPMENT.md](DEVELOPMENT.md) |
+| **API types and CRD machinery** | [api/AGENTS.md](api/AGENTS.md) |
+| **Control plane components (CPOv2)** | [support/controlplane-component/AGENTS.md](support/controlplane-component/AGENTS.md) and [support/controlplane-component/README.md](support/controlplane-component/README.md) |
+| **Control plane operator** | [control-plane-operator/AGENTS.md](control-plane-operator/AGENTS.md) |
+| **E2E v2 test framework** | [test/e2e/v2/AGENTS.md](test/e2e/v2/AGENTS.md) |
+| **Envtest (CEL validation tests)** | [test/envtest/README.md](test/envtest/README.md) — YAML-driven, runs across k8s 1.30–1.35, supports feature gate filtering |
+| **CEL over webhooks** | [.claude/rules/webhook-validation.md](.claude/rules/webhook-validation.md) |
+| **Code formatting and unit test conventions** | `.claude/skills/code-formatting` and [DEVELOPMENT.md#code-conventions](DEVELOPMENT.md#code-conventions) |
+| **Design invariants** | [docs/content/reference/goals-and-design-invariants.md](docs/content/reference/goals-and-design-invariants.md) |
+| **Versioning and support** | [docs/content/reference/versioning-support.md](docs/content/reference/versioning-support.md) |
+| **Upgrades lifecycle** | [docs/content/how-to/upgrades.md](docs/content/how-to/upgrades.md) |
 
-- **hypershift-operator**: Main operator managing HostedCluster and NodePool resources
-- **control-plane-operator**: Manages control plane components for hosted clusters. See support/controlplane-component/README.md
-- **control-plane-pki-operator**: Handles PKI and certificate management
-- **karpenter-operator**: Manages Karpenter resources for auto-scaling
-- **ignition-server**: Serves ignition configs for node bootstrapping
+## Pull Secret Cycling
 
-### Key Directories
-
-- `api/`: API definitions and CRDs for hypershift, scheduling, certificates, and karpenter
-- `cmd/`: CLI commands for cluster/nodepool management and infrastructure operations
-- `hypershift-operator/`: Main operator controllers and logic
-- `control-plane-operator/`: Control plane component management
-- `support/`: Shared utilities and libraries
-- `test/`: E2E and integration tests
-
-### Platform Support
-
-The codebase supports multiple platforms:
-
-- AWS (primary platform) - both self-managed and managed control plane (aka ROSA HCP)
-- Azure - both self-managed and managed control plane (aka ARO HCP)
-- IBM Cloud (PowerVS)
-- KubeVirt
-- OpenStack
-- Agent
-
-## Development Commands
-
-### Building
-
-```bash
-make build                    # Build all binaries
-make hypershift-operator      # Build hypershift-operator
-make control-plane-operator   # Build control-plane-operator
-make hypershift               # Build CLI
-```
-
-### Testing
-
-```bash
-make test                     # Run unit tests with race detection
-make e2e                      # Build E2E test binaries
-make tests                    # Compile all tests
-```
-
-### Code Quality
-
-```bash
-make lint                     # Run golangci-lint
-make lint-fix                 # Auto-fix linting issues
-make verify                   # Full verification (generate, fmt, vet, lint, etc.)
-make staticcheck              # Run staticcheck on core packages
-make fmt                      # Format code
-make vet                      # Run go vet
-```
-
-### API and Code Generation
-
-```bash
-make api                      # Regenerate all API resources and CRDs
-make generate                 # Run go generate
-make clients                  # Update generated clients
-make update                   # Full update (api-deps, workspace-sync, deps, api, api-docs, clients)
-```
-
-### Development Workflow
-
-See .claude/skills/dev
-
-## Testing Strategy
-
-### Unit Tests
-
-- Located throughout the codebase alongside source files
-- Use race detection and parallel execution
-- Run with `make test`
-
-### E2E Tests
-
-- Located in `test/e2e/`
-- Platform-specific tests for cluster lifecycle
-- Nodepool management and upgrade scenarios
-- Karpenter integration tests
-- v2 framework standards and patterns: see [test/e2e/v2/AGENTS.md](test/e2e/v2/AGENTS.md)
-
-### Envtest (API Validation Tests)
-
-- Located in `test/envtest/` with build tag `envtest`
-- Tests CRD validation rules (CEL, OpenAPI schema) against real kube-apiserver + etcd
-- Test cases are YAML-driven following the openshift/api convention
-- Each YAML file defines `onCreate` and `onUpdate` test cases with expected errors
-- Run with `make test-envtest-ocp` (OpenShift k8s versions) or `make test-envtest-kube` (vanilla k8s versions), or `make test-envtest-api-all` for both
-- Tests run across multiple Kubernetes versions (1.30–1.35) to verify validation ratcheting and compatibility
-- Feature gate filtering: test suites can target stable, tech-preview, or feature-gated CRD variants
-
-See test/envtest/README.md for details
-
-### Integration Tests
-
-- Located in `test/integration/`
-- Focus on controller behavior and API interactions
-
-## Key Development Patterns
-
-### Code quality, formatting and conventions
-
-Please see /hypershift/.cursor/rules/code-formatting.mdc
-
-### Operator Controllers
-
-- Follow standard controller-runtime patterns
-- Controllers in `hypershift-operator/controllers/` and `control-plane-operator/controllers/`
-- Use reconcile loops with proper error handling and requeuing
-
-### Platform Abstraction
-
-- Platform-specific logic isolated in separate packages
-- Common interfaces defined in `support/` packages
-- Platform implementations in respective controller subdirectories
-
-### Resource Management
-
-- Use `support/upsert/` for safe resource creation/updates
-- Follow owner reference patterns for proper garbage collection
-- Leverage controller-runtime's structured logging
-
-### CRD API Machinery Fundamentals
-See api/AGENTS.md
-
-### Validation: CEL Over Webhooks
-
-Do not add new validation logic to the admission webhook. Use CEL validation rules instead. See .claude/rules/webhook-validation.md for rationale and guidance.
-
-### Design Invariants
-
-See [docs/content/reference/goals-and-design-invariants.md](docs/content/reference/goals-and-design-invariants.md) for security and architectural invariants that all code changes must respect.
-
-### Versioning
-
-See [docs/content/reference/versioning-support.md](docs/content/reference/versioning-support.md) for release cycle, version skew policies, and support matrices for the HyperShift Operator, CPO, and other components.
-
-### Upgrades lifecycle
-
-See [docs/content/how-to/upgrades.md](docs/content/how-to/upgrades.md) for Control Plane and Data Plane upgrades
-
-### Pull secret cycling
-
-When changing how workers and the guest cluster authenticate to registries, treat **HostedCluster** `spec.pullSecret`, **management-cluster** Secret data, **HCCO** reconciliation into the data plane, and optional **Global Pull Secret** (`kube-system/additional-pull-secret`) as one system. Changing only the Secret bytes in place does not change `spec.pullSecret` and therefore does not drive a **NodePool** rollout, but controllers can still propagate credentials into the control plane namespace, guest `openshift-config`, `kube-system/original-pull-secret`, and (where the Global Pull Secret DaemonSet is scheduled) kubelet configuration.
+When changing how workers and the hosted cluster authenticate to registries, treat **HostedCluster** `spec.pullSecret`, **management-cluster** Secret data, **HCCO** reconciliation into the data plane, and optional **Global Pull Secret** (`kube-system/additional-pull-secret`) as one system. Changing only the Secret bytes in place does not change `spec.pullSecret` and therefore does not drive a **NodePool** rollout, but controllers can still propagate credentials into the control plane namespace, guest `openshift-config`, `kube-system/original-pull-secret`, and (where the Global Pull Secret DaemonSet is scheduled) kubelet configuration.
 
 See [docs/content/how-to/common/global-pull-secret.md](docs/content/how-to/common/global-pull-secret.md) for behavior, platform and NodePool eligibility (AWS/Azure Replace vs InPlace and other platforms), merge semantics, and operational guidance.
 
-## Dependencies and Modules
+## Fleet-Wide Rollout Impact
 
-This is a Go 1.25+ project using:
-
-- Kubernetes 0.34.x APIs
-- Controller-runtime 0.22.x
-- Various cloud provider SDKs (AWS, Azure, IBM)
-- OpenShift API dependencies
-
-The project uses vendoring (`go mod vendor`) and includes workspace configuration in `hack/workspace/`.
-
-### Multi-Module Structure
-
-This repository contains **multiple Go modules**. The `api/` directory is a **separate Go module** with its own `api/go.mod` (module path: `github.com/openshift/hypershift/api`). The main module at the repository root consumes the `api/` module through vendoring.
-
-This means:
-
-- Edits to files under `api/` (e.g. `api/hypershift/v1beta1/`) are **not visible** to the main module until the vendored copy is updated.
-- After modifying any types, constants, or functions in `api/`, you **must** run `make update` to regenerate CRDs, revendor dependencies, and sync everything. `make update` runs the full sequence: `api-deps` → `workspace-sync` → `deps` → `api` → `api-docs` → `clients` → `docs-aggregate`. Without this, the main module build will fail with `undefined` errors for any new symbols added in `api/`.
-- **Do not modify `vendor/` directories directly.** The `vendor/` directories are managed by `go mod vendor` (via `make deps` and `make api-deps`). Always use `make update` to keep them in sync.
-- Running `go build ./...` or `go vet ./...` from the repository root will **not** compile the `api/` module — it is a separate module. To build/vet the API module, run commands from within the `api/` directory.
-- The `hack/workspace/` directory contains a Go workspace configuration (`go.work`) that can be used for local development across both modules.
-
-## Common Gotchas
-
-- **`api/` is a separate Go module**: Always run `make update` after modifying types in the `api/` package. See [Multi-Module Structure](#multi-module-structure) above for details.
-- **Do not modify `vendor/` directories directly**: They are managed by `go mod vendor` via `make update`.
-- Use `make verify` before submitting PRs to catch formatting/generation issues.
-- Platform-specific controllers require their respective cloud credentials for testing.
-- E2E tests need proper cloud infrastructure setup (S3 buckets, DNS zones, etc.).
-
-## Commit Messages
-
-Use the `git-commit-format` skill for formatting rules and required footers. Validate with `make run-gitlint`. Do NOT put Jira IDs in commit messages — they belong only in PR titles.
-
-### Restructuring Commits Before PR Submission
-
-Before creating a PR or after addressing review comments, use the `restructure-hypershift-commits` skill to reorganize all branch commits into logical, component-based commits. This ensures every PR has a clean, reviewable commit history grouped by architectural boundary.
-
-## Pull Requests
-
-See [CONTRIBUTING.md](.github/CONTRIBUTING.md) for the full contribution guidelines. Key points for agents:
-
-### Before Creating a PR
-
-1. Use the `restructure-hypershift-commits` skill to organize commits by component (see [Restructuring Commits](#restructuring-commits-before-pr-submission) above)
-2. Run `make pre-commit` to update dependencies, build, verify formatting, run tests, and validate commit messages via gitlint
-
-### PR Title
-
-Prefix with a Jira ticket number: `OCPBUGS-12345: Fix memory leak in controller`. Use `NO-JIRA:` only when no Jira issue exists (sparingly).
-
-### PR Description
-
-Follow the template in `.github/PULL_REQUEST_TEMPLATE.md`.
-
-### PR Workflow
-
-1. Open the PR in **draft mode** to avoid triggering all CI jobs and notifying approvers
-2. Run necessary CI jobs manually with `/test <job-name>`
-3. Mark as "Ready for Review" once tests pass and required labels are applied
-
-### After Review Comments
-
-After addressing review feedback, use the `restructure-hypershift-commits` skill again to reorganize commits before force-pushing. This keeps the commit history clean for subsequent review rounds.
-
-## Code conventions
-
-- Prefer Gherkin Syntax to define unit test cases, e.g. "When... it should..."
-- Prefer gomega for unit test assertions
+Changes to config data, secrets, or any value that feeds into a NodePool config hash will trigger a rollout across **all** HostedClusters. Before adding new data to ignition configs, MachineConfigs, or any resource reconciled into the data plane, check whether the change affects the NodePool config hash (search for `hashStruct` / `configHash`). If it does, the PR **must** pass `e2e-aws-upgrade-hypershift-operator` to prove the rollout is safe.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,134 @@
+# Development
+
+## Key Make Targets
+
+### Building
+
+```bash
+make build                    # Build all binaries
+make hypershift-operator      # Build hypershift-operator
+make control-plane-operator   # Build control-plane-operator
+make hypershift               # Build CLI
+```
+
+### Testing
+
+```bash
+make test                     # Run unit tests with race detection
+make e2e                      # Build E2E test binaries
+make e2ev2                    # Build v2 E2E test binary (bin/test-e2e-v2)
+make tests                    # Compile all tests (no execution)
+make test-envtest-ocp         # Run envtest for CEL validations (OpenShift k8s versions)
+make test-envtest-kube        # Run envtest for vanilla k8s versions
+make test-envtest-api-all     # Run envtest for both
+```
+
+### Code Quality
+
+```bash
+make lint                     # Run golangci-lint
+make lint-fix                 # Auto-fix linting issues
+make verify                   # Full verification (generate, fmt, vet, lint, etc.)
+make staticcheck              # Run staticcheck on core packages
+make fmt                      # Format code
+make vet                      # Run go vet
+make pre-commit               # Full pre-PR gate (update, build, verify, test, gitlint)
+```
+
+### API and Code Generation
+
+```bash
+make api                      # Regenerate all CRDs, deepcopy, clients
+make api-lint-fix             # Run API linter and auto-fix violations
+make generate                 # Run go generate
+make clients                  # Update generated clients
+make update                   # Full update (api-deps, workspace-sync, deps, api, api-docs, clients, docs-aggregate)
+```
+
+## Development Patterns
+
+### Resource Management
+
+Use `support/upsert/` for safe resource creation and updates. Follow owner reference patterns for proper garbage collection.
+
+### Operator Controllers
+
+Controllers follow standard controller-runtime reconcile loop patterns. Locations:
+
+- `hypershift-operator/controllers/` — HostedCluster and NodePool reconciliation
+- `control-plane-operator/controllers/` — control plane component reconciliation (v2 framework)
+
+### Platform Abstraction
+
+Platform-specific logic is isolated in separate packages. Common interfaces are defined in `support/` packages, with platform implementations in respective controller subdirectories.
+
+## Multi-Module Structure
+
+This repository contains **multiple Go modules**. The `api/` directory is a **separate Go module** with its own `api/go.mod` (module path: `github.com/openshift/hypershift/api`). The main module at the repository root consumes the `api/` module through vendoring.
+
+This means:
+
+- Edits to files under `api/` (e.g. `api/hypershift/v1beta1/`) are **not visible** to the main module until the vendored copy is updated.
+- After modifying any types, constants, or functions in `api/`, you **must** run `make update` to regenerate CRDs, revendor dependencies, and sync everything. `make update` runs the full sequence: `api-deps` → `workspace-sync` → `deps` → `api` → `api-docs` → `clients` → `docs-aggregate`. Without this, the main module build will fail with `undefined` errors for any new symbols added in `api/`.
+- **Do not modify `vendor/` directories directly.** The `vendor/` directories are managed by `go mod vendor` (via `make deps` and `make api-deps`). Always use `make update` to keep them in sync.
+- Running `go build ./...` or `go vet ./...` from the repository root will **not** compile the `api/` module — it is a separate module. To build/vet the API module, run commands from within the `api/` directory.
+- The `hack/workspace/` directory contains a Go workspace configuration (`go.work`) that can be used for local development across both modules.
+
+## Common Gotchas
+
+- **`api/` is a separate Go module**: Always run `make update` after modifying types in the `api/` package. See [Multi-Module Structure](#multi-module-structure) above for details.
+- **Do not modify `vendor/` directories directly**: They are managed by `go mod vendor` via `make update`.
+- Use `make verify` before submitting PRs to catch formatting/generation issues.
+- Platform-specific controllers require their respective cloud credentials for testing.
+- E2E tests need proper cloud infrastructure setup (S3 buckets, DNS zones, etc.).
+- **No unrelated changes in PRs**: Do not include cosmetic formatting, whitespace, or import reordering changes in files unrelated to the PR's purpose. Unrelated changes increase review surface and make PRs harder to revert cleanly. If you notice something worth cleaning up, do it in a separate PR.
+- **Follow existing codebase patterns**: Before implementing a new approach (e.g., using service-ca operator for TLS), search the codebase for how similar problems are already solved (e.g., `reconcileSelfSignedCA`). HyperShift self-signs certificates — use the existing self-signing pattern instead of relying on external certificate operators.
+
+## Commit Messages
+
+Use the `git-commit-format` skill for formatting rules and required footers. Validate with `make run-gitlint`. Do NOT put Jira IDs in commit messages — they belong only in PR titles.
+
+### Restructuring Commits Before PR Submission
+
+Before creating a PR or after addressing review comments, use the `restructure-hypershift-commits` skill to reorganize all branch commits into logical, component-based commits. This ensures every PR has a clean, reviewable commit history grouped by architectural boundary.
+
+## Pull Requests
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contribution guidelines. Key points for agents:
+
+### Before Creating a PR
+
+1. Use the `restructure-hypershift-commits` skill to organize commits by component (see [Restructuring Commits](#restructuring-commits-before-pr-submission) above)
+2. Run `make pre-commit` to update dependencies, build, verify formatting, run tests, and validate commit messages via gitlint
+
+### PR Title
+
+Prefix with a Jira ticket number: `OCPBUGS-12345: Fix memory leak in controller`. Use `NO-JIRA:` only when no Jira issue exists (sparingly).
+
+### PR Description
+
+Follow the template in `.github/PULL_REQUEST_TEMPLATE.md`.
+
+### PR Workflow
+
+1. Open the PR in **draft mode** to avoid triggering all CI jobs and notifying approvers
+2. Run necessary CI jobs manually with `/test <job-name>`
+3. Mark as "Ready for Review" once tests pass and required labels are applied
+
+### After Review Comments
+
+After addressing review feedback, use the `restructure-hypershift-commits` skill again to reorganize commits before force-pushing. This keeps the commit history clean for subsequent review rounds.
+
+## Code Conventions
+
+For test naming and formatting rules, see `.claude/skills/code-formatting`.
+
+Additional review-derived rules:
+
+- Do not export functions that are only used in tests. Use unexported helpers or keep them in `_test.go` files.
+- Do not leave dead code (functions defined but never called). Remove unused code before submitting.
+- When adding new exported functions or methods, cover them with unit tests. For controller reconciliation methods, test at minimum: happy path, missing/empty input, disabled capability, and the primary error path.
+- Do not leave TODO comments in validation regex patterns or CEL rules — resolve them before submitting. Reviewers have blocked PRs for shipping regex patterns with placeholder character classes (e.g., allowing `{` and `}` in UUID fields, or missing anchoring constraints).
+- When writing regex for API validation, match the upstream format exactly. For UUIDs, use `[0-9a-f]{8}-...`; for Azure resource names, verify the allowed character set against Azure documentation. Do not over-broaden patterns with catch-all classes like `[a-zA-Z0-9-_().{}]`.
+- Use real-world values in test fixtures when possible (e.g., `quay.io/openshift-release-dev/ocp-release:4.21.10-x86_64` instead of `example.com/image:latest`). Real values catch edge cases that synthetic values miss.
+- When adding test assertions for OwnerReferences, check that they were actually set during reconciliation — not just that the object exists.


### PR DESCRIPTION
## What this PR does / why we need it:

Two related improvements to the AI agent guidance in this repository:

### 1. Review-comment-derived rules

Automated analysis of 78 review comments (2025-01-01 to 2026-06-05) identified recurring patterns in AI-generated PR feedback. New rules address the most common issues:

- **Fleet-wide rollout impact** (5 comments): AI PRs added data to ignition configs without understanding config hash impacts. New warning instructs agents to check `hashStruct`/`configHash` and run `e2e-aws-upgrade-hypershift-operator`.
- **No unrelated changes in PRs** (5 comments): AI PRs frequently included cosmetic import reordering or whitespace changes in unrelated files.
- **Follow existing codebase patterns** (3 comments): AI implemented TLS using service-ca operator when the codebase uses self-signed certs.
- **Validation regex correctness** (23 comments): Multiple PRs shipped regex patterns with over-broad character classes or unresolved TODOs.
- **Dead code and export hygiene** (6 comments): AI code left exported wrappers only used by tests and functions that were never called.
- **Test coverage and real-world fixtures** (11 comments): AI tests used synthetic fixtures and missed key paths.

### 2. Progressive disclosure restructuring

Restructured root `AGENTS.md` (symlinked as `CLAUDE.md`) following [Claude skill best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#progressive-disclosure-patterns):

- Root `AGENTS.md` reduced from 244 → 30 lines, restructured as a navigation hub with a reference table pointing to domain-specific docs
- Only two sections kept inline: Pull Secret Cycling (affects architectural decisions) and Fleet-Wide Rollout Impact (critical safety warning)
- New `DEVELOPMENT.md` (131 lines) created for build commands, make targets, multi-module structure, common gotchas, commit/PR workflow, and code conventions — loaded on demand via the reference table
- Removed content duplicated by existing docs (api/AGENTS.md, .claude/rules/webhook-validation.md, .claude/skills/code-formatting)

Tested by spawning fresh Claude agents with realistic tasks (API type modification, PR submission, build commands, controller development, unit test writing) — all navigated from the hub to the correct guidance in 2-4 file reads.

## Which issue(s) this PR fixes:

Depends on #8668 (ARCHITECTURE.md)

## Special notes for your reviewer:

The root `CLAUDE.md` is a symlink to `AGENTS.md`, so only `AGENTS.md` is modified.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [x] This change includes docs.
- [ ] This change includes unit tests.