### PR TITLE
OCPBUGS-13553: Trigger NodePool rollout on in-place pull secret changes

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -675,7 +675,7 @@ type HostedClusterSpec struct {
 	// TODO(alberto): Signal this in a condition.
 	// This pull secret is included in NodePool ignition/bootstrap payloads and applied to the container runtime when nodes provision.
 	// Changing this value will trigger a rollout for all existing NodePools in the cluster (for both replace and inplace upgrade types).
-	// Updating the referenced Secret's data in place (without changing this reference) does not trigger that rollout.
+	// Updating the referenced Secret's data in place (without changing this reference) will also trigger a rollout.
 	// In AWS and Azure NodePools using the Replace upgrade strategy, the Secret's data in place changes
 	// will still propagate the updated credentials down to the guest cluster and kubelet config.
 	// +required

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/AAA_ungated.yaml
@@ -5922,7 +5922,7 @@ spec:
                   If the reference is set but none of the above requirements are met, the HostedCluster will enter a degraded state.
                   This pull secret is included in NodePool ignition/bootstrap payloads and applied to the container runtime when nodes provision.
                   Changing this value will trigger a rollout for all existing NodePools in the cluster (for both replace and inplace upgrade types).
-                  Updating the referenced Secret's data in place (without changing this reference) does not trigger that rollout.
+                  Updating the referenced Secret's data in place (without changing this reference) will also trigger a rollout.
                   In AWS and Azure NodePools using the Replace upgrade strategy, the Secret's data in place changes
                   will still propagate the updated credentials down to the guest cluster and kubelet config.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterUpdateAcceptRisks.yaml
@@ -5905,7 +5905,7 @@ spec:
                   If the reference is set but none of the above requirements are met, the HostedCluster will enter a degraded state.
                   This pull secret is included in NodePool ignition/bootstrap payloads and applied to the container runtime when nodes provision.
                   Changing this value will trigger a rollout for all existing NodePools in the cluster (for both replace and inplace upgrade types).
-                  Updating the referenced Secret's data in place (without changing this reference) does not trigger that rollout.
+                  Updating the referenced Secret's data in place (without changing this reference) will also trigger a rollout.
                   In AWS and Azure NodePools using the Replace upgrade strategy, the Secret's data in place changes
                   will still propagate the updated credentials down to the guest cluster and kubelet config.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -5925,7 +5925,7 @@ spec:
                   If the reference is set but none of the above requirements are met, the HostedCluster will enter a degraded state.
                   This pull secret is included in NodePool ignition/bootstrap payloads and applied to the container runtime when nodes provision.
                   Changing this value will trigger a rollout for all existing NodePools in the cluster (for both replace and inplace upgrade types).
-                  Updating the referenced Secret's data in place (without changing this reference) does not trigger that rollout.
+                  Updating the referenced Secret's data in place (without changing this reference) will also trigger a rollout.
                   In AWS and Azure NodePools using the Replace upgrade strategy, the Secret's data in place changes
                   will still propagate the updated credentials down to the guest cluster and kubelet config.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDC.yaml
@@ -6237,7 +6237,7 @@ spec:
                   If the reference is set but none of the above requirements are met, the HostedCluster will enter a degraded state.
                   This pull secret is included in NodePool ignition/bootstrap payloads and applied to the container runtime when nodes provision.
                   Changing this value will trigger a rollout for all existing NodePools in the cluster (for both replace and inplace upgrade types).
-                  Updating the referenced Secret's data in place (without changing this reference) does not trigger that rollout.
+                  Updating the referenced Secret's data in place (without changing this reference) will also trigger a rollout.
                   In AWS and Azure NodePools using the Replace upgrade strategy, the Secret's data in place changes
                   will still propagate the updated credentials down to the guest cluster and kubelet config.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -6377,7 +6377,7 @@ spec:
                   If the reference is set but none of the above requirements are met, the HostedCluster will enter a degraded state.
                   This pull secret is included in NodePool ignition/bootstrap payloads and applied to the container runtime when nodes provision.
                   Changing this value will trigger a rollout for all existing NodePools in the cluster (for both replace and inplace upgrade types).
-                  Updating the referenced Secret's data in place (without changing this reference) does not trigger that rollout.
+                  Updating the referenced Secret's data in place (without changing this reference) will also trigger a rollout.
                   In AWS and Azure NodePools using the Replace upgrade strategy, the Secret's data in place changes
                   will still propagate the updated credentials down to the guest cluster and kubelet config.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ExternalOIDCWithUpstreamParity.yaml
@@ -6368,7 +6368,7 @@ spec:
                   If the reference is set but none of the above requirements are met, the HostedCluster will enter a degraded state.
                   This pull secret is included in NodePool ignition/bootstrap payloads and applied to the container runtime when nodes provision.
                   Changing this value will trigger a rollout for all existing NodePools in the cluster (for both replace and inplace upgrade types).
-                  Updating the referenced Secret's data in place (without changing this reference) does not trigger that rollout.
+                  Updating the referenced Secret's data in place (without changing this reference) will also trigger a rollout.
                   In AWS and Azure NodePools using the Replace upgrade strategy, the Secret's data in place changes
                   will still propagate the updated credentials down to the guest cluster and kubelet config.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/GCPPlatform.yaml
@@ -6351,7 +6351,7 @@ spec:
                   If the reference is set but none of the above requirements are met, the HostedCluster will enter a degraded state.
                   This pull secret is included in NodePool ignition/bootstrap payloads and applied to the container runtime when nodes provision.
                   Changing this value will trigger a rollout for all existing NodePools in the cluster (for both replace and inplace upgrade types).
-                  Updating the referenced Secret's data in place (without changing this reference) does not trigger that rollout.
+                  Updating the referenced Secret's data in place (without changing this reference) will also trigger a rollout.
                   In AWS and Azure NodePools using the Replace upgrade strategy, the Secret's data in place changes
                   will still propagate the updated credentials down to the guest cluster and kubelet config.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HCPEtcdBackup.yaml
@@ -5970,7 +5970,7 @@ spec:
                   If the reference is set but none of the above requirements are met, the HostedCluster will enter a degraded state.
                   This pull secret is included in NodePool ignition/bootstrap payloads and applied to the container runtime when nodes provision.
                   Changing this value will trigger a rollout for all existing NodePools in the cluster (for both replace and inplace upgrade types).
-                  Updating the referenced Secret's data in place (without changing this reference) does not trigger that rollout.
+                  Updating the referenced Secret's data in place (without changing this reference) will also trigger a rollout.
                   In AWS and Azure NodePools using the Replace upgrade strategy, the Secret's data in place changes
                   will still propagate the updated credentials down to the guest cluster and kubelet config.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/HyperShiftOnlyDynamicResourceAllocation.yaml
@@ -5927,7 +5927,7 @@ spec:
                   If the reference is set but none of the above requirements are met, the HostedCluster will enter a degraded state.
                   This pull secret is included in NodePool ignition/bootstrap payloads and applied to the container runtime when nodes provision.
                   Changing this value will trigger a rollout for all existing NodePools in the cluster (for both replace and inplace upgrade types).
-                  Updating the referenced Secret's data in place (without changing this reference) does not trigger that rollout.
+                  Updating the referenced Secret's data in place (without changing this reference) will also trigger a rollout.
                   In AWS and Azure NodePools using the Replace upgrade strategy, the Secret's data in place changes
                   will still propagate the updated credentials down to the guest cluster and kubelet config.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/ImageStreamImportMode.yaml
@@ -5923,7 +5923,7 @@ spec:
                   If the reference is set but none of the above requirements are met, the HostedCluster will enter a degraded state.
                   This pull secret is included in NodePool ignition/bootstrap payloads and applied to the container runtime when nodes provision.
                   Changing this value will trigger a rollout for all existing NodePools in the cluster (for both replace and inplace upgrade types).
-                  Updating the referenced Secret's data in place (without changing this reference) does not trigger that rollout.
+                  Updating the referenced Secret's data in place (without changing this reference) will also trigger a rollout.
                   In AWS and Azure NodePools using the Replace upgrade strategy, the Secret's data in place changes
                   will still propagate the updated credentials down to the guest cluster and kubelet config.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/KMSEncryptionProvider.yaml
@@ -5981,7 +5981,7 @@ spec:
                   If the reference is set but none of the above requirements are met, the HostedCluster will enter a degraded state.
                   This pull secret is included in NodePool ignition/bootstrap payloads and applied to the container runtime when nodes provision.
                   Changing this value will trigger a rollout for all existing NodePools in the cluster (for both replace and inplace upgrade types).
-                  Updating the referenced Secret's data in place (without changing this reference) does not trigger that rollout.
+                  Updating the referenced Secret's data in place (without changing this reference) will also trigger a rollout.
                   In AWS and Azure NodePools using the Replace upgrade strategy, the Secret's data in place changes
                   will still propagate the updated credentials down to the guest cluster and kubelet config.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/OpenStack.yaml
@@ -6456,7 +6456,7 @@ spec:
                   If the reference is set but none of the above requirements are met, the HostedCluster will enter a degraded state.
                   This pull secret is included in NodePool ignition/bootstrap payloads and applied to the container runtime when nodes provision.
                   Changing this value will trigger a rollout for all existing NodePools in the cluster (for both replace and inplace upgrade types).
-                  Updating the referenced Secret's data in place (without changing this reference) does not trigger that rollout.
+                  Updating the referenced Secret's data in place (without changing this reference) will also trigger a rollout.
                   In AWS and Azure NodePools using the Replace upgrade strategy, the Secret's data in place changes
                   will still propagate the updated credentials down to the guest cluster and kubelet config.
                 properties:

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSAdherence.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/hostedclusters.hypershift.openshift.io/TLSAdherence.yaml
@@ -5945,7 +5945,7 @@ spec:
                   If the reference is set but none of the above requirements are met, the HostedCluster will enter a degraded state.
                   This pull secret is included in NodePool ignition/bootstrap payloads and applied to the container runtime when nodes provision.
                   Changing this value will trigger a rollout for all existing NodePools in the cluster (for both replace and inplace upgrade types).
-                  Updating the referenced Secret's data in place (without changing this reference) does not trigger that rollout.
+                  Updating the referenced Secret's data in place (without changing this reference) will also trigger a rollout.
                   In AWS and Azure NodePools using the Replace upgrade strategy, the Secret's data in place changes
                   will still propagate the updated credentials down to the guest cluster and kubelet config.
                 properties:

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-CustomNoUpgrade.crd.yaml
@@ -7743,7 +7743,7 @@ spec:
                   If the reference is set but none of the above requirements are met, the HostedCluster will enter a degraded state.
                   This pull secret is included in NodePool ignition/bootstrap payloads and applied to the container runtime when nodes provision.
                   Changing this value will trigger a rollout for all existing NodePools in the cluster (for both replace and inplace upgrade types).
-                  Updating the referenced Secret's data in place (without changing this reference) does not trigger that rollout.
+                  Updating the referenced Secret's data in place (without changing this reference) will also trigger a rollout.
                   In AWS and Azure NodePools using the Replace upgrade strategy, the Secret's data in place changes
                   will still propagate the updated credentials down to the guest cluster and kubelet config.
                 properties:

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-Default.crd.yaml
@@ -6414,7 +6414,7 @@ spec:
                   If the reference is set but none of the above requirements are met, the HostedCluster will enter a degraded state.
                   This pull secret is included in NodePool ignition/bootstrap payloads and applied to the container runtime when nodes provision.
                   Changing this value will trigger a rollout for all existing NodePools in the cluster (for both replace and inplace upgrade types).
-                  Updating the referenced Secret's data in place (without changing this reference) does not trigger that rollout.
+                  Updating the referenced Secret's data in place (without changing this reference) will also trigger a rollout.
                   In AWS and Azure NodePools using the Replace upgrade strategy, the Secret's data in place changes
                   will still propagate the updated credentials down to the guest cluster and kubelet config.
                 properties:

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/hostedclusters-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -7614,7 +7614,7 @@ spec:
                   If the reference is set but none of the above requirements are met, the HostedCluster will enter a degraded state.
                   This pull secret is included in NodePool ignition/bootstrap payloads and applied to the container runtime when nodes provision.
                   Changing this value will trigger a rollout for all existing NodePools in the cluster (for both replace and inplace upgrade types).
-                  Updating the referenced Secret's data in place (without changing this reference) does not trigger that rollout.
+                  Updating the referenced Secret's data in place (without changing this reference) will also trigger a rollout.
                   In AWS and Azure NodePools using the Replace upgrade strategy, the Secret's data in place changes
                   will still propagate the updated credentials down to the guest cluster and kubelet config.
                 properties:

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -36413,7 +36413,7 @@ If the reference is set but none of the above requirements are met, the HostedCl
 TODO(alberto): Signal this in a condition.
 This pull secret is included in NodePool ignition/bootstrap payloads and applied to the container runtime when nodes provision.
 Changing this value will trigger a rollout for all existing NodePools in the cluster (for both replace and inplace upgrade types).
-Updating the referenced Secret&rsquo;s data in place (without changing this reference) does not trigger that rollout.
+Updating the referenced Secret&rsquo;s data in place (without changing this reference) will also trigger a rollout.
 In AWS and Azure NodePools using the Replace upgrade strategy, the Secret&rsquo;s data in place changes
 will still propagate the updated credentials down to the guest cluster and kubelet config.
 TODO(alberto): have our own local reference type to include our opinions and avoid transparent changes.</p>
@@ -44722,7 +44722,7 @@ If the reference is set but none of the above requirements are met, the HostedCl
 TODO(alberto): Signal this in a condition.
 This pull secret is included in NodePool ignition/bootstrap payloads and applied to the container runtime when nodes provision.
 Changing this value will trigger a rollout for all existing NodePools in the cluster (for both replace and inplace upgrade types).
-Updating the referenced Secret&rsquo;s data in place (without changing this reference) does not trigger that rollout.
+Updating the referenced Secret&rsquo;s data in place (without changing this reference) will also trigger a rollout.
 In AWS and Azure NodePools using the Replace upgrade strategy, the Secret&rsquo;s data in place changes
 will still propagate the updated credentials down to the guest cluster and kubelet config.
 TODO(alberto): have our own local reference type to include our opinions and avoid transparent changes.</p>

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -728,7 +728,7 @@ If the reference is set but none of the above requirements are met, the HostedCl
 TODO(alberto): Signal this in a condition.
 This pull secret is included in NodePool ignition/bootstrap payloads and applied to the container runtime when nodes provision.
 Changing this value will trigger a rollout for all existing NodePools in the cluster (for both replace and inplace upgrade types).
-Updating the referenced Secret&rsquo;s data in place (without changing this reference) does not trigger that rollout.
+Updating the referenced Secret&rsquo;s data in place (without changing this reference) will also trigger a rollout.
 In AWS and Azure NodePools using the Replace upgrade strategy, the Secret&rsquo;s data in place changes
 will still propagate the updated credentials down to the guest cluster and kubelet config.
 TODO(alberto): have our own local reference type to include our opinions and avoid transparent changes.</p>
@@ -9037,7 +9037,7 @@ If the reference is set but none of the above requirements are met, the HostedCl
 TODO(alberto): Signal this in a condition.
 This pull secret is included in NodePool ignition/bootstrap payloads and applied to the container runtime when nodes provision.
 Changing this value will trigger a rollout for all existing NodePools in the cluster (for both replace and inplace upgrade types).
-Updating the referenced Secret&rsquo;s data in place (without changing this reference) does not trigger that rollout.
+Updating the referenced Secret&rsquo;s data in place (without changing this reference) will also trigger a rollout.
 In AWS and Azure NodePools using the Replace upgrade strategy, the Secret&rsquo;s data in place changes
 will still propagate the updated credentials down to the guest cluster and kubelet config.
 TODO(alberto): have our own local reference type to include our opinions and avoid transparent changes.</p>

--- a/hypershift-operator/controllers/nodepool/conditions_test.go
+++ b/hypershift-operator/controllers/nodepool/conditions_test.go
@@ -189,7 +189,7 @@ func TestUpdatingConfigCondition(t *testing.T) {
 					Name:      "nodepool-name",
 					Namespace: "myns",
 					Annotations: map[string]string{
-						nodePoolAnnotationCurrentConfig: "08e4f890",
+						nodePoolAnnotationCurrentConfig: "002a8236",
 					},
 				},
 				Spec: hyperv1.NodePoolSpec{

--- a/hypershift-operator/controllers/nodepool/config.go
+++ b/hypershift-operator/controllers/nodepool/config.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
@@ -52,7 +53,9 @@ type ConfigGenerator struct {
 type rolloutConfig struct {
 	releaseImage              *releaseinfo.ReleaseImage
 	pullSecretName            string
+	pullSecretHash            string
 	additionalTrustBundleName string
+	additionalTrustBundleHash string
 	// globalConfig represents input from hostedCluster.spec.config that requires a NodePool rollout.
 	globalConfig string
 	// rawConfig is an mco consumable version of NodePool.spec.config, tuneConfig and any hypershift core machine config.
@@ -77,6 +80,15 @@ func NewConfigGenerator(ctx context.Context, client client.Client, hostedCluster
 		return nil, err
 	}
 
+	pullSecret := &corev1.Secret{}
+	if err := client.Get(ctx, types.NamespacedName{Namespace: hostedCluster.Namespace, Name: hostedCluster.Spec.PullSecret.Name}, pullSecret); err != nil {
+		return nil, fmt.Errorf("cannot get pull secret %s/%s: %w", hostedCluster.Namespace, hostedCluster.Spec.PullSecret.Name, err)
+	}
+	pullSecretData, hasPullSecret := pullSecret.Data[corev1.DockerConfigJsonKey]
+	if !hasPullSecret {
+		return nil, fmt.Errorf("pull secret %s/%s missing %q key", hostedCluster.Namespace, hostedCluster.Spec.PullSecret.Name, corev1.DockerConfigJsonKey)
+	}
+
 	cg := &ConfigGenerator{
 		Client:                client,
 		hostedCluster:         hostedCluster,
@@ -85,6 +97,7 @@ func NewConfigGenerator(ctx context.Context, client client.Client, hostedCluster
 		rolloutConfig: &rolloutConfig{
 			releaseImage:     releaseImage,
 			pullSecretName:   hostedCluster.Spec.PullSecret.Name,
+			pullSecretHash:   supportutil.HashSimple(pullSecretData),
 			globalConfig:     globalConfig,
 			haproxyRawConfig: haproxyRawConfig,
 		},
@@ -92,6 +105,15 @@ func NewConfigGenerator(ctx context.Context, client client.Client, hostedCluster
 
 	if hostedCluster.Spec.AdditionalTrustBundle != nil {
 		cg.rolloutConfig.additionalTrustBundleName = hostedCluster.Spec.AdditionalTrustBundle.Name
+		additionalTrustBundle := &corev1.ConfigMap{}
+		if err := client.Get(ctx, types.NamespacedName{Namespace: hostedCluster.Namespace, Name: hostedCluster.Spec.AdditionalTrustBundle.Name}, additionalTrustBundle); err != nil {
+			return nil, fmt.Errorf("cannot get additional trust bundle %s/%s: %w", hostedCluster.Namespace, hostedCluster.Spec.AdditionalTrustBundle.Name, err)
+		}
+		bundleData, hasBundle := additionalTrustBundle.Data["ca-bundle.crt"]
+		if !hasBundle {
+			return nil, fmt.Errorf("additional trust bundle %s/%s missing %q key", hostedCluster.Namespace, hostedCluster.Spec.AdditionalTrustBundle.Name, "ca-bundle.crt")
+		}
+		cg.rolloutConfig.additionalTrustBundleHash = supportutil.HashSimple(bundleData)
 	}
 
 	mcoRawConfig, err := cg.generateMCORawConfig(ctx, hostedCluster.Spec.Capabilities)
@@ -118,7 +140,7 @@ func (cg *ConfigGenerator) CompressedAndEncoded() (*bytes.Buffer, error) {
 // TODO(alberto): hash the struct directly instead of the string representation field by field.
 // This is kept like this for now to contain the scope of the refactor and avoid backward compatibility issues.
 func (cg *ConfigGenerator) Hash() string {
-	return supportutil.HashSimple(cg.mcoRawConfig + cg.releaseImage.Version() + cg.pullSecretName + cg.additionalTrustBundleName + cg.globalConfig)
+	return supportutil.HashSimple(cg.mcoRawConfig + cg.releaseImage.Version() + cg.pullSecretName + cg.pullSecretHash + cg.additionalTrustBundleName + cg.additionalTrustBundleHash + cg.globalConfig)
 }
 
 // HashWithOutVersion is like Hash but doesn't compute the release version.
@@ -126,7 +148,7 @@ func (cg *ConfigGenerator) Hash() string {
 // TODO(alberto): This was left inconsistent in https://github.com/openshift/hypershift/pull/3795/files. It should also contain cg.globalConfig.
 // This is kept like this for now to contain the scope of the refactor and avoid backward compatibility issues.
 func (cg *ConfigGenerator) HashWithoutVersion() string {
-	return supportutil.HashSimple(cg.mcoRawConfig + cg.pullSecretName + cg.additionalTrustBundleName)
+	return supportutil.HashSimple(cg.mcoRawConfig + cg.pullSecretName + cg.pullSecretHash + cg.additionalTrustBundleName + cg.additionalTrustBundleHash)
 }
 
 func (cg *ConfigGenerator) Version() string {

--- a/hypershift-operator/controllers/nodepool/config_test.go
+++ b/hypershift-operator/controllers/nodepool/config_test.go
@@ -152,8 +152,8 @@ spec:
 	}{
 		{
 			name:                       "When all input is given it should not return an error",
-			expectedHash:               "e1d8d58e",
-			expectedHashWithoutVersion: "0db5756d",
+			expectedHash:               "d4b0ec26",
+			expectedHashWithoutVersion: "fdbe31b5",
 			nodePool:                   &hyperv1.NodePool{},
 			releaseImage: &releaseinfo.ReleaseImage{
 				ImageStream: &imageapi.ImageStream{
@@ -184,8 +184,8 @@ spec:
 		},
 		{
 			name:                       "When nodepool has configs it should populate mcoRawConfig ",
-			expectedHash:               "801aff6a",
-			expectedHashWithoutVersion: "fef02451",
+			expectedHash:               "02f4c932",
+			expectedHashWithoutVersion: "9305e059",
 			nodePool: &hyperv1.NodePool{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
@@ -243,8 +243,8 @@ spec:
 		},
 		{
 			name:                       "When additionalTrustBundle is specified it should be included in rolloutConfig",
-			expectedHash:               "dc74976e",
-			expectedHashWithoutVersion: "71375893",
+			expectedHash:               "84684634",
+			expectedHashWithoutVersion: "de436f01",
 			nodePool: &hyperv1.NodePool{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test",
@@ -295,6 +295,36 @@ spec:
 		},
 	}
 
+	pullSecretObjects := []crclient.Object{
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pull-secret",
+				Namespace: "test",
+			},
+			Data: map[string][]byte{
+				corev1.DockerConfigJsonKey: []byte(`{"auths":{}}`),
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pull-secret-2",
+				Namespace: "test",
+			},
+			Data: map[string][]byte{
+				corev1.DockerConfigJsonKey: []byte(`{"auths":{}}`),
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "additional-trust-bundle",
+				Namespace: "test",
+			},
+			Data: map[string]string{
+				"ca-bundle.crt": "test-ca-bundle",
+			},
+		},
+	}
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
@@ -302,6 +332,7 @@ spec:
 			var client crclient.Client
 			if tc.client {
 				fakeObjects := append(tc.config, coreConfigMaps...)
+				fakeObjects = append(fakeObjects, pullSecretObjects...)
 				client = fake.NewClientBuilder().WithScheme(api.Scheme).WithObjects(fakeObjects...).Build()
 			}
 
@@ -423,16 +454,20 @@ func TestHash(t *testing.T) {
 	baseCaseMCORawConfig := "test config"
 	baseCaseReleaseVersion := "4.7.0"
 	baseCasePullSecretName := "pull-secret"
+	baseCasePullSecretHash := "test-pull-hash"
 	baseCaseAdditionalTrustBundleName := "trust-bundle"
+	baseCaseAdditionalTrustBundleHash := "test-trust-hash"
 	baseCaseGlobalConfig := "global config"
-	baseCaseHash := "bb196408"
+	baseCaseHash := "35712ed7"
 
 	testCases := []struct {
 		name                      string
 		mcoRawConfig              string
 		releaseVersion            string
 		pullSecretName            string
+		pullSecretHash            string
 		additionalTrustBundleName string
+		additionalTrustBundleHash string
 		globalConfig              string
 		expected                  string
 	}{
@@ -441,7 +476,9 @@ func TestHash(t *testing.T) {
 			mcoRawConfig:              baseCaseMCORawConfig,
 			releaseVersion:            baseCaseReleaseVersion,
 			pullSecretName:            baseCasePullSecretName,
+			pullSecretHash:            baseCasePullSecretHash,
 			additionalTrustBundleName: baseCaseAdditionalTrustBundleName,
+			additionalTrustBundleHash: baseCaseAdditionalTrustBundleHash,
 			globalConfig:              baseCaseGlobalConfig,
 			expected:                  baseCaseHash,
 		},
@@ -450,45 +487,77 @@ func TestHash(t *testing.T) {
 			mcoRawConfig:              baseCaseMCORawConfig,
 			releaseVersion:            "4.8.0",
 			pullSecretName:            baseCasePullSecretName,
+			pullSecretHash:            baseCasePullSecretHash,
 			additionalTrustBundleName: baseCaseAdditionalTrustBundleName,
+			additionalTrustBundleHash: baseCaseAdditionalTrustBundleHash,
 			globalConfig:              baseCaseGlobalConfig,
-			expected:                  "27bb7699",
+			expected:                  "73bfd900",
 		},
 		{
 			name:                      "A different mcoRawConfig should change the hash",
 			mcoRawConfig:              "different",
 			releaseVersion:            baseCaseReleaseVersion,
 			pullSecretName:            baseCasePullSecretName,
+			pullSecretHash:            baseCasePullSecretHash,
 			additionalTrustBundleName: baseCaseAdditionalTrustBundleName,
+			additionalTrustBundleHash: baseCaseAdditionalTrustBundleHash,
 			globalConfig:              baseCaseGlobalConfig,
-			expected:                  "25f99ac5",
+			expected:                  "4cafb034",
 		},
 		{
 			name:                      "A different pullSecretName should change the hash",
 			mcoRawConfig:              baseCaseMCORawConfig,
 			releaseVersion:            baseCaseReleaseVersion,
 			pullSecretName:            "different",
+			pullSecretHash:            baseCasePullSecretHash,
 			additionalTrustBundleName: baseCaseAdditionalTrustBundleName,
+			additionalTrustBundleHash: baseCaseAdditionalTrustBundleHash,
 			globalConfig:              baseCaseGlobalConfig,
-			expected:                  "d0d6f6e9",
+			expected:                  "fd71a4d0",
 		},
 		{
-			name:                      "A different trust-bundle should change the hash",
+			name:                      "A different pullSecretHash should change the hash",
 			mcoRawConfig:              baseCaseMCORawConfig,
 			releaseVersion:            baseCaseReleaseVersion,
 			pullSecretName:            baseCasePullSecretName,
-			additionalTrustBundleName: "different",
+			pullSecretHash:            "different",
+			additionalTrustBundleName: baseCaseAdditionalTrustBundleName,
+			additionalTrustBundleHash: baseCaseAdditionalTrustBundleHash,
 			globalConfig:              baseCaseGlobalConfig,
-			expected:                  "42d42744",
+			expected:                  "4e8f6bdd",
+		},
+		{
+			name:                      "A different trust-bundle name should change the hash",
+			mcoRawConfig:              baseCaseMCORawConfig,
+			releaseVersion:            baseCaseReleaseVersion,
+			pullSecretName:            baseCasePullSecretName,
+			pullSecretHash:            baseCasePullSecretHash,
+			additionalTrustBundleName: "different",
+			additionalTrustBundleHash: baseCaseAdditionalTrustBundleHash,
+			globalConfig:              baseCaseGlobalConfig,
+			expected:                  "33f21e3d",
+		},
+		{
+			name:                      "A different trust-bundle hash should change the hash",
+			mcoRawConfig:              baseCaseMCORawConfig,
+			releaseVersion:            baseCaseReleaseVersion,
+			pullSecretName:            baseCasePullSecretName,
+			pullSecretHash:            baseCasePullSecretHash,
+			additionalTrustBundleName: baseCaseAdditionalTrustBundleName,
+			additionalTrustBundleHash: "different",
+			globalConfig:              baseCaseGlobalConfig,
+			expected:                  "0f02351a",
 		},
 		{
 			name:                      "A different globalConfig should change the hash",
 			mcoRawConfig:              baseCaseMCORawConfig,
 			releaseVersion:            baseCaseReleaseVersion,
 			pullSecretName:            baseCasePullSecretName,
+			pullSecretHash:            baseCasePullSecretHash,
 			additionalTrustBundleName: baseCaseAdditionalTrustBundleName,
+			additionalTrustBundleHash: baseCaseAdditionalTrustBundleHash,
 			globalConfig:              "different",
-			expected:                  "e916ddfe",
+			expected:                  "79f723f1",
 		},
 	}
 
@@ -506,7 +575,9 @@ func TestHash(t *testing.T) {
 				rolloutConfig: &rolloutConfig{
 					mcoRawConfig:              tc.mcoRawConfig,
 					pullSecretName:            tc.pullSecretName,
+					pullSecretHash:            tc.pullSecretHash,
 					additionalTrustBundleName: tc.additionalTrustBundleName,
+					additionalTrustBundleHash: tc.additionalTrustBundleHash,
 					globalConfig:              tc.globalConfig,
 					releaseImage:              releaseImage,
 				},
@@ -526,15 +597,19 @@ func TestHashWithoutVersion(t *testing.T) {
 	baseCaseMCORawConfig := "test config"
 	baseCaseReleaseVersion := "4.7.0"
 	baseCasePullSecretName := "pull-secret"
+	baseCasePullSecretHash := "test-pull-hash"
 	baseCaseAdditionalTrustBundleName := "trust-bundle"
+	baseCaseAdditionalTrustBundleHash := "test-trust-hash"
 	baseCaseGlobalConfig := "global config"
-	baseCaseHash := "85234650"
+	baseCaseHash := "53d286d7"
 	testCases := []struct {
 		name                      string
 		mcoRawConfig              string
 		releaseVersion            string
 		pullSecretName            string
+		pullSecretHash            string
 		additionalTrustBundleName string
+		additionalTrustBundleHash string
 		globalConfig              string
 		expected                  string
 	}{
@@ -543,7 +618,9 @@ func TestHashWithoutVersion(t *testing.T) {
 			mcoRawConfig:              baseCaseMCORawConfig,
 			releaseVersion:            baseCaseReleaseVersion,
 			pullSecretName:            baseCasePullSecretName,
+			pullSecretHash:            baseCasePullSecretHash,
 			additionalTrustBundleName: baseCaseAdditionalTrustBundleName,
+			additionalTrustBundleHash: baseCaseAdditionalTrustBundleHash,
 			globalConfig:              baseCaseGlobalConfig,
 			expected:                  baseCaseHash,
 		},
@@ -552,7 +629,9 @@ func TestHashWithoutVersion(t *testing.T) {
 			mcoRawConfig:              baseCaseMCORawConfig,
 			releaseVersion:            "4.8.0",
 			pullSecretName:            baseCasePullSecretName,
+			pullSecretHash:            baseCasePullSecretHash,
 			additionalTrustBundleName: baseCaseAdditionalTrustBundleName,
+			additionalTrustBundleHash: baseCaseAdditionalTrustBundleHash,
 			globalConfig:              baseCaseGlobalConfig,
 			expected:                  baseCaseHash,
 		},
@@ -561,27 +640,55 @@ func TestHashWithoutVersion(t *testing.T) {
 			mcoRawConfig:              "different",
 			releaseVersion:            baseCaseReleaseVersion,
 			pullSecretName:            baseCasePullSecretName,
+			pullSecretHash:            baseCasePullSecretHash,
 			additionalTrustBundleName: baseCaseAdditionalTrustBundleName,
+			additionalTrustBundleHash: baseCaseAdditionalTrustBundleHash,
 			globalConfig:              baseCaseGlobalConfig,
-			expected:                  "5ea671c5",
+			expected:                  "1e76f6cc",
 		},
 		{
 			name:                      "A different pullSecretName should change the hash",
 			mcoRawConfig:              baseCaseMCORawConfig,
 			releaseVersion:            baseCaseReleaseVersion,
 			pullSecretName:            "different",
+			pullSecretHash:            baseCasePullSecretHash,
 			additionalTrustBundleName: baseCaseAdditionalTrustBundleName,
+			additionalTrustBundleHash: baseCaseAdditionalTrustBundleHash,
 			globalConfig:              baseCaseGlobalConfig,
-			expected:                  "f6e82eb7",
+			expected:                  "6700948a",
 		},
 		{
-			name:                      "A different trust-bundle should change the hash",
+			name:                      "A different pullSecretHash should change the hash",
 			mcoRawConfig:              baseCaseMCORawConfig,
 			releaseVersion:            baseCaseReleaseVersion,
 			pullSecretName:            baseCasePullSecretName,
-			additionalTrustBundleName: "different",
+			pullSecretHash:            "different",
+			additionalTrustBundleName: baseCaseAdditionalTrustBundleName,
+			additionalTrustBundleHash: baseCaseAdditionalTrustBundleHash,
 			globalConfig:              baseCaseGlobalConfig,
-			expected:                  "935c3492",
+			expected:                  "b7308d07",
+		},
+		{
+			name:                      "A different trust-bundle name should change the hash",
+			mcoRawConfig:              baseCaseMCORawConfig,
+			releaseVersion:            baseCaseReleaseVersion,
+			pullSecretName:            baseCasePullSecretName,
+			pullSecretHash:            baseCasePullSecretHash,
+			additionalTrustBundleName: "different",
+			additionalTrustBundleHash: baseCaseAdditionalTrustBundleHash,
+			globalConfig:              baseCaseGlobalConfig,
+			expected:                  "324d7f97",
+		},
+		{
+			name:                      "A different trust-bundle hash should change the hash",
+			mcoRawConfig:              baseCaseMCORawConfig,
+			releaseVersion:            baseCaseReleaseVersion,
+			pullSecretName:            baseCasePullSecretName,
+			pullSecretHash:            baseCasePullSecretHash,
+			additionalTrustBundleName: baseCaseAdditionalTrustBundleName,
+			additionalTrustBundleHash: "different",
+			globalConfig:              baseCaseGlobalConfig,
+			expected:                  "7fe29f30",
 		},
 		{
 			// TODO(alberto): This was left inconsistent in https://github.com/openshift/hypershift/pull/3795/files. It should also contain cg.globalConfig.
@@ -590,7 +697,9 @@ func TestHashWithoutVersion(t *testing.T) {
 			mcoRawConfig:              baseCaseMCORawConfig,
 			releaseVersion:            baseCaseReleaseVersion,
 			pullSecretName:            baseCasePullSecretName,
+			pullSecretHash:            baseCasePullSecretHash,
 			additionalTrustBundleName: baseCaseAdditionalTrustBundleName,
+			additionalTrustBundleHash: baseCaseAdditionalTrustBundleHash,
 			globalConfig:              "different",
 			expected:                  baseCaseHash,
 		},
@@ -610,7 +719,9 @@ func TestHashWithoutVersion(t *testing.T) {
 				rolloutConfig: &rolloutConfig{
 					mcoRawConfig:              tc.mcoRawConfig,
 					pullSecretName:            tc.pullSecretName,
+					pullSecretHash:            tc.pullSecretHash,
 					additionalTrustBundleName: tc.additionalTrustBundleName,
+					additionalTrustBundleHash: tc.additionalTrustBundleHash,
 					globalConfig:              tc.globalConfig,
 					releaseImage:              releaseImage,
 				},

--- a/hypershift-operator/controllers/nodepool/nodepool_controller.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller.go
@@ -134,8 +134,8 @@ func (r *NodePoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&hyperv1.HostedCluster{}, handler.EnqueueRequestsFromMapFunc(r.enqueueNodePoolsForHostedCluster), builder.WithPredicates(supportutil.PredicatesForHostedClusterAnnotationScoping(mgr.GetClient()))).
 		Watches(&capiv1.MachineDeployment{}, handler.EnqueueRequestsFromMapFunc(enqueueParentNodePool), builder.WithPredicates(supportutil.PredicatesForHostedClusterAnnotationScoping(mgr.GetClient()))).
 		Watches(&capiv1.MachineSet{}, handler.EnqueueRequestsFromMapFunc(enqueueParentNodePool), builder.WithPredicates(supportutil.PredicatesForHostedClusterAnnotationScoping(mgr.GetClient()))).
-		// We want to reconcile when the user data Secret or the token Secret is unexpectedly changed out of band.
-		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(enqueueParentNodePool), builder.WithPredicates(supportutil.PredicatesForHostedClusterAnnotationScoping(mgr.GetClient()))).
+		// We want to reconcile when the user data Secret, the token Secret, or the pull secret is changed.
+		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.enqueueNodePoolsForSecret), builder.WithPredicates(supportutil.PredicatesForHostedClusterAnnotationScoping(mgr.GetClient()))).
 		// We want to reconcile when the ConfigMaps referenced by the spec.config and also the core ones change.
 		Watches(&corev1.ConfigMap{}, handler.EnqueueRequestsFromMapFunc(r.enqueueNodePoolsForConfig), builder.WithPredicates(supportutil.PredicatesForHostedClusterAnnotationScoping(mgr.GetClient()))).
 		WithOptions(controller.Options{
@@ -982,6 +982,39 @@ func enqueueParentNodePool(ctx context.Context, obj client.Object) []reconcile.R
 	return []reconcile.Request{
 		{NamespacedName: supportutil.ParseNamespacedName(nodePoolName)},
 	}
+}
+
+func (r *NodePoolReconciler) enqueueNodePoolsForSecret(ctx context.Context, obj client.Object) []reconcile.Request {
+	if reqs := enqueueParentNodePool(ctx, obj); len(reqs) > 0 {
+		return reqs
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+	hcList := &hyperv1.HostedClusterList{}
+	if err := r.List(ctx, hcList, client.InNamespace(obj.GetNamespace())); err != nil {
+		log.Error(err, "Failed to list HostedClusters")
+		return nil
+	}
+	npList := &hyperv1.NodePoolList{}
+	if err := r.List(ctx, npList, client.InNamespace(obj.GetNamespace())); err != nil {
+		log.Error(err, "Failed to list NodePools")
+		return nil
+	}
+	var result []reconcile.Request
+	for i := range hcList.Items {
+		hc := &hcList.Items[i]
+		if hc.Spec.PullSecret.Name != obj.GetName() {
+			continue
+		}
+		for j := range npList.Items {
+			if npList.Items[j].Spec.ClusterName == hc.Name {
+				result = append(result, reconcile.Request{
+					NamespacedName: client.ObjectKeyFromObject(&npList.Items[j]),
+				})
+			}
+		}
+	}
+	return result
 }
 
 func (r *NodePoolReconciler) listSecrets(ctx context.Context, nodePool *hyperv1.NodePool) ([]corev1.Secret, error) {

--- a/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
+++ b/hypershift-operator/controllers/nodepool/nodepool_controller_test.go
@@ -3309,3 +3309,119 @@ func TestNodePoolReconciler_reconcile(t *testing.T) {
 		})
 	}
 }
+
+func TestEnqueueNodePoolsForSecret(t *testing.T) {
+	namespace := "test-ns"
+
+	hostedCluster := &hyperv1.HostedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-hc",
+			Namespace: namespace,
+		},
+		Spec: hyperv1.HostedClusterSpec{
+			PullSecret: corev1.LocalObjectReference{
+				Name: "my-pull-secret",
+			},
+		},
+	}
+
+	nodePool1 := &hyperv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "np-1",
+			Namespace: namespace,
+		},
+		Spec: hyperv1.NodePoolSpec{
+			ClusterName: "test-hc",
+		},
+	}
+
+	nodePool2 := &hyperv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "np-2",
+			Namespace: namespace,
+		},
+		Spec: hyperv1.NodePoolSpec{
+			ClusterName: "test-hc",
+		},
+	}
+
+	nodePoolOther := &hyperv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "np-other",
+			Namespace: namespace,
+		},
+		Spec: hyperv1.NodePoolSpec{
+			ClusterName: "other-hc",
+		},
+	}
+
+	testCases := []struct {
+		name          string
+		secret        client.Object
+		objects       []client.Object
+		expectedCount int
+		expectedNames []string
+	}{
+		{
+			name: "When secret has nodePool annotation it should use enqueueParentNodePool",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "token-secret",
+					Namespace: namespace,
+					Annotations: map[string]string{
+						nodePoolAnnotation: namespace + "/" + "np-1",
+					},
+				},
+			},
+			objects:       []client.Object{hostedCluster, nodePool1, nodePool2},
+			expectedCount: 1,
+			expectedNames: []string{"np-1"},
+		},
+		{
+			name: "When secret is a pull secret it should enqueue all matching NodePools",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-pull-secret",
+					Namespace: namespace,
+				},
+			},
+			objects:       []client.Object{hostedCluster, nodePool1, nodePool2, nodePoolOther},
+			expectedCount: 2,
+			expectedNames: []string{"np-1", "np-2"},
+		},
+		{
+			name: "When secret is not a pull secret and has no annotation it should return empty",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "unrelated-secret",
+					Namespace: namespace,
+				},
+			},
+			objects:       []client.Object{hostedCluster, nodePool1, nodePool2},
+			expectedCount: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			scheme := runtime.NewScheme()
+			g.Expect(hyperv1.AddToScheme(scheme)).To(Succeed())
+			g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.objects...).Build()
+
+			r := &NodePoolReconciler{
+				Client: fakeClient,
+			}
+
+			ctx := ctrl.LoggerInto(context.Background(), ctrl.Log)
+			reqs := r.enqueueNodePoolsForSecret(ctx, tc.secret)
+			g.Expect(reqs).To(HaveLen(tc.expectedCount))
+			for _, name := range tc.expectedNames {
+				g.Expect(reqs).To(ContainElement(reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: namespace, Name: name},
+				}))
+			}
+		})
+	}
+}

