### PR TITLE
NO-JIRA: docs: improve AGENTS.md with missing commands, cpov2 framework, and inlined conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,11 +14,23 @@ Project documentation is published via MkDocs. The site structure and navigation
 
 ### Core Components
 
-- **hypershift-operator**: Main operator managing HostedCluster and NodePool resources
-- **control-plane-operator**: Manages control plane components for hosted clusters. See support/controlplane-component/README.md
+- **hypershift-operator**: Main operator managing HostedCluster and NodePool resources on the management cluster
+- **control-plane-operator (CPO)**: Manages control plane components for hosted clusters using the cpov2 framework
 - **control-plane-pki-operator**: Handles PKI and certificate management
 - **karpenter-operator**: Manages Karpenter resources for auto-scaling
 - **ignition-server**: Serves ignition configs for node bootstrapping
+
+### Control Plane Component Framework (cpov2)
+
+Most CPO development uses the cpov2 framework in `support/controlplane-component/`. Each control plane component (KAS, etcd, OAuth, KCM, etc.) is a `ControlPlaneComponent` with:
+
+- **Manifests**: Embedded YAML in `control-plane-operator/controllers/hostedcontrolplane/v2/assets/{component-name}/`
+- **Component code**: In `control-plane-operator/controllers/hostedcontrolplane/v2/{component}/component.go`
+- **Registration**: In `control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go` via `registerComponents()`
+
+Components use a fluent builder API: `component.NewDeploymentComponent(name, opts).WithAdaptFunction(...).WithPredicate(...).WithDependencies(...).Build()`. Adapt functions dynamically modify manifests based on `HostedControlPlane` spec. Predicates gate component reconciliation. Dependencies block until other components are `Available`.
+
+See `support/controlplane-component/README.md` for the full guide to adding new components.
 
 ### Key Directories
 
@@ -73,6 +85,12 @@ To run envtest against a single k8s version:
 ENVTEST_OCP_K8S_VERSIONS=1.35.0 make test-envtest-ocp
 ```
 
+To run envtest versions in parallel:
+```bash
+ENVTEST_JOBS=MAX make test-envtest-ocp     # All versions in parallel
+ENVTEST_JOBS=3 make test-envtest-ocp       # Up to 3 versions in parallel
+```
+
 ### Code Quality
 
 ```bash
@@ -84,6 +102,7 @@ make staticcheck              # Run staticcheck on core packages
 make fmt                      # Format code
 make vet                      # Run go vet
 make verify-codespell         # Catch spelling errors in markdown
+make run-gitlint              # Validate commit message format
 ```
 
 ### API and Code Generation
@@ -176,7 +195,13 @@ Do not add new validation logic to the admission webhook. Use CEL validation rul
 
 ### Design Invariants
 
-See [docs/content/reference/goals-and-design-invariants.md](docs/content/reference/goals-and-design-invariants.md) for security and architectural invariants that all code changes must respect.
+All code changes must respect these invariants (full details in [docs/content/reference/goals-and-design-invariants.md](docs/content/reference/goals-and-design-invariants.md)):
+
+- **Unidirectional communication**: Management cluster → hosted cluster only. A hosted cluster has no awareness of its management cluster.
+- **Namespace isolation**: Management-to-hosted communication is only allowed from within each control plane namespace.
+- **Worker node purity**: Compute workers run only user workloads — no HyperShift CRDs, CRs, or pods that let users manipulate HyperShift-owned features.
+- **No user credential management**: HyperShift components must not own or manage user infrastructure platform credentials.
+- **CP/data plane ingress separation**: Control plane ingress (SNI-based routing via private router on management cluster) and data plane ingress (standard OpenShift ingress operator on guest cluster) are orthogonal and must not be conflated.
 
 ### Versioning
 
@@ -215,16 +240,37 @@ This means:
 - Running `go build ./...` or `go vet ./...` from the repository root will **not** compile the `api/` module — it is a separate module. To build/vet the API module, run commands from within the `api/` directory.
 - The `hack/workspace/` directory contains a Go workspace configuration (`go.work`) that can be used for local development across both modules.
 
+## Jira Integration
+
+- **Features/epics/stories/tasks**: Create in the **CNTRLPLANE** project (Red Hat OpenShift Control Planes)
+- **Bugs**: Create in the **OCPBUGS** project (OpenShift Bugs)
+- **Components**: Use `HyperShift / ARO` for ARO HCP, `HyperShift / ROSA` for ROSA HCP, or `HyperShift` when platform is unclear
+- PR titles are prefixed with the Jira ticket: `OCPBUGS-12345: Fix memory leak` or `NO-JIRA:` when no issue exists
+
 ## Common Gotchas
 
 - Use `make verify` before submitting PRs to catch formatting/generation issues.
 - Platform-specific controllers require their respective cloud credentials for testing.
 - E2E tests need proper cloud infrastructure setup (S3 buckets, DNS zones, etc.).
 - `make generate` cleans stale `*_mock.go` files via `git clean -fx` before regenerating — don't hand-edit mock files.
+- The `api/` module is separate — new symbols added there cause `undefined` errors in the main module until you run `make update`.
+- When writing CEL validation for optional+immutable fields, you need both "cannot be changed" and "cannot be removed" rules (see api/AGENTS.md).
 
 ## Commit Messages
 
-Use the `git-commit-format` skill for formatting rules and required footers. Validate with `make run-gitlint`. Do NOT put Jira IDs in commit messages — they belong only in PR titles.
+Use conventional commit format. Validate with `make run-gitlint`. Do NOT put Jira IDs in commit messages — they belong only in PR titles.
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+Signed-off-by: <name> <email>
+```
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `build`, `ci`, `perf`, `revert`. Title max 120 chars, body lines max 140 chars. The `Signed-off-by` footer is required — get name/email from `git config user.name` and `git config user.email`.
+
+Use the `git-commit-format` skill for full details and examples.
 
 ### Restructuring Commits Before PR Submission
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,8 @@
-This file provides guidance when working with code in this repository.
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+**Note:** `CLAUDE.md` is a symlink to `AGENTS.md` — they are the same file. Edit `AGENTS.md` directly.
 
 ## Repository Overview
 
