### PR TITLE
CNTRLPLANE-3617: Increase address-review-comments timeout to 45 minutes

### DIFF
--- a/.github/workflows/address-review-comments.yaml
+++ b/.github/workflows/address-review-comments.yaml
@@ -21,7 +21,7 @@ jobs:
        github.event.comment.author_association == 'OWNER' ||
        github.event.comment.author_association == 'COLLABORATOR')
     runs-on: arc-runner-set
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
       HOME: /tmp
     steps:


### PR DESCRIPTION
## What this PR does / why we need it:

Increases the `timeout-minutes` for the address-review-comments GHA workflow from 30 to 45 minutes. The 30-minute limit is too tight for PRs with heavy review feedback where the agent needs time to analyze comments, make code changes, and run linting.

Example failure: https://github.com/openshift/hypershift/actions/runs/27341664218 — PR #8535 had 34 review comments and `golangci-lint` was still compiling when the timeout hit.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-3617](https://redhat.atlassian.net/browse/CNTRLPLANE-3617)

## Special notes for your reviewer:

Single-line change.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow timeout configuration to improve build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->