--- a/hypershift-operator/controllers/nodepool/secret_janitor_test.go
+++ b/hypershift-operator/controllers/nodepool/secret_janitor_test.go
@@ -221,7 +221,7 @@ spec:
 			name: "related known secret with correct hash untouched",
 			input: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "token-nodepool-name-64587037",
+					Name:      "token-nodepool-name-4cb4eb0d",
 					Namespace: "myns",
 					Annotations: map[string]string{
 						nodePoolAnnotation: client.ObjectKeyFromObject(nodePool).String(),
@@ -230,7 +230,7 @@ spec:
 			},
 			expected: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "token-nodepool-name-64587037",
+					Name:      "token-nodepool-name-4cb4eb0d",
 					Namespace: "myns",
 					Annotations: map[string]string{
 						nodePoolAnnotation: client.ObjectKeyFromObject(nodePool).String(),

--- a/hypershift-operator/controllers/nodepool/token.go
+++ b/hypershift-operator/controllers/nodepool/token.go
@@ -15,7 +15,6 @@ import (
 	karpenterutil "github.com/openshift/hypershift/support/karpenter"
 	"github.com/openshift/hypershift/support/releaseinfo"
 	"github.com/openshift/hypershift/support/upsert"
-	supportutil "github.com/openshift/hypershift/support/util"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -50,18 +49,14 @@ const (
 // Token knows how to create an UUUID token for a unique configGenerator Hash.
 // It also knows how to manage the lifecycle of a corresponding token secret that it is used by the tokenSecret controller to generate the final ignition payload
 // and a user data secret that points to the ignition server URL using the UUUID as an authenticator header to get that payload.
+// Pull secret and additional trust bundle content hashes are computed in ConfigGenerator.rolloutConfig
+// so that in-place data changes are reflected in the rollout hash and trigger a NodePool rollout.
 type Token struct {
 	upsert.CreateOrUpdateProvider
 	cpoCapabilities *CPOCapabilities
 	*ConfigGenerator
-	// TODO(alberto): we don't really support content inplace changes for fields like pull secret and AdditionalTrustBundle.
-	// In fact we only trigger a rollout if the .Name referenced in the field changes.
-	// Consider removing these hash checks and consolidate with the rolloutConfig struct input.
-	// This is kept like this for now to contain the scope of the refactor and avoid backward compatibility issues.
-	pullSecretHash            []byte
-	additionalTrustBundleHash []byte
-	globalConfigHash          []byte
-	userData                  *userData
+	globalConfigHash []byte
+	userData         *userData
 }
 
 // userData contains the input necessary to generate the user data secret
@@ -82,31 +77,6 @@ func NewToken(ctx context.Context, configGenerator *ConfigGenerator, cpoCapabili
 		return nil, fmt.Errorf("cpoCapabilities can't be nil")
 	}
 
-	// TODO(alberto): tempReconciler is a NodePoolReconciler used temporarily until getPullSecretBytes and getAdditionalTrustBundle are factored.
-	// This is kept like this for now to contain the scope of the refactor and avoid backward compatibility issues.
-	tempReconciler := &NodePoolReconciler{
-		Client: configGenerator.Client,
-	}
-	pullSecretBytes, err := tempReconciler.getPullSecretBytes(ctx, configGenerator.hostedCluster)
-	if err != nil {
-		return nil, err
-	}
-
-	additionalTrustBundleCM := &corev1.ConfigMap{}
-	additionalTrustBundle := ""
-	if configGenerator.hostedCluster.Spec.AdditionalTrustBundle != nil {
-		additionalTrustBundleCM, err = tempReconciler.getAdditionalTrustBundle(ctx, configGenerator.hostedCluster)
-		if err != nil {
-			return nil, err
-		}
-		additionalTrustBundle = additionalTrustBundleCM.Data["ca-bundle.crt"]
-	}
-
-	// TODO(alberto): This hash should be consolidated with configGenerator using globalConfigString as that is what configGenerator uses to create a configGenerator.Hash() and so what triggers a rollout.
-	// This inconsistency was introduced by https://github.com/openshift/hypershift/pull/3795
-	// See reconcileTokenSecret and https://github.com/openshift/hypershift/pull/4057 for more info on how this is used.
-	// This is kept like this for now to contain the scope of the refactor and avoid backward compatibility issues.
-
 	// Some fields in the ClusterConfiguration have changes that are not backwards compatible with older versions of the CPO.
 	hcConfigurationHash, err := backwardcompat.GetBackwardCompatibleConfigHash(configGenerator.hostedCluster.Spec.Configuration)
 	if err != nil {
@@ -114,12 +84,10 @@ func NewToken(ctx context.Context, configGenerator *ConfigGenerator, cpoCapabili
 	}
 
 	token := &Token{
-		CreateOrUpdateProvider:    upsert.New(false),
-		ConfigGenerator:           configGenerator,
-		cpoCapabilities:           cpoCapabilities,
-		pullSecretHash:            []byte(supportutil.HashSimple(pullSecretBytes)),
-		additionalTrustBundleHash: []byte(supportutil.HashSimple(additionalTrustBundle)),
-		globalConfigHash:          []byte(hcConfigurationHash),
+		CreateOrUpdateProvider: upsert.New(false),
+		ConfigGenerator:        configGenerator,
+		cpoCapabilities:        cpoCapabilities,
+		globalConfigHash:       []byte(hcConfigurationHash),
 	}
 
 	// User data input.
@@ -351,8 +319,8 @@ func (t *Token) reconcileTokenSecret(tokenSecret *corev1.Secret) error {
 
 		// Hash values that are used by the "token secret controller" / "local ignition provider"  to determine if this input
 		// have changed before generating a payload for it.
-		tokenSecret.Data[TokenSecretPullSecretHashKey] = t.pullSecretHash
-		tokenSecret.Data[TokenSecretAdditionalTrustBundleKey] = t.additionalTrustBundleHash
+		tokenSecret.Data[TokenSecretPullSecretHashKey] = []byte(t.ConfigGenerator.pullSecretHash)
+		tokenSecret.Data[TokenSecretAdditionalTrustBundleKey] = []byte(t.ConfigGenerator.additionalTrustBundleHash)
 		tokenSecret.Data[TokenSecretHCConfigurationHashKey] = t.globalConfigHash
 	}
 	// TODO (alberto): Only apply this on creation and change the hash generation to only use triggering upgrade fields.

--- a/hypershift-operator/controllers/nodepool/token_test.go
+++ b/hypershift-operator/controllers/nodepool/token_test.go
@@ -100,6 +100,10 @@ func TestNewToken(t *testing.T) {
 				},
 				nodePool:              &hyperv1.NodePool{},
 				controlplaneNamespace: controlplaneNamespace,
+				rolloutConfig: &rolloutConfig{
+					pullSecretHash:            supportutil.HashSimple([]byte(`{"auths":{"example.com":{"auth":"dGVzdDp0ZXN0"}}}`)),
+					additionalTrustBundleHash: supportutil.HashSimple("test-ca-bundle"),
+				},
 			},
 			fakeObjects: []crclient.Object{
 				pullSecret,
@@ -140,66 +144,8 @@ func TestNewToken(t *testing.T) {
 			cpoCapabilities: &CPOCapabilities{},
 			expectedError:   "ignition endpoint is not set",
 		},
-		{
-			name: "When missing pullsecret it should fail",
-			configGenerator: &ConfigGenerator{
-				hostedCluster: &hyperv1.HostedCluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      hcName,
-						Namespace: hcNamespace,
-					},
-					Spec: hyperv1.HostedClusterSpec{
-						PullSecret: corev1.LocalObjectReference{
-							Name: pullSecret.GetName(),
-						},
-						AdditionalTrustBundle: &corev1.LocalObjectReference{
-							Name: additionalTrustBundle.GetName(),
-						},
-					},
-					Status: hyperv1.HostedClusterStatus{
-						IgnitionEndpoint: "https://example.com",
-					},
-				},
-				nodePool:              &hyperv1.NodePool{},
-				controlplaneNamespace: controlplaneNamespace,
-			},
-			fakeObjects: []crclient.Object{
-				additionalTrustBundle,
-				ignitionServerCACert,
-			},
-			cpoCapabilities: &CPOCapabilities{},
-			expectedError:   "cannot get pull secret namespace/pull-secret: secrets \"pull-secret\" not found",
-		},
-		{
-			name: "When missing additionalTrustBundle it should fail",
-			configGenerator: &ConfigGenerator{
-				hostedCluster: &hyperv1.HostedCluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      hcName,
-						Namespace: hcNamespace,
-					},
-					Spec: hyperv1.HostedClusterSpec{
-						PullSecret: corev1.LocalObjectReference{
-							Name: pullSecret.GetName(),
-						},
-						AdditionalTrustBundle: &corev1.LocalObjectReference{
-							Name: additionalTrustBundle.GetName(),
-						},
-					},
-					Status: hyperv1.HostedClusterStatus{
-						IgnitionEndpoint: "https://example.com",
-					},
-				},
-				nodePool:              &hyperv1.NodePool{},
-				controlplaneNamespace: controlplaneNamespace,
-			},
-			fakeObjects: []crclient.Object{
-				pullSecret,
-				ignitionServerCACert,
-			},
-			cpoCapabilities: &CPOCapabilities{},
-			expectedError:   "cannot get additionalTrustBundle namespace/additional-trust-bundle: configmaps \"additional-trust-bundle\"",
-		},
+		// NOTE: "missing pullsecret" and "missing additionalTrustBundle" error cases
+		// are now validated in NewConfigGenerator, not NewToken.
 		{
 			name: "When missing ignitionServerCACert it should fail",
 			configGenerator: &ConfigGenerator{
@@ -293,13 +239,13 @@ func TestNewToken(t *testing.T) {
 			g.Expect(token).NotTo(BeNil())
 
 			// Validate expected hashes against raw strings to guarantee expected output.
-			expectedPullSecretHash := []byte(supportutil.HashSimple([]byte(`{"auths":{"example.com":{"auth":"dGVzdDp0ZXN0"}}}`)))
-			expectedAdditionalTrustBundleHash := []byte(supportutil.HashSimple("test-ca-bundle"))
+			expectedPullSecretHash := supportutil.HashSimple([]byte(`{"auths":{"example.com":{"auth":"dGVzdDp0ZXN0"}}}`))
+			expectedAdditionalTrustBundleHash := supportutil.HashSimple("test-ca-bundle")
 			expectedGlobalConfig, err := supportutil.HashStruct(tc.configGenerator.hostedCluster.Spec.Configuration)
 			g.Expect(err).To(Not(HaveOccurred()))
 
-			g.Expect(token.pullSecretHash).To(Equal(expectedPullSecretHash))
-			g.Expect(token.additionalTrustBundleHash).To(Equal(expectedAdditionalTrustBundleHash))
+			g.Expect(token.ConfigGenerator.pullSecretHash).To(Equal(expectedPullSecretHash))
+			g.Expect(token.ConfigGenerator.additionalTrustBundleHash).To(Equal(expectedAdditionalTrustBundleHash))
 			g.Expect(token.globalConfigHash).To(Equal([]byte(expectedGlobalConfig)))
 
 			// Validate user data.
@@ -617,8 +563,10 @@ func TestTokenReconcile(t *testing.T) {
 							},
 						},
 					},
-					globalConfig: "test-global-config",
-					mcoRawConfig: "raw-config",
+					pullSecretHash:            supportutil.HashSimple([]byte(`{"auths":{"example.com":{"auth":"dGVzdDp0ZXN0"}}}`)),
+					additionalTrustBundleHash: supportutil.HashSimple("test-ca-bundle"),
+					globalConfig:              "test-global-config",
+					mcoRawConfig:              "raw-config",
 				},
 			},
 			fakeObjects: []crclient.Object{
@@ -679,8 +627,10 @@ func TestTokenReconcile(t *testing.T) {
 							},
 						},
 					},
