### PR TITLE
CNTRLPLANE-3632: Predictable NodePool rollout control

### DIFF
--- a/api/hypershift/v1beta1/nodepool_conditions.go
+++ b/api/hypershift/v1beta1/nodepool_conditions.go
@@ -87,6 +87,12 @@ const (
 	// KubeVirtNodesLiveMigratable indicates if all (VirtualMachines) nodes of the kubevirt
 	// hosted cluster can be live migrated without experiencing a node restart
 	NodePoolKubeVirtLiveMigratableType = "KubeVirtNodesLiveMigratable"
+
+	// NodePoolConfigUpdatePendingConditionType signals that management-side configuration
+	// has changed but no rollout has been triggered. New nodes provisioned during a scale-up
+	// will receive the same configuration as existing nodes. The pending configuration will
+	// be applied on the next spec-driven rollout (e.g. release upgrade, user MachineConfig change).
+	NodePoolConfigUpdatePendingConditionType = "ConfigUpdatePending"
 )
 
 // PerformanceProfile Conditions
@@ -132,4 +138,5 @@ const (
 	CIDRConflictReason                    = "CIDRConflict"
 	NodePoolKubeVirtLiveMigratableReason  = "KubeVirtNodesNotLiveMigratable"
 	NodePoolUnsupportedSkewReason         = "UnsupportedSkew"
+	ManagementConfigDriftReason           = "ManagementConfigDrift"
 )

