### PR TITLE
CNTRLPLANE-3575: test(controlplane-component): verify setDefaultOptions preserves exis…

### DIFF
--- a/support/controlplane-component/defaults_test.go
+++ b/support/controlplane-component/defaults_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"github.com/openshift/hypershift/control-plane-operator/controllers/hostedcontrolplane/imageprovider"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -521,27 +522,129 @@ func TestApplyNonOvercommitableResourceLimits(t *testing.T) {
 }
 
 func TestSetDefaultOptions(t *testing.T) {
-	g := NewGomegaWithT(t)
 	scheme := runtime.NewScheme()
 	_ = hyperv1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
 	_ = appsv1.AddToScheme(scheme)
 
-	// Test case for etcd SecurityContext.
-	controlPlaneWorkload := &controlPlaneWorkload[*appsv1.StatefulSet]{
-		name:             "etcd",
-		workloadProvider: &statefulSetProvider{},
-		ComponentOptions: &testComponent{},
-	}
-	workloadObject := &appsv1.StatefulSet{}
+	t.Run("etcd sets SecurityContext with custom UID", func(t *testing.T) {
+		g := NewGomegaWithT(t)
 
-	err := controlPlaneWorkload.setDefaultOptions(ControlPlaneContext{
-		HCP:                       &hyperv1.HostedControlPlane{},
-		SetDefaultSecurityContext: true,
-		DefaultSecurityContextUID: int64(1002),
-		Client:                    fake.NewClientBuilder().WithScheme(scheme).Build(),
-	}, workloadObject, nil)
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(workloadObject.Spec.Template.Spec.SecurityContext.RunAsUser).To(Equal(ptr.To(int64(1002))))
-	g.Expect(workloadObject.Spec.Template.Spec.SecurityContext.FSGroup).To(Equal(ptr.To(int64(1002))))
+		workload := &controlPlaneWorkload[*appsv1.StatefulSet]{
+			name:             "etcd",
+			workloadProvider: &statefulSetProvider{},
+			ComponentOptions: &testComponent{},
+		}
+		workloadObject := &appsv1.StatefulSet{}
+
+		err := workload.setDefaultOptions(ControlPlaneContext{
+			HCP:                       &hyperv1.HostedControlPlane{},
+			SetDefaultSecurityContext: true,
+			DefaultSecurityContextUID: int64(1002),
+			Client:                    fake.NewClientBuilder().WithScheme(scheme).Build(),
+		}, workloadObject, nil)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(workloadObject.Spec.Template.Spec.SecurityContext.RunAsUser).To(Equal(ptr.To(int64(1002))))
+		g.Expect(workloadObject.Spec.Template.Spec.SecurityContext.FSGroup).To(Equal(ptr.To(int64(1002))))
+	})
+
+	imageProvider := imageprovider.NewFromImages(map[string]string{
+		"hyperkube": "quay.io/test/hyperkube:latest",
+	})
+
+	resourceTests := []struct {
+		name               string
+		annotations        map[string]string
+		containerResources corev1.ResourceRequirements
+		existingResources  map[string]corev1.ResourceRequirements
+		expectedResources  corev1.ResourceRequirements
+	}{
+		{
+			name: "existing resources with both requests and limits are fully preserved",
+			containerResources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+			},
+			existingResources: map[string]corev1.ResourceRequirements{
+				"kube-apiserver": {
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("1700Mi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				},
+			},
+			expectedResources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("200m"),
+					corev1.ResourceMemory: resource.MustParse("1700Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+		},
+		{
+			name: "without existing resources container keeps its manifest defaults",
+			containerResources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+			},
+			existingResources: nil,
+			expectedResources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+			},
+		},
+	}
+
+	for _, test := range resourceTests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			workload := &controlPlaneWorkload[*appsv1.Deployment]{
+				name:             "kube-apiserver",
+				workloadProvider: &deploymentProvider{},
+				ComponentOptions: &testComponent{},
+			}
+
+			deployment := &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:      "kube-apiserver",
+									Image:     "hyperkube",
+									Resources: test.containerResources,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			hcp := &hyperv1.HostedControlPlane{}
+			hcp.Annotations = test.annotations
+
+			err := workload.setDefaultOptions(ControlPlaneContext{
+				HCP:                  hcp,
+				Client:               fake.NewClientBuilder().WithScheme(scheme).Build(),
+				ReleaseImageProvider: imageProvider,
+			}, deployment, test.existingResources)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(deployment.Spec.Template.Spec.Containers[0].Resources).To(Equal(test.expectedResources))
+		})
+	}
 }

