### PR TITLE
NO-JIRA: Add gitlint to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,12 @@ repos:
         entry: make lint-fix
         language: system
         stages: [pre-commit]
+      - id: run-gitlint
+        name: Run gitlint
+        description: Runs `make run-gitlint` to validate commit messages.
+        entry: make run-gitlint
+        language: system
+        stages: [pre-commit]
       - id: make-verify
         name: Run make verify
         description: Runs `make verify`.


### PR DESCRIPTION
## What this PR does / why we need it:

Adds `run-gitlint` to the pre-commit stage so commit message format is validated on every commit, catching formatting issues before they reach CI.

**Pre-commit hooks (on commit):**
- check-merge-conflict, check-yaml, trailing-whitespace
- codespell, CPO containerfile sync
- lint-fix (import sorting)
- **gitlint (new)** — commit message validation

**Pre-push hooks (on push):**
- make verify
- make test

## Which issue(s) this PR fixes:

N/A

## Special notes for your reviewer:

`make lint` was considered for the commit stage but excluded since `lint-fix` already runs the same linter (with `--fix`), and both depend on `generate` — running both would double the commit time unnecessarily.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development workflow tooling configuration to strengthen code quality practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->