### PR TITLE
OCPBUGS-88531: Restart cloud-network-config-controller on restart-date annotation

### DIFF
--- a/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go
@@ -2043,6 +2043,12 @@ func (r *HostedControlPlaneReconciler) cleanupClusterNetworkOperatorResources(ct
 		if err := cnov2.SetRestartAnnotationAndPatch(ctx, r.Client, ovnKubeControlPlaneDeployment, restartAnnotation); err != nil {
 			return fmt.Errorf("failed to restart ovnkube-control-plane: %w", err)
 		}
+
+		// CNO manages overall cloud-network-config-controller deployment on cloud platforms (AWS/Azure/GCP/OpenStack). CPO manages restarts.
+		cloudNetworkConfigControllerDeployment := manifests.CloudNetworkConfigControllerDeployment(hcp.Namespace)
+		if err := cnov2.SetRestartAnnotationAndPatch(ctx, r.Client, cloudNetworkConfigControllerDeployment, restartAnnotation); err != nil {
+			return fmt.Errorf("failed to restart cloud-network-config-controller: %w", err)
+		}
 	}
 
 	// Clean up ovnkube-sbdb Route if exists

--- a/control-plane-operator/controllers/hostedcontrolplane/manifests/cno.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/manifests/cno.go
@@ -13,6 +13,7 @@ const clusterNetworkOperator = "cluster-network-operator"
 const multusAdmissionController = "multus-admission-controller"
 const networkNodeIdentity = "network-node-identity"
 const ovnKubeControlPlane = "ovnkube-control-plane"
+const cloudNetworkConfigController = "cloud-network-config-controller"
 
 func ClusterNetworkOperatorDeployment(ns string) *appsv1.Deployment {
 	return &appsv1.Deployment{
@@ -73,6 +74,15 @@ func OVNKubeControlPlaneDeployment(namespace string) *appsv1.Deployment {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      ovnKubeControlPlane,
+		},
+	}
+}
+
+func CloudNetworkConfigControllerDeployment(namespace string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      cloudNetworkConfigController,
 		},
 	}
 }

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cno/component.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cno/component.go
@@ -91,11 +91,10 @@ func SetRestartAnnotationAndPatch(ctx context.Context, crclient client.Client, d
 	}
 
 	patch := dep.DeepCopy()
