### PR TITLE
OCPBUGS-87991: validate additionalNetworks name format in KubeVirt NodePools

### DIFF
--- a/api/hypershift/v1beta1/kubevirt.go
+++ b/api/hypershift/v1beta1/kubevirt.go
@@ -169,6 +169,8 @@ type KubevirtNodePoolPlatform struct {
 	// additionalNetworks specify the extra networks attached to the nodes
 	//
 	// +optional
+	// +listType=map
+	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=20
 	AdditionalNetworks []KubevirtNetwork `json:"additionalNetworks,omitempty"`
 
@@ -198,8 +200,14 @@ type KubevirtNodePoolPlatform struct {
 type KubevirtNetwork struct {
 	// name specify the network attached to the nodes
 	// it is a value with the format "[namespace]/[name]" to reference the
-	// multus network attachment definition
-	// +kubebuilder:validation:MaxLength=255
+	// multus network attachment definition, where namespace and name consist
+	// only of lowercase alphanumeric characters and hyphens, and start and
+	// end with alphanumeric characters
+	// +kubebuilder:validation:MaxLength=55
+	// MaxLength=55: KubeVirt requires Interface.Name to be a DNS label (max 63 chars).
+	// The generated name is "iface{N}_{namespace}-{name}" where N≤20 (MaxItems),
+	// giving a max prefix of "iface20_" (8 chars), leaving 55 chars for namespace/name.
+	// +kubebuilder:validation:XValidation:rule="self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?/[a-z0-9]([a-z0-9-]*[a-z0-9])?$')",message="name must be in the format <namespace>/<name> where namespace and name consist only of lowercase alphanumeric characters and hyphens, and start and end with alphanumeric characters"
 	// +required
 	Name string `json:"name"`
 }

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
@@ -1081,14 +1081,28 @@ spec:
                               description: |-
                                 name specify the network attached to the nodes
                                 it is a value with the format "[namespace]/[name]" to reference the
-                                multus network attachment definition
-                              maxLength: 255
+                                multus network attachment definition, where namespace and name consist
+                                only of lowercase alphanumeric characters and hyphens, and start and
+                                end with alphanumeric characters
+                                MaxLength=55: KubeVirt requires Interface.Name to be a DNS label (max 63 chars).
+                                The generated name is "iface{N}_{namespace}-{name}" where N≤20 (MaxItems),
+                                giving a max prefix of "iface20_" (8 chars), leaving 55 chars for namespace/name.
+                              maxLength: 55
                               type: string
+                              x-kubernetes-validations:
+                              - message: name must be in the format <namespace>/<name>
+                                  where namespace and name consist only of lowercase
+                                  alphanumeric characters and hyphens, and start and
+                                  end with alphanumeric characters
+                                rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?/[a-z0-9]([a-z0-9-]*[a-z0-9])?$')
                           required:
                           - name
                           type: object
                         maxItems: 20
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       attachDefaultNetwork:
                         default: true
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/AAA_ungated.yaml
@@ -1103,14 +1103,28 @@ spec:
                               description: |-
                                 name specify the network attached to the nodes
                                 it is a value with the format "[namespace]/[name]" to reference the
-                                multus network attachment definition
-                              maxLength: 255
+                                multus network attachment definition, where namespace and name consist
+                                only of lowercase alphanumeric characters and hyphens, and start and
+                                end with alphanumeric characters
+                                MaxLength=55: KubeVirt requires Interface.Name to be a DNS label (max 63 chars).
+                                The generated name is "iface{N}_{namespace}-{name}" where N≤20 (MaxItems),
+                                giving a max prefix of "iface20_" (8 chars), leaving 55 chars for namespace/name.
+                              maxLength: 55
                               type: string
+                              x-kubernetes-validations:
+                              - message: name must be in the format <namespace>/<name>
+                                  where namespace and name consist only of lowercase
+                                  alphanumeric characters and hyphens, and start and
+                                  end with alphanumeric characters
+                                rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?/[a-z0-9]([a-z0-9-]*[a-z0-9])?$')
                           required:
                           - name
                           type: object
                         maxItems: 20
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       attachDefaultNetwork:
                         default: true
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
@@ -1348,14 +1348,28 @@ spec:
                               description: |-
                                 name specify the network attached to the nodes
                                 it is a value with the format "[namespace]/[name]" to reference the
-                                multus network attachment definition
-                              maxLength: 255
+                                multus network attachment definition, where namespace and name consist
+                                only of lowercase alphanumeric characters and hyphens, and start and
+                                end with alphanumeric characters
+                                MaxLength=55: KubeVirt requires Interface.Name to be a DNS label (max 63 chars).
+                                The generated name is "iface{N}_{namespace}-{name}" where N≤20 (MaxItems),
+                                giving a max prefix of "iface20_" (8 chars), leaving 55 chars for namespace/name.
+                              maxLength: 55
                               type: string
+                              x-kubernetes-validations:
+                              - message: name must be in the format <namespace>/<name>
+                                  where namespace and name consist only of lowercase
+                                  alphanumeric characters and hyphens, and start and
+                                  end with alphanumeric characters
+                                rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?/[a-z0-9]([a-z0-9-]*[a-z0-9])?$')
                           required:
                           - name
                           type: object
                         maxItems: 20
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       attachDefaultNetwork:
                         default: true
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/GCPPlatform.yaml
@@ -1371,14 +1371,28 @@ spec:
                               description: |-
                                 name specify the network attached to the nodes
                                 it is a value with the format "[namespace]/[name]" to reference the
-                                multus network attachment definition
-                              maxLength: 255
+                                multus network attachment definition, where namespace and name consist
+                                only of lowercase alphanumeric characters and hyphens, and start and
+                                end with alphanumeric characters
+                                MaxLength=55: KubeVirt requires Interface.Name to be a DNS label (max 63 chars).
+                                The generated name is "iface{N}_{namespace}-{name}" where N≤20 (MaxItems),
+                                giving a max prefix of "iface20_" (8 chars), leaving 55 chars for namespace/name.
+                              maxLength: 55
                               type: string
+                              x-kubernetes-validations:
+                              - message: name must be in the format <namespace>/<name>
+                                  where namespace and name consist only of lowercase
+                                  alphanumeric characters and hyphens, and start and
+                                  end with alphanumeric characters
+                                rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?/[a-z0-9]([a-z0-9-]*[a-z0-9])?$')
                           required:
                           - name
                           type: object
                         maxItems: 20
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       attachDefaultNetwork:
                         default: true
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OSStreams.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OSStreams.yaml
@@ -1114,14 +1114,28 @@ spec:
                               description: |-
                                 name specify the network attached to the nodes
                                 it is a value with the format "[namespace]/[name]" to reference the
-                                multus network attachment definition
-                              maxLength: 255
+                                multus network attachment definition, where namespace and name consist
+                                only of lowercase alphanumeric characters and hyphens, and start and
+                                end with alphanumeric characters
+                                MaxLength=55: KubeVirt requires Interface.Name to be a DNS label (max 63 chars).
+                                The generated name is "iface{N}_{namespace}-{name}" where N≤20 (MaxItems),
+                                giving a max prefix of "iface20_" (8 chars), leaving 55 chars for namespace/name.
+                              maxLength: 55
                               type: string
+                              x-kubernetes-validations:
+                              - message: name must be in the format <namespace>/<name>
+                                  where namespace and name consist only of lowercase
+                                  alphanumeric characters and hyphens, and start and
+                                  end with alphanumeric characters
+                                rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?/[a-z0-9]([a-z0-9-]*[a-z0-9])?$')
                           required:
                           - name
                           type: object
                         maxItems: 20
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       attachDefaultNetwork:
                         default: true
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OSStreams.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OSStreams.yaml
@@ -1136,14 +1136,28 @@ spec:
                               description: |-
                                 name specify the network attached to the nodes
                                 it is a value with the format "[namespace]/[name]" to reference the
-                                multus network attachment definition
-                              maxLength: 255
+                                multus network attachment definition, where namespace and name consist
+                                only of lowercase alphanumeric characters and hyphens, and start and
+                                end with alphanumeric characters
+                                MaxLength=55: KubeVirt requires Interface.Name to be a DNS label (max 63 chars).
+                                The generated name is "iface{N}_{namespace}-{name}" where N≤20 (MaxItems),
+                                giving a max prefix of "iface20_" (8 chars), leaving 55 chars for namespace/name.
+                              maxLength: 55
                               type: string
+                              x-kubernetes-validations:
+                              - message: name must be in the format <namespace>/<name>
+                                  where namespace and name consist only of lowercase
+                                  alphanumeric characters and hyphens, and start and
+                                  end with alphanumeric characters
+                                rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?/[a-z0-9]([a-z0-9-]*[a-z0-9])?$')
                           required:
                           - name
                           type: object
                         maxItems: 20
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       attachDefaultNetwork:
                         default: true
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
@@ -1081,14 +1081,28 @@ spec:
                               description: |-
                                 name specify the network attached to the nodes
                                 it is a value with the format "[namespace]/[name]" to reference the
-                                multus network attachment definition
-                              maxLength: 255
+                                multus network attachment definition, where namespace and name consist
+                                only of lowercase alphanumeric characters and hyphens, and start and
+                                end with alphanumeric characters
+                                MaxLength=55: KubeVirt requires Interface.Name to be a DNS label (max 63 chars).
+                                The generated name is "iface{N}_{namespace}-{name}" where N≤20 (MaxItems),
+                                giving a max prefix of "iface20_" (8 chars), leaving 55 chars for namespace/name.
+                              maxLength: 55
                               type: string
+                              x-kubernetes-validations:
+                              - message: name must be in the format <namespace>/<name>
+                                  where namespace and name consist only of lowercase
+                                  alphanumeric characters and hyphens, and start and
+                                  end with alphanumeric characters
+                                rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?/[a-z0-9]([a-z0-9-]*[a-z0-9])?$')
                           required:
                           - name
                           type: object
                         maxItems: 20
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       attachDefaultNetwork:
                         default: true
                         description: |-

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OpenStack.yaml
@@ -1103,14 +1103,28 @@ spec:
                               description: |-
                                 name specify the network attached to the nodes
                                 it is a value with the format "[namespace]/[name]" to reference the
-                                multus network attachment definition
-                              maxLength: 255
+                                multus network attachment definition, where namespace and name consist
+                                only of lowercase alphanumeric characters and hyphens, and start and
+                                end with alphanumeric characters
+                                MaxLength=55: KubeVirt requires Interface.Name to be a DNS label (max 63 chars).
+                                The generated name is "iface{N}_{namespace}-{name}" where N≤20 (MaxItems),
+                                giving a max prefix of "iface20_" (8 chars), leaving 55 chars for namespace/name.
+                              maxLength: 55
                               type: string
+                              x-kubernetes-validations:
+                              - message: name must be in the format <namespace>/<name>
+                                  where namespace and name consist only of lowercase
+                                  alphanumeric characters and hyphens, and start and
+                                  end with alphanumeric characters
+                                rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?/[a-z0-9]([a-z0-9-]*[a-z0-9])?$')
                           required:
                           - name
                           type: object
                         maxItems: 20
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       attachDefaultNetwork:
                         default: true
                         description: |-

--- a/cmd/install/assets/crds/hypershift-operator/tests/nodepools.hypershift.openshift.io/stable.nodepools.kubevirt.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/nodepools.hypershift.openshift.io/stable.nodepools.kubevirt.testsuite.yaml
@@ -1,0 +1,341 @@
+apiVersion: apiextensions.k8s.io/v1
+name: "NodePool KubeVirt additionalNetworks validation"
+crdName: nodepools.hypershift.openshift.io
+version: v1beta1
+tests:
+  onCreate:
+  # --- additionalNetworks name format validation ---
+  - name: when additionalNetworks name is valid namespace/name format it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          kubevirt:
+            rootVolume:
+              type: Persistent
+              persistent:
+                size: 32Gi
+            additionalNetworks:
+              - name: "my-ns/my-nad"
+          type: KubeVirt
+
+  - name: when additionalNetworks has multiple valid networks it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          kubevirt:
+            rootVolume:
+              type: Persistent
+              persistent:
+                size: 32Gi
+            additionalNetworks:
+              - name: "ns-a/nad-1"
+              - name: "ns-b/nad-2"
+          type: KubeVirt
+
+  - name: when additionalNetworks name has no slash it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          kubevirt:
+            rootVolume:
+              type: Persistent
+              persistent:
+                size: 32Gi
+            additionalNetworks:
+              - name: "just-a-name"
+          type: KubeVirt
+    expectedError: "name must be in the format <namespace>/<name>"
+
+  - name: when additionalNetworks name has multiple slashes it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          kubevirt:
+            rootVolume:
+              type: Persistent
+              persistent:
+                size: 32Gi
+            additionalNetworks:
+              - name: "ns/sub/name"
+          type: KubeVirt
+    expectedError: "name must be in the format <namespace>/<name>"
+
+  - name: when additionalNetworks name has empty namespace it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          kubevirt:
+            rootVolume:
+              type: Persistent
+              persistent:
+                size: 32Gi
+            additionalNetworks:
+              - name: "/my-nad"
+          type: KubeVirt
+    expectedError: "name must be in the format <namespace>/<name>"
+
+  - name: when additionalNetworks name has empty name segment it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          kubevirt:
+            rootVolume:
+              type: Persistent
+              persistent:
+                size: 32Gi
+            additionalNetworks:
+              - name: "my-ns/"
+          type: KubeVirt
+    expectedError: "name must be in the format <namespace>/<name>"
+
+  - name: when additionalNetworks name has whitespace in namespace it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          kubevirt:
+            rootVolume:
+              type: Persistent
+              persistent:
+                size: 32Gi
+            additionalNetworks:
+              - name: " /name"
+          type: KubeVirt
+    expectedError: "name must be in the format <namespace>/<name>"
+
+  - name: when additionalNetworks name has whitespace in name segment it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          kubevirt:
+            rootVolume:
+              type: Persistent
+              persistent:
+                size: 32Gi
+            additionalNetworks:
+              - name: "my-ns/my nad"
+          type: KubeVirt
+    expectedError: "name must be in the format <namespace>/<name>"
+
+  - name: when additionalNetworks name has dot in name segment it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          kubevirt:
+            rootVolume:
+              type: Persistent
+              persistent:
+                size: 32Gi
+            additionalNetworks:
+              - name: "my-ns/my.nad"
+          type: KubeVirt
+    expectedError: "name must be in the format <namespace>/<name>"
+
+  - name: when additionalNetworks name has uppercase characters it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          kubevirt:
+            rootVolume:
+              type: Persistent
+              persistent:
+                size: 32Gi
+            additionalNetworks:
+              - name: "My-ns/my-nad"
+          type: KubeVirt
+    expectedError: "name must be in the format <namespace>/<name>"
+
+  - name: when additionalNetworks name has underscore in namespace it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          kubevirt:
+            rootVolume:
+              type: Persistent
+              persistent:
+                size: 32Gi
+            additionalNetworks:
+              - name: "my_ns/my-nad"
+          type: KubeVirt
+    expectedError: "name must be in the format <namespace>/<name>"
+
+  - name: when additionalNetworks has duplicate names it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          kubevirt:
+            rootVolume:
+              type: Persistent
+              persistent:
+                size: 32Gi
+            additionalNetworks:
+              - name: "ns/nad1"
+              - name: "ns/nad1"
+          type: KubeVirt
+    expectedError: "Duplicate value"
+
+  - name: when additionalNetworks name is at max length 55 it should pass
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          kubevirt:
+            rootVolume:
+              type: Persistent
+              persistent:
+                size: 32Gi
+            additionalNetworks:
+              - name: "my-namespace-name-that-is-long/my-nad-name-also-long-ab"
+          type: KubeVirt
+
+  - name: when additionalNetworks name exceeds max length 55 it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          kubevirt:
+            rootVolume:
+              type: Persistent
+              persistent:
+                size: 32Gi
+            additionalNetworks:
+              - name: "my-namespace-name-that-is-long/my-nad-name-also-long-abc"
+          type: KubeVirt
+    expectedError: "Too long"

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -1384,14 +1384,28 @@ spec:
                               description: |-
                                 name specify the network attached to the nodes
                                 it is a value with the format "[namespace]/[name]" to reference the
-                                multus network attachment definition
-                              maxLength: 255
+                                multus network attachment definition, where namespace and name consist
+                                only of lowercase alphanumeric characters and hyphens, and start and
+                                end with alphanumeric characters
+                                MaxLength=55: KubeVirt requires Interface.Name to be a DNS label (max 63 chars).
+                                The generated name is "iface{N}_{namespace}-{name}" where N≤20 (MaxItems),
+                                giving a max prefix of "iface20_" (8 chars), leaving 55 chars for namespace/name.
+                              maxLength: 55
                               type: string
+                              x-kubernetes-validations:
+                              - message: name must be in the format <namespace>/<name>
+                                  where namespace and name consist only of lowercase
+                                  alphanumeric characters and hyphens, and start and
+                                  end with alphanumeric characters
+                                rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?/[a-z0-9]([a-z0-9-]*[a-z0-9])?$')
                           required:
                           - name
                           type: object
                         maxItems: 20
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       attachDefaultNetwork:
                         default: true
                         description: |-

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -1407,14 +1407,28 @@ spec:
                               description: |-
                                 name specify the network attached to the nodes
                                 it is a value with the format "[namespace]/[name]" to reference the
-                                multus network attachment definition
-                              maxLength: 255
+                                multus network attachment definition, where namespace and name consist
+                                only of lowercase alphanumeric characters and hyphens, and start and
+                                end with alphanumeric characters
+                                MaxLength=55: KubeVirt requires Interface.Name to be a DNS label (max 63 chars).
+                                The generated name is "iface{N}_{namespace}-{name}" where N≤20 (MaxItems),
+                                giving a max prefix of "iface20_" (8 chars), leaving 55 chars for namespace/name.
+                              maxLength: 55
                               type: string
+                              x-kubernetes-validations:
+                              - message: name must be in the format <namespace>/<name>
+                                  where namespace and name consist only of lowercase
+                                  alphanumeric characters and hyphens, and start and
+                                  end with alphanumeric characters
+                                rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?/[a-z0-9]([a-z0-9-]*[a-z0-9])?$')
                           required:
                           - name
                           type: object
                         maxItems: 20
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       attachDefaultNetwork:
                         default: true
                         description: |-

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -1084,14 +1084,28 @@ spec:
                               description: |-
                                 name specify the network attached to the nodes
                                 it is a value with the format "[namespace]/[name]" to reference the
-                                multus network attachment definition
-                              maxLength: 255
+                                multus network attachment definition, where namespace and name consist
+                                only of lowercase alphanumeric characters and hyphens, and start and
+                                end with alphanumeric characters
+                                MaxLength=55: KubeVirt requires Interface.Name to be a DNS label (max 63 chars).
+                                The generated name is "iface{N}_{namespace}-{name}" where N≤20 (MaxItems),
+                                giving a max prefix of "iface20_" (8 chars), leaving 55 chars for namespace/name.
+                              maxLength: 55
                               type: string
+                              x-kubernetes-validations:
+                              - message: name must be in the format <namespace>/<name>
+                                  where namespace and name consist only of lowercase
+                                  alphanumeric characters and hyphens, and start and
+                                  end with alphanumeric characters
+                                rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?/[a-z0-9]([a-z0-9-]*[a-z0-9])?$')
                           required:
                           - name
                           type: object
                         maxItems: 20
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       attachDefaultNetwork:
                         default: true
                         description: |-

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-Default.crd.yaml
@@ -1139,14 +1139,28 @@ spec:
                               description: |-
                                 name specify the network attached to the nodes
                                 it is a value with the format "[namespace]/[name]" to reference the
-                                multus network attachment definition
-                              maxLength: 255
+                                multus network attachment definition, where namespace and name consist
+                                only of lowercase alphanumeric characters and hyphens, and start and
+                                end with alphanumeric characters
+                                MaxLength=55: KubeVirt requires Interface.Name to be a DNS label (max 63 chars).
+                                The generated name is "iface{N}_{namespace}-{name}" where N≤20 (MaxItems),
+                                giving a max prefix of "iface20_" (8 chars), leaving 55 chars for namespace/name.
+                              maxLength: 55
                               type: string
+                              x-kubernetes-validations:
+                              - message: name must be in the format <namespace>/<name>
+                                  where namespace and name consist only of lowercase
+                                  alphanumeric characters and hyphens, and start and
+                                  end with alphanumeric characters
+                                rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?/[a-z0-9]([a-z0-9-]*[a-z0-9])?$')
                           required:
                           - name
                           type: object
                         maxItems: 20
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       attachDefaultNetwork:
                         default: true
                         description: |-

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -1384,14 +1384,28 @@ spec:
                               description: |-
                                 name specify the network attached to the nodes
                                 it is a value with the format "[namespace]/[name]" to reference the
-                                multus network attachment definition
-                              maxLength: 255
+                                multus network attachment definition, where namespace and name consist
+                                only of lowercase alphanumeric characters and hyphens, and start and
+                                end with alphanumeric characters
+                                MaxLength=55: KubeVirt requires Interface.Name to be a DNS label (max 63 chars).
+                                The generated name is "iface{N}_{namespace}-{name}" where N≤20 (MaxItems),
+                                giving a max prefix of "iface20_" (8 chars), leaving 55 chars for namespace/name.
+                              maxLength: 55
                               type: string
+                              x-kubernetes-validations:
+                              - message: name must be in the format <namespace>/<name>
+                                  where namespace and name consist only of lowercase
+                                  alphanumeric characters and hyphens, and start and
+                                  end with alphanumeric characters
+                                rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?/[a-z0-9]([a-z0-9-]*[a-z0-9])?$')
                           required:
                           - name
                           type: object
                         maxItems: 20
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       attachDefaultNetwork:
                         default: true
                         description: |-

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -1407,14 +1407,28 @@ spec:
                               description: |-
                                 name specify the network attached to the nodes
                                 it is a value with the format "[namespace]/[name]" to reference the
-                                multus network attachment definition
-                              maxLength: 255
+                                multus network attachment definition, where namespace and name consist
+                                only of lowercase alphanumeric characters and hyphens, and start and
+                                end with alphanumeric characters
+                                MaxLength=55: KubeVirt requires Interface.Name to be a DNS label (max 63 chars).
+                                The generated name is "iface{N}_{namespace}-{name}" where N≤20 (MaxItems),
+                                giving a max prefix of "iface20_" (8 chars), leaving 55 chars for namespace/name.
+                              maxLength: 55
                               type: string
+                              x-kubernetes-validations:
+                              - message: name must be in the format <namespace>/<name>
+                                  where namespace and name consist only of lowercase
+                                  alphanumeric characters and hyphens, and start and
+                                  end with alphanumeric characters
+                                rule: self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?/[a-z0-9]([a-z0-9-]*[a-z0-9])?$')
                           required:
                           - name
                           type: object
                         maxItems: 20
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       attachDefaultNetwork:
                         default: true
                         description: |-

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -50057,7 +50057,12 @@ string
 <td>
 <p>name specify the network attached to the nodes
 it is a value with the format &ldquo;[namespace]/[name]&rdquo; to reference the
-multus network attachment definition</p>
+multus network attachment definition, where namespace and name consist
+only of lowercase alphanumeric characters and hyphens, and start and
+end with alphanumeric characters
+MaxLength=55: KubeVirt requires Interface.Name to be a DNS label (max 63 chars).
+The generated name is &ldquo;iface{N}<em>{namespace}-{name}&rdquo; where N≤20 (MaxItems),
+giving a max prefix of &ldquo;iface20</em>&rdquo; (8 chars), leaving 55 chars for namespace/name.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -52261,7 +52261,12 @@ string
 <td>
 <p>name specify the network attached to the nodes
 it is a value with the format &ldquo;[namespace]/[name]&rdquo; to reference the
-multus network attachment definition</p>
+multus network attachment definition, where namespace and name consist
+only of lowercase alphanumeric characters and hyphens, and start and
+end with alphanumeric characters
+MaxLength=55: KubeVirt requires Interface.Name to be a DNS label (max 63 chars).
+The generated name is &ldquo;iface{N}<em>{namespace}-{name}&rdquo; where N≤20 (MaxItems),
+giving a max prefix of &ldquo;iface20</em>&rdquo; (8 chars), leaving 55 chars for namespace/name.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -12150,7 +12150,12 @@ string
 <td>
 <p>name specify the network attached to the nodes
 it is a value with the format &ldquo;[namespace]/[name]&rdquo; to reference the
-multus network attachment definition</p>
+multus network attachment definition, where namespace and name consist
+only of lowercase alphanumeric characters and hyphens, and start and
+end with alphanumeric characters
+MaxLength=55: KubeVirt requires Interface.Name to be a DNS label (max 63 chars).
+The generated name is &ldquo;iface{N}<em>{namespace}-{name}&rdquo; where N≤20 (MaxItems),
+giving a max prefix of &ldquo;iface20</em>&rdquo; (8 chars), leaving 55 chars for namespace/name.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -12364,7 +12364,12 @@ string
 <td>
 <p>name specify the network attached to the nodes
 it is a value with the format &ldquo;[namespace]/[name]&rdquo; to reference the
-multus network attachment definition</p>
+multus network attachment definition, where namespace and name consist
+only of lowercase alphanumeric characters and hyphens, and start and
+end with alphanumeric characters
+MaxLength=55: KubeVirt requires Interface.Name to be a DNS label (max 63 chars).
+The generated name is &ldquo;iface{N}<em>{namespace}-{name}&rdquo; where N≤20 (MaxItems),
+giving a max prefix of &ldquo;iface20</em>&rdquo; (8 chars), leaving 55 chars for namespace/name.</p>
 </td>
 </tr>
 </tbody>

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/kubevirt.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/kubevirt.go
@@ -169,6 +169,8 @@ type KubevirtNodePoolPlatform struct {
 	// additionalNetworks specify the extra networks attached to the nodes
 	//
 	// +optional
+	// +listType=map
+	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=20
 	AdditionalNetworks []KubevirtNetwork `json:"additionalNetworks,omitempty"`
 
@@ -198,8 +200,14 @@ type KubevirtNodePoolPlatform struct {
 type KubevirtNetwork struct {
 	// name specify the network attached to the nodes
 	// it is a value with the format "[namespace]/[name]" to reference the
-	// multus network attachment definition
-	// +kubebuilder:validation:MaxLength=255
+	// multus network attachment definition, where namespace and name consist
+	// only of lowercase alphanumeric characters and hyphens, and start and
+	// end with alphanumeric characters
+	// +kubebuilder:validation:MaxLength=55
+	// MaxLength=55: KubeVirt requires Interface.Name to be a DNS label (max 63 chars).
+	// The generated name is "iface{N}_{namespace}-{name}" where N≤20 (MaxItems),
+	// giving a max prefix of "iface20_" (8 chars), leaving 55 chars for namespace/name.
+	// +kubebuilder:validation:XValidation:rule="self.matches('^[a-z0-9]([a-z0-9-]*[a-z0-9])?/[a-z0-9]([a-z0-9-]*[a-z0-9])?$')",message="name must be in the format <namespace>/<name> where namespace and name consist only of lowercase alphanumeric characters and hyphens, and start and end with alphanumeric characters"
 	// +required
 	Name string `json:"name"`
 }


### PR DESCRIPTION
## Summary

KubeVirt NodePools accept invalid `additionalNetworks[].name` values without admission-time rejection. The field must reference a Multus NAD as `<namespace>/<name>`, but previously nothing enforced format, uniqueness, or the KubeVirt interface-name length limit. Users who omit the namespace prefix can get a HostedCluster that looks healthy while VMs fail to start with errors buried in the hosted control plane namespace.

This PR moves validation into the **API types (CEL + schema markers)** per HyperShift convention — no new webhook validation.

## Changes

**`api/hypershift/v1beta1/kubevirt.go`**
- `AdditionalNetworks`: `+listType=map` / `+listMapKey=name` (schema-level uniqueness)
- `KubevirtNetwork.Name`:
  - CEL regex requiring `<namespace>/<name>` with DNS-label segments
  - `MaxLength` tightened from 255 → 55 (KubeVirt interface name limit: 63 − len(`iface20_`))

**Generated artifacts**
- CRD manifests + vendor copy
- API docs (`api.md`, `aggregated-docs.md`)

**Tests**
- New envtest suite: `stable.nodepools.kubevirt.testsuite.yaml` (valid/invalid formats, duplicates, maxLength)

## User experience after fix

```
$ oc apply -f nodepool.yaml
The NodePool "worker" is invalid:
* spec.platform.kubevirt.additionalNetworks[0].name: Invalid value: "storage-net":
  name must be in the format <namespace>/<name> where namespace and name consist only of lowercase alphanumeric characters and hyphens, and start and end with alphanumeric characters
```

## Backward compatibility

- No `additionalNetworks` configured → unchanged
- Valid `ns/name` entries → pass, zero behavior change
- Invalid values that previously slipped through → now rejected at admission

## Reviewer notes

Addresses @bryan-cox feedback (Jun 11 / Jul 14):
- Validation lives in API CEL markers, not the webhook
- Envtest coverage added for the new rules
- `crdify-config.yaml` policy hitchhike removed from this PR

Fixes: https://redhat.atlassian.net/browse/OCPBUGS-87991