### PR TITLE
CNTRLPLANE-3576: add RestartDateAnnotation propagation tests

### DIFF
--- a/support/controlplane-component/defaults_test.go
+++ b/support/controlplane-component/defaults_test.go
@@ -523,9 +523,15 @@ func TestApplyNonOvercommitableResourceLimits(t *testing.T) {
 
 func TestSetDefaultOptions(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = hyperv1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
+	if err := hyperv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add hyperv1 to scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 to scheme: %v", err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add appsv1 to scheme: %v", err)
+	}
 
 	t.Run("When SetDefaultSecurityContext is true it should set RunAsUser and FSGroup", func(t *testing.T) {
 		t.Parallel()
@@ -647,6 +653,64 @@ func TestSetDefaultOptions(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 
 			g.Expect(deployment.Spec.Template.Spec.Containers[0].Resources).To(Equal(test.expectedResources))
+		})
+	}
+
+	annotationTests := []struct {
+		name           string
+		hcpAnnotations map[string]string
+		expectSet      bool
+	}{
+		{
+			name: "When HCP has RestartDateAnnotation it should propagate it to the pod template",
+			hcpAnnotations: map[string]string{
+				hyperv1.RestartDateAnnotation: "2024-01-15T12:00:00Z",
+			},
+			expectSet: true,
+		},
+		{
+			name:      "When HCP has no RestartDateAnnotation it should not set it on the pod template",
+			expectSet: false,
+		},
+	}
+
+	for _, test := range annotationTests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewGomegaWithT(t)
+
+			workload := &controlPlaneWorkload[*appsv1.Deployment]{
+				name:             "kube-apiserver",
+				workloadProvider: &deploymentProvider{},
+				ComponentOptions: &testComponent{},
+			}
+			deployment := &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "kube-apiserver", Image: "hyperkube"},
+							},
+						},
+					},
+				},
+			}
+			hcp := &hyperv1.HostedControlPlane{}
+			hcp.Annotations = test.hcpAnnotations
+
+			err := workload.setDefaultOptions(ControlPlaneContext{
+				HCP:                  hcp,
+				Client:               fake.NewClientBuilder().WithScheme(scheme).Build(),
+				ReleaseImageProvider: releaseProvider,
+			}, deployment, nil)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			if test.expectSet {
+				g.Expect(deployment.Spec.Template.Annotations).To(HaveKeyWithValue(
+					hyperv1.RestartDateAnnotation, test.hcpAnnotations[hyperv1.RestartDateAnnotation]))
+			} else {
+				g.Expect(deployment.Spec.Template.Annotations).NotTo(HaveKey(hyperv1.RestartDateAnnotation))
+			}
 		})
 	}
 }


### PR DESCRIPTION
## What this PR does / why we need it:
* Convert an E2E test from openshift-tests-private into a unit test that covers the missing functionality as follows:
   * Verify that setDefaultOptions propagates RestartDateAnnotation from HCP to the pod template when set, and omits it when absent. This covers the mechanism that triggers rolling restarts via pod template annotation changes. Rolling out the new ReplicaSet is then Kubernetes' concern. The annotation propagation from  HostedCluster to HostedControlPlane is already tested in TestReconcileHostedControlPlaneAnnotations.

## Which issue(s) this PR fixes:
<!--
(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story
-->
Fixes https://redhat.atlassian.net/browse/CNTRLPLANE-3576

## Special notes for your reviewer:

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage and robustness for restart date annotation propagation in control plane components, with improved test structure and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->