### PR TITLE
NO-JIRA: fix address-review-comments workflow for fork PRs

### DIFF
--- a/.github/workflows/address-review-comments.yaml
+++ b/.github/workflows/address-review-comments.yaml
@@ -41,10 +41,20 @@ jobs:
           echo "branch=$(jq -r '.head.ref' /tmp/pr.json)" >> "$GITHUB_OUTPUT"
           echo "repo=$(jq -r '.head.repo.full_name' /tmp/pr.json)" >> "$GITHUB_OUTPUT"
 
+      - name: Select token for PR repo
+        id: token
+        run: |
+          if [[ "${{ steps.pr.outputs.repo }}" == "hypershift-community/hypershift" ]]; then
+            echo "use_fork_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "use_fork_token=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ steps.pr.outputs.branch }}
           repository: ${{ steps.pr.outputs.repo }}
+          token: ${{ steps.token.outputs.use_fork_token == 'true' && secrets.COMMUNITY_FORK_TOKEN || github.token }}
           persist-credentials: true
           fetch-depth: 0
 
@@ -72,7 +82,7 @@ jobs:
           CLAUDE_CODE_USE_VERTEX: "1"
           CLOUD_ML_REGION: global
           ANTHROPIC_VERTEX_PROJECT_ID: hosted-control-planes
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.token.outputs.use_fork_token == 'true' && secrets.COMMUNITY_FORK_TOKEN || github.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
         run: |
           claude --version


### PR DESCRIPTION
## What this PR does / why we need it:

The address-review-comments workflow uses `github.token` which is scoped to `openshift/hypershift`. When the PR originates from the `hypershift-community` fork, the token lacks access to checkout and push to the fork. This adds conditional token selection — using `COMMUNITY_FORK_TOKEN` for `hypershift-community` PRs and falling back to `github.token` otherwise.

The secret is resolved via GitHub's expression engine (not written to step outputs) to avoid leaking it to the runner filesystem.

## Which issue(s) this PR fixes:

N/A

## Special notes for your reviewer:

- `issue_comment` workflows run from the default branch, so this can't be tested in a PR — it takes effect after merge
- The `COMMUNITY_FORK_TOKEN` secret already exists in the repo (used by `sync-community-fork.yaml`)
- The "Link to run" step intentionally keeps using `github.token` since it only comments on `openshift/hypershift`

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration for improved PR handling processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->