### PR TITLE
CNTRLPLANE-3276: Add Azure ExternalPrivateService and endpoint access transition test

### DIFF
--- a/control-plane-operator/controllers/azureprivatelinkservice/controller.go
+++ b/control-plane-operator/controllers/azureprivatelinkservice/controller.go
@@ -7,16 +7,22 @@ import (
 	"time"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	manifests "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
 	"github.com/openshift/hypershift/support/azureutil"
+	"github.com/openshift/hypershift/support/config"
+	"github.com/openshift/hypershift/support/k8sutil"
+	"github.com/openshift/hypershift/support/netutil"
 
 	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v5"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
 
@@ -122,6 +128,12 @@ const (
 	//      performs Azure resource cleanup, and removes this finalizer from the HCP.
 	//   3. HCP deletion then proceeds, tearing down credentials and the namespace.
 	hcpAzurePLSFinalizerName = "hypershift.openshift.io/azure-pls-endpoint-cleanup"
+
+	// externalPrivateServiceLabelAzure labels ExternalName Services created for external-dns
+	// integration. When a cluster is private and has custom Route hostnames configured,
+	// these services tell external-dns to create public DNS records pointing to the PrivateEndpoint IP,
+	// allowing management cluster and external clients to resolve the KAS/OAuth hostnames.
+	externalPrivateServiceLabelAzure = "hypershift.openshift.io/azure-pls-external-private-svc"
 )
 
 // PrivateEndpointsAPI abstracts the Azure Private Endpoints client.
@@ -339,7 +351,16 @@ func (r *AzurePrivateLinkServiceReconciler) Reconcile(ctx context.Context, req c
 		}
 	}
 
-	// 11. Set overall Available condition
+	// 11. Reconcile ExternalPrivateService resources for external-dns integration.
+	// When the cluster is private and has custom Route hostnames, create ExternalName
+	// Services annotated for external-dns so public DNS records resolve to the PE IP.
+	if azPLS.Name == privateRouterCRName {
+		if err := r.reconcileExternalServices(ctx, azPLS, hcp, log); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// 12. Set overall Available condition
 	patch := client.MergeFrom(azPLS.DeepCopy())
 	meta.SetStatusCondition(&azPLS.Status.Conditions, metav1.Condition{
 		Type:               string(hyperv1.AzurePrivateLinkServiceAvailable),
@@ -352,7 +373,7 @@ func (r *AzurePrivateLinkServiceReconciler) Reconcile(ctx context.Context, req c
 		return ctrl.Result{}, fmt.Errorf("failed to update Available condition: %w", err)
 	}
 
-	// 12. Requeue for drift detection
+	// 13. Requeue for drift detection
 	return ctrl.Result{RequeueAfter: azureutil.DriftDetectionRequeueInterval}, nil
 }
 
@@ -822,6 +843,88 @@ func (r *AzurePrivateLinkServiceReconciler) hasSiblingCR(ctx context.Context, az
 		}
 	}
 	return false, nil
+}
+
+// externalPrivateServiceEntry pairs a Service manifest with its Route hostname for external-dns.
+type externalPrivateServiceEntry struct {
+	service  *corev1.Service
+	hostname string
+}
+
+// reconcileExternalServices creates or removes ExternalName Services for external-dns
+// integration. When the cluster is private and has custom Route hostnames configured,
+// these services cause external-dns to create public DNS A records pointing to the PrivateEndpoint IP,
+// enabling management cluster controllers and external clients to resolve KAS/OAuth hostnames.
+// When the cluster transitions to public, any existing services are cleaned up.
+func (r *AzurePrivateLinkServiceReconciler) reconcileExternalServices(ctx context.Context, azPLS *hyperv1.AzurePrivateLinkService, hcp *hyperv1.HostedControlPlane, log logr.Logger) error {
+	entries := hcpExternalPrivateServices(hcp)
+	if len(entries) == 0 {
+		return nil
+	}
+
+	if netutil.IsPublicHCP(hcp) {
+		svcs := make([]client.Object, len(entries))
+		for i, entry := range entries {
+			svcs[i] = entry.service
+		}
+		return k8sutil.DeleteAllIfNeeded(ctx, r.Client, svcs...)
+	}
+
+	var errs []error
+	for _, entry := range entries {
+		svc := entry.service
+		if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, svc, func() error {
+			log.Info("Reconciling external name service", "service", svc.Name, "hostname", entry.hostname)
+			return reconcileExternalService(svc, hcp, entry.hostname, azPLS.Status.PrivateEndpointIP)
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("failed to reconcile %s external service: %w", svc.Name, err))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to create external services for private endpoints: %w", utilerrors.NewAggregate(errs))
+	}
+	return nil
+}
+
+func reconcileExternalService(svc *corev1.Service, hcp *hyperv1.HostedControlPlane, hostName, targetIP string) error {
+	ownerRef := config.OwnerRefFrom(hcp)
+	ownerRef.ApplyTo(svc)
+	if svc.Labels == nil {
+		svc.Labels = map[string]string{}
+	}
+	if svc.Annotations == nil {
+		svc.Annotations = map[string]string{}
+	}
+	svc.Labels[externalPrivateServiceLabelAzure] = "true"
+	svc.Annotations[hyperv1.ExternalDNSHostnameAnnotation] = hostName
+	svc.Spec.Type = corev1.ServiceTypeExternalName
+	svc.Spec.ExternalName = targetIP
+	return nil
+}
+
+// hcpExternalPrivateServices returns the list of ExternalName Service entries for each
+// service publishing strategy that uses a Route with a configured hostname.
+func hcpExternalPrivateServices(hcp *hyperv1.HostedControlPlane) []externalPrivateServiceEntry {
+	type candidate struct {
+		serviceType hyperv1.ServiceType
+		manifestFn  func(string) *corev1.Service
+	}
+	candidates := []candidate{
+		{hyperv1.APIServer, manifests.KubeAPIServerExternalPrivateService},
+		{hyperv1.OAuthServer, manifests.OauthServerExternalPrivateService},
+	}
+
+	var entries []externalPrivateServiceEntry
+	for _, c := range candidates {
+		strategy := netutil.ServicePublishingStrategyByTypeForHCP(hcp, c.serviceType)
+		if strategy != nil && strategy.Type == hyperv1.Route && strategy.Route != nil && strategy.Route.Hostname != "" {
+			entries = append(entries, externalPrivateServiceEntry{
+				service:  c.manifestFn(hcp.Namespace),
+				hostname: strategy.Route.Hostname,
+			})
+		}
+	}
+	return entries
 }
 
 // handleAzureError provides differentiated backoff for Azure API errors.