@@ -50,9 +54,23 @@ make hypershift               # Build CLI
 ### Testing
 
 ```bash
-make test                     # Run unit tests with race detection
-make e2e                      # Build E2E test binaries
-make tests                    # Compile all tests
+make test                     # Run all unit tests with race detection
+make test-envtest-ocp         # Run envtest CRD validation tests (OCP versions)
+make test-envtest-kube        # Run envtest CRD validation tests (vanilla k8s)
+make test-envtest-api-all     # Run envtest for both OCP and vanilla k8s
+make e2e                      # Build all E2E test binaries
+make e2ev2                    # Build v2 E2E test binary
+make tests                    # Compile all tests (no execution)
+```
+
+To run a single unit test or package:
+```bash
+GO111MODULE=on GOWORK=off GOFLAGS=-mod=vendor go test -race -run TestName ./path/to/package/...
+```
+
+To run envtest against a single k8s version:
+```bash
+ENVTEST_OCP_K8S_VERSIONS=1.35.0 make test-envtest-ocp
 ```
 
 ### Code Quality
@@ -60,19 +78,28 @@ make tests                    # Compile all tests
 ```bash
 make lint                     # Run golangci-lint
 make lint-fix                 # Auto-fix linting issues
-make verify                   # Full verification (generate, fmt, vet, lint, etc.)
+make api-lint-fix             # Run kube-api-linter and auto-fix API violations
+make verify                   # Full verification (generate, update, staticcheck, fmt, vet, lint, codespell, gitlint)
 make staticcheck              # Run staticcheck on core packages
 make fmt                      # Format code
 make vet                      # Run go vet
+make verify-codespell         # Catch spelling errors in markdown
 ```
 
 ### API and Code Generation
 
 ```bash
-make api                      # Regenerate all API resources and CRDs
-make generate                 # Run go generate
+make api                      # Regenerate all CRDs, deepcopy, clients
+make api-lint-fix             # Run API linter (kube-api-linter) and auto-fix violations
+make generate                 # Run go generate (cleans stale *_mock.go files first)
 make clients                  # Update generated clients
-make update                   # Full update (api-deps, workspace-sync, deps, api, api-docs, clients)
+make update                   # Full update pipeline: api-deps → workspace-sync → deps → api → api-docs → clients → docs-aggregate
+```
+
+### Pre-Submission
+
+```bash
+make pre-commit               # Full check: build + verify + test + gitlint (run before creating PRs)
 ```
 
 ### Development Workflow
@@ -114,9 +141,13 @@ See test/envtest/README.md for details
 
 ## Key Development Patterns
 
-### Code quality, formatting and conventions
+### Code Conventions
 
-Please see /hypershift/.cursor/rules/code-formatting.mdc
+- Use `make lint-fix` after writing Go code to automatically fix most linting issues
+- Run `make verify` before committing
+- Use Gherkin syntax for unit test names: "When... it should..."
+- Prefer gomega for unit test assertions
+- For the kube-api-linter (`make api-lint-fix`): trust its findings and do not add exclusions unless explicitly told to by a human reviewer
 
 ### Operator Controllers
 
@@ -186,11 +217,10 @@ This means:
 
 ## Common Gotchas
 