--- a/support/controlplane-component/defaults_test.go
+++ b/support/controlplane-component/defaults_test.go
@@ -527,7 +527,8 @@ func TestSetDefaultOptions(t *testing.T) {
 	_ = corev1.AddToScheme(scheme)
 	_ = appsv1.AddToScheme(scheme)
 
-	t.Run("etcd sets SecurityContext with custom UID", func(t *testing.T) {
+	t.Run("When SetDefaultSecurityContext is true it should set RunAsUser and FSGroup", func(t *testing.T) {
+		t.Parallel()
 		g := NewGomegaWithT(t)
 
 		workload := &controlPlaneWorkload[*appsv1.StatefulSet]{
@@ -548,7 +549,7 @@ func TestSetDefaultOptions(t *testing.T) {
 		g.Expect(workloadObject.Spec.Template.Spec.SecurityContext.FSGroup).To(Equal(ptr.To(int64(1002))))
 	})
 
-	imageProvider := imageprovider.NewFromImages(map[string]string{
+	releaseProvider := imageprovider.NewFromImages(map[string]string{
 		"hyperkube": "quay.io/test/hyperkube:latest",
 	})
 
@@ -560,7 +561,7 @@ func TestSetDefaultOptions(t *testing.T) {
 		expectedResources  corev1.ResourceRequirements
 	}{
 		{
-			name: "existing resources with both requests and limits are fully preserved",
+			name: "When existing resources have both requests and limits it should fully preserve them",
 			containerResources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("100m"),
@@ -591,7 +592,7 @@ func TestSetDefaultOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "without existing resources container keeps its manifest defaults",
+			name: "When no existing resources are set it should keep the manifest defaults",
 			containerResources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("100m"),
@@ -610,6 +611,7 @@ func TestSetDefaultOptions(t *testing.T) {
 
 	for _, test := range resourceTests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			g := NewGomegaWithT(t)
 
 			workload := &controlPlaneWorkload[*appsv1.Deployment]{
@@ -640,7 +642,7 @@ func TestSetDefaultOptions(t *testing.T) {
 			err := workload.setDefaultOptions(ControlPlaneContext{
 				HCP:                  hcp,
 				Client:               fake.NewClientBuilder().WithScheme(scheme).Build(),
-				ReleaseImageProvider: imageProvider,
+				ReleaseImageProvider: releaseProvider,
 			}, deployment, test.existingResources)
 			g.Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
…ting resource requirements

## What this PR does / why we need it:


* Adds unit tests for the resource preservation behavior in setDefaultOptions (defaults.go:159-164). Covers three scenarios: annotation-based overrides taking precedence over existing resources, full ResourceRequirements struct (Requests + Limits) surviving reconciliation, and manifest defaults kept when no existing resources are present.



## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://redhat.atlassian.net/browse/CNTRLPLANE-3575
The existing E2E test in openshift-tests-private is converted to a unit test in openshift/hypershift.

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for control plane resource handling, including kube-apiserver and etcd scenarios: verifies resource override precedence, preserves existing container requests/limits when present, and keeps manifest-defined defaults when no existing resources are provided.
  * Added table-driven cases to validate multiple resource states and assertions are organized into clearer subtests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->