--- a/control-plane-operator/controllers/azureprivatelinkservice/controller_test.go
+++ b/control-plane-operator/controllers/azureprivatelinkservice/controller_test.go
@@ -4050,6 +4050,75 @@ func TestReconcileExternalServices_WhenPublic_ItShouldDeleteExistingServices(t *
 	}, oauthSvc))).To(BeTrue(), "OAuth ExternalPrivateService should be deleted")
 }
 
+func TestReconcileExternalService_WhenServiceHasExistingLabelsAndAnnotations_ItShouldPreserveThem(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	hcp := newTestHCP(t, "test-hcp", "test-ns", "api.example.com")
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "kube-apiserver-private",
+			Namespace:   "test-ns",
+			Labels:      map[string]string{"existing-label": "value"},
+			Annotations: map[string]string{"existing-annotation": "value"},
+		},
+	}
+
+	err := reconcileExternalService(svc, hcp, "api.custom.example.com", "10.0.1.5")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(svc.Labels).To(HaveKeyWithValue("existing-label", "value"))
+	g.Expect(svc.Labels).To(HaveKeyWithValue(externalPrivateServiceLabelAzure, "true"))
+	g.Expect(svc.Annotations).To(HaveKeyWithValue("existing-annotation", "value"))
+	g.Expect(svc.Annotations).To(HaveKeyWithValue(hyperv1.ExternalDNSHostnameAnnotation, "api.custom.example.com"))
+	g.Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeExternalName))
+	g.Expect(svc.Spec.ExternalName).To(Equal("10.0.1.5"))
+}
+
+func TestReconcileExternalServices_WhenCreateOrUpdateFails_ItShouldReturnAggregateError(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+	scheme := newTestScheme(t, g)
+
+	hcp := newTestHCP(t, "test-hcp", "test-ns", "api.example.com")
+	hcp.Spec.Platform.Type = hyperv1.AzurePlatform
+	hcp.Spec.Platform.Azure = &hyperv1.AzurePlatformSpec{
+		Topology: hyperv1.AzureTopologyPrivate,
+	}
+	hcp.Spec.Services = []hyperv1.ServicePublishingStrategyMapping{
+		{
+			Service: hyperv1.APIServer,
+			ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+				Type:  hyperv1.Route,
+				Route: &hyperv1.RoutePublishingStrategy{Hostname: "api.custom.example.com"},
+			},
+		},
+	}
+
+	azPLS := newTestAzurePLS(t, "private-router", "test-ns")
+	azPLS.Status.PrivateEndpointIP = "10.0.1.5"
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(hcp, azPLS).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*corev1.Service); ok {
+					return fmt.Errorf("simulated create failure")
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	r := &AzurePrivateLinkServiceReconciler{Client: fakeClient}
+
+	err := r.reconcileExternalServices(t.Context(), azPLS, hcp, testr.New(t))
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError(ContainSubstring("failed to create external services for private endpoints")))
+	g.Expect(err).To(MatchError(ContainSubstring("failed to reconcile kube-apiserver-private-external external service")))
+}
+
 func TestReconcileExternalServices_WhenPrivateWithNoExternalNames_ItShouldNotCreateServices(t *testing.T) {
 	t.Parallel()
 	g := NewGomegaWithT(t)

--- a/control-plane-operator/controllers/azureprivatelinkservice/controller_test.go
+++ b/control-plane-operator/controllers/azureprivatelinkservice/controller_test.go
@@ -225,6 +225,7 @@ func newTestScheme(t *testing.T, g Gomega) *runtime.Scheme {
 	t.Helper()
 	scheme := runtime.NewScheme()
 	g.Expect(hyperv1.AddToScheme(scheme)).ToNot(HaveOccurred())
+	g.Expect(corev1.AddToScheme(scheme)).ToNot(HaveOccurred())
 	return scheme
 }
 
@@ -3806,4 +3807,281 @@ func TestReconcile_WhenAvailableConditionPatchFails_ItShouldReturnError(t *testi
 
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err).To(MatchError(ContainSubstring("failed to update Available condition")))
+}
+
+// --- ExternalPrivateService tests ---
+
+func TestHcpExternalPrivateServices_WhenBothRouteHostnamesConfigured_ItShouldReturnBoth(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	hcp := newTestHCP(t, "test-hcp", "test-ns", "api.example.com")
+	hcp.Spec.Platform.Type = hyperv1.AzurePlatform
+	hcp.Spec.Platform.Azure = &hyperv1.AzurePlatformSpec{
+		Topology: hyperv1.AzureTopologyPrivate,
+	}
+	hcp.Spec.Services = []hyperv1.ServicePublishingStrategyMapping{
+		{
+			Service: hyperv1.APIServer,
+			ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+				Type:  hyperv1.Route,
+				Route: &hyperv1.RoutePublishingStrategy{Hostname: "api.custom.example.com"},
+			},
+		},
+		{
+			Service: hyperv1.OAuthServer,
+			ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+				Type:  hyperv1.Route,
+				Route: &hyperv1.RoutePublishingStrategy{Hostname: "oauth.custom.example.com"},
+			},
+		},
+	}
+
+	entries := hcpExternalPrivateServices(hcp)
+	g.Expect(entries).To(HaveLen(2))
+	g.Expect(entries[0].service.Name).To(Equal("kube-apiserver-private-external"))
+	g.Expect(entries[0].hostname).To(Equal("api.custom.example.com"))
+	g.Expect(entries[1].service.Name).To(Equal("oauth-private-external"))
+	g.Expect(entries[1].hostname).To(Equal("oauth.custom.example.com"))
+}
+
+func TestHcpExternalPrivateServices_WhenNoRouteStrategy_ItShouldReturnEmpty(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	hcp := newTestHCP(t, "test-hcp", "test-ns", "api.example.com")
+	hcp.Spec.Platform.Type = hyperv1.AzurePlatform
+	hcp.Spec.Services = []hyperv1.ServicePublishingStrategyMapping{
+		{
+			Service: hyperv1.APIServer,
+			ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+				Type: hyperv1.LoadBalancer,
+			},
+		},
+	}
+
+	entries := hcpExternalPrivateServices(hcp)
+	g.Expect(entries).To(BeEmpty())
+}
+
+func TestHcpExternalPrivateServices_WhenRouteHasNoHostname_ItShouldSkipIt(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	hcp := newTestHCP(t, "test-hcp", "test-ns", "api.example.com")
+	hcp.Spec.Platform.Type = hyperv1.AzurePlatform
+	hcp.Spec.Services = []hyperv1.ServicePublishingStrategyMapping{
+		{
+			Service: hyperv1.APIServer,
+			ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+				Type:  hyperv1.Route,
+				Route: &hyperv1.RoutePublishingStrategy{Hostname: ""},
+			},
+		},
+		{
+			Service: hyperv1.OAuthServer,
+			ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+				Type:  hyperv1.Route,
+				Route: &hyperv1.RoutePublishingStrategy{Hostname: "oauth.custom.example.com"},
+			},
+		},
+	}
+
+	entries := hcpExternalPrivateServices(hcp)
+	g.Expect(entries).To(HaveLen(1))
+	g.Expect(entries[0].service.Name).To(Equal("oauth-private-external"))
+	g.Expect(entries[0].hostname).To(Equal("oauth.custom.example.com"))
+}
+
+func TestReconcileExternalService_ItShouldSetAllRequiredFields(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+
+	hcp := newTestHCP(t, "test-hcp", "test-ns", "api.example.com")
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-apiserver-private",
+			Namespace: "test-ns",
+		},
+	}
+
+	err := reconcileExternalService(svc, hcp, "api.custom.example.com", "10.0.1.5")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(svc.Labels).To(HaveKeyWithValue(externalPrivateServiceLabelAzure, "true"))
+	g.Expect(svc.Annotations).To(HaveKeyWithValue(hyperv1.ExternalDNSHostnameAnnotation, "api.custom.example.com"))
+	g.Expect(svc.Spec.Type).To(Equal(corev1.ServiceTypeExternalName))
+	g.Expect(svc.Spec.ExternalName).To(Equal("10.0.1.5"))
+	g.Expect(svc.OwnerReferences).To(HaveLen(1))
+	g.Expect(svc.OwnerReferences[0].Name).To(Equal("test-hcp"))
+}
+
+func TestReconcileExternalServices_WhenPrivateWithExternalNames_ItShouldCreateServices(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+	scheme := newTestScheme(t, g)
+
+	hcp := newTestHCP(t, "test-hcp", "test-ns", "api.example.com")
+	hcp.Spec.Platform.Type = hyperv1.AzurePlatform
+	hcp.Spec.Platform.Azure = &hyperv1.AzurePlatformSpec{
+		Topology: hyperv1.AzureTopologyPrivate,
+	}
+	hcp.Spec.Services = []hyperv1.ServicePublishingStrategyMapping{
+		{
+			Service: hyperv1.APIServer,
+			ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+				Type:  hyperv1.Route,
+				Route: &hyperv1.RoutePublishingStrategy{Hostname: "api.custom.example.com"},
+			},
+		},
+		{
+			Service: hyperv1.OAuthServer,
+			ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+				Type:  hyperv1.Route,
+				Route: &hyperv1.RoutePublishingStrategy{Hostname: "oauth.custom.example.com"},
+			},
+		},
+	}
+
+	azPLS := newTestAzurePLS(t, "private-router", "test-ns")
+	azPLS.Status.PrivateEndpointIP = "10.0.1.5"
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(hcp, azPLS).
+		Build()
+
+	r := &AzurePrivateLinkServiceReconciler{Client: fakeClient}
+
+	err := r.reconcileExternalServices(t.Context(), azPLS, hcp, testr.New(t))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	kasSvc := &corev1.Service{}
+	g.Expect(fakeClient.Get(t.Context(), types.NamespacedName{
+		Name:      "kube-apiserver-private-external",
+		Namespace: "test-ns",
+	}, kasSvc)).To(Succeed())
+	g.Expect(kasSvc.Spec.Type).To(Equal(corev1.ServiceTypeExternalName))
+	g.Expect(kasSvc.Spec.ExternalName).To(Equal("10.0.1.5"))
+	g.Expect(kasSvc.Annotations[hyperv1.ExternalDNSHostnameAnnotation]).To(Equal("api.custom.example.com"))
+	g.Expect(kasSvc.Labels[externalPrivateServiceLabelAzure]).To(Equal("true"))
+
+	oauthSvc := &corev1.Service{}
+	g.Expect(fakeClient.Get(t.Context(), types.NamespacedName{
+		Name:      "oauth-private-external",
+		Namespace: "test-ns",
+	}, oauthSvc)).To(Succeed())
+	g.Expect(oauthSvc.Spec.Type).To(Equal(corev1.ServiceTypeExternalName))
+	g.Expect(oauthSvc.Spec.ExternalName).To(Equal("10.0.1.5"))
+	g.Expect(oauthSvc.Annotations[hyperv1.ExternalDNSHostnameAnnotation]).To(Equal("oauth.custom.example.com"))
+	g.Expect(oauthSvc.Labels[externalPrivateServiceLabelAzure]).To(Equal("true"))
+}
+
+func TestReconcileExternalServices_WhenPublic_ItShouldDeleteExistingServices(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+	scheme := newTestScheme(t, g)
+
+	hcp := newTestHCP(t, "test-hcp", "test-ns", "api.example.com")
+	hcp.Spec.Platform.Type = hyperv1.AzurePlatform
+	hcp.Spec.Platform.Azure = &hyperv1.AzurePlatformSpec{
+		Topology: hyperv1.AzureTopologyPublicAndPrivate,
+	}
+	hcp.Spec.Services = []hyperv1.ServicePublishingStrategyMapping{
+		{
+			Service: hyperv1.APIServer,
+			ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+				Type:  hyperv1.Route,
+				Route: &hyperv1.RoutePublishingStrategy{Hostname: "api.custom.example.com"},
+			},
+		},
+		{
+			Service: hyperv1.OAuthServer,
+			ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+				Type:  hyperv1.Route,
+				Route: &hyperv1.RoutePublishingStrategy{Hostname: "oauth.custom.example.com"},
+			},
+		},
+	}
+
+	azPLS := newTestAzurePLS(t, "private-router", "test-ns")
+
+	existingKasSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-apiserver-private-external",
+			Namespace: "test-ns",
+			Labels:    map[string]string{externalPrivateServiceLabelAzure: "true"},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:         corev1.ServiceTypeExternalName,
+			ExternalName: "10.0.1.5",
+		},
+	}
+	existingOauthSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "oauth-private-external",
+			Namespace: "test-ns",
+			Labels:    map[string]string{externalPrivateServiceLabelAzure: "true"},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:         corev1.ServiceTypeExternalName,
+			ExternalName: "10.0.1.5",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(hcp, azPLS, existingKasSvc, existingOauthSvc).
+		Build()
+
+	r := &AzurePrivateLinkServiceReconciler{Client: fakeClient}
+
+	err := r.reconcileExternalServices(t.Context(), azPLS, hcp, testr.New(t))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	kasSvc := &corev1.Service{}
+	g.Expect(apierrors.IsNotFound(fakeClient.Get(t.Context(), types.NamespacedName{
+		Name: "kube-apiserver-private-external", Namespace: "test-ns",
+	}, kasSvc))).To(BeTrue(), "KAS ExternalPrivateService should be deleted")
+
+	oauthSvc := &corev1.Service{}
+	g.Expect(apierrors.IsNotFound(fakeClient.Get(t.Context(), types.NamespacedName{
+		Name: "oauth-private-external", Namespace: "test-ns",
+	}, oauthSvc))).To(BeTrue(), "OAuth ExternalPrivateService should be deleted")
+}
+
+func TestReconcileExternalServices_WhenPrivateWithNoExternalNames_ItShouldNotCreateServices(t *testing.T) {
+	t.Parallel()
+	g := NewGomegaWithT(t)
+	scheme := newTestScheme(t, g)
+
+	hcp := newTestHCP(t, "test-hcp", "test-ns", "api.example.com")
+	hcp.Spec.Platform.Type = hyperv1.AzurePlatform
+	hcp.Spec.Platform.Azure = &hyperv1.AzurePlatformSpec{
+		Topology: hyperv1.AzureTopologyPrivate,
+	}
+	hcp.Spec.Services = []hyperv1.ServicePublishingStrategyMapping{
+		{
+			Service: hyperv1.APIServer,
+			ServicePublishingStrategy: hyperv1.ServicePublishingStrategy{
+				Type: hyperv1.LoadBalancer,
+			},
+		},
+	}
+
+	azPLS := newTestAzurePLS(t, "private-router", "test-ns")
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(hcp, azPLS).
+		Build()
+
+	r := &AzurePrivateLinkServiceReconciler{Client: fakeClient}
+
+	err := r.reconcileExternalServices(t.Context(), azPLS, hcp, testr.New(t))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	svcList := &corev1.ServiceList{}
+	g.Expect(fakeClient.List(t.Context(), svcList, client.InNamespace("test-ns"), client.HasLabels{externalPrivateServiceLabelAzure})).To(Succeed())
+	g.Expect(svcList.Items).To(BeEmpty(), "no ExternalPrivateService should be created when no Route hostnames configured")
 }