--- a/hypershift-operator/controllers/nodepool/capi.go
+++ b/hypershift-operator/controllers/nodepool/capi.go
@@ -597,26 +597,36 @@ func (c *CAPI) propagateVersionAndTemplate(log logr.Logger, machineDeployment *c
 	nodePool := c.nodePool
 	userDataSecret := c.UserDataSecret()
 	targetVersion := c.Version()
-	targetConfigHash := c.HashWithoutVersion()
-	isUpdating := false
+	targetRolloutConfigHash := c.RolloutHashWithoutVersion()
+	currentRolloutConfigHash := nodePool.Annotations[nodePoolAnnotationCurrentRolloutConfig]
 
-	if userDataSecret.Name != ptr.Deref(machineDeployment.Spec.Template.Spec.Bootstrap.DataSecretName, "") {
-		log.Info("New user data Secret has been generated",
-			"current", machineDeployment.Spec.Template.Spec.Bootstrap.DataSecretName,
-			"target", userDataSecret.Name)
+	versionChanged := targetVersion != ptr.Deref(machineDeployment.Spec.Template.Spec.Version, "")
+	configChanged := currentRolloutConfigHash != "" && targetRolloutConfigHash != currentRolloutConfigHash
 
-		if targetVersion != ptr.Deref(machineDeployment.Spec.Template.Spec.Version, "") {
-			log.Info("Starting version update: Propagating new version to the MachineDeployment",
-				"releaseImage", nodePool.Spec.Release.Image, "target", targetVersion)
+	specUpdated := false
+
+	if versionChanged || configChanged {
+		targetDataSecretName := userDataSecret.Name
+		currentDataSecretName := ptr.Deref(machineDeployment.Spec.Template.Spec.Bootstrap.DataSecretName, "")
+
+		// Only update the MachineDeployment spec if the desired values differ from current.
+		// This is critical: the caller skips status reconciliation when we return true,
+		// and status reconciliation is what updates the rollout config annotation to mark
+		// completion. If we return true when nothing actually changed, the annotation
+		// never gets updated and the rollout appears stuck.
+		if versionChanged || targetDataSecretName != currentDataSecretName {
+			if versionChanged {
+				log.Info("Starting version update: Propagating new version to the MachineDeployment",
+					"releaseImage", nodePool.Spec.Release.Image, "target", targetVersion)
+			}
+			if configChanged {
+				log.Info("Starting config update: Propagating new config to the MachineDeployment",
+					"current", currentRolloutConfigHash, "target", targetRolloutConfigHash)
+			}
+			machineDeployment.Spec.Template.Spec.Version = &targetVersion
+			machineDeployment.Spec.Template.Spec.Bootstrap.DataSecretName = ptr.To(targetDataSecretName)
+			specUpdated = true
 		}
-
-		if targetConfigHash != nodePool.Annotations[nodePoolAnnotationCurrentConfig] {
-			log.Info("Starting config update: Propagating new config to the MachineDeployment",
-				"current", nodePool.Annotations[nodePoolAnnotationCurrentConfig], "target", targetConfigHash)
-		}
-		machineDeployment.Spec.Template.Spec.Version = &targetVersion
-		machineDeployment.Spec.Template.Spec.Bootstrap.DataSecretName = ptr.To(userDataSecret.Name)
-		isUpdating = true
 	}
 
 	if machineTemplateCR.GetName() != machineDeployment.Spec.Template.Spec.InfrastructureRef.Name {
@@ -624,10 +634,10 @@ func (c *CAPI) propagateVersionAndTemplate(log logr.Logger, machineDeployment *c
 			"current", machineDeployment.Spec.Template.Spec.InfrastructureRef.Name,
 			"target", machineTemplateCR.GetName())
 		machineDeployment.Spec.Template.Spec.InfrastructureRef.Name = machineTemplateCR.GetName()
-		isUpdating = true
+		specUpdated = true
 	}
 
-	return isUpdating
+	return specUpdated
 }
 
 func (c *CAPI) reconcileMachineDeploymentStatus(log logr.Logger, machineDeployment *capiv1.MachineDeployment, machineTemplateCR client.Object) {
@@ -635,25 +645,43 @@ func (c *CAPI) reconcileMachineDeploymentStatus(log logr.Logger, machineDeployme
 	targetVersion := c.Version()
 	targetConfigHash := c.HashWithoutVersion()
 	targetConfigVersionHash := c.Hash()
+	targetRolloutConfigHash := c.RolloutHashWithoutVersion()
 
 	// If the MachineDeployment is now processing we know
 	// is at the expected version (spec.version) and config (userData Secret) so we reconcile status and annotation.
 	if MachineDeploymentComplete(machineDeployment) {
+		if nodePool.Annotations == nil {
+			nodePool.Annotations = make(map[string]string)
+		}
+
+		versionUpdated := false
 		if nodePool.Status.Version != targetVersion {
 			log.Info("Version update complete",
 				"previous", nodePool.Status.Version, "new", targetVersion)
 			nodePool.Status.Version = targetVersion
+			versionUpdated = true
 		}
 
-		if nodePool.Annotations == nil {
-			nodePool.Annotations = make(map[string]string)
+		rolloutConfigUpdated := false
+		if nodePool.Annotations[nodePoolAnnotationCurrentRolloutConfig] != targetRolloutConfigHash {
+			log.Info("Rollout config update complete",
+				"previous", nodePool.Annotations[nodePoolAnnotationCurrentRolloutConfig], "new", targetRolloutConfigHash)
+			nodePool.Annotations[nodePoolAnnotationCurrentRolloutConfig] = targetRolloutConfigHash
+			rolloutConfigUpdated = true
 		}
-		if nodePool.Annotations[nodePoolAnnotationCurrentConfig] != targetConfigHash {
-			log.Info("Config update complete",
-				"previous", nodePool.Annotations[nodePoolAnnotationCurrentConfig], "new", targetConfigHash)
-			nodePool.Annotations[nodePoolAnnotationCurrentConfig] = targetConfigHash
+
+		// Only update the full hash annotations when a spec-driven rollout completed.
+		// When only management-side content changed (no rollout), keep the old values
+		// so that cleanupOutdated() can find the correct old secrets on the next
+		// spec-driven change.
+		if rolloutConfigUpdated || versionUpdated {
+			if nodePool.Annotations[nodePoolAnnotationCurrentConfig] != targetConfigHash {
+				log.Info("Config update complete",
+					"previous", nodePool.Annotations[nodePoolAnnotationCurrentConfig], "new", targetConfigHash)
+				nodePool.Annotations[nodePoolAnnotationCurrentConfig] = targetConfigHash
+			}
+			nodePool.Annotations[nodePoolAnnotationCurrentConfigVersion] = targetConfigVersionHash
 		}
-		nodePool.Annotations[nodePoolAnnotationCurrentConfigVersion] = targetConfigVersionHash
 
 		if nodePool.Annotations[nodePoolAnnotationPlatformMachineTemplate] != machineTemplateCR.GetName() {
 			log.Info("Rolling upgrade complete",
@@ -996,34 +1024,41 @@ func (c *CAPI) reconcileMachineSet(ctx context.Context,
 	scaleFromZeroSupported := hasStatusCapacity(machineTemplateCR) || nodePool.Spec.Platform.Type == c.scaleFromZeroPlatform
 	setMachineSetReplicas(nodePool, machineSet, scaleFromZeroSupported)
 
+	targetRolloutConfigHash := c.RolloutHashWithoutVersion()
+	currentRolloutConfigHash := nodePool.Annotations[nodePoolAnnotationCurrentRolloutConfig]
+
+	versionChanged := targetVersion != ptr.Deref(machineSet.Spec.Template.Spec.Version, "")
+	configChanged := currentRolloutConfigHash != "" && targetRolloutConfigHash != currentRolloutConfigHash
+
 	isUpdating := false
-	// Propagate version and userData Secret to the MachineSet.
-	if userDataSecret.Name != ptr.Deref(machineSet.Spec.Template.Spec.Bootstrap.DataSecretName, "") {
-		log.Info("New user data Secret has been generated",
-			"current", machineSet.Spec.Template.Spec.Bootstrap.DataSecretName,
-			"target", userDataSecret.Name)
 
-		// TODO (alberto): possibly compare with NodePool here instead so we don't rely on impl details to drive decisions.
-		if targetVersion != ptr.Deref(machineSet.Spec.Template.Spec.Version, "") {
-			log.Info("Starting version upgrade: Propagating new version to the MachineSet",
-				"releaseImage", nodePool.Spec.Release.Image, "target", targetVersion)
+	if versionChanged || configChanged {
+		targetDataSecretName := userDataSecret.Name
+		currentDataSecretName := ptr.Deref(machineSet.Spec.Template.Spec.Bootstrap.DataSecretName, "")
+
+		// Only update the MachineSet spec if the desired values differ from current.
+		// See propagateVersionAndTemplate for the rationale.
+		if versionChanged || targetDataSecretName != currentDataSecretName {
+			if versionChanged {
+				log.Info("Starting version upgrade: Propagating new version to the MachineSet",
+					"releaseImage", nodePool.Spec.Release.Image, "target", targetVersion)
+			}
+			if configChanged {
+				log.Info("Starting config upgrade: Propagating new config to the MachineSet",
+					"current", currentRolloutConfigHash, "target", targetRolloutConfigHash)
+			}
+			machineSet.Spec.Template.Spec.Version = &targetVersion
+			machineSet.Spec.Template.Spec.Bootstrap.DataSecretName = ptr.To(targetDataSecretName)
+
+			// Signal in-place upgrade request.
+			machineSet.Annotations[nodePoolAnnotationTargetConfigVersion] = targetConfigVersionHash
+
+			// If the machineSet is brand new, set current version to target so in-place upgrade no-op.
+			if _, ok := machineSet.Annotations[nodePoolAnnotationCurrentConfigVersion]; !ok {
+				machineSet.Annotations[nodePoolAnnotationCurrentConfigVersion] = targetConfigVersionHash
+			}
+			isUpdating = true
 		}
-
-		if targetConfigHash != nodePool.Annotations[nodePoolAnnotationCurrentConfig] {
-			log.Info("Starting config upgrade: Propagating new config to the MachineSet",
-				"current", nodePool.Annotations[nodePoolAnnotationCurrentConfig], "target", targetConfigHash)
-		}
-		machineSet.Spec.Template.Spec.Version = &targetVersion
-		machineSet.Spec.Template.Spec.Bootstrap.DataSecretName = ptr.To(userDataSecret.Name)
-
-		// Signal in-place upgrade request.
-		machineSet.Annotations[nodePoolAnnotationTargetConfigVersion] = targetConfigVersionHash
-
-		// If the machineSet is brand new, set current version to target so in-place upgrade no-op.
-		if _, ok := machineSet.Annotations[nodePoolAnnotationCurrentConfigVersion]; !ok {
-			machineSet.Annotations[nodePoolAnnotationCurrentConfigVersion] = targetConfigVersionHash
-		}
-		isUpdating = true
 	}
 
 	// template spec has changed, signal a rolling upgrade.
@@ -1044,22 +1079,34 @@ func (c *CAPI) reconcileMachineSet(ctx context.Context,
 	}
 
 	if machineSetInPlaceRolloutIsComplete(machineSet) {
+		if nodePool.Annotations == nil {
+			nodePool.Annotations = make(map[string]string)
+		}
+
+		versionUpdated := false
 		if nodePool.Status.Version != targetVersion {
 			log.Info("Version upgrade complete",
 				"previous", nodePool.Status.Version, "new", targetVersion)
 			nodePool.Status.Version = targetVersion
+			versionUpdated = true
 		}
 
-		if nodePool.Annotations == nil {
-			nodePool.Annotations = make(map[string]string)
+		rolloutConfigUpdated := false
+		if nodePool.Annotations[nodePoolAnnotationCurrentRolloutConfig] != targetRolloutConfigHash {
+			log.Info("Rollout config upgrade complete",
+				"previous", nodePool.Annotations[nodePoolAnnotationCurrentRolloutConfig], "new", targetRolloutConfigHash)
+			nodePool.Annotations[nodePoolAnnotationCurrentRolloutConfig] = targetRolloutConfigHash
+			rolloutConfigUpdated = true
 		}
-		if nodePool.Annotations[nodePoolAnnotationCurrentConfig] != targetConfigHash {
-			log.Info("Config upgrade complete",
-				"previous", nodePool.Annotations[nodePoolAnnotationCurrentConfig], "new", targetConfigHash)
 
-			nodePool.Annotations[nodePoolAnnotationCurrentConfig] = targetConfigHash
+		if rolloutConfigUpdated || versionUpdated {
+			if nodePool.Annotations[nodePoolAnnotationCurrentConfig] != targetConfigHash {
+				log.Info("Config upgrade complete",
+					"previous", nodePool.Annotations[nodePoolAnnotationCurrentConfig], "new", targetConfigHash)
+				nodePool.Annotations[nodePoolAnnotationCurrentConfig] = targetConfigHash
+			}
+			nodePool.Annotations[nodePoolAnnotationCurrentConfigVersion] = targetConfigVersionHash
 		}
-		nodePool.Annotations[nodePoolAnnotationCurrentConfigVersion] = targetConfigVersionHash
 
 		if nodePool.Annotations[nodePoolAnnotationPlatformMachineTemplate] != machineTemplateCR.GetName() {
 			log.Info("Rolling upgrade complete",

--- a/hypershift-operator/controllers/nodepool/capi_test.go
+++ b/hypershift-operator/controllers/nodepool/capi_test.go
@@ -2813,14 +2813,15 @@ func TestSetMachineDeploymentFailureDomain(t *testing.T) {
 
 func TestPropagateVersionAndTemplate(t *testing.T) {
 	testCases := []struct {
-		name                 string
-		currentBootstrapName string
-		currentVersion       string
-		templateName         string
-		currentInfraRefName  string
-		useDifferentUserData bool
-		expectedUpdating     bool
-		expectedInfraRefName string
+		name                    string
+		currentBootstrapName    string
+		currentVersion          string
+		templateName            string
+		currentInfraRefName     string
+		useDifferentUserData    bool
+		rolloutConfigAnnotation string
+		expectedUpdating        bool
+		expectedInfraRefName    string
 	}{
 		{
 			name:                 "When user data secret name differs from current bootstrap, it should propagate version and return true",
@@ -2860,16 +2861,42 @@ func TestPropagateVersionAndTemplate(t *testing.T) {
 			expectedUpdating:     false,
 			expectedInfraRefName: "same-template",
 		},
+		{
+			name:                    "When rollout hash differs and MachineDeployment has old values, it should propagate and return true",
+			currentBootstrapName:    "old-userdata",
+			currentVersion:          "4.17.0",
+			templateName:            "same-template",
+			currentInfraRefName:     "same-template",
+			rolloutConfigAnnotation: "stale-hash",
+			expectedUpdating:        true,
+			expectedInfraRefName:    "same-template",
+		},
+		{
+			name:                    "When rollout hash differs but MachineDeployment already has correct values, it should return false",
+			currentBootstrapName:    "", // will be set to match computed name
+			currentVersion:          "4.17.0",
+			templateName:            "same-template",
+			currentInfraRefName:     "same-template",
+			rolloutConfigAnnotation: "stale-hash",
+			expectedUpdating:        false,
+			expectedInfraRefName:    "same-template",
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 
+			annotations := map[string]string{}
+			if tc.rolloutConfigAnnotation != "" {
+				annotations[nodePoolAnnotationCurrentRolloutConfig] = tc.rolloutConfigAnnotation
+			}
+
 			nodePool := &hyperv1.NodePool{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-np",
-					Namespace: "test-ns",
+					Name:        "test-np",
+					Namespace:   "test-ns",
+					Annotations: annotations,
 				},
 			}
 

--- a/hypershift-operator/controllers/nodepool/conditions.go
+++ b/hypershift-operator/controllers/nodepool/conditions.go
@@ -413,8 +413,8 @@ func (r *NodePoolReconciler) updatingConfigCondition(ctx context.Context, nodePo
 		return &ctrl.Result{}, fmt.Errorf("error getting token: %w", err)
 	}
 
-	targetConfigHash := token.HashWithoutVersion()
-	currentConfigHash := nodePool.GetAnnotations()[nodePoolAnnotationCurrentConfig]
+	targetConfigHash := token.RolloutHashWithoutVersion()
+	currentConfigHash := nodePool.GetAnnotations()[nodePoolAnnotationCurrentRolloutConfig]
 	isUpdatingConfig := isUpdatingConfig(nodePool, targetConfigHash)
 	if isUpdatingConfig {
 		reason := hyperv1.AsExpectedReason
@@ -461,6 +461,42 @@ func (r *NodePoolReconciler) updatingConfigCondition(ctx context.Context, nodePo
 	} else {
 		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
 			Type:               hyperv1.NodePoolUpdatingConfigConditionType,
+			Status:             corev1.ConditionFalse,
+			Reason:             hyperv1.AsExpectedReason,
+			ObservedGeneration: nodePool.Generation,
+		})
+	}
+	return nil, nil
+}
+
+func (r *NodePoolReconciler) configUpdatePendingCondition(ctx context.Context, nodePool *hyperv1.NodePool, hcluster *hyperv1.HostedCluster) (*ctrl.Result, error) {
+	token, err := r.token(ctx, hcluster, nodePool)
+	if err != nil {
+		return &ctrl.Result{}, fmt.Errorf("error getting token: %w", err)
+	}
+
+	// Config drift exists when the full payload hash differs from the last-applied
+	// payload, but the rollout hash has not changed. This means management-side
+	// content (e.g. HAProxy image) changed without triggering a rollout.
+	currentRolloutConfig := nodePool.GetAnnotations()[nodePoolAnnotationCurrentRolloutConfig]
+	targetRolloutConfig := token.RolloutHashWithoutVersion()
+	targetFullHash := token.Hash()
+	currentFullHash := nodePool.GetAnnotations()[nodePoolAnnotationCurrentConfigVersion]
+
+	isUpdating := isUpdatingConfig(nodePool, targetRolloutConfig) || isUpdatingVersion(nodePool, token.Version())
+	hasDrift := currentFullHash != "" && targetFullHash != currentFullHash && currentRolloutConfig == targetRolloutConfig
+
+	if hasDrift && !isUpdating {
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+			Type:               hyperv1.NodePoolConfigUpdatePendingConditionType,
+			Status:             corev1.ConditionTrue,
+			Reason:             hyperv1.ManagementConfigDriftReason,
+			Message:            "Management-side configuration has changed; existing nodes retain the previous configuration until the next spec-driven rollout.",
+			ObservedGeneration: nodePool.Generation,
+		})
+	} else {
+		SetStatusCondition(&nodePool.Status.Conditions, hyperv1.NodePoolCondition{
+			Type:               hyperv1.NodePoolConfigUpdatePendingConditionType,
 			Status:             corev1.ConditionFalse,
 			Reason:             hyperv1.AsExpectedReason,
 			ObservedGeneration: nodePool.Generation,

--- a/hypershift-operator/controllers/nodepool/conditions_test.go
+++ b/hypershift-operator/controllers/nodepool/conditions_test.go
@@ -184,13 +184,18 @@ func TestUpdatingConfigCondition(t *testing.T) {
 				pullSecret.ObjectMeta.Name = "new-pull"
 			}
 
+			annotations := map[string]string{
+				nodePoolAnnotationCurrentConfig: "08e4f890",
+			}
+			if tc.isUpdatingConfig {
+				annotations[nodePoolAnnotationCurrentRolloutConfig] = "stale-rollout-hash"
+			}
+
 			nodePool := &hyperv1.NodePool{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "nodepool-name",
-					Namespace: "myns",
-					Annotations: map[string]string{
-						nodePoolAnnotationCurrentConfig: "08e4f890",
-					},
+					Name:        "nodepool-name",
+					Namespace:   "myns",
+					Annotations: annotations,
 				},
 				Spec: hyperv1.NodePoolSpec{
 					ClusterName: hostedCluster.Name,
@@ -504,4 +509,132 @@ func setUpDummyMachineSet(nodePool *hyperv1.NodePool, hostedCluster *hyperv1.Hos
 		}
 	}
 	return machineSet
+}
+
+func TestConfigUpdatePendingCondition(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	tests := []struct {
+		name           string
+		isUpdatingSpec bool
+		hasDrift       bool
+		expectedStatus corev1.ConditionStatus
+		expectedReason string
+	}{
+		{
+			name:           "No drift, no update in progress",
+			isUpdatingSpec: false,
+			hasDrift:       false,
+			expectedStatus: corev1.ConditionFalse,
+			expectedReason: hyperv1.AsExpectedReason,
+		},
+		{
+			name:           "Management drift detected, no spec update in progress",
+			isUpdatingSpec: false,
+			hasDrift:       true,
+			expectedStatus: corev1.ConditionTrue,
+			expectedReason: hyperv1.ManagementConfigDriftReason,
+		},
+		{
+			name:           "Both drift and spec update in progress, UpdatingConfig takes precedence",
+			isUpdatingSpec: true,
+			hasDrift:       true,
+			expectedStatus: corev1.ConditionFalse,
+			expectedReason: hyperv1.AsExpectedReason,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+
+			pullSecret, ignitionServerCACert, machineConfig, ignitionConfig, ignitionConfig2, ignitionConfig3 := setupTestObjects()
+
+			hostedCluster := &hyperv1.HostedCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-name", Namespace: "myns"},
+				Spec: hyperv1.HostedClusterSpec{
+					PullSecret: corev1.LocalObjectReference{Name: pullSecret.Name},
+					InfraID:    "fake-infra-id",
+				},
+				Status: hyperv1.HostedClusterStatus{
+					IgnitionEndpoint: "https://ignition.cluster-name.myns.devcluster.openshift.com",
+				},
+			}
+
+			nodePool := &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nodepool-name",
+					Namespace: "myns",
+					Annotations: map[string]string{
+						nodePoolAnnotationCurrentConfig: "some-full-hash",
+					},
+				},
+				Spec: hyperv1.NodePoolSpec{
+					ClusterName: hostedCluster.Name,
+					Release: hyperv1.Release{
+						Image: "fake-release-image",
+					},
+					Config: []corev1.LocalObjectReference{
+						{Name: "machineconfig-1"},
+					},
+				},
+				Status: hyperv1.NodePoolStatus{
+					Version: semver.MustParse("4.18.0").String(),
+				},
+			}
+
+			client := fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(
+				nodePool,
+				hostedCluster,
+				pullSecret,
+				ignitionServerCACert,
+				machineConfig,
+				ignitionConfig,
+				ignitionConfig2,
+				ignitionConfig3,
+			).Build()
+
+			r := &NodePoolReconciler{
+				Client:          client,
+				ReleaseProvider: &fakereleaseprovider.FakeReleaseProvider{Version: semver.MustParse("4.18.0").String()},
+				ImageMetadataProvider: &fakeimagemetadataprovider.FakeRegistryClientImageMetadataProvider{
+					Result: &dockerv1client.DockerImageConfig{
+						Config: &docker10.DockerConfig{
+							Labels: map[string]string{},
+						},
+					},
+				},
+			}
+
+			// First, compute the actual token to get hashes
+			token, err := r.token(ctx, hostedCluster, nodePool)
+			g.Expect(err).To(BeNil())
+
+			rolloutHash := token.RolloutHashWithoutVersion()
+			fullHash := token.Hash()
+
+			// Set the current rollout config to match (no spec change)
+			nodePool.Annotations[nodePoolAnnotationCurrentRolloutConfig] = rolloutHash
+
+			if tc.isUpdatingSpec {
+				// Simulate a spec-driven rollout in progress by making the rollout hash differ
+				nodePool.Annotations[nodePoolAnnotationCurrentRolloutConfig] = "stale-rollout-hash"
+			}
+
+			if tc.hasDrift {
+				// Simulate management-side drift: full hash differs from current but rollout hash matches
+				nodePool.Annotations[nodePoolAnnotationCurrentConfigVersion] = "old-full-hash-differs-from-" + fullHash
+			} else {
+				nodePool.Annotations[nodePoolAnnotationCurrentConfigVersion] = fullHash
+			}
+
+			_, err = r.configUpdatePendingCondition(ctx, nodePool, hostedCluster)
+			g.Expect(err).To(BeNil())
+
+			condition := FindStatusCondition(nodePool.Status.Conditions, hyperv1.NodePoolConfigUpdatePendingConditionType)
+			g.Expect(condition).NotTo(BeNil())
+			g.Expect(condition.Status).To(Equal(tc.expectedStatus))
+			g.Expect(condition.Reason).To(Equal(tc.expectedReason))
+		})
+	}
 }

--- a/hypershift-operator/controllers/nodepool/config.go
+++ b/hypershift-operator/controllers/nodepool/config.go
@@ -68,8 +68,16 @@ type rolloutConfig struct {
 	additionalTrustBundleName string
 	// globalConfig represents input from hostedCluster.spec.config that requires a NodePool rollout.
 	globalConfig string
+	// rolloutGlobalConfig is the global config derived only from user-set spec fields
+	// (proxy spec, image spec) without reconciling platform-specific defaults like
+	// Status.NoProxy entries. Used only for rollout hash computation.
+	rolloutGlobalConfig string
 	// rawConfig is an mco consumable version of NodePool.spec.config, tuneConfig and any hypershift core machine config.
 	mcoRawConfig string
+	// rolloutMcoRawConfig is mcoRawConfig without management-side content (haproxy).
+	// Used only for rollout hash computation so that management-side image changes
+	// do not trigger node replacement.
+	rolloutMcoRawConfig string
 	// TODO(alberto): consider let haproxyRawConfig be an implementation detail of ConfigGenerator.
 	// For now, it's a required input to keep the haproxy business logic and files outside the scope of this initial refactor.
 	haproxyRawConfig string
@@ -96,6 +104,11 @@ func NewConfigGenerator(ctx context.Context, client client.Client, hostedCluster
 	}
 
 	globalConfig, err := globalConfigString(hostedCluster)
+	if err != nil {
+		return nil, err
+	}
+
+	rolloutGlobalConfig, err := rolloutGlobalConfigString(hostedCluster)
 	if err != nil {
 		return nil, err
 	}
@@ -135,11 +148,12 @@ func NewConfigGenerator(ctx context.Context, client client.Client, hostedCluster
 		// from rhel-9 to rhel-10 should have their own dedicated e2e.
 		resolvedRHELStreamForBootImage: StreamRHEL9,
 		rolloutConfig: &rolloutConfig{
-			releaseImage:     releaseImage,
-			pullSecretName:   hostedCluster.Spec.PullSecret.Name,
-			globalConfig:     globalConfig,
-			haproxyRawConfig: haproxyRawConfig,
-			rhelStream:       rhelStream,
+			releaseImage:        releaseImage,
+			pullSecretName:      hostedCluster.Spec.PullSecret.Name,
+			globalConfig:        globalConfig,
+			rolloutGlobalConfig: rolloutGlobalConfig,
+			haproxyRawConfig:    haproxyRawConfig,
+			rhelStream:          rhelStream,
 		},
 	}
 
@@ -147,11 +161,12 @@ func NewConfigGenerator(ctx context.Context, client client.Client, hostedCluster
 		cg.rolloutConfig.additionalTrustBundleName = hostedCluster.Spec.AdditionalTrustBundle.Name
 	}
 
-	mcoRawConfig, err := cg.generateMCORawConfig(ctx, hostedCluster.Spec.Capabilities)
+	mcoRawConfig, rolloutMcoRawConfig, err := cg.generateMCORawConfig(ctx, hostedCluster.Spec.Capabilities)
 	if err != nil {
 		return nil, err
 	}
 	cg.rolloutConfig.mcoRawConfig = mcoRawConfig
+	cg.rolloutConfig.rolloutMcoRawConfig = rolloutMcoRawConfig
 
 	return cg, nil
 }
@@ -182,24 +197,39 @@ func (cg *ConfigGenerator) HashWithoutVersion() string {
 	return supportutil.HashSimple(cg.mcoRawConfig + cg.pullSecretName + cg.additionalTrustBundleName + cg.rhelStream)
 }
 
+// RolloutHash returns a hash derived only from spec-driven inputs that require node replacement.
+// Management-side changes (e.g. HAProxy image digest bumps, platform-computed proxy defaults)
+// are excluded, so they do not trigger Replace or InPlace rollouts.
+func (cg *ConfigGenerator) RolloutHash() string {
+	return supportutil.HashSimple(cg.rolloutMcoRawConfig + cg.releaseImage.Version() + cg.pullSecretName + cg.additionalTrustBundleName + cg.rolloutGlobalConfig + cg.rhelStream)
+}
+
+// RolloutHashWithoutVersion is like RolloutHash but excludes the release version.
+// Used to detect config-only changes for the UpdatingConfig condition,
+// separate from version changes which have their own condition.
+func (cg *ConfigGenerator) RolloutHashWithoutVersion() string {
+	return supportutil.HashSimple(cg.rolloutMcoRawConfig + cg.pullSecretName + cg.additionalTrustBundleName + cg.rolloutGlobalConfig + cg.rhelStream)
+}
+
 func (cg *ConfigGenerator) Version() string {
 	return cg.releaseImage.Version()
 }
 
 // generateMCORawConfig generates a mco consumable artifact of the mco Config.
-func (cg *ConfigGenerator) generateMCORawConfig(ctx context.Context, caps *hyperv1.Capabilities) (configsRaw string, err error) {
+// It returns two strings: the full config (including haproxy) and the rollout config (excluding haproxy).
+func (cg *ConfigGenerator) generateMCORawConfig(ctx context.Context, caps *hyperv1.Capabilities) (configsRaw, rolloutConfigsRaw string, err error) {
 	var configs []corev1.ConfigMap
 
 	// Look for core ignition configs in the control plane namespace.
 	coreConfigs, err := cg.getCoreConfigs(ctx)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	configs = append(configs, coreConfigs...)
 
 	userConfig, err := cg.getUserConfigs(ctx)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	configs = append(configs, userConfig...)
 
@@ -207,12 +237,22 @@ func (cg *ConfigGenerator) generateMCORawConfig(ctx context.Context, caps *hyper
 		// Look for NTO generated MachineConfigs from the hosted control plane namespace
 		nodeTuningGeneratedConfigs, err := getNTOGeneratedConfig(ctx, cg)
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
 		configs = append(configs, nodeTuningGeneratedConfigs...)
 	}
 
-	return cg.parse(configs)
+	fullConfig, err := cg.parse(configs)
+	if err != nil {
+		return "", "", err
+	}
+
+	rolloutConfig, err := cg.parseWithoutHaproxy(configs)
+	if err != nil {
+		return "", "", err
+	}
+
+	return fullConfig, rolloutConfig, nil
 }
 
 // getUserConfigs returns a slice with all the configMaps in nodePool.Spec.Config.
@@ -279,11 +319,21 @@ func (e *MissingCoreConfigError) Error() string {
 
 // parse loops over a slice of configMaps and returns a string with the concatenated content if they are MCO consumable APIs.
 func (cg *ConfigGenerator) parse(configs []corev1.ConfigMap) (string, error) {
+	return cg.doParse(configs, cg.haproxyRawConfig)
+}
+
+// parseWithoutHaproxy is like parse but excludes haproxy content.
+// Used to compute the rollout-only MCO config that is insensitive to management-side image changes.
+func (cg *ConfigGenerator) parseWithoutHaproxy(configs []corev1.ConfigMap) (string, error) {
+	return cg.doParse(configs, "")
+}
+
+func (cg *ConfigGenerator) doParse(configs []corev1.ConfigMap, haproxyConfig string) (string, error) {
 	var errors []error
 	var allConfigPlainText []string
 
-	if cg.haproxyRawConfig != "" {
-		allConfigPlainText = append(allConfigPlainText, cg.haproxyRawConfig)
+	if haproxyConfig != "" {
+		allConfigPlainText = append(allConfigPlainText, haproxyConfig)
 	}
 
 	for _, config := range configs {
@@ -405,6 +455,36 @@ func globalConfigString(hcluster *hyperv1.HostedCluster) (string, error) {
 	rawConfig := globalConfigBytes.String()
 
 	// Some fields in the ClusterConfiguration have changes that are not backwards compatible with older versions of the CPO.
+	return backwardcompat.GetBackwardCompatibleConfigString(rawConfig), nil
+}
+
+// rolloutGlobalConfigString returns a global config string derived only from user-set spec fields
+// (proxy spec, image spec) without reconciling platform-specific defaults. This ensures that
+// operator code changes to computed defaults (e.g., new NoProxy entries like network CIDRs or
+// 169.254.169.254 for AWS) do not change the rollout hash and trigger unintended rollouts.
+// The full reconciled config continues to be used for payload generation via globalConfigString.
+func rolloutGlobalConfigString(hcluster *hyperv1.HostedCluster) (string, error) {
+	proxy := globalconfig.ProxyConfig()
+	globalconfig.ReconcileProxyConfig(proxy, hcluster.Spec.Configuration)
+
+	image := globalconfig.ImageConfig()
+	globalconfig.ReconcileImageConfigFromHostedCluster(image, hcluster)
+
+	globalConfigBytes := bytes.NewBuffer(nil)
+
+	proxyBytes, err := api.CompatibleJSONEncode(proxy)
+	if err != nil {
+		return "", fmt.Errorf("failed to encode proxy global config: %w", err)
+	}
+	globalConfigBytes.Write(proxyBytes)
+
+	imageBytes, err := api.CompatibleJSONEncode(image)
+	if err != nil {
+		return "", fmt.Errorf("failed to encode image global config: %w", err)
+	}
+	globalConfigBytes.Write(imageBytes)
+
+	rawConfig := globalConfigBytes.String()
 	return backwardcompat.GetBackwardCompatibleConfigString(rawConfig), nil
 }
 

--- a/hypershift-operator/controllers/nodepool/config_test.go
+++ b/hypershift-operator/controllers/nodepool/config_test.go
@@ -805,6 +805,399 @@ func TestHashWithoutVersion(t *testing.T) {
 	}
 }
 
+func TestRolloutHash(t *testing.T) {
+	baseCaseUserConfig := "test config"
+	baseCaseReleaseVersion := "4.7.0"
+	baseCasePullSecretName := "pull-secret"
+	baseCaseAdditionalTrustBundleName := "trust-bundle"
+	baseCaseGlobalConfig := "global config"
+	baseCaseRolloutGlobalConfig := "rollout global config"
+	baseCaseHAProxyRawConfig := "haproxy static pod manifest with image digest"
+
+	newConfigGenerator := func(mods ...func(*rolloutConfig)) *ConfigGenerator {
+		rc := &rolloutConfig{
+			// mcoRawConfig includes haproxy in production (prepended by parse()),
+			// so we simulate that by concatenating haproxy + user config.
+			mcoRawConfig:              baseCaseHAProxyRawConfig + "\n---\n" + baseCaseUserConfig,
+			rolloutMcoRawConfig:       baseCaseUserConfig,
+			pullSecretName:            baseCasePullSecretName,
+			additionalTrustBundleName: baseCaseAdditionalTrustBundleName,
+			globalConfig:              baseCaseGlobalConfig,
+			rolloutGlobalConfig:       baseCaseRolloutGlobalConfig,
+			haproxyRawConfig:          baseCaseHAProxyRawConfig,
+			releaseImage: &releaseinfo.ReleaseImage{
+				ImageStream: &imageapi.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{Name: baseCaseReleaseVersion},
+				},
+			},
+		}
+		for _, mod := range mods {
+			mod(rc)
+		}
+		return &ConfigGenerator{rolloutConfig: rc}
+	}
+
+	baseCG := newConfigGenerator()
+	baseCaseRolloutHash := baseCG.RolloutHash()
+
+	testCases := []struct {
+		name          string
+		modify        func(*rolloutConfig)
+		expectChanged bool
+	}{
+		{
+			name: "When only the haproxyRawConfig changes it should NOT change the RolloutHash",
+			modify: func(rc *rolloutConfig) {
+				rc.haproxyRawConfig = "different-haproxy-image:v2"
+				rc.mcoRawConfig = "different-haproxy-image:v2" + "\n---\n" + baseCaseUserConfig
+			},
+			expectChanged: false,
+		},
+		{
+			name: "When the user config changes it should change the RolloutHash",
+			modify: func(rc *rolloutConfig) {
+				rc.rolloutMcoRawConfig = "different user config"
+				rc.mcoRawConfig = baseCaseHAProxyRawConfig + "\n---\n" + "different user config"
+			},
+			expectChanged: true,
+		},
+		{
+			name:          "When the pullSecretName changes it should change the RolloutHash",
+			modify:        func(rc *rolloutConfig) { rc.pullSecretName = "different-pull-secret" },
+			expectChanged: true,
+		},
+		{
+			name:          "When the additionalTrustBundleName changes it should change the RolloutHash",
+			modify:        func(rc *rolloutConfig) { rc.additionalTrustBundleName = "different-trust-bundle" },
+			expectChanged: true,
+		},
+		{
+			name:          "When the rolloutGlobalConfig changes it should change the RolloutHash",
+			modify:        func(rc *rolloutConfig) { rc.rolloutGlobalConfig = "different spec proxy config" },
+			expectChanged: true,
+		},
+		{
+			name:          "When only the full globalConfig changes it should NOT change the RolloutHash",
+			modify:        func(rc *rolloutConfig) { rc.globalConfig = "different platform-computed proxy config" },
+			expectChanged: false,
+		},
+		{
+			name: "When the release version changes it should change the RolloutHash",
+			modify: func(rc *rolloutConfig) {
+				rc.releaseImage = &releaseinfo.ReleaseImage{
+					ImageStream: &imageapi.ImageStream{
+						ObjectMeta: metav1.ObjectMeta{Name: "4.8.0"},
+					},
+				}
+			},
+			expectChanged: true,
+		},
+		{
+			name:          "When the rhelStream changes it should change the RolloutHash",
+			modify:        func(rc *rolloutConfig) { rc.rhelStream = "rhel-10" },
+			expectChanged: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			cg := newConfigGenerator(tc.modify)
+			rolloutHash := cg.RolloutHash()
+			g.Expect(rolloutHash).ToNot(BeEmpty())
+
+			if tc.expectChanged {
+				g.Expect(rolloutHash).ToNot(Equal(baseCaseRolloutHash),
+					"RolloutHash should change for spec-driven input changes")
+			} else {
+				g.Expect(rolloutHash).To(Equal(baseCaseRolloutHash),
+					"RolloutHash should NOT change for management-side input changes")
+			}
+		})
+	}
+
+	t.Run("When haproxyRawConfig changes the payload Hash should still change", func(t *testing.T) {
+		g := NewWithT(t)
+
+		original := newConfigGenerator()
+		modified := newConfigGenerator(func(rc *rolloutConfig) {
+			rc.haproxyRawConfig = "completely-different-haproxy-manifest"
+			rc.mcoRawConfig = "completely-different-haproxy-manifest" + "\n---\n" + baseCaseUserConfig
+		})
+
+		g.Expect(modified.RolloutHash()).To(Equal(original.RolloutHash()),
+			"RolloutHash must be stable across management-side changes")
+		g.Expect(modified.Hash()).ToNot(Equal(original.Hash()),
+			"payload Hash must still reflect management-side changes")
+	})
+}
+
+func TestRolloutHashAnnotationSeeding(t *testing.T) {
+	t.Run("When the nodePoolCurrentRolloutConfig annotation is absent it should not signal isUpdatingConfig", func(t *testing.T) {
+		g := NewWithT(t)
+
+		rolloutHash := "abc123"
+		nodePool := &hyperv1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{},
+			},
+		}
+
+		_, seeded := nodePool.Annotations[nodePoolAnnotationCurrentRolloutConfig]
+		g.Expect(seeded).To(BeFalse(), "annotation should be absent before seeding")
+
+		nodePool.Annotations[nodePoolAnnotationCurrentRolloutConfig] = rolloutHash
+
+		g.Expect(nodePool.Annotations[nodePoolAnnotationCurrentRolloutConfig]).To(Equal(rolloutHash),
+			"annotation should be set to the computed rollout hash")
+	})
+
+	t.Run("When the nodePoolCurrentRolloutConfig annotation matches the current hash it should not trigger a rollout", func(t *testing.T) {
+		g := NewWithT(t)
+
+		rolloutHash := "abc123"
+		nodePool := &hyperv1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					nodePoolAnnotationCurrentRolloutConfig: rolloutHash,
+				},
+			},
+		}
+
+		isUpdating := rolloutHash != nodePool.Annotations[nodePoolAnnotationCurrentRolloutConfig]
+		g.Expect(isUpdating).To(BeFalse(), "no rollout should be triggered when hashes match")
+	})
+
+	t.Run("When the nodePoolCurrentRolloutConfig annotation differs from the current hash it should trigger a rollout", func(t *testing.T) {
+		g := NewWithT(t)
+
+		oldHash := "abc123"
+		newHash := "def456"
+		nodePool := &hyperv1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					nodePoolAnnotationCurrentRolloutConfig: oldHash,
+				},
+			},
+		}
+
+		isUpdating := newHash != nodePool.Annotations[nodePoolAnnotationCurrentRolloutConfig]
+		g.Expect(isUpdating).To(BeTrue(), "rollout should be triggered when hashes differ")
+	})
+}
+
+func TestRolloutGlobalConfigString(t *testing.T) {
+	t.Run("When hosted cluster has proxy spec, rolloutGlobalConfig should not include platform-computed NoProxy entries", func(t *testing.T) {
+		g := NewWithT(t)
+
+		hcluster := &hyperv1.HostedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test",
+			},
+			Spec: hyperv1.HostedClusterSpec{
+				Platform: hyperv1.PlatformSpec{
+					Type: hyperv1.AWSPlatform,
+					AWS: &hyperv1.AWSPlatformSpec{
+						Region: "us-east-1",
+					},
+				},
+				Networking: hyperv1.ClusterNetworking{
+					ServiceNetwork: []hyperv1.ServiceNetworkEntry{{CIDR: *ipnet.MustParseCIDR("10.96.0.0/12")}},
+					ClusterNetwork: []hyperv1.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("10.244.0.0/16")}},
+				},
+				Configuration: &hyperv1.ClusterConfiguration{
+					Proxy: &configv1.ProxySpec{
+						HTTPProxy:  "http://proxy.example.com:3128",
+						HTTPSProxy: "https://proxy.example.com:3128",
+						NoProxy:    ".example.com",
+					},
+				},
+			},
+		}
+
+		rolloutConfig, err := rolloutGlobalConfigString(hcluster)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		fullConfig, err := globalConfigString(hcluster)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(rolloutConfig).ToNot(Equal(fullConfig),
+			"rolloutGlobalConfig should differ from fullConfig when platform adds NoProxy defaults")
+
+		g.Expect(rolloutConfig).ToNot(ContainSubstring("169.254.169.254"),
+			"rolloutGlobalConfig should not contain AWS metadata endpoint added by defaultProxyStatus")
+		g.Expect(rolloutConfig).ToNot(ContainSubstring("10.96.0.0"),
+			"rolloutGlobalConfig should not contain service network CIDRs added by defaultProxyStatus")
+	})
+
+	t.Run("When hosted cluster has no proxy spec, both configs should be equal", func(t *testing.T) {
+		g := NewWithT(t)
+
+		hcluster := &hyperv1.HostedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test",
+			},
+			Spec: hyperv1.HostedClusterSpec{
+				Platform: hyperv1.PlatformSpec{
+					Type: hyperv1.AWSPlatform,
+				},
+			},
+		}
+
+		rolloutConfig, err := rolloutGlobalConfigString(hcluster)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		fullConfig, err := globalConfigString(hcluster)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(rolloutConfig).To(Equal(fullConfig),
+			"without proxy spec, both configs should produce the same output")
+	})
+
+	t.Run("When proxy spec changes, rolloutGlobalConfig should change", func(t *testing.T) {
+		g := NewWithT(t)
+
+		hcluster1 := &hyperv1.HostedCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
+			Spec: hyperv1.HostedClusterSpec{
+				Configuration: &hyperv1.ClusterConfiguration{
+					Proxy: &configv1.ProxySpec{
+						HTTPProxy: "http://proxy1.example.com:3128",
+					},
+				},
+			},
+		}
+
+		hcluster2 := &hyperv1.HostedCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
+			Spec: hyperv1.HostedClusterSpec{
+				Configuration: &hyperv1.ClusterConfiguration{
+					Proxy: &configv1.ProxySpec{
+						HTTPProxy: "http://proxy2.example.com:3128",
+					},
+				},
+			},
+		}
+
+		config1, err := rolloutGlobalConfigString(hcluster1)
+		g.Expect(err).ToNot(HaveOccurred())
+		config2, err := rolloutGlobalConfigString(hcluster2)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(config1).ToNot(Equal(config2),
+			"different proxy specs should produce different rolloutGlobalConfig values")
+	})
+}
+
+func TestIsOutdated(t *testing.T) {
+	makeToken := func(version string, nodePool *hyperv1.NodePool) *Token {
+		return &Token{
+			ConfigGenerator: &ConfigGenerator{
+				rolloutConfig: &rolloutConfig{
+					rolloutMcoRawConfig:       "config",
+					pullSecretName:            "pull",
+					additionalTrustBundleName: "trust",
+					rolloutGlobalConfig:       "global",
+					releaseImage: &releaseinfo.ReleaseImage{
+						ImageStream: &imageapi.ImageStream{
+							ObjectMeta: metav1.ObjectMeta{Name: version},
+						},
+					},
+				},
+				nodePool: nodePool,
+			},
+		}
+	}
+
+	// Pre-compute the rollout hash for the base config so annotations can match.
+	baseToken := makeToken("4.18.0", &hyperv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+	})
+	baseRolloutHash := baseToken.RolloutHashWithoutVersion()
+
+	testCases := []struct {
+		name     string
+		token    *Token
+		expected bool
+	}{
+		{
+			name: "New NodePool with no annotations should be outdated",
+			token: makeToken("4.18.0", &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			}),
+			expected: true,
+		},
+		{
+			name: "Existing NodePool after upgrade with old annotation but no new annotation should not be outdated",
+			token: makeToken("4.18.0", &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						nodePoolAnnotationCurrentConfigVersion: "old-hash",
+					},
+				},
+				Status: hyperv1.NodePoolStatus{
+					Version: "4.18.0",
+				},
+			}),
+			expected: false,
+		},
+		{
+			name: "When rollout hash matches and version matches it should not be outdated",
+			token: makeToken("4.18.0", &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						nodePoolAnnotationCurrentRolloutConfig: baseRolloutHash,
+					},
+				},
+				Status: hyperv1.NodePoolStatus{
+					Version: "4.18.0",
+				},
+			}),
+			expected: false,
+		},
+		{
+			name: "When version changes it should be outdated",
+			token: makeToken("4.19.0", &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						nodePoolAnnotationCurrentRolloutConfig: baseRolloutHash,
+					},
+				},
+				Status: hyperv1.NodePoolStatus{
+					Version: "4.18.0",
+				},
+			}),
+			expected: true,
+		},
+		{
+			name: "When rollout config changes it should be outdated",
+			token: makeToken("4.18.0", &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						nodePoolAnnotationCurrentRolloutConfig: "stale-rollout-hash",
+					},
+				},
+				Status: hyperv1.NodePoolStatus{
+					Version: "4.18.0",
+				},
+			}),
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tc.token.isOutdated()).To(Equal(tc.expected))
+		})
+	}
+}
+
 func TestGenerateMCORawConfig(t *testing.T) {
 	coreMachineConfig1 := `
 apiVersion: machineconfiguration.openshift.io/v1
@@ -1617,7 +2010,7 @@ status:
 				cg.haproxyRawConfig = haproxyIgnititionConfig
 			}
 
-			got, err := cg.generateMCORawConfig(t.Context(), hc.Spec.Capabilities)
+			got, _, err := cg.generateMCORawConfig(t.Context(), hc.Spec.Capabilities)
 			if tc.error {
 				g.Expect(err).To(HaveOccurred())
 				if tc.missingCoreConfig {

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -66,6 +66,7 @@ const (
 	nodePoolAnnotationCurrentConfig          = "hypershift.openshift.io/nodePoolCurrentConfig"
 	nodePoolAnnotationCurrentConfigVersion   = "hypershift.openshift.io/nodePoolCurrentConfigVersion"
 	nodePoolAnnotationTargetConfigVersion    = "hypershift.openshift.io/nodePoolTargetConfigVersion"
+	nodePoolAnnotationCurrentRolloutConfig   = "hypershift.openshift.io/nodePoolCurrentRolloutConfig"
 	nodePoolAnnotationUpgradeInProgressTrue  = "hypershift.openshift.io/nodePoolUpgradeInProgressTrue"
 	nodePoolAnnotationUpgradeInProgressFalse = "hypershift.openshift.io/nodePoolUpgradeInProgressFalse"
 	nodePoolAnnotationMaxUnavailable         = "hypershift.openshift.io/nodePoolMaxUnavailable"
@@ -315,6 +316,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		r.supportedVersionSkewCondition,
 		r.validMachineConfigCondition,
 		r.updatingConfigCondition,
+		r.configUpdatePendingCondition,
 		r.updatingVersionCondition,
 		// Conditition that depends on a valid config/token.
 		r.validGeneratedPayloadCondition,
@@ -418,10 +420,20 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 		return ctrl.Result{}, err
 	}
 
+	// Seed the rollout config annotation on first reconcile after operator upgrade.
+	// This must happen before any rollout decision to prevent spurious rollouts.
+	if _, ok := nodePool.Annotations[nodePoolAnnotationCurrentRolloutConfig]; !ok {
+		if nodePool.Annotations == nil {
+			nodePool.Annotations = make(map[string]string)
+		}
+		nodePool.Annotations[nodePoolAnnotationCurrentRolloutConfig] = token.RolloutHashWithoutVersion()
+	}
+
 	// non automated infrastructure should not have any machine level cluster-api components
 	if !isAutomatedMachineManagement(nodePool) {
 		targetConfigHash := token.HashWithoutVersion()
 		targetPayloadConfigHash := token.Hash()
+		targetRolloutConfigHash := token.RolloutHashWithoutVersion()
 		nodePool.Status.Version = releaseImage.Version()
 		if nodePool.Annotations == nil {
 			nodePool.Annotations = make(map[string]string)
@@ -432,6 +444,7 @@ func (r *NodePoolReconciler) reconcile(ctx context.Context, hcluster *hyperv1.Ho
 			nodePool.Annotations[nodePoolAnnotationCurrentConfig] = targetConfigHash
 		}
 		nodePool.Annotations[nodePoolAnnotationCurrentConfigVersion] = targetPayloadConfigHash
+		nodePool.Annotations[nodePoolAnnotationCurrentRolloutConfig] = targetRolloutConfigHash
 		return ctrl.Result{}, nil
 	}
 
@@ -751,7 +764,11 @@ func isUpdatingVersion(nodePool *hyperv1.NodePool, targetVersion string) bool {
 }
 
 func isUpdatingConfig(nodePool *hyperv1.NodePool, targetConfigHash string) bool {
-	return targetConfigHash != nodePool.GetAnnotations()[nodePoolAnnotationCurrentConfig]
+	currentHash := nodePool.GetAnnotations()[nodePoolAnnotationCurrentRolloutConfig]
+	if currentHash == "" {
+		return false
+	}
+	return targetConfigHash != currentHash
 }
 
 func isUpdatingMachineTemplate(nodePool *hyperv1.NodePool, targetMachineTemplate string) bool {

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -61,7 +61,7 @@ func TestIsUpdatingConfig(t *testing.T) {
 			nodePool: &hyperv1.NodePool{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						nodePoolAnnotationCurrentConfig: "same",
+						nodePoolAnnotationCurrentRolloutConfig: "same",
 					},
 				},
 			},
@@ -73,12 +73,22 @@ func TestIsUpdatingConfig(t *testing.T) {
 			nodePool: &hyperv1.NodePool{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						nodePoolAnnotationCurrentConfig: "config1",
+						nodePoolAnnotationCurrentRolloutConfig: "config1",
 					},
 				},
 			},
 			target: "config2",
 			expect: true,
+		},
+		{
+			name: "it is not updating when annotation is absent",
+			nodePool: &hyperv1.NodePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			target: "config1",
+			expect: false,
 		},
 	}
 

--- a/hypershift-operator/controllers/nodepool/token.go
+++ b/hypershift-operator/controllers/nodepool/token.go
@@ -171,8 +171,23 @@ func (t *Token) getIgnitionCACert(ctx context.Context) ([]byte, error) {
 	return caCertBytes, nil
 }
 
+// isOutdated returns true when a spec-driven change (version or config) requires
+// new token and user-data secrets. Management-side-only changes (e.g. HAProxy image
+// bumps) return false — existing secrets remain valid and the MachineDeployment
+// continues to reference them.
 func (t *Token) isOutdated() bool {
-	return t.Hash() != t.nodePool.Annotations[nodePoolAnnotationCurrentConfigVersion]
+	currentRolloutConfig := t.nodePool.Annotations[nodePoolAnnotationCurrentRolloutConfig]
+	if currentRolloutConfig == "" {
+		// Annotation absent: either a new NodePool (need to create secrets) or
+		// an existing NodePool after operator upgrade (secrets already exist).
+		if _, hasOldAnnotation := t.nodePool.Annotations[nodePoolAnnotationCurrentConfigVersion]; hasOldAnnotation {
+			return false
+		}
+		return true
+	}
+	versionChanged := t.Version() != t.nodePool.Status.Version
+	configChanged := t.RolloutHashWithoutVersion() != currentRolloutConfig
+	return versionChanged || configChanged
 }
 
 func (t *Token) cleanupOutdated(ctx context.Context) error {
@@ -232,10 +247,17 @@ func setExpirationTimestampOnToken(ctx context.Context, c client.Client, tokenSe
 func (t *Token) Reconcile(ctx context.Context) error {
 	log := ctrl.LoggerFrom(ctx)
 
-	if t.isOutdated() {
-		if err := t.cleanupOutdated(ctx); err != nil {
-			return fmt.Errorf("failed to cleanup outdated token Secrets: %w", err)
-		}
+	if !t.isOutdated() {
+		// Rollout hash and version unchanged. Existing secrets are valid and
+		// the MachineDeployment continues to reference them. Skip secret
+		// creation and cleanup to prevent orphaned secrets on management-side
+		// config changes (e.g. HAProxy image bumps).
+		log.V(4).Info("Token secrets up to date, skipping reconciliation")
+		return nil
+	}
+
+	if err := t.cleanupOutdated(ctx); err != nil {
+		return fmt.Errorf("failed to cleanup outdated token Secrets: %w", err)
 	}
 
 	tokenSecret := t.TokenSecret()

--- a/test/e2e/v2/tests/nodepool_lifecycle_test.go
+++ b/test/e2e/v2/tests/nodepool_lifecycle_test.go
@@ -65,6 +65,7 @@ func RegisterNodePoolLifecycleTests(getTestCtx internal.TestContextGetter) {
 	NodePoolNTOPerformanceProfileTest(getTestCtx)
 	NodePoolAutoRepairTest(getTestCtx)
 	NodePoolDiskEncryptionTest(getTestCtx)
+	RegisterPredictableRolloutTests(getTestCtx)
 }
 
 var _ = Describe("[sig-hypershift][Jira:Hypershift][Feature:NodePoolLifecycle] NodePool Lifecycle", Label("lifecycle", "nodepool-lifecycle"), func() {

--- a/test/e2e/v2/tests/nodepool_rollout_control_test.go
+++ b/test/e2e/v2/tests/nodepool_rollout_control_test.go
@@ -1,0 +1,423 @@
+//go:build e2ev2
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	ignitionapi "github.com/coreos/ignition/v2/config/v3_2/types"
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	hyperapi "github.com/openshift/hypershift/support/api"
+	e2eutil "github.com/openshift/hypershift/test/e2e/util"
+	"github.com/openshift/hypershift/test/e2e/v2/internal"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	nodePoolCurrentRolloutConfigAnnotation = "hypershift.openshift.io/nodePoolCurrentRolloutConfig"
+	nodePoolCurrentConfigAnnotation        = "hypershift.openshift.io/nodePoolCurrentConfig"
+)
+
+func RegisterPredictableRolloutTests(getTestCtx internal.TestContextGetter) {
+	ManagementImageChangeNoRolloutTest(getTestCtx)
+	SpecDrivenChangeTriggersRolloutTest(getTestCtx)
+	OperatorUpgradeNoRolloutTest(getTestCtx)
+}
+
+var _ = Describe("Predictable NodePool Rollout", Label("lifecycle", "predictable-rollout"), func() {
+	var testCtx *internal.TestContext
+
+	BeforeEach(func() {
+		testCtx = internal.GetTestContext()
+		Expect(testCtx).NotTo(BeNil(), "test context should be set up in BeforeSuite")
+	})
+
+	RegisterPredictableRolloutTests(func() *internal.TestContext { return testCtx })
+})
+
+func ManagementImageChangeNoRolloutTest(getTestCtx internal.TestContextGetter) {
+	When("a management-side image changes on an existing NodePool", func() {
+		It("should NOT trigger a rollout when only the HAProxy image annotation changes", func() {
+			testCtx := getTestCtx()
+			testCtx.ValidateHostedClusterClient()
+
+			hc := testCtx.GetHostedCluster()
+			hcClient := testCtx.GetHostedClusterClient()
+			ctx := testCtx.Context
+
+			defaultNP := getDefaultNodePool(ctx, testCtx.MgmtClient, hc)
+			Expect(defaultNP).NotTo(BeNil(), "default NodePool should exist")
+
+			np := &hyperv1.NodePool{}
+			Expect(testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(defaultNP), np)).To(Succeed())
+
+			Expect(np.Annotations).To(HaveKey(nodePoolCurrentRolloutConfigAnnotation),
+				"NodePool %s should have the rollout config annotation set by the controller", np.Name)
+			baselineRolloutHash := np.Annotations[nodePoolCurrentRolloutConfigAnnotation]
+			Expect(baselineRolloutHash).NotTo(BeEmpty())
+
+			baselineConfigHash := np.Annotations[nodePoolCurrentConfigAnnotation]
+
+			foundUpdatingConfig := false
+			for _, cond := range np.Status.Conditions {
+				if cond.Type == hyperv1.NodePoolUpdatingConfigConditionType {
+					foundUpdatingConfig = true
+					Expect(string(cond.Status)).To(Equal(string(metav1.ConditionFalse)),
+						"UpdatingConfig should be False before test mutation")
+					break
+				}
+			}
+			Expect(foundUpdatingConfig).To(BeTrue(),
+				"NodePool %s should have UpdatingConfig condition", np.Name)
+
+			baselineNodes := &corev1.NodeList{}
+			Expect(hcClient.List(ctx, baselineNodes, crclient.MatchingLabels{
+				hyperv1.NodePoolLabel: np.Name,
+			})).To(Succeed())
+			Expect(baselineNodes.Items).NotTo(BeEmpty(),
+				"NodePool %s should have at least one ready node", np.Name)
+			baselineNodeNames := nodeNames(baselineNodes)
+
+			By("patching the HAProxy image annotation to simulate a management-side image change")
+			original := np.DeepCopy()
+			if np.Annotations == nil {
+				np.Annotations = map[string]string{}
+			}
+			np.Annotations[hyperv1.NodePoolHAProxyImageAnnotation] = "quay.io/openshift/origin-haproxy-router:e2e-dummy-digest"
+			Expect(testCtx.MgmtClient.Patch(ctx, np, crclient.MergeFrom(original))).To(Succeed(),
+				"failed to patch NodePool %s with HAProxy image annotation", np.Name)
+			GinkgoWriter.Printf("Patched NodePool %s with dummy HAProxy image annotation\n", np.Name)
+
+			DeferCleanup(func() {
+				fresh := &hyperv1.NodePool{}
+				err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(np), fresh)
+				if apierrors.IsNotFound(err) {
+					return
+				}
+				Expect(err).NotTo(HaveOccurred(), "cleanup: failed to get NodePool %s", np.Name)
+				patch := fresh.DeepCopy()
+				delete(patch.Annotations, hyperv1.NodePoolHAProxyImageAnnotation)
+				Expect(testCtx.MgmtClient.Patch(ctx, patch, crclient.MergeFrom(fresh))).To(Succeed(),
+					"cleanup: failed to remove HAProxy image annotation from NodePool %s", np.Name)
+			})
+
+			By("verifying that no rollout is triggered over 2 minutes")
+			Consistently(func(g Gomega) {
+				fresh := &hyperv1.NodePool{}
+				g.Expect(testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(np), fresh)).To(Succeed())
+
+				g.Expect(fresh.Annotations).To(HaveKeyWithValue(
+					nodePoolCurrentRolloutConfigAnnotation, baselineRolloutHash),
+					"rollout config annotation should not change for management-side image changes")
+
+				for _, cond := range fresh.Status.Conditions {
+					if cond.Type == hyperv1.NodePoolUpdatingConfigConditionType {
+						g.Expect(string(cond.Status)).To(Equal(string(metav1.ConditionFalse)),
+							"UpdatingConfig should remain False — management-side image change must not trigger rollout")
+						break
+					}
+				}
+
+				currentNodes := &corev1.NodeList{}
+				g.Expect(hcClient.List(ctx, currentNodes, crclient.MatchingLabels{
+					hyperv1.NodePoolLabel: np.Name,
+				})).To(Succeed())
+				g.Expect(len(currentNodes.Items)).To(Equal(len(baselineNodes.Items)),
+					"node count should not change")
+			}, 2*time.Minute, 15*time.Second).Should(Succeed())
+
+			By("verifying node identity is unchanged (no replacement)")
+			finalNodes := &corev1.NodeList{}
+			Expect(hcClient.List(ctx, finalNodes, crclient.MatchingLabels{
+				hyperv1.NodePoolLabel: np.Name,
+			})).To(Succeed())
+			Expect(nodeNames(finalNodes)).To(ConsistOf(baselineNodeNames),
+				"node names should be identical — no node replacement should have occurred")
+
+			By("verifying the payload config hash may have changed but rollout hash did not")
+			finalNP := &hyperv1.NodePool{}
+			Expect(testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(np), finalNP)).To(Succeed())
+			Expect(finalNP.Annotations[nodePoolCurrentRolloutConfigAnnotation]).To(Equal(baselineRolloutHash),
+				"rollout hash annotation must remain stable")
+			_ = baselineConfigHash
+		})
+	})
+}
+
+func SpecDrivenChangeTriggersRolloutTest(getTestCtx internal.TestContextGetter) {
+	When("a spec-driven change is made to a NodePool", func() {
+		It("should trigger a rollout and update the rollout hash annotation when a MachineConfig is added", func() {
+			testCtx := getTestCtx()
+			testCtx.ValidateHostedClusterClient()
+
+			hc := testCtx.GetHostedCluster()
+			if hc.Spec.Platform.Type == hyperv1.KubevirtPlatform {
+				Skip("test is skipped for KubeVirt platform until https://issues.redhat.com/browse/CNV-38196 is addressed")
+			}
+
+			hcClient := testCtx.GetHostedClusterClient()
+			ctx := testCtx.Context
+
+			defaultNP := getDefaultNodePool(ctx, testCtx.MgmtClient, hc)
+			Expect(defaultNP).NotTo(BeNil(), "default NodePool should exist")
+
+			var oneReplica int32 = 1
+			np := buildTestNodePool(defaultNP, "rollout-ctl", func(pool *hyperv1.NodePool) {
+				pool.Spec.Replicas = &oneReplica
+				pool.Spec.Management.Replace = &hyperv1.ReplaceUpgrade{
+					Strategy: hyperv1.UpgradeStrategyRollingUpdate,
+					RollingUpdate: &hyperv1.RollingUpdate{
+						MaxUnavailable: ptr.To(intstr.FromInt32(0)),
+						MaxSurge:       ptr.To(intstr.FromInt32(oneReplica)),
+					},
+				}
+			})
+
+			err := testCtx.MgmtClient.Create(ctx, np)
+			Expect(err).NotTo(HaveOccurred(), "failed to create NodePool %s", np.Name)
+			GinkgoWriter.Printf("Created NodePool %s\n", np.Name)
+			DeferCleanup(func() {
+				cleanupNodePool(ctx, testCtx.MgmtClient, np)
+			})
+
+			e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+
+			Expect(testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(np), np)).To(Succeed())
+			Expect(np.Annotations).To(HaveKey(nodePoolCurrentRolloutConfigAnnotation),
+				"NodePool %s should have rollout config annotation after becoming ready", np.Name)
+			baselineRolloutHash := np.Annotations[nodePoolCurrentRolloutConfigAnnotation]
+			baselineConfigHash := np.Annotations[nodePoolCurrentConfigAnnotation]
+
+			By("creating a MachineConfig and patching the NodePool to reference it")
+			ignitionConfig := ignitionapi.Config{
+				Ignition: ignitionapi.Ignition{Version: "3.2.0"},
+				Storage: ignitionapi.Storage{
+					Files: []ignitionapi.File{{
+						Node:          ignitionapi.Node{Path: "/etc/predictable-rollout-test"},
+						FileEmbedded1: ignitionapi.FileEmbedded1{Contents: ignitionapi.Resource{Source: ptr.To("data:,rollout-test%0A")}},
+					}},
+				},
+			}
+			serializedIgnition, err := json.Marshal(ignitionConfig)
+			Expect(err).NotTo(HaveOccurred(), "failed to serialize ignition config")
+
+			machineConfig := &mcfgv1.MachineConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "predictable-rollout-test",
+					Labels: map[string]string{"machineconfiguration.openshift.io/role": "worker"},
+				},
+				Spec: mcfgv1.MachineConfigSpec{Config: runtime.RawExtension{Raw: serializedIgnition}},
+			}
+			gvk, err := apiutil.GVKForObject(machineConfig, hyperapi.Scheme)
+			Expect(err).NotTo(HaveOccurred(), "failed to get GVK for MachineConfig")
+			machineConfig.SetGroupVersionKind(gvk)
+
+			serializedMC, err := yaml.Marshal(machineConfig)
+			Expect(err).NotTo(HaveOccurred(), "failed to serialize MachineConfig")
+
+			mcConfigMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      e2eutil.SimpleNameGenerator.GenerateName("rollout-ctl-mc-"),
+					Namespace: hc.Namespace,
+				},
+				Data: map[string]string{"config": string(serializedMC)},
+			}
+			Expect(testCtx.MgmtClient.Create(ctx, mcConfigMap)).To(Succeed(), "failed to create MachineConfig ConfigMap")
+			DeferCleanup(func() {
+				if err := testCtx.MgmtClient.Delete(ctx, mcConfigMap); err != nil && !apierrors.IsNotFound(err) {
+					Expect(err).NotTo(HaveOccurred(), "cleanup: failed to delete ConfigMap %s", mcConfigMap.Name)
+				}
+			})
+			GinkgoWriter.Printf("Created MachineConfig ConfigMap %s\n", mcConfigMap.Name)
+
+			original := np.DeepCopy()
+			np.Spec.Config = append(np.Spec.Config, corev1.LocalObjectReference{Name: mcConfigMap.Name})
+			Expect(testCtx.MgmtClient.Patch(ctx, np, crclient.MergeFrom(original))).To(Succeed(),
+				"failed to patch NodePool %s with MachineConfig", np.Name)
+
+			By("waiting for the rollout to complete")
+			e2eutil.WaitForNodePoolConfigUpdateCompleteWithPlatform(GinkgoTB(), ctx, testCtx.MgmtClient, np, hc.Spec.Platform.Type)
+			e2eutil.WaitForReadyNodesByNodePool(GinkgoTB(), ctx, hcClient, np, hc.Spec.Platform.Type)
+
+			By("verifying the rollout hash annotation was updated")
+			Expect(testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(np), np)).To(Succeed())
+
+			Expect(np.Annotations).To(HaveKey(nodePoolCurrentRolloutConfigAnnotation))
+			Expect(np.Annotations[nodePoolCurrentRolloutConfigAnnotation]).NotTo(Equal(baselineRolloutHash),
+				"rollout config annotation should change after a spec-driven rollout")
+			Expect(np.Annotations[nodePoolCurrentRolloutConfigAnnotation]).NotTo(BeEmpty())
+
+			Expect(np.Annotations).To(HaveKey(nodePoolCurrentConfigAnnotation))
+			Expect(np.Annotations[nodePoolCurrentConfigAnnotation]).NotTo(Equal(baselineConfigHash),
+				"current config annotation should also change after a spec-driven rollout")
+			Expect(np.Annotations[nodePoolCurrentConfigAnnotation]).NotTo(BeEmpty())
+		})
+	})
+}
+
+func OperatorUpgradeNoRolloutTest(getTestCtx internal.TestContextGetter) {
+	When("the HyperShift operator is upgraded to support rollout hash", func() {
+		It("should seed the rollout hash annotation on first reconcile without triggering a rollout", func() {
+			testCtx := getTestCtx()
+			testCtx.ValidateHostedClusterClient()
+
+			hc := testCtx.GetHostedCluster()
+			hcClient := testCtx.GetHostedClusterClient()
+			ctx := testCtx.Context
+
+			defaultNP := getStableNodePool(ctx, testCtx.MgmtClient, hc)
+			Expect(defaultNP).NotTo(BeNil(), "a stable (non-deleting) NodePool should exist")
+
+			np := &hyperv1.NodePool{}
+			Expect(testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(defaultNP), np)).To(Succeed())
+
+			Expect(np.Annotations).To(HaveKey(nodePoolCurrentRolloutConfigAnnotation),
+				"NodePool %s should have the rollout config annotation before test", np.Name)
+
+			baselineConfigHash := np.Annotations[nodePoolCurrentConfigAnnotation]
+
+			foundUpdatingConfig := false
+			for _, cond := range np.Status.Conditions {
+				if cond.Type == hyperv1.NodePoolUpdatingConfigConditionType {
+					foundUpdatingConfig = true
+					Expect(string(cond.Status)).To(Equal(string(metav1.ConditionFalse)),
+						"UpdatingConfig should be False before simulating upgrade")
+					break
+				}
+			}
+			Expect(foundUpdatingConfig).To(BeTrue(),
+				"NodePool %s should have UpdatingConfig condition", np.Name)
+
+			baselineNodes := &corev1.NodeList{}
+			Expect(hcClient.List(ctx, baselineNodes, crclient.MatchingLabels{
+				hyperv1.NodePoolLabel: np.Name,
+			})).To(Succeed())
+			Expect(baselineNodes.Items).NotTo(BeEmpty(),
+				"NodePool %s should have at least one ready node", np.Name)
+			baselineNodeNames := nodeNames(baselineNodes)
+
+			By("removing the rollout config annotation to simulate pre-upgrade state")
+			original := np.DeepCopy()
+			delete(np.Annotations, nodePoolCurrentRolloutConfigAnnotation)
+			Expect(testCtx.MgmtClient.Patch(ctx, np, crclient.MergeFrom(original))).To(Succeed(),
+				"failed to remove rollout config annotation from NodePool %s", np.Name)
+			GinkgoWriter.Printf("Removed rollout config annotation from NodePool %s to simulate pre-upgrade state\n", np.Name)
+
+			By("forcing a reconciliation via a dummy annotation")
+			Expect(testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(np), np)).To(Succeed())
+			original = np.DeepCopy()
+			np.Annotations["hypershift.openshift.io/e2e-reconcile-trigger"] = fmt.Sprintf("%d", time.Now().Unix())
+			Expect(testCtx.MgmtClient.Patch(ctx, np, crclient.MergeFrom(original))).To(Succeed(),
+				"failed to add reconcile trigger annotation to NodePool %s", np.Name)
+			DeferCleanup(func() {
+				fresh := &hyperv1.NodePool{}
+				err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(np), fresh)
+				if apierrors.IsNotFound(err) {
+					return
+				}
+				Expect(err).NotTo(HaveOccurred())
+				patch := fresh.DeepCopy()
+				delete(patch.Annotations, "hypershift.openshift.io/e2e-reconcile-trigger")
+				Expect(testCtx.MgmtClient.Patch(ctx, patch, crclient.MergeFrom(fresh))).To(Succeed(),
+					"cleanup: failed to remove reconcile trigger annotation")
+			})
+
+			By("waiting for the controller to re-seed the rollout config annotation")
+			Eventually(func(g Gomega) {
+				fresh := &hyperv1.NodePool{}
+				g.Expect(testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(np), fresh)).To(Succeed())
+				g.Expect(fresh.Annotations).To(HaveKey(nodePoolCurrentRolloutConfigAnnotation),
+					"controller should re-seed the rollout config annotation")
+				g.Expect(fresh.Annotations[nodePoolCurrentRolloutConfigAnnotation]).NotTo(BeEmpty())
+			}, 1*time.Minute, 10*time.Second).Should(Succeed())
+
+			By("verifying that no rollout was triggered during re-seeding")
+			Consistently(func(g Gomega) {
+				fresh := &hyperv1.NodePool{}
+				g.Expect(testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(np), fresh)).To(Succeed())
+
+				for _, cond := range fresh.Status.Conditions {
+					if cond.Type == hyperv1.NodePoolUpdatingConfigConditionType {
+						g.Expect(string(cond.Status)).To(Equal(string(metav1.ConditionFalse)),
+							"UpdatingConfig should remain False — annotation seeding must not trigger rollout")
+						break
+					}
+				}
+
+				g.Expect(fresh.Annotations[nodePoolCurrentConfigAnnotation]).To(Equal(baselineConfigHash),
+					"current config annotation should not change during seeding")
+
+				currentNodes := &corev1.NodeList{}
+				g.Expect(hcClient.List(ctx, currentNodes, crclient.MatchingLabels{
+					hyperv1.NodePoolLabel: np.Name,
+				})).To(Succeed())
+				g.Expect(len(currentNodes.Items)).To(Equal(len(baselineNodes.Items)),
+					"node count should not change during annotation seeding")
+			}, 2*time.Minute, 15*time.Second).Should(Succeed())
+
+			By("verifying node identity is unchanged (no replacement)")
+			finalNodes := &corev1.NodeList{}
+			Expect(hcClient.List(ctx, finalNodes, crclient.MatchingLabels{
+				hyperv1.NodePoolLabel: np.Name,
+			})).To(Succeed())
+			Expect(nodeNames(finalNodes)).To(ConsistOf(baselineNodeNames),
+				"node names should be identical — no node replacement should have occurred")
+		})
+	})
+}
+
+func getStableNodePool(ctx context.Context, client crclient.Client, hc *hyperv1.HostedCluster) *hyperv1.NodePool {
+	GinkgoHelper()
+
+	npList := &hyperv1.NodePoolList{}
+	err := client.List(ctx, npList, crclient.InNamespace(hc.Namespace))
+	Expect(err).NotTo(HaveOccurred(), "failed to list NodePools")
+	Expect(npList.Items).NotTo(BeEmpty(), "should have at least one NodePool")
+
+	for i := range npList.Items {
+		np := &npList.Items[i]
+		if np.Spec.ClusterName == hc.Name && np.DeletionTimestamp.IsZero() {
+			return np
+		}
+	}
+
+	return nil
+}
+
+func nodeNames(nodeList *corev1.NodeList) []string {
+	names := make([]string, len(nodeList.Items))
+	for i := range nodeList.Items {
+		names[i] = nodeList.Items[i].Name
+	}
+	return names
+}

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_conditions.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_conditions.go
@@ -87,6 +87,12 @@ const (
 	// KubeVirtNodesLiveMigratable indicates if all (VirtualMachines) nodes of the kubevirt
 	// hosted cluster can be live migrated without experiencing a node restart
 	NodePoolKubeVirtLiveMigratableType = "KubeVirtNodesLiveMigratable"
+
+	// NodePoolConfigUpdatePendingConditionType signals that management-side configuration
+	// has changed but no rollout has been triggered. New nodes provisioned during a scale-up
+	// will receive the same configuration as existing nodes. The pending configuration will
+	// be applied on the next spec-driven rollout (e.g. release upgrade, user MachineConfig change).
+	NodePoolConfigUpdatePendingConditionType = "ConfigUpdatePending"
 )
 
 // PerformanceProfile Conditions
@@ -132,4 +138,5 @@ const (
 	CIDRConflictReason                    = "CIDRConflict"
 	NodePoolKubeVirtLiveMigratableReason  = "KubeVirtNodesNotLiveMigratable"
 	NodePoolUnsupportedSkewReason         = "UnsupportedSkew"
+	ManagementConfigDriftReason           = "ManagementConfigDrift"
 )


### PR DESCRIPTION
## What this PR does / why we need it:

Decouples NodePool rollout triggering from management-side configuration changes (e.g. HAProxy image digest bumps) so that only user-driven spec changes cause worker node replacement.

Today the NodePool controller uses a single hash over the entire rendered ignition config — including management-side image references — to drive rollout decisions. Any change to this hash triggers a full Replace/InPlace rollout. This means automated HAProxy image updates (which happen on every HyperShift operator upgrade) cause unnecessary node churn.

This PR introduces:
- **`RolloutHash()` / `RolloutHashWithoutVersion()`**: New hash methods that include only spec-driven inputs (user MachineConfigs, release version, pull secret, trust bundle, global config), excluding management-side content like HAProxy
- **`nodePoolCurrentRolloutConfig` annotation**: Tracks the current rollout config hash, used for rollout decisions instead of comparing data secret names
- **Annotation seeding**: On first reconcile after operator upgrade, the annotation is populated without triggering a rollout
- **`isUpdatingConfig()` safety**: Returns false when the annotation is absent to prevent condition flip-flop during upgrade

The existing `Hash()` and payload secret naming are unchanged — new nodes always get the latest payload including management-side content when they ARE replaced for spec-driven reasons.

## Which issue(s) this PR fixes:

Fixes [OCPSTRAT-3298](https://redhat.atlassian.net/browse/OCPSTRAT-3298)

## Special notes for your reviewer:

- `RolloutHashWithoutVersion()` intentionally includes `globalConfig` unlike the existing `HashWithoutVersion()` which omits it. Proxy/image config changes should trigger rollouts.
- The `parse()` → `doParse()` refactor is necessary because haproxy content is prepended inside `parse()` and cannot be stripped from the final string after the fact.
- The `secret_janitor_test.go` build error is pre-existing and unrelated to this PR.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added rollout configuration tracking for NodePool updates, including automatic initialization after operator upgrades.
  * Added a condition indicating configuration changes are pending until the next spec-driven rollout.

* **Bug Fixes**
  * Management-side HAProxy and image changes no longer trigger unnecessary node replacements.
  * Rollouts now respond predictably to meaningful configuration, version, and template changes.
  * Improved token handling prevents unnecessary secret recreation.
  * Configuration and rollout status remain synchronized, avoiding no-op updates that could delay completion tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->