### PR TITLE
CNTRLPLANE-3023: Add CEL rule to prevent osImageStream removal

### DIFF
--- a/api/hypershift/v1beta1/nodepool_types.go
+++ b/api/hypershift/v1beta1/nodepool_types.go
@@ -101,6 +101,7 @@ type NodePool struct {
 }
 
 // NodePoolSpec is the desired behavior of a NodePool.
+// +openshift:validation:FeatureGateAwareXValidation:featureGate=OSStreams,rule="!has(oldSelf.osImageStream) || has(self.osImageStream)",message="osImageStream cannot be removed once set; create a new NodePool instead"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.arch) || has(self.arch)", message="Arch is required once set"
 // +kubebuilder:validation:XValidation:rule="self.arch != 'arm64' || has(self.platform.aws) || has(self.platform.azure) || has(self.platform.agent) || self.platform.type == 'GCP' || self.platform.type == 'None'", message="Setting Arch to arm64 is only supported for AWS, Azure, Agent, GCP and None"
 // +kubebuilder:validation:XValidation:rule="!has(self.replicas) || !has(self.autoScaling)", message="Both replicas or autoScaling should not be set"
@@ -260,6 +261,13 @@ type NodePoolSpec struct {
 	// +optional
 	OSImageStream OSImageStreamReference `json:"osImageStream,omitzero"`
 }
