### PR TITLE
CNTRLPLANE-3617: Increase address-review-comments max turns to 200

### DIFF
--- a/.github/workflows/address-review-comments.yaml
+++ b/.github/workflows/address-review-comments.yaml
@@ -91,4 +91,4 @@ jobs:
           claude plugin marketplace add enxebre/ai-scripts
           claude plugin install git@enxebre
           claude --version
-          claude -p "/utils:address-reviews $PR_NUMBER" --model claude-opus-4-6 --max-turns 100 --allowedTools "Bash Read Write Edit Grep Glob WebFetch"
+          claude -p "/utils:address-reviews $PR_NUMBER" --model claude-opus-4-6 --max-turns 200 --allowedTools "Bash Read Write Edit Grep Glob WebFetch"


### PR DESCRIPTION
## What this PR does / why we need it:

Increases `--max-turns` from 100 to 200 for the address-review-comments GHA workflow. Complex PRs with many review comments exhaust the 100-turn limit before the agent finishes addressing all feedback.

Example failure: https://github.com/openshift/hypershift/actions/runs/27364007898 — hit the 100-turn limit after only 12 minutes on PR #8535.

## Which issue(s) this PR fixes:

Fixes [CNTRLPLANE-3617](https://redhat.atlassian.net/browse/CNTRLPLANE-3617)

## Special notes for your reviewer:

Single-line change. Follow-up to #8720 which bumped the timeout.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [ ] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal automation workflows to improve development efficiency.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->