### PR TITLE
RFE-9274: add disable-external-dns-management annotation

### DIFF
--- a/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -323,7 +323,8 @@ const (
 	InvalidAzureCredentialsReason = "InvalidAzureCredentials"
 	AzureErrorReason              = "AzureError"
 
-	ExternalDNSHostNotReachableReason = "ExternalDNSHostNotReachable"
+	ExternalDNSHostNotReachableReason   = "ExternalDNSHostNotReachable"
+	ExternalDNSManagementDisabledReason = "ExternalDNSManagementDisabled"
 
 	KASLoadBalancerNotReachableReason = "KASLoadBalancerNotReachable"
 

--- a/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -309,7 +309,8 @@ const (
 	InvalidAzureCredentialsReason = "InvalidAzureCredentials"
 	AzureErrorReason              = "AzureError"
 
-	ExternalDNSHostNotReachableReason = "ExternalDNSHostNotReachable"
+	ExternalDNSHostNotReachableReason   = "ExternalDNSHostNotReachable"
+	ExternalDNSManagementDisabledReason = "ExternalDNSManagementDisabled"
 
 	KASLoadBalancerNotReachableReason = "KASLoadBalancerNotReachable"
 

--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -159,6 +159,14 @@ const (
 	// ExternalDNSHostnameAnnotation is the annotation external-dns uses to register DNS name for different HCP services.
 	ExternalDNSHostnameAnnotation = "external-dns.alpha.kubernetes.io/hostname"
 
+	// DisableExternalDNSManagementAnnotation when set to "true" on a HostedCluster prevents the
+	// control-plane-operator from adding the external-dns hostname annotation to LoadBalancer services
+	// (KAS, Konnectivity, and OAuth). It does not affect ExternalName services used by
+	// AWS PrivateLink or GCP Private Service Connect.
+	// This allows users to manage their own DNS records for the API and Konnectivity endpoints.
+	// The value must be exactly "true" to take effect; key-existence alone is not sufficient.
+	DisableExternalDNSManagementAnnotation = "hypershift.openshift.io/disable-external-dns-management"
+
 	// ForceUpgradeToAnnotation is the annotation that forces HostedCluster upgrade even if the underlying ClusterVersion
 	// is reporting it is not Upgradeable.  The annotation value must be set to the release image being forced.
 	ForceUpgradeToAnnotation = "hypershift.openshift.io/force-upgrade-to"

--- a/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/api/hypershift/v1beta1/hostedcluster_types.go
@@ -164,6 +164,14 @@ const (
 	// ExternalDNSHostnameAnnotation is the annotation external-dns uses to register DNS name for different HCP services.
 	ExternalDNSHostnameAnnotation = "external-dns.alpha.kubernetes.io/hostname"
 
+	// DisableExternalDNSManagementAnnotation when set to "true" on a HostedCluster prevents the
+	// control-plane-operator from adding the external-dns hostname annotation to LoadBalancer services
+	// (KAS, Konnectivity, and OAuth). It does not affect ExternalName services used by
+	// AWS PrivateLink or GCP Private Service Connect.
+	// This allows users to manage their own DNS records for the API and Konnectivity endpoints.
+	// The value must be exactly "true" to take effect; key-existence alone is not sufficient.
+	DisableExternalDNSManagementAnnotation = "hypershift.openshift.io/disable-external-dns-management"
+
 	// ForceUpgradeToAnnotation is the annotation that forces HostedCluster upgrade even if the underlying ClusterVersion
 	// is reporting it is not Upgradeable.  The annotation value must be set to the release image being forced.
 	ForceUpgradeToAnnotation = "hypershift.openshift.io/force-upgrade-to"

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -773,6 +773,18 @@ func (r *HostedControlPlaneReconciler) reconcileExternalDNSStatusCondition(ctx c
 		Reason: hyperv1.StatusUnknownReason,
 	}
 
+	if hostedControlPlane.Annotations[hyperv1.DisableExternalDNSManagementAnnotation] == "true" {
+		newCondition = metav1.Condition{
+			Type:    string(hyperv1.ExternalDNSReachable),
+			Status:  metav1.ConditionTrue,
+			Reason:  hyperv1.ExternalDNSManagementDisabledReason,
+			Message: "External DNS management is disabled by annotation",
+		}
+		newCondition.ObservedGeneration = hostedControlPlane.Generation
+		meta.SetStatusCondition(&hostedControlPlane.Status.Conditions, newCondition)
+		return
+	}
+
 	kasExternalHostname := netutil.ServiceExternalDNSHostname(hostedControlPlane, hyperv1.APIServer)
 	if kasExternalHostname != "" {
 		if err := netutil.ResolveDNSHostname(ctx, kasExternalHostname); err != nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -792,6 +792,18 @@ func (r *HostedControlPlaneReconciler) reconcileExternalDNSStatusCondition(ctx c
 		Reason: hyperv1.StatusUnknownReason,
 	}
 
+	if hostedControlPlane.Annotations[hyperv1.DisableExternalDNSManagementAnnotation] == "true" {
+		newCondition = metav1.Condition{
+			Type:    string(hyperv1.ExternalDNSReachable),
+			Status:  metav1.ConditionTrue,
+			Reason:  hyperv1.ExternalDNSManagementDisabledReason,
+			Message: "External DNS management is disabled by annotation",
+		}
+		newCondition.ObservedGeneration = hostedControlPlane.Generation
+		meta.SetStatusCondition(&hostedControlPlane.Status.Conditions, newCondition)
+		return
+	}
+
 	kasExternalHostname := netutil.ServiceExternalDNSHostname(hostedControlPlane, hyperv1.APIServer)
 	if kasExternalHostname != "" {
 		if err := netutil.ResolveDNSHostname(ctx, kasExternalHostname); err != nil {

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -3798,6 +3798,22 @@ func TestReconcileExternalDNSStatusCondition(t *testing.T) {
 			expectedCondReason: hyperv1.StatusUnknownReason,
 			expectedMessage:    "External DNS is not configured",
 		},
+		{
+			name: "When disable-external-dns-management annotation is true, it should set ExternalDNSReachable to True",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-hcp",
+					Namespace:  testNamespace,
+					Generation: 1,
+					Annotations: map[string]string{
+						hyperv1.DisableExternalDNSManagementAnnotation: "true",
+					},
+				},
+			},
+			expectedCondStatus: metav1.ConditionTrue,
+			expectedCondReason: hyperv1.ExternalDNSManagementDisabledReason,
+			expectedMessage:    "External DNS management is disabled by annotation",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller_test.go
@@ -3816,6 +3816,22 @@ func TestReconcileExternalDNSStatusCondition(t *testing.T) {
 			expectedCondReason: hyperv1.StatusUnknownReason,
 			expectedMessage:    "External DNS is not configured",
 		},
+		{
+			name: "When disable-external-dns-management annotation is true, it should set ExternalDNSReachable to True",
+			hcp: &hyperv1.HostedControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-hcp",
+					Namespace:  testNamespace,
+					Generation: 1,
+					Annotations: map[string]string{
+						hyperv1.DisableExternalDNSManagementAnnotation: "true",
+					},
+				},
+			},
+			expectedCondStatus: metav1.ConditionTrue,
+			expectedCondReason: hyperv1.ExternalDNSManagementDisabledReason,
+			expectedMessage:    "External DNS management is disabled by annotation",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/infra.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/infra.go
@@ -347,7 +347,7 @@ func (r *Reconciler) reconcileOAuthServerService(ctx context.Context, hcp *hyper
 	p := oauth.NewOAuthServiceParams(hcp)
 	oauthServerService := manifests.OauthServerService(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r.Client, oauthServerService, func() error {
-		return oauth.ReconcileService(oauthServerService, p.OwnerRef, serviceStrategy, hcp.Spec.Platform.Type, netutil.IsPrivateHCP(hcp))
+		return oauth.ReconcileService(oauthServerService, p.OwnerRef, serviceStrategy, hcp.Spec.Platform.Type, netutil.IsPrivateHCP(hcp), hcp.Annotations[hyperv1.DisableExternalDNSManagementAnnotation] == "true")
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile OAuth service: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/infra/infra.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/infra/infra.go
@@ -343,7 +343,7 @@ func (r *Reconciler) reconcileOAuthServerService(ctx context.Context, hcp *hyper
 	p := oauth.NewOAuthServiceParams(hcp)
 	oauthServerService := manifests.OauthServerService(hcp.Namespace)
 	if _, err := createOrUpdate(ctx, r.Client, oauthServerService, func() error {
-		return oauth.ReconcileService(oauthServerService, p.OwnerRef, serviceStrategy, hcp.Spec.Platform.Type, netutil.IsPrivateHCP(hcp))
+		return oauth.ReconcileService(oauthServerService, p.OwnerRef, serviceStrategy, hcp.Spec.Platform.Type, netutil.IsPrivateHCP(hcp), hcp.Annotations[hyperv1.DisableExternalDNSManagementAnnotation] == "true")
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile OAuth service: %w", err)
 	}

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -77,7 +77,11 @@ func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingSt
 				svc.Annotations[AWSNLBAnnotation] = "nlb"
 			}
 			if strategy.LoadBalancer != nil && strategy.LoadBalancer.Hostname != "" {
-				svc.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = strategy.LoadBalancer.Hostname
+				if hcp.Annotations[hyperv1.DisableExternalDNSManagementAnnotation] != "true" {
+					svc.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = strategy.LoadBalancer.Hostname
+				} else {
+					delete(svc.Annotations, hyperv1.ExternalDNSHostnameAnnotation)
+				}
 			}
 			if !azureutil.IsAroHCPByHCP(hcp) {
 				svc.Spec.LoadBalancerSourceRanges = apiAllowedCIDRBlocks
@@ -309,7 +313,11 @@ func ReconcileKonnectivityServerService(svc *corev1.Service, ownerRef config.Own
 			if svc.Annotations == nil {
 				svc.Annotations = map[string]string{}
 			}
-			svc.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = strategy.LoadBalancer.Hostname
+			if hcp.Annotations[hyperv1.DisableExternalDNSManagementAnnotation] != "true" {
+				svc.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = strategy.LoadBalancer.Hostname
+			} else {
+				delete(svc.Annotations, hyperv1.ExternalDNSHostnameAnnotation)
+			}
 		}
 	case hyperv1.NodePort:
 		svc.Spec.Type = corev1.ServiceTypeNodePort

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service.go
@@ -77,7 +77,11 @@ func ReconcileService(svc *corev1.Service, strategy *hyperv1.ServicePublishingSt
 				svc.Annotations[AWSNLBAnnotation] = "nlb"
 			}
 			if strategy.LoadBalancer != nil && strategy.LoadBalancer.Hostname != "" {
-				svc.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = strategy.LoadBalancer.Hostname
+				if hcp.Annotations[hyperv1.DisableExternalDNSManagementAnnotation] != "true" {
+					svc.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = strategy.LoadBalancer.Hostname
+				} else {
+					delete(svc.Annotations, hyperv1.ExternalDNSHostnameAnnotation)
+				}
 			}
 			if !azureutil.IsAroHCPByHCP(hcp) {
 				svc.Spec.LoadBalancerSourceRanges = apiAllowedCIDRBlocks
@@ -316,7 +320,11 @@ func ReconcileKonnectivityServerService(svc *corev1.Service, ownerRef config.Own
 			if svc.Annotations == nil {
 				svc.Annotations = map[string]string{}
 			}
-			svc.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = strategy.LoadBalancer.Hostname
+			if hcp.Annotations[hyperv1.DisableExternalDNSManagementAnnotation] != "true" {
+				svc.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = strategy.LoadBalancer.Hostname
+			} else {
+				delete(svc.Annotations, hyperv1.ExternalDNSHostnameAnnotation)
+			}
 		}
 	case hyperv1.NodePort:
 		svc.Spec.Type = corev1.ServiceTypeNodePort

--- a/control-plane-operator/controllers/hostedcontrolplane/kas/service_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/kas/service_test.go
@@ -438,3 +438,141 @@ func TestKonnectivityServiceReconcile(t *testing.T) {
 		})
 	}
 }
+
+func TestReconcileServiceDisableExternalDNS(t *testing.T) {
+	host := "api.example.com"
+
+	testCases := []struct {
+		name                string
+		hcpAnnotations      map[string]string
+		existingAnnotations map[string]string
+		expectAnnotation    bool
+	}{
+		{
+			name:             "When disable annotation is absent, it should set ExternalDNS annotation",
+			hcpAnnotations:   nil,
+			expectAnnotation: true,
+		},
+		{
+			name:             "When disable annotation is true, it should not set ExternalDNS annotation",
+			hcpAnnotations:   map[string]string{hyperv1.DisableExternalDNSManagementAnnotation: "true"},
+			expectAnnotation: false,
+		},
+		{
+			name:             "When disable annotation is false, it should set ExternalDNS annotation",
+			hcpAnnotations:   map[string]string{hyperv1.DisableExternalDNSManagementAnnotation: "false"},
+			expectAnnotation: true,
+		},
+		{
+			name:           "When disable annotation is true on day-2, it should delete existing ExternalDNS annotation",
+			hcpAnnotations: map[string]string{hyperv1.DisableExternalDNSManagementAnnotation: "true"},
+			existingAnnotations: map[string]string{
+				hyperv1.ExternalDNSHostnameAnnotation: host,
+			},
+			expectAnnotation: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: tc.hcpAnnotations,
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{
+						Type: hyperv1.AWSPlatform,
+						AWS: &hyperv1.AWSPlatformSpec{
+							EndpointAccess: hyperv1.Public,
+						},
+					},
+				},
+			}
+			svc := &corev1.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: tc.existingAnnotations,
+				},
+			}
+			strategy := &hyperv1.ServicePublishingStrategy{
+				Type: hyperv1.LoadBalancer,
+				LoadBalancer: &hyperv1.LoadBalancerPublishingStrategy{
+					Hostname: host,
+				},
+			}
+
+			err := ReconcileService(svc, strategy, &v1.OwnerReference{}, 6443, []string{}, hcp)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			if tc.expectAnnotation {
+				g.Expect(svc.Annotations).To(HaveKeyWithValue(hyperv1.ExternalDNSHostnameAnnotation, host))
+			} else {
+				g.Expect(svc.Annotations).ToNot(HaveKey(hyperv1.ExternalDNSHostnameAnnotation))
+			}
+		})
+	}
+}
+
+func TestReconcileKonnectivityServiceDisableExternalDNS(t *testing.T) {
+	host := "konnectivity.example.com"
+
+	testCases := []struct {
+		name                string
+		hcpAnnotations      map[string]string
+		existingAnnotations map[string]string
+		expectAnnotation    bool
+	}{
+		{
+			name:             "When disable annotation is absent, it should set ExternalDNS annotation",
+			hcpAnnotations:   nil,
+			expectAnnotation: true,
+		},
+		{
+			name:             "When disable annotation is true, it should not set ExternalDNS annotation",
+			hcpAnnotations:   map[string]string{hyperv1.DisableExternalDNSManagementAnnotation: "true"},
+			expectAnnotation: false,
+		},
+		{
+			name:           "When disable annotation is true on day-2, it should delete existing ExternalDNS annotation",
+			hcpAnnotations: map[string]string{hyperv1.DisableExternalDNSManagementAnnotation: "true"},
+			existingAnnotations: map[string]string{
+				hyperv1.ExternalDNSHostnameAnnotation: host,
+			},
+			expectAnnotation: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			hcp := &hyperv1.HostedControlPlane{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: tc.hcpAnnotations,
+				},
+				Spec: hyperv1.HostedControlPlaneSpec{
+					Platform: hyperv1.PlatformSpec{Type: hyperv1.AWSPlatform},
+				},
+			}
+			svc := &corev1.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Annotations: tc.existingAnnotations,
+				},
+			}
+			strategy := &hyperv1.ServicePublishingStrategy{
+				Type: hyperv1.LoadBalancer,
+				LoadBalancer: &hyperv1.LoadBalancerPublishingStrategy{
+					Hostname: host,
+				},
+			}
+
+			err := ReconcileKonnectivityServerService(svc, config.OwnerRef{}, strategy, hcp)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			if tc.expectAnnotation {
+				g.Expect(svc.Annotations).To(HaveKeyWithValue(hyperv1.ExternalDNSHostnameAnnotation, host))
+			} else {
+				g.Expect(svc.Annotations).ToNot(HaveKey(hyperv1.ExternalDNSHostnameAnnotation))
+			}
+		})
+	}
+}

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/service.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/service.go
@@ -27,7 +27,7 @@ var (
 	}
 )
 