+
+const (
+	// OSImageStreamRHEL9 is the OS image stream name for RHEL 9.
+	OSImageStreamRHEL9 = "rhel-9"
+	// OSImageStreamRHEL10 is the OS image stream name for RHEL 10.
+	OSImageStreamRHEL10 = "rhel-10"
+)
 
 // OSImageStreamReference references an OSImageStream by name.
 type OSImageStreamReference struct {

--- a/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OSStreams.yaml
+++ b/api/hypershift/v1beta1/zz_generated.featuregated-crd-manifests/nodepools.hypershift.openshift.io/OSStreams.yaml
@@ -1528,6 +1528,9 @@ spec:
             - release
             type: object
             x-kubernetes-validations:
+            - message: osImageStream cannot be removed once set; create a new NodePool
+                instead
+              rule: '!has(oldSelf.osImageStream) || has(self.osImageStream)'
             - message: Arch is required once set
               rule: '!has(oldSelf.arch) || has(self.arch)'
             - message: Setting Arch to arm64 is only supported for AWS, Azure, Agent,

--- a/cmd/install/assets/crds/hypershift-operator/tests/nodepools.hypershift.openshift.io/featuregated.nodepools.osimagestream.testsuite.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/tests/nodepools.hypershift.openshift.io/featuregated.nodepools.osimagestream.testsuite.yaml
@@ -187,6 +187,55 @@ tests:
         osImageStream:
           name: "rhel-10"
 
+  - name: When removing osImageStream from an existing NodePool it should fail
+    initial: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          aws:
+            instanceProfile: a-profile
+            instanceType: m6a.2xlarge
+            rootVolume:
+              size: 120
+              type: gp3
+            subnet:
+              id: "subnet-any"
+          type: AWS
+        osImageStream:
+          name: "rhel-10"
+    updated: |
+      apiVersion: hypershift.openshift.io/v1beta1
+      kind: NodePool
+      spec:
+        arch: amd64
+        clusterName: some-cluster
+        management:
+          autoRepair: false
+          upgradeType: Replace
+        release:
+          image: quay.io/openshift-release-dev/ocp-release:4.17.0-rc.0-x86_64
+        replicas: 0
+        platform:
+          aws:
+            instanceProfile: a-profile
+            instanceType: m6a.2xlarge
+            rootVolume:
+              size: 120
+              type: gp3
+            subnet:
+              id: "subnet-any"
+          type: AWS
+    expectedError: "osImageStream cannot be removed once set; create a new NodePool instead"
+
   - name: When adding osImageStream to an existing NodePool it should succeed
     initial: |
       apiVersion: hypershift.openshift.io/v1beta1

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-CustomNoUpgrade.crd.yaml
@@ -1993,6 +1993,9 @@ spec:
             - release
             type: object
             x-kubernetes-validations:
+            - message: osImageStream cannot be removed once set; create a new NodePool
+                instead
+              rule: '!has(oldSelf.osImageStream) || has(self.osImageStream)'
             - message: Arch is required once set
               rule: '!has(oldSelf.arch) || has(self.arch)'
             - message: Setting Arch to arm64 is only supported for AWS, Azure, Agent,

--- a/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
+++ b/cmd/install/assets/crds/hypershift-operator/zz_generated.crd-manifests/nodepools-TechPreviewNoUpgrade.crd.yaml
@@ -1993,6 +1993,9 @@ spec:
             - release
             type: object
             x-kubernetes-validations:
+            - message: osImageStream cannot be removed once set; create a new NodePool
+                instead
+              rule: '!has(oldSelf.osImageStream) || has(self.osImageStream)'
             - message: Arch is required once set
               rule: '!has(oldSelf.arch) || has(self.arch)'
             - message: Setting Arch to arm64 is only supported for AWS, Azure, Agent,

--- a/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
+++ b/vendor/github.com/openshift/hypershift/api/hypershift/v1beta1/nodepool_types.go
@@ -101,6 +101,7 @@ type NodePool struct {
 }
 
 // NodePoolSpec is the desired behavior of a NodePool.
+// +openshift:validation:FeatureGateAwareXValidation:featureGate=OSStreams,rule="!has(oldSelf.osImageStream) || has(self.osImageStream)",message="osImageStream cannot be removed once set; create a new NodePool instead"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.arch) || has(self.arch)", message="Arch is required once set"
 // +kubebuilder:validation:XValidation:rule="self.arch != 'arm64' || has(self.platform.aws) || has(self.platform.azure) || has(self.platform.agent) || self.platform.type == 'GCP' || self.platform.type == 'None'", message="Setting Arch to arm64 is only supported for AWS, Azure, Agent, GCP and None"
 // +kubebuilder:validation:XValidation:rule="!has(self.replicas) || !has(self.autoScaling)", message="Both replicas or autoScaling should not be set"
@@ -260,6 +261,13 @@ type NodePoolSpec struct {
 	// +optional
 	OSImageStream OSImageStreamReference `json:"osImageStream,omitzero"`
 }
+
+const (
+	// OSImageStreamRHEL9 is the OS image stream name for RHEL 9.
+	OSImageStreamRHEL9 = "rhel-9"
+	// OSImageStreamRHEL10 is the OS image stream name for RHEL 10.
+	OSImageStreamRHEL10 = "rhel-10"
+)
 
 // OSImageStreamReference references an OSImageStream by name.
 type OSImageStreamReference struct {


### PR DESCRIPTION
## Summary

- Add a `FeatureGateAwareXValidation` CEL rule on `NodePoolSpec` that prevents removing the `osImageStream` field once set
- Add `OSImageStreamRHEL9` and `OSImageStreamRHEL10` constants for consistent stream name usage
- Add envtest case covering the removal scenario

## Description

Optional immutable fields on feature-gated types are subject to a two-step bypass: a user can (1) remove the field, then (2) re-add it with a different value. The existing field-level CEL rule on `osImageStream` prevents single-step downgrades (rhel-10 → rhel-9), but a field-level transition rule (`oldSelf`/`self`) does not fire when the field is removed entirely — the validator requires both `oldSelf` and `self` to be present.

This change adds a parent-level CEL rule on `NodePoolSpec` using `+openshift:validation:FeatureGateAwareXValidation` (gated on `OSStreams`) that rejects any update that removes `osImageStream` once it has been set:

```
!has(oldSelf.osImageStream) || has(self.osImageStream)
```

The `FeatureGateAwareXValidation` marker is used instead of `+kubebuilder:validation:XValidation` because the `osImageStream` field is stripped from the CRD schema in the Default variant (where the feature gate is disabled). A regular XValidation rule referencing `osImageStream` would fail at CRD installation time in that variant.

## Test plan

- [x] Envtest: "When removing osImageStream from an existing NodePool it should fail"
- [x] CEL rule present in TechPreviewNoUpgrade and CustomNoUpgrade CRD variants
- [x] CEL rule absent from Default CRD variant
- [x] `make update && make verify` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for RHEL 9 and RHEL 10 operating system image streams.

* **Enhancements**
  * Implemented validation to prevent removing an operating system image stream configuration once it has been set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->