-	podMeta := patch.Spec.Template.ObjectMeta
-	if podMeta.Annotations == nil {
-		podMeta.Annotations = map[string]string{}
+	if patch.Spec.Template.ObjectMeta.Annotations == nil {
+		patch.Spec.Template.ObjectMeta.Annotations = map[string]string{}
 	}
-	podMeta.Annotations[hyperv1.RestartDateAnnotation] = restartAnnotation
+	patch.Spec.Template.ObjectMeta.Annotations[hyperv1.RestartDateAnnotation] = restartAnnotation
 
 	if err := crclient.Patch(ctx, patch, client.MergeFrom(dep)); err != nil {
 		return fmt.Errorf("failed to set restart annotation: %w", err)

--- a/control-plane-operator/controllers/hostedcontrolplane/v2/cno/component_test.go
+++ b/control-plane-operator/controllers/hostedcontrolplane/v2/cno/component_test.go
@@ -1,12 +1,104 @@
 package cno
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
 
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func TestSetRestartAnnotationAndPatch(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = appsv1.AddToScheme(scheme)
+
+	tests := []struct {
+		name              string
+		existingDeploy    *appsv1.Deployment
+		restartAnnotation string
+		expectError       bool
+		expectAnnotation  bool
+	}{
+		{
+			name: "When deployment exists with nil annotations it should set the restart annotation",
+			existingDeploy: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-deploy",
+				},
+			},
+			restartAnnotation: "2026-06-15T12:00:00Z",
+			expectAnnotation:  true,
+		},
+		{
+			name: "When deployment exists with existing annotations it should set the restart annotation",
+			existingDeploy: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-deploy",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"existing-key": "existing-value",
+							},
+						},
+					},
+				},
+			},
+			restartAnnotation: "2026-06-15T12:00:00Z",
+			expectAnnotation:  true,
+		},
+		{
+			name:              "When deployment does not exist it should return nil",
+			existingDeploy:    nil,
+			restartAnnotation: "2026-06-15T12:00:00Z",
+			expectAnnotation:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			if tt.existingDeploy != nil {
+				builder = builder.WithObjects(tt.existingDeploy)
+			}
+			cl := builder.Build()
+
+			dep := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-deploy",
+				},
+			}
+
+			err := SetRestartAnnotationAndPatch(context.Background(), cl, dep, tt.restartAnnotation)
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+
+			if tt.expectAnnotation {
+				updated := &appsv1.Deployment{}
+				err = cl.Get(context.Background(), client.ObjectKeyFromObject(dep), updated)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(updated.Spec.Template.ObjectMeta.Annotations).To(HaveKeyWithValue(hyperv1.RestartDateAnnotation, tt.restartAnnotation))
+			}
+		})
+	}
+}
 
 func TestPlatformHasCloudNetworkConfigController(t *testing.T) {
 	tests := []struct {

--- a/docs/content/how-to/restart-control-plane-components.md
+++ b/docs/content/how-to/restart-control-plane-components.md
@@ -14,6 +14,7 @@ The list of components restarted are listed below:
 
 * catalog-operator
 * certified-operators-catalog
+* cloud-network-config-controller (cloud platforms only: AWS, Azure, GCP, OpenStack)
 * cluster-api
 * cluster-autoscaler
 * cluster-policy-controller
@@ -29,11 +30,14 @@ The list of components restarted are listed below:
 * kube-controller-manager
 * kube-scheduler
 * machine-approver
+* multus-admission-controller (if multi-network is enabled)
+* network-node-identity
 * oauth-openshift
 * olm-operator
 * openshift-apiserver
 * openshift-controller-manager
 * openshift-oauth-apiserver
+* ovnkube-control-plane
 * packageserver
 * redhat-marketplace-catalog
 * redhat-operators-catalog

--- a/docs/content/reference/aggregated-docs.md
+++ b/docs/content/reference/aggregated-docs.md
@@ -28444,6 +28444,7 @@ The list of components restarted are listed below:
 
 * catalog-operator
 * certified-operators-catalog
+* cloud-network-config-controller (cloud platforms only: AWS, Azure, GCP, OpenStack)
 * cluster-api
 * cluster-autoscaler
 * cluster-policy-controller
@@ -28459,11 +28460,14 @@ The list of components restarted are listed below:
 * kube-controller-manager
 * kube-scheduler
 * machine-approver
+* multus-admission-controller (if multi-network is enabled)
+* network-node-identity
 * oauth-openshift
 * olm-operator
 * openshift-apiserver
 * openshift-controller-manager
 * openshift-oauth-apiserver
+* ovnkube-control-plane
 * packageserver
 * redhat-marketplace-catalog
 * redhat-operators-catalog


### PR DESCRIPTION
## What this PR does / why we need it:

**Note: The primary fix for this bug is in CNO: https://github.com/openshift/cluster-network-operator/pull/3030**

This PR is a companion fix in hypershift that:

1. **Fixes a pre-existing value-copy bug in `SetRestartAnnotationAndPatch`** — `podMeta := patch.Spec.Template.ObjectMeta` creates a value copy, so when `podMeta.Annotations` is nil, the new map is lost. Fixed by working directly on `patch.Spec.Template.ObjectMeta.Annotations`.

2. **Adds cloud-network-config-controller restart** as a stopgap in CPO's `cleanupClusterNetworkOperatorResources` — this follows the existing pattern for multus-admission-controller, network-node-identity, and ovnkube-control-plane. Once the CNO fix lands, all CPO restart calls for CNO operands can be removed (tracked by the existing TODO comment at line 2026).

3. **Documents the four CNO-managed components** that were missing from the restart documentation.

## Which issue(s) this PR fixes:

Fixes https://issues.redhat.com/browse/OCPBUGS-88531

## Special notes for your reviewer:

The architecturally correct fix is in CNO (PR #3030), where CNO reads the `restart-date` annotation from the HCP CR and injects it into all rendered operand pod templates. This hypershift PR provides the stopgap and bug fix.

The `cleanupClusterNetworkOperatorResources` function in CPO has a long-standing TODO asking "why is this not done in CNO?" — the CNO PR addresses that for the restart-date case.

## Checklist:
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs.
- [x] This change includes unit tests.

🤖 Generated with [Claude Code](https://claude.ai/claude-code) via `/jira:solve OCPBUGS-88531`