### PR TITLE
NO-JIRA: Remove apply client workaround for controller-runtime < 0.22

### DIFF
--- a/kas-bootstrap/kas_boostrap.go
+++ b/kas-bootstrap/kas_boostrap.go
@@ -49,6 +49,8 @@ func run(ctx context.Context, opts Options) error {
 	}))
 	ctrl.SetLogger(logger)
 
+	fieldOwner := filepath.Base(os.Args[0])
+
 	adminCFG, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG_ADMIN"))
 	if err != nil {
 		return fmt.Errorf("failed to get admin config: %w", err)
@@ -57,18 +59,17 @@ func run(ctx context.Context, opts Options) error {
 	if err != nil {
 		return fmt.Errorf("failed to create admin client: %w", err)
 	}
+	adminClient = client.WithFieldOwner(adminClient, fieldOwner)
 
 	cfg, err := ctrl.GetConfig()
 	if err != nil {
 		return fmt.Errorf("failed to get config: %w", err)
 	}
-	client, err := client.New(cfg, client.Options{Scheme: configScheme})
+	bootstrapClient, err := client.New(cfg, client.Options{Scheme: configScheme})
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
 	}
-
-	adminApplyClient := &applyClient{client: adminClient}
-	applyClient := &applyClient{client: client}
+	bootstrapClient = client.WithFieldOwner(bootstrapClient, fieldOwner)
 
 	// Apply the kas-bootstrap-container rolebinding first with the admin client
 	// to grant cluster-admin to the system:kas-bootstrap-container identity.
@@ -81,7 +82,7 @@ func run(ctx context.Context, opts Options) error {
 	// This to avoid unnecessary restarts of this container.
 	if err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 3*time.Minute, true,
 		func(ctx context.Context) (done bool, err error) {
-			if err := applyManifest(ctx, adminApplyClient, filepath.Join(opts.ResourcesPath, kasBootstrapContainerRolebindingManifest)); err != nil {
+			if err := applyManifest(ctx, adminClient, filepath.Join(opts.ResourcesPath, kasBootstrapContainerRolebindingManifest)); err != nil {
 				logger.Error(err, "failed to apply kas-bootstrap-container rolebinding, retrying")
 				return false, nil
 			}
@@ -93,7 +94,7 @@ func run(ctx context.Context, opts Options) error {
 	// Apply the rest of the manifests with the system:kas-bootstrap-container identity
 	if err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 50*time.Second, true,
 		func(ctx context.Context) (done bool, err error) {
-			if err := applyBootstrapManifests(ctx, applyClient, opts.ResourcesPath); err != nil {
+			if err := applyBootstrapManifests(ctx, bootstrapClient, opts.ResourcesPath); err != nil {
 				logger.Error(err, "failed to apply bootstrap resources, retrying")
 				return false, nil
 			}
@@ -205,22 +206,7 @@ func parseFeatureGateV1(objBytes []byte) (*configv1.FeatureGate, error) {
 	return requiredObj.(*configv1.FeatureGate), nil
 }
 
-// NOTE: This is a temporary solution until the controller-runtime is upgraded to at least version 0.22.
-// The current controller-runtime version has a bug that prevents testing server side apply with the fake.Client.
-// This bug was fixed in version 0.22.
-type Apply interface {
-	Apply(ctx context.Context, obj *unstructured.Unstructured, opts ...client.PatchOption) error
-}
-
-type applyClient struct {
-	client client.Client
-}
-
-func (c *applyClient) Apply(ctx context.Context, obj *unstructured.Unstructured, opts ...client.PatchOption) error {
-	return c.client.Patch(ctx, obj, client.Apply, opts...)
-}
-
-func applyManifest(ctx context.Context, applyClient Apply, path string) error {
+func applyManifest(ctx context.Context, c client.Client, path string) error {
 	logger := ctrl.LoggerFrom(ctx).WithName("kas-bootstrap")
 	logger.Info("Applying manifest", "path", path)
 
@@ -239,15 +225,14 @@ func applyManifest(ctx context.Context, applyClient Apply, path string) error {
 		return fmt.Errorf("failed to convert to unstructured: %w", err)
 	}
 
-	fieldOwner := filepath.Base(os.Args[0])
-	if err := applyClient.Apply(ctx, &unstructured.Unstructured{Object: unstructuredObj}, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
+	if err := c.Apply(ctx, client.ApplyConfigurationFromUnstructured(&unstructured.Unstructured{Object: unstructuredObj}), client.ForceOwnership); err != nil {
 		return fmt.Errorf("failed to apply file %s: %w", path, err)
 	}
 
 	return nil
 }
 
-func applyBootstrapManifests(ctx context.Context, applyClient Apply, filesPath string) error {
+func applyBootstrapManifests(ctx context.Context, applyClient client.Client, filesPath string) error {
 	logger := ctrl.LoggerFrom(ctx).WithName("kas-bootstrap")
 
 	// Fail early if the specified path does not exist.

--- a/kas-bootstrap/kas_boostrap_test.go
+++ b/kas-bootstrap/kas_boostrap_test.go
@@ -14,11 +14,12 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"go.uber.org/zap/zapcore"
@@ -373,30 +374,23 @@ func TestReconcileFeatureGate(t *testing.T) {
 	}
 }
 
-// fakeApplyClient wraps a fake client.Client and implements the Apply interface
-// by using Create instead of Patch with client.Apply, because the current
-// controller-runtime version has a bug that prevents server-side apply with fake.Client.
-// Once controller-runtime is upgraded to >= 0.22, this can be replaced.
-type fakeApplyClient struct {
-	client.Client
-}
-
-func newFakeApplyClient() *fakeApplyClient {
+func newFakeClient() client.Client {
 	c := fake.NewClientBuilder().WithScheme(configScheme).Build()
-	return &fakeApplyClient{Client: c}
+	return client.WithFieldOwner(c, "kas-bootstrap-test")
 }
 
-func (c *fakeApplyClient) Apply(ctx context.Context, obj *unstructured.Unstructured, opts ...client.PatchOption) error {
-	return c.Client.Create(ctx, obj)
-}
-
-// errorApplyClient is an Apply implementation that always returns an error.
-type errorApplyClient struct {
-	err error
-}
-
-func (c *errorApplyClient) Apply(ctx context.Context, obj *unstructured.Unstructured, opts ...client.PatchOption) error {
-	return c.err
+// newErrorApplyClient returns a client.Client whose Apply always fails with err,
+// delegating every other method to a real fake client.
+func newErrorApplyClient(err error) client.Client {
+	c := interceptor.NewClient(
+		fake.NewClientBuilder().WithScheme(configScheme).Build(),
+		interceptor.Funcs{
+			Apply: func(_ context.Context, _ client.WithWatch, _ runtime.ApplyConfiguration, _ ...client.ApplyOption) error {
+				return err
+			},
+		},
+	)
+	return client.WithFieldOwner(c, "kas-bootstrap-test")
 }
 
 func TestApplyManifest(t *testing.T) {
@@ -407,36 +401,36 @@ func TestApplyManifest(t *testing.T) {
 
 	testCases := []struct {
 		name      string
-		setup     func(t *testing.T, g Gomega) (Apply, string)
+		setup     func(t *testing.T, g Gomega) (client.Client, string)
 		expectErr string
 	}{
 		{
 			name: "when the manifest file does not exist it should return an error",
-			setup: func(t *testing.T, g Gomega) (Apply, string) {
-				return newFakeApplyClient(), filepath.Join(t.TempDir(), "nonexistent.yaml")
+			setup: func(t *testing.T, g Gomega) (client.Client, string) {
+				return newFakeClient(), filepath.Join(t.TempDir(), "nonexistent.yaml")
 			},
 			expectErr: "failed to read file",
 		},
 		{
 			name: "when the manifest file contains invalid YAML it should return a decode error",
-			setup: func(t *testing.T, g Gomega) (Apply, string) {
+			setup: func(t *testing.T, g Gomega) (client.Client, string) {
 				invalidPath := filepath.Join(t.TempDir(), "invalid.yaml")
 				g.Expect(os.WriteFile(invalidPath, []byte("not: a: valid: k8s: resource"), 0644)).To(Succeed())
-				return newFakeApplyClient(), invalidPath
+				return newFakeClient(), invalidPath
 			},
 			expectErr: "failed to decode file",
 		},
 		{
 			name: "when the apply client returns an error it should propagate",
-			setup: func(t *testing.T, g Gomega) (Apply, string) {
-				return &errorApplyClient{err: fmt.Errorf("connection refused")}, filepath.Join(".", "testdata", kasBootstrapContainerRolebindingManifest)
+			setup: func(t *testing.T, g Gomega) (client.Client, string) {
+				return newErrorApplyClient(fmt.Errorf("connection refused")), filepath.Join(".", "testdata", kasBootstrapContainerRolebindingManifest)
 			},
 			expectErr: "failed to apply file",
 		},
 		{
 			name: "when the manifest is valid it should apply successfully",
-			setup: func(t *testing.T, g Gomega) (Apply, string) {
-				return newFakeApplyClient(), "./testdata/0000_10_config-operator_01_featuregates.crd.yaml"
+			setup: func(t *testing.T, g Gomega) (client.Client, string) {
+				return newFakeClient(), "./testdata/0000_10_config-operator_01_featuregates.crd.yaml"
 			},
 		},
 	}
@@ -465,7 +459,7 @@ func TestApplyBootstrapManifests(t *testing.T) {
 
 	t.Run("when the files path does not exist it should return an error", func(t *testing.T) {
 		g := NewGomegaWithT(t)
-		c := newFakeApplyClient()
+		c := newFakeClient()
 		err := applyBootstrapManifests(t.Context(), c, filepath.Join(t.TempDir(), "testdata-not-exist"))
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("does not exist"))
@@ -473,7 +467,7 @@ func TestApplyBootstrapManifests(t *testing.T) {
 
 	t.Run("when the apply client returns an error it should propagate", func(t *testing.T) {
 		g := NewGomegaWithT(t)
-		c := &errorApplyClient{err: fmt.Errorf("connection refused")}
+		c := newErrorApplyClient(fmt.Errorf("connection refused"))
 		err := applyBootstrapManifests(t.Context(), c, "./testdata")
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("failed to apply file"))
@@ -481,7 +475,7 @@ func TestApplyBootstrapManifests(t *testing.T) {
 
 	t.Run("it should skip the kas-bootstrap-container-rolebinding manifest", func(t *testing.T) {
 		g := NewGomegaWithT(t)
-		c := newFakeApplyClient()
+		c := newFakeClient()
 		err := applyBootstrapManifests(t.Context(), c, "./testdata")
 		g.Expect(err).ToNot(HaveOccurred())
 
@@ -505,7 +499,7 @@ func TestApplyBootstrapManifests(t *testing.T) {
 		err = os.WriteFile(filepath.Join(tmpDir, "README.md"), []byte("# not a k8s resource"), 0644)
 		g.Expect(err).ToNot(HaveOccurred())
 
-		c := newFakeApplyClient()
+		c := newFakeClient()
 		err = applyBootstrapManifests(t.Context(), c, tmpDir)
 		g.Expect(err).ToNot(HaveOccurred())
 
@@ -519,7 +513,7 @@ func TestApplyBootstrapManifests(t *testing.T) {
 
 	t.Run("it should apply all yaml manifests except the rolebinding", func(t *testing.T) {
 		g := NewGomegaWithT(t)
-		c := newFakeApplyClient()
+		c := newFakeClient()
 		err := applyBootstrapManifests(t.Context(), c, "./testdata")
 		g.Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION


<!--
Please follow our contributing guidelines located at https://github.com/openshift/hypershift/blob/main/.github/CONTRIBUTING.md.

In general, please:
- open the PR in draft mode
- keep commits as small and focused on specific changes as much as possible
- use conventional commits
- test your changes locally with `make pre-commit` before moving any PR out of draft mode
- prefix your PR with a Jira ticket number
- fill out the PR description template below

Feel free to delete this comment text block before submitting the PR.
-->

## What this PR does / why we need it:

The temporary applyClient wrapper and Apply interface existed only to work around a controller-runtime bug that prevented server-side apply with the fake client. That bug was fixed in controller-runtime 0.22, which the repository now uses.

Drop the Apply interface and applyClient/fakeApplyClient wrappers in favor of the native client.Apply API. The field owner is now set once per client via client.WithFieldOwner, and manifests are applied through client.ApplyConfigurationFromUnstructured with client.ForceOwnership.

Tests construct the error case with interceptor.NewClient instead of the custom errorApplyClient, and the fake client is wrapped with client.WithFieldOwner to mirror production behavior.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Manifest application now automatically derives field owner from the binary name, eliminating explicit options at each apply point
  * Simplified internal manifest application workflow by removing temporary interface abstractions
  * Updated function signatures to improve consistency in manifest application handling across the bootstrap process
  * Test suite refactored to validate updated manifest application patterns and client configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->