-func ReconcileService(svc *corev1.Service, ownerRef config.OwnerRef, strategy *hyperv1.ServicePublishingStrategy, platformType hyperv1.PlatformType, isPrivate bool) error {
+func ReconcileService(svc *corev1.Service, ownerRef config.OwnerRef, strategy *hyperv1.ServicePublishingStrategy, platformType hyperv1.PlatformType, isPrivate bool, disableExternalDNS bool) error {
 	ownerRef.ApplyTo(svc)
 	if svc.Spec.Selector == nil {
 		svc.Spec.Selector = oauthServerLabels
@@ -69,7 +69,11 @@ func ReconcileService(svc *corev1.Service, ownerRef config.OwnerRef, strategy *h
 			svc.Annotations = map[string]string{}
 		}
 		if strategy.LoadBalancer != nil && strategy.LoadBalancer.Hostname != "" {
-			svc.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = strategy.LoadBalancer.Hostname
+			if !disableExternalDNS {
+				svc.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = strategy.LoadBalancer.Hostname
+			} else {
+				delete(svc.Annotations, hyperv1.ExternalDNSHostnameAnnotation)
+			}
 		}
 		if isPrivate {
 			svc.Annotations[azureutil.InternalLoadBalancerAnnotation] = azureutil.InternalLoadBalancerValue

--- a/control-plane-operator/controllers/hostedcontrolplane/oauth/service_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/oauth/service_test.go
@@ -213,7 +213,7 @@ func TestOauthServiceReconcile(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			err := ReconcileService(&tc.svc_in, config.OwnerRef{}, &tc.strategy, tc.platform, tc.isPrivate)
+			err := ReconcileService(&tc.svc_in, config.OwnerRef{}, &tc.strategy, tc.platform, tc.isPrivate, false)
 
 			if tc.err == nil {
 				g.Expect(err).ToNot(HaveOccurred())
@@ -347,6 +347,62 @@ func TestReconcileServiceStatus(t *testing.T) {
 				g.Expect(message).To(ContainSubstring(tc.expectedMessage))
 			} else {
 				g.Expect(message).To(BeEmpty())
+			}
+		})
+	}
+}
+
+func TestOauthServiceDisableExternalDNS(t *testing.T) {
+	hostname := "oauth.example.com"
+
+	testCases := []struct {
+		name                string
+		disableExtDNS       bool
+		existingAnnotations map[string]string
+		expectAnnotation    bool
+	}{
+		{
+			name:             "When disable flag is false, it should set ExternalDNS annotation",
+			disableExtDNS:    false,
+			expectAnnotation: true,
+		},
+		{
+			name:             "When disable flag is true, it should not set ExternalDNS annotation",
+			disableExtDNS:    true,
+			expectAnnotation: false,
+		},
+		{
+			name:          "When disable flag is true on day-2, it should delete existing ExternalDNS annotation",
+			disableExtDNS: true,
+			existingAnnotations: map[string]string{
+				v1beta1.ExternalDNSHostnameAnnotation: hostname,
+			},
+			expectAnnotation: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tc.existingAnnotations,
+				},
+			}
+			strategy := &v1beta1.ServicePublishingStrategy{
+				Type: v1beta1.LoadBalancer,
+				LoadBalancer: &v1beta1.LoadBalancerPublishingStrategy{
+					Hostname: hostname,
+				},
+			}
+
+			err := ReconcileService(svc, config.OwnerRef{}, strategy, v1beta1.AzurePlatform, false, tc.disableExtDNS)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			if tc.expectAnnotation {
+				g.Expect(svc.Annotations).To(HaveKeyWithValue(v1beta1.ExternalDNSHostnameAnnotation, hostname))
+			} else {
+				g.Expect(svc.Annotations).ToNot(HaveKey(v1beta1.ExternalDNSHostnameAnnotation))
 			}
 		})
 	}

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2383,6 +2383,7 @@ func reconcileHostedControlPlaneAnnotations(hcp *hyperv1.HostedControlPlane, hcl
 		"hypershift.openshift.io/aws-termination-handler-queue-url",
 		hyperv1.SwiftPodNetworkInstanceAnnotation,
 		hyperv1.EnableMetricsForwarding,
+		hyperv1.DisableExternalDNSManagementAnnotation,
 	}
 	for _, key := range mirroredAnnotations {
 		val, hasVal := hcluster.Annotations[key]

--- a/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
+++ b/hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go
@@ -2631,6 +2631,7 @@ func reconcileHostedControlPlaneAnnotations(hcp *hyperv1.HostedControlPlane, hcl
 		"hypershift.openshift.io/aws-termination-handler-queue-url",
 		hyperv1.SwiftPodNetworkInstanceAnnotation,
 		hyperv1.EnableMetricsForwarding,
+		hyperv1.DisableExternalDNSManagementAnnotation,
 	}
 	for _, key := range mirroredAnnotations {
 		val, hasVal := hcluster.Annotations[key]

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -323,7 +323,8 @@ const (
 	InvalidAzureCredentialsReason = "InvalidAzureCredentials"
 	AzureErrorReason              = "AzureError"
 
-	ExternalDNSHostNotReachableReason = "ExternalDNSHostNotReachable"
+	ExternalDNSHostNotReachableReason   = "ExternalDNSHostNotReachable"
+	ExternalDNSManagementDisabledReason = "ExternalDNSManagementDisabled"
 
 	KASLoadBalancerNotReachableReason = "KASLoadBalancerNotReachable"
 

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_conditions.go
@@ -309,7 +309,8 @@ const (
 	InvalidAzureCredentialsReason = "InvalidAzureCredentials"
 	AzureErrorReason              = "AzureError"
 
-	ExternalDNSHostNotReachableReason = "ExternalDNSHostNotReachable"
+	ExternalDNSHostNotReachableReason   = "ExternalDNSHostNotReachable"
+	ExternalDNSManagementDisabledReason = "ExternalDNSManagementDisabled"
 
 	KASLoadBalancerNotReachableReason = "KASLoadBalancerNotReachable"
 

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -159,6 +159,14 @@ const (
 	// ExternalDNSHostnameAnnotation is the annotation external-dns uses to register DNS name for different HCP services.
 	ExternalDNSHostnameAnnotation = "external-dns.alpha.kubernetes.io/hostname"
 
+	// DisableExternalDNSManagementAnnotation when set to "true" on a HostedCluster prevents the
+	// control-plane-operator from adding the external-dns hostname annotation to LoadBalancer services
+	// (KAS, Konnectivity, and OAuth). It does not affect ExternalName services used by
+	// AWS PrivateLink or GCP Private Service Connect.
+	// This allows users to manage their own DNS records for the API and Konnectivity endpoints.
+	// The value must be exactly "true" to take effect; key-existence alone is not sufficient.
+	DisableExternalDNSManagementAnnotation = "hypershift.openshift.io/disable-external-dns-management"
+
 	// ForceUpgradeToAnnotation is the annotation that forces HostedCluster upgrade even if the underlying ClusterVersion
 	// is reporting it is not Upgradeable.  The annotation value must be set to the release image being forced.
 	ForceUpgradeToAnnotation = "hypershift.openshift.io/force-upgrade-to"

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/hostedcluster_types.go
@@ -164,6 +164,14 @@ const (
 	// ExternalDNSHostnameAnnotation is the annotation external-dns uses to register DNS name for different HCP services.
 	ExternalDNSHostnameAnnotation = "external-dns.alpha.kubernetes.io/hostname"
 
+	// DisableExternalDNSManagementAnnotation when set to "true" on a HostedCluster prevents the
+	// control-plane-operator from adding the external-dns hostname annotation to LoadBalancer services
+	// (KAS, Konnectivity, and OAuth). It does not affect ExternalName services used by
+	// AWS PrivateLink or GCP Private Service Connect.
+	// This allows users to manage their own DNS records for the API and Konnectivity endpoints.
+	// The value must be exactly "true" to take effect; key-existence alone is not sufficient.
+	DisableExternalDNSManagementAnnotation = "hypershift.openshift.io/disable-external-dns-management"
+
 	// ForceUpgradeToAnnotation is the annotation that forces HostedCluster upgrade even if the underlying ClusterVersion
 	// is reporting it is not Upgradeable.  The annotation value must be set to the release image being forced.
 	ForceUpgradeToAnnotation = "hypershift.openshift.io/force-upgrade-to"


### PR DESCRIPTION
# [RFE-9274](https://redhat.atlassian.net/browse/RFE-9274): Allow users to opt out of external-dns annotation injection on LoadBalancer services

**Repository:** `openshift/hypershift`
**Fixes:** [RFE-9274](https://issues.redhat.com/browse/RFE-9274)
**Files modified:** 9

---

## Objective

Add a `hypershift.openshift.io/disable-external-dns-management: "true"` annotation on HostedCluster that prevents the Control Plane Operator from injecting the `external-dns.alpha.kubernetes.io/hostname` annotation on LoadBalancer services. This enables users who manage their own DNS (BYODNS) to use HyperShift's LoadBalancer publishing strategy without a false-negative `ExternalDNSReachable` condition or coupling to an external-dns controller they don't run.

---

## Problem Statement

When `spec.services[].servicePublishingStrategy.loadBalancer.hostname` is configured, the CPO unconditionally injects `external-dns.alpha.kubernetes.io/hostname` on the KAS, Konnectivity, and (on Azure) OAuth LoadBalancer services.

In environments without an external-dns controller — Agent-based HCP on bare metal, KubeVirt with MetalLB, air-gapped clusters — this produces a permanent false-negative:

```
CONDITION            STATUS   REASON                      MESSAGE
ExternalDNSReachable False    ExternalDNSHostNotReachable  lookup api.mycluster.example.com on 172.30.0.10:53: no such host
```

**No persistent workaround exists.** Manually removing the annotation from the service is overwritten by CPO reconciliation within ~30 seconds.

---

## Scope

### This PR does:
- Suppress `external-dns.alpha.kubernetes.io/hostname` injection when the annotation is set
- Actively remove the annotation on pre-existing services (day-2 opt-out)
- Report `ExternalDNSReachable: True (ExternalDNSManagementDisabled)` when opted out
- Propagate the annotation from HostedCluster to HostedControlPlane via `mirroredAnnotations`

### This PR does NOT:
- Change the CRD schema or add new API fields
- Separate `api` from `api-int` DNS resolution
- Modify LoadBalancer provisioning behavior
- Affect Route-based or NodePort-based service publishing
- Change PKI/SAN generation, ControlPlaneEndpoint, kubeconfig, or node HAProxy behavior

### Platform applicability:

| Service | Trigger condition | Platforms affected |
|---------|------------------|--------------------|
| KAS | `LoadBalancer` strategy + public endpoint | AWS, GCP, Azure |
| Konnectivity | `LoadBalancer` strategy | Any |
| OAuth | `LoadBalancer` strategy | Azure only |

---

## Design Decision

| Approach | Pros | Cons | Verdict |
|----------|------|------|---------|
| API field `manageDNS *bool` on strategy | Type-safe, discoverable | CRD change, API review, deepcopy regen, vendor sync, no precedent for bool toggles on strategy structs | Rejected |
| Runtime external-dns operator detection | Zero config | Race condition on install/remove, violates separation of concerns | Rejected |
| Separate `dnsHostname` vs `serviceHostname` | Clean separation | Breaking API change, confusing dual-hostname semantics | Rejected |
| **Annotation** `disable-external-dns-management` | Zero CRD change, backward compatible, follows 7+ existing `disable-*` patterns, promotable to field later | Not discoverable via `oc explain` | **Chosen** |

**Closest code pattern:** `DisablePKIReconciliationAnnotation` — identical guard structure:
```go
if hcp.Annotations[hyperv1.DisablePKIReconciliationAnnotation] == "true" { ... }
```

---

## Implementation

| File | Change |
|------|--------|
| `api/hypershift/v1beta1/hostedcluster_types.go` | Add `DisableExternalDNSManagementAnnotation` constant |
| `hypershift-operator/controllers/hostedcluster/hostedcluster_controller.go` | Add to `mirroredAnnotations` (HC -> HCP propagation) |
| `control-plane-operator/controllers/hostedcontrolplane/kas/service.go` | Guard KAS + Konnectivity annotation injection (2 locations) |
| `control-plane-operator/controllers/hostedcontrolplane/oauth/service.go` | Add `disableExternalDNS` parameter, guard injection |
| `control-plane-operator/controllers/hostedcontrolplane/infra/infra.go` | Pass disable flag to OAuth reconciler |
| `control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go` | Early return in `reconcileExternalDNSStatusCondition` |
| `kas/service_test.go` | 6 new test cases |
| `oauth/service_test.go` | 2 new test cases |
| `vendor/.../hostedcluster_types.go` | Sync vendored constant |

### Core logic (KAS service):

```go
if strategy.LoadBalancer != nil && strategy.LoadBalancer.Hostname != "" {
    if hcp.Annotations[hyperv1.DisableExternalDNSManagementAnnotation] != "true" {
        svc.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = strategy.LoadBalancer.Hostname
    } else {
        delete(svc.Annotations, hyperv1.ExternalDNSHostnameAnnotation)
    }
}
```

### Condition controller:

```go
if hostedControlPlane.Annotations[hyperv1.DisableExternalDNSManagementAnnotation] == "true" {
    newCondition = metav1.Condition{
        Type:   string(hyperv1.ExternalDNSReachable),
        Status: metav1.ConditionTrue,
        Reason: "ExternalDNSManagementDisabled",
        Message: "External DNS management is disabled by annotation",
    }
    meta.SetStatusCondition(&hostedControlPlane.Status.Conditions, newCondition)
    return
}
```

---

## Testing Results

### Unit Tests

| Test function | Cases | Result |
|---------------|-------|--------|
| `TestReconcileServiceDisableExternalDNS` (KAS) | annotation absent -> set, annotation=true -> suppressed, annotation=false -> set, day-2 opt-out -> deleted | PASS |
| `TestReconcileKonnectivityServiceDisableExternalDNS` | annotation absent -> set, annotation=true -> suppressed | PASS |
| `TestOauthServiceDisableExternalDNS` | disabled=false -> set, disabled=true -> suppressed | PASS |
| All pre-existing KAS tests | 8 cases | PASS (no regression) |
| All pre-existing OAuth tests | 10 cases | PASS (no regression) |

### Integration Tests (Live Cluster)

**Environment:** OCP 4.22.0, AWS eu-north-1, MCE v2.16.1, MetalLB L2, custom CPO image with fix.

#### Test 1: AWS/None — Day-2 Opt-Out

Existing cluster with annotation already injected by stock CPO. Applied fix to verify active removal.

```
$ oc get svc kube-apiserver -n clusters-rfe9274-test -o jsonpath='{.metadata.annotations}'
{"metallb.io/ip-allocated-from-pool":"hub-vpc-pool"}

$ oc get hostedcluster rfe9274-test -n clusters \
    -o jsonpath='{.status.conditions[?(@.type=="ExternalDNSReachable")]}'
{"reason":"ExternalDNSManagementDisabled","status":"True","type":"ExternalDNSReachable"}
```

**Before:** `external-dns.alpha.kubernetes.io/hostname` present, condition `False`.
**After:** Annotation deleted by CPO on reconcile, condition `True`.

#### Test 2: KubeVirt — Greenfield

Fresh cluster with annotation set from creation. Proves annotation is never injected.

```
$ oc get svc kube-apiserver -n clusters-rfe9274-kubevirt -o jsonpath='{.metadata.annotations}'
{"metallb.io/ip-allocated-from-pool":"hub-vpc-pool"}

$ oc get nodepool rfe9274-kubevirt-workers -n clusters
NAME                       CLUSTER            DESIRED   CURRENT   VERSION
rfe9274-kubevirt-workers   rfe9274-kubevirt   2         2         4.21.0
```

Workers joined via user-managed DNS (private Route53 zone -> MetalLB IP). Full cluster lifecycle validated.

#### Test 3: Agent — Greenfield

Agent-based workers (EC2 instances booting RHCOS discovery ISO) with user-managed DNS via internal NLB.

```
$ oc get svc kube-apiserver -n clusters-rfe9274-agent -o jsonpath='{.metadata.annotations}'
{"metallb.io/ip-allocated-from-pool":"hub-vpc-pool"}

$ KUBECONFIG=/tmp/rfe9274-agent-guest.kubeconfig oc get nodes
NAME             STATUS   ROLES    AGE     VERSION
ip-10-0-75-43   Ready    worker   4m30s   v1.34.2
ip-10-0-78-88   Ready    worker   4m29s   v1.34.2
```

Workers joined, CSRs approved, guest cluster fully operational.

---

## Limitations and Known Gaps

| Gap | Severity | Mitigation |
|-----|----------|------------|
| OAuth path (Azure-only) not live-tested | Low | Unit-tested; logic identical to KAS guard; no Azure environment available |
| HO in MCE v2.16.x does not propagate the annotation | Medium | Users must manually annotate HCP until v2.17+ picks up `main` branch |
| No upstream e2e test | Medium | Needs integration with HyperShift e2e framework (follow-up PR) |
| MetalLB L2 VIPs unreachable from off-cluster nodes on AWS | N/A | Infra constraint of test env, not a product issue; solved with internal NLB in tests |

---

## Version Matrix

| MCE Version | HO Propagation | CPO Guard | User Action |
|-------------|---------------|-----------|-------------|
| v2.16.x (current GA) | Manual HCP annotation required | Active (with custom CPO) | Annotate both HC and HCP |
| v2.17+ (this PR) | Automatic (via `mirroredAnnotations`) | Active | Annotate HC only |

---

## Backward Compatibility

| Component | Impact |
|-----------|--------|
| Default behavior (no annotation) | UNCHANGED — hostname injects as before |
| PKI / SAN generation | UNCHANGED — always uses hostname |
| ControlPlaneEndpoint | UNCHANGED — always set from hostname |
| kubeconfig server URL | UNCHANGED |
| Node HAProxy backend | UNCHANGED — re-resolves hostname on TCP failure |
| Route external-dns (RouteVisibility) | UNCHANGED — separate mechanism |

---

## Usage

```yaml
apiVersion: hypershift.openshift.io/v1beta1
kind: HostedCluster
metadata:
  name: my-cluster
  namespace: clusters
  annotations:
    hypershift.openshift.io/disable-external-dns-management: "true"
spec:
  services:
    - service: APIServer
      servicePublishingStrategy:
        type: LoadBalancer
        loadBalancer:
          hostname: api.mycluster.example.com
```

**Pre-requisite:** Users must create DNS records (`api.<name>.<domain>`) pointing to the LoadBalancer IP/hostname before worker nodes can join.

---

## Related

- [RFE-9274](https://issues.redhat.com/browse/RFE-9274) — Original feature request
- `mirroredAnnotations` in HO controller already includes the propagation logic in `main`
- Future: Part 2 — separate `api-int` endpoint for internal-only resolution (design discussion pending)
- Future: Upstream e2e test PR using HyperShift test framework


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for disabling automatic external DNS management on hosted clusters via annotation, preventing external-dns hostname annotations on relevant LoadBalancer services, including KAS, Konnectivity, and OAuth.

* **Bug Fixes**
  * External DNS reachability status now reflects when external DNS management is disabled.

* **Tests**
  * Added coverage for annotation-driven hostname behavior, including removal of existing annotations when disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->