--- a/test/e2e/v2/tests/hosted_cluster_azure_test.go
+++ b/test/e2e/v2/tests/hosted_cluster_azure_test.go
@@ -19,19 +19,25 @@ package tests
 import (
 	"context"
 	"fmt"
+	"net"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	routev1 "github.com/openshift/api/route/v1"
+
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	hcpmanifests "github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/manifests"
+	hyperapi "github.com/openshift/hypershift/support/api"
 	"github.com/openshift/hypershift/support/azureutil"
 	"github.com/openshift/hypershift/support/netutil"
 	e2eutil "github.com/openshift/hypershift/test/e2e/util"
 	"github.com/openshift/hypershift/test/e2e/v2/internal"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -210,6 +216,276 @@ func AzurePrivateTopologyTest(getTestCtx internal.TestContextGetter) {
 	})
 }
 
+// AzureEndpointAccessTransitionTest validates transitioning a HostedCluster
+// between Private and PublicAndPrivate topology on Azure.
+// This test MUST be registered after AzurePrivateTopologyTest to ensure
+// stateless private-topology assertions run on the pristine Private cluster first.
+func AzureEndpointAccessTransitionTest(getTestCtx internal.TestContextGetter) {
+	Context("[Feature:AzureEndpointAccess] Azure Endpoint Access Transition", Label("Azure", "self-managed-azure-private"), Ordered, func() {
+		var testCtx *internal.TestContext
+		var hc *hyperv1.HostedCluster
+		var controlPlaneNamespace string
+
+		BeforeAll(func() {
+			testCtx = getTestCtx()
+			hc = testCtx.GetHostedCluster()
+			if hc == nil || hc.Spec.Platform.Type != hyperv1.AzurePlatform {
+				Skip("Azure endpoint access transition tests are only for Azure platform")
+			}
+			if hc.Spec.Platform.Azure == nil || hc.Spec.Platform.Azure.Topology != hyperv1.AzureTopologyPrivate {
+				Skip("Azure endpoint access transition tests require Private topology")
+			}
+			controlPlaneNamespace = testCtx.ControlPlaneNamespace
+			Expect(controlPlaneNamespace).NotTo(BeEmpty(), "control plane namespace must be set")
+
+			DeferCleanup(func() {
+				// Use context.Background() because DeferCleanup runs after the test completes,
+				// when testCtx.Context may already be canceled.
+				restoreErr := e2eutil.UpdateObject(GinkgoTB(), context.Background(), testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+					obj.Spec.Platform.Azure.Topology = hyperv1.AzureTopologyPrivate
+				})
+				if restoreErr != nil {
+					GinkgoTB().Logf("WARNING: failed to restore Private topology: %v", restoreErr)
+				}
+			})
+		})
+
+		It("should transition from Private to PublicAndPrivate", func() {
+			ctx := testCtx.Context
+
+			// Verify ExternalPrivateService resources exist in Private topology before transition.
+			e2eutil.EventuallyObject(GinkgoTB(), ctx, "KAS ExternalPrivateService exists in Private topology",
+				func(ctx context.Context) (*corev1.Service, error) {
+					svc := hcpmanifests.KubeAPIServerExternalPrivateService(controlPlaneNamespace)
+					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(svc), svc)
+					return svc, err
+				},
+				[]e2eutil.Predicate[*corev1.Service]{
+					serviceTypePredicate(corev1.ServiceTypeExternalName),
+				},
+				e2eutil.WithTimeout(2*time.Minute),
+			)
+
+			e2eutil.EventuallyObject(GinkgoTB(), ctx, "OAuth ExternalPrivateService exists in Private topology",
+				func(ctx context.Context) (*corev1.Service, error) {
+					svc := hcpmanifests.OauthServerExternalPrivateService(controlPlaneNamespace)
+					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(svc), svc)
+					return svc, err
+				},
+				[]e2eutil.Predicate[*corev1.Service]{
+					serviceTypePredicate(corev1.ServiceTypeExternalName),
+				},
+				e2eutil.WithTimeout(2*time.Minute),
+			)
+
+			err := e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+				obj.Spec.Platform.Azure.Topology = hyperv1.AzureTopologyPublicAndPrivate
+			})
+			Expect(err).NotTo(HaveOccurred(), "failed to update topology to PublicAndPrivate")
+
+			e2eutil.EventuallyObject(GinkgoTB(), ctx, "KAS external public route exists after transition to PublicAndPrivate",
+				func(ctx context.Context) (*routev1.Route, error) {
+					route := hcpmanifests.KubeAPIServerExternalPublicRoute(controlPlaneNamespace)
+					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(route), route)
+					return route, err
+				},
+				[]e2eutil.Predicate[*routev1.Route]{
+					routeHasHostPredicate(),
+				},
+				e2eutil.WithTimeout(10*time.Minute),
+			)
+
+			Eventually(func() error {
+				route := hcpmanifests.KubeAPIServerExternalPrivateRoute(controlPlaneNamespace)
+				return expectDeleted(ctx, testCtx.MgmtClient, route)
+			}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed(),
+				"KAS external private route should be deleted after transition to PublicAndPrivate")
+
+			e2eutil.EventuallyObject(GinkgoTB(), ctx, "OAuth external public route exists after transition to PublicAndPrivate",
+				func(ctx context.Context) (*routev1.Route, error) {
+					route := hcpmanifests.OauthServerExternalPublicRoute(controlPlaneNamespace)
+					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(route), route)
+					return route, err
+				},
+				[]e2eutil.Predicate[*routev1.Route]{
+					routeHasHostPredicate(),
+				},
+				e2eutil.WithTimeout(10*time.Minute),
+			)
+
+			Eventually(func() error {
+				route := hcpmanifests.OauthServerExternalPrivateRoute(controlPlaneNamespace)
+				return expectDeleted(ctx, testCtx.MgmtClient, route)
+			}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed(),
+				"OAuth external private route should be deleted after transition to PublicAndPrivate")
+
+			e2eutil.EventuallyObject(GinkgoTB(), ctx, "router-public Service is LoadBalancer after transition to PublicAndPrivate",
+				func(ctx context.Context) (*corev1.Service, error) {
+					svc := hcpmanifests.RouterPublicService(controlPlaneNamespace)
+					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(svc), svc)
+					return svc, err
+				},
+				[]e2eutil.Predicate[*corev1.Service]{
+					serviceTypePredicate(corev1.ServiceTypeLoadBalancer),
+				},
+				e2eutil.WithTimeout(10*time.Minute),
+			)
+
+			e2eutil.EventuallyObjects(GinkgoTB(), ctx, "PLS CRs still exist after transition to PublicAndPrivate",
+				func(ctx context.Context) ([]*hyperv1.AzurePrivateLinkService, error) {
+					return listPLS(ctx, testCtx.MgmtClient, controlPlaneNamespace)
+				},
+				[]e2eutil.Predicate[[]*hyperv1.AzurePrivateLinkService]{
+					plsExistsPredicate(),
+				},
+				nil,
+				e2eutil.WithTimeout(2*time.Minute),
+			)
+
+			Eventually(func() error {
+				svc := hcpmanifests.KubeAPIServerExternalPrivateService(controlPlaneNamespace)
+				return expectDeleted(ctx, testCtx.MgmtClient, svc)
+			}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed(),
+				"KAS ExternalPrivateService should be deleted after transition to PublicAndPrivate")
+
+			Eventually(func() error {
+				svc := hcpmanifests.OauthServerExternalPrivateService(controlPlaneNamespace)
+				return expectDeleted(ctx, testCtx.MgmtClient, svc)
+			}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed(),
+				"OAuth ExternalPrivateService should be deleted after transition to PublicAndPrivate")
+
+			verifyAPIReachable(testCtx, "after transition to PublicAndPrivate")
+		})
+
+		It("should transition from PublicAndPrivate back to Private", func() {
+			ctx := testCtx.Context
+
+			err := e2eutil.UpdateObject(GinkgoTB(), ctx, testCtx.MgmtClient, hc, func(obj *hyperv1.HostedCluster) {
+				obj.Spec.Platform.Azure.Topology = hyperv1.AzureTopologyPrivate
+			})
+			Expect(err).NotTo(HaveOccurred(), "failed to update topology to Private")
+
+			e2eutil.EventuallyObject(GinkgoTB(), ctx, "KAS external private route exists after restore to Private",
+				func(ctx context.Context) (*routev1.Route, error) {
+					route := hcpmanifests.KubeAPIServerExternalPrivateRoute(controlPlaneNamespace)
+					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(route), route)
+					return route, err
+				},
+				[]e2eutil.Predicate[*routev1.Route]{
+					routeHasHostPredicate(),
+				},
+				e2eutil.WithTimeout(10*time.Minute),
+			)
+
+			Eventually(func() error {
+				route := hcpmanifests.KubeAPIServerExternalPublicRoute(controlPlaneNamespace)
+				return expectDeleted(ctx, testCtx.MgmtClient, route)
+			}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed(),
+				"KAS external public route should be deleted after restore to Private")
+
+			e2eutil.EventuallyObject(GinkgoTB(), ctx, "OAuth external private route exists after restore to Private",
+				func(ctx context.Context) (*routev1.Route, error) {
+					route := hcpmanifests.OauthServerExternalPrivateRoute(controlPlaneNamespace)
+					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(route), route)
+					return route, err
+				},
+				[]e2eutil.Predicate[*routev1.Route]{
+					routeHasHostPredicate(),
+				},
+				e2eutil.WithTimeout(10*time.Minute),
+			)
+
+			Eventually(func() error {
+				route := hcpmanifests.OauthServerExternalPublicRoute(controlPlaneNamespace)
+				return expectDeleted(ctx, testCtx.MgmtClient, route)
+			}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed(),
+				"OAuth external public route should be deleted after restore to Private")
+
+			Eventually(func() error {
+				svc := hcpmanifests.RouterPublicService(controlPlaneNamespace)
+				return expectDeleted(ctx, testCtx.MgmtClient, svc)
+			}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(Succeed(),
+				"router-public Service should be deleted after restore to Private")
+
+			e2eutil.EventuallyObjects(GinkgoTB(), ctx, "PLS CRs still exist after restore to Private",
+				func(ctx context.Context) ([]*hyperv1.AzurePrivateLinkService, error) {
+					return listPLS(ctx, testCtx.MgmtClient, controlPlaneNamespace)
+				},
+				[]e2eutil.Predicate[[]*hyperv1.AzurePrivateLinkService]{
+					plsExistsPredicate(),
+				},
+				nil,
+				e2eutil.WithTimeout(2*time.Minute),
+			)
+
+			e2eutil.EventuallyObject(GinkgoTB(), ctx, "KAS ExternalPrivateService recreated after restore to Private",
+				func(ctx context.Context) (*corev1.Service, error) {
+					svc := hcpmanifests.KubeAPIServerExternalPrivateService(controlPlaneNamespace)
+					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(svc), svc)
+					return svc, err
+				},
+				[]e2eutil.Predicate[*corev1.Service]{
+					serviceTypePredicate(corev1.ServiceTypeExternalName),
+				},
+				e2eutil.WithTimeout(10*time.Minute),
+			)
+
+			e2eutil.EventuallyObject(GinkgoTB(), ctx, "OAuth ExternalPrivateService recreated after restore to Private",
+				func(ctx context.Context) (*corev1.Service, error) {
+					svc := hcpmanifests.OauthServerExternalPrivateService(controlPlaneNamespace)
+					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(svc), svc)
+					return svc, err
+				},
+				[]e2eutil.Predicate[*corev1.Service]{
+					serviceTypePredicate(corev1.ServiceTypeExternalName),
+				},
+				e2eutil.WithTimeout(10*time.Minute),
+			)
+		})
+
+		It("should remain available after restoring Private topology", func() {
+			// Private clusters' DNS zones are linked only to the guest VNet, so the
+			// management cluster cannot resolve the KAS hostname. Validate health
+			// via HostedCluster conditions instead of direct API connectivity,
+			// matching the pattern from ValidatePrivateCluster in the v1 framework.
+			e2eutil.EventuallyObject(GinkgoTB(), testCtx.Context, "HostedCluster is Available and not Degraded after restore to Private",
+				func(ctx context.Context) (*hyperv1.HostedCluster, error) {
+					freshHC := &hyperv1.HostedCluster{}
+					err := testCtx.MgmtClient.Get(ctx, crclient.ObjectKeyFromObject(hc), freshHC)
+					return freshHC, err
+				},
+				[]e2eutil.Predicate[*hyperv1.HostedCluster]{
+					func(hc *hyperv1.HostedCluster) (done bool, reasons string, err error) {
+						for _, cond := range hc.Status.Conditions {
+							if cond.Type == string(hyperv1.HostedClusterAvailable) {
+								if cond.Status == metav1.ConditionTrue {
+									return true, "HostedCluster Available=True", nil
+								}
+								return false, fmt.Sprintf("HostedCluster Available=%s reason=%s: %s",
+									cond.Status, cond.Reason, cond.Message), nil
+							}
+						}
+						return false, "HostedCluster Available condition not found", nil
+					},
+					func(hc *hyperv1.HostedCluster) (done bool, reasons string, err error) {
+						for _, cond := range hc.Status.Conditions {
+							if cond.Type == string(hyperv1.HostedClusterDegraded) {
+								if cond.Status == metav1.ConditionTrue {
+									return false, fmt.Sprintf("HostedCluster Degraded=True reason=%s: %s",
+										cond.Reason, cond.Message), nil
+								}
+								return true, "HostedCluster Degraded!=True", nil
+							}
+						}
+						return true, "HostedCluster Degraded condition not found (not degraded)", nil
+					},
+				},
+				e2eutil.WithTimeout(15*time.Minute),
+			)
+		})
+	})
+}
+
 // listPLS returns all AzurePrivateLinkService CRs in the given namespace.
 func listPLS(ctx context.Context, client crclient.Client, namespace string) ([]*hyperv1.AzurePrivateLinkService, error) {
 	plsList := &hyperv1.AzurePrivateLinkServiceList{}
@@ -221,6 +497,122 @@ func listPLS(ctx context.Context, client crclient.Client, namespace string) ([]*
 		items[i] = &plsList.Items[i]
 	}
 	return items, nil
+}
+
+func routeHasHostPredicate() e2eutil.Predicate[*routev1.Route] {
+	return func(route *routev1.Route) (done bool, reasons string, err error) {
+		if route.Spec.Host != "" {
+			return true, fmt.Sprintf("route has host %q", route.Spec.Host), nil
+		}
+		return false, "route has no host yet", nil
+	}
+}
+
+func expectDeleted(ctx context.Context, client crclient.Client, obj crclient.Object) error {
+	err := client.Get(ctx, crclient.ObjectKeyFromObject(obj), obj)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to check %T %s/%s: %w", obj, obj.GetNamespace(), obj.GetName(), err)
+	}
+	return fmt.Errorf("%T %s/%s still exists", obj, obj.GetNamespace(), obj.GetName())
+}
+
+func serviceTypePredicate(expected corev1.ServiceType) e2eutil.Predicate[*corev1.Service] {
+	return func(svc *corev1.Service) (done bool, reasons string, err error) {
+		if svc.Spec.Type == expected {
+			return true, fmt.Sprintf("service type is %s", expected), nil
+		}
+		return false, fmt.Sprintf("service type is %s, want %s", svc.Spec.Type, expected), nil
+	}
+}
+
+func plsExistsPredicate() e2eutil.Predicate[[]*hyperv1.AzurePrivateLinkService] {
+	return func(items []*hyperv1.AzurePrivateLinkService) (done bool, reasons string, err error) {
+		if len(items) == 0 {
+			return false, "no AzurePrivateLinkService CRs found", nil
+		}
+		return true, fmt.Sprintf("%d AzurePrivateLinkService CR(s) exist", len(items)), nil
+	}
+}
+
+func verifyAPIReachable(testCtx *internal.TestContext, phase string) {
+	attempts := 0
+	Eventually(func(g Gomega) {
+		attempts++
+		hc := testCtx.GetHostedCluster()
+		g.Expect(hc).NotTo(BeNil(), "hosted cluster is nil %s", phase)
+		g.Expect(hc.Status.KubeConfig).NotTo(BeNil(), "hosted cluster kubeconfig status not set %s", phase)
+
+		var kubeconfigSecret corev1.Secret
+		g.Expect(testCtx.MgmtClient.Get(testCtx.Context, crclient.ObjectKey{
+			Namespace: hc.Namespace,
+			Name:      hc.Status.KubeConfig.Name,
+		}, &kubeconfigSecret)).To(Succeed(), "failed to get kubeconfig secret %s", phase)
+
+		kubeconfigData, ok := kubeconfigSecret.Data["kubeconfig"]
+		g.Expect(ok).To(BeTrue(), "kubeconfig key missing from secret %s", phase)
+
+		restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigData)
+		g.Expect(err).NotTo(HaveOccurred(), "failed to parse kubeconfig %s", phase)
+
+		if attempts%6 == 1 {
+			host := restConfig.Host
+			GinkgoLogr.Info("API reachability attempt", "phase", phase, "attempt", attempts, "host", host)
+			addrs, dnsErr := net.LookupHost(extractHostname(host))
+			if dnsErr != nil {
+				GinkgoLogr.Info("DNS lookup failed", "host", host, "error", dnsErr)
+			} else {
+				GinkgoLogr.Info("DNS lookup succeeded", "host", host, "addrs", addrs)
+			}
+
+			controlPlaneNamespace := testCtx.ControlPlaneNamespace
+			extPrivRoute := hcpmanifests.KubeAPIServerExternalPrivateRoute(controlPlaneNamespace)
+			if routeErr := testCtx.MgmtClient.Get(testCtx.Context, crclient.ObjectKeyFromObject(extPrivRoute), extPrivRoute); routeErr != nil {
+				GinkgoLogr.Info("external-private Route not found", "error", routeErr)
+			} else {
+				visLabel := extPrivRoute.Labels[hyperv1.RouteVisibilityLabel]
+				hcpLabel := extPrivRoute.Labels[netutil.HCPRouteLabel]
+				intLabel := extPrivRoute.Labels[netutil.InternalRouteLabel]
+				var canonicalHost, routerName string
+				if len(extPrivRoute.Status.Ingress) > 0 {
+					canonicalHost = extPrivRoute.Status.Ingress[0].RouterCanonicalHostname
+					routerName = extPrivRoute.Status.Ingress[0].RouterName
+				}
+				GinkgoLogr.Info("external-private Route state",
+					"specHost", extPrivRoute.Spec.Host,
+					"visibilityLabel", visLabel,
+					"hcpLabel", hcpLabel,
+					"internalLabel", intLabel,
+					"ingressCount", len(extPrivRoute.Status.Ingress),
+					"routerCanonicalHostname", canonicalHost,
+					"routerName", routerName,
+				)
+			}
+		}
+
+		freshClient, err := crclient.New(restConfig, crclient.Options{Scheme: hyperapi.Scheme})
+		g.Expect(err).NotTo(HaveOccurred(), "failed to create fresh client %s", phase)
+
+		nsList := &corev1.NamespaceList{}
+		g.Expect(freshClient.List(testCtx.Context, nsList)).To(Succeed(), "failed to list namespaces %s", phase)
+		g.Expect(nsList.Items).NotTo(BeEmpty(), "namespace list is empty %s", phase)
+	}).WithTimeout(15 * time.Minute).WithPolling(10 * time.Second).Should(Succeed(), "API server not reachable %s", phase)
+}
+
+func extractHostname(host string) string {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		return h
+	}
+	if strings.HasPrefix(host, "https://") {
+		host = strings.TrimPrefix(host, "https://")
+		if h, _, err := net.SplitHostPort(host); err == nil {
+			return h
+		}
+		return host
+	}
+	return host
 }
 
 // AzureOAuthLoadBalancerTest registers tests for Azure OAuth LoadBalancer publishing validation.
