### PR TITLE
CNTRLPLANE-3568: test(e2e): verify AWS additional-tags propagation to guest infrastruc…

### DIFF
--- a/test/e2e/v2/tests/hosted_cluster_aws_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_aws_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	configv1 "github.com/openshift/api/config/v1"
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	awsutil "github.com/openshift/hypershift/cmd/infra/aws/util"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
@@ -41,6 +42,7 @@ import (
 
 func RegisterHostedClusterAWSTests(getTestCtx internal.TestContextGetter) {
 	EnsureDefaultSecurityGroupTagsTest(getTestCtx)
+	EnsureInfrastructureResourceTagsTest(getTestCtx)
 	AWSCCMWithCustomizationsTest(getTestCtx)
 }
 
@@ -122,6 +124,66 @@ func EnsureDefaultSecurityGroupTagsTest(getTestCtx internal.TestContextGetter) {
 					Value: aws.String(day2TagValue),
 				}), "day-2 tag should be applied to the default worker security group")
 			}, 10*time.Minute, time.Second).Should(Succeed())
+		})
+	})
+}
+
+func EnsureInfrastructureResourceTagsTest(getTestCtx internal.TestContextGetter) {
+	When("a HostedCluster is created with additional AWS resource tags", func() {
+		It("should propagate those tags to the infrastructure resource in the hosted cluster", Label("AWS"), func() {
+			tc := getTestCtx()
+			hc := tc.GetHostedCluster()
+			if hc.Spec.Platform.Type != hyperv1.AWSPlatform {
+				Skip("hosted cluster infrastructure resource tags test is only for AWS platform")
+			}
+			if hc.Spec.Platform.AWS == nil {
+				Skip("HostedCluster does not have AWS platform spec")
+			}
+
+			specTags := hc.Spec.Platform.AWS.ResourceTags
+			if len(specTags) == 0 {
+				Skip("HostedCluster does not have AWS resource tags configured")
+			}
+
+			// Filter kubernetes.io prefixed keys to match production logic in
+			// support/globalconfig/infrastructure.go which skips them to avoid
+			// breaking the AWS CSI driver.
+			var expectedTags []configv1.AWSResourceTag
+			for _, tag := range specTags {
+				if strings.HasPrefix(tag.Key, "kubernetes.io") {
+					continue
+				}
+				expectedTags = append(expectedTags, configv1.AWSResourceTag{
+					Key:   tag.Key,
+					Value: tag.Value,
+				})
+			}
+			if len(expectedTags) == 0 {
+				Skip("HostedCluster has only kubernetes.io-prefixed tags which are filtered out")
+			}
+
+			tc.ValidateHostedClusterClient()
+			hcClient := tc.GetHostedClusterClient()
+
+			infra := &configv1.Infrastructure{}
+			Expect(hcClient.Get(tc.Context, crclient.ObjectKey{Name: "cluster"}, infra)).To(Succeed(),
+				"failed to get infrastructure/cluster from hosted cluster")
+
+			Expect(infra.Status.PlatformStatus).NotTo(BeNil(),
+				"infrastructure/cluster should have platform status")
+			Expect(infra.Status.PlatformStatus.AWS).NotTo(BeNil(),
+				"infrastructure/cluster should have AWS platform status")
+			Expect(infra.Status.PlatformStatus.AWS.ResourceTags).NotTo(BeEmpty(),
+				"infrastructure/cluster AWS platform status should have resource tags")
+
+			for _, expected := range expectedTags {
+				Expect(infra.Status.PlatformStatus.AWS.ResourceTags).To(
+					ContainElement(expected),
+					"infrastructure resource should contain tag %s=%s", expected.Key, expected.Value)
+			}
+
+			Expect(infra.Status.PlatformStatus.AWS.ResourceTags).To(HaveLen(len(expectedTags)),
+				"infrastructure resource should have exactly the non-kubernetes.io tags, no extra tags should leak through")
 		})
 	})
 }


### PR DESCRIPTION
…ture

## What this PR does / why we need it:

Add a v2 e2e test that reads the HostedCluster's spec.platform.aws.resourceTags and verifies they appear in the guest cluster's infrastructure/cluster .status.platformStatus.aws.resourceTags. Tags with the kubernetes.io prefix are filtered to match the production logic in support/globalconfig/infrastructure.go.

Covers https://redhat.atlassian.net/browse/CNTRLPLANE-3568
The original test logic has a few more assertions but they are already tested in other parts of the E2E test suite. This new PR only covers what was left - propagating resource tags from HostedCluster to Infrastructure on guest cluster.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes 

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an AWS-only end-to-end test that verifies AWS resource tags from a HostedCluster spec are propagated into the guest cluster infrastructure/platform status. The test skips non-AWS clusters or when no AWS tags are present, ignores keys starting with "kubernetes.io", and asserts that the remaining expected tags are present and that the status tag list matches the expected count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->