-- **`api/` is a separate Go module**: Always run `make update` after modifying types in the `api/` package. See [Multi-Module Structure](#multi-module-structure) above for details.
-- **Do not modify `vendor/` directories directly**: They are managed by `go mod vendor` via `make update`.
 - Use `make verify` before submitting PRs to catch formatting/generation issues.
 - Platform-specific controllers require their respective cloud credentials for testing.
 - E2E tests need proper cloud infrastructure setup (S3 buckets, DNS zones, etc.).
+- `make generate` cleans stale `*_mock.go` files via `git clean -fx` before regenerating — don't hand-edit mock files.
 
 ## Commit Messages
 
@@ -226,9 +256,3 @@ Follow the template in `.github/PULL_REQUEST_TEMPLATE.md`.
 ### After Review Comments
 
 After addressing review feedback, use the `restructure-hypershift-commits` skill again to reorganize commits before force-pushing. This keeps the commit history clean for subsequent review rounds.
-
-## Code conventions
-
-- Prefer Gherkin Syntax to define unit test cases, e.g. "When... it should..."
-- Prefer gomega for unit test assertions
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Most CPO development uses the cpov2 framework in `support/controlplane-component
 
 Components use a fluent builder API: `component.NewDeploymentComponent(name, opts).WithAdaptFunction(...).WithPredicate(...).WithDependencies(...).Build()`. Adapt functions dynamically modify manifests based on `HostedControlPlane` spec. Predicates gate component reconciliation. Dependencies block until other components are `Available`.
 
-See `support/controlplane-component/README.md` for the full guide to adding new components.
+See `support/controlplane-component/README.md` for the full guide to adding new components. See `support/controlplane-component/CLAUDE.md` for key files, CR representation, and reuse beyond CPO (Karpenter Operator, HyperShift Operator).
 
 ### Key Directories
 
@@ -147,9 +147,15 @@ See .claude/skills/dev
 - Tests CRD validation rules (CEL, OpenAPI schema) against real kube-apiserver + etcd
 - Test cases are YAML-driven following the openshift/api convention
 - Each YAML file defines `onCreate` and `onUpdate` test cases with expected errors
+- Test suite YAMLs live in `cmd/install/assets/crds/hypershift-operator/tests/{crd-group}/` (not in `test/envtest/` itself)
 - Run with `make test-envtest-ocp` (OpenShift k8s versions) or `make test-envtest-kube` (vanilla k8s versions), or `make test-envtest-api-all` for both
 - Tests run across multiple Kubernetes versions (1.30–1.35) to verify validation ratcheting and compatibility
 - Feature gate filtering: test suites can target stable, tech-preview, or feature-gated CRD variants
+
+To run envtest for a single suite, use Ginkgo's `--focus` flag with the suite name pattern (names follow `[GVR][FeatureSet=...][File=...] suite-name`):
+```bash
+GO111MODULE=on GOWORK=off GOFLAGS=-mod=vendor go test -tags envtest -race ./test/envtest/... -- --focus="hostedclusters.*etcd"
+```
 
 See test/envtest/README.md for details
 
@@ -191,7 +197,7 @@ See api/AGENTS.md
 
 ### Validation: CEL Over Webhooks
 
-Do not add new validation logic to the admission webhook. Use CEL validation rules instead. See .claude/rules/webhook-validation.md for rationale and guidance.
+Do not add new validation logic to the admission webhook. Use CEL validation rules instead. See .claude/rules/webhook-validation.md for rationale and guidance. The exception is CAPI resources, where a conversion webhook is required during the v1beta2 migration period.
 
 ### Design Invariants
 


### PR DESCRIPTION
## What this PR does / why we need it:

Improves `AGENTS.md` (symlinked as `CLAUDE.md`) with content that was either missing, outdated, or only reachable by following external references. Key changes:

- **Header and symlink note**: Added `# CLAUDE.md` header and note explaining the AGENTS.md ↔ CLAUDE.md symlink relationship
- **cpov2 framework section**: Added dedicated section documenting the Control Plane Component Framework — builder API, manifest layout, component registration, and cross-references to `support/controlplane-component/` docs
- **Missing commands**: Added `make pre-commit`, `make api-lint-fix`, `make verify-codespell`, `make run-gitlint`, `make e2ev2`, `make test-envtest-*` variants, and envtest parallel execution (`ENVTEST_JOBS`)
- **Single test/envtest invocation**: Added exact commands for running a single unit test package and focusing envtest on a specific suite
- **Design invariants inlined**: Expanded the design invariants section with all five invariants instead of just linking to the doc
- **Code conventions inlined**: Replaced the `.cursor/rules/code-formatting.mdc` reference with the actual conventions (Gherkin test names, gomega, lint-fix, api-lint-fix trust policy)
- **Commit message format**: Added the full conventional commit template with types, line limits, and Signed-off-by requirement
- **Jira integration**: Added section documenting CNTRLPLANE vs OCPBUGS project usage and component selection
- **Common gotchas**: Added mock file cleanup warning, CEL immutability two-rule pattern, and CAPI webhook exception
- **Envtest details**: Added test suite YAML location, single-suite focus command, and `ENVTEST_OCP_K8S_VERSIONS` usage

## Which issue(s) this PR fixes:

N/A — documentation improvement

## Special notes for your reviewer:

This is a docs-only change to `AGENTS.md`. The `CLAUDE.md` symlink means both files are updated. No code changes.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.
- [ ] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated contributor and developer guidance documentation with architecture details and component framework overview.
- Enhanced testing strategy documentation with Envtest suite details and command examples.
- Added code conventions, validation requirements, and design invariant clarifications.
- Updated commit message formatting and Jira integration instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->