@@ -290,6 +682,7 @@ func AzureOAuthLoadBalancerTest(getTestCtx internal.TestContextGetter) {
 func RegisterHostedClusterAzureTests(getTestCtx internal.TestContextGetter) {
 	AzurePublicClusterTest(getTestCtx)
 	AzurePrivateTopologyTest(getTestCtx)
+	AzureEndpointAccessTransitionTest(getTestCtx)
 	AzureOAuthLoadBalancerTest(getTestCtx)
 }
 


### PR DESCRIPTION
## What this PR does / why we need it:

Adds ExternalPrivateService support to the Azure PLS controller and a v2 e2e lifecycle test validating topology transitions on Azure self-managed clusters.

### Controller changes (`control-plane-operator`)

The Azure PLS controller now creates ExternalName Services with `external-dns.alpha.kubernetes.io/hostname` annotations when a cluster is Private with custom Route hostnames configured. This brings Azure to parity with AWS and GCP private link controllers:

- Uses PE IP as ExternalName target (matching GCP PSC pattern, not CNAME like AWS)
- Labels services with `hypershift.openshift.io/azure-pls-external-private-svc` for lifecycle management
- Deletes services by label when cluster transitions to public (`IsPublicHCP`)
- Sets owner reference to HCP for garbage collection
- Only reconciles for the `private-router` CR

Unit tests cover all three new functions: `hcpExternalNames`, `reconcileExternalService`, and `reconcileExternalServices`.

### E2E test (`test/e2e/v2`)

Validates transitioning a HostedCluster between Private and PublicAndPrivate topology:

1. **Private state**: Verifies KAS and OAuth ExternalPrivateService exist (ExternalName type)
2. **Private → PublicAndPrivate**: Confirms public routes created, private routes deleted, ExternalPrivateService cleaned up, PLS CRs persist, API reachable via public route
3. **PublicAndPrivate → Private**: Confirms private routes recreated, ExternalPrivateService recreated, PLS CRs persist, cluster Available and not Degraded

`DeferCleanup` restores Private topology if the test fails mid-transition.

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/CNTRLPLANE-3276

## Special notes for your reviewer:

- ExternalPrivateService implementation mirrors the established AWS/GCP pattern
- Uses `controllerutil.CreateOrUpdate` (Azure PLS controller doesn't embed the upsert provider)
- ExternalPrivateService convergence after restore to Private takes ~3 minutes (controller reconcile cycle)
- No changes to `lifecycle/azure.go` — the private variant's `LabelFilter` already includes `self-managed-azure-private`
- `DeferCleanup` uses `context.Background()` intentionally — cleanup may run after testCtx.Context is cancelled on timeout

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.