### PR TITLE
AROSLSRE-1158: add --install-scope flag to hypershift install

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -164,6 +164,7 @@ type Options struct {
 	AWSOperatorRolesFile                      string
 	RenderSensitive                           bool
 	HCPEgressBlockCIDRs                       []string
+	InstallScope                              string
 }
 
 func (o *Options) Complete() error {
@@ -181,6 +182,13 @@ func (o *Options) Complete() error {
 
 func (o *Options) Validate() error {
 	var errs []error
+
+	if o.InstallScope != "" && !Outputs(o.InstallScope).IsValid() {
+		errs = append(errs, fmt.Errorf("invalid --install-scope value %q: must be '%s', '%s', or '%s'", o.InstallScope, OutputAll, OutputCRDs, OutputResources))
+	}
+	if Outputs(o.InstallScope) == OutputCRDs && o.WaitUntilAvailable {
+		errs = append(errs, fmt.Errorf("--wait-until-available has no effect with --install-scope=crds"))
+	}
 
 	errs = append(errs, o.validatePlatformConfig()...)
 	errs = append(errs, o.validateOIDCConfig()...)
@@ -504,6 +512,7 @@ func NewCommand() *cobra.Command {
 	cmd.PersistentFlags().StringArrayVar(&opts.HCPEgressBlockCIDRs, "hcp-egress-block-cidrs", nil, "Static CIDRs to block in HCP namespace egress NetworkPolicies instead of dynamically-discovered hosting cluster KAS endpoint IPs. When specified, eliminates NetworkPolicy churn during hosting cluster KAS rolling restarts and avoids OVN port-group reconciliation races that can drop traffic to HCP routers. May be specified multiple times.")
 	cmd.PersistentFlags().StringVar(&opts.AWSRoleCredentialSource, "aws-role-credential-source", aws.CredentialSourceWebIdentity, "Credential source for AWS role ARN flags: 'web-identity' (uses projected SA token) or 'ec2-instance-metadata' (uses EC2 instance metadata)")
 	cmd.PersistentFlags().StringVar(&opts.AWSOperatorRolesFile, "aws-operator-roles-file", "", "Path to JSON output file from 'hypershift create operator-roles aws' (sets all three role ARN flags at once)")
+	cmd.Flags().StringVar(&opts.InstallScope, "install-scope", string(OutputAll), "Scope of installation: 'all' installs CRDs and resources (default), 'crds' installs only CRDs, 'resources' installs only resources assuming CRDs were installed previously (operator deployment and RBAC)")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		return InstallHyperShiftOperator(cmd.Context(), cmd.OutOrStdout(), opts)
@@ -537,61 +546,80 @@ func InstallHyperShiftOperator(ctx context.Context, out io.Writer, opts Options)
 		return err
 	}
 
-	// Validate all CRDs via dry-run before applying
-	if err := dryRunValidateCRDs(ctx, out, crds); err != nil {
-		return err
-	}
+	scope := Outputs(opts.InstallScope)
+	crdsToApply, objectsToApply := filterManifestsByScope(crds, objects, scope)
 
-	// Coordinate with Cluster CAPI Operator if the ClusterAPI API is available.
-	// This is done after dry-run so the ClusterAPI config is not mutated if CRDs
-	// cannot be applied.
-	config, err := util.GetConfig()
-	if err != nil {
-		return fmt.Errorf("failed to get kubernetes config: %w", err)
-	}
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
-	if err != nil {
-		return fmt.Errorf("failed to create discovery client: %w", err)
-	}
-	registered, err := isClusterAPIRegistered(discoveryClient)
-	if err != nil {
-		return err
-	}
-	if registered {
-		fmt.Fprintf(out, "ClusterAPI API detected, coordinating with Cluster CAPI Operator\n")
-		generation, err := ensureUnmanagedCRDs(ctx, out, client, crds)
+	if len(crdsToApply) > 0 {
+		// Validate all CRDs via dry-run before applying
+		if err := dryRunValidateCRDs(ctx, out, crdsToApply); err != nil {
+			return err
+		}
+
+		// Coordinate with Cluster CAPI Operator if the ClusterAPI API is available.
+		// This is done after dry-run so the ClusterAPI config is not mutated if CRDs
+		// cannot be applied.
+		config, err := util.GetConfig()
+		if err != nil {
+			return fmt.Errorf("failed to get kubernetes config: %w", err)
+		}
+		discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+		if err != nil {
+			return fmt.Errorf("failed to create discovery client: %w", err)
+		}
+		registered, err := isClusterAPIRegistered(discoveryClient)
 		if err != nil {
 			return err
 		}
-		if generation > 0 {
-			if err := waitForCAPIOperatorSync(ctx, out, client, generation); err != nil {
+		if registered {
+			fmt.Fprintf(out, "ClusterAPI API detected, coordinating with Cluster CAPI Operator\n")
+			generation, err := ensureUnmanagedCRDs(ctx, out, client, crdsToApply)
+			if err != nil {
+				return err
+			}
+			if generation > 0 {
+				if err := waitForCAPIOperatorSync(ctx, out, client, generation); err != nil {
+					return err
+				}
+			}
+		}
+
+		err = apply(ctx, out, crdsToApply)
+		if err != nil {
+			return err
+		}
+
+		if opts.WaitUntilAvailable || opts.WaitUntilEstablished {
+			if err := waitUntilEstablished(ctx, crdsToApply); err != nil {
 				return err
 			}
 		}
 	}
 
-	err = apply(ctx, out, crds)
-	if err != nil {
-		return err
-	}
-
-	if opts.WaitUntilAvailable || opts.WaitUntilEstablished {
-		if err := waitUntilEstablished(ctx, crds); err != nil {
+	if len(objectsToApply) > 0 {
+		err = apply(ctx, out, objectsToApply)
+		if err != nil {
 			return err
 		}
-	}
 
-	err = apply(ctx, out, objects)
-	if err != nil {
-		return err
-	}
-
-	if opts.WaitUntilAvailable {
-		if _, err := WaitUntilAvailable(ctx, opts); err != nil {
-			return err
+		if opts.WaitUntilAvailable {
+			if _, err := WaitUntilAvailable(ctx, opts); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
+}
+
+// filterManifestsByScope returns the CRDs and resources that should be applied
+// based on the given install scope.
+func filterManifestsByScope(crds, objects []crclient.Object, scope Outputs) (crdsToApply, objectsToApply []crclient.Object) {
+	if scope.IncludesCRDs() {
+		crdsToApply = crds
+	}
+	if scope.IncludesResources() {
+		objectsToApply = objects
+	}
+	return
 }
 
 // NewInstallOptionsWithDefaults returns an Options instance with the default values sets.
@@ -617,6 +645,7 @@ func NewInstallOptionsWithDefaults() Options {
 	opts.PrivatePlatform = string(hyperv1.NonePlatform)
 	opts.ImagePullPolicy = "IfNotPresent"
 	opts.AdditionalOperatorEnvVars = map[string]string{}
+	opts.InstallScope = string(OutputAll)
 
 	return opts
 }

--- a/cmd/install/install_render.go
+++ b/cmd/install/install_render.go
@@ -12,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -26,6 +25,23 @@ const (
 	OutputCRDs      Outputs = "crds"
 	OutputResources Outputs = "resources"
 )
+
+func (o Outputs) IsValid() bool {
+	switch o {
+	case OutputAll, OutputCRDs, OutputResources:
+		return true
+	default:
+		return false
+	}
+}
+
+func (o Outputs) IncludesCRDs() bool {
+	return o == OutputAll || o == OutputCRDs
+}
+
+func (o Outputs) IncludesResources() bool {
+	return o == OutputAll || o == OutputResources
+}
 
 var (
 	RenderFormatYaml = "yaml"
@@ -89,9 +105,8 @@ func (o *Options) ValidateRender() error {
 		return fmt.Errorf("--format must be %s or %s", RenderFormatYaml, RenderFormatJson)
 	}
 
-	outputs := sets.New(OutputAll, OutputCRDs, OutputResources)
-	if !outputs.Has(Outputs(o.OutputTypes)) {
-		return fmt.Errorf("--outputs must be one of %v", outputs.UnsortedList())
+	if !Outputs(o.OutputTypes).IsValid() {
+		return fmt.Errorf("invalid --outputs value %q: must be '%s', '%s', or '%s'", o.OutputTypes, OutputAll, OutputCRDs, OutputResources)
 	}
 
 	return nil
@@ -129,14 +144,13 @@ func RenderHyperShiftOperator(ctx context.Context, cmdOut io.Writer, opts *Optio
 		}
 	}
 
+	scope := Outputs(opts.OutputTypes)
 	var objectsToRender []crclient.Object
-	switch Outputs(opts.OutputTypes) {
-	case OutputAll:
-		objectsToRender = append(crds, objects...)
-	case OutputCRDs:
-		objectsToRender = crds
-	case OutputResources:
-		objectsToRender = objects
+	if scope.IncludesCRDs() {
+		objectsToRender = append(objectsToRender, crds...)
+	}
+	if scope.IncludesResources() {
+		objectsToRender = append(objectsToRender, objects...)
 	}
 
 	if !opts.RenderSensitive {

--- a/cmd/install/install_test.go
+++ b/cmd/install/install_test.go
@@ -425,6 +425,42 @@ func TestOptions_Validate(t *testing.T) {
 			},
 			expectError: false,
 		},
+		"when install-scope is all it should not error": {
+			inputOptions: Options{
+				PrivatePlatform: string(hyperv1.NonePlatform),
+				InstallScope:    string(OutputAll),
+			},
+			expectError: false,
+		},
+		"when install-scope is crds it should not error": {
+			inputOptions: Options{
+				PrivatePlatform: string(hyperv1.NonePlatform),
+				InstallScope:    string(OutputCRDs),
+			},
+			expectError: false,
+		},
+		"when install-scope is resources it should not error": {
+			inputOptions: Options{
+				PrivatePlatform: string(hyperv1.NonePlatform),
+				InstallScope:    string(OutputResources),
+			},
+			expectError: false,
+		},
+		"when install-scope is invalid it should error": {
+			inputOptions: Options{
+				PrivatePlatform: string(hyperv1.NonePlatform),
+				InstallScope:    "bogus",
+			},
+			expectError: true,
+		},
+		"when install-scope is crds with wait-until-available it should error": {
+			inputOptions: Options{
+				PrivatePlatform:    string(hyperv1.NonePlatform),
+				InstallScope:       string(OutputCRDs),
+				WaitUntilAvailable: true,
+			},
+			expectError: true,
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -812,6 +848,94 @@ func TestRenderHyperShiftOperator_RenderSensitive(t *testing.T) {
 		}
 		g.Expect(nonWebhookSecretCount).To(BeNumerically(">", 0), "expected at least one non-webhook secret to be rendered")
 	})
+}
+
+func TestRenderOutputsScope(t *testing.T) {
+	baseOpts := Options{
+		PrivatePlatform: string(hyperv1.NonePlatform),
+		Format:          RenderFormatYaml,
+		RenderSensitive: true,
+	}
+
+	tests := []struct {
+		name            string
+		outputs         string
+		expectCRDs      bool
+		expectResources bool
+		expectError     bool
+	}{
+		{"when outputs is all it should include CRDs and resources", string(OutputAll), true, true, false},
+		{"when outputs is crds it should include only CRDs", string(OutputCRDs), true, false, false},
+		{"when outputs is resources it should include only resources", string(OutputResources), false, true, false},
+		{"when outputs is invalid it should error", "bogus", false, false, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			opts := baseOpts
+			opts.OutputTypes = tc.outputs
+			var buf bytes.Buffer
+			err := RenderHyperShiftOperator(t.Context(), &buf, &opts)
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred(), "expected error for --outputs=%s", tc.outputs)
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred(), "RenderHyperShiftOperator failed for --outputs=%s", tc.outputs)
+
+			var crdCount, resourceCount int
+			for doc := range strings.SplitSeq(buf.String(), "\n---\n") {
+				if strings.TrimSpace(doc) == "" {
+					continue
+				}
+				obj, _, err := hyperapi.YamlSerializer.Decode([]byte(doc), nil, nil)
+				g.Expect(err).NotTo(HaveOccurred(), "failed to decode rendered manifest")
+				if _, isCRD := obj.(*apiextensionsv1.CustomResourceDefinition); isCRD {
+					crdCount++
+				} else {
+					resourceCount++
+				}
+			}
+
+			if tc.expectCRDs {
+				g.Expect(crdCount).To(BeNumerically(">", 0), "expected CRDs in output for --outputs=%s", tc.outputs)
+			} else {
+				g.Expect(crdCount).To(Equal(0), "expected no CRDs in output for --outputs=%s, got %d", tc.outputs, crdCount)
+			}
+			if tc.expectResources {
+				g.Expect(resourceCount).To(BeNumerically(">", 0), "expected resources in output for --outputs=%s", tc.outputs)
+			} else {
+				g.Expect(resourceCount).To(Equal(0), "expected no resources in output for --outputs=%s, got %d", tc.outputs, resourceCount)
+			}
+		})
+	}
+}
+
+func TestOutputsHelpers(t *testing.T) {
+	tests := []struct {
+		name              string
+		output            Outputs
+		isValid           bool
+		includesCRDs      bool
+		includesResources bool
+	}{
+		{"when output is all it should be valid and include both", OutputAll, true, true, true},
+		{"when output is crds it should be valid and include only CRDs", OutputCRDs, true, true, false},
+		{"when output is resources it should be valid and include only resources", OutputResources, true, false, true},
+		{"when output is empty it should be invalid", Outputs(""), false, false, false},
+		{"when output is bogus it should be invalid", Outputs("bogus"), false, false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+			g.Expect(tc.output.IsValid()).To(Equal(tc.isValid))
+			g.Expect(tc.output.IncludesCRDs()).To(Equal(tc.includesCRDs))
+			g.Expect(tc.output.IncludesResources()).To(Equal(tc.includesResources))
+		})
+	}
 }
 
 func TestHyperShiftOperatorManifests_SharedIngress(t *testing.T) {
@@ -1280,6 +1404,45 @@ func TestApplyDefaults(t *testing.T) {
 			g.Expect(tc.opts.RenderNamespace).To(BeTrue())
 		})
 	}
+}
+
+func TestFilterManifestsByScope(t *testing.T) {
+	t.Parallel()
+	fakeCRD := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-crd"},
+	}
+	fakeDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-deployment"},
+	}
+	crds := []crclient.Object{fakeCRD}
+	objects := []crclient.Object{fakeDeployment}
+
+	tests := []struct {
+		name            string
+		scope           Outputs
+		expectCRDs      int
+		expectResources int
+	}{
+		{"when scope is all it should return both CRDs and resources", OutputAll, 1, 1},
+		{"when scope is crds it should return only CRDs", OutputCRDs, 1, 0},
+		{"when scope is resources it should return only resources", OutputResources, 0, 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+			gotCRDs, gotObjects := filterManifestsByScope(crds, objects, tc.scope)
+			g.Expect(gotCRDs).To(HaveLen(tc.expectCRDs))
+			g.Expect(gotObjects).To(HaveLen(tc.expectResources))
+		})
+	}
+}
+
+func TestNewInstallOptionsWithDefaults_InstallScope(t *testing.T) {
+	g := NewGomegaWithT(t)
+	opts := NewInstallOptionsWithDefaults()
+	g.Expect(opts.InstallScope).To(Equal(string(OutputAll)), "InstallScope should default to 'all'")
 }
 
 func TestIsAWSPlatformEnabled(t *testing.T) {


### PR DESCRIPTION
## What this PR does / why we need it

Adds a new `--install-scope` flag to the `hypershift install` command that controls which subset of manifests are applied:

- `all` (default): installs CRDs and resources (existing behavior, fully backwards compatible)
- `crds`: installs only CRDs
- `resources`: installs only resources (operator deployment and RBAC)

## Why we need it

In ARO-HCP, the HyperShift Helm chart uses post-install hooks to run `hypershift install`. There's a race condition where the operator starts and creates a `ClusterSizingConfiguration` before the Helm hook can apply its own version, causing apply conflicts.

Splitting the install into phases allows:
1. CRDs to be installed first (`--install-scope=crds`)
2. CRD-dependent manifests (like `ClusterSizingConfiguration`) to be applied by Helm
3. The operator to start last (`--install-scope=resources`)

## Which issue(s) this PR fixes

Fixes: https://redhat.atlassian.net/browse/AROSLSRE-1158
Related: https://redhat.atlassian.net/browse/AROSLSRE-313

## Checklist
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.
- [x] This change includes unit tests.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--install-scope` (default: `all`) to control whether CRDs, operator resources, or both are installed.
  * The installer now runs CRD-related steps only when the scope includes CRDs, and operator resource steps only when it includes resources.

* **Refactor**
  * Improved `--outputs` validation and manifest selection using explicit CRD-vs-resource scoping rules.

* **Tests**
  * Extended validation tests for `--install-scope`.
  * Added tests ensuring rendered manifests match the selected scope, including CRD presence/absence checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->