### PR TITLE
NO-JIRA: chore: add unit test naming and placement conventions

### DIFF
--- a/.claude/skills/code-formatting/SKILL.md
+++ b/.claude/skills/code-formatting/SKILL.md
@@ -13,6 +13,8 @@ description: "MANDATORY: When writing Go tests, you MUST use 'When...it should..
 
 ## Test Conventions - MANDATORY
 
+### Test naming
+
 **NON-NEGOTIABLE RULE**: Every Go test name MUST follow this exact format:
 ```go
 name: "When <condition>, it should <expected behavior>"
@@ -35,7 +37,30 @@ name: "When encryption is enabled, it should configure disk encryption set"
 - ✅ "When NodePool has ImageID, it should create basic Azure machine template"
 - ✅ "When subnet ID is invalid, it should return error with subnet parse message"
 
+### Unit test function naming
+
+Unit test functions MUST be named after the function they test, using the standard Go `Test<FunctionName>` convention:
+
+```go
+// Testing function ReconcileNodePool
+func TestReconcileNodePool(t *testing.T) { ... }
+
+// Testing function buildAzureMachineTemplate
+func TestBuildAzureMachineTemplate(t *testing.T) { ... }
+```
+
+**NEVER use generic or disconnected test function names like:**
+- ❌ `TestNodePoolFeatures`
+- ❌ `TestAzureIntegration`
+- ❌ `TestVariousCases`
+
+Each test function should map 1:1 to the function under test. If a function is complex enough to warrant many test cases, use table-driven tests within a single `Test<FunctionName>` function with the "When...it should..." naming for each case.
+
+### Unit test placement
+
 - **Always include unit tests** when creating new functions or modifying existing ones
+- **Place unit tests next to the code they test** — in the same package directory, in a `_test.go` file
+- **Do NOT place new tests in `test/integration/`** — this is a legacy directory. New unit tests go alongside the code under test. New integration-style tests that require a cluster should use `test/e2e/` or `test/envtest/`
 
 ## Quick Checklist
 


### PR DESCRIPTION
## Summary
- Unit test functions must be named after the function under test (`TestFunctionName`)
- Unit tests go next to the code they test (same package `_test.go`), not in `test/integration/` (legacy)
- Integration-style tests that need a cluster should use `test/e2e/` or `test/envtest/`

## Test plan
- [x] Verify codespell passes
- [ ] Review skill file for clarity and completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Code Formatting skill guide with enhanced test conventions, including explicit test naming standards, unit test function naming patterns, and placement guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->