-					globalConfig: "test-global-config",
-					mcoRawConfig: "raw-config",
+					pullSecretHash:            supportutil.HashSimple([]byte(`{"auths":{"example.com":{"auth":"dGVzdDp0ZXN0"}}}`)),
+					additionalTrustBundleHash: supportutil.HashSimple("test-ca-bundle"),
+					globalConfig:              "test-global-config",
+					mcoRawConfig:              "raw-config",
 				},
 			},
 			fakeObjects: []crclient.Object{
@@ -748,7 +698,7 @@ func TestTokenReconcile(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(decodedAndDecompressed.String()).To(Equal("raw-config"))
 
-			// Validate hashes are set.
+			// Validate hashes are set. These come from ConfigGenerator which computes HashSimple([]byte(...)).
 			expectedPullSecretHash := []byte(supportutil.HashSimple([]byte(`{"auths":{"example.com":{"auth":"dGVzdDp0ZXN0"}}}`)))
 			expectedAdditionalTrustBundleHash := []byte(supportutil.HashSimple("test-ca-bundle"))
 			expectedGlobalConfig, err := supportutil.HashStruct(tc.configGenerator.hostedCluster.Spec.Configuration)

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -675,7 +675,7 @@ type HostedClusterSpec struct {
 	// TODO(alberto): Signal this in a condition.
 	// This pull secret is included in NodePool ignition/bootstrap payloads and applied to the container runtime when nodes provision.
 	// Changing this value will trigger a rollout for all existing NodePools in the cluster (for both replace and inplace upgrade types).
-	// Updating the referenced Secret's data in place (without changing this reference) does not trigger that rollout.
+	// Updating the referenced Secret's data in place (without changing this reference) will also trigger a rollout.
 	// In AWS and Azure NodePools using the Replace upgrade strategy, the Secret's data in place changes
 	// will still propagate the updated credentials down to the guest cluster and kubelet config.
 	// +required


### PR DESCRIPTION
## What this PR does / why we need it:

Previously, modifying the pull secret or additional trust bundle data in-place (without changing
the Secret/ConfigMap reference name) did not trigger a NodePool rollout because the rollout hash
only included the resource name, not a content hash.

This PR:
- Adds `pullSecretHash` and `additionalTrustBundleHash` fields to `ConfigGenerator.rolloutConfig`, computed from actual Secret/ConfigMap data
- Includes these content hashes in both `Hash()` and `HashWithoutVersion()` so in-place data changes produce a different rollout hash
- Removes the redundant hash computation from the `Token` struct (previously duplicated with TODO comments acknowledging the gap)
- Adds `enqueueNodePoolsForSecret` watcher so pull secret data changes trigger NodePool reconciliation (the pull secret lacks the `nodePoolAnnotation`, so the existing `enqueueParentNodePool` didn't match it)
- Updates the `PullSecret` field API doc to reflect the new behavior

**Note:** Deploying this fix will cause a one-time rollout for all existing NodePools on first reconciliation, because the hash now includes content hashes that were not previously part of the computation. This is expected and unavoidable.

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/OCPBUGS-13553

## Special notes for your reviewer:

- The `additionalTrustBundleHash` uses `HashSimple(string)` (not `[]byte`) to match the ignition server's `fetchAdditionalTrustBundle` which returns `string`. The `pullSecretHash` uses `HashSimple([]byte)` to match the ignition server's `fetchPullSecret` which returns `[]byte`.
- The AdditionalTrustBundle ConfigMap watcher is a pre-existing gap (no watcher triggers reconciliation when trust bundle data changes in-place). This is out of scope for this JIRA and can be a follow-up.
- Tested on a live KubeVirt HCP cluster (`dhruvhcp-new500`): confirmed that modifying pull secret in-place now triggers `UpdatingConfig=True` with a new target hash.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rollout identity now reflects pull-secret and trust-bundle contents so updates to those secrets cause NodePool rollouts.
  * Controller now enqueues NodePool reconciliations when a HostedCluster pull Secret changes.

* **Bug Fixes**
  * Fixed detection so in-place updates to a referenced pull Secret or trust bundle trigger rollouts for existing NodePools.

* **Documentation**
  * Clarified that updating Secret data in place will trigger NodePool rollouts.

* **Tests**
  * Added and updated unit tests covering secret-change handling and new hashing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->